### PR TITLE
Fix backward compatibility issues in WindowOperatorQueryFrameProcessorFactory and WindowOperatorQueryFrameProcessor

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessor.java
@@ -39,9 +39,13 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.msq.indexing.error.MSQException;
 import org.apache.druid.msq.indexing.error.TooManyRowsInAWindowFault;
 import org.apache.druid.msq.util.MultiStageQueryContext;
+import org.apache.druid.query.operator.AbstractPartitioningOperatorFactory;
+import org.apache.druid.query.operator.AbstractSortOperatorFactory;
+import org.apache.druid.query.operator.GlueingPartitioningOperatorFactory;
 import org.apache.druid.query.operator.OffsetLimit;
 import org.apache.druid.query.operator.Operator;
 import org.apache.druid.query.operator.OperatorFactory;
+import org.apache.druid.query.operator.PartitionSortOperatorFactory;
 import org.apache.druid.query.operator.WindowOperatorQuery;
 import org.apache.druid.query.rowsandcols.ConcatRowsAndColumns;
 import org.apache.druid.query.rowsandcols.LazilyDecoratedRowsAndColumns;
@@ -95,9 +99,9 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
     this.inputChannel = inputChannel;
     this.outputChannel = outputChannel;
     this.frameWriterFactory = frameWriterFactory;
-    this.operatorFactoryList = operatorFactoryList;
     this.resultRowAndCols = new ArrayList<>();
     this.maxRowsMaterialized = MultiStageQueryContext.getMaxRowsMaterializedInWindow(query.context());
+    this.operatorFactoryList = getOperatorFactoryListForStageDefinition(operatorFactoryList);
     this.frameRowsAndColsBuilder = new RowsAndColumnsBuilder(this.maxRowsMaterialized);
 
     this.frameReader = frameReader;
@@ -398,5 +402,37 @@ public class WindowOperatorQueryFrameProcessor implements FrameProcessor<Object>
   {
     resultRowAndCols.clear();
     rowId.set(0);
+  }
+
+  /**
+   * This method converts the operator chain received from native plan into MSQ plan.
+   * (NaiveSortOperator -> Naive/GlueingPartitioningOperator -> WindowOperator) is converted into (GlueingPartitioningOperator -> PartitionSortOperator -> WindowOperator).
+   * We rely on MSQ's shuffling to do the clustering on partitioning keys for us at every stage.
+   * This conversion allows us to blindly read N rows from input channel and push them into the operator chain, and repeat until the input channel isn't finished.
+   * @param operatorFactoryListFromQuery
+   * @return
+   */
+  private List<OperatorFactory> getOperatorFactoryListForStageDefinition(List<OperatorFactory> operatorFactoryListFromQuery)
+  {
+    final List<OperatorFactory> operatorFactoryList = new ArrayList<>();
+    final List<OperatorFactory> sortOperatorFactoryList = new ArrayList<>();
+    for (OperatorFactory operatorFactory : operatorFactoryListFromQuery) {
+      if (operatorFactory instanceof AbstractPartitioningOperatorFactory) {
+        AbstractPartitioningOperatorFactory partition = (AbstractPartitioningOperatorFactory) operatorFactory;
+        operatorFactoryList.add(new GlueingPartitioningOperatorFactory(partition.getPartitionColumns(), this.maxRowsMaterialized));
+      } else if (operatorFactory instanceof AbstractSortOperatorFactory) {
+        AbstractSortOperatorFactory sortOperatorFactory = (AbstractSortOperatorFactory) operatorFactory;
+        sortOperatorFactoryList.add(new PartitionSortOperatorFactory(sortOperatorFactory.getSortColumns()));
+      } else {
+        // Add all the PartitionSortOperator(s) before every window operator.
+        operatorFactoryList.addAll(sortOperatorFactoryList);
+        sortOperatorFactoryList.clear();
+        operatorFactoryList.add(operatorFactory);
+      }
+    }
+
+    operatorFactoryList.addAll(sortOperatorFactoryList);
+    sortOperatorFactoryList.clear();
+    return operatorFactoryList;
   }
 }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorFactoryTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/querykit/WindowOperatorQueryFrameProcessorFactoryTest.java
@@ -28,7 +28,13 @@ public class WindowOperatorQueryFrameProcessorFactoryTest
   public void testEqualsAndHashcode()
   {
     EqualsVerifier.forClass(WindowOperatorQueryFrameProcessorFactory.class)
-                  .withNonnullFields("query", "operatorList", "stageRowSignature")
+                  .withNonnullFields(
+                      "query",
+                      "operatorList",
+                      "stageRowSignature",
+                      "maxRowsMaterializedInWindow",
+                      "partitionColumnNames"
+                  )
                   .usingGetClass()
                   .verify();
   }


### PR DESCRIPTION
### Description

As part of the GlueingPartitioningOperator changes in #17038, we removed 2 fields from `WindowOperatorQueryFrameProcessorFactory`: `maxRowsMaterializedInWindow` and `partitionColumnNames`. This introduces backward incompatibility when the MSQ controller has the Glueing PR changes, but the worker doesn't:
![image](https://github.com/user-attachments/assets/2e6fbeef-0f64-4ef0-93e9-6115cf3991b4)

This PR adds those fields back to ensure backward compatibility.

Even after adding the 2 fields back, if controller has the Glueing PR changes, but workers don't - then we run into another issue where the controller sends the operatorFactoryList with the new operators, but the workers aren't aware of the new operators (GlueingPartitioningOperator and PartitionSortOperator). This causes the following issue:
```
org.apache.druid.rpc.HttpResponseException: Server error [400 Bad Request]; body: {"error":"Please make sure to load all the necessary extensions and jars with type 'glueingPartition' on 'druid/indexer' service. Could not resolve type id 'glueingPartition' as a subtype of `org.apache.druid.query.operator.OperatorFactory` known type ids = [naivePartition, naiveSort, scan, window] (for POJO property 'operatorList')
```
![image](https://github.com/user-attachments/assets/3d17846b-ca45-4676-a287-7fd9dd53c750)

This PR handles this by moving the operator transformation logic (`NaiveSortOperator -> NaivePartitioningOperator -> WindowOperator` to `GlueingPartitioningOperator -> PartitionSortOperator -> WindowOperator`) from `WindowOperatorQueryKit` layer to the `WindowOperatorQueryFrameProcessor` layer. This would allow the worker to either run the older operator chain (if they are on older version, not having the Glueing PR changes), or run the new operator chain (if they have the Glueing PR changes).

### Test Plan

To test out the compatibility scenarios, I ran 2 indexers on my local setup, and validated queries for following cases:
1. Indexer1 (controller) is on older version, indexer2 (some subset of workers) is on newer version.
2. Indexer1 (controller) is on newer version, indexer2 (some subset of workers) is on older version. 

#### Release note

We are marking 2 fields deprecated for window query execution for MSQ task engine. These will be removed in future releases of Druid, so the upgrade plan should involve this intermediate upgrade stage with these backward compatibility code changes.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
