### PR TITLE
Change name of export destination datasource to `__query_export`

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
@@ -79,6 +79,7 @@ public class MSQControllerTask extends AbstractTask implements ClientTaskQuery, 
 {
   public static final String TYPE = "query_controller";
   public static final String DUMMY_DATASOURCE_FOR_SELECT = "__query_select";
+  public static final String DUMMY_DATASOURCE_FOR_EXPORT = "__query_export";
   private static final Logger log = new Logger(MSQControllerTask.class);
 
   private final MSQSpec querySpec;
@@ -332,6 +333,8 @@ public class MSQControllerTask extends AbstractTask implements ClientTaskQuery, 
 
     if (destination instanceof DataSourceMSQDestination) {
       return ((DataSourceMSQDestination) destination).getDataSource();
+    } else if (destination instanceof ExportMSQDestination) {
+      return DUMMY_DATASOURCE_FOR_EXPORT;
     } else {
       return DUMMY_DATASOURCE_FOR_SELECT;
     }

--- a/integration-tests-ex/cases/src/test/resources/indexer/export_task.json
+++ b/integration-tests-ex/cases/src/test/resources/indexer/export_task.json
@@ -215,7 +215,7 @@
     "forceTimeChunkLock": true
   },
   "groupId": "%%QUERY_ID%%",
-  "dataSource": "__query_select",
+  "dataSource": "__query_export",
   "resource": {
     "availabilityGroup": "%%QUERY_ID%%",
     "requiredCapacity": 1


### PR DESCRIPTION
Changes placeholder destination data source name of export queries from `__query_select` to ` __query_export`

Changes on the console look like ⬇️ 

<img width="1716" alt="Screenshot 2024-10-17 at 11 24 24 AM" src="https://github.com/user-attachments/assets/afd4cce7-03d7-464b-8a08-a87803380941">
