### PR TITLE
MSQ: Include stageId, workerNumber in processing thread names.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -969,10 +969,11 @@ public class WorkerImpl implements Worker
 
   /**
    * Returns cancellation ID for a particular stage, to be used in {@link FrameProcessorExecutor#cancel(String)}.
+   * In addition to being a token for cancellation, this also appears in thread dumps, so make it a little descriptive.
    */
   private static String cancellationIdFor(final StageId stageId, final int workerNumber)
   {
-    return StringUtils.format("%s_%s", stageId, workerNumber);
+    return StringUtils.format("dart-worker[%s_%s]", stageId, workerNumber);
   }
 
   /**

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerImpl.java
@@ -973,7 +973,7 @@ public class WorkerImpl implements Worker
    */
   private static String cancellationIdFor(final StageId stageId, final int workerNumber)
   {
-    return StringUtils.format("dart-worker[%s_%s]", stageId, workerNumber);
+    return StringUtils.format("msq-worker[%s_%s]", stageId, workerNumber);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/FrameProcessorExecutor.java
@@ -222,12 +222,18 @@ public class FrameProcessorExecutor
           }
         }
 
+        final String threadName = Thread.currentThread().getName();
         boolean canceled = false;
         Either<Throwable, ReturnOrAwait<T>> retVal;
 
         try {
           if (Thread.interrupted()) {
             throw new InterruptedException();
+          }
+
+          if (cancellationId != null) {
+            // Set the thread name to something involving the cancellationId, to make thread dumps more useful.
+            Thread.currentThread().setName(threadName + "-" + cancellationId);
           }
 
           retVal = Either.value(processor.runIncrementally(readableInputs));
@@ -253,6 +259,9 @@ public class FrameProcessorExecutor
                 canceled = true;
               }
             }
+
+            // Restore original thread name.
+            Thread.currentThread().setName(threadName);
           }
         }
 


### PR DESCRIPTION
Helps identify which query was running in a thread dump.