### PR TITLE
Kubernetes service discovery breaking change in version 29.0.0

### DIFF
--- a/docs/release-info/upgrade-notes.md
+++ b/docs/release-info/upgrade-notes.md
@@ -193,6 +193,34 @@ Removed the `auto` search strategy from the native search query. Setting `search
 
 [#15550](https://github.com/apache/druid/pull/15550)
 
+### Incompatible changes
+
+#### Changes to date format in kubernetes service discovery
+
+Druid 29.0.0 includes a breaking change for those using kubernetes service discovery. The date format used in the config maps used for leader election of coordinators and overlords has changed. 
+
+If you're upgrading from any version prior to 29.0.0 manual intervention is required. The steps to fix are as follows:
+
+kubectl get cm -n <druid namespace>
+
+you should see 2 config maps of the form:
+
+<cluster-identifier>-leaderelection-coordinator
+<cluster-identifier>-leaderelection-overlord
+
+verify the date from your error message appears in the annotations:
+
+kubectl describe cm <cluster-identifier>-leaderelection-coordinator -n <druid namespace>
+kubectl describe cm <cluster-identifier>-leaderelection-overlord -n <druid namespace>
+
+remove these by:
+
+kubectl delete cm <cluster-identifier>-leaderelection-coordinator -n <druid namespace>
+kubectl delete cm <cluster-identifier>-leaderelection-overlord -n <druid namespace>
+
+These will be recreated by the services which will then successfully start.
+
+
 ## 28.0.0
 
 ### Upgrade notes


### PR DESCRIPTION
Fixes #15942

### Description
This PR updates the Apache Druid documentation to highlight a breaking change in Kubernetes service discovery behavior introduced in version 29. Specifically, the format of the timestamps used in the `<cluster-identifier>-leaderelection-coordinator` and `<cluster-identifier>-leaderelection-overlord` ConfigMaps was updated to a new format that was not documented. This change caused errors during leader election and service discovery due to mismatched date parsing expectations.

The goal of this PR is to ensure that users upgrading to version 29 are aware of this breaking change and can make the necessary adjustments to avoid issues in their Druid clusters.

Documentation Changes
Added a note in the Upgrade notes documentation for version 29 about the updated date format in ConfigMaps.
Provided an example of the command required to help users update their clusters accordingly.

#### Release Note
This PR updates the documentation to warn users about a breaking change in Kubernetes service discovery introduced in version 29. The date format in leader election ConfigMaps (`<cluster-identifier>-leaderelection-coordinator` and `<cluster-identifier>-leaderelection-overlord`) was updated to a stricter ISO-8601-like format. Users should ensure they delete the old config mapss once upgrade to version 29.0.0 and above so they are recreated with the correct date format.

<hr>
Key changed/added classes in this PR  
Documentation updates only, no code changes.
<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.