### PR TITLE
Enhance injector usage during conglomerate builds in tests

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/QueryRunnerFactoryConglomerate.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryRunnerFactoryConglomerate.java
@@ -19,9 +19,22 @@
 
 package org.apache.druid.query;
 
+import org.apache.druid.error.DruidException;
+
 /**
  */
-public interface QueryRunnerFactoryConglomerate
+public interface QueryRunnerFactoryConglomerate extends QueryToolChestWarehouse
 {
   <T, QueryType extends Query<T>> QueryRunnerFactory<T, QueryType> findFactory(QueryType query);
+
+  @Override
+  default <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(QueryType query)
+  {
+    QueryRunnerFactory<T, QueryType> factory = findFactory(query);
+    if (factory == null) {
+      throw DruidException
+          .defensive("QueryRunnerFactory for QueryType [%s] is not registered!", query.getClass().getName());
+    }
+    return factory.getToolchest();
+  }
 }

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientPerfTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientPerfTest.java
@@ -172,7 +172,6 @@ public class CachingClusteredClientPerfTest
 
   private static class MockQueryToolChestWareHouse implements QueryToolChestWarehouse
   {
-
     @Override
     public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(QueryType query)
     {

--- a/server/src/test/java/org/apache/druid/query/ConglomerateBackedQueryToolChestWarehouse.java
+++ b/server/src/test/java/org/apache/druid/query/ConglomerateBackedQueryToolChestWarehouse.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+public class ConglomerateBackedQueryToolChestWarehouse implements QueryToolChestWarehouse
+{
+  private QueryRunnerFactoryConglomerate conglomerate;
+
+  public ConglomerateBackedQueryToolChestWarehouse(QueryRunnerFactoryConglomerate conglomerate)
+  {
+    this.conglomerate = conglomerate;
+  }
+
+  @Override
+  public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(final QueryType query)
+  {
+    return conglomerate.findFactory(query).getToolchest();
+  }
+}

--- a/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
+++ b/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
@@ -109,7 +109,7 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
         CLOSER,
         TopNQueryConfig.DEFAULT_MIN_TOPN_THRESHOLD
     );
-    toolChestWarehouse = conglomerate;
+    toolChestWarehouse = new ConglomerateBackedQueryToolChestWarehouse(conglomerate);
   }
 
   @AfterClass

--- a/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
+++ b/server/src/test/java/org/apache/druid/query/QueryRunnerBasedOnClusteredClientTestBase.java
@@ -107,17 +107,9 @@ public abstract class QueryRunnerBasedOnClusteredClientTestBase
   {
     conglomerate = QueryStackTests.createQueryRunnerFactoryConglomerate(
         CLOSER,
-        () -> TopNQueryConfig.DEFAULT_MIN_TOPN_THRESHOLD
+        TopNQueryConfig.DEFAULT_MIN_TOPN_THRESHOLD
     );
-
-    toolChestWarehouse = new QueryToolChestWarehouse()
-    {
-      @Override
-      public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(final QueryType query)
-      {
-        return conglomerate.findFactory(query).getToolchest();
-      }
-    };
+    toolChestWarehouse = conglomerate;
   }
 
   @AfterClass

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
@@ -31,10 +31,8 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
 import org.apache.druid.query.DefaultQueryConfig;
-import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.QuerySegmentWalker;
-import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.QueryToolChestWarehouse;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -112,14 +110,7 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
   {
     resourceCloser = Closer.create();
     conglomerate = QueryStackTests.createQueryRunnerFactoryConglomerate(resourceCloser);
-    queryToolChestWarehouse = new QueryToolChestWarehouse()
-    {
-      @Override
-      public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(final QueryType query)
-      {
-        return conglomerate.findFactory(query).getToolchest();
-      }
-    };
+    queryToolChestWarehouse = conglomerate;
   }
 
   public void setUpData() throws Exception

--- a/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/SegmentMetadataCacheTestBase.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.impl.MapInputRowParser;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.ConglomerateBackedQueryToolChestWarehouse;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
 import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
@@ -110,7 +111,7 @@ public abstract class SegmentMetadataCacheTestBase extends InitializedNullHandli
   {
     resourceCloser = Closer.create();
     conglomerate = QueryStackTests.createQueryRunnerFactoryConglomerate(resourceCloser);
-    queryToolChestWarehouse = conglomerate;
+    queryToolChestWarehouse = new ConglomerateBackedQueryToolChestWarehouse(conglomerate);
   }
 
   public void setUpData() throws Exception

--- a/server/src/test/java/org/apache/druid/server/QueryStackTests.java
+++ b/server/src/test/java/org/apache/druid/server/QueryStackTests.java
@@ -33,6 +33,7 @@ import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.query.BrokerParallelMergeConfig;
+import org.apache.druid.query.ConglomerateBackedQueryToolChestWarehouse;
 import org.apache.druid.query.DataSource;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
 import org.apache.druid.query.DefaultQueryRunnerFactoryConglomerate;
@@ -95,7 +96,6 @@ import org.apache.druid.utils.JvmUtils;
 import org.junit.Assert;
 
 import javax.annotation.Nullable;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -135,7 +135,7 @@ public class QueryStackTests
         emitter,
         clusterWalker,
         localWalker,
-        conglomerate,
+        new ConglomerateBackedQueryToolChestWarehouse(conglomerate),
         joinableFactory,
         new RetryQueryRunnerConfig(),
         injector.getInstance(ObjectMapper.class),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/SqlTestFrameworkConfig.java
@@ -31,6 +31,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.quidem.DruidAvaticaTestDriver;
+import org.apache.druid.server.QueryStackTests;
 import org.apache.druid.sql.calcite.util.CacheTestHelperModule.ResultCacheMode;
 import org.apache.druid.sql.calcite.util.SqlTestFramework;
 import org.apache.druid.sql.calcite.util.SqlTestFramework.QueryComponentSupplier;
@@ -94,7 +95,7 @@ public class SqlTestFrameworkConfig
 {
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.METHOD, ElementType.TYPE})
-  @NumMergeBuffers(0)
+  @NumMergeBuffers(QueryStackTests.DEFAULT_NUM_MERGE_BUFFERS)
   public @interface NumMergeBuffers
   {
     ConfigOptionProcessor<Integer> PROCESSOR = new ConfigOptionProcessor<Integer>(NumMergeBuffers.class)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
@@ -28,6 +28,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.druid.client.InternalQueryConfig;
 import org.apache.druid.java.util.emitter.core.NoopEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
+import org.apache.druid.query.ConglomerateBackedQueryToolChestWarehouse;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
 import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.GlobalTableDataSource;
@@ -73,7 +74,6 @@ import org.apache.druid.sql.calcite.view.ViewManager;
 import org.easymock.EasyMock;
 
 import javax.annotation.Nullable;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -88,7 +88,7 @@ public class QueryFrameworkUtils
   )
   {
     return new QueryLifecycleFactory(
-        conglomerate,
+        new ConglomerateBackedQueryToolChestWarehouse(conglomerate),
         walker,
         new DefaultGenericQueryMetricsFactory(),
         new ServiceEmitter("dummy", "dummy", new NoopEmitter()),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
@@ -31,11 +31,8 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
 import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.GlobalTableDataSource;
-import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.QuerySegmentWalker;
-import org.apache.druid.query.QueryToolChest;
-import org.apache.druid.query.QueryToolChestWarehouse;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.segment.join.JoinableFactory;
 import org.apache.druid.segment.loading.SegmentCacheManager;
@@ -76,6 +73,7 @@ import org.apache.druid.sql.calcite.view.ViewManager;
 import org.easymock.EasyMock;
 
 import javax.annotation.Nullable;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -90,14 +88,7 @@ public class QueryFrameworkUtils
   )
   {
     return new QueryLifecycleFactory(
-        new QueryToolChestWarehouse()
-        {
-          @Override
-          public <T, QueryType extends Query<T>> QueryToolChest<T, QueryType> getToolChest(final QueryType query)
-          {
-            return conglomerate.findFactory(query).getToolchest();
-          }
-        },
+        conglomerate,
         walker,
         new DefaultGenericQueryMetricsFactory(),
         new ServiceEmitter("dummy", "dummy", new NoopEmitter()),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/SqlTestFramework.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/SqlTestFramework.java
@@ -39,9 +39,15 @@ import org.apache.druid.initialization.ServiceInjectorBuilder;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.query.DefaultQueryRunnerFactoryConglomerate;
+import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.query.GlobalTableDataSource;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryRunnerFactory;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.QuerySegmentWalker;
+import org.apache.druid.query.TestBufferPool;
+import org.apache.druid.query.groupby.TestGroupByBuffers;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.quidem.TestSqlModule;
@@ -82,6 +88,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -146,18 +153,13 @@ public class SqlTestFramework
      */
     void gatherProperties(Properties properties);
 
+
     /**
      * Configure modules needed for tests. This is the preferred way to configure
      * Jackson: include the production module in this method that includes the
      * required Jackson configuration.
      */
     void configureGuice(DruidInjectorBuilder builder);
-
-    QueryRunnerFactoryConglomerate createCongolmerate(
-        Builder builder,
-        Closer closer,
-        ObjectMapper jsonMapper
-    );
 
     SpecificSegmentsQuerySegmentWalker createQuerySegmentWalker(
         QueryRunnerFactoryConglomerate conglomerate,
@@ -204,6 +206,91 @@ public class SqlTestFramework
      * MSQ right now needs a full query run.
      */
     Boolean isExplainSupported();
+
+    QueryRunnerFactoryConglomerate wrapConglomerate(QueryRunnerFactoryConglomerate conglomerate, Closer resourceCloser);
+  }
+
+  public abstract static class QueryComponentSupplierDelegate implements QueryComponentSupplier
+  {
+    private final QueryComponentSupplier delegate;
+
+    public QueryComponentSupplierDelegate(QueryComponentSupplier delegate)
+    {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void gatherProperties(Properties properties)
+    {
+      delegate.gatherProperties(properties);
+    }
+
+    @Override
+    public void configureGuice(DruidInjectorBuilder builder)
+    {
+      delegate.configureGuice(builder);
+    }
+
+    @Override
+    public SpecificSegmentsQuerySegmentWalker createQuerySegmentWalker(
+        QueryRunnerFactoryConglomerate conglomerate,
+        JoinableFactoryWrapper joinableFactory,
+        Injector injector)
+    {
+      return delegate.createQuerySegmentWalker(conglomerate, joinableFactory, injector);
+    }
+
+    @Override
+    public SqlEngine createEngine(
+        QueryLifecycleFactory qlf,
+        ObjectMapper objectMapper,
+        Injector injector)
+    {
+      return delegate.createEngine(qlf, objectMapper, injector);
+    }
+
+    @Override
+    public void configureJsonMapper(ObjectMapper mapper)
+    {
+      delegate.configureJsonMapper(mapper);
+    }
+
+    @Override
+    public JoinableFactoryWrapper createJoinableFactoryWrapper(LookupExtractorFactoryContainerProvider lookupProvider)
+    {
+      return delegate.createJoinableFactoryWrapper(lookupProvider);
+    }
+
+    @Override
+    public void finalizeTestFramework(SqlTestFramework sqlTestFramework)
+    {
+      delegate.finalizeTestFramework(sqlTestFramework);
+    }
+
+    @Override
+    public PlannerComponentSupplier getPlannerComponentSupplier()
+    {
+      return delegate.getPlannerComponentSupplier();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+      delegate.close();
+    }
+
+    @Override
+    public Boolean isExplainSupported()
+    {
+      return delegate.isExplainSupported();
+    }
+
+    @Override
+    public QueryRunnerFactoryConglomerate wrapConglomerate(QueryRunnerFactoryConglomerate conglomerate,
+        Closer resourceCloser)
+    {
+      return delegate.wrapConglomerate(conglomerate, resourceCloser);
+    }
   }
 
   public interface PlannerComponentSupplier
@@ -256,28 +343,6 @@ public class SqlTestFramework
     @Override
     public void configureGuice(DruidInjectorBuilder builder)
     {
-    }
-
-    @Override
-    public QueryRunnerFactoryConglomerate createCongolmerate(
-        Builder builder,
-        Closer resourceCloser,
-        ObjectMapper jsonMapper
-    )
-    {
-      if (builder.mergeBufferCount == 0) {
-        return QueryStackTests.createQueryRunnerFactoryConglomerate(
-            resourceCloser,
-            () -> builder.minTopNThreshold,
-            jsonMapper
-        );
-      } else {
-        return QueryStackTests.createQueryRunnerFactoryConglomerate(
-            resourceCloser,
-            QueryStackTests.getProcessingConfig(builder.mergeBufferCount),
-            jsonMapper
-        );
-      }
     }
 
     @Override
@@ -347,6 +412,13 @@ public class SqlTestFramework
     public Boolean isExplainSupported()
     {
       return true;
+    }
+
+    @Override
+    public QueryRunnerFactoryConglomerate wrapConglomerate(QueryRunnerFactoryConglomerate conglomerate,
+        Closer resourceCloser)
+    {
+      return conglomerate;
     }
   }
 
@@ -548,6 +620,8 @@ public class SqlTestFramework
     }
   }
 
+  public static final String SQL_TEST_FRAME_WORK = "sqlTestFrameWork";
+
   /**
    * Guice module to create the various query framework items. By creating items within
    * a module, later items can depend on those created earlier by grabbing them from the
@@ -592,11 +666,61 @@ public class SqlTestFramework
       binder.bind(DefaultColumnFormatConfig.class).toInstance(new DefaultColumnFormatConfig(null, null));
     }
 
+
+    @Provides
+    public @Named(SQL_TEST_FRAME_WORK) Map<Class<? extends Query>, QueryRunnerFactory> makeRunnerFactories(
+        ObjectMapper jsonMapper,
+        final TestBufferPool testBufferPool,
+        final TestGroupByBuffers groupByBuffers,
+        @Named(SqlTestFramework.SQL_TEST_FRAME_WORK) DruidProcessingConfig processingConfig)
+    {
+      return ImmutableMap.<Class<? extends Query>, QueryRunnerFactory>builder()
+          .putAll(
+              QueryStackTests
+                  .makeDefaultQueryRunnerFactories(
+                      processingConfig,
+                      builder.minTopNThreshold,
+                      jsonMapper,
+                      testBufferPool,
+                      groupByBuffers
+                  )
+          )
+          .build();
+
+    }
+
+    /*
+     * Ideally this should not have a Named annotation, but it clashes with {@link DruidProcessingModule}.
+     */
+    @Named(SQL_TEST_FRAME_WORK)
     @Provides
     @LazySingleton
-    public QueryRunnerFactoryConglomerate conglomerate()
+    public DruidProcessingConfig makeProcessingConfig()
     {
-      return componentSupplier.createCongolmerate(builder, resourceCloser, queryJsonMapper());
+      return QueryStackTests.getProcessingConfig(builder.mergeBufferCount);
+    }
+
+    @Provides
+    @LazySingleton
+    public TestBufferPool makeTestBufferPool()
+    {
+      return QueryStackTests.makeTestBufferPool(resourceCloser);
+    }
+
+    @Provides
+    @LazySingleton
+    public TestGroupByBuffers makeTestGroupByBuffers(@Named(SQL_TEST_FRAME_WORK) DruidProcessingConfig processingConfig)
+    {
+      return QueryStackTests.makeGroupByBuffers(resourceCloser, processingConfig);
+    }
+
+    @Provides
+    @LazySingleton
+    public QueryRunnerFactoryConglomerate conglomerate(
+        @Named(SQL_TEST_FRAME_WORK) Map<Class<? extends Query>, QueryRunnerFactory> factories)
+    {
+      QueryRunnerFactoryConglomerate conglomerate = new DefaultQueryRunnerFactoryConglomerate(factories);
+      return componentSupplier.wrapConglomerate(conglomerate, resourceCloser);
     }
 
     @Provides


### PR DESCRIPTION
* relies more on the injector
* enables to override later the `TestBufferPool` and other things more easily

