### PR TITLE
Fix compilation error for MSQCompactionRunnerTest

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/indexing/MSQCompactionRunnerTest.java
@@ -149,7 +149,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         null,
-        null,
         null
     );
     CompactionConfigValidationResult validationResult = MSQ_COMPACTION_RUNNER.validateCompactionTask(
@@ -171,7 +170,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         null,
-        null,
         null
     );
     Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
@@ -184,7 +182,6 @@ public class MSQCompactionRunnerTest
         new DimensionRangePartitionsSpec(TARGET_ROWS_PER_SEGMENT, null, PARTITION_DIMENSIONS, false),
         null,
         Collections.emptyMap(),
-        null,
         null,
         null
     );
@@ -199,7 +196,6 @@ public class MSQCompactionRunnerTest
         new DimensionRangePartitionsSpec(TARGET_ROWS_PER_SEGMENT, null, longPartitionDimension, false),
         null,
         Collections.emptyMap(),
-        null,
         null,
         null
     );
@@ -223,7 +219,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         null,
-        null,
         null
     );
 
@@ -245,7 +240,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         null,
-        null,
         null
     );
     Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
@@ -258,7 +252,6 @@ public class MSQCompactionRunnerTest
         new DynamicPartitionsSpec(3, null),
         null,
         Collections.emptyMap(),
-        null,
         null,
         null
     );
@@ -273,7 +266,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         new ClientCompactionTaskGranularitySpec(null, Granularities.ALL, null),
-        null,
         null
     );
     Assert.assertTrue(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
@@ -287,7 +279,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         new ClientCompactionTaskGranularitySpec(null, null, false),
-        null,
         AGGREGATORS.toArray(new AggregatorFactory[0])
     );
     Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
@@ -301,7 +292,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         new ClientCompactionTaskGranularitySpec(null, null, true),
-        null,
         null
     );
     Assert.assertFalse(MSQ_COMPACTION_RUNNER.validateCompactionTask(compactionTask, INTERVAL_DATASCHEMAS).isValid());
@@ -318,7 +308,6 @@ public class MSQCompactionRunnerTest
         null,
         Collections.emptyMap(),
         new ClientCompactionTaskGranularitySpec(null, null, true),
-        null,
         new AggregatorFactory[]{new LongSumAggregatorFactory(outputColName, inputColName)}
     );
     CompactionConfigValidationResult validationResult = MSQ_COMPACTION_RUNNER.validateCompactionTask(
@@ -335,7 +324,7 @@ public class MSQCompactionRunnerTest
   @Test
   public void testRunCompactionTasksWithEmptyTaskListFails() throws Exception
   {
-    CompactionTask compactionTask = createCompactionTask(null, null, Collections.emptyMap(), null, null, null);
+    CompactionTask compactionTask = createCompactionTask(null, null, Collections.emptyMap(), null, null);
     TaskStatus taskStatus = MSQ_COMPACTION_RUNNER.runCompactionTasks(compactionTask, Collections.emptyMap(), null);
     Assert.assertTrue(taskStatus.isFailure());
   }
@@ -349,7 +338,6 @@ public class MSQCompactionRunnerTest
         new DimensionRangePartitionsSpec(TARGET_ROWS_PER_SEGMENT, null, PARTITION_DIMENSIONS, false),
         dimFilter,
         Collections.emptyMap(),
-        null,
         null,
         null
     );
@@ -481,7 +469,6 @@ public class MSQCompactionRunnerTest
         dimFilter,
         Collections.emptyMap(),
         null,
-        null,
         null
     );
 
@@ -561,7 +548,6 @@ public class MSQCompactionRunnerTest
       @Nullable DimFilter dimFilter,
       Map<String, Object> contextParams,
       @Nullable ClientCompactionTaskGranularitySpec granularitySpec,
-      @Nullable List<DimensionSchema> dimensionSchemas,
       @Nullable AggregatorFactory[] metricsSpec
   )
   {
@@ -585,7 +571,7 @@ public class MSQCompactionRunnerTest
         ))
         .transformSpec(transformSpec)
         .granularitySpec(granularitySpec)
-        .dimensionsSpec(new DimensionsSpec(dimensionSchemas))
+        .dimensionsSpec(new DimensionsSpec(null))
         .metricsSpec(metricsSpec)
         .compactionRunner(MSQ_COMPACTION_RUNNER)
         .context(context);


### PR DESCRIPTION
Fixes compilation error for `MSQCompactionRunnerTest` by removing the redundant argument to `createCompactionTask`