### PR TITLE
Web console: better timing bar styling

### DIFF
--- a/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.scss
+++ b/web-console/src/views/workbench-view/execution-stages-pane/execution-stages-pane.scss
@@ -145,10 +145,11 @@
 
     .timing-bar {
       position: absolute;
-      top: 10px;
-      height: 36px;
+      top: 1px;
+      height: 3px;
+      border-radius: 2px;
       background: $druid-brand;
-      opacity: 0.15;
+      opacity: 0.8;
     }
   }
 }


### PR DESCRIPTION
Make the stage timing bar more visible and less confusing

After:

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/55e70824-d391-4841-867d-a5c5416f40f4">


Before:

<img width="1274" alt="image" src="https://github.com/user-attachments/assets/ca53384c-848b-43d4-9c2b-df2dc2f287e7">
