### PR TITLE
Upgrade minor jetty version to fix vulnerability

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2065,7 +2065,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.54.v20240208
+version: 9.4.56.v20240826
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <guava.version>32.0.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.54.v20240208</jetty.version>
+        <jetty.version>9.4.56.v20240826</jetty.version>
         <jersey.version>1.19.4</jersey.version>
         <jackson.version>2.12.7.20221012</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>


### PR DESCRIPTION
Upgrading jetty from version `9.4.54.v20240208` to `9.4.56.v20240826` to fix CVE-2024-8184.

Refer: https://avd.aquasec.com/nvd/cve-2024-8184 
(org.eclipse.jetty:jetty-server: jetty: Jetty ThreadLimitHandler.getRemote() vulnerable to remote DoS attacks)