### PR TITLE
RunWorkOrder: Skip creating sorterTmpDir up front.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
@@ -825,11 +825,6 @@ public class RunWorkOrder
             final StageDefinition stageDefinition = workOrder.getStageDefinition();
 
             final File sorterTmpDir = frameContext.tempDir("super-sort");
-            FileUtils.mkdirp(sorterTmpDir);
-            if (!sorterTmpDir.isDirectory()) {
-              throw new IOException("Cannot create directory: " + sorterTmpDir);
-            }
-
             final WorkerMemoryParameters memoryParameters = frameContext.memoryParameters();
             final SuperSorter sorter = new SuperSorter(
                 resultAndChannels.getOutputChannels().getAllReadableChannels(),


### PR DESCRIPTION
There's no need to create it upfront, because it will be created on demand if we actually need it. And, if we don't end up needing it (because the sort can be done in memory), then we can skip creating it altogether.