### PR TITLE
Remove `zeroMeansUndefined: true` for Delta snapshotVersion

### DIFF
--- a/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
+++ b/web-console/src/druid-models/ingestion-spec/ingestion-spec.tsx
@@ -1115,7 +1115,6 @@ export function getIoConfigFormFields(ingestionComboType: IngestionComboType): F
           label: 'Delta snapshot version',
           type: 'number',
           placeholder: '(latest)',
-          zeroMeansUndefined: true,
           info: (
             <>
               The snapshot version to read from the Delta table. By default, the latest snapshot is

--- a/web-console/src/druid-models/input-source/input-source.tsx
+++ b/web-console/src/druid-models/input-source/input-source.tsx
@@ -667,7 +667,6 @@ export const INPUT_SOURCE_FIELDS: Field<InputSource>[] = [
     label: 'Delta snapshot version',
     type: 'number',
     placeholder: '(latest)',
-    zeroMeansUndefined: true,
     defined: typeIsKnown(KNOWN_TYPES, 'delta'),
     info: (
       <>


### PR DESCRIPTION
Delta snapshots are zero-indexed. Previously, the console set `zeroMeanUndefined` to true, causing it to silently default to the latest snapshot even when a user entered 0 in the text box.

By removing that option, users can now filter by `snapshotVersion: 0`.

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
