### PR TITLE
update kafka dependency version to 3.9.0

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3165,7 +3165,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 3.6.1
+version: 3.9.0
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -3174,7 +3174,7 @@ libraries:
 notices:
   - kafka-clients: |
       Apache Kafka
-      Copyright 2023 The Apache Software Foundation.
+      Copyright 2024 The Apache Software Foundation.
 
       This product includes software developed at
       The Apache Software Foundation (https://www.apache.org/).

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>5.5.0</apache.curator.version>
-        <apache.kafka.version>3.6.1</apache.kafka.version>
+        <apache.kafka.version>3.9.0</apache.kafka.version>
         <!-- when updating apache ranger, verify the usage of aws-bundle-sdk vs aws-logs-sdk
         and update as needed in extensions-core/druid-ranger-security/pm.xml  -->
         <apache.ranger.version>2.4.0</apache.ranger.version>


### PR DESCRIPTION
Also resolves CVE-2024-31141, though I don't think we are much impacted by it since kafka related stuff is only done by trusted admin like users