### PR TITLE
Run JDK 21 workflows with 21.0.4.

### DIFF
--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [8, 17, 21]
+        jdk: ['8', '17', '21.0.4']
     uses: ./.github/workflows/reusable-standard-its.yml
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: ['8', '17', '21.0.4']
+        jdk: [8, 17, 21]
     uses: ./.github/workflows/reusable-standard-its.yml
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '8', '11', '17', '21' ]
+        java: [ '8', '11', '17', '21.0.4' ]
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -41,6 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
         java: [ '8', '11', '17', '21.0.4' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -79,6 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
         jdk: [ '8', '11', '17', '21.0.4' ]
     runs-on: ubuntu-latest
     steps:
@@ -160,6 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
         jdk: [ '11', '17', '21.0.4' ]
     name: "unit tests (jdk${{ matrix.jdk }}, sql-compat=true)"
     uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '8', '11', '17', '21' ]
+        jdk: [ '8', '11', '17', '21.0.4' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 11, 17, 21 ]
+        jdk: [ '11', '17', '21.0.4' ]
     name: "unit tests (jdk${{ matrix.jdk }}, sql-compat=true)"
     uses: ./.github/workflows/unit-tests.yml
     needs: unit-tests


### PR DESCRIPTION
To work around #17429, run our JDK 21 workflows with version 21.0.4. It does not appear to have this problem.