### PR TITLE
Maintain TaskLockbox at datasource level for higher concurrency

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueue.java
@@ -26,7 +26,7 @@ import org.apache.druid.indexing.common.task.IndexTaskUtils;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.Segments;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
@@ -74,7 +74,7 @@ public class SegmentAllocationQueue
 
   private final long maxWaitTimeMillis;
 
-  private final TaskLockbox taskLockbox;
+  private final GlobalTaskLockbox taskLockbox;
   private final IndexerMetadataStorageCoordinator metadataStorage;
   private final AtomicBoolean isLeader = new AtomicBoolean(false);
   private final ServiceEmitter emitter;
@@ -89,7 +89,7 @@ public class SegmentAllocationQueue
 
   @Inject
   public SegmentAllocationQueue(
-      TaskLockbox taskLockbox,
+      GlobalTaskLockbox taskLockbox,
       TaskLockConfig taskLockConfig,
       IndexerMetadataStorageCoordinator metadataStorage,
       ServiceEmitter emitter,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskActionToolbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskActionToolbox.java
@@ -24,7 +24,7 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.indexing.overlord.TaskRunnerFactory;
 import org.apache.druid.indexing.overlord.TaskStorage;
@@ -33,7 +33,7 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 
 public class TaskActionToolbox
 {
-  private final TaskLockbox taskLockbox;
+  private final GlobalTaskLockbox taskLockbox;
   private final TaskStorage taskStorage;
   private final SegmentAllocationQueue segmentAllocationQueue;
   private final IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator;
@@ -44,7 +44,7 @@ public class TaskActionToolbox
 
   @Inject
   public TaskActionToolbox(
-      TaskLockbox taskLockbox,
+      GlobalTaskLockbox taskLockbox,
       TaskStorage taskStorage,
       IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator,
       SegmentAllocationQueue segmentAllocationQueue,
@@ -63,7 +63,7 @@ public class TaskActionToolbox
   }
 
   public TaskActionToolbox(
-      TaskLockbox taskLockbox,
+      GlobalTaskLockbox taskLockbox,
       TaskStorage taskStorage,
       IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator,
       ServiceEmitter emitter,
@@ -82,7 +82,7 @@ public class TaskActionToolbox
     );
   }
 
-  public TaskLockbox getTaskLockbox()
+  public GlobalTaskLockbox getTaskLockbox()
   {
     return taskLockbox;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java
@@ -28,7 +28,7 @@ import org.apache.druid.indexing.common.TimeChunkLock;
 import org.apache.druid.indexing.common.task.AbstractBatchIndexTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.Tasks;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.metadata.ReplaceTaskLock;
@@ -52,7 +52,7 @@ public class TaskLocks
 {
   static void checkLockCoversSegments(
       final Task task,
-      final TaskLockbox taskLockbox,
+      final GlobalTaskLockbox taskLockbox,
       final Collection<DataSegment> segments
   )
   {
@@ -69,7 +69,7 @@ public class TaskLocks
   @VisibleForTesting
   static boolean isLockCoversSegments(
       final Task task,
-      final TaskLockbox taskLockbox,
+      final GlobalTaskLockbox taskLockbox,
       final Collection<DataSegment> segments
   )
   {
@@ -176,7 +176,7 @@ public class TaskLocks
    */
   public static Map<DataSegment, ReplaceTaskLock> findReplaceLocksCoveringSegments(
       final String datasource,
-      final TaskLockbox taskLockbox,
+      final GlobalTaskLockbox taskLockbox,
       final Set<DataSegment> segments
   )
   {
@@ -206,7 +206,7 @@ public class TaskLocks
 
   public static List<TaskLock> findLocksForSegments(
       final Task task,
-      final TaskLockbox taskLockbox,
+      final GlobalTaskLockbox taskLockbox,
       final Collection<DataSegment> segments
   )
   {
@@ -245,7 +245,7 @@ public class TaskLocks
     return found;
   }
 
-  private static NavigableMap<DateTime, List<TaskLock>> getTaskLockMap(TaskLockbox taskLockbox, Task task)
+  private static NavigableMap<DateTime, List<TaskLock>> getTaskLockMap(GlobalTaskLockbox taskLockbox, Task task)
   {
     final List<TaskLock> taskLocks = taskLockbox.findLocksForTask(task);
     final NavigableMap<DateTime, List<TaskLock>> taskLockMap = new TreeMap<>();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CriticalAction.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/CriticalAction.java
@@ -27,13 +27,13 @@ import org.joda.time.Interval;
  * This class represents a critical action must be done while the task's lock is guaranteed to not be revoked in the
  * middle of the action.
  *
- * Implementations must not change the lock state by calling {@link TaskLockbox#lock)}, {@link TaskLockbox#tryLock)},
- * or {@link TaskLockbox#unlock(Task, Interval)}.
+ * Implementations must not change the lock state by calling {@link GlobalTaskLockbox#lock)}, {@link GlobalTaskLockbox#tryLock)},
+ * or {@link GlobalTaskLockbox#unlock(Task, Interval)}.
  *
- * Also, implementations should be finished as soon as possible because all methods in {@link TaskLockbox} are blocked
+ * Also, implementations should be finished as soon as possible because all methods in {@link GlobalTaskLockbox} are blocked
  * until this action is finished.
  *
- * @see TaskLockbox#doInCriticalSection
+ * @see GlobalTaskLockbox#doInCriticalSection
  */
 public class CriticalAction<T>
 {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
@@ -76,7 +76,7 @@ public class DruidOverlord
       final TaskLockConfig taskLockConfig,
       final TaskQueueConfig taskQueueConfig,
       final DefaultTaskConfig defaultTaskConfig,
-      final TaskLockbox taskLockbox,
+      final GlobalTaskLockbox taskLockbox,
       final TaskStorage taskStorage,
       final TaskActionClientFactory taskActionClientFactory,
       @Self final DruidNode selfNode,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/GlobalTaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/GlobalTaskLockbox.java
@@ -1,0 +1,401 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import org.apache.druid.indexing.common.LockGranularity;
+import org.apache.druid.indexing.common.TaskLock;
+import org.apache.druid.indexing.common.actions.SegmentAllocateAction;
+import org.apache.druid.indexing.common.actions.SegmentAllocateRequest;
+import org.apache.druid.indexing.common.actions.SegmentAllocateResult;
+import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.java.util.common.Pair;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.metadata.LockFilterPolicy;
+import org.apache.druid.metadata.ReplaceTaskLock;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Remembers which activeTasks have locked which intervals or which segments. Tasks are permitted to lock an interval
+ * or a segment if no other task outside their group has locked an overlapping interval for the same datasource or
+ * the same segments. Note that TaskLockbox is also responsible for allocating segmentIds when a task requests to lock
+ * a new segment. Task lock might involve version assignment.
+ *
+ * - When a task locks an interval or a new segment, it is assigned a new version string that it can use to publish
+ *   segments.
+ * - When a task locks a existing segment, it doesn't need to be assigned a new version.
+ *
+ * Note that tasks of higher priorities can revoke locks of tasks of lower priorities.
+ */
+public class GlobalTaskLockbox
+{
+  private static final Logger log = new Logger(GlobalTaskLockbox.class);
+
+  private final TaskStorage taskStorage;
+  private final IndexerMetadataStorageCoordinator metadataStorageCoordinator;
+  private final ReentrantReadWriteLock globalLock = new ReentrantReadWriteLock(true);
+  private final ConcurrentHashMap<String, TaskLockbox> datasourceLocks = new ConcurrentHashMap<>();
+
+  @Inject
+  public GlobalTaskLockbox(
+      TaskStorage taskStorage,
+      IndexerMetadataStorageCoordinator metadataStorageCoordinator
+  )
+  {
+    this.taskStorage = taskStorage;
+    this.metadataStorageCoordinator = metadataStorageCoordinator;
+  }
+
+  private TaskLockbox getDatasourceLockbox(Task task)
+  {
+    return getDatasourceLockbox(task.getDataSource());
+  }
+
+  private TaskLockbox getDatasourceLockbox(String datasource)
+  {
+    return datasourceLocks.computeIfAbsent(
+        datasource,
+        ds -> new TaskLockbox(ds, new DatasourceLock(), taskStorage, metadataStorageCoordinator)
+    );
+  }
+
+  private class DatasourceLock extends ReentrantLock
+  {
+    @Override
+    public void lock()
+    {
+      globalLock.readLock().lock();
+      super.lock();
+    }
+
+    @Override
+    public void lockInterruptibly() throws InterruptedException
+    {
+      globalLock.readLock().lock();
+      super.lockInterruptibly();
+    }
+
+    @Override
+    public void unlock()
+    {
+      super.unlock();
+      globalLock.readLock().unlock();
+    }
+  }
+
+  /**
+   * Wipe out our current in-memory state and resync it from our bundled {@link TaskStorage}.
+   *
+   * @return SyncResult which needs to be processed by the caller
+   */
+  public TaskLockboxSyncResult syncFromStorage()
+  {
+    globalLock.writeLock().lock();
+
+    try {
+      // Load stuff from taskStorage first. If this fails, we don't want to lose all our locks.
+      final Set<Task> storedActiveTasks = new HashSet<>();
+      final List<Pair<Task, TaskLock>> storedLocks = new ArrayList<>();
+      for (final Task task : taskStorage.getActiveTasks()) {
+        storedActiveTasks.add(task);
+        for (final TaskLock taskLock : taskStorage.getLocks(task.getId())) {
+          storedLocks.add(Pair.of(task, taskLock));
+        }
+      }
+
+      // Set of task groups in which at least one task failed to re-acquire a lock
+      final Set<Task> tasksToFail = new HashSet<>();
+      int taskLockCount = 0;
+      for (TaskLockbox datasourceLockbox : datasourceLocks.values()) {
+        TaskLockboxSyncResult result = datasourceLockbox.resetState(storedActiveTasks, storedLocks);
+        tasksToFail.addAll(result.getTasksToFail());
+        taskLockCount += result.getTaskLockCount();
+      }
+
+      log.info(
+          "Synced [%,d] locks for [%,d] activeTasks from storage ([%,d] locks ignored).",
+          taskLockCount,
+          storedActiveTasks.size(),
+          storedLocks.size() - taskLockCount
+      );
+
+      return new TaskLockboxSyncResult(tasksToFail, taskLockCount);
+    }
+    finally {
+      globalLock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * This method is called only in {@link #syncFromStorage()} and verifies the given task and the taskLock have the same
+   * groupId, dataSource, and priority.
+   */
+  @VisibleForTesting
+  @Nullable
+  TaskLockbox.TaskLockPosse verifyAndCreateOrFindLockPosse(Task task, TaskLock taskLock)
+  {
+    return getDatasourceLockbox(task).verifyAndCreateOrFindLockPosse(task, taskLock);
+  }
+
+  /**
+   * Acquires a lock on behalf of a task.  Blocks until the lock is acquired.
+   *
+   * @return {@link LockResult} containing a new or an existing lock if succeeded. Otherwise, {@link LockResult} with a
+   * {@link LockResult#revoked} flag.
+   *
+   * @throws InterruptedException if the current thread is interrupted
+   */
+  public LockResult lock(final Task task, final LockRequest request) throws InterruptedException
+  {
+    return getDatasourceLockbox(task).lock(task, request);
+  }
+
+  /**
+   * Acquires a lock on behalf of a task, waiting up to the specified wait time if necessary.
+   *
+   * @return {@link LockResult} containing a new or an existing lock if succeeded. Otherwise, {@link LockResult} with a
+   * {@link LockResult#revoked} flag.
+   *
+   * @throws InterruptedException if the current thread is interrupted
+   */
+  public LockResult lock(final Task task, final LockRequest request, long timeoutMs) throws InterruptedException
+  {
+    return getDatasourceLockbox(task).lock(task, request, timeoutMs);
+  }
+
+  /**
+   * Attempt to acquire a lock for a task, without removing it from the queue. Can safely be called multiple times on
+   * the same task until the lock is preempted.
+   *
+   * @return {@link LockResult} containing a new or an existing lock if succeeded. Otherwise, {@link LockResult} with a
+   * {@link LockResult#revoked} flag.
+   *
+   * @throws IllegalStateException if the task is not a valid active task
+   */
+  public LockResult tryLock(final Task task, final LockRequest request)
+  {
+    return getDatasourceLockbox(task).tryLock(task, request);
+  }
+
+  /**
+   * Attempts to allocate segments for the given requests. Each request contains
+   * a {@link Task} and a {@link SegmentAllocateAction}. This method tries to
+   * acquire the task locks on the required intervals/segments and then performs
+   * a batch allocation of segments. It is possible that some requests succeed
+   * successfully and others failed. In that case, only the failed ones should be
+   * retried.
+   *
+   * @param requests                List of allocation requests
+   * @param dataSource              Datasource for which segment is to be allocated.
+   * @param interval                Interval for which segment is to be allocated.
+   * @param skipSegmentLineageCheck Whether lineage check is to be skipped
+   *                                (this is true for streaming ingestion)
+   * @param lockGranularity         Granularity of task lock
+   * @return List of allocation results in the same order as the requests.
+   */
+  public List<SegmentAllocateResult> allocateSegments(
+      List<SegmentAllocateRequest> requests,
+      String dataSource,
+      Interval interval,
+      boolean skipSegmentLineageCheck,
+      LockGranularity lockGranularity
+  )
+  {
+    return getDatasourceLockbox(dataSource).allocateSegments(
+        requests,
+        dataSource,
+        interval,
+        skipSegmentLineageCheck,
+        lockGranularity
+    );
+  }
+
+  /**
+   * Perform the given action with a guarantee that the locks of the task are not revoked in the middle of action.  This
+   * method first checks that all locks for the given task and intervals are valid and perform the right action.
+   * <p>
+   * The given action should be finished as soon as possible because all other methods in this class are blocked until
+   * this method is finished.
+   *
+   * @param task      task performing a critical action
+   * @param intervals intervals
+   * @param action    action to be performed inside of the critical section
+   */
+  public <T> T doInCriticalSection(Task task, Set<Interval> intervals, CriticalAction<T> action) throws Exception
+  {
+    return getDatasourceLockbox(task).doInCriticalSection(task, intervals, action);
+  }
+
+  /**
+   * Mark the lock as revoked. Note that revoked locks are NOT removed. Instead, they are kept in memory
+   * and {@link #taskStorage} as the normal locks do. This is to check locks are revoked when they are requested to be
+   * acquired and notify to the callers if revoked. Revoked locks are removed by calling
+   * {@link #unlock(Task, Interval)}.
+   *
+   * @param taskId an id of the task holding the lock
+   * @param lock   lock to be revoked
+   */
+  @VisibleForTesting
+  public void revokeLock(String taskId, TaskLock lock)
+  {
+    getDatasourceLockbox(lock.getDataSource()).revokeLock(taskId, lock);
+  }
+
+  /**
+   * Return the currently-active locks for some task.
+   *
+   * @param task task for which to locate locks
+   * @return currently-active locks for the given task
+   */
+  public List<TaskLock> findLocksForTask(final Task task)
+  {
+    return getDatasourceLockbox(task).findLocksForTask(task);
+  }
+
+  /**
+   * Finds the active non-revoked REPLACE locks held by the given task.
+   */
+  public Set<ReplaceTaskLock> findReplaceLocksForTask(Task task)
+  {
+    return getDatasourceLockbox(task).findReplaceLocksForTask(task);
+  }
+
+  /**
+   * Finds all the active non-revoked REPLACE locks for the given datasource.
+   */
+  public Set<ReplaceTaskLock> getAllReplaceLocksForDatasource(String datasource)
+  {
+    return getDatasourceLockbox(datasource).getAllReplaceLocksForDatasource(datasource);
+  }
+
+  /**
+   * @param lockFilterPolicies Lock filters for the given datasources
+   * @return Map from datasource to intervals locked by tasks satisfying the lock filter condititions
+   */
+  public Map<String, List<Interval>> getLockedIntervals(List<LockFilterPolicy> lockFilterPolicies)
+  {
+    final Map<String, List<LockFilterPolicy>> datasourceToFilterPolicies = new HashMap<>();
+    for (LockFilterPolicy policy : lockFilterPolicies) {
+      datasourceToFilterPolicies.computeIfAbsent(policy.getDatasource(), ds -> new ArrayList<>())
+                                .add(policy);
+    }
+
+    final Map<String, List<Interval>> datasourceToLockedIntervals = new HashMap<>();
+    datasourceToFilterPolicies.forEach(
+        (datasource, policies) -> datasourceToLockedIntervals.put(
+            datasource,
+            getDatasourceLockbox(datasource).getLockedIntervals(policies)
+        )
+    );
+
+    return datasourceToLockedIntervals;
+  }
+
+  /**
+   * @param lockFilterPolicies Lock filters for the given datasources
+   * @return Map from datasource to list of non-revoked locks with at least as much priority and an overlapping interval
+   */
+  public Map<String, List<TaskLock>> getActiveLocks(List<LockFilterPolicy> lockFilterPolicies)
+  {
+    final Map<String, List<LockFilterPolicy>> datasourceToFilterPolicies = new HashMap<>();
+    for (LockFilterPolicy policy : lockFilterPolicies) {
+      datasourceToFilterPolicies.computeIfAbsent(policy.getDatasource(), ds -> new ArrayList<>())
+                                .add(policy);
+    }
+
+    final Map<String, List<TaskLock>> datasourceToActiveLocks = new HashMap<>();
+    datasourceToFilterPolicies.forEach(
+        (datasource, policies) -> datasourceToActiveLocks.put(
+            datasource,
+            getDatasourceLockbox(datasource).getActiveLocks(policies)
+        )
+    );
+
+    return datasourceToActiveLocks;
+  }
+
+  public void unlock(final Task task, final Interval interval)
+  {
+    getDatasourceLockbox(task).unlock(task, interval);
+  }
+
+  public void unlockAll(Task task)
+  {
+    getDatasourceLockbox(task).unlockAll(task);
+  }
+
+  public void add(Task task)
+  {
+    getDatasourceLockbox(task).add(task);
+  }
+
+  /**
+   * Release all locks for a task and remove task from set of active tasks. Does nothing if the task is not currently locked or not an active task.
+   *
+   * @param task task to unlock
+   */
+  public void remove(final Task task)
+  {
+    getDatasourceLockbox(task).remove(task);
+  }
+
+  @VisibleForTesting
+  Optional<TaskLockbox.TaskLockPosse> getOnlyTaskLockPosseContainingInterval(Task task, Interval interval)
+  {
+    return getDatasourceLockbox(task).getOnlyTaskLockPosseContainingInterval(task, interval);
+  }
+
+  @VisibleForTesting
+  Set<String> getActiveTasks()
+  {
+    final Set<String> allActiveTasks = new HashSet<>();
+    datasourceLocks.values().forEach(lockbox -> allActiveTasks.addAll(lockbox.getActiveTasks()));
+
+    return allActiveTasks;
+  }
+
+  @VisibleForTesting
+  Map<String, NavigableMap<DateTime, SortedMap<Interval, List<TaskLockbox.TaskLockPosse>>>> getAllLocks()
+  {
+    Map<String, NavigableMap<DateTime, SortedMap<Interval, List<TaskLockbox.TaskLockPosse>>>> allLocks
+        = new HashMap<>();
+
+    datasourceLocks.forEach((datasource, lockbox) -> allLocks.put(datasource, lockbox.getAllLocks()));
+
+    return allLocks;
+  }
+
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/LockResult.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/LockResult.java
@@ -27,7 +27,7 @@ import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import javax.annotation.Nullable;
 
 /**
- * This class represents the result of {@link TaskLockbox#tryLock}. If the lock
+ * This class represents the result of {@link GlobalTaskLockbox#tryLock}. If the lock
  * acquisition fails, the callers can tell that it was failed because it was preempted by other locks of higher
  * priorities or not by checking the {@link #revoked} flag.
  *

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockboxSyncResult.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockboxSyncResult.java
@@ -29,10 +29,12 @@ import java.util.Set;
  */
 class TaskLockboxSyncResult
 {
+  private final int taskLockCount;
   private final Set<Task> tasksToFail;
 
-  TaskLockboxSyncResult(Set<Task> tasksToFail)
+  TaskLockboxSyncResult(Set<Task> tasksToFail, int taskLockCount)
   {
+    this.taskLockCount = taskLockCount;
     this.tasksToFail = tasksToFail;
   }
 
@@ -42,5 +44,10 @@ class TaskLockboxSyncResult
   Set<Task> getTasksToFail()
   {
     return tasksToFail;
+  }
+
+  int getTaskLockCount()
+  {
+    return taskLockCount;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
@@ -57,7 +57,7 @@ import java.util.stream.Stream;
 /**
  * Provides read-only methods to fetch information related to tasks.
  * This class may serve information that is cached in memory in {@link TaskQueue}
- * or {@link TaskLockbox}. If not present in memory, then the underlying
+ * or {@link GlobalTaskLockbox}. If not present in memory, then the underlying
  * {@link TaskStorage} is queried.
  */
 public class TaskQueryTool
@@ -65,7 +65,7 @@ public class TaskQueryTool
   private static final Logger log = new Logger(TaskQueryTool.class);
 
   private final TaskStorage storage;
-  private final TaskLockbox taskLockbox;
+  private final GlobalTaskLockbox taskLockbox;
   private final TaskMaster taskMaster;
   private final Supplier<WorkerBehaviorConfig> workerBehaviorConfigSupplier;
   private final ProvisioningStrategy provisioningStrategy;
@@ -73,7 +73,7 @@ public class TaskQueryTool
   @Inject
   public TaskQueryTool(
       TaskStorage storage,
-      TaskLockbox taskLockbox,
+      GlobalTaskLockbox taskLockbox,
       TaskMaster taskMaster,
       ProvisioningStrategy provisioningStrategy,
       Supplier<WorkerBehaviorConfig> workerBehaviorConfigSupplier

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -123,7 +123,7 @@ public class TaskQueue
   private final TaskStorage taskStorage;
   private final TaskRunner taskRunner;
   private final TaskActionClientFactory taskActionClientFactory;
-  private final TaskLockbox taskLockbox;
+  private final GlobalTaskLockbox taskLockbox;
   private final ServiceEmitter emitter;
   private final ObjectMapper passwordRedactingMapper;
   private final TaskContextEnricher taskContextEnricher;
@@ -169,7 +169,7 @@ public class TaskQueue
       TaskStorage taskStorage,
       TaskRunner taskRunner,
       TaskActionClientFactory taskActionClientFactory,
-      TaskLockbox taskLockbox,
+      GlobalTaskLockbox taskLockbox,
       ServiceEmitter emitter,
       ObjectMapper mapper,
       TaskContextEnricher taskContextEnricher

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
@@ -31,7 +31,7 @@ import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -1133,7 +1133,7 @@ public class SegmentAllocateActionTest
   public void testSegmentIdMustNotBeReused()
   {
     final IndexerMetadataStorageCoordinator coordinator = taskActionTestKit.getMetadataStorageCoordinator();
-    final TaskLockbox lockbox = taskActionTestKit.getTaskLockbox();
+    final GlobalTaskLockbox lockbox = taskActionTestKit.getTaskLockbox();
     final Task task0 = NoopTask.ofPriority(25);
     lockbox.add(task0);
     final NoopTask task1 = NoopTask.ofPriority(50);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
@@ -25,7 +25,7 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.config.TaskLockConfig;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
@@ -50,7 +50,7 @@ public class TaskActionTestKit extends ExternalResource
   private final MetadataStorageTablesConfig metadataStorageTablesConfig = MetadataStorageTablesConfig.fromBase("druid");
 
   private TaskStorage taskStorage;
-  private TaskLockbox taskLockbox;
+  private GlobalTaskLockbox taskLockbox;
   private TestDerbyConnector testDerbyConnector;
   private IndexerMetadataStorageCoordinator metadataStorageCoordinator;
   private SegmentsMetadataManager segmentsMetadataManager;
@@ -58,7 +58,7 @@ public class TaskActionTestKit extends ExternalResource
   private SegmentSchemaManager segmentSchemaManager;
   private SegmentSchemaCache segmentSchemaCache;
 
-  public TaskLockbox getTaskLockbox()
+  public GlobalTaskLockbox getTaskLockbox()
   {
     return taskLockbox;
   }
@@ -102,7 +102,7 @@ public class TaskActionTestKit extends ExternalResource
         return 2;
       }
     };
-    taskLockbox = new TaskLockbox(taskStorage, metadataStorageCoordinator);
+    taskLockbox = new GlobalTaskLockbox(taskStorage, metadataStorageCoordinator);
     segmentSchemaCache = new SegmentSchemaCache(NoopServiceEmitter.instance());
     segmentsMetadataManager = new SqlSegmentsMetadataManager(
         objectMapper,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskLocksTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskLocksTest.java
@@ -34,7 +34,7 @@ import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.LockResult;
 import org.apache.druid.indexing.overlord.SpecificSegmentLockRequest;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.TimeChunkLockRequest;
 import org.apache.druid.indexing.test.TestIndexerMetadataStorageCoordinator;
@@ -58,14 +58,14 @@ import java.util.stream.IntStream;
 
 public class TaskLocksTest
 {
-  private TaskLockbox lockbox;
+  private GlobalTaskLockbox lockbox;
   private Task task;
 
   @Before
   public void setup()
   {
     final TaskStorage taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
-    lockbox = new TaskLockbox(
+    lockbox = new GlobalTaskLockbox(
         taskStorage,
         new TestIndexerMetadataStorageCoordinator()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -51,7 +51,7 @@ import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.indexing.overlord.TaskRunnerListener;
 import org.apache.druid.indexing.overlord.TaskRunnerWorkItem;
@@ -122,7 +122,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
   private TaskStorage taskStorage;
   private IndexerSQLMetadataStorageCoordinator storageCoordinator;
   private SegmentsMetadataManager segmentsMetadataManager;
-  private TaskLockbox lockbox;
+  private GlobalTaskLockbox lockbox;
   private File baseDir;
   private SegmentSchemaManager segmentSchemaManager;
   private SegmentSchemaCache segmentSchemaCache;
@@ -165,7 +165,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
         CentralizedDatasourceSchemaConfig.create(),
         NoopServiceEmitter.instance()
     );
-    lockbox = new TaskLockbox(taskStorage, storageCoordinator);
+    lockbox = new GlobalTaskLockbox(taskStorage, storageCoordinator);
     segmentCacheManagerFactory = new SegmentCacheManagerFactory(TestIndex.INDEX_IO, getObjectMapper());
     reportsFile = temporaryFolder.newFile();
     dataSegmentKiller = new TestDataSegmentKiller();
@@ -228,7 +228,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
     return segmentsMetadataManager;
   }
 
-  public TaskLockbox getLockbox()
+  public GlobalTaskLockbox getLockbox()
   {
     return lockbox;
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
@@ -29,7 +29,7 @@ import org.apache.druid.indexing.common.config.TaskStorageConfig;
 import org.apache.druid.indexing.common.task.CompactionTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskQueryTool;
 import org.apache.druid.indexing.overlord.TaskQueue;
@@ -129,7 +129,7 @@ public class OverlordCompactionSchedulerTest
 
   private void initScheduler()
   {
-    TaskLockbox taskLockbox = new TaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator());
+    GlobalTaskLockbox taskLockbox = new GlobalTaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator());
     WorkerBehaviorConfig defaultWorkerConfig
         = new DefaultWorkerBehaviorConfig(WorkerBehaviorConfig.DEFAULT_STRATEGY, null);
     scheduler = new OverlordCompactionScheduler(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLifecycleTest.java
@@ -232,7 +232,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
   private ObjectMapper mapper;
   private TaskQueryTool tsqa = null;
   private TaskStorage taskStorage = null;
-  private TaskLockbox taskLockbox = null;
+  private GlobalTaskLockbox taskLockbox = null;
   private TaskQueue taskQueue = null;
   private TaskRunner taskRunner = null;
   private TestIndexerMetadataStorageCoordinator mdc = null;
@@ -547,7 +547,7 @@ public class TaskLifecycleTest extends InitializedNullHandlingTest
     Preconditions.checkNotNull(taskStorage);
     Preconditions.checkNotNull(emitter);
 
-    taskLockbox = new TaskLockbox(taskStorage, mdc);
+    taskLockbox = new GlobalTaskLockbox(taskStorage, mdc);
     tac = new LocalTaskActionClientFactory(
         new TaskActionToolbox(
             taskLockbox,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockBoxConcurrencyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockBoxConcurrencyTest.java
@@ -58,7 +58,7 @@ public class TaskLockBoxConcurrencyTest
   private final ObjectMapper objectMapper = new DefaultObjectMapper();
   private ExecutorService service;
   private TaskStorage taskStorage;
-  private TaskLockbox lockbox;
+  private GlobalTaskLockbox lockbox;
   private SegmentSchemaManager segmentSchemaManager;
 
   @Before
@@ -77,7 +77,7 @@ public class TaskLockBoxConcurrencyTest
     );
 
     segmentSchemaManager = new SegmentSchemaManager(derby.metadataTablesConfigSupplier().get(), objectMapper, derbyConnector);
-    lockbox = new TaskLockbox(
+    lockbox = new GlobalTaskLockbox(
         taskStorage,
         new IndexerSQLMetadataStorageCoordinator(
             objectMapper,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockConfigTest.java
@@ -112,7 +112,7 @@ public class TaskLockConfigTest
     final TaskQueueConfig queueConfig = new TaskQueueConfig(null, null, null, null, null, null);
     final TaskRunner taskRunner = EasyMock.createNiceMock(RemoteTaskRunner.class);
     final TaskActionClientFactory actionClientFactory = EasyMock.createNiceMock(LocalTaskActionClientFactory.class);
-    final TaskLockbox lockbox = new TaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator());
+    final GlobalTaskLockbox lockbox = new GlobalTaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator());
     final ServiceEmitter emitter = new NoopServiceEmitter();
     return new TaskQueue(
         lockConfig,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueScaleTest.java
@@ -127,7 +127,7 @@ public class TaskQueueScaleTest
         taskStorage,
         taskRunner,
         unsupportedTaskActionFactory, // Not used for anything serious
-        new TaskLockbox(taskStorage, storageCoordinator),
+        new GlobalTaskLockbox(taskStorage, storageCoordinator),
         new NoopServiceEmitter(),
         jsonMapper,
         new NoopTaskContextEnricher()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -543,7 +543,7 @@ public class TaskQueueTest extends IngestionTestBase
         taskStorage,
         EasyMock.createMock(HttpRemoteTaskRunner.class),
         createActionClientFactory(),
-        new TaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator()),
+        new GlobalTaskLockbox(taskStorage, new TestIndexerMetadataStorageCoordinator()),
         new StubServiceEmitter("druid/overlord", "testHost"),
         mapper,
         new NoopTaskContextEnricher()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceTest.java
@@ -44,7 +44,7 @@ import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.DruidOverlord;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageAdapter;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskQueryTool;
 import org.apache.druid.indexing.overlord.TaskQueue;
@@ -107,7 +107,7 @@ public class OverlordResourceTest
   private DruidOverlord overlord;
   private TaskMaster taskMaster;
   private TaskStorage taskStorage;
-  private TaskLockbox taskLockbox;
+  private GlobalTaskLockbox taskLockbox;
   private JacksonConfigManager configManager;
   private ProvisioningStrategy provisioningStrategy;
   private AuthConfig authConfig;
@@ -133,7 +133,7 @@ public class OverlordResourceTest
     overlord = EasyMock.createStrictMock(DruidOverlord.class);
     taskMaster = EasyMock.createStrictMock(TaskMaster.class);
     taskStorage = EasyMock.createStrictMock(TaskStorage.class);
-    taskLockbox = EasyMock.createStrictMock(TaskLockbox.class);
+    taskLockbox = EasyMock.createStrictMock(GlobalTaskLockbox.class);
     taskQueryTool = new TaskQueryTool(
         taskStorage,
         taskLockbox,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordTest.java
@@ -52,7 +52,7 @@ import org.apache.druid.indexing.overlord.DruidOverlord;
 import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageAdapter;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskQueryTool;
 import org.apache.druid.indexing.overlord.TaskRunner;
@@ -110,7 +110,7 @@ public class OverlordTest
   private CuratorFramework curator;
   private DruidOverlord overlord;
   private TaskMaster taskMaster;
-  private TaskLockbox taskLockbox;
+  private GlobalTaskLockbox taskLockbox;
   private TaskStorage taskStorage;
   private TaskActionClientFactory taskActionClientFactory;
   private CountDownLatch announcementLatch;
@@ -179,7 +179,7 @@ public class OverlordTest
 
     IndexerMetadataStorageCoordinator mdc = new TestIndexerMetadataStorageCoordinator();
 
-    taskLockbox = new TaskLockbox(taskStorage, mdc);
+    taskLockbox = new GlobalTaskLockbox(taskStorage, mdc);
 
     task0 = NoopTask.create();
     taskId0 = task0.getId();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -72,7 +72,7 @@ import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.MetadataTaskStorage;
 import org.apache.druid.indexing.overlord.Segments;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
 import org.apache.druid.indexing.test.TestDataSegmentAnnouncer;
@@ -200,7 +200,7 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
   protected File reportsFile;
   protected TaskToolboxFactory toolboxFactory;
   protected TaskStorage taskStorage;
-  protected TaskLockbox taskLockbox;
+  protected GlobalTaskLockbox taskLockbox;
   protected IndexerMetadataStorageCoordinator metadataStorageCoordinator;
   protected final Set<Integer> checkpointRequestsHash = new HashSet<>();
   protected SegmentSchemaManager segmentSchemaManager;
@@ -598,7 +598,7 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
         segmentSchemaManager,
         CentralizedDatasourceSchemaConfig.create()
     );
-    taskLockbox = new TaskLockbox(taskStorage, metadataStorageCoordinator);
+    taskLockbox = new GlobalTaskLockbox(taskStorage, metadataStorageCoordinator);
     final TaskActionToolbox taskActionToolbox = new TaskActionToolbox(
         taskLockbox,
         taskStorage,

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -75,7 +75,7 @@ import org.apache.druid.indexing.overlord.HeapMemoryTaskStorage;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageAdapter;
 import org.apache.druid.indexing.overlord.MetadataTaskStorage;
 import org.apache.druid.indexing.overlord.RemoteTaskRunnerFactory;
-import org.apache.druid.indexing.overlord.TaskLockbox;
+import org.apache.druid.indexing.overlord.GlobalTaskLockbox;
 import org.apache.druid.indexing.overlord.TaskMaster;
 import org.apache.druid.indexing.overlord.TaskQueryTool;
 import org.apache.druid.indexing.overlord.TaskRunnerFactory;
@@ -245,7 +245,7 @@ public class CliOverlord extends ServerRunnable
 
             binder.bind(TaskActionClientFactory.class).to(LocalTaskActionClientFactory.class).in(LazySingleton.class);
             binder.bind(TaskActionToolbox.class).in(LazySingleton.class);
-            binder.bind(TaskLockbox.class).in(LazySingleton.class);
+            binder.bind(GlobalTaskLockbox.class).in(LazySingleton.class);
             binder.bind(TaskQueryTool.class).in(LazySingleton.class);
             binder.bind(IndexerMetadataStorageAdapter.class).in(LazySingleton.class);
             binder.bind(CompactionScheduler.class).to(OverlordCompactionScheduler.class).in(LazySingleton.class);


### PR DESCRIPTION
### Description

In clusters with a large number of datasources, task operations block each other owing to the `giant` lock in the `TaskLockbox`. This can become particularly problematic in cases of streaming ingestion being done into multiple datasources, where segment allocations become very slow since all of them must pass through a single queue.

None of the task operations share a critical section across datasources and it should suffice to perform the locking at the datasource level.

This patch is an attempt to remediate this problem.

### Changes

- Dedicate `TaskLockbox` to a single datasource.
- Add a `GlobalTaskLockbox` which delegates to the respective datasource for any operation.
- The `GlobalTaskLockbox.sync()` must still be mutually exclusive from any operation being performed on any of the datasources. This is performed by using a `ReentrantReadWriteLock`.

### Pending
- Maintain `SegmentAllocationQueue` at datasource level.
- Fix up tests
- Clean up the `TaskLockbox` for a datasource when it is not needed anymore
- Try out changes in a cluster

---

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
