### PR TITLE
Cleanup after refactors to processing module

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnSerializer.java
@@ -423,8 +423,9 @@ public class VariantColumnSerializer extends NestedCommonFormatColumnSerializer
   }
 
   /**
-   * Internal serializer used to serailize a {@link VariantColumn}. Contains the logic to write out the column to a
-   * {@link FileSmoosher}. Created by {@link VariantColumnSerializer} once it is closed for writes.
+   * Internal serializer used to serialize a {@link VariantColumn}. Encapsulates just the logic to write out the column
+   * to a {@link FileSmoosher} without the parts to update the dictionaries themselves, so that it can be reused.
+   * Created by {@link VariantColumnSerializer} once it is closed for writes.
    */
   public static class InternalSerializer implements Serializer
   {
@@ -475,18 +476,20 @@ public class VariantColumnSerializer extends NestedCommonFormatColumnSerializer
       this.writeDictionary = writeDictionary;
       this.dictionaryIdLookup = dictionaryIdLookup;
 
-      boolean[] dictionariesSorted = new boolean[]{
-          dictionaryWriter.isSorted(),
-          longDictionaryWriter.isSorted(),
-          doubleDictionaryWriter.isSorted(),
-          arrayDictionaryWriter.isSorted()
-      };
-      for (boolean sorted : dictionariesSorted) {
-        if (writeDictionary && !sorted) {
-          throw DruidException.defensive(
-              "Dictionary is not sorted? [%s]  Should always be sorted",
-              Arrays.toString(dictionariesSorted)
-          );
+      if (writeDictionary) {
+        boolean[] dictionariesSorted = new boolean[]{
+            dictionaryWriter.isSorted(),
+            longDictionaryWriter.isSorted(),
+            doubleDictionaryWriter.isSorted(),
+            arrayDictionaryWriter.isSorted()
+        };
+        for (boolean sorted : dictionariesSorted) {
+          if (!sorted) {
+            throw DruidException.defensive(
+                "Dictionary is not sorted? [%s]  Should always be sorted",
+                Arrays.toString(dictionariesSorted)
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
Follow-up PR to https://github.com/apache/druid/pull/17493 to address pending unaddressed comments.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
