### PR TITLE
Fixed NPE in `array_overlap` and `array_contains`.

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Function.java
@@ -3974,7 +3974,7 @@ public interface Function extends NamedFunction
     {
       if (args.get(1).isLiteral()) {
         final ExpressionType lhsType = args.get(0).getOutputType(inspector);
-        if (lhsType == null) {
+        if (lhsType == null || !(lhsType.isPrimitive() || lhsType.isPrimitiveArray())) {
           return this;
         }
         final ExpressionType lhsArrayType = ExpressionType.asArrayType(lhsType);
@@ -4107,7 +4107,7 @@ public interface Function extends NamedFunction
     {
       if (args.get(1).isLiteral()) {
         final ExpressionType lhsType = args.get(0).getOutputType(inspector);
-        if (lhsType == null) {
+        if (lhsType == null || !(lhsType.isPrimitive() || lhsType.isPrimitiveArray())) {
           return this;
         }
         final ExpressionType lhsArrayType = ExpressionType.asArrayType(lhsType);

--- a/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
@@ -419,6 +419,22 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
     eval = expr.eval(inputBindings);
     Assert.assertEquals(3L, eval.value());
     Assert.assertEquals(ExpressionType.LONG, eval.type());
+
+    expr = Parser.parse("array_contains(json_query_array(nest, '$.x'), 100)", MACRO_TABLE);
+    expr = expr.asSingleThreaded(inputBindings);
+    Assert.assertEquals(1L, expr.eval(inputBindings).value());
+
+    expr = Parser.parse("array_contains(json_query_array(nest, '$.x'), 101)", MACRO_TABLE);
+    expr = expr.asSingleThreaded(inputBindings);
+    Assert.assertEquals(0L, expr.eval(inputBindings).value());
+
+    expr = Parser.parse("array_overlap(json_query_array(nest, '$.x'), [100, 101])", MACRO_TABLE);
+    expr = expr.asSingleThreaded(inputBindings);
+    Assert.assertEquals(1L, expr.eval(inputBindings).value());
+
+    expr = Parser.parse("array_overlap(json_query_array(nest, '$.x'), [101, 102])", MACRO_TABLE);
+    expr = expr.asSingleThreaded(inputBindings);
+    Assert.assertEquals(0L, expr.eval(inputBindings).value());
   }
 
   @Test


### PR DESCRIPTION
Fixes #17440.

### Description

This PR will address the NPE in `array_overlap` and `array_contains` with Complex type.
Also added UT.

#### Fixed the bug #17440

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
