### PR TITLE
Swap Zulu for Corretto.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     - uses: actions/setup-java@v4
       with:
-        distribution: 'zulu'
+        distribution: 'corretto'
         java-version: '8'
         cache: 'maven'
 

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'zulu'
+          distribution: 'corretto'
 
       - name: Cache Maven m2 repository
         id: maven
@@ -123,7 +123,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'zulu'
+          distribution: 'corretto'
           cache: maven
 
       - name: maven build # needed to rebuild incase of maven snapshot resolution fails

--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.build_jdk }}
-          distribution: 'zulu'
+          distribution: 'corretto'
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: ${{ inputs.runtime_jdk }}
-          distribution: 'zulu'
+          distribution: 'corretto'
 
       - name: Restore Maven repository
         id: maven-restore

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -63,7 +63,7 @@ jobs:
       # different cache key since we cannot reuse it across commits.
       - uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: ${{ inputs.jdk }}
 
       # the build step produces SNAPSHOT artifacts into the local maven repository,

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'zulu'
+          distribution: 'corretto'
 
       # the build step produces SNAPSHOT artifacts into the local maven repository,
       # we include github.sha in the cache key to make it specific to that build/jdk

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
@@ -122,7 +122,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: '8'
           cache: 'maven'
 
@@ -152,7 +152,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: '8'
           cache: 'maven'
 
@@ -184,7 +184,7 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: '17'
           cache: 'maven'
 

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -89,7 +89,7 @@ jobs:
       # different cache key since we cannot reuse it across commits.
       - uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: ${{ matrix.jdk }}
 
       # the build step produces SNAPSHOT artifacts into the local maven repository,


### PR DESCRIPTION
Recently we've been seeing segfaults in JDK 21 unit tests. This patch checks whether changing to an alternate JDK would be helpful.