### PR TITLE
statsd-emitter: Add dutyGroup to coordinator global time metric

### DIFF
--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -159,7 +159,7 @@
   "jetty/threadPool/queueSize": { "dimensions" : [], "type" : "gauge" },
 
   "coordinator/time" : { "dimensions" : [], "type" : "timer"},
-  "coordinator/global/time" : { "dimensions" : [], "type" : "timer"},
+  "coordinator/global/time" : { "dimensions" : ["dutyGroup"], "type" : "timer"},
 
   "tier/required/capacity" : { "dimensions" : ["tier"], "type" : "gauge" },
   "tier/total/capacity" : { "dimensions" : ["tier"], "type" : "gauge" },


### PR DESCRIPTION
### Description
The duty group is a low cardinality dimension and can be helpful in providing insight into whether a particular duty group is not running fast enough on the coordinator.

#### Release note
Duty Group is reported as a dimension for the coordinator.global.time metric reported from the statsd-emitter

<hr>


This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] been tested in a test Druid cluster.
