### PR TITLE
DartWorkerModule: Replace en dash with regular dash.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartWorkerModule.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/guice/DartWorkerModule.java
@@ -113,7 +113,7 @@ public class DartWorkerModule implements DruidModule
         final AuthorizerMapper authorizerMapper
     )
     {
-      final ExecutorService exec = Execs.multiThreaded(memoryIntrospector.numTasksInJvm(), "dart–worker-%s");
+      final ExecutorService exec = Execs.multiThreaded(memoryIntrospector.numTasksInJvm(), "dart-worker-%s");
       final File baseTempDir =
           new File(processingConfig.getTmpDir(), StringUtils.format("dart_%s", selfNode.getPortToUse()));
       return new DartWorkerRunner(


### PR DESCRIPTION
Due to a typo, the thread name of the worker executor used an en dash (–) rather than a regular hyphen (-). This was unintentional, and makes it difficult to search for in thread dumps.