### PR TITLE
ManageLifecycle DropwizardEmitter instantiation

### DIFF
--- a/extensions-contrib/dropwizard-emitter/src/main/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterModule.java
+++ b/extensions-contrib/dropwizard-emitter/src/main/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterModule.java
@@ -28,6 +28,7 @@ import com.google.inject.Provides;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 import org.apache.druid.guice.JsonConfigProvider;
+import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.emitter.core.Emitter;
 
@@ -52,6 +53,7 @@ public class DropwizardEmitterModule implements DruidModule
   }
 
   @Provides
+  @ManageLifecycle
   @Named(EMITTER_TYPE)
   public Emitter getEmitter(
       DropwizardEmitterConfig dropwizardEmitterConfig,


### PR DESCRIPTION
### Problem
Fixes the issue reported in https://apachedruidworkspace.slack.com/archives/C030CMF6B70/p1730782496492849.
```
java.util.concurrent.RejectedExecutionException: Dropwizard emitter Service not started.
        at org.apache.druid.emitter.dropwizard.DropwizardEmitter.emit(DropwizardEmitter.java:96) ~[?:?]
        at org.apache.druid.java.util.emitter.core.ComposingEmitter.emit(ComposingEmitter.java:57) ~[druid-processing-27.0.0.3.2.2.0-1.jar:27.0.0.3.2.2.0-1]
        at org.apache.druid.java.util.emitter.service.ServiceEmitter.emit(ServiceEmitter.java:67) ~[druid-processing-27.0.0.3.2.2.0-1.jar:27.0.0.3.2.2.0-1]
        at org.apache.druid.java.util.emitter.service.ServiceEmitter.emit(ServiceEmitter.java:72) ~[druid-processing-27.0.0.3.2.2.0-1.jar:27.0.0.3.2.2.0-1]
```

### Fix
Without the `ManageLifecycle` annotation, an instance of the emitter will be instantiated without proper initialization. Having the dropwizard emitter on the `ManageLifecycle` ensures that an instance of the emitter gets registered with the lifecycle such that it starts doing things based on `start()` & `stop()` from the lifecycle. The alternative would be to use the `LazySingleton` scope but `ManageLifecycle` is what [all](https://github.com/apache/druid/blob/master/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitterModule.java#L52) the [other](https://github.com/apache/druid/blob/master/extensions-contrib/prometheus-emitter/src/main/java/org/apache/druid/emitter/prometheus/PrometheusEmitterModule.java#L56) emitter implementations do.


### Release note

Fixes an issue with the dropwizard emitter instantiation, where the emitter starts up without proper initialization thereby bringing down Druid processes.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
