### PR TITLE
docs: relnotes cleanup

### DIFF
--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -26,9 +26,11 @@ title: "Release notes"
 
 Apache Druid 31.0.1 is a patch release that contains an important fix for the new complex metric column compression feature introduced in Druid 31.0.0. It also contains fixes for the web console, the new projections feature, and a fix for a minor performance regression.
 
+For information about new features in Druid 31, see the [Druid 31 release notes](https://druid.apache.org/docs/31.0.0/release-info/release-notes/).
+
 ## Bug fixes
 
-* Fixes a byte order issue with compression complex metric feature [#17422](https://github.com/apache/druid/pull/17422)
+* Fixed an issue with complex metric compression that caused some complex column data with compression enabled to be read incorrectly, resulting in segment data corruption or system instability due to out-of-memory exceptions. We recommend that you reingest data if you're using complex metric compression [#17422](https://github.com/apache/druid/pull/17422)
 * Fixes an issue with projection segment merging [#17460](https://github.com/apache/druid/pull/17460)
 * Fixes web console progress indicator [#17334](https://github.com/apache/druid/pull/17334)
 * Fixes a minor performance regression with query processing [#17397](https://github.com/apache/druid/pull/17397)

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -30,7 +30,7 @@ For information about new features in Druid 31, see the [Druid 31 release notes]
 
 ## Bug fixes
 
-* Fixed an issue with complex metric compression that caused some complex column data with compression enabled to be read incorrectly, resulting in segment data corruption or system instability due to out-of-memory exceptions. We recommend that you reingest data if you're using complex metric compression [#17422](https://github.com/apache/druid/pull/17422)
+* Fixes an issue with complex metric compression that caused some data to be read incorrectly, resulting in segment data corruption or system instability due to out-of-memory exceptions. We recommend that you reingest data if you use compression for complex metric columns [#17422](https://github.com/apache/druid/pull/17422)
 * Fixes an issue with projection segment merging [#17460](https://github.com/apache/druid/pull/17460)
 * Fixes web console progress indicator [#17334](https://github.com/apache/druid/pull/17334)
 * Fixes a minor performance regression with query processing [#17397](https://github.com/apache/druid/pull/17397)


### PR DESCRIPTION
- Updates 17422 to be more descriptive
- Adds a link to the 31.0.0 release notes in case someone wants to see the new features info etc
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
