### PR TITLE
projection segment merge fixes

### DIFF
--- a/processing/src/main/java/org/apache/druid/common/utils/SerializerUtils.java
+++ b/processing/src/main/java/org/apache/druid/common/utils/SerializerUtils.java
@@ -22,21 +22,14 @@ package org.apache.druid.common.utils;
 import com.google.common.io.ByteStreams;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
-import org.apache.druid.annotations.SuppressFBWarnings;
-import org.apache.druid.error.DruidException;
 import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.segment.serde.Serializer;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
-import java.nio.channels.FileChannel;
-import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.EnumSet;
 
@@ -238,84 +231,5 @@ public class SerializerUtils
   public int getSerializedStringByteSize(String str)
   {
     return Integer.BYTES + StringUtils.toUtf8(str).length;
-  }
-
-
-  /**
-   * Write a {@link Serializer} to a {@link Path} and then map it as a read-only {@link MappedByteBuffer}
-   */
-  @SuppressFBWarnings("NP_NONNULL_PARAM_VIOLATION")
-  public static MappedByteBuffer mapSerializer(Path path, Serializer writer)
-  {
-    try (final FileChannel fileChannel = FileChannel.open(path, MAP_SERIALIZER_OPTIONS);
-         final GatheringByteChannel smooshChannel = createSerializableChannel(fileChannel, writer.getSerializedSize())) {
-      //noinspection DataFlowIssue
-      writer.writeTo(smooshChannel, null);
-      return fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, writer.getSerializedSize());
-    }
-    catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  /**
-   * Create a {@link GatheringByteChannel} from another {@link FileChannel} with size set correctly so it is suitable
-   * to use for writing with a {@link Serializer}
-   */
-  private static GatheringByteChannel createSerializableChannel(FileChannel channel, long size)
-  {
-    // this is pretty similar to some implementations of SmooshedWriter in FileSmoosher, some of which could probably
-    // be refactored to use this method in the future.
-    return new GatheringByteChannel()
-    {
-      private boolean isClosed = false;
-      private long currOffset = 0;
-
-      @Override
-      public boolean isOpen()
-      {
-        return !isClosed;
-      }
-
-      @Override
-      public void close() throws IOException
-      {
-        channel.close();
-        isClosed = true;
-      }
-
-      @Override
-      public int write(ByteBuffer buffer) throws IOException
-      {
-        return addToOffset(channel.write(buffer));
-      }
-
-      @Override
-      public long write(ByteBuffer[] srcs, int offset, int length) throws IOException
-      {
-        return addToOffset(channel.write(srcs, offset, length));
-      }
-
-      @Override
-      public long write(ByteBuffer[] srcs) throws IOException
-      {
-        return addToOffset(channel.write(srcs));
-      }
-
-      public int addToOffset(long numBytesWritten)
-      {
-        final long bytesLeft = size - currOffset;
-        if (numBytesWritten > bytesLeft) {
-          throw DruidException.defensive(
-              "Wrote more bytes[%,d] than available[%,d]. Don't do that.",
-              numBytesWritten,
-              bytesLeft
-          );
-        }
-        currOffset += numBytesWritten;
-
-        return Ints.checkedCast(numBytesWritten);
-      }
-    };
   }
 }

--- a/processing/src/main/java/org/apache/druid/common/utils/SerializerUtils.java
+++ b/processing/src/main/java/org/apache/druid/common/utils/SerializerUtils.java
@@ -30,18 +30,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.StandardOpenOption;
-import java.util.EnumSet;
 
 public class SerializerUtils
 {
-  private static final EnumSet<StandardOpenOption> MAP_SERIALIZER_OPTIONS = EnumSet.of(
-      StandardOpenOption.READ,
-      StandardOpenOption.WRITE,
-      StandardOpenOption.CREATE,
-      StandardOpenOption.TRUNCATE_EXISTING
-  );
-
   public <T extends OutputStream> void writeString(T out, String name) throws IOException
   {
     byte[] nameBytes = StringUtils.toUtf8(name);

--- a/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnMerger.java
@@ -50,7 +50,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -89,7 +88,7 @@ public class AutoTypeColumnMerger implements DimensionMergerV9
   private boolean isVariantType = false;
   private byte variantTypeByte = 0x00;
 
-  private final Path segmentBasePath;
+  private final File segmentBaseDir;
 
   /**
    * @param name                  column name
@@ -119,7 +118,7 @@ public class AutoTypeColumnMerger implements DimensionMergerV9
     this.castToType = castToType;
     this.indexSpec = indexSpec;
     this.segmentWriteOutMedium = segmentWriteOutMedium;
-    this.segmentBasePath = segmentBaseDir.toPath();
+    this.segmentBaseDir = segmentBaseDir;
     this.closer = closer;
   }
 
@@ -271,7 +270,7 @@ public class AutoTypeColumnMerger implements DimensionMergerV9
         );
       }
 
-      serializer.openDictionaryWriter(segmentBasePath);
+      serializer.openDictionaryWriter(segmentBaseDir);
       serializer.serializeFields(mergedFields);
 
       int stringCardinality;

--- a/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/AutoTypeColumnMerger.java
@@ -46,9 +46,11 @@ import org.apache.druid.segment.serde.NestedCommonFormatColumnPartSerde;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -87,6 +89,8 @@ public class AutoTypeColumnMerger implements DimensionMergerV9
   private boolean isVariantType = false;
   private byte variantTypeByte = 0x00;
 
+  private final Path segmentBasePath;
+
   /**
    * @param name                  column name
    * @param outputName            output smoosh file name. if this is a base table column, it will be the equivalent to
@@ -105,6 +109,7 @@ public class AutoTypeColumnMerger implements DimensionMergerV9
       @Nullable ColumnType castToType,
       IndexSpec indexSpec,
       SegmentWriteOutMedium segmentWriteOutMedium,
+      File segmentBaseDir,
       Closer closer
   )
   {
@@ -114,6 +119,7 @@ public class AutoTypeColumnMerger implements DimensionMergerV9
     this.castToType = castToType;
     this.indexSpec = indexSpec;
     this.segmentWriteOutMedium = segmentWriteOutMedium;
+    this.segmentBasePath = segmentBaseDir.toPath();
     this.closer = closer;
   }
 
@@ -265,7 +271,7 @@ public class AutoTypeColumnMerger implements DimensionMergerV9
         );
       }
 
-      serializer.openDictionaryWriter();
+      serializer.openDictionaryWriter(segmentBasePath);
       serializer.serializeFields(mergedFields);
 
       int stringCardinality;

--- a/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
@@ -118,7 +118,7 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
 
   protected File segmentBaseDir;
   @MonotonicNonNull
-  protected PersistedIdConversions persistedIdConversions = null;
+  protected PersistedIdConversions persistedIdConversions;
 
   public DictionaryEncodedColumnMerger(
       String dimensionName,

--- a/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
@@ -759,7 +759,7 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
     }
 
     @Override
-    public long getSerializedSize() throws IOException
+    public long getSerializedSize()
     {
       return (long) buffer.capacity() * Integer.BYTES;
     }
@@ -848,7 +848,7 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
     }
 
     @Override
-    public void close() throws IOException
+    public void close()
     {
       isClosed = true;
       ByteBufferUtils.unmap(mappedBuffer);

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandler.java
@@ -104,6 +104,9 @@ public interface DimensionHandler
 
   /**
    * @deprecated use {@link #makeMerger(String, IndexSpec, SegmentWriteOutMedium, ColumnCapabilities, ProgressIndicator, File, Closer)}
+   *
+   * This method exists for backwards compatiblity with older versions of Druid since this is an unofficial extension
+   * point that must be implemented to create custom dimension types, and will be removed in a future release.
    */
   @Deprecated
   default DimensionMergerV9 makeMerger(

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandler.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment;
 
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionSchema.MultiValueHandling;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.dimension.DimensionSpec;
@@ -29,6 +30,7 @@ import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.util.Comparator;
 
 /**
@@ -101,6 +103,25 @@ public interface DimensionHandler
   DimensionIndexer<EncodedType, EncodedKeyComponentType, ActualType> makeIndexer(boolean useMaxMemoryEstimates);
 
   /**
+   * @deprecated use {@link #makeMerger(String, IndexSpec, SegmentWriteOutMedium, ColumnCapabilities, ProgressIndicator, File, Closer)}
+   */
+  @Deprecated
+  default DimensionMergerV9 makeMerger(
+      String outputName,
+      IndexSpec indexSpec,
+      SegmentWriteOutMedium segmentWriteOutMedium,
+      ColumnCapabilities capabilities,
+      ProgressIndicator progress,
+      Closer closer
+  )
+  {
+    throw DruidException.defensive(
+        "this method is no longer supported, use makeMerger(String, IndexSpec, SegmentWriteOutMedium, ColumnCapabilities, ProgressIndicator, File, Closer) instead"
+    );
+  }
+
+
+  /**
    * Creates a new DimensionMergerV9, a per-dimension object responsible for merging indexes/row data across segments
    * and building the on-disk representation of a dimension. For use with IndexMergerV9 only.
    *
@@ -113,16 +134,32 @@ public interface DimensionHandler
    *                              needed
    * @param capabilities          The ColumnCapabilities of the dimension represented by this DimensionHandler
    * @param progress              ProgressIndicator used by the merging process
+   * @param segmentBaseDir        segment write out path; temporary files may be created here, though should delete
+   *                              after merge is finished OR be registered with the Closer parameter
+   * @param closer                Closer tied to segment completion. Anything which is not cleaned up inside of the
+   *                              merger after merge is complete should be registered with this closer. For example,
+   *                              resources which are required for final serialization of the column
    * @return A new DimensionMergerV9 object.
    */
-  DimensionMergerV9 makeMerger(
+  default DimensionMergerV9 makeMerger(
       String outputName,
       IndexSpec indexSpec,
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
-  );
+  )
+  {
+    return makeMerger(
+        outputName,
+        indexSpec,
+        segmentWriteOutMedium,
+        capabilities,
+        progress,
+        closer
+    );
+  }
 
   /**
    * Given an key component representing a single set of row value(s) for this dimension as an Object,

--- a/processing/src/main/java/org/apache/druid/segment/DimensionMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionMergerV9.java
@@ -40,6 +40,16 @@ public interface DimensionMergerV9 extends DimensionMerger
   ColumnDescriptor makeColumnDescriptor();
 
   /**
+   * Sets this merger as the "parent" of another merger for a "projection", allowing for this merger to preserve any
+   * state which might be required for the projection mergers to do their thing. This method MUST be called prior to
+   * performing any merge work
+   */
+  default void markAsParent()
+  {
+    // do nothing
+  }
+
+  /**
    * Attaches the {@link DimensionMergerV9} of a "projection" parent column so that stuff like value dictionaries can
    * be shared between parent and child
    */

--- a/processing/src/main/java/org/apache/druid/segment/DimensionMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionMergerV9.java
@@ -42,7 +42,8 @@ public interface DimensionMergerV9 extends DimensionMerger
   /**
    * Sets this merger as the "parent" of another merger for a "projection", allowing for this merger to preserve any
    * state which might be required for the projection mergers to do their thing. This method MUST be called prior to
-   * performing any merge work
+   * performing any merge work. Typically, this method is only implemented if
+   * {@link #attachParent(DimensionMergerV9, List)} requires it.
    */
   default void markAsParent()
   {
@@ -51,10 +52,14 @@ public interface DimensionMergerV9 extends DimensionMerger
 
   /**
    * Attaches the {@link DimensionMergerV9} of a "projection" parent column so that stuff like value dictionaries can
-   * be shared between parent and child
+   * be shared between parent and child. This method is called during merging instead of {@link #writeMergedValueDictionary(List)} if
+   * the parent column exists.
+   * 
+   * @see IndexMergerV9#makeProjections 
    */
   default void attachParent(DimensionMergerV9 parent, List<IndexableAdapter> projectionAdapters) throws IOException
   {
-    // do nothing
+    // by default fall through to writing merged dictionary
+    writeMergedValueDictionary(projectionAdapters);
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/DoubleDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/DoubleDimensionHandler.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.selector.settable.SettableDoubleColumnValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
+import java.io.File;
 import java.util.Comparator;
 
 public class DoubleDimensionHandler implements DimensionHandler<Double, Double, Double>
@@ -82,6 +83,7 @@ public class DoubleDimensionHandler implements DimensionHandler<Double, Double, 
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
   )
   {

--- a/processing/src/main/java/org/apache/druid/segment/FloatDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/FloatDimensionHandler.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.selector.settable.SettableFloatColumnValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
+import java.io.File;
 import java.util.Comparator;
 
 public class FloatDimensionHandler implements DimensionHandler<Float, Float, Float>
@@ -82,6 +83,7 @@ public class FloatDimensionHandler implements DimensionHandler<Float, Float, Flo
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
   )
   {

--- a/processing/src/main/java/org/apache/druid/segment/IndexIO.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexIO.java
@@ -719,6 +719,7 @@ public class IndexIO
 
         if (groupingColumn.equals(projectionSpec.getSchema().getTimeColumnName())) {
           projectionColumns.put(ColumnHolder.TIME_COLUMN_NAME, projectionColumns.get(groupingColumn));
+          projectionColumns.remove(groupingColumn);
         }
       }
       for (AggregatorFactory aggregator : projectionSpec.getSchema().getAggregators()) {

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -234,7 +234,7 @@ public class IndexMergerV9 implements IndexMerger
         mergersMap.put(mergedDimensions.get(i), merger);
       }
 
-      if (segmentMetadata.getProjections() != null) {
+      if (segmentMetadata != null && segmentMetadata.getProjections() != null) {
         for (AggregateProjectionMetadata projectionMetadata : segmentMetadata.getProjections()) {
           for (String dimension : projectionMetadata.getSchema().getGroupingColumns()) {
             DimensionMergerV9 merger = mergersMap.get(dimension);

--- a/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexMergerV9.java
@@ -227,10 +227,22 @@ public class IndexMergerV9 implements IndexMerger
             segmentWriteOutMedium,
             dimFormats.get(i).toColumnCapabilities(),
             progress,
+            outDir,
             closer
         );
         mergers.add(merger);
         mergersMap.put(mergedDimensions.get(i), merger);
+      }
+
+      if (segmentMetadata.getProjections() != null) {
+        for (AggregateProjectionMetadata projectionMetadata : segmentMetadata.getProjections()) {
+          for (String dimension : projectionMetadata.getSchema().getGroupingColumns()) {
+            DimensionMergerV9 merger = mergersMap.get(dimension);
+            if (merger != null) {
+              merger.markAsParent();
+            }
+          }
+        }
       }
 
       /************* Setup Dim Conversions **************/
@@ -302,6 +314,7 @@ public class IndexMergerV9 implements IndexMerger
             indexSpec,
             segmentWriteOutMedium,
             progress,
+            outDir,
             closer,
             mergersMap,
             segmentMetadata
@@ -356,6 +369,7 @@ public class IndexMergerV9 implements IndexMerger
       final IndexSpec indexSpec,
       final SegmentWriteOutMedium segmentWriteOutMedium,
       final ProgressIndicator progress,
+      final File segmentBaseDir,
       final Closer closer,
       final Map<String, DimensionMergerV9> parentMergers,
       final Metadata segmentMetadata
@@ -389,6 +403,7 @@ public class IndexMergerV9 implements IndexMerger
             segmentWriteOutMedium,
             dimensionFormat.toColumnCapabilities(),
             progress,
+            segmentBaseDir,
             closer
         );
         if (parentMergers.containsKey(dimension)) {

--- a/processing/src/main/java/org/apache/druid/segment/LongDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/LongDimensionHandler.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.selector.settable.SettableLongColumnValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
+import java.io.File;
 import java.util.Comparator;
 
 public class LongDimensionHandler implements DimensionHandler<Long, Long, Long>
@@ -82,6 +83,7 @@ public class LongDimensionHandler implements DimensionHandler<Long, Long, Long>
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
   )
   {

--- a/processing/src/main/java/org/apache/druid/segment/NestedCommonFormatColumnHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/NestedCommonFormatColumnHandler.java
@@ -31,6 +31,7 @@ import org.apache.druid.segment.selector.settable.SettableObjectColumnValueSelec
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.util.Comparator;
 
 public class NestedCommonFormatColumnHandler implements DimensionHandler<StructuredData, StructuredData, StructuredData>
@@ -82,10 +83,11 @@ public class NestedCommonFormatColumnHandler implements DimensionHandler<Structu
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
   )
   {
-    return new AutoTypeColumnMerger(name, outputName, castTo, indexSpec, segmentWriteOutMedium, closer);
+    return new AutoTypeColumnMerger(name, outputName, castTo, indexSpec, segmentWriteOutMedium, segmentBaseDir, closer);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/NestedDataColumnHandlerV4.java
+++ b/processing/src/main/java/org/apache/druid/segment/NestedDataColumnHandlerV4.java
@@ -30,6 +30,7 @@ import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.selector.settable.SettableObjectColumnValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
+import java.io.File;
 import java.util.Comparator;
 
 public class NestedDataColumnHandlerV4 implements DimensionHandler<StructuredData, StructuredData, StructuredData>
@@ -78,6 +79,7 @@ public class NestedDataColumnHandlerV4 implements DimensionHandler<StructuredDat
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
   )
   {

--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -44,6 +44,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -239,21 +240,36 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
   public QueryableIndex getProjectionQueryableIndex(String name)
   {
     final AggregateProjectionMetadata projectionSpec = projectionsMap.get(name);
+    final Metadata projectionMetadata = new Metadata(
+        null,
+        projectionSpec.getSchema().getAggregators(),
+        null,
+        null,
+        true,
+        projectionSpec.getSchema().getOrderingWithTimeColumnSubstitution(),
+        null
+    );
     return new SimpleQueryableIndex(
         dataInterval,
-        new ListIndexed<>(projectionSpec.getSchema().getGroupingColumns()),
+        new ListIndexed<>(
+            projectionSpec.getSchema()
+                          .getGroupingColumns()
+                          .stream()
+                          .filter(x -> !x.equals(projectionSpec.getSchema().getTimeColumnName()))
+                          .collect(Collectors.toList())
+        ),
         bitmapFactory,
         projectionColumns.get(name),
         fileMapper,
         true,
-        null,
+        projectionMetadata,
         null
     )
     {
       @Override
       public Metadata getMetadata()
       {
-        return null;
+        return projectionMetadata;
       }
 
       @Override

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
@@ -32,6 +32,7 @@ import org.apache.druid.segment.selector.settable.SettableColumnValueSelector;
 import org.apache.druid.segment.selector.settable.SettableDimensionValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.Comparator;
 
@@ -169,6 +170,7 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
   )
   {
@@ -188,6 +190,7 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
         segmentWriteOutMedium,
         capabilities,
         progress,
+        segmentBaseDir,
         closer
     );
   }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionMergerV9.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionMergerV9.java
@@ -48,6 +48,7 @@ import org.apache.druid.segment.serde.DictionaryEncodedColumnPartSerde;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
@@ -84,10 +85,11 @@ public class StringDimensionMergerV9 extends DictionaryEncodedColumnMerger<Strin
       SegmentWriteOutMedium segmentWriteOutMedium,
       ColumnCapabilities capabilities,
       ProgressIndicator progress,
+      File segmentBaseDir,
       Closer closer
   )
   {
-    super(dimensionName, outputName, indexSpec, segmentWriteOutMedium, capabilities, progress, closer);
+    super(dimensionName, outputName, indexSpec, segmentWriteOutMedium, capabilities, progress, segmentBaseDir, closer);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/nested/DictionaryIdLookup.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/DictionaryIdLookup.java
@@ -294,7 +294,6 @@ public final class DictionaryIdLookup implements Closeable
   private File makeTempDir(String fileName)
   {
     try {
-      // creates files in temp path in the form of 'name.partName.tmp'
       final File f = new File(tempBasePath, StringUtils.urlEncode(fileName));
       FileUtils.mkdirp(f);
       closer.register(() -> FileUtils.deleteDirectory(f));

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedCommonFormatColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedCommonFormatColumnSerializer.java
@@ -27,6 +27,7 @@ import org.apache.druid.segment.serde.Serializer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
 import java.util.SortedMap;
 
 /**
@@ -50,7 +51,7 @@ public abstract class NestedCommonFormatColumnSerializer implements GenericColum
   public static final String RAW_FILE_NAME = "__raw";
   public static final String NESTED_FIELD_PREFIX = "__field_";
 
-  public abstract void openDictionaryWriter() throws IOException;
+  public abstract void openDictionaryWriter(Path segmentBasePath) throws IOException;
 
   public void serializeFields(SortedMap<String, FieldTypeInfo.MutableTypeSet> fields) throws IOException
   {

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
@@ -27,7 +27,6 @@ import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
-import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.java.util.common.io.smoosh.SmooshedWriter;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.math.expr.ExprEval;
@@ -49,11 +48,11 @@ import org.apache.druid.segment.serde.ColumnSerializerUtils;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -200,7 +199,7 @@ public class NestedDataColumnSerializer extends NestedCommonFormatColumnSerializ
   }
 
   @Override
-  public void openDictionaryWriter(Path segmentBasePath) throws IOException
+  public void openDictionaryWriter(File segmentBaseDir) throws IOException
   {
     fieldsWriter = new GenericIndexedWriter<>(segmentWriteOutMedium, name, GenericIndexed.STRING_STRATEGY);
     fieldsWriter.open();
@@ -242,7 +241,7 @@ public class NestedDataColumnSerializer extends NestedCommonFormatColumnSerializ
     globalDictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            segmentBasePath,
+            segmentBaseDir,
             dictionaryWriter,
             longDictionaryWriter,
             doubleDictionaryWriter,
@@ -447,37 +446,22 @@ public class NestedDataColumnSerializer extends NestedCommonFormatColumnSerializ
 
     if (writeDictionary) {
       if (globalDictionaryIdLookup.getStringBufferMapper() != null) {
-        SmooshedFileMapper fileMapper = globalDictionaryIdLookup.getStringBufferMapper();
-        for (String internalName : fileMapper.getInternalFilenames()) {
-          smoosher.add(internalName, fileMapper.mapFile(internalName));
-        }
+        copyFromTempSmoosh(smoosher, globalDictionaryIdLookup.getStringBufferMapper());
       } else {
         writeInternal(smoosher, dictionaryWriter, ColumnSerializerUtils.STRING_DICTIONARY_FILE_NAME);
       }
-      if (globalDictionaryIdLookup.getLongBuffer() != null) {
-        writeInternal(
-            smoosher,
-            globalDictionaryIdLookup.getLongBuffer(),
-            ColumnSerializerUtils.LONG_DICTIONARY_FILE_NAME
-        );
+      if (globalDictionaryIdLookup.getLongBufferMapper() != null) {
+        copyFromTempSmoosh(smoosher, globalDictionaryIdLookup.getLongBufferMapper());
       } else {
         writeInternal(smoosher, longDictionaryWriter, ColumnSerializerUtils.LONG_DICTIONARY_FILE_NAME);
       }
-      if (globalDictionaryIdLookup.getDoubleBuffer() != null) {
-        writeInternal(
-            smoosher,
-            globalDictionaryIdLookup.getDoubleBuffer(),
-            ColumnSerializerUtils.DOUBLE_DICTIONARY_FILE_NAME
-        );
+      if (globalDictionaryIdLookup.getDoubleBufferMapper() != null) {
+        copyFromTempSmoosh(smoosher, globalDictionaryIdLookup.getDoubleBufferMapper());
       } else {
         writeInternal(smoosher, doubleDictionaryWriter, ColumnSerializerUtils.DOUBLE_DICTIONARY_FILE_NAME);
       }
-      if (globalDictionaryIdLookup.getArrayBuffer() != null) {
-        writeInternal(
-            smoosher,
-            globalDictionaryIdLookup.getArrayBuffer(),
-            ColumnSerializerUtils.ARRAY_DICTIONARY_FILE_NAME
-        );
+      if (globalDictionaryIdLookup.getArrayBufferMapper() != null) {
+        copyFromTempSmoosh(smoosher, globalDictionaryIdLookup.getArrayBufferMapper());
       } else {
         writeInternal(smoosher, arrayDictionaryWriter, ColumnSerializerUtils.ARRAY_DICTIONARY_FILE_NAME);
       }

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializer.java
@@ -25,7 +25,6 @@ import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.bitmap.MutableBitmap;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
 import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
@@ -54,6 +53,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -200,7 +200,7 @@ public class NestedDataColumnSerializer extends NestedCommonFormatColumnSerializ
   }
 
   @Override
-  public void openDictionaryWriter() throws IOException
+  public void openDictionaryWriter(Path segmentBasePath) throws IOException
   {
     fieldsWriter = new GenericIndexedWriter<>(segmentWriteOutMedium, name, GenericIndexed.STRING_STRATEGY);
     fieldsWriter.open();
@@ -242,7 +242,7 @@ public class NestedDataColumnSerializer extends NestedCommonFormatColumnSerializ
     globalDictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            FileUtils.getTempDir(),
+            segmentBasePath,
             dictionaryWriter,
             longDictionaryWriter,
             doubleDictionaryWriter,

--- a/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializerV4.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/NestedDataColumnSerializerV4.java
@@ -200,7 +200,7 @@ public class NestedDataColumnSerializerV4 implements GenericColumnSerializer<Str
     globalDictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            FileUtils.getTempDir(),
+            FileUtils.getTempDir().toFile(),
             dictionaryWriter,
             longDictionaryWriter,
             doubleDictionaryWriter,

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarDoubleColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarDoubleColumnSerializer.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.segment.nested;
 
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
@@ -37,6 +36,7 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.file.Path;
 
 /**
  * Serializer for a {@link ScalarDoubleColumn}
@@ -66,7 +66,7 @@ public class ScalarDoubleColumnSerializer extends ScalarNestedCommonFormatColumn
   }
 
   @Override
-  public void openDictionaryWriter() throws IOException
+  public void openDictionaryWriter(Path segmentBasePath) throws IOException
   {
     dictionaryWriter = new FixedIndexedWriter<>(
         segmentWriteOutMedium,
@@ -79,7 +79,7 @@ public class ScalarDoubleColumnSerializer extends ScalarNestedCommonFormatColumn
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            FileUtils.getTempDir(),
+            segmentBasePath,
             null,
             null,
             dictionaryWriter,

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarDoubleColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarDoubleColumnSerializer.java
@@ -34,9 +34,9 @@ import org.apache.druid.segment.serde.ColumnSerializerUtils;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.nio.file.Path;
 
 /**
  * Serializer for a {@link ScalarDoubleColumn}
@@ -66,7 +66,7 @@ public class ScalarDoubleColumnSerializer extends ScalarNestedCommonFormatColumn
   }
 
   @Override
-  public void openDictionaryWriter(Path segmentBasePath) throws IOException
+  public void openDictionaryWriter(File segmentBaseDir) throws IOException
   {
     dictionaryWriter = new FixedIndexedWriter<>(
         segmentWriteOutMedium,
@@ -79,7 +79,7 @@ public class ScalarDoubleColumnSerializer extends ScalarNestedCommonFormatColumn
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            segmentBasePath,
+            segmentBaseDir,
             null,
             null,
             dictionaryWriter,
@@ -136,8 +136,8 @@ public class ScalarDoubleColumnSerializer extends ScalarNestedCommonFormatColumn
   @Override
   protected void writeDictionaryFile(FileSmoosher smoosher) throws IOException
   {
-    if (dictionaryIdLookup.getDoubleBuffer() != null) {
-      writeInternal(smoosher, dictionaryIdLookup.getDoubleBuffer(), ColumnSerializerUtils.DOUBLE_DICTIONARY_FILE_NAME);
+    if (dictionaryIdLookup.getDoubleBufferMapper() != null) {
+      copyFromTempSmoosh(smoosher, dictionaryIdLookup.getDoubleBufferMapper());
     } else {
       writeInternal(smoosher, dictionaryWriter, ColumnSerializerUtils.DOUBLE_DICTIONARY_FILE_NAME);
     }

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarLongColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarLongColumnSerializer.java
@@ -34,9 +34,9 @@ import org.apache.druid.segment.serde.ColumnSerializerUtils;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.nio.file.Path;
 
 /**
  * Serializer for a {@link ScalarLongColumn}
@@ -67,7 +67,7 @@ public class ScalarLongColumnSerializer extends ScalarNestedCommonFormatColumnSe
   }
 
   @Override
-  public void openDictionaryWriter(Path segmentBasePath) throws IOException
+  public void openDictionaryWriter(File segmentBaseDir) throws IOException
   {
     dictionaryWriter = new FixedIndexedWriter<>(
         segmentWriteOutMedium,
@@ -80,7 +80,7 @@ public class ScalarLongColumnSerializer extends ScalarNestedCommonFormatColumnSe
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            segmentBasePath,
+            segmentBaseDir,
             null,
             dictionaryWriter,
             null,
@@ -136,8 +136,8 @@ public class ScalarLongColumnSerializer extends ScalarNestedCommonFormatColumnSe
   @Override
   protected void writeDictionaryFile(FileSmoosher smoosher) throws IOException
   {
-    if (dictionaryIdLookup.getLongBuffer() != null) {
-      writeInternal(smoosher, dictionaryIdLookup.getLongBuffer(), ColumnSerializerUtils.LONG_DICTIONARY_FILE_NAME);
+    if (dictionaryIdLookup.getLongBufferMapper() != null) {
+      copyFromTempSmoosh(smoosher, dictionaryIdLookup.getLongBufferMapper());
     } else {
       writeInternal(smoosher, dictionaryWriter, ColumnSerializerUtils.LONG_DICTIONARY_FILE_NAME);
     }

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarLongColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarLongColumnSerializer.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.segment.nested;
 
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
@@ -37,6 +36,7 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteOrder;
+import java.nio.file.Path;
 
 /**
  * Serializer for a {@link ScalarLongColumn}
@@ -67,7 +67,7 @@ public class ScalarLongColumnSerializer extends ScalarNestedCommonFormatColumnSe
   }
 
   @Override
-  public void openDictionaryWriter() throws IOException
+  public void openDictionaryWriter(Path segmentBasePath) throws IOException
   {
     dictionaryWriter = new FixedIndexedWriter<>(
         segmentWriteOutMedium,
@@ -80,7 +80,7 @@ public class ScalarLongColumnSerializer extends ScalarNestedCommonFormatColumnSe
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            FileUtils.getTempDir(),
+            segmentBasePath,
             null,
             dictionaryWriter,
             null,

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarStringColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarStringColumnSerializer.java
@@ -20,7 +20,6 @@
 package org.apache.druid.segment.nested;
 
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
@@ -35,6 +34,7 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * Serializer for a string {@link NestedCommonFormatColumn} that can be read with
@@ -62,7 +62,7 @@ public class ScalarStringColumnSerializer extends ScalarNestedCommonFormatColumn
   }
 
   @Override
-  public void openDictionaryWriter() throws IOException
+  public void openDictionaryWriter(Path segmentBasePath) throws IOException
   {
     dictionaryWriter = StringEncodingStrategies.getStringDictionaryWriter(
         indexSpec.getStringDictionaryEncoding(),
@@ -73,7 +73,7 @@ public class ScalarStringColumnSerializer extends ScalarNestedCommonFormatColumn
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            FileUtils.getTempDir(),
+            segmentBasePath,
             dictionaryWriter,
             null,
             null,

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarStringColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarStringColumnSerializer.java
@@ -33,8 +33,8 @@ import org.apache.druid.segment.serde.ColumnSerializerUtils;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * Serializer for a string {@link NestedCommonFormatColumn} that can be read with
@@ -62,7 +62,7 @@ public class ScalarStringColumnSerializer extends ScalarNestedCommonFormatColumn
   }
 
   @Override
-  public void openDictionaryWriter(Path segmentBasePath) throws IOException
+  public void openDictionaryWriter(File segmentBaseDir) throws IOException
   {
     dictionaryWriter = StringEncodingStrategies.getStringDictionaryWriter(
         indexSpec.getStringDictionaryEncoding(),
@@ -73,7 +73,7 @@ public class ScalarStringColumnSerializer extends ScalarNestedCommonFormatColumn
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            segmentBasePath,
+            segmentBaseDir,
             dictionaryWriter,
             null,
             null,

--- a/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnSerializer.java
@@ -31,7 +31,6 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
-import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
@@ -51,11 +50,11 @@ import org.apache.druid.segment.serde.ColumnSerializerUtils;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
-import java.nio.file.Path;
 
 /**
  * Serializer for a {@link NestedCommonFormatColumn} for single type arrays and mixed type columns, but not columns
@@ -133,7 +132,7 @@ public class VariantColumnSerializer extends NestedCommonFormatColumnSerializer
   }
 
   @Override
-  public void openDictionaryWriter(Path segmentBasePath) throws IOException
+  public void openDictionaryWriter(File segmentBaseDir) throws IOException
   {
     dictionaryWriter = StringEncodingStrategies.getStringDictionaryWriter(
         indexSpec.getStringDictionaryEncoding(),
@@ -171,7 +170,7 @@ public class VariantColumnSerializer extends NestedCommonFormatColumnSerializer
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            segmentBasePath,
+            segmentBaseDir,
             dictionaryWriter,
             longDictionaryWriter,
             doubleDictionaryWriter,
@@ -423,29 +422,22 @@ public class VariantColumnSerializer extends NestedCommonFormatColumnSerializer
 
     if (writeDictionary) {
       if (dictionaryIdLookup.getStringBufferMapper() != null) {
-        SmooshedFileMapper fileMapper = dictionaryIdLookup.getStringBufferMapper();
-        for (String internalName : fileMapper.getInternalFilenames()) {
-          smoosher.add(internalName, fileMapper.mapFile(internalName));
-        }
+        copyFromTempSmoosh(smoosher, dictionaryIdLookup.getStringBufferMapper());
       } else {
         writeInternal(smoosher, dictionaryWriter, ColumnSerializerUtils.STRING_DICTIONARY_FILE_NAME);
       }
-      if (dictionaryIdLookup.getLongBuffer() != null) {
-        writeInternal(smoosher, dictionaryIdLookup.getLongBuffer(), ColumnSerializerUtils.LONG_DICTIONARY_FILE_NAME);
+      if (dictionaryIdLookup.getLongBufferMapper() != null) {
+        copyFromTempSmoosh(smoosher, dictionaryIdLookup.getLongBufferMapper());
       } else {
         writeInternal(smoosher, longDictionaryWriter, ColumnSerializerUtils.LONG_DICTIONARY_FILE_NAME);
       }
-      if (dictionaryIdLookup.getDoubleBuffer() != null) {
-        writeInternal(
-            smoosher,
-            dictionaryIdLookup.getDoubleBuffer(),
-            ColumnSerializerUtils.DOUBLE_DICTIONARY_FILE_NAME
-        );
+      if (dictionaryIdLookup.getDoubleBufferMapper() != null) {
+        copyFromTempSmoosh(smoosher, dictionaryIdLookup.getDoubleBufferMapper());
       } else {
         writeInternal(smoosher, doubleDictionaryWriter, ColumnSerializerUtils.DOUBLE_DICTIONARY_FILE_NAME);
       }
-      if (dictionaryIdLookup.getArrayBuffer() != null) {
-        writeInternal(smoosher, dictionaryIdLookup.getArrayBuffer(), ColumnSerializerUtils.ARRAY_DICTIONARY_FILE_NAME);
+      if (dictionaryIdLookup.getArrayBufferMapper() != null) {
+        copyFromTempSmoosh(smoosher, dictionaryIdLookup.getArrayBufferMapper());
       } else {
         writeInternal(smoosher, arrayDictionaryWriter, ColumnSerializerUtils.ARRAY_DICTIONARY_FILE_NAME);
       }

--- a/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnSerializer.java
@@ -26,7 +26,6 @@ import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.bitmap.MutableBitmap;
 import org.apache.druid.common.config.NullHandling;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -56,6 +55,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.WritableByteChannel;
+import java.nio.file.Path;
 
 /**
  * Serializer for a {@link NestedCommonFormatColumn} for single type arrays and mixed type columns, but not columns
@@ -133,7 +133,7 @@ public class VariantColumnSerializer extends NestedCommonFormatColumnSerializer
   }
 
   @Override
-  public void openDictionaryWriter() throws IOException
+  public void openDictionaryWriter(Path segmentBasePath) throws IOException
   {
     dictionaryWriter = StringEncodingStrategies.getStringDictionaryWriter(
         indexSpec.getStringDictionaryEncoding(),
@@ -171,7 +171,7 @@ public class VariantColumnSerializer extends NestedCommonFormatColumnSerializer
     dictionaryIdLookup = closer.register(
         new DictionaryIdLookup(
             name,
-            FileUtils.getTempDir(),
+            segmentBasePath,
             dictionaryWriter,
             longDictionaryWriter,
             doubleDictionaryWriter,

--- a/processing/src/main/java/org/apache/druid/segment/serde/Serializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/Serializer.java
@@ -36,8 +36,11 @@ public interface Serializer
   long getSerializedSize() throws IOException;
 
   /**
-   * Writes serialized form of this object to the given channel. If parallel data streams are needed, they could be
-   * created with the provided smoosher.
+   * Writes the serialized form of this object. The entire object may be written to the provided channel, or the object
+   * may be split over the provided channel and files added to the {@link FileSmoosher], where additional channels can
+   * be created via {@link FileSmoosher#addWithSmooshedWriter(String, long)}. The latter approach is useful when the
+   * serialized form of the object is too large for a single smoosh container. At the time this javadoc was written,
+   * the max smoosh container size is limit to the max {@link java.nio.ByteBuffer} size.
    */
   void writeTo(WritableByteChannel channel, FileSmoosher smoosher) throws IOException;
 }

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -30,7 +30,9 @@ import it.unimi.dsi.fastutil.ints.IntIterator;
 import org.apache.druid.collections.bitmap.RoaringBitmapFactory;
 import org.apache.druid.common.config.NullHandling;
 import org.apache.druid.data.input.InputRow;
+import org.apache.druid.data.input.ListBasedInputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
+import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.data.input.impl.DimensionSchema;
 import org.apache.druid.data.input.impl.DimensionSchema.MultiValueHandling;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -39,17 +41,23 @@ import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.frame.testutil.FrameTestUtil;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.query.BitmapResultFactory;
 import org.apache.druid.query.DefaultBitmapResultFactory;
 import org.apache.druid.query.OrderBy;
+import org.apache.druid.query.QueryContext;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnIndexSupplier;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.DictionaryEncodedColumn;
+import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.StringUtf8DictionaryEncodedColumn;
 import org.apache.druid.segment.data.BitmapSerdeFactory;
 import org.apache.druid.segment.data.BitmapValues;
@@ -63,9 +71,11 @@ import org.apache.druid.segment.incremental.IncrementalIndexAdapter;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.index.semantic.StringValueSetIndexes;
+import org.apache.druid.segment.index.semantic.ValueIndexes;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
+import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -143,6 +153,7 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
   private final IndexSpec indexSpec;
   private final IndexIO indexIO;
   private final boolean useBitmapIndexes;
+  private final BitmapSerdeFactory serdeFactory;
 
   @Rule
   public final CloserRule closer = new CloserRule(false);
@@ -163,6 +174,7 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
                               .withLongEncoding(longEncodingStrategy)
                               .build();
     this.indexIO = TestHelper.getTestIndexIO();
+    this.serdeFactory = bitmapSerdeFactory;
     this.useBitmapIndexes = bitmapSerdeFactory != null;
   }
 
@@ -3031,6 +3043,229 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
     validateTestMaxColumnsToMergeOutputSegment(merged7);
   }
 
+  @Test
+  public void testMergeProjections() throws IOException
+  {
+    File tmp = FileUtils.createTempDir();
+    closer.closeLater(tmp::delete);
+
+    final DateTime timestamp = Granularities.DAY.bucket(DateTimes.nowUtc()).getStart();
+
+    final RowSignature rowSignature = RowSignature.builder()
+                                                  .add("a", ColumnType.STRING)
+                                                  .add("b", ColumnType.STRING)
+                                                  .add("c", ColumnType.LONG)
+                                                  .build();
+
+    final List<InputRow> rows1 = Arrays.asList(
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp,
+            rowSignature.getColumnNames(),
+            Arrays.asList("a", "x", 1L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusMinutes(1),
+            rowSignature.getColumnNames(),
+            Arrays.asList("b", "y", 2L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusHours(2),
+            rowSignature.getColumnNames(),
+            Arrays.asList("a", "z", 3L)
+        )
+    );
+
+    final List<InputRow> rows2 = Arrays.asList(
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp,
+            rowSignature.getColumnNames(),
+            Arrays.asList("b", "y", 1L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusMinutes(1),
+            rowSignature.getColumnNames(),
+            Arrays.asList("d", "w", 2L)
+        ),
+        new ListBasedInputRow(
+            rowSignature,
+            timestamp.plusHours(2),
+            rowSignature.getColumnNames(),
+            Arrays.asList("b", "z", 3L)
+        )
+    );
+
+    final DimensionsSpec.Builder dimensionsBuilder =
+        DimensionsSpec.builder()
+                      .setDimensions(
+                          Arrays.asList(
+                              new StringDimensionSchema("a"),
+                              new StringDimensionSchema("b")
+                          )
+                      );
+
+    List<AggregateProjectionSpec> projections = Arrays.asList(
+        new AggregateProjectionSpec(
+            "a_hourly_c_sum",
+            VirtualColumns.create(
+                Granularities.toVirtualColumn(Granularities.HOUR, "__gran")
+            ),
+            Arrays.asList(
+                new StringDimensionSchema("a"),
+                new LongDimensionSchema("__gran")
+            ),
+            new AggregatorFactory[]{
+                new LongSumAggregatorFactory("c_sum", "c")
+            }
+        ),
+        new AggregateProjectionSpec(
+            "a_c_sum",
+            VirtualColumns.EMPTY,
+            Collections.singletonList(
+                new StringDimensionSchema("a")
+            ),
+            new AggregatorFactory[]{
+                new LongSumAggregatorFactory("c_sum", "c")
+            }
+        )
+    );
+
+    IndexBuilder bob = IndexBuilder.create()
+                                   .tmpDir(tmp)
+                                   .schema(
+                                       IncrementalIndexSchema.builder()
+                                                             .withDimensionsSpec(dimensionsBuilder.build())
+                                                             .withRollup(false)
+                                                             .withProjections(projections)
+                                                             .build()
+                                   )
+                                   .rows(rows1);
+
+    IndexBuilder bob2 = IndexBuilder.create()
+                                    .tmpDir(tmp)
+                                    .schema(
+                                        IncrementalIndexSchema.builder()
+                                                              .withDimensionsSpec(dimensionsBuilder.build())
+                                                              .withRollup(false)
+                                                              .withProjections(projections)
+                                                              .build()
+                                    )
+                                    .rows(rows2);
+
+    QueryableIndex q1 = bob.buildMMappedIndex();
+    QueryableIndex q2 = bob2.buildMMappedIndex();
+
+    QueryableIndex merged = indexIO.loadIndex(
+        indexMerger.merge(
+            Arrays.asList(
+                new QueryableIndexIndexableAdapter(q1),
+                new QueryableIndexIndexableAdapter(q2)
+            ),
+            true,
+            new AggregatorFactory[0],
+            temporaryFolder.newFolder(),
+            dimensionsBuilder.build(),
+            IndexSpec.DEFAULT,
+            -1
+        )
+    );
+
+    CursorBuildSpec p1Spec = CursorBuildSpec.builder()
+                                            .setQueryContext(
+                                                QueryContext.of(
+                                                    ImmutableMap.of(QueryContexts.USE_PROJECTION, "a_hourly_c_sum")
+                                                )
+                                            )
+                                            .setVirtualColumns(
+                                                VirtualColumns.create(
+                                                    Granularities.toVirtualColumn(Granularities.HOUR, "gran")
+                                                )
+                                            )
+                                            .setAggregators(
+                                                Collections.singletonList(
+                                                    new LongSumAggregatorFactory("c", "c")
+                                                )
+                                            )
+                                            .setGroupingColumns(Collections.singletonList("a"))
+                                            .build();
+    CursorBuildSpec p2Spec = CursorBuildSpec.builder()
+                                            .setQueryContext(
+                                                QueryContext.of(
+                                                    ImmutableMap.of(QueryContexts.USE_PROJECTION, "a_c_sum")
+                                                )
+                                            )
+                                            .setAggregators(
+                                                Collections.singletonList(
+                                                    new LongSumAggregatorFactory("c", "c")
+                                                )
+                                            )
+                                            .setGroupingColumns(Collections.singletonList("a"))
+                                            .build();
+
+
+    QueryableIndexCursorFactory cursorFactory = new QueryableIndexCursorFactory(merged);
+
+    try (final CursorHolder cursorHolder = cursorFactory.makeCursorHolder(p1Spec)) {
+      final Cursor cursor = cursorHolder.asCursor();
+      int rowCount = 0;
+      while (!cursor.isDone()) {
+        rowCount++;
+        cursor.advance();
+      }
+      Assert.assertEquals(5, rowCount);
+    }
+
+    try (final CursorHolder cursorHolder = cursorFactory.makeCursorHolder(p2Spec)) {
+      final Cursor cursor = cursorHolder.asCursor();
+      int rowCount = 0;
+      while (!cursor.isDone()) {
+        rowCount++;
+        cursor.advance();
+      }
+      Assert.assertEquals(3, rowCount);
+    }
+
+    QueryableIndex p1Index = merged.getProjectionQueryableIndex("a_hourly_c_sum");
+    Assert.assertNotNull(p1Index);
+    ColumnHolder aHolder = p1Index.getColumnHolder("a");
+    DictionaryEncodedColumn aCol = (DictionaryEncodedColumn) aHolder.getColumn();
+    Assert.assertEquals(3, aCol.getCardinality());
+
+    QueryableIndex p2Index = merged.getProjectionQueryableIndex("a_c_sum");
+    Assert.assertNotNull(p2Index);
+    ColumnHolder aHolder2 = p2Index.getColumnHolder("a");
+    DictionaryEncodedColumn aCol2 = (DictionaryEncodedColumn) aHolder2.getColumn();
+    Assert.assertEquals(3, aCol2.getCardinality());
+
+    if (serdeFactory != null) {
+
+      BitmapResultFactory resultFactory = new DefaultBitmapResultFactory(serdeFactory.getBitmapFactory());
+
+      Assert.assertEquals(
+          2,
+          resultFactory.toImmutableBitmap(
+              aHolder.getIndexSupplier()
+                     .as(ValueIndexes.class)
+                     .forValue("a", ColumnType.STRING)
+                     .computeBitmapResult(resultFactory, false)
+          ).size()
+      );
+
+      Assert.assertEquals(
+          1,
+          resultFactory.toImmutableBitmap(
+              aHolder2.getIndexSupplier()
+                      .as(ValueIndexes.class)
+                      .forValue("a", ColumnType.STRING)
+                      .computeBitmapResult(resultFactory, false)
+          ).size()
+      );
+    }
+  }
 
   private QueryableIndex persistAndLoad(List<DimensionSchema> schema, InputRow... rows) throws IOException
   {

--- a/processing/src/test/java/org/apache/druid/segment/nested/DictionaryIdLookupTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/DictionaryIdLookupTest.java
@@ -38,7 +38,6 @@ import org.junit.rules.TemporaryFolder;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.nio.file.Path;
 
 public class DictionaryIdLookupTest extends InitializedNullHandlingTest
 {
@@ -92,12 +91,12 @@ public class DictionaryIdLookupTest extends InitializedNullHandlingTest
         4
     );
 
-    Path dictTempPath = temp.newFolder().toPath();
+    File dictTempDir = temp.newFolder();
 
     // make lookup with references to writers
     DictionaryIdLookup idLookup = new DictionaryIdLookup(
         "test",
-        dictTempPath,
+        dictTempDir,
         stringWriter,
         longWriter,
         doubleWriter,
@@ -110,7 +109,7 @@ public class DictionaryIdLookupTest extends InitializedNullHandlingTest
     doubleWriter.open();
     arrayWriter.open();
 
-    File tempDir = dictTempPath.toFile();
+    File tempDir = dictTempDir;
     Assert.assertEquals(0, tempDir.listFiles().length);
 
     for (String s : sortedValueDictionary.getSortedStrings()) {

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -197,7 +197,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
+      serializer.openDictionaryWriter(tempFolder.newFolder());
       serializer.serializeFields(sortedFields);
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -197,7 +197,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter();
+      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
       serializer.serializeFields(sortedFields);
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/ScalarDoubleColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/ScalarDoubleColumnSupplierTest.java
@@ -150,7 +150,7 @@ public class ScalarDoubleColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter();
+      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/ScalarDoubleColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/ScalarDoubleColumnSupplierTest.java
@@ -150,7 +150,7 @@ public class ScalarDoubleColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
+      serializer.openDictionaryWriter(tempFolder.newFolder());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/ScalarLongColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/ScalarLongColumnSupplierTest.java
@@ -150,7 +150,7 @@ public class ScalarLongColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter();
+      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/ScalarLongColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/ScalarLongColumnSupplierTest.java
@@ -150,7 +150,7 @@ public class ScalarLongColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
+      serializer.openDictionaryWriter(tempFolder.newFolder());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/ScalarStringColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/ScalarStringColumnSupplierTest.java
@@ -150,7 +150,7 @@ public class ScalarStringColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
+      serializer.openDictionaryWriter(tempFolder.newFolder());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/ScalarStringColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/ScalarStringColumnSupplierTest.java
@@ -150,7 +150,7 @@ public class ScalarStringColumnSupplierTest extends InitializedNullHandlingTest
       SortedValueDictionary globalDictionarySortedCollector = mergable.getValueDictionary();
       mergable.mergeFieldsInto(sortedFields);
 
-      serializer.openDictionaryWriter();
+      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/VariantColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/VariantColumnSupplierTest.java
@@ -275,7 +275,7 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
           closer
       );
 
-      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
+      serializer.openDictionaryWriter(tempFolder.newFolder());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),

--- a/processing/src/test/java/org/apache/druid/segment/nested/VariantColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/VariantColumnSupplierTest.java
@@ -275,7 +275,7 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
           closer
       );
 
-      serializer.openDictionaryWriter();
+      serializer.openDictionaryWriter(tempFolder.newFolder().toPath());
       serializer.serializeDictionaries(
           globalDictionarySortedCollector.getSortedStrings(),
           globalDictionarySortedCollector.getSortedLongs(),


### PR DESCRIPTION
changes:
* fix issue when merging projections from multiple-incremental persists which was hoping that some 'dim conversion' buffers were not closed, but they already were (by the merging iterator). fix involves selectively persisting these conversion buffers to temp files in the segment write out directory and mapping them and tying them to the segment level closer so that they are available after the lifetime of the parent merger
* modify auto column serializers to use segment write out directory for temp files instead of java.io.tmpdir
* fix queryable index projection to not put the time-like column as a dimension, instead only adding it as __time

Alternative to #17388, this does a nicer thing of persisting temporary files containing the id mapping buffers of parent mergers to re-use when merging projections, similar to what auto columns were doing with their dictionary.

I made a conservative but kind of odd change to `DimensionHandler` interface involving a default implementation of `makeMerger` that calls a now deprecated existing version of `makeMerger` to do a signature change to make this PR a bit less disruptive in the event we want to do a 31.1 patch release (i would like to do this to fix another issue with the 31 release, I will start a thread soonly). `DimensionHandler` is not officially an extension point, but is the mechanism which custom dimensions can be defined, so I wanted to be chill about this change. After this PR I will open another one to delete the deprecated thing and remove the default implementation. The interface was changed to add a parameter for the path to where we are writing out the segment in case a merger or serializer needs to create any temporary files, since prior to this the task define storage location was not directly available to the mergers, so this lets things write stuff to a more correct place.

While I was here I modified the 'auto' column merger to use this new segment write out path argument for its temp files instead of `java.io.tmpDir`.

Also fixes an issue with projections on a `QueryableIndex` to make them not put the time-like column as a dimension, instead only adding it as `__time` to ensure it doesn't get handled incorrectly.