### PR TITLE
Update errorprone, mockito, jacoco, checkerframework.

### DIFF
--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.aggregation.datasketches.hll;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.datasketches.hll.HllSketch;
 import org.apache.datasketches.hll.TgtHllType;
 import org.apache.druid.java.util.common.StringEncoding;
@@ -120,11 +121,9 @@ public class HllSketchAggregatorFactoryTest
   }
 
   @Test
-  public void testEqualsSameObject()
+  public void testEquals()
   {
-    //noinspection EqualsWithItself
-    Assert.assertEquals(target, target);
-    Assert.assertArrayEquals(target.getCacheKey(), target.getCacheKey());
+    EqualsVerifier.forClass(HllSketchAggregatorFactory.class).usingGetClass().verify();
   }
 
   @Test

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.data.input.kafkainput;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.data.input.kafka.KafkaRecordEntity;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Pair;
@@ -72,15 +73,11 @@ public class KafkaStringHeaderFormatTest
       }
   );
   private KafkaRecordEntity inputEntity;
-  private long timestamp = DateTimes.of("2021-06-24T00:00:00.000Z").getMillis();
+  private final long timestamp = DateTimes.of("2021-06-24T00:00:00.000Z").getMillis();
 
   @Test
   public void testSerde() throws JsonProcessingException
   {
-    Assert.assertEquals(
-        KAFKAHEADERNOENCODE,
-        KAFKAHEADERNOENCODE
-    );
     Assert.assertEquals(
         KAFKAHEADERNOENCODE,
         MAPPER.readValue(MAPPER.writeValueAsString(KAFKAHEADERNOENCODE), KafkaStringHeaderFormat.class)
@@ -90,6 +87,12 @@ public class KafkaStringHeaderFormatTest
         KAFKAHEADERNOENCODE,
         kafkaAsciiHeader
     );
+  }
+
+  @Test
+  public void testEquals()
+  {
+    EqualsVerifier.forClass(KafkaStringHeaderFormat.class).usingGetClass().verify();
   }
 
   @Test

--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -140,6 +140,11 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- explicitly declare mockito-core dependency to make anaylize-dependencies happy when running with Java 8 -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DataSegmentAndIndexZipFilePath.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DataSegmentAndIndexZipFilePath.java
@@ -70,19 +70,22 @@ public class DataSegmentAndIndexZipFilePath
   @Override
   public boolean equals(Object o)
   {
-    if (o instanceof DataSegmentAndIndexZipFilePath) {
-      DataSegmentAndIndexZipFilePath that = (DataSegmentAndIndexZipFilePath) o;
-      return segment.equals(((DataSegmentAndIndexZipFilePath) o).getSegment())
-          && tmpIndexZipFilePath.equals(that.getTmpIndexZipFilePath())
-          && finalIndexZipFilePath.equals(that.getFinalIndexZipFilePath());
+    if (this == o) {
+      return true;
     }
-    return false;
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DataSegmentAndIndexZipFilePath that = (DataSegmentAndIndexZipFilePath) o;
+    return Objects.equals(segment, that.segment)
+           && Objects.equals(tmpIndexZipFilePath, that.tmpIndexZipFilePath)
+           && Objects.equals(finalIndexZipFilePath, that.finalIndexZipFilePath);
   }
 
   @Override
   public int hashCode()
   {
-    return Objects.hash(segment.getId(), tmpIndexZipFilePath);
+    return Objects.hash(segment, tmpIndexZipFilePath, finalIndexZipFilePath);
   }
 
   @Override

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DataSegmentAndIndexZipFilePathTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DataSegmentAndIndexZipFilePathTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexer;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
@@ -149,17 +150,9 @@ public class DataSegmentAndIndexZipFilePathTest
   }
 
   @Test
-  public void test_equals_sameObject_equal()
+  public void test_equals()
   {
-    String tmpPath = "tmpPath";
-    String finalPath = "finalPath";
-    target = new DataSegmentAndIndexZipFilePath(
-        SEGMENT,
-        tmpPath,
-        finalPath
-    );
-
-    Assert.assertEquals(target, target);
+    EqualsVerifier.forClass(DataSegmentAndIndexZipFilePath.class).usingGetClass().verify();
   }
 
   @Test

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -331,7 +331,7 @@ name: Error Prone Annotations
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.20.0
+version: 2.35.1
 libraries:
   - com.google.errorprone: error_prone_annotations
 
@@ -3285,7 +3285,7 @@ name: Checker Qual
 license_category: binary
 module: java-core
 license_name: MIT License
-version: 2.5.7
+version: 3.48.1
 copyright: the Checker Framework developers
 license_file_path: licenses/bin/checker-qual.MIT
 libraries:

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.2.22</dropwizard.metrics.version>
-        <errorprone.version>2.20.0</errorprone.version>
+        <errorprone.version>2.35.1</errorprone.version>
         <fastutil.version>8.5.4</fastutil.version>
         <guava.version>32.0.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
@@ -114,19 +114,19 @@
         <jna.version>5.13.0</jna.version>
         <jna-platform.version>5.13.0</jna-platform.version>
         <hadoop.compile.version>3.3.6</hadoop.compile.version>
-        <mockito.version>5.5.0</mockito.version>
+        <mockito.version>5.14.2</mockito.version>
         <!-- mockito-inline artifact was removed in mockito 5.3 (mockito 5.x is required for Java >17),
              however it is required in some cases when running against mockito 4.x (mockito 4.x is required for Java <11.
              We use the following property to pick the proper artifact based on Java version (see pre-java-11 profile) -->
         <mockito.inline.artifact>core</mockito.inline.artifact>
         <aws.sdk.version>1.12.638</aws.sdk.version>
         <caffeine.version>2.8.0</caffeine.version>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
         <zookeeper.version>3.8.4</zookeeper.version>
-        <checkerframework.version>2.5.7</checkerframework.version>
+        <checkerframework.version>3.48.1</checkerframework.version>
         <com.google.apis.client.version>2.2.0</com.google.apis.client.version>
         <com.google.http.client.apis.version>1.42.3</com.google.http.client.apis.version>
         <com.google.apis.compute.version>v1-rev20230606-2.0.0</com.google.apis.compute.version>

--- a/processing/src/main/java/org/apache/druid/query/operator/ScanOperatorFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/operator/ScanOperatorFactory.java
@@ -115,16 +115,16 @@ public class ScanOperatorFactory implements OperatorFactory
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ScanOperatorFactory)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
     ScanOperatorFactory that = (ScanOperatorFactory) o;
-    return Objects.equals(offsetLimit, that.offsetLimit)
-        && Objects.equals(timeRange, that.timeRange)
-        && Objects.equals(filter, that.filter)
-        && Objects.equals(projectedColumns, that.projectedColumns)
-        && Objects.equals(virtualColumns, that.virtualColumns)
-        && Objects.equals(ordering, that.ordering);
+    return Objects.equals(timeRange, that.timeRange)
+           && Objects.equals(filter, that.filter)
+           && Objects.equals(offsetLimit, that.offsetLimit)
+           && Objects.equals(projectedColumns, that.projectedColumns)
+           && Objects.equals(virtualColumns, that.virtualColumns)
+           && Objects.equals(ordering, that.ordering);
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/java/util/metrics/AllocationMetricCollectorTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/metrics/AllocationMetricCollectorTest.java
@@ -48,7 +48,6 @@ public class AllocationMetricCollectorTest
     }
 
     long delta = collector.calculateDelta();
-    Assert.assertNotNull(delta);
     Assert.assertTrue(delta > 0);
     log.info("First delta: %s", delta);
 

--- a/processing/src/test/java/org/apache/druid/java/util/metrics/JvmPidDiscovererTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/metrics/JvmPidDiscovererTest.java
@@ -19,7 +19,8 @@
 
 package org.apache.druid.java.util.metrics;
 
-import org.junit.Assert;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 public class JvmPidDiscovererTest
@@ -27,6 +28,9 @@ public class JvmPidDiscovererTest
   @Test
   public void getPid()
   {
-    Assert.assertNotNull(JvmPidDiscoverer.instance().getPid());
+    MatcherAssert.assertThat(
+        JvmPidDiscoverer.instance().getPid(),
+        Matchers.greaterThan(0L)
+    );
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/operator/ScanOperatorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/operator/ScanOperatorFactoryTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
@@ -58,24 +59,7 @@ public class ScanOperatorFactoryTest
   @Test
   public void testEquals()
   {
-    final Builder bob = new Builder();
-    bob.timeRange = Intervals.utc(0, 6);
-    bob.filter = DimFilters.dimEquals("abc", "b");
-    bob.offsetLimit = OffsetLimit.limit(48);
-    bob.projectedColumns = Arrays.asList("a", "b");
-    bob.virtualColumns = VirtualColumns.EMPTY;
-    bob.ordering = Collections.singletonList(ColumnWithDirection.ascending("a"));
-    ScanOperatorFactory factory = bob.build();
-
-    Assert.assertEquals(factory, factory);
-    Assert.assertNotEquals(factory, new Object());
-
-    Assert.assertNotEquals(factory, bob.copy().setTimeRange(null).build());
-    Assert.assertNotEquals(factory, bob.copy().setFilter(null).build());
-    Assert.assertNotEquals(factory, bob.copy().setOffsetLimit(null).build());
-    Assert.assertNotEquals(factory, bob.copy().setProjectedColumns(null).build());
-    Assert.assertNotEquals(factory, bob.copy().setVirtualColumns(null).build());
-    Assert.assertNotEquals(factory, bob.copy().setOrdering(null).build());
+    EqualsVerifier.forClass(ScanOperatorFactory.class).usingGetClass().verify();
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/VirtualColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/VirtualColumnsTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Longs;
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
 import org.apache.druid.query.dimension.ExtractionDimensionSpec;
@@ -395,26 +396,16 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   @Test
   public void testEqualsAndHashCode()
   {
-    final VirtualColumns virtualColumns = VirtualColumns.create(
-        ImmutableList.of(
-            new ExpressionVirtualColumn("expr", "x + y", ColumnType.FLOAT, TestExprMacroTable.INSTANCE)
-        )
-    );
-
-    final VirtualColumns virtualColumns2 = VirtualColumns.create(
-        ImmutableList.of(
-            new ExpressionVirtualColumn("expr", "x + y", ColumnType.FLOAT, TestExprMacroTable.INSTANCE)
-        )
-    );
-
-    Assert.assertEquals(virtualColumns, virtualColumns);
-    Assert.assertEquals(virtualColumns, virtualColumns2);
-    Assert.assertNotEquals(VirtualColumns.EMPTY, virtualColumns);
-    Assert.assertNotEquals(VirtualColumns.EMPTY, null);
-
-    Assert.assertEquals(virtualColumns.hashCode(), virtualColumns.hashCode());
-    Assert.assertEquals(virtualColumns.hashCode(), virtualColumns2.hashCode());
-    Assert.assertNotEquals(VirtualColumns.EMPTY.hashCode(), virtualColumns.hashCode());
+    EqualsVerifier.forClass(VirtualColumns.class)
+                  .usingGetClass()
+                  .withIgnoredFields(
+                      "virtualColumnNames",
+                      "equivalence",
+                      "withDotSupport",
+                      "withoutDotSupport",
+                      "hasNoDotColumns"
+                  )
+                  .verify();
   }
 
   @Test

--- a/server/src/test/java/org/apache/druid/catalog/model/TableMetadataTest.java
+++ b/server/src/test/java/org/apache/druid/catalog/model/TableMetadataTest.java
@@ -42,7 +42,6 @@ public class TableMetadataTest
   public void testId()
   {
     TableId id1 = new TableId("schema", "table");
-    assertEquals(id1, id1);
     assertEquals("schema", id1.schema());
     assertEquals("table", id1.name());
     assertEquals("\"schema\".\"table\"", id1.sqlName());

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -1389,7 +1389,6 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
           ),
           rows
       );
-      Assert.assertEquals(rows, rows);
     }
   }
 


### PR DESCRIPTION
This patch updates various build and test dependencies, to see if they cause unit tests on JDK 21 to behave more reliably.