### PR TITLE
DartWorkerContext: Return the correct workerId().

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
@@ -58,7 +58,7 @@ public class DartWorkerContext implements WorkerContext
 {
   private final String queryId;
   private final String controllerHost;
-  private final String workerId;
+  private final WorkerId workerId;
   private final DruidNode selfNode;
   private final ObjectMapper jsonMapper;
   private final Injector injector;
@@ -82,7 +82,6 @@ public class DartWorkerContext implements WorkerContext
   DartWorkerContext(
       final String queryId,
       final String controllerHost,
-      final String workerId,
       final DruidNode selfNode,
       final ObjectMapper jsonMapper,
       final Injector injector,
@@ -100,7 +99,7 @@ public class DartWorkerContext implements WorkerContext
   {
     this.queryId = queryId;
     this.controllerHost = controllerHost;
-    this.workerId = workerId;
+    this.workerId = WorkerId.fromDruidNode(selfNode, queryId);
     this.selfNode = selfNode;
     this.jsonMapper = jsonMapper;
     this.injector = injector;
@@ -125,7 +124,7 @@ public class DartWorkerContext implements WorkerContext
   @Override
   public String workerId()
   {
-    return workerId;
+    return workerId.toString();
   }
 
   @Override

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerFactoryImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerFactoryImpl.java
@@ -29,7 +29,6 @@ import org.apache.druid.guice.annotations.Smile;
 import org.apache.druid.messages.server.Outbox;
 import org.apache.druid.msq.dart.Dart;
 import org.apache.druid.msq.dart.controller.messages.ControllerMessage;
-import org.apache.druid.msq.dart.worker.http.DartWorkerResource;
 import org.apache.druid.msq.exec.MemoryIntrospector;
 import org.apache.druid.msq.exec.ProcessingBuffersProvider;
 import org.apache.druid.msq.exec.Worker;
@@ -44,15 +43,12 @@ import org.apache.druid.segment.SegmentWrangler;
 import org.apache.druid.server.DruidNode;
 
 import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 /**
  * Production implementation of {@link DartWorkerFactory}.
  */
 public class DartWorkerFactoryImpl implements DartWorkerFactory
 {
-  private final String id;
   private final DruidNode selfNode;
   private final ObjectMapper jsonMapper;
   private final ObjectMapper smileMapper;
@@ -82,7 +78,6 @@ public class DartWorkerFactoryImpl implements DartWorkerFactory
       Outbox<ControllerMessage> outbox
   )
   {
-    this.id = makeWorkerId(selfNode);
     this.selfNode = selfNode;
     this.jsonMapper = jsonMapper;
     this.smileMapper = smileMapper;
@@ -103,7 +98,6 @@ public class DartWorkerFactoryImpl implements DartWorkerFactory
     final WorkerContext workerContext = new DartWorkerContext(
         queryId,
         controllerHost,
-        id,
         selfNode,
         jsonMapper,
         injector,
@@ -120,23 +114,5 @@ public class DartWorkerFactoryImpl implements DartWorkerFactory
     );
 
     return new WorkerImpl(null, workerContext);
-  }
-
-  private static String makeWorkerId(final DruidNode selfNode)
-  {
-    try {
-      return new URI(
-          selfNode.getServiceScheme(),
-          null,
-          selfNode.getHost(),
-          selfNode.getPortToUse(),
-          DartWorkerResource.PATH,
-          null,
-          null
-      ).toString();
-    }
-    catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
   }
 }


### PR DESCRIPTION
Prior to this patch, the `workerId()` method did not actually return the worker ID. It returned some other string that had similar information, but was different. This caused the `/druid/dart-worker/workers` API to return an internal server error. The API is useful for debugging, although it is not used during actual queries.