### PR TITLE
Migrate jaxb bind dependency to jakarta

### DIFF
--- a/LABELS
+++ b/LABELS
@@ -55,11 +55,6 @@ This product bundles Java Servlet API version 2.5, copyright Oracle and/or its a
   * https://github.com/javaee/servlet-spec
   * javax.servlet:javax.servlet-api
 
-This product bundles JAXB version 2.2.2, copyright Oracle and/or its affiliates.,
- which is available under the CDDL 1.1. For details, see licenses/bin/javax.CDDL11
-  * https://github.com/javaee/jaxb-v2
-  * javax.xml.bind:jaxb-api
-
 This product bundles stax-api version 1.0-2, copyright Oracle and/or its affiliates.,
  which is available under the CDDL 1.1. For details, see licenses/bin/javax.CDDL11
   * https://github.com/javaee/

--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -96,8 +96,8 @@
                     <artifactId>jsr311-api</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
@@ -131,8 +131,8 @@
                     <artifactId>commons-lang</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>javax.xml.bind</groupId>
-                    <artifactId>jaxb-api</artifactId>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5012,7 +5012,7 @@ module: core
 license_name: Eclipse Distribution License 1.0
 version: 1.2.2
 libraries:
-  - jakarta.activation:jakarta.activation-api
+  - jakarta.activation: jakarta.activation-api
 
 ---
 name: jakarta.xml.bind-api
@@ -5021,7 +5021,7 @@ module: core
 license_name: Eclipse Distribution License 1.0
 version: 2.3.3
 libraries:
-  - jakarta.xml.bind:jakarta.xml.bind-api
+  - jakarta.xml.bind: jakarta.xml.bind-api
 ---
 
 # Web console modules start

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -5006,6 +5006,23 @@ libraries:
   - com.sun.activation: jakarta.activation
 
 ---
+name: jakarta.activation-api
+license_category: binary
+module: core
+license_name: Eclipse Distribution License 1.0
+version: 1.2.2
+libraries:
+  - jakarta.activation:jakarta.activation-api
+
+---
+name: jakarta.xml.bind-api
+license_category: binary
+module: core
+license_name: Eclipse Distribution License 1.0
+version: 2.3.3
+libraries:
+  - jakarta.xml.bind:jakarta.xml.bind-api
+---
 
 # Web console modules start
 name: "@babel/code-frame"

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3724,30 +3724,6 @@ libraries:
 
 ---
 
-name: JAXB
-license_category: binary
-module: hadoop-client
-license_name: CDDL 1.1
-version: 2.2.2
-copyright: Oracle and/or its affiliates.
-license_file_path: licenses/bin/javax.CDDL11
-libraries:
-  - javax.xml.bind: jaxb-api
-
----
-
-name: JAXB
-license_category: binary
-module: java-core
-license_name: CDDL 1.1
-version: 2.3.1
-copyright: Oracle and/or its affiliates.
-license_file_path: licenses/bin/javax.CDDL11
-libraries:
-  - javax.xml.bind: jaxb-api
-
----
-
 name: jsp-api
 license_category: binary
 module: hadoop-client

--- a/pom.xml
+++ b/pom.xml
@@ -644,9 +644,9 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>2.3.1</version>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
@@ -661,7 +661,7 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>2.3.1</version>
+                <version>2.3.3</version>
             </dependency>
             <dependency>
                 <groupId>org.jdbi</groupId>

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -157,8 +157,8 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -234,8 +234,8 @@
             <version>3.6.0</version>
         </dependency>
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jdbi</groupId>
@@ -341,15 +341,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <configuration>
-                    <!--
-                      ~ The analysis gets confused between javax.xml.bind:jaxb-api and jakarta.xml.bind:jakarta.xml.bind-api.
-                      ~ The former is a direct dependency, and the latter is a transitive dependency of jackson 2.10+.
-                      -->
-                    <usedDependencies>
-                        <dependency>javax.xml.bind:jaxb-api</dependency>
-                    </usedDependencies>
                     <ignoredUsedUndeclaredDependencies>
-                        <ignoredUsedUndeclaredDependency>jakarta.xml.bind:jakarta.xml.bind-api</ignoredUsedUndeclaredDependency>
                         <ignoredUsedUndeclaredDependency>jakarta.inject:jakarta.inject-api</ignoredUsedUndeclaredDependency>
                     </ignoredUsedUndeclaredDependencies>
                 </configuration>


### PR DESCRIPTION
Fixes #17340

### Description
* Migrated from `javax.xml.bind ` to `jakarta.xml.bind`.
* Minor version is modified to avoid any breaking changes.
* EOL Dependecy - https://github.com/javaee/jaxb-spec


### Testing
* Local Build
* Local Deployment
* Deployed on Druid Cluster

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.

### Release Note
* Dependency Migration: Migrated XML binding from javax.xml.bind to jakarta.xml.bind to ensure compatibility with the latest standards and ongoing support.
* Version Update: Minor version incremented to maintain backward compatibility.
* End-of-Life (EOL) Dependency: Deprecated javax.xml.bind dependency removed; refer to the JAXB Specification ([GitHub link](https://github.com/javaee/jaxb-spec)) for more details.
