### PR TITLE
projections fixes

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
@@ -710,9 +710,9 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
 
   protected static class InitializedDictionaryMergerLookups<T>
   {
-    public final int numMergeIndex;
-    public final Indexed<T> dimValueLookup;
-    public final Indexed<T>[] dimValueLookups;
+    private final int numMergeIndex;
+    private final Indexed<T> dimValueLookup;
+    private final Indexed<T>[] dimValueLookups;
 
     public InitializedDictionaryMergerLookups(int numMergeIndex, Indexed<T> dimValueLookup, Indexed<T>[] dimValueLookups)
     {
@@ -720,6 +720,20 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
       this.dimValueLookup = dimValueLookup;
       this.dimValueLookups = dimValueLookups;
     }
-  }
 
+    public Indexed<T> getDimValueLookup()
+    {
+      return dimValueLookup;
+    }
+
+    public int getNumMergeIndex()
+    {
+      return numMergeIndex;
+    }
+
+    public Indexed<T>[] getDimValueLookups()
+    {
+      return dimValueLookups;
+    }
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
@@ -721,16 +721,6 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
       this.dimValueLookups = dimValueLookups;
     }
 
-    public Indexed<T> getDimValueLookup()
-    {
-      return dimValueLookup;
-    }
-
-    public int getNumMergeIndex()
-    {
-      return numMergeIndex;
-    }
-
     public Indexed<T>[] getDimValueLookups()
     {
       return dimValueLookups;

--- a/processing/src/main/java/org/apache/druid/segment/IndexIO.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexIO.java
@@ -719,6 +719,7 @@ public class IndexIO
 
         if (groupingColumn.equals(projectionSpec.getSchema().getTimeColumnName())) {
           projectionColumns.put(ColumnHolder.TIME_COLUMN_NAME, projectionColumns.get(groupingColumn));
+          projectionColumns.remove(groupingColumn);
         }
       }
       for (AggregatorFactory aggregator : projectionSpec.getSchema().getAggregators()) {

--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -44,6 +44,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -239,21 +240,22 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
   public QueryableIndex getProjectionQueryableIndex(String name)
   {
     final AggregateProjectionMetadata projectionSpec = projectionsMap.get(name);
+    final Metadata projectionMetadata = new Metadata(null, projectionSpec.getSchema().getAggregators(), null, null, true, projectionSpec.getSchema().getOrderingWithTimeColumnSubstitution(), null);
     return new SimpleQueryableIndex(
         dataInterval,
-        new ListIndexed<>(projectionSpec.getSchema().getGroupingColumns()),
+        new ListIndexed<>(projectionSpec.getSchema().getGroupingColumns().stream().filter(x -> !x.equals(projectionSpec.getSchema().getTimeColumnName())).collect(Collectors.toList())),
         bitmapFactory,
         projectionColumns.get(name),
         fileMapper,
         true,
-        null,
+        projectionMetadata,
         null
     )
     {
       @Override
       public Metadata getMetadata()
       {
-        return null;
+        return projectionMetadata;
       }
 
       @Override

--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -243,7 +243,13 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
     final Metadata projectionMetadata = new Metadata(null, projectionSpec.getSchema().getAggregators(), null, null, true, projectionSpec.getSchema().getOrderingWithTimeColumnSubstitution(), null);
     return new SimpleQueryableIndex(
         dataInterval,
-        new ListIndexed<>(projectionSpec.getSchema().getGroupingColumns().stream().filter(x -> !x.equals(projectionSpec.getSchema().getTimeColumnName())).collect(Collectors.toList())),
+        new ListIndexed<>(
+            projectionSpec.getSchema()
+                          .getGroupingColumns()
+                          .stream()
+                          .filter(x -> !x.equals(projectionSpec.getSchema().getTimeColumnName()))
+                          .collect(Collectors.toList())
+        ),
         bitmapFactory,
         projectionColumns.get(name),
         fileMapper,

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionMergerV9.java
@@ -184,7 +184,7 @@ public class StringDimensionMergerV9 extends DictionaryEncodedColumnMerger<Strin
       }
       InitializedDictionaryMergerLookups<String> lookups = initializeDictionaryMergerLookups(projectionAdapters);
       dictionaryMergeIterator = new DictionaryMergingIterator<>(
-          lookups.dimValueLookups,
+          lookups.getDimValueLookups(),
           getDictionaryMergingComparator(),
           true
       );
@@ -195,7 +195,7 @@ public class StringDimensionMergerV9 extends DictionaryEncodedColumnMerger<Strin
         dictionaryMergeIterator.next();
       }
       for (int i = 0; i < adapters.size(); i++) {
-        if (lookups.dimValueLookups[i] != null && dictionaryMergeIterator.needConversion(i)) {
+        if (lookups.getDimValueLookups()[i] != null && dictionaryMergeIterator.needConversion(i)) {
           dimConversions.set(i, dictionaryMergeIterator.conversions[i]);
         }
       }

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -3044,7 +3044,6 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
     validateTestMaxColumnsToMergeOutputSegment(merged7);
   }
 
-
   @Test
   public void testMergeProjections() throws IOException
   {
@@ -3236,14 +3235,6 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
     ColumnHolder aHolder = p1Index.getColumnHolder("a");
     DictionaryEncodedColumn aCol = (DictionaryEncodedColumn) aHolder.getColumn();
     Assert.assertEquals(3, aCol.getCardinality());
-    BitmapResultFactory resultFactory = new DefaultBitmapResultFactory(serdeFactory.getBitmapFactory());
-
-    Assert.assertEquals(
-        2,
-        resultFactory.toImmutableBitmap(
-            aHolder.getIndexSupplier().as(ValueIndexes.class).forValue("a", ColumnType.STRING).computeBitmapResult(resultFactory, false)
-        ).size()
-    );
 
     QueryableIndex p2Index = merged.getProjectionQueryableIndex("a_c_sum");
     Assert.assertNotNull(p2Index);
@@ -3251,12 +3242,30 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
     DictionaryEncodedColumn aCol2 = (DictionaryEncodedColumn) aHolder2.getColumn();
     Assert.assertEquals(3, aCol2.getCardinality());
 
-    Assert.assertEquals(
-        1,
-        resultFactory.toImmutableBitmap(
-            aHolder2.getIndexSupplier().as(ValueIndexes.class).forValue("a", ColumnType.STRING).computeBitmapResult(resultFactory, false)
-        ).size()
-    );
+    if (serdeFactory != null) {
+
+      BitmapResultFactory resultFactory = new DefaultBitmapResultFactory(serdeFactory.getBitmapFactory());
+
+      Assert.assertEquals(
+          2,
+          resultFactory.toImmutableBitmap(
+              aHolder.getIndexSupplier()
+                     .as(ValueIndexes.class)
+                     .forValue("a", ColumnType.STRING)
+                     .computeBitmapResult(resultFactory, false)
+          ).size()
+      );
+
+      Assert.assertEquals(
+          1,
+          resultFactory.toImmutableBitmap(
+              aHolder2.getIndexSupplier()
+                      .as(ValueIndexes.class)
+                      .forValue("a", ColumnType.STRING)
+                      .computeBitmapResult(resultFactory, false)
+          ).size()
+      );
+    }
   }
 
   private QueryableIndex persistAndLoad(List<DimensionSchema> schema, InputRow... rows) throws IOException

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -30,7 +30,9 @@ import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.apache.druid.collections.bitmap.RoaringBitmapFactory;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.ListBasedInputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionSchema.MultiValueHandling;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -39,17 +41,23 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.frame.testutil.FrameTestUtil;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.query.BitmapResultFactory;
 import org.apache.druid.query.DefaultBitmapResultFactory;
 import org.apache.druid.query.OrderBy;
+import org.apache.druid.query.QueryContext;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
+import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.StringUtf8DictionaryEncodedColumn;
 import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.BitmapValues;
@@ -63,9 +71,11 @@ import org.apache.druid.segment.incremental.IncrementalIndexAdapter;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.index.semantic.StringValueSetIndexes;
+import org.apache.druid.segment.index.semantic.ValueIndexes;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
+import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -147,6 +157,8 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
   @Rule
   public final CloserRule closer = new CloserRule(false);
 
+  private final BitmapSerdeFactory serdeFactory;
+
   protected IndexMergerTestBase(
       @Nullable BitmapSerdeFactory bitmapSerdeFactory,
       CompressionStrategy compressionStrategy,
@@ -154,6 +166,7 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
       CompressionFactory.LongEncodingStrategy longEncodingStrategy
   )
   {
+    this.serdeFactory = bitmapSerdeFactory;
     this.indexSpec = IndexSpec.builder()
                               .withBitmapSerdeFactory(bitmapSerdeFactory != null
                                                       ? bitmapSerdeFactory
@@ -3031,6 +3044,219 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
     validateTestMaxColumnsToMergeOutputSegment(merged7);
   }
 
+  @Test
+  public void testMergeProjections() throws IOException
+  {
+    File tmp = FileUtils.createTempDir();
+    closer.closeLater(tmp::delete);
+
+    final DateTime timestamp = Granularities.DAY.bucket(DateTimes.nowUtc()).getStart();
+
+    final RowSignature rowSignature = RowSignature.builder()
+                                                  .add("a", ColumnType.STRING)
+                                                  .add("b", ColumnType.STRING)
+                                                  .add("c", ColumnType.LONG)
+                                                  .build();
+
+    final List<InputRow> rows1 = Arrays.asList(
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp,
+            rowSignature.getColumnNames(),
+            Arrays.asList("a", "x", 1L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusMinutes(1),
+            rowSignature.getColumnNames(),
+            Arrays.asList("b", "y", 2L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusHours(2),
+            rowSignature.getColumnNames(),
+            Arrays.asList("a", "z", 3L)
+        )
+    );
+
+    final List<InputRow> rows2 = Arrays.asList(
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp,
+            rowSignature.getColumnNames(),
+            Arrays.asList("b", "y", 1L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusMinutes(1),
+            rowSignature.getColumnNames(),
+            Arrays.asList("d", "w", 2L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusHours(2),
+            rowSignature.getColumnNames(),
+            Arrays.asList("b", "z", 3L)
+        )
+    );
+
+    final DimensionsSpec.Builder dimensionsBuilder =
+        DimensionsSpec.builder()
+                      .setDimensions(
+                          Arrays.asList(
+                              new StringDimensionSchema("a"),
+                              new StringDimensionSchema("b")
+                          )
+                      );
+
+    List<AggregateProjectionSpec> projections = Arrays.asList(
+        new AggregateProjectionSpec(
+            "ab_hourly_c_sum",
+            VirtualColumns.create(
+                Granularities.toVirtualColumn(Granularities.HOUR, "__gran")
+            ),
+            Arrays.asList(
+                new StringDimensionSchema("a"),
+                new LongDimensionSchema("__gran")
+            ),
+            new AggregatorFactory[]{
+                new LongSumAggregatorFactory("c_sum", "c")
+            }
+        ),
+        new AggregateProjectionSpec(
+            "ab_c_sum",
+            VirtualColumns.EMPTY,
+            Collections.singletonList(
+                new StringDimensionSchema("a")
+            ),
+            new AggregatorFactory[]{
+                new LongSumAggregatorFactory("c_sum", "c")
+            }
+        )
+    );
+
+    IndexBuilder bob = IndexBuilder.create()
+                       .tmpDir(tmp)
+                       .schema(
+                           IncrementalIndexSchema.builder()
+                                                 .withDimensionsSpec(dimensionsBuilder.build())
+                                                 .withRollup(false)
+                                                 .withProjections(projections)
+                                                 .build()
+                       )
+                       .rows(rows1);
+
+    IndexBuilder bob2 = IndexBuilder.create()
+                                   .tmpDir(tmp)
+                                   .schema(
+                                       IncrementalIndexSchema.builder()
+                                                             .withDimensionsSpec(dimensionsBuilder.build())
+                                                             .withRollup(false)
+                                                             .withProjections(projections)
+                                                             .build()
+                                   )
+                                   .rows(rows2);
+
+    QueryableIndex q1 = bob.buildMMappedIndex();
+    QueryableIndex q2 = bob2.buildMMappedIndex();
+
+    QueryableIndex merged = indexIO.loadIndex(
+        indexMerger.merge(
+            Arrays.asList(
+                new QueryableIndexIndexableAdapter(q1),
+                new QueryableIndexIndexableAdapter(q2)
+            ),
+            true,
+            new AggregatorFactory[0],
+            temporaryFolder.newFolder(),
+            dimensionsBuilder.build(),
+            IndexSpec.DEFAULT,
+            -1
+        )
+    );
+
+    CursorBuildSpec p1Spec = CursorBuildSpec.builder()
+                                            .setQueryContext(
+                                                QueryContext.of(
+                                                    ImmutableMap.of(QueryContexts.USE_PROJECTION, "ab_hourly_c_sum")
+                                                )
+                                            )
+                                            .setVirtualColumns(
+                                                VirtualColumns.create(
+                                                    Granularities.toVirtualColumn(Granularities.HOUR, "gran")
+                                                )
+                                            )
+                                            .setAggregators(
+                                                Collections.singletonList(
+                                                    new LongSumAggregatorFactory("c", "c")
+                                                )
+                                            )
+                                            .setGroupingColumns(Collections.singletonList("a"))
+                                            .build();
+    CursorBuildSpec p2Spec = CursorBuildSpec.builder()
+                                            .setQueryContext(
+                                                QueryContext.of(
+                                                    ImmutableMap.of(QueryContexts.USE_PROJECTION, "ab_c_sum")
+                                                )
+                                            )
+                                            .setAggregators(
+                                                Collections.singletonList(
+                                                    new LongSumAggregatorFactory("c", "c")
+                                                )
+                                            )
+                                            .setGroupingColumns(Collections.singletonList("a"))
+                                            .build();
+
+
+    QueryableIndexCursorFactory cursorFactory = new QueryableIndexCursorFactory(merged);
+
+    try (final CursorHolder cursorHolder = cursorFactory.makeCursorHolder(p1Spec)) {
+      final Cursor cursor = cursorHolder.asCursor();
+      int rowCount = 0;
+      while (!cursor.isDone()) {
+        rowCount++;
+        cursor.advance();
+      }
+      Assert.assertEquals(5, rowCount);
+    }
+
+    try (final CursorHolder cursorHolder = cursorFactory.makeCursorHolder(p2Spec)) {
+      final Cursor cursor = cursorHolder.asCursor();
+      int rowCount = 0;
+      while (!cursor.isDone()) {
+        rowCount++;
+        cursor.advance();
+      }
+      Assert.assertEquals(3, rowCount);
+    }
+
+    QueryableIndex p1Index = merged.getProjectionQueryableIndex("ab_hourly_c_sum");
+    Assert.assertNotNull(p1Index);
+    ColumnHolder aHolder = p1Index.getColumnHolder("a");
+    DictionaryEncodedColumn aCol = (DictionaryEncodedColumn) aHolder.getColumn();
+    Assert.assertEquals(3, aCol.getCardinality());
+    BitmapResultFactory resultFactory = new DefaultBitmapResultFactory(serdeFactory.getBitmapFactory());
+
+    Assert.assertEquals(
+        2,
+        resultFactory.toImmutableBitmap(
+            aHolder.getIndexSupplier().as(ValueIndexes.class).forValue("a", ColumnType.STRING).computeBitmapResult(resultFactory, false)
+        ).size()
+    );
+
+    QueryableIndex p2Index = merged.getProjectionQueryableIndex("ab_hourly_c_sum");
+    Assert.assertNotNull(p2Index);
+    ColumnHolder aHolder2 = p2Index.getColumnHolder("a");
+    DictionaryEncodedColumn aCol2 = (DictionaryEncodedColumn) aHolder2.getColumn();
+    Assert.assertEquals(3, aCol2.getCardinality());
+
+    Assert.assertEquals(
+        2,
+        resultFactory.toImmutableBitmap(
+            aHolder2.getIndexSupplier().as(ValueIndexes.class).forValue("a", ColumnType.STRING).computeBitmapResult(resultFactory, false)
+        ).size()
+    );
+  }
 
   private QueryableIndex persistAndLoad(List<DimensionSchema> schema, InputRow... rows) throws IOException
   {


### PR DESCRIPTION
changes:
* fix issue when merging projections from multiple-incremental persists which was hoping that some 'dim conversion' buffers were not closed, but they already were (by the merging iterator). fix involves recreating the merging iterator to rebuild the dim conversions, which is sad, but maybe better than keeping the buffers open for the entire lifetime of the segment writeout
* fix queryable index projection to not put the time-like column as a dimension, instead only adding it as __time
