### PR TITLE
Fix NPE in segment allocation when reduceMetadataIO is true

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
+++ b/server/src/main/java/org/apache/druid/metadata/IndexerSQLMetadataStorageCoordinator.java
@@ -2943,7 +2943,7 @@ public class IndexerSQLMetadataStorageCoordinator implements IndexerMetadataStor
           = versionIntervalToSmallestSegmentId.computeIfAbsent(segmentId.getVersion(), v -> new HashMap<>());
       final SegmentId value = map.get(segmentId.getInterval());
       if (value == null || value.getPartitionNum() > segmentId.getPartitionNum()) {
-        map.put(interval, segmentId);
+        map.put(segmentId.getInterval(), segmentId);
       }
     }
 


### PR DESCRIPTION
#17496 introduced an NPE due to an incorrect map key.
This patch fixes that bug.