### PR TITLE
MSQ WorkerResource: Fix timeout handler for httpGetChannelData.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/rpc/WorkerResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/rpc/WorkerResource.java
@@ -120,12 +120,10 @@ public class WorkerResource
           public void onTimeout(AsyncEvent event)
           {
             if (responseResolved.compareAndSet(false, true)) {
-              return;
+              HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
+              response.setStatus(HttpServletResponse.SC_OK);
+              event.getAsyncContext().complete();
             }
-
-            HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
-            response.setStatus(HttpServletResponse.SC_OK);
-            event.getAsyncContext().complete();
           }
 
           @Override


### PR DESCRIPTION
The timeout handler should fire if the response has not been handled yet (i.e. if responseResolved was previously false). However, it erroneously fires only if the response *was* handled. This causes HTTP 500 errors if the timeout actually does fire. The timeout is 30 seconds, which can be hit during pipelined queries, if an earlier stage of the query hasn't produced its first frame within 30 seconds.

This fixes a regression introduced in #17140.