### PR TITLE
Use jfr-profiler for JDK 17 tests only.

### DIFF
--- a/.github/scripts/setup_test_profiling_env.sh
+++ b/.github/scripts/setup_test_profiling_env.sh
@@ -25,7 +25,7 @@ if [ "$#" -ne 5 ]; then
     echo "usage: $0 <jdk_version> <run_id> <run_number> <run_attempt> <module>"
 fi
 
-if [[ "$1" -ge "17" ]];
+if [[ "$1" -eq "17" ]];
 then
   curl https://static.imply.io/cp/$JAR_INPUT_FILE -s -o $JAR_OUTPUT_FILE
 


### PR DESCRIPTION
Currently the jfr-profiler jar is loaded for JDK 17 and higher. This patch changes it to only run for JDK 17. This may improve the stability of JDK 21 unit tests.