### PR TITLE
Added basic framework for json_merge_aggr

### DIFF
--- a/processing/src/main/java/org/apache/druid/guice/ExpressionModule.java
+++ b/processing/src/main/java/org/apache/druid/guice/ExpressionModule.java
@@ -82,6 +82,7 @@ public class ExpressionModule implements Module
                    .add(HyperUniqueExpressions.HllRoundEstimateExprMacro.class)
                    .add(NestedDataExpressions.JsonObjectExprMacro.class)
                    .add(NestedDataExpressions.JsonMergeExprMacro.class)
+                   .add(NestedDataExpressions.JsonMergeAggrExprMacro.class)
                    .add(NestedDataExpressions.JsonKeysExprMacro.class)
                    .add(NestedDataExpressions.JsonPathsExprMacro.class)
                    .add(NestedDataExpressions.JsonValueExprMacro.class)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidOperatorTable.java
@@ -354,6 +354,7 @@ public class DruidOperatorTable implements SqlOperatorTable
                    .add(new NestedDataOperatorConversions.JsonValueReturningArrayVarcharOperatorConversion())
                    .add(new NestedDataOperatorConversions.JsonObjectOperatorConversion())
                    .add(new NestedDataOperatorConversions.JsonMergeOperatorConversion())
+                   .add(new NestedDataOperatorConversions.JsonMergeAggrOperatorConversion())
                    .add(new NestedDataOperatorConversions.ToJsonStringOperatorConversion())
                    .add(new NestedDataOperatorConversions.ParseJsonOperatorConversion())
                    .add(new NestedDataOperatorConversions.TryParseJsonOperatorConversion())

--- a/website/.spelling
+++ b/website/.spelling
@@ -386,6 +386,7 @@ json_query
 json_query_array
 json_value
 json_merge
+json_merge_aggr
 karlkfi
 kbps
 kerberos


### PR DESCRIPTION
Fixes #17284 

### Description
This PR adds a new function JSON_MERGE_AGGR(<AGGREGATE>,<JSON 1>, <JSON 2> .... <JSON N>) which performs the aggregation when the leaf elements have the same key.

Currently only two aggregators are added - ADD & MULTIPLY
For Array, it retains the functionality of JSON_MERGE function.
 
##### Example 
`JSON_MERGE_AGGR('ADD', {"key": 2}, {"key":3}) -> {"key":5}`
`JSON_MERGE_AGGR('MULTIPLY', {"key": {"k2": 2}}, {"key":{"k2":3}}) -> {"key":{"k2":6}}`
 
##### Retained JSON_MERGE functionality 
`JSON_MERGE_AGGR('ADD', {"key": [1,2,3]}, {"key":[4,5]}) -> {"key":[1,2,3,4,5]}`
`JSON_MERGE_AGGR('ADD', {"key": [1,2]}, {"key":3}) -> {"key":3}`
`JSON_MERGE_AGGR('ADD', [1,2,3], [4,5]) -> [1,2,3,4,5]`

##### Key changed/added classes in this PR
 * `json_merge_aggr` expression function
 * `json_merge_aggr` sql function

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
