### PR TITLE
[Draft] Install python setup-tools as it is no longer pre-installed

### DIFF
--- a/.github/scripts/setup_generate_license.sh
+++ b/.github/scripts/setup_generate_license.sh
@@ -19,5 +19,6 @@ set -e
 
 sudo apt-get update && sudo apt-get install python3 -y
 curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | sudo -H python3
+pip3 install setup-tools # setup-tools is no longer pre-installed
 pip3 install wheel  # install wheel first explicitly
 pip3 install --upgrade pyyaml


### PR DESCRIPTION
Script `setup_generate_license.sh` is starting to fail with the error `ModuleNotFoundError: No module named 'pip._vendor.six.moves'`. This is because `setup_tools` is no longer pre-installed with python env (https://docs.python.org/3/whatsnew/3.12.html)