### PR TITLE
Parallelize supervisor stop logic to make it run faster

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -221,7 +221,7 @@ public class SupervisorManager
       log.info("Stopping [%d] supervisors", supervisors.keySet().size());
       for (String id : supervisors.keySet()) {
         try {
-          stopFutures.add(supervisors.get(id).lhs.stopAsync(false));
+          stopFutures.add(supervisors.get(id).lhs.stopAsync());
           SupervisorTaskAutoScaler autoscaler = autoscalers.get(id);
           if (autoscaler != null) {
             autoscaler.stop();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
-
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.common.TaskLockType;
@@ -34,7 +33,6 @@ import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorSpec;
-import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorTuningConfig;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
@@ -50,14 +48,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-
-import static org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorTuningConfig.DEFAULT_SHUTDOWN_TIMEOUT;
 
 /**
  * Manages the creation and lifetime of {@link Supervisor}.
@@ -250,12 +243,9 @@ public class SupervisorManager
       }
       log.info("Waiting for [%d] supervisors to shutdown", stopFutures.size());
       try {
-        long waitMillis = SeekableStreamSupervisorTuningConfig.defaultDuration(
-            null,
-            DEFAULT_SHUTDOWN_TIMEOUT
-        ).getMillis();
-        FutureUtils.coalesce(stopFutures).get(waitMillis, TimeUnit.MILLISECONDS);
-      } catch (Exception e) {
+        FutureUtils.coalesce(stopFutures).get(80, TimeUnit.SECONDS);
+      }
+      catch (Exception e) {
         log.warn(
             "Stopped [%d] out of [%d] supervisors. Remaining supervisors will be killed.",
             stopFutures.stream().filter(Future::isDone).count(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -22,8 +22,6 @@ package org.apache.druid.indexing.overlord.supervisor;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.error.DruidException;
@@ -34,7 +32,6 @@ import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAu
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorSpec;
 import org.apache.druid.java.util.common.Pair;
-import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
@@ -50,7 +47,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Manages the creation and lifetime of {@link Supervisor}.
@@ -223,16 +219,16 @@ public class SupervisorManager
     List<ListenableFuture<Void>> stopFutures = new ArrayList<>();
     synchronized (lock) {
       for (String id : supervisors.keySet()) {
-          try {
-            stopFutures.add(supervisors.get(id).lhs.stopAsync(false));
-            SupervisorTaskAutoScaler autoscaler = autoscalers.get(id);
-            if (autoscaler != null) {
-              autoscaler.stop();
-            }
+        try {
+          stopFutures.add(supervisors.get(id).lhs.stopAsync(false));
+          SupervisorTaskAutoScaler autoscaler = autoscalers.get(id);
+          if (autoscaler != null) {
+            autoscaler.stop();
           }
-          catch (Exception e) {
-            log.warn(e, "Caught exception while stopping supervisor [%s]", id);
-          }
+        }
+        catch (Exception e) {
+          log.warn(e, "Caught exception while stopping supervisor [%s]", id);
+        }
       }
       log.info("Waiting for [%d] supervisors to shutdown", stopFutures.size());
       try {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManager.java
@@ -218,6 +218,7 @@ public class SupervisorManager
     Preconditions.checkState(started, "SupervisorManager not started");
     List<ListenableFuture<Void>> stopFutures = new ArrayList<>();
     synchronized (lock) {
+      log.info("Stopping [%d] supervisors", supervisors.keySet().size());
       for (String id : supervisors.keySet()) {
         try {
           stopFutures.add(supervisors.get(id).lhs.stopAsync(false));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1075,7 +1075,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
             long shutdownTimeoutMillis = tuningConfig.getShutdownTimeout().getMillis();
             long endTime = System.currentTimeMillis() + shutdownTimeoutMillis;
-            while (!stopped) {
+            while (!stopped && stopGracefully) {
               long sleepTime = endTime - System.currentTimeMillis();
               if (sleepTime <= 0) {
                 log.info("Timed out while waiting for shutdown (timeout [%,dms])", shutdownTimeoutMillis);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1077,10 +1077,6 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
             long shutdownTimeoutMillis = tuningConfig.getShutdownTimeout().getMillis();
             long endTime = System.currentTimeMillis() + shutdownTimeoutMillis;
             while (!stopped) {
-              if (!stopGracefully) {
-                stopped = true;
-                break;
-              }
               long sleepTime = endTime - System.currentTimeMillis();
               if (sleepTime <= 0) {
                 log.info("Timed out while waiting for shutdown (timeout [%,dms])", shutdownTimeoutMillis);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1105,17 +1105,18 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   }
 
   @Override
-  public ListenableFuture<Void> stopAsync(boolean stopGracefully)
+  public ListenableFuture<Void> stopAsync()
   {
     ListeningExecutorService shutdownExec = MoreExecutors.listeningDecorator(
         Execs.singleThreaded("supervisor-shutdown-" + StringUtils.encodeForFormat(supervisorId) + "--%d")
     );
     return shutdownExec.submit(() -> {
-      stop(stopGracefully);
+      stop(false);
       shutdownExec.shutdown();
       return null;
     });
   }
+
   @Override
   public void reset(@Nullable final DataSourceMetadata dataSourceMetadata)
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1108,7 +1108,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   public ListenableFuture<Void> stopAsync(boolean stopGracefully)
   {
     ListeningExecutorService shutdownExec = MoreExecutors.listeningDecorator(
-        Execs.singleThreaded(StringUtils.encodeForFormat(supervisorId) + "-Shutdown-%d")
+        Execs.singleThreaded("supervisor-shutdown-" + StringUtils.encodeForFormat(supervisorId) + "--%d")
     );
     return shutdownExec.submit(() -> {
       stop(stopGracefully);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -34,6 +34,7 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
@@ -123,6 +124,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1107,6 +1109,15 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
     }
   }
 
+  @Override
+  public ListenableFuture<Void> stopAsync(boolean stopGracefully) {
+    ListeningExecutorService shutdownExec = MoreExecutors.listeningDecorator(Execs.singleThreaded(StringUtils.encodeForFormat(supervisorId) + "-Shutdown-%d"));
+    return shutdownExec.submit(() -> {
+      stop(stopGracefully);
+      shutdownExec.shutdown();
+      return null;
+    });
+  }
   @Override
   public void reset(@Nullable final DataSourceMetadata dataSourceMetadata)
   {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -124,7 +124,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1110,8 +1109,11 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
   }
 
   @Override
-  public ListenableFuture<Void> stopAsync(boolean stopGracefully) {
-    ListeningExecutorService shutdownExec = MoreExecutors.listeningDecorator(Execs.singleThreaded(StringUtils.encodeForFormat(supervisorId) + "-Shutdown-%d"));
+  public ListenableFuture<Void> stopAsync(boolean stopGracefully)
+  {
+    ListeningExecutorService shutdownExec = MoreExecutors.listeningDecorator(
+        Execs.singleThreaded(StringUtils.encodeForFormat(supervisorId) + "-Shutdown-%d")
+    );
     return shutdownExec.submit(() -> {
       stop(stopGracefully);
       shutdownExec.shutdown();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -1075,7 +1075,11 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
             long shutdownTimeoutMillis = tuningConfig.getShutdownTimeout().getMillis();
             long endTime = System.currentTimeMillis() + shutdownTimeoutMillis;
-            while (!stopped && stopGracefully) {
+            while (!stopped) {
+              if (!stopGracefully) {
+                stopped = true;
+                break;
+              }
               long sleepTime = endTime - System.currentTimeMillis();
               if (sleepTime <= 0) {
                 log.info("Timed out while waiting for shutdown (timeout [%,dms])", shutdownTimeoutMillis);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -133,7 +133,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     resetAll();
     SettableFuture<Void> stopFuture = SettableFuture.create();
     stopFuture.set(null);
-    EasyMock.expect(supervisor3.stopAsync(false)).andReturn(stopFuture);
+    EasyMock.expect(supervisor3.stopAsync()).andReturn(stopFuture);
     replayAll();
 
     manager.stop();
@@ -364,7 +364,7 @@ public class SupervisorManagerTest extends EasyMockSupport
 
     EasyMock.expect(metadataSupervisorManager.getLatest()).andReturn(existingSpecs);
     supervisor1.start();
-    supervisor1.stopAsync(false);
+    supervisor1.stopAsync();
     EasyMock.expectLastCall().andThrow(new RuntimeException("RTE"));
     replayAll();
 
@@ -516,7 +516,7 @@ public class SupervisorManagerTest extends EasyMockSupport
     resetAll();
     SettableFuture<Void> stopFuture = SettableFuture.create();
     stopFuture.set(null);
-    EasyMock.expect(supervisor3.stopAsync(false)).andReturn(stopFuture);
+    EasyMock.expect(supervisor3.stopAsync()).andReturn(stopFuture);
     replayAll();
 
     manager.stop();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorManagerTest.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.SettableFuture;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexing.common.TaskLockType;
@@ -130,7 +131,9 @@ public class SupervisorManagerTest extends EasyMockSupport
     verifyAll();
 
     resetAll();
-    supervisor3.stop(false);
+    SettableFuture<Void> stopFuture = SettableFuture.create();
+    stopFuture.set(null);
+    EasyMock.expect(supervisor3.stopAsync(false)).andReturn(stopFuture);
     replayAll();
 
     manager.stop();
@@ -361,7 +364,7 @@ public class SupervisorManagerTest extends EasyMockSupport
 
     EasyMock.expect(metadataSupervisorManager.getLatest()).andReturn(existingSpecs);
     supervisor1.start();
-    supervisor1.stop(false);
+    supervisor1.stopAsync(false);
     EasyMock.expectLastCall().andThrow(new RuntimeException("RTE"));
     replayAll();
 
@@ -511,7 +514,9 @@ public class SupervisorManagerTest extends EasyMockSupport
 
     // mock manager shutdown to ensure supervisor 3 stops
     resetAll();
-    supervisor3.stop(false);
+    SettableFuture<Void> stopFuture = SettableFuture.create();
+    stopFuture.set(null);
+    EasyMock.expect(supervisor3.stopAsync(false)).andReturn(stopFuture);
     replayAll();
 
     manager.stop();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -1017,7 +1017,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
     supervisor.runInternal();
-    ListenableFuture<Void> stopFuture = supervisor.stopAsync(false);
+    ListenableFuture<Void> stopFuture = supervisor.stopAsync();
     stopFuture.get();
     verifyAll();
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -1001,6 +1001,28 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   }
 
   @Test
+  public void testStopGracefully() throws Exception
+  {
+    EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();
+    EasyMock.expect(recordSupplier.getPartitionIds(STREAM)).andReturn(ImmutableSet.of(SHARD_ID)).anyTimes();
+    EasyMock.expect(taskStorage.getActiveTasksByDatasource(DATASOURCE)).andReturn(ImmutableList.of()).anyTimes();
+    EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).anyTimes();
+
+    taskRunner.unregisterListener("testSupervisorId");
+    indexTaskClient.close();
+    recordSupplier.close();
+
+    replayAll();
+    SeekableStreamSupervisor supervisor = new TestSeekableStreamSupervisor();
+
+    supervisor.start();
+    supervisor.runInternal();
+    ListenableFuture<Void> stopFuture = supervisor.stopAsync(false);
+    stopFuture.get();
+    verifyAll();
+  }
+
+  @Test
   public void testStoppingGracefully()
   {
     EasyMock.expect(spec.isSuspended()).andReturn(false).anyTimes();

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -46,11 +46,19 @@ public interface Supervisor
    */
   void stop(boolean stopGracefully);
 
-  default ListenableFuture<Void> stopAsync(boolean stopGracefully)
+  /**
+   * Starts non-graceful shutdown of the supervisor and returns a future that completes when shutdown is complete.
+   */
+  default ListenableFuture<Void> stopAsync()
   {
     SettableFuture<Void> stopFuture = SettableFuture.create();
-    stop(stopGracefully);
-    stopFuture.set(null);
+    try {
+      stop(false);
+      stopFuture.set(null);
+    }
+    catch (Exception e) {
+      stopFuture.setException(e);
+    }
     return stopFuture;
   }
 

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -21,12 +21,17 @@ package org.apache.druid.indexing.overlord.supervisor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import net.spy.memcached.internal.ImmediateFuture;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.segment.incremental.ParseExceptionReport;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 
 /**
  * An interface representing a general supervisor for managing ingestion tasks. For streaming ingestion use cases,
@@ -43,6 +48,13 @@ public interface Supervisor
    *                       running tasks as they are.
    */
   void stop(boolean stopGracefully);
+
+  default ListenableFuture<Void> stopAsync(boolean stopGracefully) {
+    stop(stopGracefully);
+    SettableFuture<Void> stopFuture = SettableFuture.create();
+    stopFuture.set(null);
+    return stopFuture;
+  }
 
   SupervisorReport getStatus();
 

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/Supervisor.java
@@ -23,15 +23,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import net.spy.memcached.internal.ImmediateFuture;
 import org.apache.druid.indexing.overlord.DataSourceMetadata;
 import org.apache.druid.segment.incremental.ParseExceptionReport;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 
 /**
  * An interface representing a general supervisor for managing ingestion tasks. For streaming ingestion use cases,
@@ -49,9 +46,10 @@ public interface Supervisor
    */
   void stop(boolean stopGracefully);
 
-  default ListenableFuture<Void> stopAsync(boolean stopGracefully) {
-    stop(stopGracefully);
+  default ListenableFuture<Void> stopAsync(boolean stopGracefully)
+  {
     SettableFuture<Void> stopFuture = SettableFuture.create();
+    stop(stopGracefully);
     stopFuture.set(null);
     return stopFuture;
   }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/StreamSupervisorTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/StreamSupervisorTest.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
+import java.util.concurrent.Future;
 
 public class StreamSupervisorTest
 {
@@ -99,5 +100,75 @@ public class StreamSupervisorTest
         "Supervisor does not have the feature to handoff task groups early implemented",
         ex.getMessage()
     );
+  }
+
+  @Test
+  public void testDefaultStopAsync()
+  {
+    // Create an instance of stream supervisor without overriding stopAsync().
+    final StreamSupervisor streamSupervisor = new StreamSupervisor()
+    {
+      private SupervisorStateManager.State state = SupervisorStateManager.BasicState.RUNNING;
+
+      @Override
+      public void start()
+      {
+
+      }
+
+      @Override
+      public void stop(boolean stopGracefully)
+      {
+        state = SupervisorStateManager.BasicState.STOPPING;
+      }
+
+      @Override
+      public SupervisorReport getStatus()
+      {
+        return null;
+      }
+
+      @Override
+      public SupervisorStateManager.State getState()
+      {
+        return state;
+      }
+
+      @Override
+      public void reset(@Nullable DataSourceMetadata dataSourceMetadata)
+      {
+
+      }
+
+      @Override
+      public void resetOffsets(DataSourceMetadata resetDataSourceMetadata)
+      {
+
+      }
+
+      @Override
+      public void checkpoint(int taskGroupId, DataSourceMetadata checkpointMetadata)
+      {
+
+      }
+
+      @Override
+      public LagStats computeLagStats()
+      {
+        return null;
+      }
+
+      @Override
+      public int getActiveTaskGroupsCount()
+      {
+        return 0;
+      }
+    };
+
+    Future<Void> stopAsyncFuture = streamSupervisor.stopAsync(true);
+    Assert.assertTrue(stopAsyncFuture.isDone());
+
+    // stop should be called by stopAsync
+    Assert.assertEquals(SupervisorStateManager.BasicState.STOPPING, streamSupervisor.getState());
   }
 }

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/StreamSupervisorTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/StreamSupervisorTest.java
@@ -165,7 +165,7 @@ public class StreamSupervisorTest
       }
     };
 
-    Future<Void> stopAsyncFuture = streamSupervisor.stopAsync(true);
+    Future<Void> stopAsyncFuture = streamSupervisor.stopAsync();
     Assert.assertTrue(stopAsyncFuture.isDone());
 
     // stop should be called by stopAsync


### PR DESCRIPTION
Sometimes the LifecycleStop method of SupervisorManager (SupervisorManager.stop()) can take a long time to run. This is because the method iterates through all running supervisors and calls stop on them serially. Each streaming supervisor.stop() call tries to push a ShutdownNotice to its notice queue and then wait for the ShutdownNotice to run and set stopped = true up to tuningConfig.shutdownTimeout. This means the total run time can be the sum of tuningConfig.shutdownTimeout (default 80 seconds) across all supervisors.

This long stop time can cause lots of issues, most notably overlord leadership issues if the ZK leader is terminated (but the ensemble maintains quorum). This is because a overlord pod can get becomeLeader queued up behind stopLeader if it disconnects and then reconnects to ZK (the giant lock shared between the two methods).

This PR attempts to ensure SupervisorManager completes faster to prevent this issue.

### Description
- In SupervisorManager use a static pool of shutdownThreads to stop supervisors in parallel in the stop method to prevent a single or few slow supervisors from slowing down overall shutdown.
- In SeekableStreamSupervisor, when stopGracefully is false (as it is when we are shutting down SupervisorManager), don't wait for the ShutdownNotice to run. This means that the recordSupplier (e.g. kafka consumer) may not be cleaned up immediately, but since all the supervisor objects are dereferenced and can be GC'd later i don't think this is a huge deal.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...
- I used a static thread pool in SupervisorManager for now, it's possible it should be configurable but IMO the main point of the thread pool is to not let a few slow supervisor shutdowns run in series block the entire supervisor manager from shutting down. **(changed in review)**
- I'm not sure if changing the SeekableStreamSupervisor.stop method when stopGracefully = false is necessary, but it didn't make sense to me to specify a non-graceful shutdown and then try to wait for things to clean up. **(changed in review)**

#### Release note
Improve recovery time for overlord leadership after zk nodes are bounced.

##### Key changed/added classes in this PR
 * `SupervisorManager`
 * `SeekableStreamSupervisor`

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
