### PR TITLE
ServerSelector: Synchronize getAllServers().

### DIFF
--- a/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ServerSelector.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.client.selector;
 
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 import org.apache.druid.client.DataSegmentInterner;
 import org.apache.druid.query.Query;
@@ -40,9 +41,10 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ServerSelector implements Overshadowable<ServerSelector>
 {
-
+  @GuardedBy("this")
   private final Int2ObjectRBTreeMap<Set<QueryableDruidServer>> historicalServers;
 
+  @GuardedBy("this")
   private final Int2ObjectRBTreeMap<Set<QueryableDruidServer>> realtimeServers;
 
   private final TierSelectorStrategy strategy;
@@ -145,18 +147,21 @@ public class ServerSelector implements Overshadowable<ServerSelector>
 
   public List<DruidServerMetadata> getAllServers()
   {
-    List<DruidServerMetadata> servers = new ArrayList<>();
-    historicalServers.values()
-        .stream()
-        .flatMap(Collection::stream)
-        .map(server -> server.getServer().getMetadata())
-        .forEach(servers::add);
+    final List<DruidServerMetadata> servers = new ArrayList<>();
 
-    realtimeServers.values()
-        .stream()
-        .flatMap(Collection::stream)
-        .map(server -> server.getServer().getMetadata())
-        .forEach(servers::add);
+    synchronized (this) {
+      historicalServers.values()
+                       .stream()
+                       .flatMap(Collection::stream)
+                       .map(server -> server.getServer().getMetadata())
+                       .forEach(servers::add);
+
+      realtimeServers.values()
+                     .stream()
+                     .flatMap(Collection::stream)
+                     .map(server -> server.getServer().getMetadata())
+                     .forEach(servers::add);
+    }
 
     return servers;
   }


### PR DESCRIPTION
This method was missing some required synchronization. This patch also adds GuardedBy annotations to historicalServers and realtimeServers, which would have caught it.