### PR TITLE
use big endian for compressed complex column values to fit ObjectStrategy expectations

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedLongsReader.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedLongsReader.java
@@ -29,7 +29,12 @@ public final class CompressedLongsReader implements ColumnarLongs
 {
   public static Supplier<CompressedLongsReader> fromByteBuffer(ByteBuffer buffer, ByteOrder order)
   {
-    final Supplier<CompressedBlockReader> baseReader = CompressedBlockReader.fromByteBuffer(buffer, order, false);
+    final Supplier<CompressedBlockReader> baseReader = CompressedBlockReader.fromByteBuffer(
+        buffer,
+        order,
+        order, // long serializer uses native order, same as compression
+        false
+    );
     return () -> new CompressedLongsReader(baseReader.get());
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedVariableSizedBlobColumnSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedVariableSizedBlobColumnSupplier.java
@@ -34,17 +34,19 @@ public class CompressedVariableSizedBlobColumnSupplier implements Supplier<Compr
   public static CompressedVariableSizedBlobColumnSupplier fromByteBuffer(
       String filenameBase,
       ByteBuffer buffer,
-      ByteOrder order,
+      ByteOrder compressionOrder,
+      ByteOrder valueOrder,
       SmooshedFileMapper mapper
   ) throws IOException
   {
-    return fromByteBuffer(filenameBase, buffer, order, false, mapper);
+    return fromByteBuffer(filenameBase, buffer, compressionOrder, valueOrder, false, mapper);
   }
 
   public static CompressedVariableSizedBlobColumnSupplier fromByteBuffer(
       String filenameBase,
       ByteBuffer buffer,
-      ByteOrder order,
+      ByteOrder compressionOrder,
+      ByteOrder valueOrder,
       boolean copyValuesOnRead,
       SmooshedFileMapper mapper
   ) throws IOException
@@ -59,7 +61,14 @@ public class CompressedVariableSizedBlobColumnSupplier implements Supplier<Compr
       final ByteBuffer dataBuffer = mapper.mapFile(
           CompressedVariableSizedBlobColumnSerializer.getCompressedBlobsFileName(filenameBase)
       );
-      return new CompressedVariableSizedBlobColumnSupplier(offsetsBuffer, dataBuffer, order, numElements, copyValuesOnRead);
+      return new CompressedVariableSizedBlobColumnSupplier(
+          offsetsBuffer,
+          dataBuffer,
+          compressionOrder,
+          valueOrder,
+          numElements,
+          copyValuesOnRead
+      );
     }
     throw new IAE("Unknown version[%s]", versionFromBuffer);
   }
@@ -72,14 +81,15 @@ public class CompressedVariableSizedBlobColumnSupplier implements Supplier<Compr
   private CompressedVariableSizedBlobColumnSupplier(
       ByteBuffer offsetsBuffer,
       ByteBuffer dataBuffer,
-      ByteOrder order,
+      ByteOrder compressionOrder,
+      ByteOrder valueOrder,
       int numElements,
       boolean copyValuesOnRead
   )
   {
     this.numElements = numElements;
-    this.offsetReaderSupplier = CompressedLongsReader.fromByteBuffer(offsetsBuffer, order);
-    this.blockDataReaderSupplier = CompressedBlockReader.fromByteBuffer(dataBuffer, order, copyValuesOnRead);
+    this.offsetReaderSupplier = CompressedLongsReader.fromByteBuffer(offsetsBuffer, compressionOrder);
+    this.blockDataReaderSupplier = CompressedBlockReader.fromByteBuffer(dataBuffer, compressionOrder, valueOrder, copyValuesOnRead);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSupplier.java
@@ -141,6 +141,7 @@ public class NestedDataColumnSupplier implements Supplier<NestedCommonFormatColu
             ),
             rawBuffer,
             byteOrder,
+            byteOrder, // byte order doesn't matter since serde is byte blobs
             mapper
         );
         if (hasNulls) {

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSupplierV4.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSupplierV4.java
@@ -164,6 +164,7 @@ public class NestedDataColumnSupplierV4 implements Supplier<ComplexColumn>
             ),
             rawBuffer,
             metadata.getByteOrder(),
+            metadata.getByteOrder(), // byte order doesn't matter since serde is byte blobs
             mapper
         );
         if (metadata.hasNulls()) {

--- a/processing/src/main/java/org/apache/druid/segment/serde/CompressedComplexColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/CompressedComplexColumn.java
@@ -28,18 +28,18 @@ import org.apache.druid.utils.CloseableUtils;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 
-public final class CompressedComplexColumn implements ComplexColumn
+public final class CompressedComplexColumn<T> implements ComplexColumn
 {
   private final String typeName;
   private final CompressedVariableSizedBlobColumn compressedColumn;
   private final ImmutableBitmap nullValues;
-  private final ObjectStrategy<?> objectStrategy;
+  private final ObjectStrategy<T> objectStrategy;
 
   public CompressedComplexColumn(
       String typeName,
       CompressedVariableSizedBlobColumn compressedColumn,
       ImmutableBitmap nullValues,
-      ObjectStrategy<?> objectStrategy
+      ObjectStrategy<T> objectStrategy
   )
   {
     this.typeName = typeName;
@@ -62,7 +62,7 @@ public final class CompressedComplexColumn implements ComplexColumn
 
   @Override
   @Nullable
-  public Object getRowValue(int rowNum)
+  public T getRowValue(int rowNum)
   {
     if (nullValues.get(rowNum)) {
       return null;

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVariableSizeBlobColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVariableSizeBlobColumnTest.java
@@ -88,6 +88,7 @@ public class CompressedVariableSizeBlobColumnTest
         fileNameBase,
         base,
         ByteOrder.nativeOrder(),
+        ByteOrder.nativeOrder(),
         fileMapper
     ).get();
     for (int row = 0; row < numWritten; row++) {
@@ -151,6 +152,7 @@ public class CompressedVariableSizeBlobColumnTest
         fileNameBase,
         base,
         ByteOrder.nativeOrder(),
+        ByteOrder.nativeOrder(),
         fileMapper
     ).get();
     for (int row = 0; row < numWritten; row++) {
@@ -165,6 +167,68 @@ public class CompressedVariableSizeBlobColumnTest
       byte[] bytes = new byte[value.remaining()];
       value.get(bytes);
       Assert.assertArrayEquals("Row " + row, values.get(row), bytes);
+    }
+    column.close();
+    fileMapper.close();
+  }
+
+  @Test
+  public void testSomeValuesByteBuffersBigEndian() throws IOException
+  {
+    final File tmpFile = tempFolder.newFolder();
+    final FileSmoosher smoosher = new FileSmoosher(tmpFile);
+
+    final File tmpFile2 = tempFolder.newFolder();
+    final SegmentWriteOutMedium writeOutMedium =
+        TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(tmpFile2);
+
+    final String fileNameBase = "test";
+
+    final CompressionStrategy compressionStrategy = CompressionStrategy.LZ4;
+    CompressedVariableSizedBlobColumnSerializer serializer = new CompressedVariableSizedBlobColumnSerializer(
+        fileNameBase,
+        writeOutMedium,
+        compressionStrategy
+    );
+    serializer.open();
+
+    int numWritten = 0;
+    final Random r = ThreadLocalRandom.current();
+    final List<Long> values = new ArrayList<>();
+    final ByteBuffer longValueConverter = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.BIG_ENDIAN);
+    for (int i = 0, offset = 0; offset < CompressedPools.BUFFER_SIZE * 4; i++, offset = 1 << i) {
+      final long l = r.nextLong();
+      values.add(l);
+      longValueConverter.clear();
+      longValueConverter.putLong(l);
+      longValueConverter.rewind();
+      serializer.addValue(longValueConverter.array());
+      numWritten++;
+    }
+
+    SmooshedWriter writer = smoosher.addWithSmooshedWriter(fileNameBase, serializer.getSerializedSize());
+    serializer.writeTo(writer, smoosher);
+    writer.close();
+    smoosher.close();
+    SmooshedFileMapper fileMapper = SmooshedFileMapper.load(tmpFile);
+
+    ByteBuffer base = fileMapper.mapFile(fileNameBase);
+
+    CompressedVariableSizedBlobColumn column = CompressedVariableSizedBlobColumnSupplier.fromByteBuffer(
+        fileNameBase,
+        base,
+        ByteOrder.nativeOrder(),
+        ByteOrder.BIG_ENDIAN,
+        fileMapper
+    ).get();
+    for (int row = 0; row < numWritten; row++) {
+      ByteBuffer value = column.get(row);
+      Assert.assertEquals("Row " + row, values.get(row).longValue(), value.getLong());
+    }
+    for (int rando = 0; rando < numWritten; rando++) {
+      int row = ThreadLocalRandom.current().nextInt(0, numWritten - 1);
+      ByteBuffer value = column.get(row);
+      Assert.assertEquals("Row " + row, values.get(row).longValue(), value.getLong());
     }
     column.close();
     fileMapper.close();


### PR DESCRIPTION
### Description
Less ambitious fix than #17391, which adds the concept of value byte ordering to `ObjectStrategy`, this PR instead just hard-codes `CompressedComplexColumn` to use big endian value buffers in order to fix an issue related to value endianness with some `ObjectStrategy` implementations when used with the compression added in #16863.

I would still like to do the changes in the other PR at some point because it is a path to allowing all the stuff in segments to use native endian, but there are a lot of additional changes which need to be done first, such as squaring up the things that use `ByteBufferWriter`/ `ObjectStrategy.fromByteBufferWithSize` to determine if the header (size) int value endian should match the endian of the object strategy or not, and determining a more elegant way to handle this stuff.

#### Release note
Fixes an issue related to value buffers being ordered with the incorrect endianness which can cause some complex types, such as `approxHistogram` to incorrectly be read, and can lead to out of memory exceptions in some cases.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
