### PR TITLE
DruidOverlord: Move becomeLeader/stopBeingLeader earlier.

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
@@ -172,7 +172,7 @@ public class DruidOverlord
                 {
                   serviceAnnouncer.unannounce(node);
                   compactionScheduler.stop();
-                  taskMaster.stopBeingLeader();
+                  taskMaster.downgradeToHalfLeader();
                 }
               }
           );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
@@ -132,6 +132,21 @@ public class DruidOverlord
 
           leaderLifecycle.addManagedInstance(taskRunner);
           leaderLifecycle.addManagedInstance(taskQueue);
+          leaderLifecycle.addHandler(
+              new Lifecycle.Handler() {
+                @Override
+                public void start()
+                {
+                  taskMaster.becomeLeader(taskRunner, taskQueue);
+                }
+
+                @Override
+                public void stop()
+                {
+                  taskMaster.stopBeingLeader();
+                }
+              }
+          );
           leaderLifecycle.addManagedInstance(supervisorManager);
           leaderLifecycle.addManagedInstance(overlordDutyExecutor);
           leaderLifecycle.addHandler(
@@ -141,7 +156,6 @@ public class DruidOverlord
                 public void start()
                 {
                   segmentAllocationQueue.becomeLeader();
-                  taskMaster.becomeLeader(taskRunner, taskQueue);
                   compactionScheduler.start();
 
                   // Announce the node only after all the services have been initialized
@@ -154,7 +168,6 @@ public class DruidOverlord
                 {
                   serviceAnnouncer.unannounce(node);
                   compactionScheduler.stop();
-                  taskMaster.stopBeingLeader();
                   segmentAllocationQueue.stopBeingLeader();
                 }
               }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
@@ -74,13 +74,21 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
   }
 
   /**
-   * Enter state {@link LeadershipState#HALF_LEADER}.
+   * Enter state {@link LeadershipState#HALF_LEADER}, from any state.
    */
   public void becomeHalfLeader(TaskRunner taskRunner, TaskQueue taskQueue)
   {
     this.taskRunner = taskRunner;
     this.taskQueue = taskQueue;
     leadershipState.set(LeadershipState.HALF_LEADER);
+  }
+
+  /**
+   * Enter state {@link LeadershipState#HALF_LEADER}, from {@link LeadershipState#FULL_LEADER}.
+   */
+  public void downgradeToHalfLeader()
+  {
+    leadershipState.compareAndSet(LeadershipState.FULL_LEADER, LeadershipState.HALF_LEADER);
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
@@ -103,8 +103,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<TaskRunner> getTaskRunner()
   {
-    if (leadershipState.get() == LeadershipState.HALF_LEADER
-        || leadershipState.get() == LeadershipState.FULL_LEADER) {
+    if (isHalfOrFullLeader()) {
       return Optional.of(taskRunner);
     } else {
       return Optional.absent();
@@ -113,8 +112,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<TaskQueue> getTaskQueue()
   {
-    if (leadershipState.get() == LeadershipState.HALF_LEADER
-        || leadershipState.get() == LeadershipState.FULL_LEADER) {
+    if (isHalfOrFullLeader()) {
       return Optional.of(taskQueue);
     } else {
       return Optional.absent();
@@ -123,8 +121,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<TaskActionClient> getTaskActionClient(Task task)
   {
-    if (leadershipState.get() == LeadershipState.HALF_LEADER
-        || leadershipState.get() == LeadershipState.FULL_LEADER) {
+    if (isHalfOrFullLeader()) {
       return Optional.of(taskActionClientFactory.create(task));
     } else {
       return Optional.absent();
@@ -133,8 +130,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<ScalingStats> getScalingStats()
   {
-    if (leadershipState.get() == LeadershipState.HALF_LEADER
-        || leadershipState.get() == LeadershipState.FULL_LEADER) {
+    if (isHalfOrFullLeader()) {
       return taskRunner.getScalingStats();
     } else {
       return Optional.absent();
@@ -143,7 +139,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<SupervisorManager> getSupervisorManager()
   {
-    if (leadershipState.get() == LeadershipState.FULL_LEADER) {
+    if (isFullLeader()) {
       return Optional.of(supervisorManager);
     } else {
       return Optional.absent();
@@ -274,5 +270,16 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
     } else {
       return null;
     }
+  }
+
+  public boolean isHalfOrFullLeader()
+  {
+    final LeadershipState state = leadershipState.get();
+    return state == LeadershipState.HALF_LEADER || state == LeadershipState.FULL_LEADER;
+  }
+
+  public boolean isFullLeader()
+  {
+    return leadershipState.get() == LeadershipState.FULL_LEADER;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskMaster.java
@@ -32,7 +32,7 @@ import org.apache.druid.server.metrics.TaskSlotCountStatsProvider;
 
 import javax.annotation.Nullable;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Encapsulates various Overlord classes that allow querying and updating the
@@ -40,12 +40,28 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsProvider
 {
+  enum LeadershipState
+  {
+    NOT_LEADER,
+
+    /**
+     * Leader of essential services only: task queue, task action client, and task runner. We enter this state after
+     * the queue and runner are initialized, but before the supervisor manager is not yet initialized.
+     */
+    HALF_LEADER,
+
+    /**
+     * Leader of all services. We enter this state after the supervisor manager is initialized.
+     */
+    FULL_LEADER
+  }
+
   private final TaskActionClientFactory taskActionClientFactory;
   private final SupervisorManager supervisorManager;
   private volatile TaskRunner taskRunner;
   private volatile TaskQueue taskQueue;
 
-  private final AtomicBoolean isLeader = new AtomicBoolean(false);
+  private final AtomicReference<LeadershipState> leadershipState = new AtomicReference<>(LeadershipState.NOT_LEADER);
 
   @Inject
   public TaskMaster(
@@ -57,28 +73,38 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
     this.supervisorManager = supervisorManager;
   }
 
-  public void becomeLeader(TaskRunner taskRunner, TaskQueue taskQueue)
+  /**
+   * Enter state {@link LeadershipState#HALF_LEADER}.
+   */
+  public void becomeHalfLeader(TaskRunner taskRunner, TaskQueue taskQueue)
   {
     this.taskRunner = taskRunner;
     this.taskQueue = taskQueue;
-    isLeader.set(true);
+    leadershipState.set(LeadershipState.HALF_LEADER);
   }
 
+  /**
+   * Enter state {@link LeadershipState#FULL_LEADER}.
+   */
+  public void becomeFullLeader()
+  {
+    leadershipState.set(LeadershipState.FULL_LEADER);
+  }
+
+  /**
+   * Enter state {@link LeadershipState#NOT_LEADER}.
+   */
   public void stopBeingLeader()
   {
-    isLeader.set(false);
+    leadershipState.set(LeadershipState.NOT_LEADER);
     this.taskQueue = null;
     this.taskRunner = null;
   }
 
-  private boolean isLeader()
-  {
-    return isLeader.get();
-  }
-
   public Optional<TaskRunner> getTaskRunner()
   {
-    if (isLeader()) {
+    if (leadershipState.get() == LeadershipState.HALF_LEADER
+        || leadershipState.get() == LeadershipState.FULL_LEADER) {
       return Optional.of(taskRunner);
     } else {
       return Optional.absent();
@@ -87,7 +113,8 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<TaskQueue> getTaskQueue()
   {
-    if (isLeader()) {
+    if (leadershipState.get() == LeadershipState.HALF_LEADER
+        || leadershipState.get() == LeadershipState.FULL_LEADER) {
       return Optional.of(taskQueue);
     } else {
       return Optional.absent();
@@ -96,7 +123,8 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<TaskActionClient> getTaskActionClient(Task task)
   {
-    if (isLeader()) {
+    if (leadershipState.get() == LeadershipState.HALF_LEADER
+        || leadershipState.get() == LeadershipState.FULL_LEADER) {
       return Optional.of(taskActionClientFactory.create(task));
     } else {
       return Optional.absent();
@@ -105,7 +133,8 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<ScalingStats> getScalingStats()
   {
-    if (isLeader()) {
+    if (leadershipState.get() == LeadershipState.HALF_LEADER
+        || leadershipState.get() == LeadershipState.FULL_LEADER) {
       return taskRunner.getScalingStats();
     } else {
       return Optional.absent();
@@ -114,7 +143,7 @@ public class TaskMaster implements TaskCountStatsProvider, TaskSlotCountStatsPro
 
   public Optional<SupervisorManager> getSupervisorManager()
   {
-    if (isLeader()) {
+    if (leadershipState.get() == LeadershipState.FULL_LEADER) {
       return Optional.of(supervisorManager);
     } else {
       return Optional.absent();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
@@ -113,6 +113,7 @@ public class OverlordCompactionSchedulerTest
 
     taskMaster = new TaskMaster(null, null);
     taskMaster.becomeHalfLeader(taskRunner, taskQueue);
+    taskMaster.becomeFullLeader();
 
     taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
@@ -95,7 +95,6 @@ public class OverlordCompactionSchedulerTest
   private CoordinatorOverlordServiceConfig coordinatorOverlordServiceConfig;
 
   private TaskMaster taskMaster;
-  private TaskRunner taskRunner;
   private TaskQueue taskQueue;
   private BlockingExecutorService executor;
 
@@ -108,12 +107,20 @@ public class OverlordCompactionSchedulerTest
   @Before
   public void setUp()
   {
-    taskRunner = Mockito.mock(TaskRunner.class);
+    final TaskRunner taskRunner = Mockito.mock(TaskRunner.class);
     taskQueue = Mockito.mock(TaskQueue.class);
 
     taskMaster = new TaskMaster(null, null);
+    Assert.assertFalse(taskMaster.isHalfOrFullLeader());
+    Assert.assertFalse(taskMaster.isFullLeader());
+
     taskMaster.becomeHalfLeader(taskRunner, taskQueue);
+    Assert.assertTrue(taskMaster.isHalfOrFullLeader());
+    Assert.assertFalse(taskMaster.isFullLeader());
+
     taskMaster.becomeFullLeader();
+    Assert.assertTrue(taskMaster.isHalfOrFullLeader());
+    Assert.assertTrue(taskMaster.isFullLeader());
 
     taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
@@ -112,7 +112,7 @@ public class OverlordCompactionSchedulerTest
     taskQueue = Mockito.mock(TaskQueue.class);
 
     taskMaster = new TaskMaster(null, null);
-    taskMaster.becomeLeader(taskRunner, taskQueue);
+    taskMaster.becomeHalfLeader(taskRunner, taskQueue);
 
     taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
 


### PR DESCRIPTION
On becoming leader, it is helpful for the TaskRunner and TaskQueue to be available when the SupervisorManager starts up, to aid the supervisors in discovering their tasks.

On stopping leadership, it is helpful for the TaskRunner and TaskQueue to be available until the SupervisorManager has finished shutting down.

To achieve this, this patch splits the TaskMaster leader concept into "half leader" (queue and runner only) and "full leader" (queue, runner, and supervisor manager). The TaskMaster becomes half leader while the SupervisorManager is starting or stopping; full leader while the SupervisorManager is running.