### PR TITLE
MSQ: Allow for worker gaps.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/stage/ReadablePartition.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/stage/ReadablePartition.java
@@ -60,6 +60,18 @@ public class ReadablePartition
   }
 
   /**
+   * Returns an output partition that is striped across a set of {@code workerNumbers}.
+   */
+  public static ReadablePartition striped(
+      final int stageNumber,
+      final IntSortedSet workerNumbers,
+      final int partitionNumber
+  )
+  {
+    return new ReadablePartition(stageNumber, workerNumbers, partitionNumber);
+  }
+
+  /**
    * Returns an output partition that has been collected onto a single worker.
    */
   public static ReadablePartition collected(final int stageNumber, final int workerNumber, final int partitionNumber)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/stage/SparseStripedReadablePartitions.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/stage/SparseStripedReadablePartitions.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.msq.input.stage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.Iterators;
+import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
+import org.apache.druid.msq.input.SlicerUtils;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Set of partitions striped across a sparse set of {@code workers}. Each worker contains a "stripe" of each partition.
+ *
+ * @see StripedReadablePartitions dense version, where workers from [0..N) are all used.
+ */
+public class SparseStripedReadablePartitions implements ReadablePartitions
+{
+  private final int stageNumber;
+  private final IntSortedSet workers;
+  private final IntSortedSet partitionNumbers;
+
+  /**
+   * Constructor. Most callers should use {@link ReadablePartitions#striped(int, int, int)} instead, which takes
+   * a partition count rather than a set of partition numbers.
+   */
+  public SparseStripedReadablePartitions(
+      final int stageNumber,
+      final IntSortedSet workers,
+      final IntSortedSet partitionNumbers
+  )
+  {
+    this.stageNumber = stageNumber;
+    this.workers = workers;
+    this.partitionNumbers = partitionNumbers;
+  }
+
+  @JsonCreator
+  private SparseStripedReadablePartitions(
+      @JsonProperty("stageNumber") final int stageNumber,
+      @JsonProperty("workers") final Set<Integer> workers,
+      @JsonProperty("partitionNumbers") final Set<Integer> partitionNumbers
+  )
+  {
+    this(stageNumber, new IntAVLTreeSet(workers), new IntAVLTreeSet(partitionNumbers));
+  }
+
+  @Override
+  public Iterator<ReadablePartition> iterator()
+  {
+    return Iterators.transform(
+        partitionNumbers.iterator(),
+        partitionNumber -> ReadablePartition.striped(stageNumber, workers, partitionNumber)
+    );
+  }
+
+  @Override
+  public List<ReadablePartitions> split(final int maxNumSplits)
+  {
+    final List<ReadablePartitions> retVal = new ArrayList<>();
+
+    for (List<Integer> entries : SlicerUtils.makeSlicesStatic(partitionNumbers.iterator(), maxNumSplits)) {
+      if (!entries.isEmpty()) {
+        retVal.add(new SparseStripedReadablePartitions(stageNumber, workers, new IntAVLTreeSet(entries)));
+      }
+    }
+
+    return retVal;
+  }
+
+  @JsonProperty
+  int getStageNumber()
+  {
+    return stageNumber;
+  }
+
+  @JsonProperty
+  IntSortedSet getWorkers()
+  {
+    return workers;
+  }
+
+  @JsonProperty
+  IntSortedSet getPartitionNumbers()
+  {
+    return partitionNumbers;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SparseStripedReadablePartitions that = (SparseStripedReadablePartitions) o;
+    return stageNumber == that.stageNumber
+           && Objects.equals(workers, that.workers)
+           && Objects.equals(partitionNumbers, that.partitionNumbers);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(stageNumber, workers, partitionNumbers);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "StripedReadablePartitions{" +
+           "stageNumber=" + stageNumber +
+           ", workers=" + workers +
+           ", partitionNumbers=" + partitionNumbers +
+           '}';
+  }
+}

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CollectedReadablePartitionsTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CollectedReadablePartitionsTest.java
@@ -33,21 +33,24 @@ public class CollectedReadablePartitionsTest
   @Test
   public void testPartitionToWorkerMap()
   {
-    final CollectedReadablePartitions partitions = ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
+    final CollectedReadablePartitions partitions =
+        (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
     Assert.assertEquals(ImmutableMap.of(0, 1, 1, 2, 2, 1), partitions.getPartitionToWorkerMap());
   }
 
   @Test
   public void testStageNumber()
   {
-    final CollectedReadablePartitions partitions = ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
+    final CollectedReadablePartitions partitions =
+        (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
     Assert.assertEquals(1, partitions.getStageNumber());
   }
 
   @Test
   public void testSplit()
   {
-    final CollectedReadablePartitions partitions = ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
+    final CollectedReadablePartitions partitions =
+        (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
 
     Assert.assertEquals(
         ImmutableList.of(
@@ -64,7 +67,8 @@ public class CollectedReadablePartitionsTest
     final ObjectMapper mapper = TestHelper.makeJsonMapper()
                                           .registerModules(new MSQIndexingModule().getJacksonModules());
 
-    final CollectedReadablePartitions partitions = ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
+    final CollectedReadablePartitions partitions =
+        (CollectedReadablePartitions) ReadablePartitions.collected(1, ImmutableMap.of(0, 1, 1, 2, 2, 1));
 
     Assert.assertEquals(
         partitions,

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CombinedReadablePartitionsTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/CombinedReadablePartitionsTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 public class CombinedReadablePartitionsTest
 {
-  private static final CombinedReadablePartitions PARTITIONS = ReadablePartitions.combine(
+  private static final ReadablePartitions PARTITIONS = ReadablePartitions.combine(
       ImmutableList.of(
           ReadablePartitions.striped(0, 2, 2),
           ReadablePartitions.striped(1, 2, 4)

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/SparseStripedReadablePartitionsTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/stage/SparseStripedReadablePartitionsTest.java
@@ -23,68 +23,50 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.msq.guice.MSQIndexingModule;
 import org.apache.druid.segment.TestHelper;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class StripedReadablePartitionsTest
+public class SparseStripedReadablePartitionsTest
 {
-  @Test
-  public void testFromDenseSet()
-  {
-    // Tests that when ReadablePartitions.striped is called with a dense set, we get StripedReadablePartitions.
-
-    final IntAVLTreeSet workers = new IntAVLTreeSet();
-    workers.add(0);
-    workers.add(1);
-
-    final ReadablePartitions readablePartitionsFromSet = ReadablePartitions.striped(1, workers, 3);
-
-    MatcherAssert.assertThat(
-        readablePartitionsFromSet,
-        CoreMatchers.instanceOf(StripedReadablePartitions.class)
-    );
-
-    Assert.assertEquals(
-        ReadablePartitions.striped(1, 2, 3),
-        readablePartitionsFromSet
-    );
-  }
-
   @Test
   public void testPartitionNumbers()
   {
-    final StripedReadablePartitions partitions = (StripedReadablePartitions) ReadablePartitions.striped(1, 2, 3);
+    final SparseStripedReadablePartitions partitions =
+        (SparseStripedReadablePartitions) ReadablePartitions.striped(1, new IntAVLTreeSet(new int[]{1, 3}), 3);
     Assert.assertEquals(ImmutableSet.of(0, 1, 2), partitions.getPartitionNumbers());
   }
 
   @Test
-  public void testNumWorkers()
+  public void testWorkers()
   {
-    final StripedReadablePartitions partitions = (StripedReadablePartitions) ReadablePartitions.striped(1, 2, 3);
-    Assert.assertEquals(2, partitions.getNumWorkers());
+    final SparseStripedReadablePartitions partitions =
+        (SparseStripedReadablePartitions) ReadablePartitions.striped(1, new IntAVLTreeSet(new int[]{1, 3}), 3);
+    Assert.assertEquals(IntSet.of(1, 3), partitions.getWorkers());
   }
 
   @Test
   public void testStageNumber()
   {
-    final StripedReadablePartitions partitions = (StripedReadablePartitions) ReadablePartitions.striped(1, 2, 3);
+    final SparseStripedReadablePartitions partitions =
+        (SparseStripedReadablePartitions) ReadablePartitions.striped(1, new IntAVLTreeSet(new int[]{1, 3}), 3);
     Assert.assertEquals(1, partitions.getStageNumber());
   }
 
   @Test
   public void testSplit()
   {
-    final ReadablePartitions partitions = ReadablePartitions.striped(1, 2, 3);
+    final IntAVLTreeSet workers = new IntAVLTreeSet(new int[]{1, 3});
+    final SparseStripedReadablePartitions partitions =
+        (SparseStripedReadablePartitions) ReadablePartitions.striped(1, workers, 3);
 
     Assert.assertEquals(
         ImmutableList.of(
-            new StripedReadablePartitions(1, 2, new IntAVLTreeSet(new int[]{0, 2})),
-            new StripedReadablePartitions(1, 2, new IntAVLTreeSet(new int[]{1}))
+            new SparseStripedReadablePartitions(1, workers, new IntAVLTreeSet(new int[]{0, 2})),
+            new SparseStripedReadablePartitions(1, workers, new IntAVLTreeSet(new int[]{1}))
         ),
         partitions.split(2)
     );
@@ -96,7 +78,8 @@ public class StripedReadablePartitionsTest
     final ObjectMapper mapper = TestHelper.makeJsonMapper()
                                           .registerModules(new MSQIndexingModule().getJacksonModules());
 
-    final ReadablePartitions partitions = ReadablePartitions.striped(1, 2, 3);
+    final IntAVLTreeSet workers = new IntAVLTreeSet(new int[]{1, 3});
+    final ReadablePartitions partitions = ReadablePartitions.striped(1, workers, 3);
 
     Assert.assertEquals(
         partitions,
@@ -110,6 +93,6 @@ public class StripedReadablePartitionsTest
   @Test
   public void testEquals()
   {
-    EqualsVerifier.forClass(StripedReadablePartitions.class).usingGetClass().verify();
+    EqualsVerifier.forClass(SparseStripedReadablePartitions.class).usingGetClass().verify();
   }
 }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/WorkerInputsTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/kernel/controller/WorkerInputsTest.java
@@ -25,9 +25,11 @@ import it.unimi.dsi.fastutil.ints.Int2IntMaps;
 import it.unimi.dsi.fastutil.ints.Int2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.msq.exec.Limits;
 import org.apache.druid.msq.exec.OutputChannelMode;
 import org.apache.druid.msq.input.InputSlice;
@@ -75,7 +77,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(4), true),
         WorkerAssignmentStrategy.MAX,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -86,6 +88,35 @@ public class WorkerInputsTest
                     .put(1, Collections.singletonList(new TestInputSlice(2)))
                     .put(2, Collections.singletonList(new TestInputSlice(3)))
                     .put(3, Collections.singletonList(new TestInputSlice()))
+                    .build(),
+        inputs.assignmentsMap()
+    );
+  }
+
+  @Test
+  public void test_max_threeInputs_fourWorkers_withGaps()
+  {
+    final StageDefinition stageDef =
+        StageDefinition.builder(0)
+                       .inputs(new TestInputSpec(1, 2, 3))
+                       .maxWorkerCount(4)
+                       .processorFactory(new OffsetLimitFrameProcessorFactory(0, 0L))
+                       .build(QUERY_ID);
+
+    final WorkerInputs inputs = WorkerInputs.create(
+        stageDef,
+        Int2IntMaps.EMPTY_MAP,
+        new TestInputSpecSlicer(new IntAVLTreeSet(new int[]{1, 3, 4, 5}), true),
+        WorkerAssignmentStrategy.MAX,
+        Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
+    );
+
+    Assert.assertEquals(
+        ImmutableMap.<Integer, List<InputSlice>>builder()
+                    .put(1, Collections.singletonList(new TestInputSlice(1)))
+                    .put(3, Collections.singletonList(new TestInputSlice(2)))
+                    .put(4, Collections.singletonList(new TestInputSlice(3)))
+                    .put(5, Collections.singletonList(new TestInputSlice()))
                     .build(),
         inputs.assignmentsMap()
     );
@@ -104,7 +135,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(4), true),
         WorkerAssignmentStrategy.MAX,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -133,7 +164,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(4), true),
         WorkerAssignmentStrategy.AUTO,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -159,7 +190,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(4), true),
         WorkerAssignmentStrategy.AUTO,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -186,7 +217,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(4), true),
         WorkerAssignmentStrategy.AUTO,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -212,7 +243,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(4), true),
         WorkerAssignmentStrategy.AUTO,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -324,7 +355,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(4), true),
         WorkerAssignmentStrategy.AUTO,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -351,7 +382,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(2), true),
         WorkerAssignmentStrategy.AUTO,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -384,7 +415,7 @@ public class WorkerInputsTest
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
         Int2IntMaps.EMPTY_MAP,
-        new TestInputSpecSlicer(true),
+        new TestInputSpecSlicer(denseWorkers(1), true),
         WorkerAssignmentStrategy.AUTO,
         Limits.DEFAULT_MAX_INPUT_BYTES_PER_WORKER
     );
@@ -411,7 +442,7 @@ public class WorkerInputsTest
                        .processorFactory(new OffsetLimitFrameProcessorFactory(0, 0L))
                        .build(QUERY_ID);
 
-    TestInputSpecSlicer testInputSpecSlicer = spy(new TestInputSpecSlicer(true));
+    TestInputSpecSlicer testInputSpecSlicer = spy(new TestInputSpecSlicer(denseWorkers(3), true));
 
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
@@ -455,7 +486,7 @@ public class WorkerInputsTest
                        .processorFactory(new OffsetLimitFrameProcessorFactory(0, 0L))
                        .build(QUERY_ID);
 
-    TestInputSpecSlicer testInputSpecSlicer = spy(new TestInputSpecSlicer(true));
+    TestInputSpecSlicer testInputSpecSlicer = spy(new TestInputSpecSlicer(denseWorkers(3), true));
 
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
@@ -498,7 +529,7 @@ public class WorkerInputsTest
                        .processorFactory(new OffsetLimitFrameProcessorFactory(0, 0L))
                        .build(QUERY_ID);
 
-    TestInputSpecSlicer testInputSpecSlicer = spy(new TestInputSpecSlicer(true));
+    TestInputSpecSlicer testInputSpecSlicer = spy(new TestInputSpecSlicer(denseWorkers(3), true));
 
     final WorkerInputs inputs = WorkerInputs.create(
         stageDef,
@@ -585,11 +616,23 @@ public class WorkerInputsTest
 
   private static class TestInputSpecSlicer implements InputSpecSlicer
   {
+    private final IntSortedSet workers;
     private final boolean canSliceDynamic;
 
-    public TestInputSpecSlicer(boolean canSliceDynamic)
+    /**
+     * Create a test slicer.
+     *
+     * @param workers         Set of workers to consider assigning work to.
+     * @param canSliceDynamic Whether this slicer can slice dynamically.
+     */
+    public TestInputSpecSlicer(final IntSortedSet workers, final boolean canSliceDynamic)
     {
+      this.workers = workers;
       this.canSliceDynamic = canSliceDynamic;
+
+      if (workers.isEmpty()) {
+        throw DruidException.defensive("Need more than one worker in workers[%s]", workers);
+      }
     }
 
     @Override
@@ -606,9 +649,9 @@ public class WorkerInputsTest
           SlicerUtils.makeSlicesStatic(
               testInputSpec.values.iterator(),
               i -> i,
-              maxNumSlices
+              Math.min(maxNumSlices, workers.size())
           );
-      return makeSlices(assignments);
+      return makeSlices(workers, assignments);
     }
 
     @Override
@@ -624,24 +667,39 @@ public class WorkerInputsTest
           SlicerUtils.makeSlicesDynamic(
               testInputSpec.values.iterator(),
               i -> i,
-              maxNumSlices,
+              Math.min(maxNumSlices, workers.size()),
               maxFilesPerSlice,
               maxBytesPerSlice
           );
-      return makeSlices(assignments);
+      return makeSlices(workers, assignments);
     }
 
     private static List<InputSlice> makeSlices(
+        final IntSortedSet workers,
         final List<List<Long>> assignments
     )
     {
       final List<InputSlice> retVal = new ArrayList<>(assignments.size());
-
-      for (final List<Long> assignment : assignments) {
-        retVal.add(new TestInputSlice(new LongArrayList(assignment)));
+      for (int assignment = 0, workerNumber = 0;
+           workerNumber <= workers.lastInt() && assignment < assignments.size();
+           workerNumber++) {
+        if (workers.contains(workerNumber)) {
+          retVal.add(new TestInputSlice(new LongArrayList(assignments.get(assignment++))));
+        } else {
+          retVal.add(NilInputSlice.INSTANCE);
+        }
       }
 
       return retVal;
     }
+  }
+
+  private static IntSortedSet denseWorkers(final int numWorkers)
+  {
+    final IntAVLTreeSet workers = new IntAVLTreeSet();
+    for (int i = 0; i < numWorkers; i++) {
+      workers.add(i);
+    }
+    return workers;
   }
 }


### PR DESCRIPTION
In a Dart query, all Historicals are given worker IDs, but not all of them are going to actually be started or receive work orders. This can create gaps in the set of workers. For example, workers 1 and 3 could have work assigned while workers 0 and 2 do not.

This patch updates ControllerStageTracker and WorkerInputs to handle such gaps, by using the set of actual worker numbers, rather than 0..workerCount, in various places.