### PR TITLE
Load getTaskLocation on task startup in mmless ingestion

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
@@ -20,6 +20,7 @@
 package org.apache.druid.k8s.overlord;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -31,6 +32,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
@@ -177,6 +179,11 @@ public class KubernetesPeonLifecycle
   protected synchronized TaskStatus join(long timeout) throws IllegalStateException
   {
     try {
+      /* It's okay to store taskLocation because podIP only changes on pod restart, and we have to set restartPolicy to Never
+        since Druid doesn't support retrying tasks from a external system (K8s). We can explore adding a fabric8 watcher
+        if we decide we need to change this later.
+      **/
+      taskLocation = getTaskLocationFromK8s();
       updateState(new State[]{State.NOT_STARTED, State.PENDING}, State.RUNNING);
 
       JobResponse jobResponse = kubernetesClient.waitForPeonJobCompletion(
@@ -254,24 +261,8 @@ public class KubernetesPeonLifecycle
     if we decide we need to change this later.
     **/
     if (taskLocation == null) {
-      Optional<Pod> maybePod = kubernetesClient.getPeonPod(taskId.getK8sJobName());
-      if (!maybePod.isPresent()) {
-        return TaskLocation.unknown();
-      }
-
-      Pod pod = maybePod.get();
-      PodStatus podStatus = pod.getStatus();
-
-      if (podStatus == null || podStatus.getPodIP() == null) {
-        return TaskLocation.unknown();
-      }
-      taskLocation = TaskLocation.create(
-          podStatus.getPodIP(),
-          DruidK8sConstants.PORT,
-          DruidK8sConstants.TLS_PORT,
-          Boolean.parseBoolean(pod.getMetadata().getAnnotations().getOrDefault(DruidK8sConstants.TLS_ENABLED, "false")),
-          pod.getMetadata() != null ? pod.getMetadata().getName() : ""
-      );
+      log.warn("Unknown task location for [%s]", taskId);
+      return TaskLocation.unknown();
     }
 
     return taskLocation;
@@ -377,5 +368,29 @@ public class KubernetesPeonLifecycle
         targetState
     );
     stateListener.stateChanged(state.get(), taskId.getOriginalTaskId());
+  }
+
+  @VisibleForTesting
+  protected TaskLocation getTaskLocationFromK8s()
+  {
+    Pod pod = kubernetesClient.getPeonPodWithRetries(taskId.getK8sJobName());
+    PodStatus podStatus = pod.getStatus();
+
+    if (podStatus == null || podStatus.getPodIP() == null) {
+      throw new ISE("Could not find location of running task [%s]", taskId);
+    }
+
+    return TaskLocation.create(
+        podStatus.getPodIP(),
+        DruidK8sConstants.PORT,
+        DruidK8sConstants.TLS_PORT,
+        Boolean.parseBoolean(
+            pod.getMetadata() != null && pod.getMetadata().getAnnotations() != null ?
+                pod.getMetadata().getAnnotations().getOrDefault(DruidK8sConstants.TLS_ENABLED, "false") :
+                "false"
+        ),
+        pod.getMetadata() != null ? pod.getMetadata().getName() : ""
+    );
+
   }
 }


### PR DESCRIPTION
Fixes a bug with mmless ingestion when overlord leadership is rolled over.

### Description
When a overlord newly attains leadership in a cluster running mmless ingestion, it will load all the running tasks from kubernetes, but not the value of taskLocation. taskLocation is populated the first time getTaskLocation() is called on each task.

The problem with this is getTaskLocation is called in the serviceLocator.locate() method, which runs under the ServiceClientFactory thread pool and is not supposed to make a lot of network calls. Frequently the first caller (before taskLocation is cached) is a supervisor trying to contact its tasks. If there are many supervisors and kafka tasks running in the cluster, the ServiceClientFactory threads can get stuck trying to call locate() (since the function will block on reaching out to k8s for the pod ips).

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...
Since we don't actually need to update taskLocation (the pod IP is static through the lifetime of a k8s pod and we don't retry jobs), we can just load taskLocation right after the pod has started (in the join method).

#### Release note
- fix bug with mmless ingestion in high scale clusters

##### Key changed/added classes in this PR
 * `KubernetesPeonLifecycle`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
