### PR TITLE
Handle empty values for task and datasource conditions in pod template selector

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/Selector.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/Selector.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.query.DruidMetrics;
+import org.apache.druid.utils.CollectionUtils;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -70,6 +72,7 @@ public class Selector
   public boolean evaluate(Task task)
   {
     boolean isMatch = true;
+
     if (cxtTagsConditions != null) {
       isMatch = cxtTagsConditions.entrySet().stream().allMatch(entry -> {
         String tagKey = entry.getKey();
@@ -80,15 +83,15 @@ public class Selector
         }
         Object tagValue = tags.get(tagKey);
 
-        return tagValue == null ? false : tagValues.contains((String) tagValue);
+        return tagValue != null && tagValues.contains((String) tagValue);
       });
     }
 
-    if (isMatch && taskTypeCondition != null) {
+    if (isMatch && !CollectionUtils.isNullOrEmpty(taskTypeCondition)) {
       isMatch = taskTypeCondition.contains(task.getType());
     }
 
-    if (isMatch && dataSourceCondition != null) {
+    if (isMatch && !CollectionUtils.isNullOrEmpty(dataSourceCondition)) {
       isMatch = dataSourceCondition.contains(task.getDataSource());
     }
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/Selector.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/Selector.java
@@ -25,7 +25,6 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.utils.CollectionUtils;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorTest.java
@@ -30,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -47,7 +48,7 @@ public class SelectorTest
         "TestSelector",
         cxtTagsConditions,
         Sets.newHashSet(NoopTask.TYPE),
-        Sets.newHashSet()
+        new HashSet<>()
     );
 
     Assert.assertTrue(selector.evaluate(task));
@@ -65,7 +66,7 @@ public class SelectorTest
     Selector selector = new Selector(
         "TestSelector",
         cxtTagsConditions,
-        Sets.newHashSet(),
+        new HashSet<>(),
         Sets.newHashSet(datasource)
     );
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorTest.java
@@ -37,7 +37,8 @@ import java.util.Set;
 public class SelectorTest
 {
   @Test
-  public void shouldReturnTrueWhenMatchTasksTagsAndEmptyDataSource() {
+  public void shouldReturnTrueWhenMatchTasksTagsAndEmptyDataSource()
+  {
     Map<String, Set<String>> cxtTagsConditions = new HashMap<>();
     cxtTagsConditions.put("tag1", Sets.newHashSet("tag1Value"));
 
@@ -55,7 +56,8 @@ public class SelectorTest
   }
 
   @Test
-  public void shouldReturnTrueWhenMatchDataSourceTagsAndEmptyTasks() {
+  public void shouldReturnTrueWhenMatchDataSourceTagsAndEmptyTasks()
+  {
     String datasource = "table";
     Map<String, Set<String>> cxtTagsConditions = new HashMap<>();
     cxtTagsConditions.put("tag1", Sets.newHashSet("tag1Value"));
@@ -74,7 +76,8 @@ public class SelectorTest
   }
 
   @Test
-  public void shouldReturnTrueWhenMatchDataSourceTasksAndEmptyTags() {
+  public void shouldReturnTrueWhenMatchDataSourceTasksAndEmptyTags()
+  {
     String datasource = "table";
     Map<String, Set<String>> cxtTagsConditions = new HashMap<>();
 

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorTest.java
@@ -35,6 +35,59 @@ import java.util.Set;
 
 public class SelectorTest
 {
+  @Test
+  public void shouldReturnTrueWhenMatchTasksTagsAndEmptyDataSource() {
+    Map<String, Set<String>> cxtTagsConditions = new HashMap<>();
+    cxtTagsConditions.put("tag1", Sets.newHashSet("tag1Value"));
+
+    Task task = NoopTask.create();
+    task.addToContext(DruidMetrics.TAGS, ImmutableMap.of("tag1", "tag1Value"));
+
+    Selector selector = new Selector(
+        "TestSelector",
+        cxtTagsConditions,
+        Sets.newHashSet(NoopTask.TYPE),
+        Sets.newHashSet()
+    );
+
+    Assert.assertTrue(selector.evaluate(task));
+  }
+
+  @Test
+  public void shouldReturnTrueWhenMatchDataSourceTagsAndEmptyTasks() {
+    String datasource = "table";
+    Map<String, Set<String>> cxtTagsConditions = new HashMap<>();
+    cxtTagsConditions.put("tag1", Sets.newHashSet("tag1Value"));
+
+    Task task = NoopTask.forDatasource(datasource);
+    task.addToContext(DruidMetrics.TAGS, ImmutableMap.of("tag1", "tag1Value"));
+
+    Selector selector = new Selector(
+        "TestSelector",
+        cxtTagsConditions,
+        Sets.newHashSet(),
+        Sets.newHashSet(datasource)
+    );
+
+    Assert.assertTrue(selector.evaluate(task));
+  }
+
+  @Test
+  public void shouldReturnTrueWhenMatchDataSourceTasksAndEmptyTags() {
+    String datasource = "table";
+    Map<String, Set<String>> cxtTagsConditions = new HashMap<>();
+
+    Task task = NoopTask.forDatasource(datasource);
+
+    Selector selector = new Selector(
+        "TestSelector",
+        cxtTagsConditions,
+        Sets.newHashSet(NoopTask.TYPE),
+        Sets.newHashSet(datasource)
+    );
+
+    Assert.assertTrue(selector.evaluate(task));
+  }
 
   @Test
   public void shouldReturnTrueWhenAllTagsAndTasksMatch()


### PR DESCRIPTION
### Description

The condition based selector that evaluates tasks based on specified criteria failed to handle empty values for task type or datasource. If the condition is empty or null it can be matched to any task, but previous logic checked for task type or task datasource in the empty set resulting in skipping of that selector. Expected behavior is to treat empty sets the same as null.
Fixed the evaluate method in Selector to check if the task type or datasource conditions are null or empty instead of just a null check.

#### Release note
Fixed: You can now pass empty arrays to `type` and `dataSource` keys in selector based pod template selection strategy
<hr>

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.