### PR TITLE
Emit QueryCountMetrics for SQL Queries

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
@@ -33,6 +33,7 @@ import org.apache.druid.msq.dart.controller.DartControllerRegistry;
 import org.apache.druid.msq.dart.controller.sql.DartSqlClients;
 import org.apache.druid.msq.dart.controller.sql.DartSqlEngine;
 import org.apache.druid.query.DefaultQueryConfig;
+import org.apache.druid.server.BaseQueryCountResource;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.ResponseContextConfig;
 import org.apache.druid.server.initialization.ServerConfig;
@@ -98,7 +99,8 @@ public class DartSqlResource extends SqlResource
       final ServerConfig serverConfig,
       final ResponseContextConfig responseContextConfig,
       @Self final DruidNode selfNode,
-      @Dart final DefaultQueryConfig dartQueryConfig
+      @Dart final DefaultQueryConfig dartQueryConfig,
+      final BaseQueryCountResource baseQueryResource
   )
   {
     super(
@@ -108,7 +110,8 @@ public class DartSqlResource extends SqlResource
         sqlLifecycleManager,
         serverConfig,
         responseContextConfig,
-        selfNode
+        selfNode,
+        baseQueryResource
     );
     this.controllerRegistry = controllerRegistry;
     this.sqlLifecycleManager = sqlLifecycleManager;

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -51,6 +51,7 @@ import org.apache.druid.msq.test.MSQTestControllerContext;
 import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryContexts;
+import org.apache.druid.server.BaseQueryCountResource;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.QueryStackTests;
 import org.apache.druid.server.ResponseContextConfig;
@@ -239,7 +240,8 @@ public class DartSqlResourceTest extends MSQTestBase
         new ServerConfig() /* currently only used for error transform strategy */,
         ResponseContextConfig.newConfig(false),
         SELF_NODE,
-        new DefaultQueryConfig(ImmutableMap.of("foo", "bar"))
+        new DefaultQueryConfig(ImmutableMap.of("foo", "bar")),
+        new BaseQueryCountResource()
     );
 
     // Setup mocks

--- a/quidem-ut/src/main/java/org/apache/druid/quidem/ExposedAsBrokerQueryComponentSupplierWrapper.java
+++ b/quidem-ut/src/main/java/org/apache/druid/quidem/ExposedAsBrokerQueryComponentSupplierWrapper.java
@@ -74,6 +74,7 @@ import org.apache.druid.metadata.storage.derby.DerbyMetadataStorageDruidModule;
 import org.apache.druid.query.RetryQueryRunnerConfig;
 import org.apache.druid.rpc.guice.ServiceClientModule;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumModule;
+import org.apache.druid.server.BaseQueryCountResource;
 import org.apache.druid.server.BrokerQueryResource;
 import org.apache.druid.server.ClientInfoResource;
 import org.apache.druid.server.DruidNode;
@@ -242,7 +243,7 @@ public class ExposedAsBrokerQueryComponentSupplierWrapper extends QueryComponent
           binder.bind(BrokerQueryResource.class).in(LazySingleton.class);
           Jerseys.addResource(binder, BrokerQueryResource.class);
           binder.bind(SubqueryGuardrailHelper.class).toProvider(SubqueryGuardrailHelperProvider.class);
-          binder.bind(QueryCountStatsProvider.class).to(BrokerQueryResource.class).in(LazySingleton.class);
+          binder.bind(QueryCountStatsProvider.class).to(BaseQueryCountResource.class).in(LazySingleton.class);
           binder.bind(SubqueryCountStatsProvider.class).toInstance(new SubqueryCountStatsProvider());
           Jerseys.addResource(binder, BrokerResource.class);
           Jerseys.addResource(binder, ClientInfoResource.class);

--- a/server/src/main/java/org/apache/druid/server/BaseQueryCountResource.java
+++ b/server/src/main/java/org/apache/druid/server/BaseQueryCountResource.java
@@ -1,0 +1,63 @@
+package org.apache.druid.server;
+
+import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.server.metrics.QueryCountStatsProvider;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@LazySingleton
+public class BaseQueryCountResource implements QueryCountStatsProvider, QueryMetricCounter
+{
+  private final AtomicLong successfulQueryCount = new AtomicLong();
+  private final AtomicLong failedQueryCount = new AtomicLong();
+  private final AtomicLong interruptedQueryCount = new AtomicLong();
+  private final AtomicLong timedOutQueryCount = new AtomicLong();
+
+  @Override
+  public long getSuccessfulQueryCount()
+  {
+    return successfulQueryCount.get();
+  }
+
+  @Override
+  public long getFailedQueryCount()
+  {
+    return failedQueryCount.get();
+  }
+
+  @Override
+  public long getInterruptedQueryCount()
+  {
+    return interruptedQueryCount.get();
+  }
+
+  @Override
+  public long getTimedOutQueryCount()
+  {
+    return timedOutQueryCount.get();
+  }
+
+  @Override
+  public void incrementSuccess()
+  {
+    successfulQueryCount.incrementAndGet();
+  }
+
+  @Override
+  public void incrementFailed()
+  {
+    failedQueryCount.incrementAndGet();
+  }
+
+  @Override
+  public void incrementInterrupted()
+  {
+    interruptedQueryCount.incrementAndGet();
+  }
+
+  @Override
+  public void incrementTimedOut()
+  {
+    timedOutQueryCount.incrementAndGet();
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/BaseQueryCountResource.java
+++ b/server/src/main/java/org/apache/druid/server/BaseQueryCountResource.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.server;
 
 import org.apache.druid.guice.LazySingleton;

--- a/server/src/main/java/org/apache/druid/server/BrokerQueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/BrokerQueryResource.java
@@ -63,7 +63,8 @@ public class BrokerQueryResource extends QueryResource
       AuthorizerMapper authorizerMapper,
       ResponseContextConfig responseContextConfig,
       @Self DruidNode selfNode,
-      TimelineServerView brokerServerView
+      TimelineServerView brokerServerView,
+      BaseQueryCountResource counter
   )
   {
     super(
@@ -74,7 +75,9 @@ public class BrokerQueryResource extends QueryResource
         authConfig,
         authorizerMapper,
         responseContextConfig,
-        selfNode
+        selfNode,
+        counter
+
     );
     this.brokerServerView = brokerServerView;
   }

--- a/server/src/main/java/org/apache/druid/server/BrokerQueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/BrokerQueryResource.java
@@ -77,7 +77,6 @@ public class BrokerQueryResource extends QueryResource
         responseContextConfig,
         selfNode,
         counter
-
     );
     this.brokerServerView = brokerServerView;
   }

--- a/server/src/main/java/org/apache/druid/server/QueryMetricCounter.java
+++ b/server/src/main/java/org/apache/druid/server/QueryMetricCounter.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.druid.server;
 
 public interface QueryMetricCounter

--- a/server/src/main/java/org/apache/druid/server/QueryMetricCounter.java
+++ b/server/src/main/java/org/apache/druid/server/QueryMetricCounter.java
@@ -1,0 +1,12 @@
+package org.apache.druid.server;
+
+public interface QueryMetricCounter
+{
+  void incrementSuccess();
+
+  void incrementFailed();
+
+  void incrementInterrupted();
+
+  void incrementTimedOut();
+}

--- a/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
@@ -233,6 +233,7 @@ public abstract class QueryResultPusher
   {
     if (resultsWriter != null) {
       resultsWriter.recordFailure(e);
+      counter.incrementFailed();
 
       if (accumulator != null && accumulator.isInitialized()) {
         // We already started sending a response when we got the error message.  In this case we just give up
@@ -242,7 +243,6 @@ public abstract class QueryResultPusher
         // the future.
         trailerFields.put(QueryResource.ERROR_MESSAGE_TRAILER_HEADER, e.getMessage());
         trailerFields.put(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER, "false");
-        counter.incrementFailed();
         return null;
       }
     }

--- a/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
@@ -63,7 +63,7 @@ public abstract class QueryResultPusher
   private final ObjectMapper jsonMapper;
   private final ResponseContextConfig responseContextConfig;
   private final DruidNode selfNode;
-  private final QueryResource.QueryMetricCounter counter;
+  private final QueryMetricCounter counter;
   private final MediaType contentType;
   private final Map<String, String> extraHeaders;
   private final HttpFields trailerFields;
@@ -77,7 +77,7 @@ public abstract class QueryResultPusher
       ObjectMapper jsonMapper,
       ResponseContextConfig responseContextConfig,
       DruidNode selfNode,
-      QueryResource.QueryMetricCounter counter,
+      QueryMetricCounter counter,
       String queryId,
       MediaType contentType,
       Map<String, String> extraHeaders
@@ -233,7 +233,6 @@ public abstract class QueryResultPusher
   {
     if (resultsWriter != null) {
       resultsWriter.recordFailure(e);
-      counter.incrementFailed();
 
       if (accumulator != null && accumulator.isInitialized()) {
         // We already started sending a response when we got the error message.  In this case we just give up
@@ -243,6 +242,7 @@ public abstract class QueryResultPusher
         // the future.
         trailerFields.put(QueryResource.ERROR_MESSAGE_TRAILER_HEADER, e.getMessage());
         trailerFields.put(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER, "false");
+        counter.incrementFailed();
         return null;
       }
     }

--- a/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResourceTest.java
@@ -253,7 +253,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         responseContextConfig,
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
   }
 
@@ -288,7 +289,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
     expectPermissiveHappyPathAuth();
@@ -362,7 +364,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
     expectPermissiveHappyPathAuth();
@@ -450,7 +453,8 @@ public class QueryResourceTest
       new AuthConfig(),
       null,
       ResponseContextConfig.newConfig(true),
-      DRUID_NODE
+      DRUID_NODE,
+      new BaseQueryCountResource()
     );
 
     expectPermissiveHappyPathAuth();
@@ -492,7 +496,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
     expectPermissiveHappyPathAuth();
@@ -574,7 +579,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
     expectPermissiveHappyPathAuth();
@@ -616,7 +622,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
     expectPermissiveHappyPathAuth();
@@ -659,7 +666,7 @@ public class QueryResourceTest
         SIMPLE_TIMESERIES_QUERY.getBytes(StandardCharsets.UTF_8),
         queryResource
     );
-    Assert.assertEquals(1, queryResource.getInterruptedQueryCount());
+    Assert.assertEquals(1, queryResource.counter.getInterruptedQueryCount());
     Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatus());
     final String expectedException = new QueryInterruptedException(
         new TruncatedResponseContextException("Serialized response context exceeds the max size[0]"),
@@ -853,7 +860,8 @@ public class QueryResourceTest
         new AuthConfig(),
         authMapper,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
 
@@ -928,7 +936,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
     expectPermissiveHappyPathAuth();
 
@@ -957,7 +966,7 @@ public class QueryResourceTest
     Assert.assertEquals("Query did not complete within configured timeout period. You can " +
                         "increase query timeout or tune the performance of query.", ex.getMessage());
     Assert.assertEquals(QueryException.QUERY_TIMEOUT_ERROR_CODE, ex.getErrorCode());
-    Assert.assertEquals(1, timeoutQueryResource.getTimedOutQueryCount());
+    Assert.assertEquals(1, timeoutQueryResource.counter.getTimedOutQueryCount());
 
   }
 
@@ -1024,7 +1033,8 @@ public class QueryResourceTest
         new AuthConfig(),
         authMapper,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
     final String queryString = "{\"queryType\":\"timeBoundary\", \"dataSource\":\"allow\","
@@ -1131,7 +1141,8 @@ public class QueryResourceTest
         new AuthConfig(),
         authMapper,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
 
     final String queryString = "{\"queryType\":\"timeBoundary\", \"dataSource\":\"allow\","
@@ -1483,7 +1494,8 @@ public class QueryResourceTest
         new AuthConfig(),
         null,
         ResponseContextConfig.newConfig(true),
-        DRUID_NODE
+        DRUID_NODE,
+        new BaseQueryCountResource()
     );
   }
 

--- a/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.server.QueryResource.QueryMetricCounter;
 import org.apache.druid.server.QueryResultPusher.ResultsWriter;
 import org.apache.druid.server.QueryResultPusher.Writer;
 import org.apache.druid.server.mocks.MockHttpServletRequest;
@@ -58,7 +57,7 @@ public class QueryResultPusherTest
     ObjectMapper jsonMapper = new DefaultObjectMapper();
     ResponseContextConfig responseContextConfig = ResponseContextConfig.newConfig(true);
     DruidNode selfNode = DRUID_NODE;
-    QueryResource.QueryMetricCounter counter = new NoopQueryMetricCounter();
+    QueryMetricCounter counter = new NoopQueryMetricCounter();
     String queryId = "someQuery";
     MediaType contentType = MediaType.APPLICATION_JSON_TYPE;
     Map<String, String> extraHeaders = new HashMap<String, String>();

--- a/services/src/main/java/org/apache/druid/cli/CliBroker.java
+++ b/services/src/main/java/org/apache/druid/cli/CliBroker.java
@@ -56,6 +56,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.RetryQueryRunnerConfig;
 import org.apache.druid.query.lookup.LookupModule;
+import org.apache.druid.server.BaseQueryCountResource;
 import org.apache.druid.server.BrokerQueryResource;
 import org.apache.druid.server.ClientInfoResource;
 import org.apache.druid.server.ClientQuerySegmentWalker;
@@ -154,7 +155,7 @@ public class CliBroker extends ServerRunnable
           binder.bind(BrokerQueryResource.class).in(LazySingleton.class);
           Jerseys.addResource(binder, BrokerQueryResource.class);
           binder.bind(SubqueryGuardrailHelper.class).toProvider(SubqueryGuardrailHelperProvider.class);
-          binder.bind(QueryCountStatsProvider.class).to(BrokerQueryResource.class).in(LazySingleton.class);
+          binder.bind(QueryCountStatsProvider.class).to(BaseQueryCountResource.class).in(LazySingleton.class);
           binder.bind(SubqueryCountStatsProvider.class).toInstance(new SubqueryCountStatsProvider());
           Jerseys.addResource(binder, BrokerResource.class);
           Jerseys.addResource(binder, ClientInfoResource.class);

--- a/services/src/main/java/org/apache/druid/cli/CliHistorical.java
+++ b/services/src/main/java/org/apache/druid/cli/CliHistorical.java
@@ -47,6 +47,7 @@ import org.apache.druid.guice.ServerTypeConfig;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.lookup.LookupModule;
+import org.apache.druid.server.BaseQueryCountResource;
 import org.apache.druid.server.QueryResource;
 import org.apache.druid.server.ResponseContextConfig;
 import org.apache.druid.server.SegmentManager;
@@ -119,7 +120,7 @@ public class CliHistorical extends ServerRunnable
 
           binder.bind(ServerTypeConfig.class).toInstance(new ServerTypeConfig(ServerType.HISTORICAL));
           binder.bind(JettyServerInitializer.class).to(QueryJettyServerInitializer.class).in(LazySingleton.class);
-          binder.bind(QueryCountStatsProvider.class).to(QueryResource.class);
+          binder.bind(QueryCountStatsProvider.class).to(BaseQueryCountResource.class);
           Jerseys.addResource(binder, QueryResource.class);
           Jerseys.addResource(binder, SegmentListerResource.class);
           Jerseys.addResource(binder, HistoricalResource.class);

--- a/services/src/main/java/org/apache/druid/guice/QueryablePeonModule.java
+++ b/services/src/main/java/org/apache/druid/guice/QueryablePeonModule.java
@@ -21,6 +21,7 @@ package org.apache.druid.guice;
 
 import com.google.inject.Binder;
 import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.server.BaseQueryCountResource;
 import org.apache.druid.server.QueryResource;
 import org.apache.druid.server.metrics.QueryCountStatsProvider;
 
@@ -29,7 +30,7 @@ public class QueryablePeonModule implements DruidModule
   @Override
   public void configure(Binder binder)
   {
-    binder.bind(QueryCountStatsProvider.class).to(QueryResource.class);
+    binder.bind(QueryCountStatsProvider.class).to(BaseQueryCountResource.class);
     Jerseys.addResource(binder, QueryResource.class);
     LifecycleModule.register(binder, QueryResource.class);
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes https://github.com/apache/druid/issues/11652.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

This pulls out the query count metrics logic from `QueryResource` and places it into `BaseQueryCounterResource`, which allows for `SqlResource` to share this codepath. An alternative approach is [here](https://github.com/jtuglu-netflix/druid/tree/add-query-metrics-for-sql), which avoids shared logic between the two resources. As stated in the issue, the ideal change would be to have `SqlResource` inherit, or simply pass on, all query handling to `QueryResource`, but that seemed a bit out of scope for this PR (but I can do this).

Notes:
- I removed the get/increment handles from both `QueryResource` and `SqlResource` for simplicity, and simply made the counter package-private for accessing in tests. I can add the `get()` accessors back if necessary.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
* `extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java`
* `extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java`
* `quidem-ut/src/main/java/org/apache/druid/quidem/ExposedAsBrokerQueryComponentSupplierWrapper.java`
* `server/src/main/java/org/apache/druid/server/BaseQueryCountResource.java`
* `server/src/main/java/org/apache/druid/server/BrokerQueryResource.java`
* `server/src/main/java/org/apache/druid/server/QueryMetricCounter.java`
* `server/src/main/java/org/apache/druid/server/QueryResource.java`
* `server/src/main/java/org/apache/druid/server/QueryResultPusher.java`
* `server/src/test/java/org/apache/druid/server/QueryResourceTest.java`
* `server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java`
* `services/src/main/java/org/apache/druid/cli/CliBroker.java`
* `services/src/main/java/org/apache/druid/cli/CliHistorical.java`
* `services/src/main/java/org/apache/druid/guice/QueryablePeonModule.java`
* `sql/src/main/java/org/apache/druid/sql/http/SqlResource.java`
* `sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
