### PR TITLE
Revert "Use canonical hostname instead of ip by default (#16386)"

### DIFF
--- a/.github/scripts/setup_generate_license.sh
+++ b/.github/scripts/setup_generate_license.sh
@@ -18,6 +18,6 @@
 set -e
 
 sudo apt-get update && sudo apt-get install python3 -y
-curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | sudo -H python3
+curl https://bootstrap.pypa.io/pip/3.7/get-pip.py | sudo -H python3
 pip3 install wheel  # install wheel first explicitly
 pip3 install --upgrade pyyaml

--- a/.github/scripts/setup_generate_license.sh
+++ b/.github/scripts/setup_generate_license.sh
@@ -18,6 +18,5 @@
 set -e
 
 sudo apt-get update && sudo apt-get install python3 -y
-curl https://bootstrap.pypa.io/pip/3.7/get-pip.py | sudo -H python3
 pip3 install wheel  # install wheel first explicitly
 pip3 install --upgrade pyyaml

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -138,8 +138,8 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-0}
-if [ "${DRUID_SET_HOST_IP}" = "1" ]
+DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+if [ "${DRUID_SET_HOST}" = "1" ]
 then
     setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
 fi

--- a/distribution/docker/peon.sh
+++ b/distribution/docker/peon.sh
@@ -97,8 +97,8 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-0}
-if [ "${DRUID_SET_HOST_IP}" = "1" ]
+DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+if [ "${DRUID_SET_HOST}" = "1" ]
 then
     setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
 fi


### PR DESCRIPTION
This reverts commit 9459722ebf6565d7161edab671d91588ff2c6e1b.

The effect of PR https://github.com/apache/druid/pull/16386 is that by default, services would advertise themselves with localhost instead of their IP address and because of that, services in docker no longer can discover each other. I ran into this issue while verifying the docker image of 31 RC 1. We don't see this being an issue in IT because there, druid.host is already set to the container name.