### PR TITLE
Add per-event JVM GC duration tracking

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -427,6 +427,8 @@ For more information, see [Enabling Metrics](../configuration/index.md#enabling-
 |`jvm/mem/committed`|Committed memory|`memKind`, `jvmVersion`|Close to max memory|
 |`jvm/gc/count`|Garbage collection count|`gcName` (cms/g1/parallel/etc.), `gcGen` (old/young), `jvmVersion`|Varies|
 |`jvm/gc/cpu`|Count of CPU time in Nanoseconds spent on garbage collection. Note: `jvm/gc/cpu` represents the total time over multiple GC cycles; divide by `jvm/gc/count` to get the mean GC time per cycle.|`gcName`, `gcGen`, `jvmVersion`|Sum of `jvm/gc/cpu` should be within 10-30% of sum of `jvm/cpu/total`, depending on the GC algorithm used (reported by [`JvmCpuMonitor`](../configuration/index.md#enabling-metrics)). |
+|`jvm/gc/pause`| Stop-the-world garbage collection JVM-reported pause time (ms). Only emitted if `druid.monitoring.jvm.duration=true`.| `gcName` (cms/g1/parallel/etc.), `gcGen` (old/young), `jvmVersion` | Varies|
+|`jvm/gc/concurrentTime`| JVM-reported time spent in concurrent phases of CMS pauses (ms). Only emitted if `druid.monitoring.jvm.duration=true`.| `gcName`(cms/g1/etc.), `gcGen` (old/young), `jvmVersion` | Varies| 
 
 ### ZooKeeper
 

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/EventBuffer.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/EventBuffer.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.metrics;
+
+
+import java.lang.reflect.Array;
+
+// A fixed-size, thread-safe, append-only ring buffer for buffering events prior to emission.
+// Events will overflow and wrap-around if buffer size is exceeded within a single emission window.
+public class EventBuffer<Event>
+{
+  private final Event[] buffer;
+  private final Class<Event> clazz;
+  private final int capacity;
+  private int back;
+  private int size;
+
+  public EventBuffer(Class<Event> clazz, int capacity)
+  {
+    this.clazz = clazz;
+    this.buffer = (Event[]) Array.newInstance(clazz, capacity);
+    this.capacity = capacity;
+    this.back = 0;
+  }
+
+  public synchronized int getCapacity()
+  {
+    return capacity;
+  }
+
+  public synchronized int getSize()
+  {
+    return size;
+  }
+
+  public synchronized void push(Event event)
+  {
+    buffer[back] = event;
+    back = (back + 1) % capacity;
+
+    if (size < capacity) {
+      ++size;
+    }
+  }
+
+  public synchronized Event[] extract()
+  {
+    final Event[] finalEvents = (Event[]) Array.newInstance(clazz, size);
+    System.arraycopy(buffer, 0, finalEvents, 0, size);
+    size = back = 0;
+    return finalEvents;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/JvmMonitorConfig.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/JvmMonitorConfig.java
@@ -1,0 +1,21 @@
+package org.apache.druid.java.util.metrics;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JvmMonitorConfig
+{
+  // The JVMMonitor is really more like a JVM memory + GC monitor
+  public static final String PREFIX = "druid.monitoring.jvm";
+
+  @JsonProperty("duration")
+  private boolean duration = false;
+
+  public boolean recordDuration() {
+    return duration;
+  }
+
+  public JvmMonitorConfig(@JsonProperty("duration") final boolean duration)
+  {
+    this.duration = duration;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/Monitors.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/Monitors.java
@@ -25,36 +25,38 @@ import java.util.Map;
 public class Monitors
 {
   /**
-   * Creates a JVM monitor, configured with the given dimensions, that gathers all currently available JVM-wide
+   * Creates a JVM monitor, configured with the given dimensions and config that gathers all currently available JVM-wide
    * monitors. Emitted events have default feed {@link FeedDefiningMonitor#DEFAULT_METRICS_FEED}
-   * See: {@link Monitors#createCompoundJvmMonitor(Map, String)}
+   * See: {@link Monitors#createCompoundJvmMonitor(Map, String, JvmMonitorConfig)}
    *
    * @param dimensions common dimensions to configure the JVM monitor with
+   * @param config JVM-wide monitor config
    *
    * @return a universally useful JVM-wide monitor
    */
-  public static Monitor createCompoundJvmMonitor(Map<String, String[]> dimensions)
+  public static Monitor createCompoundJvmMonitor(Map<String, String[]> dimensions, JvmMonitorConfig config)
   {
-    return createCompoundJvmMonitor(dimensions, FeedDefiningMonitor.DEFAULT_METRICS_FEED);
+    return createCompoundJvmMonitor(dimensions, FeedDefiningMonitor.DEFAULT_METRICS_FEED, config);
   }
 
   /**
-   * Creates a JVM monitor, configured with the given dimensions, that gathers all currently available JVM-wide
+   * Creates a JVM monitor, configured with the given dimensions and config that gathers all currently available JVM-wide
    * monitors: {@link JvmMonitor}, {@link JvmCpuMonitor} and {@link JvmThreadsMonitor} (this list may
    * change in any future release of this library, including a minor release).
    *
    * @param dimensions common dimensions to configure the JVM monitor with
    * @param feed       feed for all emitted events
+   * @param config JVM-wide monitor config
    *
    * @return a universally useful JVM-wide monitor
    */
-  public static Monitor createCompoundJvmMonitor(Map<String, String[]> dimensions, String feed)
+  public static Monitor createCompoundJvmMonitor(Map<String, String[]> dimensions, String feed, JvmMonitorConfig config)
   {
     // This list doesn't include SysMonitor because it should probably be run only in one JVM, if several JVMs are
     // running on the same instance, so most of the time SysMonitor should be configured/set up differently than
     // "simple" JVM monitors, created below.
     return and(// Could equally be or(), because all member monitors always return true from their monitor() methods.
-                new JvmMonitor(dimensions, feed),
+                new JvmMonitor(dimensions, feed, config),
                 new JvmCpuMonitor(dimensions, feed),
                 new JvmThreadsMonitor(dimensions, feed)
     );

--- a/processing/src/main/java/org/apache/druid/java/util/metrics/jvm/gc/GcEvent.java
+++ b/processing/src/main/java/org/apache/druid/java/util/metrics/jvm/gc/GcEvent.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.metrics.jvm.gc;
+
+import org.apache.druid.java.util.common.Pair;
+
+import java.util.Optional;
+
+public class GcEvent
+{
+  private static final String GC_YOUNG_GENERATION_NAME = "young";
+  private static final String GC_OLD_GENERATION_NAME = "old";
+  private static final String GC_ZGC_GENERATION_NAME = "zgc";
+  private static final String GC_G1_CONCURRENT_GENERATION_NAME = "g1_concurrent";
+  private static final String CMS_COLLECTOR_NAME = "cms";
+  private static final String G1_COLLECTOR_NAME = "g1";
+  private static final String PARALLEL_COLLECTOR_NAME = "parallel";
+  private static final String SERIAL_COLLECTOR_NAME = "serial";
+  private static final String ZGC_COLLECTOR_NAME = "zgc";
+  private static final String SHENANDOAN_COLLECTOR_NAME = "shenandoah";
+
+  public final String druidGenerationName;
+  public final String druidCollectorName;
+  public final String jvmGcName;
+  public final Optional<String> jvmGcCause;
+
+  public GcEvent(final String jvmGcName)
+  {
+    this.jvmGcName = jvmGcName;
+    this.jvmGcCause = Optional.empty();
+
+    final Pair<String, String> druidNames = convertEventName(jvmGcName);
+    this.druidGenerationName = druidNames.lhs;
+    this.druidCollectorName = druidNames.rhs;
+  }
+
+  public GcEvent(final String jvmGcName, final String jvmGcCause)
+  {
+    this.jvmGcName = jvmGcName;
+    this.jvmGcCause = Optional.of(jvmGcCause);
+
+    final Pair<String, String> druidNames = convertEventName(jvmGcName);
+    this.druidGenerationName = druidNames.lhs;
+    this.druidCollectorName = druidNames.rhs;
+  }
+
+  private static Pair<String, String> convertEventName(final String jvmGcName)
+  {
+    switch (jvmGcName) {
+      // CMS
+      case "ParNew":
+        return new Pair<>(GC_YOUNG_GENERATION_NAME, CMS_COLLECTOR_NAME);
+      case "ConcurrentMarkSweep":
+        return new Pair<>(GC_OLD_GENERATION_NAME, CMS_COLLECTOR_NAME);
+
+      // G1
+      case "G1 Young Generation":
+        return new Pair<>(GC_YOUNG_GENERATION_NAME, G1_COLLECTOR_NAME);
+      case "G1 Old Generation":
+        return new Pair<>(GC_OLD_GENERATION_NAME, G1_COLLECTOR_NAME);
+      case "G1 Concurrent GC":
+        return new Pair<>(GC_G1_CONCURRENT_GENERATION_NAME, G1_COLLECTOR_NAME);
+
+      // Parallel
+      case "PS Scavenge":
+        return new Pair<>(GC_YOUNG_GENERATION_NAME, PARALLEL_COLLECTOR_NAME);
+      case "PS MarkSweep":
+        return new Pair<>(GC_OLD_GENERATION_NAME, PARALLEL_COLLECTOR_NAME);
+
+      // Serial
+      case "Copy":
+        return new Pair<>(GC_YOUNG_GENERATION_NAME, SERIAL_COLLECTOR_NAME);
+      case "MarkSweepCompact":
+        return new Pair<>(GC_OLD_GENERATION_NAME, SERIAL_COLLECTOR_NAME);
+
+      // zgc
+      case "ZGC":
+        return new Pair<>(GC_ZGC_GENERATION_NAME, ZGC_COLLECTOR_NAME);
+
+      // Shenandoah
+      case "Shenandoah Cycles":
+        return new Pair<>(GC_YOUNG_GENERATION_NAME, SHENANDOAN_COLLECTOR_NAME);
+      case "Shenandoah Pauses":
+        return new Pair<>(GC_OLD_GENERATION_NAME, SHENANDOAN_COLLECTOR_NAME);
+
+      default:
+        return new Pair<>(jvmGcName, jvmGcName);
+    }
+  }
+
+  public boolean isConcurrent()
+  {
+    return (
+        jvmGcName.endsWith(" Cycles") ||
+        druidGenerationName.equals(GC_G1_CONCURRENT_GENERATION_NAME) ||
+        (jvmGcCause.isPresent() && jvmGcCause.get().equals("No GC")));
+  }
+}

--- a/processing/src/test/java/org/apache/druid/java/util/metrics/EventBufferTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/metrics/EventBufferTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.java.util.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EventBufferTest
+{
+  private EventBuffer<ServiceMetricEvent> buffer;
+  private final int capacity = 5;
+
+  @BeforeEach
+  public void setUp()
+  {
+    buffer = new EventBuffer<>(ServiceMetricEvent.class, capacity);
+  }
+
+  @Test
+  public void testInsertAndSize()
+  {
+    fill(capacity);
+    buffer.push(ServiceMetricEvent.builder().setMetric("my/other/test/metric", capacity).build(ImmutableMap.of()));
+    Assertions.assertEquals(capacity, buffer.getSize(), "Size should not exceed capacity");
+  }
+
+  @Test
+  public void testExtractAndSize()
+  {
+    int numPush = capacity + 1;
+    fill(numPush);
+
+    ServiceMetricEvent[] extractedEvents = buffer.extract();
+
+    for (int i = numPush - 1; i >= numPush - capacity; --i) {
+      ServiceMetricEvent event = extractedEvents[i % capacity];
+
+      Assertions.assertEquals("my/test/metric", event.getMetric(), "Metric name incorrect");
+      Assertions.assertEquals(i, event.getValue(), "Metric value should equal index");
+    }
+    Assertions.assertEquals(0, buffer.getSize(), "EventBuffer::extract() should clear size");
+  }
+
+  private void fill(int n)
+  {
+    for (int i = 0; i < n; ++i) {
+      ServiceMetricEvent.Builder builder = ServiceMetricEvent.builder();
+      builder.setMetric("my/test/metric", i);
+      buffer.push(builder.build(ImmutableMap.of()));
+      Assertions.assertEquals(Math.min(i + 1, capacity), buffer.getSize(), "Size should not exceed capacity");
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/java/util/metrics/MonitorsTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/metrics/MonitorsTest.java
@@ -45,7 +45,7 @@ public class MonitorsTest
   {
     String feed = "testFeed";
     StubServiceEmitter emitter = new StubServiceEmitter("dev/monitor-test", "localhost:0000");
-    Monitor m = Monitors.createCompoundJvmMonitor(ImmutableMap.of(), feed);
+    Monitor m = Monitors.createCompoundJvmMonitor(ImmutableMap.of(), feed, new JvmMonitorConfig(false));
     m.start();
     m.monitor(emitter);
     m.stop();
@@ -56,7 +56,7 @@ public class MonitorsTest
   public void testDefaultFeed()
   {
     StubServiceEmitter emitter = new StubServiceEmitter("dev/monitor-test", "localhost:0000");
-    Monitor m = Monitors.createCompoundJvmMonitor(ImmutableMap.of());
+    Monitor m = Monitors.createCompoundJvmMonitor(ImmutableMap.of(), new JvmMonitorConfig(false));
     m.start();
     m.monitor(emitter);
     m.stop();

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -44,6 +44,7 @@ import org.apache.druid.java.util.metrics.ClockDriftSafeMonitorScheduler;
 import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
 import org.apache.druid.java.util.metrics.JvmCpuMonitor;
 import org.apache.druid.java.util.metrics.JvmMonitor;
+import org.apache.druid.java.util.metrics.JvmMonitorConfig;
 import org.apache.druid.java.util.metrics.JvmThreadsMonitor;
 import org.apache.druid.java.util.metrics.Monitor;
 import org.apache.druid.java.util.metrics.MonitorScheduler;
@@ -88,6 +89,7 @@ public class MetricsModule implements Module
     JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX, DruidMonitorSchedulerConfig.class);
     JsonConfigProvider.bind(binder, MONITORING_PROPERTY_PREFIX, MonitorsConfig.class);
     JsonConfigProvider.bind(binder, OshiSysMonitorConfig.PREFIX, OshiSysMonitorConfig.class);
+    JsonConfigProvider.bind(binder, JvmMonitorConfig.PREFIX, JvmMonitorConfig.class);
 
     DruidBinders.metricMonitorBinder(binder); // get the binder so that it will inject the empty set at a minimum.
 
@@ -151,14 +153,15 @@ public class MetricsModule implements Module
   @Provides
   @ManageLifecycle
   public JvmMonitor getJvmMonitor(
-      DataSourceTaskIdHolder dataSourceTaskIdHolder
+      DataSourceTaskIdHolder dataSourceTaskIdHolder,
+      JvmMonitorConfig config
   )
   {
     Map<String, String[]> dimensions = MonitorsConfig.mapOfDatasourceAndTaskID(
         dataSourceTaskIdHolder.getDataSource(),
         dataSourceTaskIdHolder.getTaskId()
     );
-    return new JvmMonitor(dimensions);
+    return new JvmMonitor(dimensions, config);
   }
 
   @Provides


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

This PR provides enhances JVM GC metrics to the `JvmMonitor` monitor. Namely:
- `jvm/gc/pause`: Stop-the-world garbage collection JVM-reported pause time (ms)
- `jvm/gc/concurrentTime`: JVM-reported time spent in concurrent phases of CMS pauses (ms)

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Pulls GC event subscription logic from https://github.com/Netflix/spectator. I'm wondering whether more metrics from this list: https://netflix.github.io/atlas-docs/spectator/lang/java/ext/jvm-gc/#jvmgcpause – we currently take aggregate statistics from getMemoryPoolMXBeans() on total mem usage, etc. via `GcSpaceCollector`.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Adds `jvm/gc/pause` and `jvm/gc/concurrentTime` metrics to JvmMonitor.

<hr>

##### Key changed/added classes in this PR
* `docs/operations/metrics.md`
* `processing/src/main/java/org/apache/druid/java/util/metrics/EventBuffer.java`
* `processing/src/main/java/org/apache/druid/java/util/metrics/JvmMonitor.java`
* `processing/src/main/java/org/apache/druid/java/util/metrics/JvmMonitorConfig.java`
* `processing/src/main/java/org/apache/druid/java/util/metrics/Monitors.java`
* `processing/src/main/java/org/apache/druid/java/util/metrics/jvm/gc/GcEvent.java`
* `processing/src/test/java/org/apache/druid/java/util/metrics/EventBufferTest.java`
* `processing/src/test/java/org/apache/druid/java/util/metrics/JvmMonitorTest.java`
* `processing/src/test/java/org/apache/druid/java/util/metrics/MonitorsTest.java`
* `server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
