### PR TITLE
Add TopN Query Aggregator Memory Guardrails

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2147,9 +2147,10 @@ context). If query does have `maxQueuedBytes` in the context, then that value is
 
 ### TopN query config
 
-|Property|Description|Default|
-|--------|-----------|-------|
-|`druid.query.topN.minTopNThreshold`|See [TopN Aliasing](../querying/topnquery.md#aliasing) for details.|1000|
+|Property| Description                                                                   | Default |
+|--------|-------------------------------------------------------------------------------|---------|
+|`druid.query.topN.minTopNThreshold`| See [TopN Aliasing](../querying/topnquery.md#aliasing) for details.           | 1000    |
+|`druid.query.topN.maxTopNAggregatorHeapSizeBytes`| The maximum amount of aggregator heap bytes a given segment runner can acrue. | 10MB    |
 
 ### Search query config
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -2147,10 +2147,10 @@ context). If query does have `maxQueuedBytes` in the context, then that value is
 
 ### TopN query config
 
-|Property| Description                                                                   | Default |
-|--------|-------------------------------------------------------------------------------|---------|
-|`druid.query.topN.minTopNThreshold`| See [TopN Aliasing](../querying/topnquery.md#aliasing) for details.           | 1000    |
-|`druid.query.topN.maxTopNAggregatorHeapSizeBytes`| The maximum amount of aggregator heap bytes a given segment runner can acrue. | 10MB    |
+|Property| Description                                                                         | Default |
+|--------|-------------------------------------------------------------------------------------|---------|
+|`druid.query.topN.minTopNThreshold`| See [TopN Aliasing](../querying/topnquery.md#aliasing) for details.                 | 1000    |
+|`druid.query.topN.maxTopNAggregatorHeapSizeBytes`| The maximum amount of aggregator heap bytes a given query can acrue per historical. | 10MB    |
 
 ### Search query config
 

--- a/extensions-contrib/distinctcount/src/test/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.topn.TopNQuery;
 import org.apache.druid.query.topn.TopNQueryBuilder;
+import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.query.topn.TopNQueryEngine;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.segment.IncrementalIndexSegment;
@@ -133,6 +134,7 @@ public class DistinctCountTopNQueryTest extends InitializedNullHandlingTest
     final Iterable<Result<TopNResultValue>> results =
         engine.query(
             query,
+            new TopNQueryConfig(),
             new IncrementalIndexSegment(index, SegmentId.dummy(QueryRunnerTestHelper.DATA_SOURCE)),
             null
         ).toList();

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -87,6 +87,7 @@ public class QueryContexts
   public static final String SERIALIZE_DATE_TIME_AS_LONG_INNER_KEY = "serializeDateTimeAsLongInner";
   public static final String UNCOVERED_INTERVALS_LIMIT_KEY = "uncoveredIntervalsLimit";
   public static final String MIN_TOP_N_THRESHOLD = "minTopNThreshold";
+  public static final String MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES = "maxTopNAggregatorHeapSizeBytes";
   public static final String CATALOG_VALIDATION_ENABLED = "catalogValidationEnabled";
 
   // projection context keys

--- a/processing/src/main/java/org/apache/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/BaseTopNAlgorithm.java
@@ -41,8 +41,11 @@ import java.util.List;
 public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Parameters extends TopNParams>
     implements TopNAlgorithm<DimValSelector, Parameters>
 {
-  public static Aggregator[] makeAggregators(Cursor cursor, List<AggregatorFactory> aggregatorSpecs)
+
+  public static Aggregator[] makeAggregators(TopNQuery query, Cursor cursor)
   {
+    query.getAggregatorHelper().addAggregatorMemory();
+    final List<AggregatorFactory> aggregatorSpecs = query.getAggregatorSpecs();
     Aggregator[] aggregators = new Aggregator[aggregatorSpecs.size()];
     int aggregatorIndex = 0;
     for (AggregatorFactory spec : aggregatorSpecs) {
@@ -52,8 +55,10 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
     return aggregators;
   }
 
-  protected static BufferAggregator[] makeBufferAggregators(Cursor cursor, List<AggregatorFactory> aggregatorSpecs)
+  protected static BufferAggregator[] makeBufferAggregators(TopNQuery query, Cursor cursor)
   {
+    query.getAggregatorHelper().addAggregatorMemory();
+    final List<AggregatorFactory> aggregatorSpecs = query.getAggregatorSpecs();
     BufferAggregator[] aggregators = new BufferAggregator[aggregatorSpecs.size()];
     int aggregatorIndex = 0;
     for (AggregatorFactory spec : aggregatorSpecs) {

--- a/processing/src/main/java/org/apache/druid/query/topn/BaseTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/BaseTopNAlgorithm.java
@@ -44,7 +44,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
 
   public static Aggregator[] makeAggregators(TopNQuery query, Cursor cursor)
   {
-    query.getAggregatorHelper().addAggregatorMemory();
+    query.trackAggregatorMemory();
     final List<AggregatorFactory> aggregatorSpecs = query.getAggregatorSpecs();
     Aggregator[] aggregators = new Aggregator[aggregatorSpecs.size()];
     int aggregatorIndex = 0;
@@ -57,7 +57,7 @@ public abstract class BaseTopNAlgorithm<DimValSelector, DimValAggregateStore, Pa
 
   protected static BufferAggregator[] makeBufferAggregators(TopNQuery query, Cursor cursor)
   {
-    query.getAggregatorHelper().addAggregatorMemory();
+    query.trackAggregatorMemory();
     final List<AggregatorFactory> aggregatorSpecs = query.getAggregatorSpecs();
     BufferAggregator[] aggregators = new BufferAggregator[aggregatorSpecs.size()];
     int aggregatorIndex = 0;

--- a/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
@@ -255,6 +255,8 @@ public class PooledTopNAlgorithm
       resultsBuf.clear();
 
       final int numBytesToWorkWith = resultsBuf.remaining();
+
+      query.getAggregatorHelper().addAggregatorMemory();
       final int[] aggregatorSizes = new int[query.getAggregatorSpecs().size()];
       int numBytesPerRecord = 0;
 
@@ -329,7 +331,7 @@ public class PooledTopNAlgorithm
   @Override
   protected BufferAggregator[] makeDimValAggregateStore(PooledTopNParams params)
   {
-    return makeBufferAggregators(params.getCursor(), query.getAggregatorSpecs());
+    return makeBufferAggregators(query, params.getCursor());
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java
@@ -256,7 +256,7 @@ public class PooledTopNAlgorithm
 
       final int numBytesToWorkWith = resultsBuf.remaining();
 
-      query.getAggregatorHelper().addAggregatorMemory();
+      query.trackAggregatorMemory();
       final int[] aggregatorSizes = new int[query.getAggregatorSpecs().size()];
       int numBytesPerRecord = 0;
 

--- a/processing/src/main/java/org/apache/druid/query/topn/TimeExtractionTopNAlgorithm.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TimeExtractionTopNAlgorithm.java
@@ -98,7 +98,7 @@ public class TimeExtractionTopNAlgorithm extends BaseTopNAlgorithm<int[], Map<Ob
 
       Aggregator[] theAggregators = aggregatesStore.computeIfAbsent(
           key,
-          k -> makeAggregators(cursor, query.getAggregatorSpecs())
+          k -> makeAggregators(query, cursor)
       );
 
       for (Aggregator aggregator : theAggregators) {

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNAggregatorResourceHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNAggregatorResourceHelper.java
@@ -26,9 +26,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class TopNAggregatorResourceHelper
 {
-  public static class Config {
+  public static class Config
+  {
     public final long maxAggregatorHeapSize;
-    public Config(final long maxAggregatorHeapSize) {
+
+    public Config(final long maxAggregatorHeapSize)
+    {
       this.maxAggregatorHeapSize = maxAggregatorHeapSize;
     }
   }
@@ -37,15 +40,21 @@ public class TopNAggregatorResourceHelper
   private final long newAggregatorEstimatedMemorySize;
   private final AtomicLong used = new AtomicLong(0);
 
-  TopNAggregatorResourceHelper(final long newAggregatorEstimatedMemorySize, final Config config) {
+  TopNAggregatorResourceHelper(final long newAggregatorEstimatedMemorySize, final Config config)
+  {
     this.newAggregatorEstimatedMemorySize = newAggregatorEstimatedMemorySize;
     this.config = config;
   }
 
-  public void addAggregatorMemory() {
+  public void addAggregatorMemory()
+  {
     final long newTotal = used.addAndGet(newAggregatorEstimatedMemorySize);
-    if (newTotal > config.maxAggregatorHeapSize){
-      throw new ResourceLimitExceededException(StringUtils.format("Query ran out of memory. Maximum allowed bytes=[%d], Hit bytes=[%d]", config.maxAggregatorHeapSize, newTotal));
+    if (newTotal > config.maxAggregatorHeapSize) {
+      throw new ResourceLimitExceededException(StringUtils.format(
+          "Query ran out of memory. Maximum allowed bytes=[%d], Hit bytes=[%d]",
+          config.maxAggregatorHeapSize,
+          newTotal
+      ));
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNAggregatorResourceHelper.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNAggregatorResourceHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.topn;
+
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.ResourceLimitExceededException;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TopNAggregatorResourceHelper
+{
+  public static class Config {
+    public final long maxAggregatorHeapSize;
+    public Config(final long maxAggregatorHeapSize) {
+      this.maxAggregatorHeapSize = maxAggregatorHeapSize;
+    }
+  }
+
+  private final Config config;
+  private final long newAggregatorEstimatedMemorySize;
+  private final AtomicLong used = new AtomicLong(0);
+
+  TopNAggregatorResourceHelper(final long newAggregatorEstimatedMemorySize, final Config config) {
+    this.newAggregatorEstimatedMemorySize = newAggregatorEstimatedMemorySize;
+    this.config = config;
+  }
+
+  public void addAggregatorMemory() {
+    final long newTotal = used.addAndGet(newAggregatorEstimatedMemorySize);
+    if (newTotal > config.maxAggregatorHeapSize){
+      throw new ResourceLimitExceededException(StringUtils.format("Query ran out of memory. Maximum allowed bytes=[%d], Hit bytes=[%d]", config.maxAggregatorHeapSize, newTotal));
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
@@ -61,7 +61,7 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
   private final DimFilter dimFilter;
   private final List<AggregatorFactory> aggregatorSpecs;
   private final List<PostAggregator> postAggregatorSpecs;
-  private TopNAggregatorResourceHelper aggregatorHelper;
+  private final TopNAggregatorResourceHelper aggregatorHelper;
 
   @JsonCreator
   public TopNQuery(
@@ -104,11 +104,6 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     this.aggregatorHelper = new TopNAggregatorResourceHelper(expectedAllocBytes, new TopNAggregatorResourceHelper.Config(maxAggregatorHeapSizeBytes));
 
     topNMetricSpec.verifyPreconditions(this.aggregatorSpecs, this.postAggregatorSpecs);
-  }
-
-  public TopNAggregatorResourceHelper getAggregatorHelper()
-  {
-    return aggregatorHelper;
   }
 
   @Override
@@ -232,6 +227,10 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
   public Query<Result<TopNResultValue>> withDataSource(DataSource dataSource)
   {
     return new TopNQueryBuilder(this).dataSource(dataSource).build();
+  }
+
+  public void trackAggregatorMemory() {
+    aggregatorHelper.addAggregatorMemory();
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java
@@ -99,7 +99,6 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
             : postAggregatorSpecs
     );
 
-
     final long expectedAllocBytes = aggregatorSpecs.stream().mapToLong(AggregatorFactory::getMaxIntermediateSizeWithNulls).sum();
     final long maxAggregatorHeapSizeBytes = this.context().getLong(QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES, TopNQueryConfig.DEFAULT_MAX_AGGREGATOR_HEAP_SIZE_BYTES);
     this.aggregatorHelper = new TopNAggregatorResourceHelper(expectedAllocBytes, new TopNAggregatorResourceHelper.Config(maxAggregatorHeapSizeBytes));
@@ -107,7 +106,8 @@ public class TopNQuery extends BaseQuery<Result<TopNResultValue>>
     topNMetricSpec.verifyPreconditions(this.aggregatorSpecs, this.postAggregatorSpecs);
   }
 
-  public TopNAggregatorResourceHelper getAggregatorHelper() {
+  public TopNAggregatorResourceHelper getAggregatorHelper()
+  {
     return aggregatorHelper;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryBuilder.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryBuilder.java
@@ -82,6 +82,7 @@ public class TopNQueryBuilder
   private List<AggregatorFactory> aggregatorSpecs;
   private List<PostAggregator> postAggregatorSpecs;
   private Map<String, Object> context;
+  private TopNAggregatorResourceHelper helper;
 
   public TopNQueryBuilder()
   {
@@ -96,6 +97,7 @@ public class TopNQueryBuilder
     aggregatorSpecs = new ArrayList<>();
     postAggregatorSpecs = new ArrayList<>();
     context = null;
+    helper = null;
   }
 
   public TopNQueryBuilder(final TopNQuery query)
@@ -111,6 +113,7 @@ public class TopNQueryBuilder
     this.aggregatorSpecs = query.getAggregatorSpecs();
     this.postAggregatorSpecs = query.getPostAggregatorSpecs();
     this.context = query.getContext();
+    this.helper = query.getAggregatorHelper();
   }
 
   public TopNQuery build()
@@ -126,7 +129,8 @@ public class TopNQueryBuilder
         granularity,
         aggregatorSpecs,
         postAggregatorSpecs,
-        context
+        context,
+        helper
     );
   }
 
@@ -150,7 +154,8 @@ public class TopNQueryBuilder
         .granularity(builder.granularity)
         .aggregators(builder.aggregatorSpecs)
         .postAggregators(builder.postAggregatorSpecs)
-        .context(builder.context);
+        .context(builder.context)
+        .helper(builder.helper);
   }
 
   public TopNQueryBuilder dataSource(String d)
@@ -282,6 +287,12 @@ public class TopNQueryBuilder
   public TopNQueryBuilder context(Map<String, Object> c)
   {
     this.context = c;
+    return this;
+  }
+
+  public TopNQueryBuilder helper(TopNAggregatorResourceHelper helper)
+  {
+    this.helper = helper;
     return this;
   }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryConfig.java
@@ -28,6 +28,7 @@ import javax.validation.constraints.Min;
 public class TopNQueryConfig
 {
   public static final int DEFAULT_MIN_TOPN_THRESHOLD = 1000;
+  public static final long DEFAULT_MAX_AGGREGATOR_HEAP_SIZE_BYTES = 10 * (2 << 20); // 10mb
 
   @JsonProperty
   @Min(1)
@@ -36,5 +37,14 @@ public class TopNQueryConfig
   public int getMinTopNThreshold()
   {
     return minTopNThreshold;
+  }
+
+  @JsonProperty
+  @Min(0)
+  private long maxTopNAggregatorHeapSizeBytes = DEFAULT_MAX_AGGREGATOR_HEAP_SIZE_BYTES;
+
+  public long getMaxTopNAggregatorHeapSizeBytes()
+  {
+    return maxTopNAggregatorHeapSizeBytes;
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -89,8 +89,11 @@ public class TopNQueryEngine
       );
     }
 
-    if (!query.context().containsKey(QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES)){
-      query = query.withOverriddenContext(ImmutableMap.of(QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES, config.getMaxTopNAggregatorHeapSizeBytes()));
+    if (!query.context().containsKey(QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES)) {
+      query = query.withOverriddenContext(ImmutableMap.of(
+          QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES,
+          config.getMaxTopNAggregatorHeapSizeBytes()
+      ));
     }
 
     final CursorBuildSpec buildSpec = makeCursorBuildSpec(query, queryMetrics);
@@ -185,7 +188,14 @@ public class TopNQueryEngine
     );
 
     final TopNAlgorithm<?, ?> topNAlgorithm;
-    if (canUsePooledAlgorithm(selector, query, columnCapabilities, bufferPool, cursorInspector.getDimensionCardinality(), numBytesPerRecord)) {
+    if (canUsePooledAlgorithm(
+        selector,
+        query,
+        columnCapabilities,
+        bufferPool,
+        cursorInspector.getDimensionCardinality(),
+        numBytesPerRecord
+    )) {
       // pool based algorithm selection, if we can
       if (selector.isAggregateAllMetrics()) {
         // if sorted by dimension we should aggregate all metrics in a single pass, use the regular pooled algorithm for

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.topn;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.collections.NonBlockingPool;
 import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -28,6 +29,7 @@ import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.query.ColumnSelectorPlus;
 import org.apache.druid.query.CursorGranularizer;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -75,6 +77,7 @@ public class TopNQueryEngine
    */
   public Sequence<Result<TopNResultValue>> query(
       TopNQuery query,
+      TopNQueryConfig config,
       final Segment segment,
       @Nullable final TopNQueryMetrics queryMetrics
   )
@@ -84,6 +87,10 @@ public class TopNQueryEngine
       throw new SegmentMissingException(
           "Null cursor factory found. Probably trying to issue a query against a segment being memory unmapped."
       );
+    }
+
+    if (!query.context().containsKey(QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES)){
+      query = query.withOverriddenContext(ImmutableMap.of(QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES, config.getMaxTopNAggregatorHeapSizeBytes()));
     }
 
     final CursorBuildSpec buildSpec = makeCursorBuildSpec(query, queryMetrics);

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
@@ -552,6 +552,11 @@ public class TopNQueryQueryToolChest extends QueryToolChest<Result<TopNResultVal
     );
   }
 
+  public TopNQueryConfig getConfig()
+  {
+    return this.config;
+  }
+
   /**
    * This returns a single frame containing the rows of the topN query's results
    */

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryRunnerFactory.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryRunnerFactory.java
@@ -77,6 +77,7 @@ public class TopNQueryRunnerFactory implements QueryRunnerFactory<Result<TopNRes
         TopNQuery query = (TopNQuery) input.getQuery();
         return queryEngine.query(
             query,
+            toolchest.getConfig(),
             segment,
             (TopNQueryMetrics) input.getQueryMetrics()
         );

--- a/processing/src/main/java/org/apache/druid/query/topn/types/DoubleTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/DoubleTopNColumnAggregatesProcessor.java
@@ -50,7 +50,7 @@ public class DoubleTopNColumnAggregatesProcessor
     long key = Double.doubleToLongBits(selector.getDouble());
     return aggregatesStore.computeIfAbsent(
         key,
-        k -> BaseTopNAlgorithm.makeAggregators(cursor, query.getAggregatorSpecs())
+        k -> BaseTopNAlgorithm.makeAggregators(query, cursor)
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/types/FloatTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/FloatTopNColumnAggregatesProcessor.java
@@ -50,7 +50,7 @@ public class FloatTopNColumnAggregatesProcessor
     int key = Float.floatToIntBits(selector.getFloat());
     return aggregatesStore.computeIfAbsent(
         key,
-        k -> BaseTopNAlgorithm.makeAggregators(cursor, query.getAggregatorSpecs())
+        k -> BaseTopNAlgorithm.makeAggregators(query, cursor)
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/types/LongTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/LongTopNColumnAggregatesProcessor.java
@@ -46,7 +46,7 @@ public class LongTopNColumnAggregatesProcessor
     long key = selector.getLong();
     return aggregatesStore.computeIfAbsent(
         key,
-        k -> BaseTopNAlgorithm.makeAggregators(cursor, query.getAggregatorSpecs())
+        k -> BaseTopNAlgorithm.makeAggregators(query, cursor)
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/query/topn/types/NullableNumericTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/NullableNumericTopNColumnAggregatesProcessor.java
@@ -97,7 +97,7 @@ public abstract class NullableNumericTopNColumnAggregatesProcessor<Selector exte
     while (!cursor.isDone()) {
       if (hasNulls && selector.isNull()) {
         if (nullValueAggregates == null) {
-          nullValueAggregates = BaseTopNAlgorithm.makeAggregators(cursor, query.getAggregatorSpecs());
+          nullValueAggregates = BaseTopNAlgorithm.makeAggregators(query, cursor);
         }
         for (Aggregator aggregator : nullValueAggregates) {
           aggregator.aggregate();

--- a/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/types/StringTopNColumnAggregatesProcessor.java
@@ -159,7 +159,7 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
           final Object key = dimensionValueConverter.apply(selector.lookupName(dimIndex));
           aggs = aggregatesStore.computeIfAbsent(
               key,
-              k -> BaseTopNAlgorithm.makeAggregators(cursor, query.getAggregatorSpecs())
+              k -> BaseTopNAlgorithm.makeAggregators(query, cursor)
           );
           rowSelector[dimIndex] = aggs;
         }
@@ -199,7 +199,7 @@ public class StringTopNColumnAggregatesProcessor implements TopNColumnAggregates
         final Object key = dimensionValueConverter.apply(selector.lookupName(dimIndex));
         Aggregator[] aggs = aggregatesStore.computeIfAbsent(
             key,
-            k -> BaseTopNAlgorithm.makeAggregators(cursor, query.getAggregatorSpecs())
+            k -> BaseTopNAlgorithm.makeAggregators(query, cursor)
         );
         for (Aggregator aggregator : aggs) {
           aggregator.aggregate();

--- a/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerFailureTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerFailureTest.java
@@ -174,7 +174,7 @@ public class TopNQueryRunnerFailureTest extends InitializedNullHandlingTest
       TopNQuery query
   )
   {
-    final Sequence<Result<TopNResultValue>> retval = runWithMerge(query);;
+    final Sequence<Result<TopNResultValue>> retval = runWithMerge(query);
     TestHelper.assertExpectedResults(expectedResults, retval);
     return retval;
   }
@@ -251,14 +251,15 @@ public class TopNQueryRunnerFailureTest extends InitializedNullHandlingTest
         .build();
 
     List<Result<TopNResultValue>> expectedResults = Collections.emptyList();
-    assertExpectedResults(expectedResults,
-                          query.withAggregatorSpecs(Lists.newArrayList(Iterables.concat(
-                              QueryRunnerTestHelper.COMMON_FLOAT_AGGREGATORS,
-                              Lists.newArrayList(
-                                  new FloatMaxAggregatorFactory("maxIndex", "indexFloat"),
-                                  new FloatMinAggregatorFactory("minIndex", "indexFloat")
-                              )
-                          )))
+    assertExpectedResults(
+        expectedResults,
+        query.withAggregatorSpecs(Lists.newArrayList(Iterables.concat(
+            QueryRunnerTestHelper.COMMON_FLOAT_AGGREGATORS,
+            Lists.newArrayList(
+                new FloatMaxAggregatorFactory("maxIndex", "indexFloat"),
+                new FloatMinAggregatorFactory("minIndex", "indexFloat")
+            )
+        )))
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerFailureTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerFailureTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.topn;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import org.apache.druid.collections.CloseableStupidPool;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.guava.Sequence;
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.QueryContexts;
+import org.apache.druid.query.QueryPlus;
+import org.apache.druid.query.QueryRunner;
+import org.apache.druid.query.QueryRunnerTestHelper;
+import org.apache.druid.query.ResourceLimitExceededException;
+import org.apache.druid.query.Result;
+import org.apache.druid.query.TestQueryRunners;
+import org.apache.druid.query.aggregation.AggregatorFactory;
+import org.apache.druid.query.aggregation.DoubleMaxAggregatorFactory;
+import org.apache.druid.query.aggregation.DoubleMinAggregatorFactory;
+import org.apache.druid.query.aggregation.FloatMaxAggregatorFactory;
+import org.apache.druid.query.aggregation.FloatMinAggregatorFactory;
+import org.apache.druid.query.aggregation.firstlast.first.DoubleFirstAggregatorFactory;
+import org.apache.druid.query.context.ResponseContext;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ */
+@RunWith(Parameterized.class)
+public class TopNQueryRunnerFailureTest extends InitializedNullHandlingTest
+{
+  private static final Closer RESOURCE_CLOSER = Closer.create();
+
+  @AfterClass
+  public static void teardown() throws IOException
+  {
+    RESOURCE_CLOSER.close();
+  }
+
+  @Parameterized.Parameters(name = "{7}")
+  public static Iterable<Object[]> constructorFeeder()
+  {
+    List<QueryRunner<Result<TopNResultValue>>> retVal = queryRunners();
+    List<Object[]> parameters = new ArrayList<>();
+    final int nParam = 7;
+    for (int i = 0; i < 32; i++) {
+      for (QueryRunner<Result<TopNResultValue>> firstParameter : retVal) {
+        Object[] params = new Object[nParam];
+        params[0] = firstParameter;
+        params[1] = (i & 1) != 0;
+        params[2] = (i & 2) != 0;
+        params[3] = (i & 4) != 0;
+        params[4] = (i & 8) != 0;
+        params[5] = QueryRunnerTestHelper.COMMON_DOUBLE_AGGREGATORS;
+        params[6] = firstParameter + " double aggs";
+        Object[] params2 = Arrays.copyOf(params, nParam);
+        params2[5] = QueryRunnerTestHelper.COMMON_FLOAT_AGGREGATORS;
+        params2[6] = firstParameter + " float aggs";
+        parameters.add(params);
+        parameters.add(params2);
+      }
+    }
+    return parameters;
+  }
+
+  public static List<QueryRunner<Result<TopNResultValue>>> queryRunners()
+  {
+    final CloseableStupidPool<ByteBuffer> defaultPool = TestQueryRunners.createDefaultNonBlockingPool();
+    final CloseableStupidPool<ByteBuffer> customPool = new CloseableStupidPool<>(
+        "TopNQueryRunnerFactory-bufferPool",
+        () -> ByteBuffer.allocate(20000)
+    );
+
+    List<QueryRunner<Result<TopNResultValue>>> retVal = new ArrayList<>();
+    retVal.addAll(
+        QueryRunnerTestHelper.makeQueryRunnersToMerge(
+            new TopNQueryRunnerFactory(
+                defaultPool,
+                new TopNQueryQueryToolChest(new TopNQueryConfig()),
+                QueryRunnerTestHelper.NOOP_QUERYWATCHER
+            ),
+            false
+        )
+    );
+    retVal.addAll(
+        QueryRunnerTestHelper.makeQueryRunnersToMerge(
+            new TopNQueryRunnerFactory(
+                customPool,
+                new TopNQueryQueryToolChest(new TopNQueryConfig()),
+                QueryRunnerTestHelper.NOOP_QUERYWATCHER
+            ),
+            false
+        )
+    );
+
+    RESOURCE_CLOSER.register(() -> {
+      // Verify that all objects have been returned to the pool.
+      Assert.assertEquals("defaultPool objects created", defaultPool.poolSize(), defaultPool.objectsCreatedCount());
+      Assert.assertEquals("customPool objects created", customPool.poolSize(), customPool.objectsCreatedCount());
+      defaultPool.close();
+      customPool.close();
+    });
+
+    return retVal;
+  }
+
+  private final QueryRunner<Result<TopNResultValue>> runner;
+  private final List<AggregatorFactory> commonAggregators;
+
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @SuppressWarnings("unused")
+  public TopNQueryRunnerFailureTest(
+      QueryRunner<Result<TopNResultValue>> runner,
+      boolean specializeGeneric1AggPooledTopN,
+      boolean specializeGeneric2AggPooledTopN,
+      boolean specializeHistorical1SimpleDoubleAggPooledTopN,
+      boolean specializeHistoricalSingleValueDimSelector1SimpleDoubleAggPooledTopN,
+      List<AggregatorFactory> commonAggregators,
+      String testName
+  )
+  {
+    this.runner = runner;
+    PooledTopNAlgorithm.setSpecializeGeneric1AggPooledTopN(specializeGeneric1AggPooledTopN);
+    PooledTopNAlgorithm.setSpecializeGeneric2AggPooledTopN(specializeGeneric2AggPooledTopN);
+    PooledTopNAlgorithm.setSpecializeHistorical1SimpleDoubleAggPooledTopN(
+        specializeHistorical1SimpleDoubleAggPooledTopN
+    );
+    PooledTopNAlgorithm.setSpecializeHistoricalSingleValueDimSelector1SimpleDoubleAggPooledTopN(
+        specializeHistoricalSingleValueDimSelector1SimpleDoubleAggPooledTopN
+    );
+    this.commonAggregators = commonAggregators;
+  }
+
+  private Sequence<Result<TopNResultValue>> assertExpectedResults(
+      Iterable<Result<TopNResultValue>> expectedResults,
+      TopNQuery query
+  )
+  {
+    final Sequence<Result<TopNResultValue>> retval = runWithMerge(query);;
+    TestHelper.assertExpectedResults(expectedResults, retval);
+    return retval;
+  }
+
+  private Sequence<Result<TopNResultValue>> runWithMerge(TopNQuery query)
+  {
+    return runWithMerge(query, ResponseContext.createEmpty());
+  }
+
+  private Sequence<Result<TopNResultValue>> runWithMerge(TopNQuery query, ResponseContext context)
+  {
+    return runner.run(QueryPlus.wrap(query), context);
+  }
+
+  @Test
+  public void testEmptyTopN()
+  {
+    TopNQuery query = new TopNQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .granularity(QueryRunnerTestHelper.ALL_GRAN)
+        .dimension(QueryRunnerTestHelper.MARKET_DIMENSION)
+        .metric(QueryRunnerTestHelper.INDEX_METRIC)
+        .threshold(4)
+        .intervals(QueryRunnerTestHelper.EMPTY_INTERVAL)
+        .aggregators(
+            Lists.newArrayList(
+                Iterables.concat(
+                    commonAggregators,
+                    Lists.newArrayList(
+                        new DoubleMaxAggregatorFactory("maxIndex", "index"),
+                        new DoubleMinAggregatorFactory("minIndex", "index"),
+                        new DoubleFirstAggregatorFactory("first", "index", null)
+                    )
+                )
+            )
+        )
+        .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
+        .build();
+
+    List<Result<TopNResultValue>> expectedResults = ImmutableList.of(
+        new Result<>(
+            DateTimes.of("2020-04-02T00:00:00.000Z"),
+            TopNResultValue.create(ImmutableList.of())
+        )
+    );
+    assertExpectedResults(expectedResults, query);
+  }
+
+  @Test(expected = ResourceLimitExceededException.class)
+  public void testFullOnTopN()
+  {
+    Map<String, Object> context = new HashMap<>();
+    context.put(QueryContexts.MAX_TOP_N_AGGREGATOR_HEAP_SIZE_BYTES, 1);
+    TopNQuery query = new TopNQueryBuilder()
+        .dataSource(QueryRunnerTestHelper.DATA_SOURCE)
+        .granularity(QueryRunnerTestHelper.ALL_GRAN)
+        .dimension(QueryRunnerTestHelper.MARKET_DIMENSION)
+        .metric(QueryRunnerTestHelper.INDEX_METRIC)
+        .threshold(4)
+        .context(context)
+        .intervals(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+        .aggregators(
+            Lists.newArrayList(
+                Iterables.concat(
+                    commonAggregators,
+                    Lists.newArrayList(
+                        new DoubleMaxAggregatorFactory("maxIndex", "index"),
+                        new DoubleMinAggregatorFactory("minIndex", "index")
+                    )
+                )
+            )
+        )
+        .postAggregators(QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT)
+        .build();
+
+    List<Result<TopNResultValue>> expectedResults = Collections.emptyList();
+    assertExpectedResults(expectedResults,
+                          query.withAggregatorSpecs(Lists.newArrayList(Iterables.concat(
+                              QueryRunnerTestHelper.COMMON_FLOAT_AGGREGATORS,
+                              Lists.newArrayList(
+                                  new FloatMaxAggregatorFactory("maxIndex", "indexFloat"),
+                                  new FloatMinAggregatorFactory("minIndex", "indexFloat")
+                              )
+                          )))
+    );
+  }
+}

--- a/processing/src/test/java/org/apache/druid/segment/CursorHolderPreaggTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CursorHolderPreaggTest.java
@@ -42,6 +42,7 @@ import org.apache.druid.query.timeseries.TimeseriesQueryEngine;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.query.topn.TopNQuery;
 import org.apache.druid.query.topn.TopNQueryBuilder;
+import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.query.topn.TopNQueryEngine;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.segment.column.ColumnCapabilities;
@@ -218,6 +219,7 @@ public class CursorHolderPreaggTest extends InitializedNullHandlingTest
                                                       .build();
     Sequence<Result<TopNResultValue>> results = topNQueryEngine.query(
         topNQuery,
+        new TopNQueryConfig(),
         segment,
         null
     );

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactoryTest.java
@@ -59,6 +59,7 @@ import org.apache.druid.query.groupby.GroupByResourcesReservationPool;
 import org.apache.druid.query.groupby.GroupingEngine;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.topn.TopNQueryBuilder;
+import org.apache.druid.query.topn.TopNQueryConfig;
 import org.apache.druid.query.topn.TopNQueryEngine;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.segment.CloserRule;
@@ -391,6 +392,7 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
                 .threshold(10)
                 .aggregators(new LongSumAggregatorFactory("cnt", "cnt"))
                 .build(),
+            new TopNQueryConfig(),
             new IncrementalIndexSegment(index, SegmentId.dummy("test")),
             null
         )


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Adds a way to monitor aggregator map entry increases for TopN queries. This is in response to a problem we've seen in queries where a topN query is done with an expensive aggregator on a high-cardinality dimension. I've reproduced this problem locally, and confirmed that this fixes the issue in *most* cases. The other cases are outlined in Drawbacks.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

#### Approach
Use a configurable per (query, historical) fixed size byte amount that aggregators can take up. The byte count is maintained at a segment-level during each query runner's pass through a segment (getting result sequence). I opted for this instead of doing a %-of-heap based approach as in high-traffic scenarios, there could be multiple queries racing to allocate some memory for aggregators, and these could all read say, 5% of total available heap (let's say this is permissible % to allocate). If we're already at 80-90%, this could result poorly. Instead, using a fixed amount is a bit more cumbersome, but at least guarantees a realistic upper-bound on how much memory N concurrent queries could theoretically use. Changing to either approach (or another) is easy enough. I found the latter performed more consistently in local testing with artificially low heap sizes and with parallel queries. Another alternative I was thinking was a shared buffer that queries can "borrow" from for doing their queries, where this pool would be shared amongst all running queries. This is a bit like what GroupBy does.

#### Drawbacks
- No spilling to disk. This will have to come in a separate PR, ideally sharing some of the code in groupby.
- No knowledge of # of parallel queries. GroupBy is cognizant of this with `processing.numMergeBuffers`. I could use this as an "automated" way of determining the available buffer size instead of hardcoding a default constant, for example: `some % of maxJVMHeap / # max parallel queries`

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
* `extensions-contrib/distinctcount/src/test/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java`
* `processing/src/main/java/org/apache/druid/query/topn/BaseTopNAlgorithm.java`
* `processing/src/main/java/org/apache/druid/query/topn/PooledTopNAlgorithm.java`
* `processing/src/main/java/org/apache/druid/query/topn/TopNAggregatorResourceHelper.java`
* `processing/src/main/java/org/apache/druid/query/topn/TopNQuery.java`
* `processing/src/main/java/org/apache/druid/query/topn/TopNQueryEngine.java`
* `processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java`
* `processing/src/main/java/org/apache/druid/query/topn/TopNQueryRunnerFactory.java`
* `processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerFailureTest.java`
* `processing/src/test/java/org/apache/druid/segment/CursorHolderPreaggTest.java`
* `processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactoryTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
