### PR TITLE
[Backport] Resolve CVEs: Upgrade jetty version and suppress azure cve

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -1999,7 +1999,7 @@ name: Jetty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 9.4.54.v20240208
+version: 9.4.56.v20240826
 libraries:
   - org.eclipse.jetty: jetty-client
   - org.eclipse.jetty: jetty-continuation

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -649,10 +649,12 @@
   </suppress>
   <suppress>
     <notes><![CDATA[
-        FP per issue #6100 - CVE-2023-36052 since it is related to Azure-cli not to the azure-core libraries
+        FP per issue #6100 - CVE-2023-36052 since it is related to azure-cli not to the azure-core libraries
+        CVE-2024-43591 is also related to azure-cli
         ]]></notes>
     <packageUrl regex="true">^pkg:maven/com\.azure/azure*@*.*$</packageUrl>
     <cve>CVE-2023-36052</cve>
+    <cve>CVE-2024-43591</cve>
   </suppress>
   <suppress>
     <!-- CVE is for a totally unrelated Sketch mac app -->
@@ -745,5 +747,4 @@
     ]]></notes>
     <vulnerabilityName>CVE-2024-45772</vulnerabilityName>
   </suppress>
-
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <guava.version>32.0.1-jre</guava.version>
         <guice.version>4.1.0</guice.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <jetty.version>9.4.54.v20240208</jetty.version>
+        <jetty.version>9.4.56.v20240826</jetty.version>
         <jersey.version>1.19.4</jersey.version>
         <jackson.version>2.12.7.20221012</jackson.version>
         <codehaus.jackson.version>1.9.13</codehaus.jackson.version>


### PR DESCRIPTION
Backport of #17385 to 31.0.1.