### PR TITLE
fix endianness related issue with complex metric compression

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderObjectStrategy.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderObjectStrategy.java
@@ -79,6 +79,12 @@ public class HllSketchHolderObjectStrategy implements ObjectStrategy<HllSketchHo
     );
   }
 
+  @Override
+  public ByteOrder getByteOrder()
+  {
+    return ByteOrder.LITTLE_ENDIAN;
+  }
+
   /**
    * Checks if a sketch is empty and can be converted to null. Returns true if it is and false if it is not, or if is
    * not possible to say for sure.

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchObjectStrategy.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchObjectStrategy.java
@@ -73,4 +73,10 @@ public class KllDoublesSketchObjectStrategy implements ObjectStrategy<KllDoubles
         SafeWritableMemory.wrap(buffer, ByteOrder.LITTLE_ENDIAN).region(buffer.position(), numBytes)
     );
   }
+
+  @Override
+  public ByteOrder getByteOrder()
+  {
+    return ByteOrder.LITTLE_ENDIAN;
+  }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchObjectStrategy.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchObjectStrategy.java
@@ -73,4 +73,10 @@ public class KllFloatsSketchObjectStrategy implements ObjectStrategy<KllFloatsSk
         SafeWritableMemory.wrap(buffer, ByteOrder.LITTLE_ENDIAN).region(buffer.position(), numBytes)
     );
   }
+
+  @Override
+  public ByteOrder getByteOrder()
+  {
+    return ByteOrder.LITTLE_ENDIAN;
+  }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchObjectStrategy.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchObjectStrategy.java
@@ -73,4 +73,10 @@ public class DoublesSketchObjectStrategy implements ObjectStrategy<DoublesSketch
         SafeWritableMemory.wrap(buffer, ByteOrder.LITTLE_ENDIAN).region(buffer.position(), numBytes)
     );
   }
+
+  @Override
+  public ByteOrder getByteOrder()
+  {
+    return ByteOrder.LITTLE_ENDIAN;
+  }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchHolderObjectStrategy.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchHolderObjectStrategy.java
@@ -80,4 +80,10 @@ public class SketchHolderObjectStrategy implements ObjectStrategy<SketchHolder>
         SafeWritableMemory.wrap(buffer, ByteOrder.LITTLE_ENDIAN).region(buffer.position(), numBytes)
     );
   }
+
+  @Override
+  public ByteOrder getByteOrder()
+  {
+    return ByteOrder.LITTLE_ENDIAN;
+  }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchObjectStrategy.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchObjectStrategy.java
@@ -72,4 +72,10 @@ public class ArrayOfDoublesSketchObjectStrategy implements ObjectStrategy<ArrayO
         SafeWritableMemory.wrap(buffer, ByteOrder.LITTLE_ENDIAN).region(buffer.position(), numBytes)
     );
   }
+
+  @Override
+  public ByteOrder getByteOrder()
+  {
+    return ByteOrder.LITTLE_ENDIAN;
+  }
 }

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedBlockReader.java
@@ -59,6 +59,7 @@ public final class CompressedBlockReader implements Closeable
   public static Supplier<CompressedBlockReader> fromByteBuffer(
       ByteBuffer buffer,
       ByteOrder byteOrder,
+      ByteOrder valueOrder,
       boolean copyValuesOnRead
   )
   {
@@ -94,7 +95,8 @@ public final class CompressedBlockReader implements Closeable
           copyValuesOnRead,
           offsetView.asReadOnlyBuffer(),
           compressedDataView.asReadOnlyBuffer().order(byteOrder),
-          byteOrder
+          byteOrder,
+          valueOrder
       );
     }
     throw new IAE("Unknown version[%s]", versionFromBuffer);
@@ -123,7 +125,8 @@ public final class CompressedBlockReader implements Closeable
       boolean copyValuesOnRead,
       IntBuffer endOffsetsBuffer,
       ByteBuffer compressedDataBuffer,
-      ByteOrder byteOrder
+      ByteOrder compressionOrder,
+      ByteOrder valueOrder
   )
   {
     this.decompressor = compressionStrategy.getDecompressor();
@@ -134,11 +137,11 @@ public final class CompressedBlockReader implements Closeable
     this.endOffsetsBuffer = endOffsetsBuffer;
     this.compressedDataBuffer = compressedDataBuffer;
     this.closer = Closer.create();
-    this.decompressedDataBufferHolder = CompressedPools.getByteBuf(byteOrder);
+    this.decompressedDataBufferHolder = CompressedPools.getByteBuf(compressionOrder);
     closer.register(decompressedDataBufferHolder);
     this.decompressedDataBuffer = decompressedDataBufferHolder.get();
     this.decompressedDataBuffer.clear();
-    this.byteOrder = byteOrder;
+    this.byteOrder = valueOrder;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedLongsReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedLongsReader.java
@@ -29,7 +29,7 @@ public final class CompressedLongsReader implements ColumnarLongs
 {
   public static Supplier<CompressedLongsReader> fromByteBuffer(ByteBuffer buffer, ByteOrder order)
   {
-    final Supplier<CompressedBlockReader> baseReader = CompressedBlockReader.fromByteBuffer(buffer, order, false);
+    final Supplier<CompressedBlockReader> baseReader = CompressedBlockReader.fromByteBuffer(buffer, order, order, false);
     return () -> new CompressedLongsReader(baseReader.get());
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/data/ObjectStrategy.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/ObjectStrategy.java
@@ -26,6 +26,7 @@ import org.apache.druid.segment.writeout.WriteOutBytes;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Comparator;
 
 @ExtensionPoint
@@ -75,6 +76,18 @@ public interface ObjectStrategy<T> extends Comparator<T>
   default boolean readRetainsBufferReference()
   {
     return true;
+  }
+
+  /**
+   * Preferred byte order to read values from a buffer with {@link #fromByteBuffer(ByteBuffer, int)} and similar methods
+   *
+   * This is currently only used as a helper for {@link org.apache.druid.segment.serde.CompressedComplexColumn} when
+   * {@link org.apache.druid.segment.IndexSpec#complexMetricCompression} is set, so that the buffer does not need
+   * to be explicitly set inside the object strategy when materializing values
+   */
+  default ByteOrder getByteOrder()
+  {
+    return ByteOrder.BIG_ENDIAN;
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataComplexTypeSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataComplexTypeSerde.java
@@ -43,6 +43,7 @@ import org.apache.druid.segment.serde.ComplexMetricSerde;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public class NestedDataComplexTypeSerde extends ComplexMetricSerde
 {
@@ -146,6 +147,12 @@ public class NestedDataComplexTypeSerde extends ComplexMetricSerde
       public boolean readRetainsBufferReference()
       {
         return false;
+      }
+
+      @Override
+      public ByteOrder getByteOrder()
+      {
+        return ByteOrder.LITTLE_ENDIAN;
       }
     };
   }

--- a/processing/src/main/java/org/apache/druid/segment/serde/CompressedComplexColumnSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/CompressedComplexColumnSupplier.java
@@ -67,6 +67,7 @@ public class CompressedComplexColumnSupplier implements Supplier<ComplexColumn>
             ),
             fileBuffer,
             metadata.getByteOrder(),
+            objectStrategy.getByteOrder(),
             objectStrategy.readRetainsBufferReference(),
             mapper
         );


### PR DESCRIPTION
This PR is a follow-up to #16863 to fix a problem for any complex metrics which do not specify the byte order of the underlying buffer and were counting on the java big endian default (such as `approxHistogram`).

The underlying `CompressedBlockReader` already had the ability to specify an order on the buffer for values it reads, but it was just specifying the same order that the compression was using, which is native order by default for performance reasons.

To push this into the block reader, I have added `ObjectStrategy.getByteOrder()` with a default implementation returning big endian, though it probably would have been safe to hard-code to use big endian, since the things that need little endian were already explicitly ordering stuff on value read. However, thinking forward it seems like it would be nice to not have to re-order the values again in the object strategy if we can know ahead of time.

I have added implementations for `ObjectStrategy` which i knew were little endian, even though they are already explicitly ordering values on read due to the behavior of the uncompressed complex columns.