### PR TITLE
Refactor: Minor cleanup of segment allocation flow

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -183,7 +183,7 @@ public class TaskLockbox
                                       ? savedTaskLock.withPriority(task.getPriority())
                                       : savedTaskLock;
 
-        final TaskLockPosse taskLockPosse = verifyAndCreateOrFindLockPosse(
+        final TaskLockPosse taskLockPosse = reacquireLockOnStartup(
             task,
             savedTaskLockWithPriority
         );
@@ -192,15 +192,11 @@ public class TaskLockbox
 
           if (savedTaskLockWithPriority.getVersion().equals(taskLock.getVersion())) {
             taskLockCount++;
-            log.info(
-                "Reacquired lock[%s] for task: %s",
-                taskLock,
-                task.getId()
-            );
+            log.info("Reacquired lock[%s] for task[%s].", taskLock, task.getId());
           } else {
             taskLockCount++;
             log.info(
-                "Could not reacquire lock on interval[%s] version[%s] (got version[%s] instead) for task: %s",
+                "Could not reacquire lock on interval[%s] version[%s] (got version[%s] instead) for task[%s].",
                 savedTaskLockWithPriority.getInterval(),
                 savedTaskLockWithPriority.getVersion(),
                 taskLock.getVersion(),
@@ -210,7 +206,7 @@ public class TaskLockbox
         } else {
           failedToReacquireLockTaskGroups.add(task.getGroupId());
           log.error(
-              "Could not reacquire lock on interval[%s] version[%s] for task: %s from group %s.",
+              "Could not reacquire lock on interval[%s] version[%s] for task[%s], groupId[%s].",
               savedTaskLockWithPriority.getInterval(),
               savedTaskLockWithPriority.getVersion(),
               task.getId(),
@@ -253,38 +249,28 @@ public class TaskLockbox
   }
 
   /**
-   * This method is called only in {@link #syncFromStorage()} and verifies the given task and the taskLock have the same
-   * groupId, dataSource, and priority.
+   * Reacquire lock during {@link #syncFromStorage()}.
+   *
+   * @return null if the lock could not be reacquired.
    */
   @VisibleForTesting
   @Nullable
-  protected TaskLockPosse verifyAndCreateOrFindLockPosse(Task task, TaskLock taskLock)
+  protected TaskLockPosse reacquireLockOnStartup(Task task, TaskLock taskLock)
   {
+    if (!taskMatchesLock(task, taskLock)) {
+      log.warn(
+          "Task[datasource: %s, groupId: %s, priority: %s] does not match"
+          + " TaskLock[datasource: %s, groupId: %s, priority: %s].",
+          task.getDataSource(), task.getGroupId(), task.getPriority(),
+          taskLock.getDataSource(), taskLock.getGroupId(), taskLock.getNonNullPriority()
+      );
+      return null;
+    }
+
     giant.lock();
 
     try {
-      Preconditions.checkArgument(
-          task.getGroupId().equals(taskLock.getGroupId()),
-          "lock groupId[%s] is different from task groupId[%s]",
-          taskLock.getGroupId(),
-          task.getGroupId()
-      );
-      Preconditions.checkArgument(
-          task.getDataSource().equals(taskLock.getDataSource()),
-          "lock dataSource[%s] is different from task dataSource[%s]",
-          taskLock.getDataSource(),
-          task.getDataSource()
-      );
       final int taskPriority = task.getPriority();
-      final int lockPriority = taskLock.getNonNullPriority();
-
-      Preconditions.checkArgument(
-          lockPriority == taskPriority,
-          "lock priority[%s] is different from task priority[%s]",
-          lockPriority,
-          taskPriority
-      );
-
       final LockRequest request;
       switch (taskLock.getGranularity()) {
         case SEGMENT:
@@ -313,20 +299,29 @@ public class TaskLockbox
           );
           break;
         default:
-          throw new ISE("Unknown lockGranularity[%s]", taskLock.getGranularity());
+          throw DruidException.defensive("Unknown lockGranularity[%s]", taskLock.getGranularity());
       }
 
       return createOrFindLockPosse(request, task, false);
     }
     catch (Exception e) {
-      log.error(e,
-                "Could not reacquire lock for task: %s from metadata store", task.getId()
-      );
+      log.error(e, "Could not reacquire lock for task[%s] from metadata store", task.getId());
       return null;
     }
     finally {
       giant.unlock();
     }
+  }
+
+  /**
+   * Returns true if the datasource, groupId and priority of the given Task
+   * match that of the TaskLock.
+   */
+  private boolean taskMatchesLock(Task task, TaskLock taskLock)
+  {
+    return task.getGroupId().equals(taskLock.getGroupId())
+        && task.getDataSource().equals(taskLock.getDataSource())
+        && task.getPriority() == taskLock.getNonNullPriority();
   }
 
   /**
@@ -751,13 +746,16 @@ public class TaskLockbox
   {
     return metadataStorageCoordinator.allocatePendingSegment(
         request.getDataSource(),
-        request.getSequenceName(),
-        request.getPreviousSegmentId(),
         request.getInterval(),
-        request.getPartialShardSpec(),
-        version,
         request.isSkipSegmentLineageCheck(),
-        allocatorId
+        new SegmentCreateRequest(
+            request.getSequenceName(),
+            request.getPreviousSegmentId(),
+            version,
+            request.getPartialShardSpec(),
+            null,
+            allocatorId
+        )
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskLockbox.java
@@ -753,7 +753,6 @@ public class TaskLockbox
             request.getPreviousSegmentId(),
             version,
             request.getPartialShardSpec(),
-            null,
             allocatorId
         )
     );
@@ -1816,7 +1815,6 @@ public class TaskLockbox
             action.getPreviousSegmentId(),
             acquiredLock == null ? lockRequest.getVersion() : acquiredLock.getVersion(),
             action.getPartialShardSpec(),
-            null,
             ((PendingSegmentAllocatingTask) task).getTaskAllocatorId()
         );
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -2270,10 +2270,10 @@ public class TaskLockboxTest
     }
 
     @Override
-    protected TaskLockPosse verifyAndCreateOrFindLockPosse(Task task, TaskLock taskLock)
+    protected TaskLockPosse reacquireLockOnStartup(Task task, TaskLock taskLock)
     {
       return task.getGroupId()
-                 .contains("FailingLockAcquisition") ? null : super.verifyAndCreateOrFindLockPosse(task, taskLock);
+                 .contains("FailingLockAcquisition") ? null : super.reacquireLockOnStartup(task, taskLock);
     }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/test/TestIndexerMetadataStorageCoordinator.java
@@ -36,7 +36,6 @@ import org.apache.druid.segment.SegmentSchemaMapping;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
-import org.apache.druid.timeline.partition.PartialShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -242,20 +241,16 @@ public class TestIndexerMetadataStorageCoordinator implements IndexerMetadataSto
   @Override
   public SegmentIdWithShardSpec allocatePendingSegment(
       String dataSource,
-      String sequenceName,
-      String previousSegmentId,
       Interval interval,
-      PartialShardSpec partialShardSpec,
-      String maxVersion,
       boolean skipSegmentLineageCheck,
-      String taskAllocatorId
+      SegmentCreateRequest createRequest
   )
   {
     return new SegmentIdWithShardSpec(
         dataSource,
         interval,
-        maxVersion,
-        partialShardSpec.complete(objectMapper, 0, 0)
+        createRequest.getVersion(),
+        createRequest.getPartialShardSpec().complete(objectMapper, 0, 0)
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/timeline/partition/OverwriteShardSpec.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/OverwriteShardSpec.java
@@ -21,6 +21,7 @@ package org.apache.druid.timeline.partition;
 
 /**
  * ShardSpec for non-first-generation segments.
+ * This shardSpec is created only by overwriting tasks using segment locks.
  * This shardSpec is allocated a partitionId between {@link PartitionIds#NON_ROOT_GEN_START_PARTITION_ID} and
  * {@link PartitionIds#NON_ROOT_GEN_END_PARTITION_ID}.
  *

--- a/processing/src/main/java/org/apache/druid/timeline/partition/PartitionIds.java
+++ b/processing/src/main/java/org/apache/druid/timeline/partition/PartitionIds.java
@@ -31,6 +31,7 @@ public final class PartitionIds
   public static final int ROOT_GEN_END_PARTITION_ID = 32768; // exclusive
   /**
    * Start partitionId available for non-root generation segments.
+   * Used only with segment locks.
    */
   public static final int NON_ROOT_GEN_START_PARTITION_ID = 32768;
   /**

--- a/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/IndexerMetadataStorageCoordinator.java
@@ -26,7 +26,6 @@ import org.apache.druid.segment.SegmentSchemaMapping;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
-import org.apache.druid.timeline.partition.PartialShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -215,34 +214,23 @@ public interface IndexerMetadataStorageCoordinator
    * Note that a segment sequence may include segments with a variety of different intervals and versions.
    *
    * @param dataSource              dataSource for which to allocate a segment
-   * @param sequenceName            name of the group of ingestion tasks producing a segment series
-   * @param previousSegmentId       previous segment in the series; may be null or empty, meaning this is the first
-   *                                segment
    * @param interval                interval for which to allocate a segment
-   * @param partialShardSpec        partialShardSpec containing all necessary information to create a shardSpec for the
-   *                                new segmentId
-   * @param maxVersion              use this version if we have no better version to use. The returned segment
-   *                                identifier may have a version lower than this one, but will not have one higher.
    * @param skipSegmentLineageCheck if true, perform lineage validation using previousSegmentId for this sequence.
    *                                Should be set to false if replica tasks would index events in same order
-   * @param taskAllocatorId         The task allocator id with which the pending segment is associated
    * @return the pending segment identifier, or null if it was impossible to allocate a new segment
    */
+  @Nullable
   SegmentIdWithShardSpec allocatePendingSegment(
       String dataSource,
-      String sequenceName,
-      @Nullable String previousSegmentId,
       Interval interval,
-      PartialShardSpec partialShardSpec,
-      String maxVersion,
       boolean skipSegmentLineageCheck,
-      String taskAllocatorId
+      SegmentCreateRequest createRequest
   );
 
   /**
    * Delete pending segments created in the given interval belonging to the given data source from the pending segments
    * table. The {@code created_date} field of the pending segments table is checked to find segments to be deleted.
-   *
+   * <p>
    * Note that the semantic of the interval (for `created_date`s) is different from the semantic of the interval
    * parameters in some other methods in this class, such as {@link #retrieveUsedSegmentsForInterval} (where the
    * interval is about the time column value in rows belonging to the segment).
@@ -269,7 +257,7 @@ public interface IndexerMetadataStorageCoordinator
    * <p/>
    * If startMetadata and endMetadata are set, this insertion will be atomic with a compare-and-swap on dataSource
    * commit metadata.
-   *
+   * <p>
    * If segmentsToDrop is not null and not empty, this insertion will be atomic with a insert-and-drop on inserting
    * {@param segments} and dropping {@param segmentsToDrop}.
    *
@@ -426,7 +414,7 @@ public interface IndexerMetadataStorageCoordinator
    * Similar to {@link #commitSegments}, but meant for streaming ingestion tasks for handling
    * the case where the task ingested no records and created no segments, but still needs to update the metadata
    * with the progress that the task made.
-   *
+   * <p>
    * The metadata should undergo the same validation checks as performed by {@link #commitSegments}.
    *
    *

--- a/server/src/main/java/org/apache/druid/indexing/overlord/SegmentCreateRequest.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/SegmentCreateRequest.java
@@ -38,7 +38,6 @@ public class SegmentCreateRequest
   private final String sequenceName;
   private final String previousSegmentId;
   private final PartialShardSpec partialShardSpec;
-  private final String upgradedFromSegmentId;
   private final String taskAllocatorId;
 
   public SegmentCreateRequest(
@@ -46,7 +45,6 @@ public class SegmentCreateRequest
       String previousSegmentId,
       String version,
       PartialShardSpec partialShardSpec,
-      String upgradedFromSegmentId,
       String taskAllocatorId
   )
   {
@@ -54,7 +52,6 @@ public class SegmentCreateRequest
     this.previousSegmentId = previousSegmentId == null ? "" : previousSegmentId;
     this.version = version;
     this.partialShardSpec = partialShardSpec;
-    this.upgradedFromSegmentId = upgradedFromSegmentId;
     this.taskAllocatorId = taskAllocatorId;
   }
 
@@ -88,11 +85,6 @@ public class SegmentCreateRequest
   public PartialShardSpec getPartialShardSpec()
   {
     return partialShardSpec;
-  }
-
-  public String getUpgradedFromSegmentId()
-  {
-    return upgradedFromSegmentId;
   }
 
   public String getTaskAllocatorId()

--- a/server/src/main/java/org/apache/druid/indexing/overlord/SegmentCreateRequest.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/SegmentCreateRequest.java
@@ -58,20 +58,28 @@ public class SegmentCreateRequest
     this.taskAllocatorId = taskAllocatorId;
   }
 
+  /**
+   * Represents group of ingestion tasks that produce a segment series.
+   */
   public String getSequenceName()
   {
     return sequenceName;
   }
 
   /**
-   * Non-null previous segment id. This can be used for persisting to the
-   * pending segments table in the metadata store.
+   * Previous segment id allocated for this sequence.
+   *
+   * @return Empty string if there is no previous segment in the series.
    */
   public String getPreviousSegmentId()
   {
     return previousSegmentId;
   }
 
+  /**
+   * Version of the lock held by the task that has requested the segment allocation.
+   * The allocated segment must have a version less than or equal to this version.
+   */
   public String getVersion()
   {
     return version;

--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -1736,17 +1736,14 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
           pendingSegmentId,
           request.getSequenceName(),
           request.getPreviousSegmentId(),
-          request.getUpgradedFromSegmentId(),
+          null,
           request.getTaskAllocatorId()
       );
 
     } else if (!overallMaxId.getInterval().equals(interval)) {
       log.warn(
           "Cannot allocate new segment for dataSource[%s], interval[%s], existingVersion[%s]: conflicting segment[%s].",
-          dataSource,
-          interval,
-          existingVersion,
-          overallMaxId
+          dataSource, interval, existingVersion, overallMaxId
       );
       return null;
     } else if (committedMaxId != null
@@ -1754,8 +1751,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
                   == SingleDimensionShardSpec.UNKNOWN_NUM_CORE_PARTITIONS) {
       log.warn(
           "Cannot allocate new segment because of unknown core partition size of segment[%s], shardSpec[%s]",
-          committedMaxId,
-          committedMaxId.getShardSpec()
+          committedMaxId, committedMaxId.getShardSpec()
       );
       return null;
     } else {
@@ -1776,7 +1772,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
           getTrueAllocatedId(pendingSegmentId),
           request.getSequenceName(),
           request.getPreviousSegmentId(),
-          request.getUpgradedFromSegmentId(),
+          null,
           request.getTaskAllocatorId()
       );
     }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/SegmentCreateRequestTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/SegmentCreateRequestTest.java
@@ -36,7 +36,6 @@ public class SegmentCreateRequestTest
         null,
         "version",
         partialShardSpec,
-        null,
         null
     );
     Assert.assertEquals("sequence", request.getSequenceName());

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -2678,7 +2678,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
     final String sequenceName = "seq";
 
-    final SegmentCreateRequest request = new SegmentCreateRequest(sequenceName, null, "v1", partialShardSpec, null, null);
+    final SegmentCreateRequest request = new SegmentCreateRequest(sequenceName, null, "v1", partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId0 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2690,7 +2690,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1", segmentId0.toString());
 
     final SegmentCreateRequest request1 =
-        new SegmentCreateRequest(sequenceName, segmentId0.toString(), segmentId0.getVersion(), partialShardSpec, null, null);
+        new SegmentCreateRequest(sequenceName, segmentId0.toString(), segmentId0.getVersion(), partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId1 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2702,7 +2702,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_1", segmentId1.toString());
 
     final SegmentCreateRequest request2 =
-        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null, null);
+        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId2 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2714,7 +2714,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId2.toString());
 
     final SegmentCreateRequest request3 =
-        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null, null);
+        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId3 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2727,7 +2727,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals(segmentId2, segmentId3);
 
     final SegmentCreateRequest request4 =
-        new SegmentCreateRequest("seq1", null, "v1", partialShardSpec, null, null);
+        new SegmentCreateRequest("seq1", null, "v1", partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId4 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2747,7 +2747,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
     final String sequenceName = "seq";
 
-    final SegmentCreateRequest request = new SegmentCreateRequest(sequenceName, null, "v1", partialShardSpec, null, null);
+    final SegmentCreateRequest request = new SegmentCreateRequest(sequenceName, null, "v1", partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId0 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2759,7 +2759,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1", segmentId0.toString());
 
     final SegmentCreateRequest request1 =
-        new SegmentCreateRequest(sequenceName, segmentId0.toString(), segmentId0.getVersion(), partialShardSpec, null, null);
+        new SegmentCreateRequest(sequenceName, segmentId0.toString(), segmentId0.getVersion(), partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId1 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2771,7 +2771,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_1", segmentId1.toString());
 
     final SegmentCreateRequest request2 =
-        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null, null);
+        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId2 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2783,7 +2783,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_v1_2", segmentId2.toString());
 
     final SegmentCreateRequest request3 =
-        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null, null);
+        new SegmentCreateRequest(sequenceName, segmentId1.toString(), segmentId1.getVersion(), partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId3 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -2796,7 +2796,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals(segmentId2, segmentId3);
 
     final SegmentCreateRequest request4 =
-        new SegmentCreateRequest("seq1", null, "v1", partialShardSpec, null, null);
+        new SegmentCreateRequest("seq1", null, "v1", partialShardSpec, null);
     final SegmentIdWithShardSpec segmentId4 = coordinator.allocatePendingSegments(
         dataSource,
         interval,
@@ -3811,7 +3811,6 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
             previousSegmentId,
             maxVersion,
             partialShardSpec,
-            null,
             taskAllocatorId
         )
     );

--- a/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinatorTest.java
@@ -2280,7 +2280,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final PartialShardSpec partialShardSpec = NumberedPartialShardSpec.instance();
     final String dataSource = "ds";
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
-    final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier = allocatePendingSegment(
         dataSource,
         "seq",
         null,
@@ -2293,7 +2293,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version", identifier.toString());
 
-    final SegmentIdWithShardSpec identifier1 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier1 = allocatePendingSegment(
         dataSource,
         "seq",
         identifier.toString(),
@@ -2306,7 +2306,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_1", identifier1.toString());
 
-    final SegmentIdWithShardSpec identifier2 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier2 = allocatePendingSegment(
         dataSource,
         "seq",
         identifier1.toString(),
@@ -2319,7 +2319,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier2.toString());
 
-    final SegmentIdWithShardSpec identifier3 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier3 = allocatePendingSegment(
         dataSource,
         "seq",
         identifier1.toString(),
@@ -2333,7 +2333,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_2", identifier3.toString());
     Assert.assertEquals(identifier2, identifier3);
 
-    final SegmentIdWithShardSpec identifier4 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier4 = allocatePendingSegment(
         dataSource,
         "seq1",
         null,
@@ -2370,7 +2370,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final PartialShardSpec partialShardSpec = NumberedPartialShardSpec.instance();
     final String dataSource = "ds";
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
-    final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier = allocatePendingSegment(
         dataSource,
         "seq",
         null,
@@ -2385,7 +2385,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals(0, identifier.getShardSpec().getNumCorePartitions());
 
     // simulate one more load using kafka streaming (as if previous segment was published, note different sequence name)
-    final SegmentIdWithShardSpec identifier1 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier1 = allocatePendingSegment(
         dataSource,
         "seq2",
         identifier.toString(),
@@ -2400,7 +2400,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals(0, identifier1.getShardSpec().getNumCorePartitions());
 
     // simulate one more load using kafka streaming (as if previous segment was published, note different sequence name)
-    final SegmentIdWithShardSpec identifier2 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier2 = allocatePendingSegment(
         dataSource,
         "seq3",
         identifier1.toString(),
@@ -2431,7 +2431,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals("ds_2017-01-01T00:00:00.000Z_2017-02-01T00:00:00.000Z_version_new", ids.get(0));
 
     // one more load on same interval:
-    final SegmentIdWithShardSpec identifier3 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier3 = allocatePendingSegment(
         dataSource,
         "seq4",
         identifier1.toString(),
@@ -2450,7 +2450,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     // and final load, this reproduces an issue that could happen with multiple streaming appends,
     // followed by a reindex, followed by a drop, and more streaming data coming in for same interval
-    final SegmentIdWithShardSpec identifier4 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier4 = allocatePendingSegment(
         dataSource,
         "seq5",
         identifier1.toString(),
@@ -2484,7 +2484,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final PartialShardSpec partialShardSpec = NumberedPartialShardSpec.instance();
     final String dataSource = "ds";
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
-    final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier = allocatePendingSegment(
         dataSource,
         "seq",
         null,
@@ -2513,7 +2513,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
 
     // 1.1) simulate one more append load  (as if previous segment was published, note different sequence name)
-    final SegmentIdWithShardSpec identifier1 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier1 = allocatePendingSegment(
         dataSource,
         "seq2",
         identifier.toString(),
@@ -2542,7 +2542,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
 
     // 1.2) simulate one more append load  (as if previous segment was published, note different sequence name)
-    final SegmentIdWithShardSpec identifier2 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier2 = allocatePendingSegment(
         dataSource,
         "seq3",
         identifier1.toString(),
@@ -2597,7 +2597,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // unused segment:
 
     // 4) pending segment of version = B, id = 1 <= appending new data, aborted
-    final SegmentIdWithShardSpec identifier3 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier3 = allocatePendingSegment(
         dataSource,
         "seq4",
         identifier2.toString(),
@@ -2632,7 +2632,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertEquals(1, unused.size());
 
     // Simulate one more append load
-    final SegmentIdWithShardSpec identifier4 = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier4 = allocatePendingSegment(
         dataSource,
         "seq5",
         identifier1.toString(),
@@ -2833,7 +2833,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final PartialShardSpec partialShardSpec = NumberedPartialShardSpec.instance();
     final String dataSource = "ds";
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
-    final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier = allocatePendingSegment(
         dataSource,
         "seq",
         null,
@@ -2857,7 +2857,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final DateTime begin = DateTimes.nowUtc();
 
     for (int i = 0; i < 10; i++) {
-      final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+      final SegmentIdWithShardSpec identifier = allocatePendingSegment(
           dataSource,
           "seq",
           prevSegmentId,
@@ -2873,7 +2873,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
 
     final DateTime secondBegin = DateTimes.nowUtc();
     for (int i = 0; i < 5; i++) {
-      final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+      final SegmentIdWithShardSpec identifier = allocatePendingSegment(
           dataSource,
           "seq",
           prevSegmentId,
@@ -2901,7 +2901,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     String prevSegmentId = null;
 
     for (int i = 0; i < 10; i++) {
-      final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+      final SegmentIdWithShardSpec identifier = allocatePendingSegment(
           dataSource,
           "seq",
           prevSegmentId,
@@ -2970,7 +2970,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     final String dataSource = "ds";
     final Interval interval = Intervals.of("2017-01-01/2017-02-01");
 
-    SegmentIdWithShardSpec id = coordinator.allocatePendingSegment(
+    SegmentIdWithShardSpec id = allocatePendingSegment(
         dataSource,
         "seq",
         null,
@@ -3003,7 +3003,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    id = coordinator.allocatePendingSegment(
+    id = allocatePendingSegment(
         dataSource,
         "seq2",
         null,
@@ -3036,7 +3036,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)
     );
 
-    id = coordinator.allocatePendingSegment(
+    id = allocatePendingSegment(
         dataSource,
         "seq3",
         null,
@@ -3084,7 +3084,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       );
     }
     coordinator.commitSegments(originalSegments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    final SegmentIdWithShardSpec id = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec id = allocatePendingSegment(
         datasource,
         "seq",
         null,
@@ -3130,7 +3130,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
       );
     }
     coordinator.commitSegments(originalSegments, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION));
-    final SegmentIdWithShardSpec id = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec id = allocatePendingSegment(
         datasource,
         "seq",
         null,
@@ -3377,7 +3377,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertTrue(coordinator.commitSegments(tombstones, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(tombstones));
 
     // Allocate and commit a data segment by appending to the same interval
-    final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier = allocatePendingSegment(
         TestDataSource.WIKI,
         "seq",
         tombstoneSegment.getVersion(),
@@ -3432,7 +3432,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     Assert.assertTrue(coordinator.commitSegments(tombstones, new SegmentSchemaMapping(CentralizedDatasourceSchemaConfig.SCHEMA_VERSION)).containsAll(tombstones));
 
     // Allocate and commit a data segment by appending to the same interval
-    final SegmentIdWithShardSpec identifier = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec identifier = allocatePendingSegment(
         TestDataSource.WIKI,
         "seq",
         tombstoneSegment.getVersion(),
@@ -3471,7 +3471,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
   @Test
   public void testSegmentIdShouldNotBeReallocated()
   {
-    final SegmentIdWithShardSpec idWithNullTaskAllocator = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec idWithNullTaskAllocator = allocatePendingSegment(
         TestDataSource.WIKI,
         "seq",
         "0",
@@ -3487,7 +3487,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
         idWithNullTaskAllocator.getShardSpec()
     );
 
-    final SegmentIdWithShardSpec idWithValidTaskAllocator = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec idWithValidTaskAllocator = allocatePendingSegment(
         TestDataSource.WIKI,
         "seq",
         "1",
@@ -3510,7 +3510,7 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     // Mark all segments as unused
     coordinator.markSegmentsAsUnusedWithinInterval(TestDataSource.WIKI, Intervals.ETERNITY);
 
-    final SegmentIdWithShardSpec theId = coordinator.allocatePendingSegment(
+    final SegmentIdWithShardSpec theId = allocatePendingSegment(
         TestDataSource.WIKI,
         "seq",
         "2",
@@ -3791,6 +3791,31 @@ public class IndexerSQLMetadataStorageCoordinatorTest extends IndexerSqlMetadata
     );
   }
 
+  private SegmentIdWithShardSpec allocatePendingSegment(
+      String datasource,
+      String sequenceName,
+      String previousSegmentId,
+      Interval interval,
+      PartialShardSpec partialShardSpec,
+      String maxVersion,
+      boolean skipSegmentLineageCheck,
+      String taskAllocatorId
+  )
+  {
+    return coordinator.allocatePendingSegment(
+        datasource,
+        interval,
+        skipSegmentLineageCheck,
+        new SegmentCreateRequest(
+            sequenceName,
+            previousSegmentId,
+            maxVersion,
+            partialShardSpec,
+            null,
+            taskAllocatorId
+        )
+    );
+  }
 
   private void insertUsedSegments(Set<DataSegment> segments, Map<String, String> upgradedFromSegmentIdMap)
   {


### PR DESCRIPTION
### Changes

- Simplify the arguments of `IndexerMetadataStorageCoordinator.allocatePendingSegment`
- Remove field `SegmentCreateRequest.upgradedFromSegmentId` as it was always null
- Miscellaneous cleanup