### PR TITLE
Datasource based exemption from deprioritization

### DIFF
--- a/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
@@ -76,7 +76,7 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
     this.segmentRangeThreshold = segmentRangeThresholdString == null
                                  ? Optional.empty()
                                  : Optional.of(new Period(segmentRangeThresholdString).toStandardDuration());
-    this.exemptDatasources = (exemptDatasources == null) ? Collections.emptySet(): exemptDatasources;
+    this.exemptDatasources = (exemptDatasources == null) ? Collections.emptySet() : exemptDatasources;
     Preconditions.checkArgument(
         segmentCountThreshold != null || periodThreshold.isPresent() || durationThreshold.isPresent() || segmentRangeThreshold.isPresent(),
         "periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"

--- a/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.client.SegmentServerSelector;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.query.DataSource;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryPlus;
 import org.apache.druid.server.QueryPrioritizationStrategy;
@@ -34,6 +35,7 @@ import org.joda.time.base.AbstractInterval;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -51,6 +53,7 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
   private final Optional<Duration> periodThreshold;
   private final Optional<Duration> durationThreshold;
   private final Optional<Duration> segmentRangeThreshold;
+  private final Set<String> exemptDatasources;
 
   @JsonCreator
   public ThresholdBasedQueryPrioritizationStrategy(
@@ -58,6 +61,7 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
       @JsonProperty("durationThreshold") @Nullable String durationThresholdString,
       @JsonProperty("segmentCountThreshold") @Nullable Integer segmentCountThreshold,
       @JsonProperty("segmentRangeThreshold") @Nullable String segmentRangeThresholdString,
+      @JsonProperty("exemptDatasources") @Nullable Set<String> exemptDatasources,
       @JsonProperty("adjustment") @Nullable Integer adjustment
   )
   {
@@ -72,6 +76,7 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
     this.segmentRangeThreshold = segmentRangeThresholdString == null
                                  ? Optional.empty()
                                  : Optional.of(new Period(segmentRangeThresholdString).toStandardDuration());
+    this.exemptDatasources = (exemptDatasources == null) ? Collections.emptySet():exemptDatasources;
     Preconditions.checkArgument(
         segmentCountThreshold != null || periodThreshold.isPresent() || durationThreshold.isPresent() || segmentRangeThreshold.isPresent(),
         "periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"
@@ -82,6 +87,15 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
   public <T> Optional<Integer> computePriority(QueryPlus<T> query, Set<SegmentServerSelector> segments)
   {
     Query<T> theQuery = query.getQuery();
+    DataSource datasource = theQuery.getDataSource();
+
+    if (!exemptDatasources.isEmpty()) {
+      boolean isExempt = exemptDatasources.containsAll(datasource.getTableNames());
+      if(isExempt) {
+        return Optional.empty();
+      }
+    }
+
     final boolean violatesPeriodThreshold = periodThreshold.map(duration -> {
       final DateTime periodThresholdStartDate = DateTimes.nowUtc().minus(duration);
       return theQuery.getIntervals()

--- a/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategy.java
@@ -76,7 +76,7 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
     this.segmentRangeThreshold = segmentRangeThresholdString == null
                                  ? Optional.empty()
                                  : Optional.of(new Period(segmentRangeThresholdString).toStandardDuration());
-    this.exemptDatasources = (exemptDatasources == null) ? Collections.emptySet():exemptDatasources;
+    this.exemptDatasources = (exemptDatasources == null) ? Collections.emptySet(): exemptDatasources;
     Preconditions.checkArgument(
         segmentCountThreshold != null || periodThreshold.isPresent() || durationThreshold.isPresent() || segmentRangeThreshold.isPresent(),
         "periodThreshold, durationThreshold, segmentCountThreshold or segmentRangeThreshold must be set"
@@ -91,7 +91,7 @@ public class ThresholdBasedQueryPrioritizationStrategy implements QueryPrioritiz
 
     if (!exemptDatasources.isEmpty()) {
       boolean isExempt = exemptDatasources.containsAll(datasource.getTableNames());
-      if(isExempt) {
+      if (isExempt) {
         return Optional.empty();
       }
     }

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -1326,7 +1326,7 @@ public class QueryResourceTest
     final CountDownLatch waitOneScheduled = new CountDownLatch(1);
     final QueryScheduler scheduler = new QueryScheduler(
         40,
-        new ThresholdBasedQueryPrioritizationStrategy(null, "P90D", null, null, null),
+        new ThresholdBasedQueryPrioritizationStrategy(null, "P90D", null, null, null, null),
         new HiLoQueryLaningStrategy(1),
         new ServerConfig()
     );

--- a/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
@@ -60,7 +60,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
   public void testPrioritizationPeriodThresholdInsidePeriod()
   {
     QueryPrioritizationStrategy strategy = new ThresholdBasedQueryPrioritizationStrategy(
-        "P90D", null, null, null,null, adjustment);
+        "P90D", null, null, null, null, adjustment);
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))

--- a/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
@@ -64,6 +64,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+                                        .dataSource("generalDatasource")
                                         .granularity(Granularities.MINUTE)
                                         .context(ImmutableMap.of())
                                         .build();
@@ -87,6 +88,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(100);
     DateTime endDate = DateTimes.nowUtc().minusDays(80);
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+                                        .dataSource("generalDatasource")
                                         .granularity(Granularities.HOUR)
                                         .context(ImmutableMap.of())
                                         .build();
@@ -111,6 +113,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+                                        .dataSource("generalDatasource")
                                         .granularity(Granularities.MINUTE)
                                         .context(ImmutableMap.of())
                                         .build();
@@ -134,6 +137,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(20);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+                                        .dataSource("generalDatasource")
                                         .granularity(Granularities.HOUR)
                                         .context(ImmutableMap.of())
                                         .build();
@@ -158,6 +162,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+                                        .dataSource("generalDatasource")
                                         .granularity(Granularities.MINUTE)
                                         .context(ImmutableMap.of())
                                         .build();
@@ -184,6 +189,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(20);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+                                        .dataSource("generalDatasource")
                                         .granularity(Granularities.HOUR)
                                         .context(ImmutableMap.of())
                                         .build();
@@ -215,6 +221,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(1);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+            .dataSource("generalDatasource")
             .granularity(Granularities.MINUTE)
             .context(ImmutableMap.of())
             .build();
@@ -240,6 +247,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(20);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+            .dataSource("generalDatasource")
             .granularity(Granularities.HOUR)
             .context(ImmutableMap.of())
             .build();
@@ -266,6 +274,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(20);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
+            .dataSource("generalDatasource")
             .granularity(Granularities.HOUR)
             .context(ImmutableMap.of())
             .build();

--- a/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/scheduling/ThresholdBasedQueryPrioritizationStrategyTest.java
@@ -274,7 +274,7 @@ public class ThresholdBasedQueryPrioritizationStrategyTest
     DateTime startDate = DateTimes.nowUtc().minusDays(20);
     DateTime endDate = DateTimes.nowUtc();
     TimeseriesQuery query = queryBuilder.intervals(ImmutableList.of(new Interval(startDate, endDate)))
-            .dataSource("generalDatasource")
+            .dataSource("exemptDatasource")
             .granularity(Granularities.HOUR)
             .context(ImmutableMap.of())
             .build();


### PR DESCRIPTION
### Description

As of today tthere isn't a way to define high/low priority datasources. There are situations where we want to deprioritize queries based on the already present time based thresholds, but its possible that the druid cluster might host datasources that are higher in priority compared to others. For this reason, I've added another Optional json parameter `exemptDatasources`, which would host those high-priority datasources, which will skip the deprioritization logic entirely if the query being executed hosts any of the exempted datasources.

Updated the class ThresholdBasedQueryPrioritizationStrategy.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
