### PR TITLE
GroupByQueryConfig: Skip unnecessary toString.

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryConfig.java
@@ -370,7 +370,7 @@ public class GroupByQueryConfig
         isMultiValueUnnestingEnabled()
     );
 
-    logger.debug("Override config for GroupBy query %s - %s", query.getId(), newConfig.toString());
+    logger.debug("Override config for GroupBy query %s - %s", query.getId(), newConfig);
     return newConfig;
   }
 


### PR DESCRIPTION
Calling toString on newConfig is unnecessary, because it will be done automatically by the logger. This saves some effort under log levels higher than DEBUG.