### PR TITLE
Cache DataSegments and PendingSegments on the Overlord

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -38,6 +38,7 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.apache.druid.metadata.IndexerSQLMetadataStorageCoordinator;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.DataSegment;
@@ -380,8 +381,9 @@ public class SegmentAllocationQueue
 
   private Set<DataSegment> retrieveUsedSegments(AllocateRequestKey key)
   {
+    IndexerSQLMetadataStorageCoordinator coordinator = (IndexerSQLMetadataStorageCoordinator) metadataStorage;
     return new HashSet<>(
-        metadataStorage.retrieveUsedSegmentsForInterval(
+        coordinator.retrieveUsedSegmentsForIntervalsFromCache(
             key.dataSource,
             key.preferredAllocationInterval,
             Segments.ONLY_VISIBLE

--- a/processing/src/main/java/org/apache/druid/timeline/SegmentTimeline.java
+++ b/processing/src/main/java/org/apache/druid/timeline/SegmentTimeline.java
@@ -21,6 +21,7 @@ package org.apache.druid.timeline;
 
 import com.google.common.collect.Iterators;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 
@@ -58,6 +59,13 @@ public class SegmentTimeline extends VersionedIntervalTimeline<String, DataSegme
             )
         )
     );
+  }
+
+  public void removeSegments(Collection<DataSegment> segments)
+  {
+    for (DataSegment segment : segments) {
+      remove(segment.getInterval(), segment.getVersion(), segment.getShardSpec().createChunk(segment));
+    }
   }
 
   public boolean isOvershadowed(DataSegment segment)

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -471,6 +471,12 @@
             <artifactId>commons-text</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-reflect</artifactId>
+        <version>2.13.11</version>
+        <scope>compile</scope>
+      </dependency>
     </dependencies>
 
     <build>

--- a/server/src/main/java/org/apache/druid/metadata/SegmentCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/SegmentCache.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.metadata;
+
+import com.google.common.collect.ImmutableSet;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentTimeline;
+import org.joda.time.Interval;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class SegmentCache
+{
+  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+  private final Map<String, SegmentTimeline> datasourceTimelines = new HashMap<>();
+  private final Set<DataSegment> addedSegments = new HashSet<>();
+  private final Set<DataSegment> removedSegments = new HashSet<>();
+  private final Map<String, Map<Interval, Set<SegmentIdWithShardSpec>>> datasourcePendingSegments
+      = new HashMap<>();
+
+  public void clear()
+  {
+    lock.writeLock().lock();
+    try {
+      datasourceTimelines.clear();
+      addedSegments.clear();
+      removedSegments.clear();
+      datasourcePendingSegments.clear();
+    }
+    finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public void addPendingSegments(String datasource, Collection<SegmentIdWithShardSpec> pendingSegments)
+  {
+    lock.writeLock().lock();
+    try {
+      datasourcePendingSegments.putIfAbsent(datasource, new HashMap<>());
+      for (SegmentIdWithShardSpec pendingSegment : pendingSegments) {
+        datasourcePendingSegments.get(datasource)
+                                 .computeIfAbsent(pendingSegment.getInterval(), itvl -> new HashSet<>())
+                                 .add(pendingSegment);
+      }
+    }
+    finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public Set<SegmentIdWithShardSpec> getPendingSegments(String datasource, Interval interval)
+  {
+    lock.readLock().lock();
+    try {
+      if (!datasourcePendingSegments.containsKey(datasource)) {
+        return Collections.emptySet();
+      }
+      Set<SegmentIdWithShardSpec> pendingSegments = new HashSet<>();
+      for (Interval itvl : datasourcePendingSegments.get(datasource).keySet()) {
+        if (itvl.overlaps(interval)) {
+          pendingSegments.addAll(datasourcePendingSegments.get(datasource).get(itvl));
+        }
+      }
+      return pendingSegments;
+    }
+    finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  public void addSegments(String datasource, Collection<DataSegment> segments)
+  {
+    lock.writeLock().lock();
+    try {
+      //addedSegments.addAll(segments);
+      //removedSegments.removeAll(segments);
+      datasourceTimelines.computeIfAbsent(datasource, ds -> new SegmentTimeline())
+                         .addSegments(segments.iterator());
+    }
+    finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public void removeSegments(String datasource, Collection<DataSegment> segments)
+  {
+    lock.writeLock().lock();
+    try {
+      SegmentTimeline timeline = datasourceTimelines.get(datasource);
+      if (timeline == null) {
+        return;
+      }
+      timeline.removeSegments(segments);
+      if (timeline.isEmpty()) {
+        datasourceTimelines.remove(datasource);
+      }
+      removedSegments.addAll(segments);
+      addedSegments.removeAll(segments);
+    }
+    finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public Map<String, SegmentTimeline> getDatasourceTimelines()
+  {
+    lock.readLock().lock();
+    try {
+      return datasourceTimelines;
+    }
+    finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  public Pair<Set<DataSegment>, Set<DataSegment>> getChangeSetAndReset()
+  {
+    lock.writeLock().lock();
+    try {
+      Pair<Set<DataSegment>, Set<DataSegment>> changeSet = new Pair<>(
+          ImmutableSet.copyOf(addedSegments),
+          ImmutableSet.copyOf(removedSegments)
+      );
+      addedSegments.clear();
+      removedSegments.clear();
+      return changeSet;
+    }
+    finally {
+      lock.writeLock().unlock();
+    }
+  }
+}


### PR DESCRIPTION
### Description
Polling the druid_segments and druid_pendingSegments tables can be a bottleneck for several operations in Druid and the load on the metadata store increases at least linearly with the number of segments in the cluster.
This PR aims to maintain a central cache of active segments and relevant pending segments on the Overlord and use this wherever possible.


### Advantages
- Faster segment allocation (`40x` in SegmentAllocateActionTest#testBenchmark) -> Lower lag especially in situations where data is being backfilled
- (TODO?) Faster segment syncing on coordinator -> Faster ingestion handoff on clusters where polling millions of segments (with hundreds of columns) takes several seconds

### Changes

- Cache segment timelines for used segments and pending segments for intervals with active locks on the overlord.
- Use this info for segment allocation
- (TODO) Make all the calls from the Coordinator go through the Overlord before altering druid_segments or druid_pendingSegments in order to have a centralized cache
- (TODO?) Use this cache and poll segments incrementally on the Coodinator


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
