### PR TITLE
remove stale comment in QueryableIndexCursorHolder

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorHolder.java
@@ -249,8 +249,6 @@ public class QueryableIndexCursorHolder implements CursorHolder
     final NumericColumn timestamps = resources.timestamps;
     final ColumnCache columnCache = resources.columnCache;
     final Order timeOrder = resources.timeOrder;
-    // Wrap the remainder of cursor setup in a try, so if an error is encountered while setting it up, we don't
-    // leak columns in the ColumnCache.
 
     // sanity check
     if (!canVectorize()) {


### PR DESCRIPTION
Remove comment that is stale after #16533, all calls to `asVectorCursor` are under a `try` which closes the cursor holder now.