### PR TITLE
Pull Dependencies only once

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -185,6 +185,9 @@
                                         <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
                                         </argument>
                                         <argument>
+                                            -Ddruid.extensions.commonDependenciesDir=${project.build.directory}/commonDeps
+                                        </argument>
+                                        <argument>
                                             -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies
                                         </argument>
                                         <argument>org.apache.druid.cli.Main</argument>
@@ -386,6 +389,9 @@
                                         <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
                                         </argument>
                                         <argument>
+                                            -Ddruid.extensions.commonDependenciesDir=${project.build.directory}/commonDeps
+                                        </argument>
+                                        <argument>
                                             -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies
                                         </argument>
                                         <argument>org.apache.druid.cli.Main</argument>
@@ -492,6 +498,9 @@
                                         <classpath />
                                         <argument>-Ddruid.extensions.loadList=[]</argument>
                                         <argument>-Ddruid.extensions.directory=${project.build.directory}/extensions
+                                        </argument>
+                                        <argument>
+                                            -Ddruid.extensions.commonDependenciesDir=${project.build.directory}/commonDeps
                                         </argument>
                                         <argument>
                                             -Ddruid.extensions.hadoopDependenciesDir=${project.build.directory}/hadoop-dependencies

--- a/distribution/src/assembly/assembly.xml
+++ b/distribution/src/assembly/assembly.xml
@@ -35,6 +35,15 @@
         </fileSet>
 
         <fileSet>
+            <directory>${project.build.directory}/commonDeps</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
+
+
+        <fileSet>
             <directory>${project.build.directory}/hadoop-dependencies</directory>
             <includes>
                 <include>*/*/*</include>

--- a/distribution/src/assembly/integration-test-assembly.xml
+++ b/distribution/src/assembly/integration-test-assembly.xml
@@ -36,6 +36,14 @@
         </fileSet>
 
         <fileSet>
+            <directory>${project.build.directory}/commonDeps</directory>
+            <includes>
+                <include>*</include>
+            </includes>
+            <outputDirectory>lib</outputDirectory>
+        </fileSet>
+
+        <fileSet>
             <directory>${project.build.directory}/hadoop-dependencies</directory>
             <includes>
                 <include>*/*/*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -1873,7 +1873,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>

--- a/processing/src/main/java/org/apache/druid/guice/ExtensionsConfig.java
+++ b/processing/src/main/java/org/apache/druid/guice/ExtensionsConfig.java
@@ -46,6 +46,9 @@ public class ExtensionsConfig
   @JsonProperty
   private String hadoopContainerDruidClasspath = null;
 
+  @JsonProperty
+  private String commonDependenciesDir = null;
+
   //Only applicable when hadoopContainerDruidClasspath is explicitly specified.
   @JsonProperty
   private boolean addExtensionsToHadoopContainer = false;
@@ -71,6 +74,11 @@ public class ExtensionsConfig
   public String getHadoopDependenciesDir()
   {
     return hadoopDependenciesDir;
+  }
+
+  public String getCommonDependenciesDir()
+  {
+    return commonDependenciesDir;
   }
 
   public String getHadoopContainerDruidClasspath()

--- a/services/src/main/java/org/apache/druid/cli/PullDependencies.java
+++ b/services/src/main/java/org/apache/druid/cli/PullDependencies.java
@@ -61,8 +61,10 @@ import org.eclipse.aether.util.repository.DefaultProxySelector;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -79,7 +81,7 @@ public class PullDependencies implements Runnable
       "https://repo1.maven.org/maven2/"
   );
 
-  private static final HashSet<Artifact> ARTIFACT_HASH_SET = new HashSet<>();
+  private static final HashMap<Artifact, File> ARTIFACT_FILE_HASH_MAP = new HashMap<>();
 
   private static final Dependencies PROVIDED_BY_CORE_DEPENDENCIES =
       Dependencies.builder()
@@ -403,11 +405,15 @@ public class PullDependencies implements Runnable
       for (Artifact artifact : artifacts) {
         if (exclusions.contain(artifact)) {
           log.debug("Skipped Artifact[%s]", artifact);
-        } else if (ARTIFACT_HASH_SET.contains(artifact)) {
-          log.debug("Skipped Artifact[%s]", artifact);
+        } else if (ARTIFACT_FILE_HASH_MAP.containsKey(artifact)) {
+          Path relativePath = toLocation.toPath().relativize(ARTIFACT_FILE_HASH_MAP.get(artifact).toPath());
+          log.debug("Creating symlink for artifact [%s] -> [%s]", artifact, relativePath);
+          File artifactFile = new File(toLocation, artifact.getFile().getName());
+          Files.createSymbolicLink(artifactFile.toPath(), relativePath);
         } else {
           log.info("Adding file [%s] at [%s]", artifact.getFile().getName(), toLocation.getAbsolutePath());
-          ARTIFACT_HASH_SET.add(artifact);
+          File file = new File(toLocation, artifact.getFile().getName());
+          ARTIFACT_FILE_HASH_MAP.put(artifact, file);
           org.apache.commons.io.FileUtils.copyFileToDirectory(artifact.getFile(), toLocation);
         }
       }

--- a/services/src/main/java/org/apache/druid/cli/PullDependencies.java
+++ b/services/src/main/java/org/apache/druid/cli/PullDependencies.java
@@ -62,6 +62,7 @@ import org.eclipse.aether.util.repository.DefaultProxySelector;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -77,6 +78,8 @@ public class PullDependencies implements Runnable
   private static final List<String> DEFAULT_REMOTE_REPOSITORIES = ImmutableList.of(
       "https://repo1.maven.org/maven2/"
   );
+
+  private static final HashSet<Artifact> ARTIFACT_HASH_SET = new HashSet<>();
 
   private static final Dependencies PROVIDED_BY_CORE_DEPENDENCIES =
       Dependencies.builder()
@@ -400,8 +403,11 @@ public class PullDependencies implements Runnable
       for (Artifact artifact : artifacts) {
         if (exclusions.contain(artifact)) {
           log.debug("Skipped Artifact[%s]", artifact);
+        } else if (ARTIFACT_HASH_SET.contains(artifact)) {
+          log.debug("Skipped Artifact[%s]", artifact);
         } else {
           log.info("Adding file [%s] at [%s]", artifact.getFile().getName(), toLocation.getAbsolutePath());
+          ARTIFACT_HASH_SET.add(artifact);
           org.apache.commons.io.FileUtils.copyFileToDirectory(artifact.getFile(), toLocation);
         }
       }


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/17014

As part of this, there will still be some copies but it significantly reduces the overall size.

Currently there can be three copies
1. in lib
2. from dist profile
3. from bundle-contrib-exts profile

Distribution size before fix - 911M
Distribution size after fix - 603M