### PR TITLE
Suppress `okio-fakefilesystem` vulnerability: `CVE-2023-3635`

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -466,6 +466,16 @@
     <cve>CVE-2023-3635</cve>  <!-- Suppressed since okio requests in Druid are internal, and not user-facing -->
   </suppress>
 
+  <!-- Suppressed since this is a compile-time dependency for software.amazon.glue:schema-registry-serde,
+    ~ and the latest release for software.amazon.glue:schema-registry-serde (1.1.21) still has the vulnerability.-->
+  <suppress>
+    <notes><![CDATA[
+    file names: okio-fakefilesystem-3.2.0.jar, okio-fakefilesystem-jvm-3.2.0.jar
+  ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.squareup\.okio/okio\-fakefilesystem(-jvm)?@.*$</packageUrl>
+    <cve>CVE-2023-3635</cve>
+  </suppress>
+
   <!-- CVE-2022-4244 is affecting plexus-utils package, plexus-interpolation is wrongly matched - https://github.com/jeremylong/DependencyCheck/issues/5973 -->
   <suppress base="true">
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.plexus/plexus-interpolation@.*$</packageUrl>


### PR DESCRIPTION
### Description

This PR suppresses `CVE-2023-3635` for `okio-fakefilesystem` dependency, which is a compile-time dependency for `software.amazon.glue:schema-registry-serde`.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
