### PR TITLE
Reduce occurrences of failed IT builds

### DIFF
--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -28,10 +28,10 @@ ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
 ARG SETUP_RETRIES=3
 # Retry mechanism for running the setup script up to limit of 3 times.
 RUN set -e; \
-    for i in {1..$SETUP_RETRIES}; do \
+    for i in $(seq 1 $SETUP_RETRIES); do \
         echo "Attempt $i to run the setup script..."; \
         APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && break || { \
-            echo "Attempt $i failed. Retrying..."; \
+            echo "Set up script attempt $i/$SETUP_RETRIES failed. Retrying..."; \
             sleep 2; \
         }; \
     done; \

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -25,7 +25,17 @@ ARG KAFKA_VERSION
 # This is passed in by maven at build time to align with the client version we depend on in the pom file
 ARG ZK_VERSION
 ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
-RUN APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh
+ARG SETUP_RETRIES=3
+# Retry mechanism for running the setup script up to limit of 3 times.
+RUN set -e; \
+    for i in {1..$SETUP_RETRIES}; do \
+        echo "Attempt $i to run the setup script..."; \
+        APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && break || { \
+            echo "Attempt $i failed. Retrying..."; \
+            sleep 2; \
+        }; \
+    done; \
+    rm -f /root/base-setup.sh
 
 FROM druidbase
 ARG MYSQL_VERSION

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -31,7 +31,7 @@ RUN set -e; \
     for i in $(seq 1 $SETUP_RETRIES); do \
         echo "Attempt $i to run the setup script..."; \
         APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && break || { \
-            echo "Set up script attempt $i/$SETUP_RETRIES failed. Retrying..."; \
+            echo "Set up script attempt $i/$SETUP_RETRIES failed."; \
             sleep 2; \
         }; \
     done; \

--- a/integration-tests/docker/base-setup.sh
+++ b/integration-tests/docker/base-setup.sh
@@ -31,34 +31,9 @@ apt-get install -y default-mysql-server
 # Supervisor
 apt-get install -y supervisor
 
-# Retry function to make setup process more robust
-retry() {
-  local retries="$1"
-  shift
-  local count=0
-  local success=false
-
-  while [ $count -lt "$retries" ]; do
-    echo "Attempting command... (Attempt $((count + 1)) of $retries)"
-
-    if "$@"; then
-      success=true
-      break
-    else
-      count=$((count + 1))
-      sleep 2  # Optional: wait before retrying
-    fi
-  done
-
-  if [ "$success" = false ]; then
-    echo "Command failed after $retries attempts."
-    exit 1
-  fi
-}
-
 # Zookeeper
 install_zk() {
-  retry 3 wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
+  wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
   tar -xzf /tmp/$ZK_TAR.tar.gz -C /usr/local
   cp /usr/local/$ZK_TAR/conf/zoo_sample.cfg /usr/local/$ZK_TAR/conf/zoo.cfg
   rm /tmp/$ZK_TAR.tar.gz

--- a/integration-tests/docker/base-setup.sh
+++ b/integration-tests/docker/base-setup.sh
@@ -32,6 +32,7 @@ apt-get install -y default-mysql-server
 apt-get install -y supervisor
 
 # Zookeeper
+
 install_zk() {
   wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
   tar -xzf /tmp/$ZK_TAR.tar.gz -C /usr/local

--- a/integration-tests/docker/base-setup.sh
+++ b/integration-tests/docker/base-setup.sh
@@ -31,10 +31,34 @@ apt-get install -y default-mysql-server
 # Supervisor
 apt-get install -y supervisor
 
-# Zookeeper
+# Retry function to make setup process more robust
+retry() {
+  local retries="$1"
+  shift
+  local count=0
+  local success=false
 
+  while [ $count -lt "$retries" ]; do
+    echo "Attempting command... (Attempt $((count + 1)) of $retries)"
+
+    if "$@"; then
+      success=true
+      break
+    else
+      count=$((count + 1))
+      sleep 2  # Optional: wait before retrying
+    fi
+  done
+
+  if [ "$success" = false ]; then
+    echo "Command failed after $retries attempts."
+    exit 1
+  fi
+}
+
+# Zookeeper
 install_zk() {
-  wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
+  retry 3 wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
   tar -xzf /tmp/$ZK_TAR.tar.gz -C /usr/local
   cp /usr/local/$ZK_TAR/conf/zoo_sample.cfg /usr/local/$ZK_TAR/conf/zoo.cfg
   rm /tmp/$ZK_TAR.tar.gz


### PR DESCRIPTION
### Description

Currently, Standard ITS integration tests fail on the command:
```
RUN APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh
```

We will see the following error logged when this happens:
`ERROR: failed to solve: process "/bin/sh -c APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh" did not complete successfully: exit code: 4`


A [brief online search](https://forums.docker.com/t/failed-build-with-dockerfile-returned-a-non-zero-code-4/9189) shows that the exit code 4 signifies some network issues, probably due to the `wget` commands in `integration-tests/docker/base-setup.sh`. This PR aims to reduce the chances of failing due to these network issues, by rerunning the setup script.


<hr>

This PR has:

- [x] been self-reviewed.
