### PR TITLE
MSQ ingestion: Improve error message on encountering non-long timestamp column

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
@@ -114,7 +114,13 @@ public class MSQTasks
       // be a long at execution time. So a nice user-friendly message isn't needed here: it would only happen
       // if the SQL layer is bypassed. Nice, friendly users wouldn't do that :)
       final UnknownFault fault =
-          UnknownFault.forMessage(StringUtils.format("Incorrect type for [%s]", ColumnHolder.TIME_COLUMN_NAME));
+          UnknownFault.forMessage(
+              StringUtils.format(
+                  "Incorrect type for column [%s]. Expected [Long] but got [%s]. Please ensure the value is casted to [Long].",
+                  ColumnHolder.TIME_COLUMN_NAME,
+                  timestamp.getClass().getSimpleName()
+              )
+          );
       throw new MSQException(fault);
     }
   }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/MSQTasks.java
@@ -116,7 +116,7 @@ public class MSQTasks
       final UnknownFault fault =
           UnknownFault.forMessage(
               StringUtils.format(
-                  "Incorrect type for column [%s]. Expected [Long] but got [%s]. Please ensure the value is casted to [Long].",
+                  "Incorrect type for column [%s]. Expected LONG but got type [%s]. Please ensure that the value is cast to LONG.",
                   ColumnHolder.TIME_COLUMN_NAME,
                   timestamp.getClass().getSimpleName()
               )

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
@@ -278,7 +278,8 @@ public class MSQTasksTest
                 ColumnHolder.TIME_COLUMN_NAME,
                 timestamp.getClass().getSimpleName()
             )
-        ), e.getFault()
+        ),
+        e.getFault()
     );
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQTasksTest.java
@@ -34,8 +34,10 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.msq.indexing.MSQWorkerTask;
 import org.apache.druid.msq.indexing.MSQWorkerTaskLauncher;
+import org.apache.druid.msq.indexing.error.InsertTimeNullFault;
 import org.apache.druid.msq.indexing.error.MSQErrorReport;
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.indexing.error.MSQFaultUtils;
@@ -46,6 +48,7 @@ import org.apache.druid.msq.indexing.error.TooManyColumnsFault;
 import org.apache.druid.msq.indexing.error.TooManyWorkersFault;
 import org.apache.druid.msq.indexing.error.UnknownFault;
 import org.apache.druid.msq.indexing.error.WorkerRpcFailedFault;
+import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.utils.CollectionUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -242,6 +245,41 @@ public class MSQTasksTest
           MSQFaultUtils.generateMessageWithErrorCode(((MSQException) e.getCause()).getFault())
       );
     }
+  }
+
+  @Test
+  public void test_getPrimaryTimestampFromObjectForInsert_longValue()
+  {
+    Assert.assertEquals(100, MSQTasks.primaryTimestampFromObjectForInsert(100L));
+  }
+
+  @Test
+  public void test_getPrimaryTimestampFromObjectForInsert_nullValueShouldThrowError()
+  {
+    final MSQException e = Assert.assertThrows(
+        MSQException.class,
+        () -> MSQTasks.primaryTimestampFromObjectForInsert(null)
+    );
+    Assert.assertEquals(InsertTimeNullFault.INSTANCE, e.getFault());
+  }
+
+  @Test
+  public void test_getPrimaryTimestampFromObjectForInsert_DoubleValueShouldThrowError()
+  {
+    final Object timestamp = 1.693837200123456E15;
+    final MSQException e = Assert.assertThrows(
+        MSQException.class,
+        () -> MSQTasks.primaryTimestampFromObjectForInsert(timestamp)
+    );
+    Assert.assertEquals(
+        UnknownFault.forMessage(
+            StringUtils.format(
+                "Incorrect type for column [%s]. Expected LONG but got type [%s]. Please ensure that the value is cast to LONG.",
+                ColumnHolder.TIME_COLUMN_NAME,
+                timestamp.getClass().getSimpleName()
+            )
+        ), e.getFault()
+    );
   }
 
   static class TasksTestOverlordClient extends NoopOverlordClient


### PR DESCRIPTION
### Description

This PR improves the error message during MSQ ingestion if we encounter a non-long timestamp column.

Sample error message shown to user:
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/a9fe3d4e-f886-4ada-b6eb-b2e9d5e702db">

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
