### PR TITLE
Prioritize query stats in RequestLogLine.getNativeQueryLine

### DIFF
--- a/server/src/main/java/org/apache/druid/server/RequestLogLine.java
+++ b/server/src/main/java/org/apache/druid/server/RequestLogLine.java
@@ -84,8 +84,8 @@ public class RequestLogLine
         Arrays.asList(
             timestamp,
             remoteAddr,
-            objectMapper.writeValueAsString(query),
-            objectMapper.writeValueAsString(queryStats)
+            objectMapper.writeValueAsString(queryStats),
+            objectMapper.writeValueAsString(query)
         )
     );
   }


### PR DESCRIPTION
### Description
This change switches the order of query vs stats in `getNativeQueryLine` to keep it consistent with `getSqlQueryLine`.

It happens on non-trivial occasions when a long list of `intervals.segments` in the query object exceeds the max cut-off of whichever logging system is deployed by the user and makes the stats unavailable for subsequent log searches. In those situations, we prefer to have the more important stats logged first and sacrifice the list of intervals.

The same change should be applied to the order of fields in the native query object, moving `intervals` to the last. However, that's a bigger change.

#### Release note

<hr>

##### Key changed/added classes in this PR
 * `RequestLogLine`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
