### PR TITLE
Fixed two non deterministic test in MaterializedViewQueryQueryToolChestTest

### DIFF
--- a/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
+++ b/extensions-contrib/materialized-view-selection/src/test/java/org/apache/druid/query/materializedview/MaterializedViewQueryQueryToolChestTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.materializedview;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.config.NullHandling;
@@ -112,6 +113,7 @@ public class MaterializedViewQueryQueryToolChestTest extends InitializedNullHand
   @Test
   public void testDecorateObjectMapper() throws IOException
   {
+    JSON_MAPPER.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     GroupByQuery realQuery = GroupByQuery.builder()
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)
@@ -170,6 +172,7 @@ public class MaterializedViewQueryQueryToolChestTest extends InitializedNullHand
   @Test
   public void testDecorateObjectMapperMaterializedViewQuery() throws IOException
   {
+    JSON_MAPPER.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     GroupByQuery realQuery = GroupByQuery.builder()
         .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
         .setQuerySegmentSpec(QueryRunnerTestHelper.FIRST_TO_THIRD)


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixed 2 non deterministic tests in MaterializedViewQueryQueryToolChestTest 

- `testDecorateObjectMapperMaterializedViewQuery`

- `testDecorateObjectMapper`

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Steps to reproduce
To reproduce the problem, first build the module `materialized-view-selection`:

> mvn install -pl extensions-contrib/materialized-view-selection -am -DskipTests

Then, run the regular test:

For testDecorateObjectMapperMaterializedViewQuery
> mvn -pl materialized-view-selection test -Dtest=org.apache.druid.query.materializedview.MaterializedViewQueryQueryToolChestTest#testDecorateObjectMapperMaterializedViewQuery

For testDecorateObjectMapper
> mvn -pl materialized-view-selection test -Dtest=org.apache.druid.query.materializedview.MaterializedViewQueryQueryToolChestTest#testDecorateObjectMapper

To identify the flaky test, execute the following [nondex](https://github.com/TestingResearchIllinois/NonDex) command:

For testDecorateObjectMapperMaterializedViewQuery
> mvn -pl materialized-view-selection edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.druid.query.materializedview.MaterializedViewQueryQueryToolChestTest#testDecorateObjectMapperMaterializedViewQuery

For testDecorateObjectMapper
> mvn -pl materialized-view-selection edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.druid.query.materializedview.MaterializedViewQueryQueryToolChestTest#testDecorateObjectMapper

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
The failure in the testDecorateObjectMapperMaterializedViewQuery test within MaterializedViewQueryQueryToolChestTest appears to be due to a mismatch in the JSON structure, specifically the order of fields within the event object. In this test, there is a comparison between an expected JSON structure and an actual result generated during the test. Here’s what’s happening:

> Expected Output: {"alias":"automotive","rows":1,"idx":135}
> Actual Output: {"alias":"automotive","idx":135,"rows":1}

The flaky behavior in the testDecorateObjectMapper test in MaterializedViewQueryQueryToolChestTest also appears to stem from the inconsistency in the ordering of fields within a JSON object. Here’s a closer look at the issue:

> Expected JSON Structure: {"rows":1,"idx":118,"alias":"business"}
> Actual JSON Structure: {"alias":"business","idx":118,"rows":1}

The fields in the event object (rows, idx, and alias) are in different orders in the expected vs. actual outputs. As in the previous test, this order discrepancy is likely causing a failure in the direct string comparison of JSON data.

### Fix
The fix involves configuring the object mapper for deterministic output by sorting it.
<hr>

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
