### PR TITLE
MSQ: Use leaf worker count for stages that have any leaf inputs.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/InputSpecs.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/InputSpecs.java
@@ -22,6 +22,7 @@ package org.apache.druid.msq.input;
 import it.unimi.dsi.fastutil.ints.IntRBTreeSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import org.apache.druid.msq.input.stage.StageInputSpec;
+import org.apache.druid.msq.kernel.StageDefinition;
 
 import java.util.List;
 
@@ -49,5 +50,24 @@ public class InputSpecs
     }
 
     return retVal;
+  }
+
+  /**
+   * Returns whether any of the provided input specs are leafs. Leafs are anything that is not broadcast and not another
+   * stage. For example, regular tables and external files are leafs.
+   *
+   * @param inputSpecs      list of input specs, corresponds to {@link StageDefinition#getInputSpecs()}
+   * @param broadcastInputs positions in "inputSpecs" which are broadcast specs, corresponds to
+   *                        {@link StageDefinition#getBroadcastInputNumbers()}
+   */
+  public static boolean hasLeafInputs(final List<InputSpec> inputSpecs, final IntSet broadcastInputs)
+  {
+    for (int i = 0; i < inputSpecs.size(); i++) {
+      final InputSpec spec = inputSpecs.get(i);
+      if (!broadcastInputs.contains(i) && !(spec instanceof StageInputSpec)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/DataSourcePlan.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/DataSourcePlan.java
@@ -32,6 +32,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.msq.input.InputSpec;
+import org.apache.druid.msq.input.InputSpecs;
 import org.apache.druid.msq.input.external.ExternalInputSpec;
 import org.apache.druid.msq.input.inline.InlineInputSpec;
 import org.apache.druid.msq.input.lookup.LookupInputSpec;
@@ -123,7 +124,7 @@ public class DataSourcePlan
   /**
    * Build a plan.
    *
-   * @param queryKitSpec reference for recursive planning
+   * @param queryKitSpec     reference for recursive planning
    * @param queryContext     query context
    * @param dataSource       datasource to plan
    * @param querySegmentSpec intervals for mandatory pruning. Must be {@link MultipleIntervalSegmentSpec}. The returned
@@ -134,7 +135,6 @@ public class DataSourcePlan
    * @param minStageNumber   starting stage number for subqueries
    * @param broadcast        whether the plan should broadcast data for this datasource
    */
-  @SuppressWarnings("rawtypes")
   public static DataSourcePlan forDataSource(
       final QueryKitSpec queryKitSpec,
       final QueryContext queryContext,
@@ -272,6 +272,20 @@ public class DataSourcePlan
   public IntSet getBroadcastInputs()
   {
     return broadcastInputs;
+  }
+
+  /**
+   * Figure for {@link StageDefinition#getMaxWorkerCount()} that should be used when processing.
+   */
+  public int getMaxWorkerCount(final QueryKitSpec queryKitSpec)
+  {
+    if (isSingleWorker()) {
+      return 1;
+    } else if (InputSpecs.hasLeafInputs(inputSpecs, broadcastInputs)) {
+      return queryKitSpec.getMaxLeafWorkerCount();
+    } else {
+      return queryKitSpec.getMaxNonLeafWorkerCount();
+    }
   }
 
   /**

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/QueryKitSpec.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/QueryKitSpec.java
@@ -19,12 +19,10 @@
 
 package org.apache.druid.msq.querykit;
 
-import org.apache.druid.msq.input.InputSpec;
 import org.apache.druid.msq.input.InputSpecs;
 import org.apache.druid.msq.kernel.QueryDefinition;
+import org.apache.druid.msq.kernel.StageDefinition;
 import org.apache.druid.query.Query;
-
-import java.util.List;
 
 /**
  * Collection of parameters for {@link QueryKit#makeQueryDefinition}.
@@ -42,9 +40,9 @@ public class QueryKitSpec
    *                                  {@link org.apache.druid.query.QueryDataSource}. Typically a {@link MultiQueryKit}.
    * @param queryId                   queryId of the resulting {@link QueryDefinition}
    * @param maxLeafWorkerCount        maximum number of workers for leaf stages: becomes
-   *                                  {@link org.apache.druid.msq.kernel.StageDefinition#getMaxWorkerCount()}
+   *                                  {@link StageDefinition#getMaxWorkerCount()}
    * @param maxNonLeafWorkerCount     maximum number of workers for non-leaf stages: becomes
-   *                                  {@link org.apache.druid.msq.kernel.StageDefinition#getMaxWorkerCount()}
+   *                                  {@link StageDefinition#getMaxWorkerCount()}
    * @param targetPartitionsPerWorker preferred number of partitions per worker for subqueries
    */
   public QueryKitSpec(
@@ -79,20 +77,15 @@ public class QueryKitSpec
   }
 
   /**
-   * Maximum worker count for a stage with the given inputs. Will use {@link #maxNonLeafWorkerCount} if there are
-   * any stage inputs, {@link #maxLeafWorkerCount} otherwise.
+   * Maximum number of workers for leaf stages. See {@link InputSpecs#hasLeafInputs}.
    */
-  public int getMaxWorkerCount(final List<InputSpec> inputSpecs)
+  public int getMaxLeafWorkerCount()
   {
-    if (InputSpecs.getStageNumbers(inputSpecs).isEmpty()) {
-      return maxLeafWorkerCount;
-    } else {
-      return maxNonLeafWorkerCount;
-    }
+    return maxLeafWorkerCount;
   }
 
   /**
-   * Maximum number of workers for non-leaf stages (where there are some stage inputs).
+   * Maximum number of workers for non-leaf stages. See {@link InputSpecs#hasLeafInputs}.
    */
   public int getMaxNonLeafWorkerCount()
   {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByQueryKit.java
@@ -163,10 +163,7 @@ public class GroupByQueryKit implements QueryKit<GroupByQuery>
                        .broadcastInputs(dataSourcePlan.getBroadcastInputs())
                        .signature(intermediateSignature)
                        .shuffleSpec(shuffleSpecFactoryPreAggregation.build(intermediateClusterBy, true))
-                       .maxWorkerCount(
-                           dataSourcePlan.isSingleWorker()
-                           ? 1
-                           : queryKitSpec.getMaxWorkerCount(dataSourcePlan.getInputSpecs()))
+                       .maxWorkerCount(dataSourcePlan.getMaxWorkerCount(queryKitSpec))
                        .processorFactory(new GroupByPreShuffleFrameProcessorFactory(queryToRun))
     );
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryKit.java
@@ -173,10 +173,7 @@ public class ScanQueryKit implements QueryKit<ScanQuery>
                        .broadcastInputs(dataSourcePlan.getBroadcastInputs())
                        .shuffleSpec(scanShuffleSpec)
                        .signature(signatureToUse)
-                       .maxWorkerCount(
-                           dataSourcePlan.isSingleWorker()
-                           ? 1
-                           : queryKitSpec.getMaxWorkerCount(dataSourcePlan.getInputSpecs()))
+                       .maxWorkerCount(dataSourcePlan.getMaxWorkerCount(queryKitSpec))
                        .processorFactory(new ScanQueryFrameProcessorFactory(queryToRun))
     );
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/InputSpecsTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/input/InputSpecsTest.java
@@ -21,7 +21,10 @@ package org.apache.druid.msq.input;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
 import org.apache.druid.msq.input.stage.StageInputSpec;
+import org.apache.druid.msq.input.table.TableInputSpec;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,6 +40,87 @@ public class InputSpecsTest
                 new StageInputSpec(1),
                 new StageInputSpec(2)
             )
+        )
+    );
+  }
+
+  @Test
+  public void test_getHasLeafInputs_allStages()
+  {
+    Assert.assertFalse(
+        InputSpecs.hasLeafInputs(
+            ImmutableList.of(
+                new StageInputSpec(1),
+                new StageInputSpec(2)
+            ),
+            IntSets.emptySet()
+        )
+    );
+  }
+
+  @Test
+  public void test_getHasLeafInputs_broadcastTable()
+  {
+    Assert.assertFalse(
+        InputSpecs.hasLeafInputs(
+            ImmutableList.of(new TableInputSpec("tbl", null, null, null)),
+            IntSet.of(0)
+        )
+    );
+  }
+
+  @Test
+  public void test_getHasLeafInputs_oneTableOneStage()
+  {
+    Assert.assertTrue(
+        InputSpecs.hasLeafInputs(
+            ImmutableList.of(
+                new TableInputSpec("tbl", null, null, null),
+                new StageInputSpec(0)
+            ),
+            IntSets.emptySet()
+        )
+    );
+  }
+
+  @Test
+  public void test_getHasLeafInputs_oneTableOneBroadcastStage()
+  {
+    Assert.assertTrue(
+        InputSpecs.hasLeafInputs(
+            ImmutableList.of(
+                new TableInputSpec("tbl", null, null, null),
+                new StageInputSpec(0)
+            ),
+            IntSet.of(1)
+        )
+    );
+  }
+
+  @Test
+  public void test_getHasLeafInputs_oneBroadcastTableOneStage()
+  {
+    Assert.assertFalse(
+        InputSpecs.hasLeafInputs(
+            ImmutableList.of(
+                new TableInputSpec("tbl", null, null, null),
+                new StageInputSpec(0)
+            ),
+            IntSet.of(0)
+        )
+    );
+  }
+
+  @Test
+  public void test_getHasLeafInputs_oneTableOneBroadcastTable()
+  {
+    Assert.assertTrue(
+        InputSpecs.hasLeafInputs(
+            ImmutableList.of(
+                new TableInputSpec("tbl", null, null, null),
+                new TableInputSpec("tbl2", null, null, null)
+            ),
+            IntSet.of(1)
         )
     );
   }


### PR DESCRIPTION
Previously, the leaf worker count was used for stages that have *no* stage inputs. It should actually be used for stages that have *any* non-broadcast, non-stage inputs.

This fixes a bug with broadcast joins. In a broadcast join, the stage has both a table and a broadcast stage as input. Previously, it would be planned using the non-leaf worker count. It should actually be planned using the leaf worker count.