### PR TITLE
Adding 3 sets of SQL tests to quidem

### DIFF
--- a/quidem-ut/src/test/quidem/org.apache.druid.quidem.QTest/qaSQL_scalar_datetime.iq
+++ b/quidem-ut/src/test/quidem/org.apache.druid.quidem.QTest/qaSQL_scalar_datetime.iq
@@ -1,0 +1,2498 @@
+!set useApproximateCountDistinct false
+!use druidtest:///?componentSupplier=KttmNestedComponentSupplier
+!set outputformat mysql
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00';
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A1: plain_value_datetime
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (__time IS NULL
+       OR (__time = __time
+           AND __time IS NOT DISTINCT
+           FROM __time
+           AND __time <> __time - interval '2' YEAR
+           AND (__time IS DISTINCT
+                FROM __time - interval '2' YEAR)
+           AND __time > __time - interval '2' YEAR
+           AND __time >= __time - interval '2' YEAR
+           AND __time < __time + interval '2' YEAR
+           AND __time <= __time + interval '2' YEAR
+           AND (__time <> __time - interval '2' YEAR) IS TRUE
+           AND (__time = __time - interval '2' YEAR) IS NOT TRUE
+           AND (__time = __time - interval '2' YEAR) IS FALSE
+           AND (__time <> __time - interval '2' YEAR) IS NOT FALSE
+           AND __time BETWEEN __time - interval '2' YEAR AND __time + interval '2' YEAR
+           AND __time NOT BETWEEN __time AND __time - interval '2' YEAR
+           AND __time like '%'
+           AND __time not like '__DOES_NOT_EXIST__%'
+           AND __time IN (__time - interval '2' YEAR,
+                          __time,
+                          __time + interval '2' YEAR)
+           AND __time NOT IN (__time - interval '2' YEAR,
+                              __time + interval '2' YEAR))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (__time IS NULL
+       OR __time IN
+         (SELECT __time
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (__time IS NULL
+                 OR (__time = __time
+                     AND __time IS NOT DISTINCT
+                     FROM __time
+                     AND __time <> __time - interval '2' YEAR
+                     AND (__time IS DISTINCT
+                          FROM __time - interval '2' YEAR)
+                     AND __time > __time - interval '2' YEAR
+                     AND __time >= __time - interval '2' YEAR
+                     AND __time < __time + interval '2' YEAR
+                     AND __time <= __time + interval '2' YEAR
+                     AND (__time <> __time - interval '2' YEAR) IS TRUE
+                     AND (__time = __time - interval '2' YEAR) IS NOT TRUE
+                     AND (__time = __time - interval '2' YEAR) IS FALSE
+                     AND (__time <> __time - interval '2' YEAR) IS NOT FALSE
+                     AND __time BETWEEN __time - interval '2' YEAR AND __time + interval '2' YEAR
+                     AND __time NOT BETWEEN __time AND __time - interval '2' YEAR
+                     AND __time like '%'
+                     AND __time not like '__DOES_NOT_EXIST__%'
+                     AND __time IN (__time - interval '2' YEAR,
+                                    __time,
+                                    __time + interval '2' YEAR)
+                     AND __time NOT IN (__time - interval '2' YEAR,
+                                        __time + interval '2' YEAR)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          __time,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (__time IS NULL
+          OR (__time = __time
+              AND __time IS NOT DISTINCT
+              FROM __time
+              AND __time <> __time - interval '2' YEAR
+              AND (__time IS DISTINCT
+                   FROM __time - interval '2' YEAR)
+              AND __time > __time - interval '2' YEAR
+              AND __time >= __time - interval '2' YEAR
+              AND __time < __time + interval '2' YEAR
+              AND __time <= __time + interval '2' YEAR
+              AND (__time <> __time - interval '2' YEAR) IS TRUE
+              AND (__time = __time - interval '2' YEAR) IS NOT TRUE
+              AND (__time = __time - interval '2' YEAR) IS FALSE
+              AND (__time <> __time - interval '2' YEAR) IS NOT FALSE
+              AND __time BETWEEN __time - interval '2' YEAR AND __time + interval '2' YEAR
+              AND __time NOT BETWEEN __time AND __time - interval '2' YEAR
+              AND __time like '%'
+              AND __time not like '__DOES_NOT_EXIST__%'
+              AND __time IN (__time - interval '2' YEAR,
+                             __time,
+                             __time + interval '2' YEAR)
+              AND __time NOT IN (__time - interval '2' YEAR,
+                                 __time + interval '2' YEAR)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A2: current_timestamp
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(CURRENT_TIMESTAMP TO YEAR) IS NULL
+       OR (floor(CURRENT_TIMESTAMP TO YEAR) = floor(CURRENT_TIMESTAMP TO YEAR)
+           AND floor(CURRENT_TIMESTAMP TO YEAR) IS NOT DISTINCT
+           FROM floor(CURRENT_TIMESTAMP TO YEAR)
+           AND floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+           AND (floor(CURRENT_TIMESTAMP TO YEAR) IS DISTINCT
+                FROM floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR))
+           AND floor(CURRENT_TIMESTAMP TO YEAR) > floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+           AND floor(CURRENT_TIMESTAMP TO YEAR) >= floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+           AND floor(CURRENT_TIMESTAMP TO YEAR) < floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+           AND floor(CURRENT_TIMESTAMP TO YEAR) <= floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+           AND (floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS TRUE
+           AND (floor(CURRENT_TIMESTAMP TO YEAR) = floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS NOT TRUE
+           AND (floor(CURRENT_TIMESTAMP TO YEAR) = floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS FALSE
+           AND (floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS NOT FALSE
+           AND floor(CURRENT_TIMESTAMP TO YEAR) BETWEEN floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR) AND floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+           AND floor(CURRENT_TIMESTAMP TO YEAR) NOT BETWEEN floor(CURRENT_TIMESTAMP TO YEAR) AND floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+           AND floor(CURRENT_TIMESTAMP TO YEAR) like '%'
+           AND floor(CURRENT_TIMESTAMP TO YEAR) not like '__DOES_NOT_EXIST__%'
+           AND floor(CURRENT_TIMESTAMP TO YEAR) IN (floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR),
+                                                    floor(CURRENT_TIMESTAMP TO YEAR),
+                                                    floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR))
+           AND floor(CURRENT_TIMESTAMP TO YEAR) NOT IN (floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR),
+                                                        floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(CURRENT_TIMESTAMP TO YEAR) IS NULL
+       OR floor(CURRENT_TIMESTAMP TO YEAR) IN
+         (SELECT floor(CURRENT_TIMESTAMP TO YEAR)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(CURRENT_TIMESTAMP TO YEAR) IS NULL
+                 OR (floor(CURRENT_TIMESTAMP TO YEAR) = floor(CURRENT_TIMESTAMP TO YEAR)
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) IS NOT DISTINCT
+                     FROM floor(CURRENT_TIMESTAMP TO YEAR)
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+                     AND (floor(CURRENT_TIMESTAMP TO YEAR) IS DISTINCT
+                          FROM floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR))
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) > floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) >= floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) < floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) <= floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+                     AND (floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS TRUE
+                     AND (floor(CURRENT_TIMESTAMP TO YEAR) = floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS NOT TRUE
+                     AND (floor(CURRENT_TIMESTAMP TO YEAR) = floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS FALSE
+                     AND (floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS NOT FALSE
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) BETWEEN floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR) AND floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) NOT BETWEEN floor(CURRENT_TIMESTAMP TO YEAR) AND floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) like '%'
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) not like '__DOES_NOT_EXIST__%'
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) IN (floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR),
+                                                              floor(CURRENT_TIMESTAMP TO YEAR),
+                                                              floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR))
+                     AND floor(CURRENT_TIMESTAMP TO YEAR) NOT IN (floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR),
+                                                                  floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(CURRENT_TIMESTAMP TO YEAR),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(CURRENT_TIMESTAMP TO YEAR) IS NULL
+          OR (floor(CURRENT_TIMESTAMP TO YEAR) = floor(CURRENT_TIMESTAMP TO YEAR)
+              AND floor(CURRENT_TIMESTAMP TO YEAR) IS NOT DISTINCT
+              FROM floor(CURRENT_TIMESTAMP TO YEAR)
+              AND floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+              AND (floor(CURRENT_TIMESTAMP TO YEAR) IS DISTINCT
+                   FROM floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR))
+              AND floor(CURRENT_TIMESTAMP TO YEAR) > floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+              AND floor(CURRENT_TIMESTAMP TO YEAR) >= floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+              AND floor(CURRENT_TIMESTAMP TO YEAR) < floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+              AND floor(CURRENT_TIMESTAMP TO YEAR) <= floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+              AND (floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS TRUE
+              AND (floor(CURRENT_TIMESTAMP TO YEAR) = floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS NOT TRUE
+              AND (floor(CURRENT_TIMESTAMP TO YEAR) = floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS FALSE
+              AND (floor(CURRENT_TIMESTAMP TO YEAR) <> floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)) IS NOT FALSE
+              AND floor(CURRENT_TIMESTAMP TO YEAR) BETWEEN floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR) AND floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR)
+              AND floor(CURRENT_TIMESTAMP TO YEAR) NOT BETWEEN floor(CURRENT_TIMESTAMP TO YEAR) AND floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR)
+              AND floor(CURRENT_TIMESTAMP TO YEAR) like '%'
+              AND floor(CURRENT_TIMESTAMP TO YEAR) not like '__DOES_NOT_EXIST__%'
+              AND floor(CURRENT_TIMESTAMP TO YEAR) IN (floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR),
+                                                       floor(CURRENT_TIMESTAMP TO YEAR),
+                                                       floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR))
+              AND floor(CURRENT_TIMESTAMP TO YEAR) NOT IN (floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', -2) TO YEAR),
+                                                           floor(time_shift(CURRENT_TIMESTAMP, 'P1Y', 2) TO YEAR))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A3: current_date
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS NULL
+       OR (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(cast(CURRENT_DATE AS timestamp) TO YEAR)
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS NOT DISTINCT
+           FROM floor(cast(CURRENT_DATE AS timestamp) TO YEAR)
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+           AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS DISTINCT
+                FROM floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR))
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) > floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) >= floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) < floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <= floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+           AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS TRUE
+           AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS NOT TRUE
+           AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS FALSE
+           AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS NOT FALSE
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) BETWEEN floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR) AND floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) NOT BETWEEN floor(cast(CURRENT_DATE AS timestamp) TO YEAR) AND floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) like '%'
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) not like '__DOES_NOT_EXIST__%'
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IN (floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR),
+                                                                  floor(cast(CURRENT_DATE AS timestamp) TO YEAR),
+                                                                  floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR))
+           AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) NOT IN (floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR),
+                                                                      floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS NULL
+       OR floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IN
+         (SELECT floor(cast(CURRENT_DATE AS timestamp) TO YEAR)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS NULL
+                 OR (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(cast(CURRENT_DATE AS timestamp) TO YEAR)
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS NOT DISTINCT
+                     FROM floor(cast(CURRENT_DATE AS timestamp) TO YEAR)
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+                     AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS DISTINCT
+                          FROM floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR))
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) > floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) >= floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) < floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <= floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+                     AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS TRUE
+                     AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS NOT TRUE
+                     AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS FALSE
+                     AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS NOT FALSE
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) BETWEEN floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR) AND floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) NOT BETWEEN floor(cast(CURRENT_DATE AS timestamp) TO YEAR) AND floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) like '%'
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) not like '__DOES_NOT_EXIST__%'
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IN (floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR),
+                                                                            floor(cast(CURRENT_DATE AS timestamp) TO YEAR),
+                                                                            floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR))
+                     AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) NOT IN (floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR),
+                                                                                floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(cast(CURRENT_DATE AS timestamp) TO YEAR),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS NULL
+          OR (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(cast(CURRENT_DATE AS timestamp) TO YEAR)
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS NOT DISTINCT
+              FROM floor(cast(CURRENT_DATE AS timestamp) TO YEAR)
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+              AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IS DISTINCT
+                   FROM floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR))
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) > floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) >= floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) < floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <= floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+              AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS TRUE
+              AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS NOT TRUE
+              AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) = floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS FALSE
+              AND (floor(cast(CURRENT_DATE AS timestamp) TO YEAR) <> floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)) IS NOT FALSE
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) BETWEEN floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR) AND floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR)
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) NOT BETWEEN floor(cast(CURRENT_DATE AS timestamp) TO YEAR) AND floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR)
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) like '%'
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) not like '__DOES_NOT_EXIST__%'
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) IN (floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR),
+                                                                     floor(cast(CURRENT_DATE AS timestamp) TO YEAR),
+                                                                     floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR))
+              AND floor(cast(CURRENT_DATE AS timestamp) TO YEAR) NOT IN (floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', -2) TO YEAR),
+                                                                         floor(time_shift(cast(CURRENT_DATE AS timestamp), 'P1Y', 2) TO YEAR))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A4: date_trunc
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (date_trunc('week', __time) IS NULL
+       OR (date_trunc('week', __time) = date_trunc('week', __time)
+           AND date_trunc('week', __time) IS NOT DISTINCT
+           FROM date_trunc('week', __time)
+           AND date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)
+           AND (date_trunc('week', __time) IS DISTINCT
+                FROM time_shift(date_trunc('week', __time), 'P1D', -2))
+           AND date_trunc('week', __time) > time_shift(date_trunc('week', __time), 'P1D', -2)
+           AND date_trunc('week', __time) >= time_shift(date_trunc('week', __time), 'P1D', -2)
+           AND date_trunc('week', __time) < time_shift(date_trunc('week', __time), 'P1D', 2)
+           AND date_trunc('week', __time) <= time_shift(date_trunc('week', __time), 'P1D', 2)
+           AND (date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)) IS TRUE
+           AND (date_trunc('week', __time) = time_shift(date_trunc('week', __time), 'P1D', -2)) IS NOT TRUE
+           AND (date_trunc('week', __time) = time_shift(date_trunc('week', __time), 'P1D', -2)) IS FALSE
+           AND (date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)) IS NOT FALSE
+           AND date_trunc('week', __time) BETWEEN time_shift(date_trunc('week', __time), 'P1D', -2) AND time_shift(date_trunc('week', __time), 'P1D', 2)
+           AND date_trunc('week', __time) NOT BETWEEN date_trunc('week', __time) AND time_shift(date_trunc('week', __time), 'P1D', -2)
+           AND date_trunc('week', __time) like '%'
+           AND date_trunc('week', __time) not like '__DOES_NOT_EXIST__%'
+           AND date_trunc('week', __time) IN (time_shift(date_trunc('week', __time), 'P1D', -2),
+                                              date_trunc('week', __time),
+                                              time_shift(date_trunc('week', __time), 'P1D', 2))
+           AND date_trunc('week', __time) NOT IN (time_shift(date_trunc('week', __time), 'P1D', -2),
+                                                  time_shift(date_trunc('week', __time), 'P1D', 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (date_trunc('week', __time) IS NULL
+       OR date_trunc('week', __time) IN
+         (SELECT date_trunc('week', __time)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (date_trunc('week', __time) IS NULL
+                 OR (date_trunc('week', __time) = date_trunc('week', __time)
+                     AND date_trunc('week', __time) IS NOT DISTINCT
+                     FROM date_trunc('week', __time)
+                     AND date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)
+                     AND (date_trunc('week', __time) IS DISTINCT
+                          FROM time_shift(date_trunc('week', __time), 'P1D', -2))
+                     AND date_trunc('week', __time) > time_shift(date_trunc('week', __time), 'P1D', -2)
+                     AND date_trunc('week', __time) >= time_shift(date_trunc('week', __time), 'P1D', -2)
+                     AND date_trunc('week', __time) < time_shift(date_trunc('week', __time), 'P1D', 2)
+                     AND date_trunc('week', __time) <= time_shift(date_trunc('week', __time), 'P1D', 2)
+                     AND (date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)) IS TRUE
+                     AND (date_trunc('week', __time) = time_shift(date_trunc('week', __time), 'P1D', -2)) IS NOT TRUE
+                     AND (date_trunc('week', __time) = time_shift(date_trunc('week', __time), 'P1D', -2)) IS FALSE
+                     AND (date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)) IS NOT FALSE
+                     AND date_trunc('week', __time) BETWEEN time_shift(date_trunc('week', __time), 'P1D', -2) AND time_shift(date_trunc('week', __time), 'P1D', 2)
+                     AND date_trunc('week', __time) NOT BETWEEN date_trunc('week', __time) AND time_shift(date_trunc('week', __time), 'P1D', -2)
+                     AND date_trunc('week', __time) like '%'
+                     AND date_trunc('week', __time) not like '__DOES_NOT_EXIST__%'
+                     AND date_trunc('week', __time) IN (time_shift(date_trunc('week', __time), 'P1D', -2),
+                                                        date_trunc('week', __time),
+                                                        time_shift(date_trunc('week', __time), 'P1D', 2))
+                     AND date_trunc('week', __time) NOT IN (time_shift(date_trunc('week', __time), 'P1D', -2),
+                                                            time_shift(date_trunc('week', __time), 'P1D', 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          date_trunc('week', __time),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (date_trunc('week', __time) IS NULL
+          OR (date_trunc('week', __time) = date_trunc('week', __time)
+              AND date_trunc('week', __time) IS NOT DISTINCT
+              FROM date_trunc('week', __time)
+              AND date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)
+              AND (date_trunc('week', __time) IS DISTINCT
+                   FROM time_shift(date_trunc('week', __time), 'P1D', -2))
+              AND date_trunc('week', __time) > time_shift(date_trunc('week', __time), 'P1D', -2)
+              AND date_trunc('week', __time) >= time_shift(date_trunc('week', __time), 'P1D', -2)
+              AND date_trunc('week', __time) < time_shift(date_trunc('week', __time), 'P1D', 2)
+              AND date_trunc('week', __time) <= time_shift(date_trunc('week', __time), 'P1D', 2)
+              AND (date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)) IS TRUE
+              AND (date_trunc('week', __time) = time_shift(date_trunc('week', __time), 'P1D', -2)) IS NOT TRUE
+              AND (date_trunc('week', __time) = time_shift(date_trunc('week', __time), 'P1D', -2)) IS FALSE
+              AND (date_trunc('week', __time) <> time_shift(date_trunc('week', __time), 'P1D', -2)) IS NOT FALSE
+              AND date_trunc('week', __time) BETWEEN time_shift(date_trunc('week', __time), 'P1D', -2) AND time_shift(date_trunc('week', __time), 'P1D', 2)
+              AND date_trunc('week', __time) NOT BETWEEN date_trunc('week', __time) AND time_shift(date_trunc('week', __time), 'P1D', -2)
+              AND date_trunc('week', __time) like '%'
+              AND date_trunc('week', __time) not like '__DOES_NOT_EXIST__%'
+              AND date_trunc('week', __time) IN (time_shift(date_trunc('week', __time), 'P1D', -2),
+                                                 date_trunc('week', __time),
+                                                 time_shift(date_trunc('week', __time), 'P1D', 2))
+              AND date_trunc('week', __time) NOT IN (time_shift(date_trunc('week', __time), 'P1D', -2),
+                                                     time_shift(date_trunc('week', __time), 'P1D', 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A5: time_ceil
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+       OR (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NOT DISTINCT
+           FROM time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS DISTINCT
+                FROM time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2))
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') > time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') >= time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') < time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <= time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+           AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS TRUE
+           AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT TRUE
+           AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS FALSE
+           AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT FALSE
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') BETWEEN time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2) AND time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT BETWEEN time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') AND time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') like '%'
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') not like '__DOES_NOT_EXIST__%'
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN (time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                             time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                                                                             time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))
+           AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT IN (time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                 time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+       OR time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN
+         (SELECT time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+                 OR (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NOT DISTINCT
+                     FROM time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS DISTINCT
+                          FROM time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2))
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') > time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') >= time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') < time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <= time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+                     AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS TRUE
+                     AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT TRUE
+                     AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS FALSE
+                     AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT FALSE
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') BETWEEN time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2) AND time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT BETWEEN time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') AND time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') like '%'
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') not like '__DOES_NOT_EXIST__%'
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN (time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                       time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                                                                                       time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))
+                     AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT IN (time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                           time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+          OR (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NOT DISTINCT
+              FROM time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS DISTINCT
+                   FROM time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2))
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') > time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') >= time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') < time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <= time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+              AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS TRUE
+              AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT TRUE
+              AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS FALSE
+              AND (time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT FALSE
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') BETWEEN time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2) AND time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT BETWEEN time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') AND time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') like '%'
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') not like '__DOES_NOT_EXIST__%'
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN (time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                                                                                time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))
+              AND time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT IN (time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                    time_shift(time_ceil(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A6: time_floor
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+       OR (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NOT DISTINCT
+           FROM time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS DISTINCT
+                FROM time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2))
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') > time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') >= time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') < time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <= time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+           AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS TRUE
+           AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT TRUE
+           AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS FALSE
+           AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT FALSE
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') BETWEEN time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2) AND time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT BETWEEN time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') AND time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') like '%'
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') not like '__DOES_NOT_EXIST__%'
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN (time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                              time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                                                                              time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))
+           AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT IN (time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                  time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+       OR time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN
+         (SELECT time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+                 OR (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NOT DISTINCT
+                     FROM time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS DISTINCT
+                          FROM time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2))
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') > time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') >= time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') < time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <= time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+                     AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS TRUE
+                     AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT TRUE
+                     AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS FALSE
+                     AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT FALSE
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') BETWEEN time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2) AND time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT BETWEEN time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') AND time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') like '%'
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') not like '__DOES_NOT_EXIST__%'
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN (time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                        time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                                                                                        time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))
+                     AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT IN (time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                            time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NULL
+          OR (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS NOT DISTINCT
+              FROM time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00')
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IS DISTINCT
+                   FROM time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2))
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') > time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') >= time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') < time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <= time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+              AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS TRUE
+              AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT TRUE
+              AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') = time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS FALSE
+              AND (time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') <> time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)) IS NOT FALSE
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') BETWEEN time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2) AND time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2)
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT BETWEEN time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') AND time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2)
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') like '%'
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') not like '__DOES_NOT_EXIST__%'
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') IN (time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                 time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'),
+                                                                                 time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))
+              AND time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00') NOT IN (time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', -2),
+                                                                                     time_shift(time_floor(__time, 'P1D', timestamp '2000-01-01 00:30:00'), 'P1D', 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A7: time_shift
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_shift(__time, 'P1D', -1) IS NULL
+       OR (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -1)
+           AND time_shift(__time, 'P1D', -1) IS NOT DISTINCT
+           FROM time_shift(__time, 'P1D', -1)
+           AND time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)
+           AND (time_shift(__time, 'P1D', -1) IS DISTINCT
+                FROM time_shift(__time, 'P1D', -2))
+           AND time_shift(__time, 'P1D', -1) > time_shift(__time, 'P1D', -2)
+           AND time_shift(__time, 'P1D', -1) >= time_shift(__time, 'P1D', -2)
+           AND time_shift(__time, 'P1D', -1) < time_shift(__time, 'P1D', 2)
+           AND time_shift(__time, 'P1D', -1) <= time_shift(__time, 'P1D', 2)
+           AND (time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)) IS TRUE
+           AND (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -2)) IS NOT TRUE
+           AND (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -2)) IS FALSE
+           AND (time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)) IS NOT FALSE
+           AND time_shift(__time, 'P1D', -1) BETWEEN time_shift(__time, 'P1D', -2) AND time_shift(__time, 'P1D', 2)
+           AND time_shift(__time, 'P1D', -1) NOT BETWEEN time_shift(__time, 'P1D', -1) AND time_shift(__time, 'P1D', -2)
+           AND time_shift(__time, 'P1D', -1) like '%'
+           AND time_shift(__time, 'P1D', -1) not like '__DOES_NOT_EXIST__%'
+           AND time_shift(__time, 'P1D', -1) IN (time_shift(__time, 'P1D', -2),
+                                                 time_shift(__time, 'P1D', -1),
+                                                 time_shift(__time, 'P1D', 2))
+           AND time_shift(__time, 'P1D', -1) NOT IN (time_shift(__time, 'P1D', -2),
+                                                     time_shift(__time, 'P1D', 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_shift(__time, 'P1D', -1) IS NULL
+       OR time_shift(__time, 'P1D', -1) IN
+         (SELECT time_shift(__time, 'P1D', -1)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (time_shift(__time, 'P1D', -1) IS NULL
+                 OR (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -1)
+                     AND time_shift(__time, 'P1D', -1) IS NOT DISTINCT
+                     FROM time_shift(__time, 'P1D', -1)
+                     AND time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)
+                     AND (time_shift(__time, 'P1D', -1) IS DISTINCT
+                          FROM time_shift(__time, 'P1D', -2))
+                     AND time_shift(__time, 'P1D', -1) > time_shift(__time, 'P1D', -2)
+                     AND time_shift(__time, 'P1D', -1) >= time_shift(__time, 'P1D', -2)
+                     AND time_shift(__time, 'P1D', -1) < time_shift(__time, 'P1D', 2)
+                     AND time_shift(__time, 'P1D', -1) <= time_shift(__time, 'P1D', 2)
+                     AND (time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)) IS TRUE
+                     AND (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -2)) IS NOT TRUE
+                     AND (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -2)) IS FALSE
+                     AND (time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)) IS NOT FALSE
+                     AND time_shift(__time, 'P1D', -1) BETWEEN time_shift(__time, 'P1D', -2) AND time_shift(__time, 'P1D', 2)
+                     AND time_shift(__time, 'P1D', -1) NOT BETWEEN time_shift(__time, 'P1D', -1) AND time_shift(__time, 'P1D', -2)
+                     AND time_shift(__time, 'P1D', -1) like '%'
+                     AND time_shift(__time, 'P1D', -1) not like '__DOES_NOT_EXIST__%'
+                     AND time_shift(__time, 'P1D', -1) IN (time_shift(__time, 'P1D', -2),
+                                                           time_shift(__time, 'P1D', -1),
+                                                           time_shift(__time, 'P1D', 2))
+                     AND time_shift(__time, 'P1D', -1) NOT IN (time_shift(__time, 'P1D', -2),
+                                                               time_shift(__time, 'P1D', 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          time_shift(__time, 'P1D', -1),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (time_shift(__time, 'P1D', -1) IS NULL
+          OR (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -1)
+              AND time_shift(__time, 'P1D', -1) IS NOT DISTINCT
+              FROM time_shift(__time, 'P1D', -1)
+              AND time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)
+              AND (time_shift(__time, 'P1D', -1) IS DISTINCT
+                   FROM time_shift(__time, 'P1D', -2))
+              AND time_shift(__time, 'P1D', -1) > time_shift(__time, 'P1D', -2)
+              AND time_shift(__time, 'P1D', -1) >= time_shift(__time, 'P1D', -2)
+              AND time_shift(__time, 'P1D', -1) < time_shift(__time, 'P1D', 2)
+              AND time_shift(__time, 'P1D', -1) <= time_shift(__time, 'P1D', 2)
+              AND (time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)) IS TRUE
+              AND (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -2)) IS NOT TRUE
+              AND (time_shift(__time, 'P1D', -1) = time_shift(__time, 'P1D', -2)) IS FALSE
+              AND (time_shift(__time, 'P1D', -1) <> time_shift(__time, 'P1D', -2)) IS NOT FALSE
+              AND time_shift(__time, 'P1D', -1) BETWEEN time_shift(__time, 'P1D', -2) AND time_shift(__time, 'P1D', 2)
+              AND time_shift(__time, 'P1D', -1) NOT BETWEEN time_shift(__time, 'P1D', -1) AND time_shift(__time, 'P1D', -2)
+              AND time_shift(__time, 'P1D', -1) like '%'
+              AND time_shift(__time, 'P1D', -1) not like '__DOES_NOT_EXIST__%'
+              AND time_shift(__time, 'P1D', -1) IN (time_shift(__time, 'P1D', -2),
+                                                    time_shift(__time, 'P1D', -1),
+                                                    time_shift(__time, 'P1D', 2))
+              AND time_shift(__time, 'P1D', -1) NOT IN (time_shift(__time, 'P1D', -2),
+                                                        time_shift(__time, 'P1D', 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A8: time_extract
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_extract(__time, 'DOW') IS NULL
+       OR (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')
+           AND time_extract(__time, 'DOW') IS NOT DISTINCT
+           FROM time_extract(__time, 'DOW')
+           AND time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1
+           AND (time_extract(__time, 'DOW') IS DISTINCT
+                FROM time_extract(__time, 'DOW')-1)
+           AND time_extract(__time, 'DOW') > time_extract(__time, 'DOW')-1
+           AND time_extract(__time, 'DOW') >= time_extract(__time, 'DOW')-1
+           AND time_extract(__time, 'DOW') < time_extract(__time, 'DOW')+1
+           AND time_extract(__time, 'DOW') <= time_extract(__time, 'DOW')+1
+           AND (time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1) IS TRUE
+           AND (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')-1) IS NOT TRUE
+           AND (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')-1) IS FALSE
+           AND (time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1) IS NOT FALSE
+           AND time_extract(__time, 'DOW') BETWEEN time_extract(__time, 'DOW')-1 AND time_extract(__time, 'DOW')+1
+           AND time_extract(__time, 'DOW') NOT BETWEEN time_extract(__time, 'DOW') AND time_extract(__time, 'DOW')-1
+           AND time_extract(__time, 'DOW') like '%'
+           AND time_extract(__time, 'DOW') not like '__DOES_NOT_EXIST__%'
+           AND time_extract(__time, 'DOW') IN (time_extract(__time, 'DOW')-1,
+                                                                          time_extract(__time, 'DOW'),
+                                                                          time_extract(__time, 'DOW')+1)
+           AND time_extract(__time, 'DOW') NOT IN (time_extract(__time, 'DOW')-1,
+                                                                              time_extract(__time, 'DOW')+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_extract(__time, 'DOW') IS NULL
+       OR time_extract(__time, 'DOW') IN
+         (SELECT time_extract(__time, 'DOW')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (time_extract(__time, 'DOW') IS NULL
+                 OR (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')
+                     AND time_extract(__time, 'DOW') IS NOT DISTINCT
+                     FROM time_extract(__time, 'DOW')
+                     AND time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1
+                     AND (time_extract(__time, 'DOW') IS DISTINCT
+                          FROM time_extract(__time, 'DOW')-1)
+                     AND time_extract(__time, 'DOW') > time_extract(__time, 'DOW')-1
+                     AND time_extract(__time, 'DOW') >= time_extract(__time, 'DOW')-1
+                     AND time_extract(__time, 'DOW') < time_extract(__time, 'DOW')+1
+                     AND time_extract(__time, 'DOW') <= time_extract(__time, 'DOW')+1
+                     AND (time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1) IS TRUE
+                     AND (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')-1) IS NOT TRUE
+                     AND (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')-1) IS FALSE
+                     AND (time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1) IS NOT FALSE
+                     AND time_extract(__time, 'DOW') BETWEEN time_extract(__time, 'DOW')-1 AND time_extract(__time, 'DOW')+1
+                     AND time_extract(__time, 'DOW') NOT BETWEEN time_extract(__time, 'DOW') AND time_extract(__time, 'DOW')-1
+                     AND time_extract(__time, 'DOW') like '%'
+                     AND time_extract(__time, 'DOW') not like '__DOES_NOT_EXIST__%'
+                     AND time_extract(__time, 'DOW') IN (time_extract(__time, 'DOW')-1,
+                                                                                    time_extract(__time, 'DOW'),
+                                                                                    time_extract(__time, 'DOW')+1)
+                     AND time_extract(__time, 'DOW') NOT IN (time_extract(__time, 'DOW')-1,
+                                                                                        time_extract(__time, 'DOW')+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          time_extract(__time, 'DOW'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (time_extract(__time, 'DOW') IS NULL
+          OR (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')
+              AND time_extract(__time, 'DOW') IS NOT DISTINCT
+              FROM time_extract(__time, 'DOW')
+              AND time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1
+              AND (time_extract(__time, 'DOW') IS DISTINCT
+                   FROM time_extract(__time, 'DOW')-1)
+              AND time_extract(__time, 'DOW') > time_extract(__time, 'DOW')-1
+              AND time_extract(__time, 'DOW') >= time_extract(__time, 'DOW')-1
+              AND time_extract(__time, 'DOW') < time_extract(__time, 'DOW')+1
+              AND time_extract(__time, 'DOW') <= time_extract(__time, 'DOW')+1
+              AND (time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1) IS TRUE
+              AND (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')-1) IS NOT TRUE
+              AND (time_extract(__time, 'DOW') = time_extract(__time, 'DOW')-1) IS FALSE
+              AND (time_extract(__time, 'DOW') <> time_extract(__time, 'DOW')-1) IS NOT FALSE
+              AND time_extract(__time, 'DOW') BETWEEN time_extract(__time, 'DOW')-1 AND time_extract(__time, 'DOW')+1
+              AND time_extract(__time, 'DOW') NOT BETWEEN time_extract(__time, 'DOW') AND time_extract(__time, 'DOW')-1
+              AND time_extract(__time, 'DOW') like '%'
+              AND time_extract(__time, 'DOW') not like '__DOES_NOT_EXIST__%'
+              AND time_extract(__time, 'DOW') IN (time_extract(__time, 'DOW')-1,
+                                                                             time_extract(__time, 'DOW'),
+                                                                             time_extract(__time, 'DOW')+1)
+              AND time_extract(__time, 'DOW') NOT IN (time_extract(__time, 'DOW')-1,
+                                                                                 time_extract(__time, 'DOW')+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A9: time_parse
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_parse(cast(__time AS char)) IS NULL
+       OR (time_parse(cast(__time AS char)) = time_parse(cast(__time AS char))
+           AND time_parse(cast(__time AS char)) IS NOT DISTINCT
+           FROM time_parse(cast(__time AS char))
+           AND time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+           AND (time_parse(cast(__time AS char)) IS DISTINCT
+                FROM time_shift(time_parse(cast(__time AS char)), 'P1D', -2))
+           AND time_parse(cast(__time AS char)) > time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+           AND time_parse(cast(__time AS char)) >= time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+           AND time_parse(cast(__time AS char)) < time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+           AND time_parse(cast(__time AS char)) <= time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+           AND (time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS TRUE
+           AND (time_parse(cast(__time AS char)) = time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS NOT TRUE
+           AND (time_parse(cast(__time AS char)) = time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS FALSE
+           AND (time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS NOT FALSE
+           AND time_parse(cast(__time AS char)) BETWEEN time_shift(time_parse(cast(__time AS char)), 'P1D', -2) AND time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+           AND time_parse(cast(__time AS char)) NOT BETWEEN time_parse(cast(__time AS char)) AND time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+           AND time_parse(cast(__time AS char)) like '%'
+           AND time_parse(cast(__time AS char)) not like '__DOES_NOT_EXIST__%'
+           AND time_parse(cast(__time AS char)) IN (time_shift(time_parse(cast(__time AS char)), 'P1D', -2),
+                                                    time_parse(cast(__time AS char)),
+                                                    time_shift(time_parse(cast(__time AS char)), 'P1D', 2))
+           AND time_parse(cast(__time AS char)) NOT IN (time_shift(time_parse(cast(__time AS char)), 'P1D', -2),
+                                                        time_shift(time_parse(cast(__time AS char)), 'P1D', 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (time_parse(cast(__time AS char)) IS NULL
+       OR time_parse(cast(__time AS char)) IN
+         (SELECT time_parse(cast(__time AS char))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (time_parse(cast(__time AS char)) IS NULL
+                 OR (time_parse(cast(__time AS char)) = time_parse(cast(__time AS char))
+                     AND time_parse(cast(__time AS char)) IS NOT DISTINCT
+                     FROM time_parse(cast(__time AS char))
+                     AND time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+                     AND (time_parse(cast(__time AS char)) IS DISTINCT
+                          FROM time_shift(time_parse(cast(__time AS char)), 'P1D', -2))
+                     AND time_parse(cast(__time AS char)) > time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+                     AND time_parse(cast(__time AS char)) >= time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+                     AND time_parse(cast(__time AS char)) < time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+                     AND time_parse(cast(__time AS char)) <= time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+                     AND (time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS TRUE
+                     AND (time_parse(cast(__time AS char)) = time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS NOT TRUE
+                     AND (time_parse(cast(__time AS char)) = time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS FALSE
+                     AND (time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS NOT FALSE
+                     AND time_parse(cast(__time AS char)) BETWEEN time_shift(time_parse(cast(__time AS char)), 'P1D', -2) AND time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+                     AND time_parse(cast(__time AS char)) NOT BETWEEN time_parse(cast(__time AS char)) AND time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+                     AND time_parse(cast(__time AS char)) like '%'
+                     AND time_parse(cast(__time AS char)) not like '__DOES_NOT_EXIST__%'
+                     AND time_parse(cast(__time AS char)) IN (time_shift(time_parse(cast(__time AS char)), 'P1D', -2),
+                                                              time_parse(cast(__time AS char)),
+                                                              time_shift(time_parse(cast(__time AS char)), 'P1D', 2))
+                     AND time_parse(cast(__time AS char)) NOT IN (time_shift(time_parse(cast(__time AS char)), 'P1D', -2),
+                                                                  time_shift(time_parse(cast(__time AS char)), 'P1D', 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          time_parse(cast(__time AS char)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (time_parse(cast(__time AS char)) IS NULL
+          OR (time_parse(cast(__time AS char)) = time_parse(cast(__time AS char))
+              AND time_parse(cast(__time AS char)) IS NOT DISTINCT
+              FROM time_parse(cast(__time AS char))
+              AND time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+              AND (time_parse(cast(__time AS char)) IS DISTINCT
+                   FROM time_shift(time_parse(cast(__time AS char)), 'P1D', -2))
+              AND time_parse(cast(__time AS char)) > time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+              AND time_parse(cast(__time AS char)) >= time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+              AND time_parse(cast(__time AS char)) < time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+              AND time_parse(cast(__time AS char)) <= time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+              AND (time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS TRUE
+              AND (time_parse(cast(__time AS char)) = time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS NOT TRUE
+              AND (time_parse(cast(__time AS char)) = time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS FALSE
+              AND (time_parse(cast(__time AS char)) <> time_shift(time_parse(cast(__time AS char)), 'P1D', -2)) IS NOT FALSE
+              AND time_parse(cast(__time AS char)) BETWEEN time_shift(time_parse(cast(__time AS char)), 'P1D', -2) AND time_shift(time_parse(cast(__time AS char)), 'P1D', 2)
+              AND time_parse(cast(__time AS char)) NOT BETWEEN time_parse(cast(__time AS char)) AND time_shift(time_parse(cast(__time AS char)), 'P1D', -2)
+              AND time_parse(cast(__time AS char)) like '%'
+              AND time_parse(cast(__time AS char)) not like '__DOES_NOT_EXIST__%'
+              AND time_parse(cast(__time AS char)) IN (time_shift(time_parse(cast(__time AS char)), 'P1D', -2),
+                                                       time_parse(cast(__time AS char)),
+                                                       time_shift(time_parse(cast(__time AS char)), 'P1D', 2))
+              AND time_parse(cast(__time AS char)) NOT IN (time_shift(time_parse(cast(__time AS char)), 'P1D', -2),
+                                                           time_shift(time_parse(cast(__time AS char)), 'P1D', 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A10: time_format
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||time_format(__time) IS NULL
+       OR ('1'||time_format(__time) = 1||time_format(__time)
+           AND '1'||time_format(__time) IS NOT DISTINCT
+           FROM 1||time_format(__time)
+           AND '1'||time_format(__time) <> '0'||time_format(__time)
+           AND ('1'||time_format(__time) IS DISTINCT
+                FROM '0'||time_format(__time))
+           AND '1'||time_format(__time) > '0'||time_format(__time)
+           AND '1'||time_format(__time) >= '0'||time_format(__time)
+           AND '1'||time_format(__time) < 2||time_format(__time)
+           AND '1'||time_format(__time) <= 2||time_format(__time)
+           AND ('1'||time_format(__time) <> '0'||time_format(__time)) IS TRUE
+           AND ('1'||time_format(__time) = '0'||time_format(__time)) IS NOT TRUE
+           AND ('1'||time_format(__time) = '0'||time_format(__time)) IS FALSE
+           AND ('1'||time_format(__time) <> '0'||time_format(__time)) IS NOT FALSE
+           AND '1'||time_format(__time) BETWEEN '0'||time_format(__time) AND 2||time_format(__time)
+           AND '1'||time_format(__time) NOT BETWEEN '1'||time_format(__time) AND '0'||time_format(__time)
+           AND '1'||time_format(__time) like '%'
+           AND '1'||time_format(__time) not like '__DOES_NOT_EXIST__%'
+           AND '1'||time_format(__time) IN ('0'||time_format(__time),
+                                            1||time_format(__time),
+                                            2||time_format(__time))
+           AND '1'||time_format(__time) NOT IN ('0'||time_format(__time),
+                                                2||time_format(__time)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||time_format(__time) IS NULL
+       OR '1'||time_format(__time) IN
+         (SELECT '1'||time_format(__time)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||time_format(__time) IS NULL
+                 OR ('1'||time_format(__time) = 1||time_format(__time)
+                     AND '1'||time_format(__time) IS NOT DISTINCT
+                     FROM 1||time_format(__time)
+                     AND '1'||time_format(__time) <> '0'||time_format(__time)
+                     AND ('1'||time_format(__time) IS DISTINCT
+                          FROM '0'||time_format(__time))
+                     AND '1'||time_format(__time) > '0'||time_format(__time)
+                     AND '1'||time_format(__time) >= '0'||time_format(__time)
+                     AND '1'||time_format(__time) < 2||time_format(__time)
+                     AND '1'||time_format(__time) <= 2||time_format(__time)
+                     AND ('1'||time_format(__time) <> '0'||time_format(__time)) IS TRUE
+                     AND ('1'||time_format(__time) = '0'||time_format(__time)) IS NOT TRUE
+                     AND ('1'||time_format(__time) = '0'||time_format(__time)) IS FALSE
+                     AND ('1'||time_format(__time) <> '0'||time_format(__time)) IS NOT FALSE
+                     AND '1'||time_format(__time) BETWEEN '0'||time_format(__time) AND 2||time_format(__time)
+                     AND '1'||time_format(__time) NOT BETWEEN '1'||time_format(__time) AND '0'||time_format(__time)
+                     AND '1'||time_format(__time) like '%'
+                     AND '1'||time_format(__time) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||time_format(__time) IN ('0'||time_format(__time),
+                                                      1||time_format(__time),
+                                                      2||time_format(__time))
+                     AND '1'||time_format(__time) NOT IN ('0'||time_format(__time),
+                                                          2||time_format(__time))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||time_format(__time),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||time_format(__time) IS NULL
+          OR ('1'||time_format(__time) = 1||time_format(__time)
+              AND '1'||time_format(__time) IS NOT DISTINCT
+              FROM 1||time_format(__time)
+              AND '1'||time_format(__time) <> '0'||time_format(__time)
+              AND ('1'||time_format(__time) IS DISTINCT
+                   FROM '0'||time_format(__time))
+              AND '1'||time_format(__time) > '0'||time_format(__time)
+              AND '1'||time_format(__time) >= '0'||time_format(__time)
+              AND '1'||time_format(__time) < 2||time_format(__time)
+              AND '1'||time_format(__time) <= 2||time_format(__time)
+              AND ('1'||time_format(__time) <> '0'||time_format(__time)) IS TRUE
+              AND ('1'||time_format(__time) = '0'||time_format(__time)) IS NOT TRUE
+              AND ('1'||time_format(__time) = '0'||time_format(__time)) IS FALSE
+              AND ('1'||time_format(__time) <> '0'||time_format(__time)) IS NOT FALSE
+              AND '1'||time_format(__time) BETWEEN '0'||time_format(__time) AND 2||time_format(__time)
+              AND '1'||time_format(__time) NOT BETWEEN '1'||time_format(__time) AND '0'||time_format(__time)
+              AND '1'||time_format(__time) like '%'
+              AND '1'||time_format(__time) not like '__DOES_NOT_EXIST__%'
+              AND '1'||time_format(__time) IN ('0'||time_format(__time),
+                                               1||time_format(__time),
+                                               2||time_format(__time))
+              AND '1'||time_format(__time) NOT IN ('0'||time_format(__time),
+                                                   2||time_format(__time))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A11: time_in_interval
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') IS NULL
+       OR ('1'||time_in_interval(__time, '2000-01-01/P20Y') = 1||time_in_interval(__time, '2000-01-01/P20Y')
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') IS NOT DISTINCT
+           FROM 1||time_in_interval(__time, '2000-01-01/P20Y')
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')
+           AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') IS DISTINCT
+                FROM '0'||time_in_interval(__time, '2000-01-01/P20Y'))
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') > '0'||time_in_interval(__time, '2000-01-01/P20Y')
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') >= '0'||time_in_interval(__time, '2000-01-01/P20Y')
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') < 2||time_in_interval(__time, '2000-01-01/P20Y')
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') <= 2||time_in_interval(__time, '2000-01-01/P20Y')
+           AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS TRUE
+           AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') = '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS NOT TRUE
+           AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') = '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS FALSE
+           AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS NOT FALSE
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') BETWEEN '0'||time_in_interval(__time, '2000-01-01/P20Y') AND 2||time_in_interval(__time, '2000-01-01/P20Y')
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') NOT BETWEEN '1'||time_in_interval(__time, '2000-01-01/P20Y') AND '0'||time_in_interval(__time, '2000-01-01/P20Y')
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') like '%'
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') not like '__DOES_NOT_EXIST__%'
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') IN ('0'||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                    1||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                    2||time_in_interval(__time, '2000-01-01/P20Y'))
+           AND '1'||time_in_interval(__time, '2000-01-01/P20Y') NOT IN ('0'||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                        2||time_in_interval(__time, '2000-01-01/P20Y')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') IS NULL
+       OR '1'||time_in_interval(__time, '2000-01-01/P20Y') IN
+         (SELECT '1'||time_in_interval(__time, '2000-01-01/P20Y')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') IS NULL
+                 OR ('1'||time_in_interval(__time, '2000-01-01/P20Y') = 1||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') IS NOT DISTINCT
+                     FROM 1||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') IS DISTINCT
+                          FROM '0'||time_in_interval(__time, '2000-01-01/P20Y'))
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') > '0'||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') >= '0'||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') < 2||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') <= 2||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS TRUE
+                     AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') = '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS NOT TRUE
+                     AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') = '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS FALSE
+                     AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS NOT FALSE
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') BETWEEN '0'||time_in_interval(__time, '2000-01-01/P20Y') AND 2||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') NOT BETWEEN '1'||time_in_interval(__time, '2000-01-01/P20Y') AND '0'||time_in_interval(__time, '2000-01-01/P20Y')
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') like '%'
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') IN ('0'||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                              1||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                              2||time_in_interval(__time, '2000-01-01/P20Y'))
+                     AND '1'||time_in_interval(__time, '2000-01-01/P20Y') NOT IN ('0'||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                                  2||time_in_interval(__time, '2000-01-01/P20Y'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||time_in_interval(__time, '2000-01-01/P20Y'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') IS NULL
+          OR ('1'||time_in_interval(__time, '2000-01-01/P20Y') = 1||time_in_interval(__time, '2000-01-01/P20Y')
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') IS NOT DISTINCT
+              FROM 1||time_in_interval(__time, '2000-01-01/P20Y')
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')
+              AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') IS DISTINCT
+                   FROM '0'||time_in_interval(__time, '2000-01-01/P20Y'))
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') > '0'||time_in_interval(__time, '2000-01-01/P20Y')
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') >= '0'||time_in_interval(__time, '2000-01-01/P20Y')
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') < 2||time_in_interval(__time, '2000-01-01/P20Y')
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') <= 2||time_in_interval(__time, '2000-01-01/P20Y')
+              AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS TRUE
+              AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') = '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS NOT TRUE
+              AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') = '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS FALSE
+              AND ('1'||time_in_interval(__time, '2000-01-01/P20Y') <> '0'||time_in_interval(__time, '2000-01-01/P20Y')) IS NOT FALSE
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') BETWEEN '0'||time_in_interval(__time, '2000-01-01/P20Y') AND 2||time_in_interval(__time, '2000-01-01/P20Y')
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') NOT BETWEEN '1'||time_in_interval(__time, '2000-01-01/P20Y') AND '0'||time_in_interval(__time, '2000-01-01/P20Y')
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') like '%'
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') not like '__DOES_NOT_EXIST__%'
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') IN ('0'||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                       1||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                       2||time_in_interval(__time, '2000-01-01/P20Y'))
+              AND '1'||time_in_interval(__time, '2000-01-01/P20Y') NOT IN ('0'||time_in_interval(__time, '2000-01-01/P20Y'),
+                                                                           2||time_in_interval(__time, '2000-01-01/P20Y'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A12: millis_to_timestamp
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (millis_to_timestamp(extract(millisecond
+                                   FROM __time)) IS NULL
+       OR (millis_to_timestamp(extract(millisecond
+                                       FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                   FROM __time))
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) IS NOT DISTINCT
+           FROM millis_to_timestamp(extract(millisecond
+                                            FROM __time))
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                        FROM __time)-2)
+           AND (millis_to_timestamp(extract(millisecond
+                                            FROM __time)) IS DISTINCT
+                FROM millis_to_timestamp(extract(millisecond
+                                                 FROM __time)-2))
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) > millis_to_timestamp(extract(millisecond
+                                                                                       FROM __time)-2)
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) >= millis_to_timestamp(extract(millisecond
+                                                                                        FROM __time)-2)
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) < millis_to_timestamp(extract(millisecond
+                                                                                       FROM __time)+2)
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) <= millis_to_timestamp(extract(millisecond
+                                                                                        FROM __time)+2)
+           AND (millis_to_timestamp(extract(millisecond
+                                            FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                         FROM __time)-2)) IS TRUE
+           AND (millis_to_timestamp(extract(millisecond
+                                            FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                        FROM __time)-2)) IS NOT TRUE
+           AND (millis_to_timestamp(extract(millisecond
+                                            FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                        FROM __time)-2)) IS FALSE
+           AND (millis_to_timestamp(extract(millisecond
+                                            FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                         FROM __time)-2)) IS NOT FALSE
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) BETWEEN millis_to_timestamp(extract(millisecond
+                                                                                             FROM __time)-2) AND millis_to_timestamp(extract(millisecond
+                                                                                                                                             FROM __time)+2)
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) NOT BETWEEN millis_to_timestamp(extract(millisecond
+                                                                                                 FROM __time)) AND millis_to_timestamp(extract(millisecond
+                                                                                                                                               FROM __time)-2)
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) like '%'
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) not like '__DOES_NOT_EXIST__%'
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) IN (millis_to_timestamp(extract(millisecond
+                                                                                         FROM __time)-2),
+                                                             millis_to_timestamp(extract(millisecond
+                                                                                         FROM __time)),
+                                                             millis_to_timestamp(extract(millisecond
+                                                                                         FROM __time)+2))
+           AND millis_to_timestamp(extract(millisecond
+                                           FROM __time)) NOT IN (millis_to_timestamp(extract(millisecond
+                                                                                             FROM __time)-2),
+                                                                 millis_to_timestamp(extract(millisecond
+                                                                                             FROM __time)+2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (millis_to_timestamp(extract(millisecond
+                                   FROM __time)) IS NULL
+       OR millis_to_timestamp(extract(millisecond
+                                      FROM __time)) IN
+         (SELECT millis_to_timestamp(extract(millisecond
+                                             FROM __time))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (millis_to_timestamp(extract(millisecond
+                                             FROM __time)) IS NULL
+                 OR (millis_to_timestamp(extract(millisecond
+                                                 FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                             FROM __time))
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) IS NOT DISTINCT
+                     FROM millis_to_timestamp(extract(millisecond
+                                                      FROM __time))
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                                  FROM __time)-2)
+                     AND (millis_to_timestamp(extract(millisecond
+                                                      FROM __time)) IS DISTINCT
+                          FROM millis_to_timestamp(extract(millisecond
+                                                           FROM __time)-2))
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) > millis_to_timestamp(extract(millisecond
+                                                                                                 FROM __time)-2)
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) >= millis_to_timestamp(extract(millisecond
+                                                                                                  FROM __time)-2)
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) < millis_to_timestamp(extract(millisecond
+                                                                                                 FROM __time)+2)
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) <= millis_to_timestamp(extract(millisecond
+                                                                                                  FROM __time)+2)
+                     AND (millis_to_timestamp(extract(millisecond
+                                                      FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                                   FROM __time)-2)) IS TRUE
+                     AND (millis_to_timestamp(extract(millisecond
+                                                      FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                                  FROM __time)-2)) IS NOT TRUE
+                     AND (millis_to_timestamp(extract(millisecond
+                                                      FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                                  FROM __time)-2)) IS FALSE
+                     AND (millis_to_timestamp(extract(millisecond
+                                                      FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                                   FROM __time)-2)) IS NOT FALSE
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) BETWEEN millis_to_timestamp(extract(millisecond
+                                                                                                       FROM __time)-2) AND millis_to_timestamp(extract(millisecond
+                                                                                                                                                       FROM __time)+2)
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) NOT BETWEEN millis_to_timestamp(extract(millisecond
+                                                                                                           FROM __time)) AND millis_to_timestamp(extract(millisecond
+                                                                                                                                                         FROM __time)-2)
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) like '%'
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) not like '__DOES_NOT_EXIST__%'
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) IN (millis_to_timestamp(extract(millisecond
+                                                                                                   FROM __time)-2),
+                                                                       millis_to_timestamp(extract(millisecond
+                                                                                                   FROM __time)),
+                                                                       millis_to_timestamp(extract(millisecond
+                                                                                                   FROM __time)+2))
+                     AND millis_to_timestamp(extract(millisecond
+                                                     FROM __time)) NOT IN (millis_to_timestamp(extract(millisecond
+                                                                                                       FROM __time)-2),
+                                                                           millis_to_timestamp(extract(millisecond
+                                                                                                       FROM __time)+2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          millis_to_timestamp(extract(millisecond
+                                                      FROM __time)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (millis_to_timestamp(extract(millisecond
+                                      FROM __time)) IS NULL
+          OR (millis_to_timestamp(extract(millisecond
+                                          FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                      FROM __time))
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) IS NOT DISTINCT
+              FROM millis_to_timestamp(extract(millisecond
+                                               FROM __time))
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                           FROM __time)-2)
+              AND (millis_to_timestamp(extract(millisecond
+                                               FROM __time)) IS DISTINCT
+                   FROM millis_to_timestamp(extract(millisecond
+                                                    FROM __time)-2))
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) > millis_to_timestamp(extract(millisecond
+                                                                                          FROM __time)-2)
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) >= millis_to_timestamp(extract(millisecond
+                                                                                           FROM __time)-2)
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) < millis_to_timestamp(extract(millisecond
+                                                                                          FROM __time)+2)
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) <= millis_to_timestamp(extract(millisecond
+                                                                                           FROM __time)+2)
+              AND (millis_to_timestamp(extract(millisecond
+                                               FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                            FROM __time)-2)) IS TRUE
+              AND (millis_to_timestamp(extract(millisecond
+                                               FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                           FROM __time)-2)) IS NOT TRUE
+              AND (millis_to_timestamp(extract(millisecond
+                                               FROM __time)) = millis_to_timestamp(extract(millisecond
+                                                                                           FROM __time)-2)) IS FALSE
+              AND (millis_to_timestamp(extract(millisecond
+                                               FROM __time)) <> millis_to_timestamp(extract(millisecond
+                                                                                            FROM __time)-2)) IS NOT FALSE
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) BETWEEN millis_to_timestamp(extract(millisecond
+                                                                                                FROM __time)-2) AND millis_to_timestamp(extract(millisecond
+                                                                                                                                                FROM __time)+2)
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) NOT BETWEEN millis_to_timestamp(extract(millisecond
+                                                                                                    FROM __time)) AND millis_to_timestamp(extract(millisecond
+                                                                                                                                                  FROM __time)-2)
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) like '%'
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) not like '__DOES_NOT_EXIST__%'
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) IN (millis_to_timestamp(extract(millisecond
+                                                                                            FROM __time)-2),
+                                                                millis_to_timestamp(extract(millisecond
+                                                                                            FROM __time)),
+                                                                millis_to_timestamp(extract(millisecond
+                                                                                            FROM __time)+2))
+              AND millis_to_timestamp(extract(millisecond
+                                              FROM __time)) NOT IN (millis_to_timestamp(extract(millisecond
+                                                                                                FROM __time)-2),
+                                                                    millis_to_timestamp(extract(millisecond
+                                                                                                FROM __time)+2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A13: timestamp_to_millis
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (timestamp_to_millis(__time) IS NULL
+       OR (timestamp_to_millis(__time) = timestamp_to_millis(__time)
+           AND timestamp_to_millis(__time) IS NOT DISTINCT
+           FROM timestamp_to_millis(__time)
+           AND timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2
+           AND (timestamp_to_millis(__time) IS DISTINCT
+                FROM timestamp_to_millis(__time)-2)
+           AND timestamp_to_millis(__time) > timestamp_to_millis(__time)-2
+           AND timestamp_to_millis(__time) >= timestamp_to_millis(__time)-2
+           AND timestamp_to_millis(__time) < timestamp_to_millis(__time)+2
+           AND timestamp_to_millis(__time) <= timestamp_to_millis(__time)+2
+           AND (timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2) IS TRUE
+           AND (timestamp_to_millis(__time) = timestamp_to_millis(__time)-2) IS NOT TRUE
+           AND (timestamp_to_millis(__time) = timestamp_to_millis(__time)-2) IS FALSE
+           AND (timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2) IS NOT FALSE
+           AND timestamp_to_millis(__time) BETWEEN timestamp_to_millis(__time)-2 AND timestamp_to_millis(__time)+2
+           AND timestamp_to_millis(__time) NOT BETWEEN timestamp_to_millis(__time) AND timestamp_to_millis(__time)-2
+           AND timestamp_to_millis(__time) like '%'
+           AND timestamp_to_millis(__time) not like '__DOES_NOT_EXIST__%'
+           AND timestamp_to_millis(__time) IN (timestamp_to_millis(__time)-2,
+                                                                          timestamp_to_millis(__time),
+                                                                          timestamp_to_millis(__time)+2)
+           AND timestamp_to_millis(__time) NOT IN (timestamp_to_millis(__time)-2,
+                                                                              timestamp_to_millis(__time)+2))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (timestamp_to_millis(__time) IS NULL
+       OR timestamp_to_millis(__time) IN
+         (SELECT timestamp_to_millis(__time)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (timestamp_to_millis(__time) IS NULL
+                 OR (timestamp_to_millis(__time) = timestamp_to_millis(__time)
+                     AND timestamp_to_millis(__time) IS NOT DISTINCT
+                     FROM timestamp_to_millis(__time)
+                     AND timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2
+                     AND (timestamp_to_millis(__time) IS DISTINCT
+                          FROM timestamp_to_millis(__time)-2)
+                     AND timestamp_to_millis(__time) > timestamp_to_millis(__time)-2
+                     AND timestamp_to_millis(__time) >= timestamp_to_millis(__time)-2
+                     AND timestamp_to_millis(__time) < timestamp_to_millis(__time)+2
+                     AND timestamp_to_millis(__time) <= timestamp_to_millis(__time)+2
+                     AND (timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2) IS TRUE
+                     AND (timestamp_to_millis(__time) = timestamp_to_millis(__time)-2) IS NOT TRUE
+                     AND (timestamp_to_millis(__time) = timestamp_to_millis(__time)-2) IS FALSE
+                     AND (timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2) IS NOT FALSE
+                     AND timestamp_to_millis(__time) BETWEEN timestamp_to_millis(__time)-2 AND timestamp_to_millis(__time)+2
+                     AND timestamp_to_millis(__time) NOT BETWEEN timestamp_to_millis(__time) AND timestamp_to_millis(__time)-2
+                     AND timestamp_to_millis(__time) like '%'
+                     AND timestamp_to_millis(__time) not like '__DOES_NOT_EXIST__%'
+                     AND timestamp_to_millis(__time) IN (timestamp_to_millis(__time)-2,
+                                                                                    timestamp_to_millis(__time),
+                                                                                    timestamp_to_millis(__time)+2)
+                     AND timestamp_to_millis(__time) NOT IN (timestamp_to_millis(__time)-2,
+                                                                                        timestamp_to_millis(__time)+2)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          timestamp_to_millis(__time),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (timestamp_to_millis(__time) IS NULL
+          OR (timestamp_to_millis(__time) = timestamp_to_millis(__time)
+              AND timestamp_to_millis(__time) IS NOT DISTINCT
+              FROM timestamp_to_millis(__time)
+              AND timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2
+              AND (timestamp_to_millis(__time) IS DISTINCT
+                   FROM timestamp_to_millis(__time)-2)
+              AND timestamp_to_millis(__time) > timestamp_to_millis(__time)-2
+              AND timestamp_to_millis(__time) >= timestamp_to_millis(__time)-2
+              AND timestamp_to_millis(__time) < timestamp_to_millis(__time)+2
+              AND timestamp_to_millis(__time) <= timestamp_to_millis(__time)+2
+              AND (timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2) IS TRUE
+              AND (timestamp_to_millis(__time) = timestamp_to_millis(__time)-2) IS NOT TRUE
+              AND (timestamp_to_millis(__time) = timestamp_to_millis(__time)-2) IS FALSE
+              AND (timestamp_to_millis(__time) <> timestamp_to_millis(__time)-2) IS NOT FALSE
+              AND timestamp_to_millis(__time) BETWEEN timestamp_to_millis(__time)-2 AND timestamp_to_millis(__time)+2
+              AND timestamp_to_millis(__time) NOT BETWEEN timestamp_to_millis(__time) AND timestamp_to_millis(__time)-2
+              AND timestamp_to_millis(__time) like '%'
+              AND timestamp_to_millis(__time) not like '__DOES_NOT_EXIST__%'
+              AND timestamp_to_millis(__time) IN (timestamp_to_millis(__time)-2,
+                                                                             timestamp_to_millis(__time),
+                                                                             timestamp_to_millis(__time)+2)
+              AND timestamp_to_millis(__time) NOT IN (timestamp_to_millis(__time)-2,
+                                                                                 timestamp_to_millis(__time)+2)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A14: extract
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (extract(HOUR
+               FROM __time) IS NULL
+       OR (extract(HOUR
+                   FROM __time) = extract(HOUR
+                                          FROM __time)
+           AND extract(HOUR
+                       FROM __time) IS NOT DISTINCT
+           FROM extract(HOUR
+                        FROM __time)
+           AND extract(HOUR
+                       FROM __time) <> extract(HOUR
+                                               FROM __time)-2
+           AND (extract(HOUR
+                        FROM __time) IS DISTINCT
+                FROM extract(HOUR
+                             FROM __time)-2)
+           AND extract(HOUR
+                       FROM __time) > extract(HOUR
+                                              FROM __time)-2
+           AND extract(HOUR
+                       FROM __time) >= extract(HOUR
+                                               FROM __time)-2
+           AND extract(HOUR
+                       FROM __time) < extract(HOUR
+                                              FROM __time)+2
+           AND extract(HOUR
+                       FROM __time) <= extract(HOUR
+                                               FROM __time)+2
+           AND (extract(HOUR
+                        FROM __time) <> extract(HOUR
+                                                FROM __time)-2) IS TRUE
+           AND (extract(HOUR
+                        FROM __time) = extract(HOUR
+                                               FROM __time)-2) IS NOT TRUE
+           AND (extract(HOUR
+                        FROM __time) = extract(HOUR
+                                               FROM __time)-2) IS FALSE
+           AND (extract(HOUR
+                        FROM __time) <> extract(HOUR
+                                                FROM __time)-2) IS NOT FALSE
+           AND extract(HOUR
+                       FROM __time) BETWEEN extract(HOUR
+                                                    FROM __time)-2 AND extract(HOUR
+                                                                               FROM __time)+2
+           AND extract(HOUR
+                       FROM __time) NOT BETWEEN extract(HOUR
+                                                        FROM __time) AND extract(HOUR
+                                                                                 FROM __time)-2
+           AND extract(HOUR
+                       FROM __time) like '%'
+           AND extract(HOUR
+                       FROM __time) not like '__DOES_NOT_EXIST__%'
+           AND extract(HOUR
+                       FROM __time) IN (extract(HOUR
+                                                FROM __time)-2,
+                                                            extract(HOUR
+                                                                    FROM __time),
+                                                            extract(HOUR
+                                                                    FROM __time)+2)
+           AND extract(HOUR
+                       FROM __time) NOT IN (extract(HOUR
+                                                    FROM __time)-2,
+                                                                extract(HOUR
+                                                                        FROM __time)+2))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (extract(HOUR
+               FROM __time) IS NULL
+       OR extract(HOUR
+                  FROM __time) IN
+         (SELECT extract(HOUR
+                         FROM __time)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (extract(HOUR
+                         FROM __time) IS NULL
+                 OR (extract(HOUR
+                             FROM __time) = extract(HOUR
+                                                    FROM __time)
+                     AND extract(HOUR
+                                 FROM __time) IS NOT DISTINCT
+                     FROM extract(HOUR
+                                  FROM __time)
+                     AND extract(HOUR
+                                 FROM __time) <> extract(HOUR
+                                                         FROM __time)-2
+                     AND (extract(HOUR
+                                  FROM __time) IS DISTINCT
+                          FROM extract(HOUR
+                                       FROM __time)-2)
+                     AND extract(HOUR
+                                 FROM __time) > extract(HOUR
+                                                        FROM __time)-2
+                     AND extract(HOUR
+                                 FROM __time) >= extract(HOUR
+                                                         FROM __time)-2
+                     AND extract(HOUR
+                                 FROM __time) < extract(HOUR
+                                                        FROM __time)+2
+                     AND extract(HOUR
+                                 FROM __time) <= extract(HOUR
+                                                         FROM __time)+2
+                     AND (extract(HOUR
+                                  FROM __time) <> extract(HOUR
+                                                          FROM __time)-2) IS TRUE
+                     AND (extract(HOUR
+                                  FROM __time) = extract(HOUR
+                                                         FROM __time)-2) IS NOT TRUE
+                     AND (extract(HOUR
+                                  FROM __time) = extract(HOUR
+                                                         FROM __time)-2) IS FALSE
+                     AND (extract(HOUR
+                                  FROM __time) <> extract(HOUR
+                                                          FROM __time)-2) IS NOT FALSE
+                     AND extract(HOUR
+                                 FROM __time) BETWEEN extract(HOUR
+                                                              FROM __time)-2 AND extract(HOUR
+                                                                                         FROM __time)+2
+                     AND extract(HOUR
+                                 FROM __time) NOT BETWEEN extract(HOUR
+                                                                  FROM __time) AND extract(HOUR
+                                                                                           FROM __time)-2
+                     AND extract(HOUR
+                                 FROM __time) like '%'
+                     AND extract(HOUR
+                                 FROM __time) not like '__DOES_NOT_EXIST__%'
+                     AND extract(HOUR
+                                 FROM __time) IN (extract(HOUR
+                                                          FROM __time)-2,
+                                                                      extract(HOUR
+                                                                              FROM __time),
+                                                                      extract(HOUR
+                                                                              FROM __time)+2)
+                     AND extract(HOUR
+                                 FROM __time) NOT IN (extract(HOUR
+                                                              FROM __time)-2,
+                                                                          extract(HOUR
+                                                                                  FROM __time)+2)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          extract(HOUR
+                                  FROM __time),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (extract(HOUR
+                  FROM __time) IS NULL
+          OR (extract(HOUR
+                      FROM __time) = extract(HOUR
+                                             FROM __time)
+              AND extract(HOUR
+                          FROM __time) IS NOT DISTINCT
+              FROM extract(HOUR
+                           FROM __time)
+              AND extract(HOUR
+                          FROM __time) <> extract(HOUR
+                                                  FROM __time)-2
+              AND (extract(HOUR
+                           FROM __time) IS DISTINCT
+                   FROM extract(HOUR
+                                FROM __time)-2)
+              AND extract(HOUR
+                          FROM __time) > extract(HOUR
+                                                 FROM __time)-2
+              AND extract(HOUR
+                          FROM __time) >= extract(HOUR
+                                                  FROM __time)-2
+              AND extract(HOUR
+                          FROM __time) < extract(HOUR
+                                                 FROM __time)+2
+              AND extract(HOUR
+                          FROM __time) <= extract(HOUR
+                                                  FROM __time)+2
+              AND (extract(HOUR
+                           FROM __time) <> extract(HOUR
+                                                   FROM __time)-2) IS TRUE
+              AND (extract(HOUR
+                           FROM __time) = extract(HOUR
+                                                  FROM __time)-2) IS NOT TRUE
+              AND (extract(HOUR
+                           FROM __time) = extract(HOUR
+                                                  FROM __time)-2) IS FALSE
+              AND (extract(HOUR
+                           FROM __time) <> extract(HOUR
+                                                   FROM __time)-2) IS NOT FALSE
+              AND extract(HOUR
+                          FROM __time) BETWEEN extract(HOUR
+                                                       FROM __time)-2 AND extract(HOUR
+                                                                                  FROM __time)+2
+              AND extract(HOUR
+                          FROM __time) NOT BETWEEN extract(HOUR
+                                                           FROM __time) AND extract(HOUR
+                                                                                    FROM __time)-2
+              AND extract(HOUR
+                          FROM __time) like '%'
+              AND extract(HOUR
+                          FROM __time) not like '__DOES_NOT_EXIST__%'
+              AND extract(HOUR
+                          FROM __time) IN (extract(HOUR
+                                                   FROM __time)-2,
+                                                               extract(HOUR
+                                                                       FROM __time),
+                                                               extract(HOUR
+                                                                       FROM __time)+2)
+              AND extract(HOUR
+                          FROM __time) NOT IN (extract(HOUR
+                                                       FROM __time)-2,
+                                                                   extract(HOUR
+                                                                           FROM __time)+2)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A15: floor
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(__time TO DAY) IS NULL
+       OR (floor(__time TO DAY) = floor(__time TO DAY)
+           AND floor(__time TO DAY) IS NOT DISTINCT
+           FROM floor(__time TO DAY)
+           AND floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)
+           AND (floor(__time TO DAY) IS DISTINCT
+                FROM floor(time_shift(__time, 'P1D', -2) TO DAY))
+           AND floor(__time TO DAY) > floor(time_shift(__time, 'P1D', -2) TO DAY)
+           AND floor(__time TO DAY) >= floor(time_shift(__time, 'P1D', -2) TO DAY)
+           AND floor(__time TO DAY) < floor(time_shift(__time, 'P1D', 2) TO DAY)
+           AND floor(__time TO DAY) <= floor(time_shift(__time, 'P1D', 2) TO DAY)
+           AND (floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)) IS TRUE
+           AND (floor(__time TO DAY) = floor(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT TRUE
+           AND (floor(__time TO DAY) = floor(time_shift(__time, 'P1D', -2) TO DAY)) IS FALSE
+           AND (floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT FALSE
+           AND floor(__time TO DAY) BETWEEN floor(time_shift(__time, 'P1D', -2) TO DAY) AND floor(time_shift(__time, 'P1D', 2) TO DAY)
+           AND floor(__time TO DAY) NOT BETWEEN floor(__time TO DAY) AND floor(time_shift(__time, 'P1D', -2) TO DAY)
+           AND floor(__time TO DAY) like '%'
+           AND floor(__time TO DAY) not like '__DOES_NOT_EXIST__%'
+           AND floor(__time TO DAY) IN (floor(time_shift(__time, 'P1D', -2) TO DAY),
+                                        floor(__time TO DAY),
+                                        floor(time_shift(__time, 'P1D', 2) TO DAY))
+           AND floor(__time TO DAY) NOT IN (floor(time_shift(__time, 'P1D', -2) TO DAY),
+                                            floor(time_shift(__time, 'P1D', 2) TO DAY)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(__time TO DAY) IS NULL
+       OR floor(__time TO DAY) IN
+         (SELECT floor(__time TO DAY)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(__time TO DAY) IS NULL
+                 OR (floor(__time TO DAY) = floor(__time TO DAY)
+                     AND floor(__time TO DAY) IS NOT DISTINCT
+                     FROM floor(__time TO DAY)
+                     AND floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND (floor(__time TO DAY) IS DISTINCT
+                          FROM floor(time_shift(__time, 'P1D', -2) TO DAY))
+                     AND floor(__time TO DAY) > floor(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND floor(__time TO DAY) >= floor(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND floor(__time TO DAY) < floor(time_shift(__time, 'P1D', 2) TO DAY)
+                     AND floor(__time TO DAY) <= floor(time_shift(__time, 'P1D', 2) TO DAY)
+                     AND (floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)) IS TRUE
+                     AND (floor(__time TO DAY) = floor(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT TRUE
+                     AND (floor(__time TO DAY) = floor(time_shift(__time, 'P1D', -2) TO DAY)) IS FALSE
+                     AND (floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT FALSE
+                     AND floor(__time TO DAY) BETWEEN floor(time_shift(__time, 'P1D', -2) TO DAY) AND floor(time_shift(__time, 'P1D', 2) TO DAY)
+                     AND floor(__time TO DAY) NOT BETWEEN floor(__time TO DAY) AND floor(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND floor(__time TO DAY) like '%'
+                     AND floor(__time TO DAY) not like '__DOES_NOT_EXIST__%'
+                     AND floor(__time TO DAY) IN (floor(time_shift(__time, 'P1D', -2) TO DAY),
+                                                  floor(__time TO DAY),
+                                                  floor(time_shift(__time, 'P1D', 2) TO DAY))
+                     AND floor(__time TO DAY) NOT IN (floor(time_shift(__time, 'P1D', -2) TO DAY),
+                                                      floor(time_shift(__time, 'P1D', 2) TO DAY))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(__time TO DAY),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(__time TO DAY) IS NULL
+          OR (floor(__time TO DAY) = floor(__time TO DAY)
+              AND floor(__time TO DAY) IS NOT DISTINCT
+              FROM floor(__time TO DAY)
+              AND floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)
+              AND (floor(__time TO DAY) IS DISTINCT
+                   FROM floor(time_shift(__time, 'P1D', -2) TO DAY))
+              AND floor(__time TO DAY) > floor(time_shift(__time, 'P1D', -2) TO DAY)
+              AND floor(__time TO DAY) >= floor(time_shift(__time, 'P1D', -2) TO DAY)
+              AND floor(__time TO DAY) < floor(time_shift(__time, 'P1D', 2) TO DAY)
+              AND floor(__time TO DAY) <= floor(time_shift(__time, 'P1D', 2) TO DAY)
+              AND (floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)) IS TRUE
+              AND (floor(__time TO DAY) = floor(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT TRUE
+              AND (floor(__time TO DAY) = floor(time_shift(__time, 'P1D', -2) TO DAY)) IS FALSE
+              AND (floor(__time TO DAY) <> floor(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT FALSE
+              AND floor(__time TO DAY) BETWEEN floor(time_shift(__time, 'P1D', -2) TO DAY) AND floor(time_shift(__time, 'P1D', 2) TO DAY)
+              AND floor(__time TO DAY) NOT BETWEEN floor(__time TO DAY) AND floor(time_shift(__time, 'P1D', -2) TO DAY)
+              AND floor(__time TO DAY) like '%'
+              AND floor(__time TO DAY) not like '__DOES_NOT_EXIST__%'
+              AND floor(__time TO DAY) IN (floor(time_shift(__time, 'P1D', -2) TO DAY),
+                                           floor(__time TO DAY),
+                                           floor(time_shift(__time, 'P1D', 2) TO DAY))
+              AND floor(__time TO DAY) NOT IN (floor(time_shift(__time, 'P1D', -2) TO DAY),
+                                               floor(time_shift(__time, 'P1D', 2) TO DAY))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A16: ceil
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (ceil(__time TO DAY) IS NULL
+       OR (ceil(__time TO DAY) = ceil(__time TO DAY)
+           AND ceil(__time TO DAY) IS NOT DISTINCT
+           FROM ceil(__time TO DAY)
+           AND ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)
+           AND (ceil(__time TO DAY) IS DISTINCT
+                FROM ceil(time_shift(__time, 'P1D', -2) TO DAY))
+           AND ceil(__time TO DAY) > ceil(time_shift(__time, 'P1D', -2) TO DAY)
+           AND ceil(__time TO DAY) >= ceil(time_shift(__time, 'P1D', -2) TO DAY)
+           AND ceil(__time TO DAY) < floor(time_shift(__time, 'P1D', 2) TO DAY)
+           AND ceil(__time TO DAY) <= floor(time_shift(__time, 'P1D', 2) TO DAY)
+           AND (ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS TRUE
+           AND (ceil(__time TO DAY) = ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT TRUE
+           AND (ceil(__time TO DAY) = ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS FALSE
+           AND (ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT FALSE
+           AND ceil(__time TO DAY) BETWEEN ceil(time_shift(__time, 'P1D', -2) TO DAY) AND floor(time_shift(__time, 'P1D', 2) TO DAY)
+           AND ceil(__time TO DAY) NOT BETWEEN ceil(__time TO DAY) AND ceil(time_shift(__time, 'P1D', -2) TO DAY)
+           AND ceil(__time TO DAY) like '%'
+           AND ceil(__time TO DAY) not like '__DOES_NOT_EXIST__%'
+           AND ceil(__time TO DAY) IN (ceil(time_shift(__time, 'P1D', -2) TO DAY),
+                                       ceil(__time TO DAY),
+                                       floor(time_shift(__time, 'P1D', 2) TO DAY))
+           AND ceil(__time TO DAY) NOT IN (ceil(time_shift(__time, 'P1D', -2) TO DAY),
+                                           floor(time_shift(__time, 'P1D', 2) TO DAY)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (ceil(__time TO DAY) IS NULL
+       OR ceil(__time TO DAY) IN
+         (SELECT ceil(__time TO DAY)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (ceil(__time TO DAY) IS NULL
+                 OR (ceil(__time TO DAY) = ceil(__time TO DAY)
+                     AND ceil(__time TO DAY) IS NOT DISTINCT
+                     FROM ceil(__time TO DAY)
+                     AND ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND (ceil(__time TO DAY) IS DISTINCT
+                          FROM ceil(time_shift(__time, 'P1D', -2) TO DAY))
+                     AND ceil(__time TO DAY) > ceil(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND ceil(__time TO DAY) >= ceil(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND ceil(__time TO DAY) < floor(time_shift(__time, 'P1D', 2) TO DAY)
+                     AND ceil(__time TO DAY) <= floor(time_shift(__time, 'P1D', 2) TO DAY)
+                     AND (ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS TRUE
+                     AND (ceil(__time TO DAY) = ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT TRUE
+                     AND (ceil(__time TO DAY) = ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS FALSE
+                     AND (ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT FALSE
+                     AND ceil(__time TO DAY) BETWEEN ceil(time_shift(__time, 'P1D', -2) TO DAY) AND floor(time_shift(__time, 'P1D', 2) TO DAY)
+                     AND ceil(__time TO DAY) NOT BETWEEN ceil(__time TO DAY) AND ceil(time_shift(__time, 'P1D', -2) TO DAY)
+                     AND ceil(__time TO DAY) like '%'
+                     AND ceil(__time TO DAY) not like '__DOES_NOT_EXIST__%'
+                     AND ceil(__time TO DAY) IN (ceil(time_shift(__time, 'P1D', -2) TO DAY),
+                                                 ceil(__time TO DAY),
+                                                 floor(time_shift(__time, 'P1D', 2) TO DAY))
+                     AND ceil(__time TO DAY) NOT IN (ceil(time_shift(__time, 'P1D', -2) TO DAY),
+                                                     floor(time_shift(__time, 'P1D', 2) TO DAY))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          ceil(__time TO DAY),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (ceil(__time TO DAY) IS NULL
+          OR (ceil(__time TO DAY) = ceil(__time TO DAY)
+              AND ceil(__time TO DAY) IS NOT DISTINCT
+              FROM ceil(__time TO DAY)
+              AND ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)
+              AND (ceil(__time TO DAY) IS DISTINCT
+                   FROM ceil(time_shift(__time, 'P1D', -2) TO DAY))
+              AND ceil(__time TO DAY) > ceil(time_shift(__time, 'P1D', -2) TO DAY)
+              AND ceil(__time TO DAY) >= ceil(time_shift(__time, 'P1D', -2) TO DAY)
+              AND ceil(__time TO DAY) < floor(time_shift(__time, 'P1D', 2) TO DAY)
+              AND ceil(__time TO DAY) <= floor(time_shift(__time, 'P1D', 2) TO DAY)
+              AND (ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS TRUE
+              AND (ceil(__time TO DAY) = ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT TRUE
+              AND (ceil(__time TO DAY) = ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS FALSE
+              AND (ceil(__time TO DAY) <> ceil(time_shift(__time, 'P1D', -2) TO DAY)) IS NOT FALSE
+              AND ceil(__time TO DAY) BETWEEN ceil(time_shift(__time, 'P1D', -2) TO DAY) AND floor(time_shift(__time, 'P1D', 2) TO DAY)
+              AND ceil(__time TO DAY) NOT BETWEEN ceil(__time TO DAY) AND ceil(time_shift(__time, 'P1D', -2) TO DAY)
+              AND ceil(__time TO DAY) like '%'
+              AND ceil(__time TO DAY) not like '__DOES_NOT_EXIST__%'
+              AND ceil(__time TO DAY) IN (ceil(time_shift(__time, 'P1D', -2) TO DAY),
+                                          ceil(__time TO DAY),
+                                          floor(time_shift(__time, 'P1D', 2) TO DAY))
+              AND ceil(__time TO DAY) NOT IN (ceil(time_shift(__time, 'P1D', -2) TO DAY),
+                                              floor(time_shift(__time, 'P1D', 2) TO DAY))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A17: timestampadd
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (timestampadd(DAY, 1, __time) IS NULL
+       OR (timestampadd(DAY, 1, __time) = timestampadd(DAY, 1, __time)
+           AND timestampadd(DAY, 1, __time) IS NOT DISTINCT
+           FROM timestampadd(DAY, 1, __time)
+           AND timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)
+           AND (timestampadd(DAY, 1, __time) IS DISTINCT
+                FROM timestampadd(DAY, -1, __time))
+           AND timestampadd(DAY, 1, __time) > timestampadd(DAY, -1, __time)
+           AND timestampadd(DAY, 1, __time) >= timestampadd(DAY, -1, __time)
+           AND timestampadd(DAY, 1, __time) < timestampadd(DAY, 2, __time)
+           AND timestampadd(DAY, 1, __time) <= timestampadd(DAY, 2, __time)
+           AND (timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)) IS TRUE
+           AND (timestampadd(DAY, 1, __time) = timestampadd(DAY, -1, __time)) IS NOT TRUE
+           AND (timestampadd(DAY, 1, __time) = timestampadd(DAY, -1, __time)) IS FALSE
+           AND (timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)) IS NOT FALSE
+           AND timestampadd(DAY, 1, __time) BETWEEN timestampadd(DAY, -1, __time) AND timestampadd(DAY, 2, __time)
+           AND timestampadd(DAY, 1, __time) NOT BETWEEN timestampadd(DAY, 1, __time) AND timestampadd(DAY, -1, __time)
+           AND timestampadd(DAY, 1, __time) like '%'
+           AND timestampadd(DAY, 1, __time) not like '__DOES_NOT_EXIST__%'
+           AND timestampadd(DAY, 1, __time) IN (timestampadd(DAY, -1, __time),
+                                                timestampadd(DAY, 1, __time),
+                                                timestampadd(DAY, 2, __time))
+           AND timestampadd(DAY, 1, __time) NOT IN (timestampadd(DAY, -1, __time),
+                                                    timestampadd(DAY, 2, __time)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (timestampadd(DAY, 1, __time) IS NULL
+       OR timestampadd(DAY, 1, __time) IN
+         (SELECT timestampadd(DAY, 1, __time)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (timestampadd(DAY, 1, __time) IS NULL
+                 OR (timestampadd(DAY, 1, __time) = timestampadd(DAY, 1, __time)
+                     AND timestampadd(DAY, 1, __time) IS NOT DISTINCT
+                     FROM timestampadd(DAY, 1, __time)
+                     AND timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)
+                     AND (timestampadd(DAY, 1, __time) IS DISTINCT
+                          FROM timestampadd(DAY, -1, __time))
+                     AND timestampadd(DAY, 1, __time) > timestampadd(DAY, -1, __time)
+                     AND timestampadd(DAY, 1, __time) >= timestampadd(DAY, -1, __time)
+                     AND timestampadd(DAY, 1, __time) < timestampadd(DAY, 2, __time)
+                     AND timestampadd(DAY, 1, __time) <= timestampadd(DAY, 2, __time)
+                     AND (timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)) IS TRUE
+                     AND (timestampadd(DAY, 1, __time) = timestampadd(DAY, -1, __time)) IS NOT TRUE
+                     AND (timestampadd(DAY, 1, __time) = timestampadd(DAY, -1, __time)) IS FALSE
+                     AND (timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)) IS NOT FALSE
+                     AND timestampadd(DAY, 1, __time) BETWEEN timestampadd(DAY, -1, __time) AND timestampadd(DAY, 2, __time)
+                     AND timestampadd(DAY, 1, __time) NOT BETWEEN timestampadd(DAY, 1, __time) AND timestampadd(DAY, -1, __time)
+                     AND timestampadd(DAY, 1, __time) like '%'
+                     AND timestampadd(DAY, 1, __time) not like '__DOES_NOT_EXIST__%'
+                     AND timestampadd(DAY, 1, __time) IN (timestampadd(DAY, -1, __time),
+                                                          timestampadd(DAY, 1, __time),
+                                                          timestampadd(DAY, 2, __time))
+                     AND timestampadd(DAY, 1, __time) NOT IN (timestampadd(DAY, -1, __time),
+                                                              timestampadd(DAY, 2, __time))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          timestampadd(DAY, 1, __time),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (timestampadd(DAY, 1, __time) IS NULL
+          OR (timestampadd(DAY, 1, __time) = timestampadd(DAY, 1, __time)
+              AND timestampadd(DAY, 1, __time) IS NOT DISTINCT
+              FROM timestampadd(DAY, 1, __time)
+              AND timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)
+              AND (timestampadd(DAY, 1, __time) IS DISTINCT
+                   FROM timestampadd(DAY, -1, __time))
+              AND timestampadd(DAY, 1, __time) > timestampadd(DAY, -1, __time)
+              AND timestampadd(DAY, 1, __time) >= timestampadd(DAY, -1, __time)
+              AND timestampadd(DAY, 1, __time) < timestampadd(DAY, 2, __time)
+              AND timestampadd(DAY, 1, __time) <= timestampadd(DAY, 2, __time)
+              AND (timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)) IS TRUE
+              AND (timestampadd(DAY, 1, __time) = timestampadd(DAY, -1, __time)) IS NOT TRUE
+              AND (timestampadd(DAY, 1, __time) = timestampadd(DAY, -1, __time)) IS FALSE
+              AND (timestampadd(DAY, 1, __time) <> timestampadd(DAY, -1, __time)) IS NOT FALSE
+              AND timestampadd(DAY, 1, __time) BETWEEN timestampadd(DAY, -1, __time) AND timestampadd(DAY, 2, __time)
+              AND timestampadd(DAY, 1, __time) NOT BETWEEN timestampadd(DAY, 1, __time) AND timestampadd(DAY, -1, __time)
+              AND timestampadd(DAY, 1, __time) like '%'
+              AND timestampadd(DAY, 1, __time) not like '__DOES_NOT_EXIST__%'
+              AND timestampadd(DAY, 1, __time) IN (timestampadd(DAY, -1, __time),
+                                                   timestampadd(DAY, 1, __time),
+                                                   timestampadd(DAY, 2, __time))
+              AND timestampadd(DAY, 1, __time) NOT IN (timestampadd(DAY, -1, __time),
+                                                       timestampadd(DAY, 2, __time))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A18: timestampdiff
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS NULL
+       OR (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 2, __time))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS NOT DISTINCT
+           FROM timestampdiff(DAY, __time, timestampadd(DAY, 2, __time))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+           AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS DISTINCT
+                FROM timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) > timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) >= timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) < timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <= timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+           AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS TRUE
+           AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS NOT TRUE
+           AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS FALSE
+           AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS NOT FALSE
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) BETWEEN timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)) AND timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) NOT BETWEEN timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) AND timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) like '%'
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) not like '__DOES_NOT_EXIST__%'
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IN (timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)),
+                                                                            timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)),
+                                                                            timestampdiff(DAY, __time, timestampadd(DAY, 3, __time)))
+           AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) NOT IN (timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)),
+                                                                                timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS NULL
+       OR timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IN
+         (SELECT timestampdiff(DAY, __time, timestampadd(DAY, 2, __time))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS NULL
+                 OR (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 2, __time))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS NOT DISTINCT
+                     FROM timestampdiff(DAY, __time, timestampadd(DAY, 2, __time))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+                     AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS DISTINCT
+                          FROM timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) > timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) >= timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) < timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <= timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+                     AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS TRUE
+                     AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS NOT TRUE
+                     AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS FALSE
+                     AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS NOT FALSE
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) BETWEEN timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)) AND timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) NOT BETWEEN timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) AND timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) like '%'
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) not like '__DOES_NOT_EXIST__%'
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IN (timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)),
+                                                                                      timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)),
+                                                                                      timestampdiff(DAY, __time, timestampadd(DAY, 3, __time)))
+                     AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) NOT IN (timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)),
+                                                                                          timestampdiff(DAY, __time, timestampadd(DAY, 3, __time)))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS NULL
+          OR (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 2, __time))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS NOT DISTINCT
+              FROM timestampdiff(DAY, __time, timestampadd(DAY, 2, __time))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+              AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IS DISTINCT
+                   FROM timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) > timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) >= timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) < timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <= timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+              AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS TRUE
+              AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS NOT TRUE
+              AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) = timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS FALSE
+              AND (timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) <> timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))) IS NOT FALSE
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) BETWEEN timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)) AND timestampdiff(DAY, __time, timestampadd(DAY, 3, __time))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) NOT BETWEEN timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) AND timestampdiff(DAY, __time, timestampadd(DAY, 1, __time))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) like '%'
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) not like '__DOES_NOT_EXIST__%'
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) IN (timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)),
+                                                                               timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)),
+                                                                               timestampdiff(DAY, __time, timestampadd(DAY, 3, __time)))
+              AND timestampdiff(DAY, __time, timestampadd(DAY, 2, __time)) NOT IN (timestampdiff(DAY, __time, timestampadd(DAY, 1, __time)),
+                                                                                   timestampdiff(DAY, __time, timestampadd(DAY, 3, __time)))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# Total query count 55
+#-------------------------------------------------------------------------

--- a/quidem-ut/src/test/quidem/org.apache.druid.quidem.QTest/qaSQL_scalar_numeric.iq
+++ b/quidem-ut/src/test/quidem/org.apache.druid.quidem.QTest/qaSQL_scalar_numeric.iq
@@ -1,0 +1,4482 @@
+!set useApproximateCountDistinct false
+!use druidtest:///?componentSupplier=KttmNestedComponentSupplier
+!set outputformat mysql
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00';
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A1: plain_value_numeric
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (session_length IS NULL
+       OR (session_length = session_length
+           AND session_length IS NOT DISTINCT
+           FROM session_length
+           AND session_length <> session_length-1
+           AND (session_length IS DISTINCT
+                FROM session_length-1)
+           AND session_length > session_length-1
+           AND session_length >= session_length-1
+           AND session_length < session_length+1
+           AND session_length <= session_length+1
+           AND (session_length <> session_length-1) IS TRUE
+           AND (session_length = session_length-1) IS NOT TRUE
+           AND (session_length = session_length-1) IS FALSE
+           AND (session_length <> session_length-1) IS NOT FALSE
+           AND session_length BETWEEN session_length-1 AND session_length+1
+           AND session_length NOT BETWEEN session_length AND session_length-1
+           AND session_length like '%'
+           AND session_length not like '__DOES_NOT_EXIST__%'
+           AND session_length IN (session_length-1,
+                                                session_length,
+                                                session_length+1)
+           AND session_length NOT IN (session_length-1,
+                                                    session_length+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (session_length IS NULL
+       OR session_length IN
+         (SELECT session_length
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (session_length IS NULL
+                 OR (session_length = session_length
+                     AND session_length IS NOT DISTINCT
+                     FROM session_length
+                     AND session_length <> session_length-1
+                     AND (session_length IS DISTINCT
+                          FROM session_length-1)
+                     AND session_length > session_length-1
+                     AND session_length >= session_length-1
+                     AND session_length < session_length+1
+                     AND session_length <= session_length+1
+                     AND (session_length <> session_length-1) IS TRUE
+                     AND (session_length = session_length-1) IS NOT TRUE
+                     AND (session_length = session_length-1) IS FALSE
+                     AND (session_length <> session_length-1) IS NOT FALSE
+                     AND session_length BETWEEN session_length-1 AND session_length+1
+                     AND session_length NOT BETWEEN session_length AND session_length-1
+                     AND session_length like '%'
+                     AND session_length not like '__DOES_NOT_EXIST__%'
+                     AND session_length IN (session_length-1,
+                                                          session_length,
+                                                          session_length+1)
+                     AND session_length NOT IN (session_length-1,
+                                                              session_length+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          session_length,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (session_length IS NULL
+          OR (session_length = session_length
+              AND session_length IS NOT DISTINCT
+              FROM session_length
+              AND session_length <> session_length-1
+              AND (session_length IS DISTINCT
+                   FROM session_length-1)
+              AND session_length > session_length-1
+              AND session_length >= session_length-1
+              AND session_length < session_length+1
+              AND session_length <= session_length+1
+              AND (session_length <> session_length-1) IS TRUE
+              AND (session_length = session_length-1) IS NOT TRUE
+              AND (session_length = session_length-1) IS FALSE
+              AND (session_length <> session_length-1) IS NOT FALSE
+              AND session_length BETWEEN session_length-1 AND session_length+1
+              AND session_length NOT BETWEEN session_length AND session_length-1
+              AND session_length like '%'
+              AND session_length not like '__DOES_NOT_EXIST__%'
+              AND session_length IN (session_length-1,
+                                                   session_length,
+                                                   session_length+1)
+              AND session_length NOT IN (session_length-1,
+                                                       session_length+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A2: pi
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (pi IS NULL
+       OR (pi = pi+0
+           AND pi IS NOT DISTINCT
+           FROM pi+0
+           AND pi <> pi-1
+           AND (pi IS DISTINCT
+                FROM pi-1)
+           AND pi > pi-1
+           AND pi >= pi-1
+           AND pi < pi+1
+           AND pi <= pi+1
+           AND (pi <> pi-1) IS TRUE
+           AND (pi = pi-1) IS NOT TRUE
+           AND (pi = pi-1) IS FALSE
+           AND (pi <> pi-1) IS NOT FALSE
+           AND pi BETWEEN pi-1 AND pi+1
+           AND pi NOT BETWEEN pi AND pi-1
+           AND pi like '%'
+           AND pi not like '__DOES_NOT_EXIST__%'
+           AND pi IN (pi-1,
+                        pi+0,
+                        pi+1)
+           AND pi NOT IN (pi-1,
+                            pi+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (pi IS NULL
+       OR pi IN
+         (SELECT pi
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (pi IS NULL
+                 OR (pi = pi+0
+                     AND pi IS NOT DISTINCT
+                     FROM pi+0
+                     AND pi <> pi-1
+                     AND (pi IS DISTINCT
+                          FROM pi-1)
+                     AND pi > pi-1
+                     AND pi >= pi-1
+                     AND pi < pi+1
+                     AND pi <= pi+1
+                     AND (pi <> pi-1) IS TRUE
+                     AND (pi = pi-1) IS NOT TRUE
+                     AND (pi = pi-1) IS FALSE
+                     AND (pi <> pi-1) IS NOT FALSE
+                     AND pi BETWEEN pi-1 AND pi+1
+                     AND pi NOT BETWEEN pi AND pi-1
+                     AND pi like '%'
+                     AND pi not like '__DOES_NOT_EXIST__%'
+                     AND pi IN (pi-1,
+                                  pi+0,
+                                  pi+1)
+                     AND pi NOT IN (pi-1,
+                                      pi+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          pi,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (pi IS NULL
+          OR (pi = pi+0
+              AND pi IS NOT DISTINCT
+              FROM pi+0
+              AND pi <> pi-1
+              AND (pi IS DISTINCT
+                   FROM pi-1)
+              AND pi > pi-1
+              AND pi >= pi-1
+              AND pi < pi+1
+              AND pi <= pi+1
+              AND (pi <> pi-1) IS TRUE
+              AND (pi = pi-1) IS NOT TRUE
+              AND (pi = pi-1) IS FALSE
+              AND (pi <> pi-1) IS NOT FALSE
+              AND pi BETWEEN pi-1 AND pi+1
+              AND pi NOT BETWEEN pi AND pi-1
+              AND pi like '%'
+              AND pi not like '__DOES_NOT_EXIST__%'
+              AND pi IN (pi-1,
+                           pi+0,
+                           pi+1)
+              AND pi NOT IN (pi-1,
+                               pi+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A3: abs
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (abs(session_length) IS NULL
+       OR (abs(session_length) = abs(session_length)+0
+           AND abs(session_length) IS NOT DISTINCT
+           FROM abs(session_length)+0
+           AND abs(session_length) <> abs(session_length)-1
+           AND (abs(session_length) IS DISTINCT
+                FROM abs(session_length)-1)
+           AND abs(session_length) > abs(session_length)-1
+           AND abs(session_length) >= abs(session_length)-1
+           AND abs(session_length) < abs(session_length)+1
+           AND abs(session_length) <= abs(session_length)+1
+           AND (abs(session_length) <> abs(session_length)-1) IS TRUE
+           AND (abs(session_length) = abs(session_length)-1) IS NOT TRUE
+           AND (abs(session_length) = abs(session_length)-1) IS FALSE
+           AND (abs(session_length) <> abs(session_length)-1) IS NOT FALSE
+           AND abs(session_length) BETWEEN abs(session_length)-1 AND abs(session_length)+1
+           AND abs(session_length) NOT BETWEEN abs(session_length) AND abs(session_length)-1
+           AND abs(session_length) like '%'
+           AND abs(session_length) not like '__DOES_NOT_EXIST__%'
+           AND abs(session_length) IN (abs(session_length)-1,
+                                                          abs(session_length)+0,
+                                                          abs(session_length)+1)
+           AND abs(session_length) NOT IN (abs(session_length)-1,
+                                                              abs(session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (abs(session_length) IS NULL
+       OR abs(session_length) IN
+         (SELECT abs(session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (abs(session_length) IS NULL
+                 OR (abs(session_length) = abs(session_length)+0
+                     AND abs(session_length) IS NOT DISTINCT
+                     FROM abs(session_length)+0
+                     AND abs(session_length) <> abs(session_length)-1
+                     AND (abs(session_length) IS DISTINCT
+                          FROM abs(session_length)-1)
+                     AND abs(session_length) > abs(session_length)-1
+                     AND abs(session_length) >= abs(session_length)-1
+                     AND abs(session_length) < abs(session_length)+1
+                     AND abs(session_length) <= abs(session_length)+1
+                     AND (abs(session_length) <> abs(session_length)-1) IS TRUE
+                     AND (abs(session_length) = abs(session_length)-1) IS NOT TRUE
+                     AND (abs(session_length) = abs(session_length)-1) IS FALSE
+                     AND (abs(session_length) <> abs(session_length)-1) IS NOT FALSE
+                     AND abs(session_length) BETWEEN abs(session_length)-1 AND abs(session_length)+1
+                     AND abs(session_length) NOT BETWEEN abs(session_length) AND abs(session_length)-1
+                     AND abs(session_length) like '%'
+                     AND abs(session_length) not like '__DOES_NOT_EXIST__%'
+                     AND abs(session_length) IN (abs(session_length)-1,
+                                                                    abs(session_length)+0,
+                                                                    abs(session_length)+1)
+                     AND abs(session_length) NOT IN (abs(session_length)-1,
+                                                                        abs(session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          abs(session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (abs(session_length) IS NULL
+          OR (abs(session_length) = abs(session_length)+0
+              AND abs(session_length) IS NOT DISTINCT
+              FROM abs(session_length)+0
+              AND abs(session_length) <> abs(session_length)-1
+              AND (abs(session_length) IS DISTINCT
+                   FROM abs(session_length)-1)
+              AND abs(session_length) > abs(session_length)-1
+              AND abs(session_length) >= abs(session_length)-1
+              AND abs(session_length) < abs(session_length)+1
+              AND abs(session_length) <= abs(session_length)+1
+              AND (abs(session_length) <> abs(session_length)-1) IS TRUE
+              AND (abs(session_length) = abs(session_length)-1) IS NOT TRUE
+              AND (abs(session_length) = abs(session_length)-1) IS FALSE
+              AND (abs(session_length) <> abs(session_length)-1) IS NOT FALSE
+              AND abs(session_length) BETWEEN abs(session_length)-1 AND abs(session_length)+1
+              AND abs(session_length) NOT BETWEEN abs(session_length) AND abs(session_length)-1
+              AND abs(session_length) like '%'
+              AND abs(session_length) not like '__DOES_NOT_EXIST__%'
+              AND abs(session_length) IN (abs(session_length)-1,
+                                                             abs(session_length)+0,
+                                                             abs(session_length)+1)
+              AND abs(session_length) NOT IN (abs(session_length)-1,
+                                                                 abs(session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A4: ceil
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (ceil(session_length) IS NULL
+       OR (ceil(session_length) = ceil(session_length)+0
+           AND ceil(session_length) IS NOT DISTINCT
+           FROM ceil(session_length)+0
+           AND ceil(session_length) <> ceil(session_length)-1
+           AND (ceil(session_length) IS DISTINCT
+                FROM ceil(session_length)-1)
+           AND ceil(session_length) > ceil(session_length)-1
+           AND ceil(session_length) >= ceil(session_length)-1
+           AND ceil(session_length) < ceil(session_length)+1
+           AND ceil(session_length) <= ceil(session_length)+1
+           AND (ceil(session_length) <> ceil(session_length)-1) IS TRUE
+           AND (ceil(session_length) = ceil(session_length)-1) IS NOT TRUE
+           AND (ceil(session_length) = ceil(session_length)-1) IS FALSE
+           AND (ceil(session_length) <> ceil(session_length)-1) IS NOT FALSE
+           AND ceil(session_length) BETWEEN ceil(session_length)-1 AND ceil(session_length)+1
+           AND ceil(session_length) NOT BETWEEN ceil(session_length) AND ceil(session_length)-1
+           AND ceil(session_length) like '%'
+           AND ceil(session_length) not like '__DOES_NOT_EXIST__%'
+           AND ceil(session_length) IN (ceil(session_length)-1,
+                                                            ceil(session_length)+0,
+                                                            ceil(session_length)+1)
+           AND ceil(session_length) NOT IN (ceil(session_length)-1,
+                                                                ceil(session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (ceil(session_length) IS NULL
+       OR ceil(session_length) IN
+         (SELECT ceil(session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (ceil(session_length) IS NULL
+                 OR (ceil(session_length) = ceil(session_length)+0
+                     AND ceil(session_length) IS NOT DISTINCT
+                     FROM ceil(session_length)+0
+                     AND ceil(session_length) <> ceil(session_length)-1
+                     AND (ceil(session_length) IS DISTINCT
+                          FROM ceil(session_length)-1)
+                     AND ceil(session_length) > ceil(session_length)-1
+                     AND ceil(session_length) >= ceil(session_length)-1
+                     AND ceil(session_length) < ceil(session_length)+1
+                     AND ceil(session_length) <= ceil(session_length)+1
+                     AND (ceil(session_length) <> ceil(session_length)-1) IS TRUE
+                     AND (ceil(session_length) = ceil(session_length)-1) IS NOT TRUE
+                     AND (ceil(session_length) = ceil(session_length)-1) IS FALSE
+                     AND (ceil(session_length) <> ceil(session_length)-1) IS NOT FALSE
+                     AND ceil(session_length) BETWEEN ceil(session_length)-1 AND ceil(session_length)+1
+                     AND ceil(session_length) NOT BETWEEN ceil(session_length) AND ceil(session_length)-1
+                     AND ceil(session_length) like '%'
+                     AND ceil(session_length) not like '__DOES_NOT_EXIST__%'
+                     AND ceil(session_length) IN (ceil(session_length)-1,
+                                                                      ceil(session_length)+0,
+                                                                      ceil(session_length)+1)
+                     AND ceil(session_length) NOT IN (ceil(session_length)-1,
+                                                                          ceil(session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          ceil(session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (ceil(session_length) IS NULL
+          OR (ceil(session_length) = ceil(session_length)+0
+              AND ceil(session_length) IS NOT DISTINCT
+              FROM ceil(session_length)+0
+              AND ceil(session_length) <> ceil(session_length)-1
+              AND (ceil(session_length) IS DISTINCT
+                   FROM ceil(session_length)-1)
+              AND ceil(session_length) > ceil(session_length)-1
+              AND ceil(session_length) >= ceil(session_length)-1
+              AND ceil(session_length) < ceil(session_length)+1
+              AND ceil(session_length) <= ceil(session_length)+1
+              AND (ceil(session_length) <> ceil(session_length)-1) IS TRUE
+              AND (ceil(session_length) = ceil(session_length)-1) IS NOT TRUE
+              AND (ceil(session_length) = ceil(session_length)-1) IS FALSE
+              AND (ceil(session_length) <> ceil(session_length)-1) IS NOT FALSE
+              AND ceil(session_length) BETWEEN ceil(session_length)-1 AND ceil(session_length)+1
+              AND ceil(session_length) NOT BETWEEN ceil(session_length) AND ceil(session_length)-1
+              AND ceil(session_length) like '%'
+              AND ceil(session_length) not like '__DOES_NOT_EXIST__%'
+              AND ceil(session_length) IN (ceil(session_length)-1,
+                                                               ceil(session_length)+0,
+                                                               ceil(session_length)+1)
+              AND ceil(session_length) NOT IN (ceil(session_length)-1,
+                                                                   ceil(session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A5: exp
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(exp(least(session_length, 10))) IS NULL
+       OR (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))+0
+           AND floor(exp(least(session_length, 10))) IS NOT DISTINCT
+           FROM floor(exp(least(session_length, 10)))+0
+           AND floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1
+           AND (floor(exp(least(session_length, 10))) IS DISTINCT
+                FROM floor(exp(least(session_length, 10)))-1)
+           AND floor(exp(least(session_length, 10))) > floor(exp(least(session_length, 10)))-1
+           AND floor(exp(least(session_length, 10))) >= floor(exp(least(session_length, 10)))-1
+           AND floor(exp(least(session_length, 10))) < floor(exp(least(session_length, 10)))+1
+           AND floor(exp(least(session_length, 10))) <= floor(exp(least(session_length, 10)))+1
+           AND (floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1) IS TRUE
+           AND (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))-1) IS NOT TRUE
+           AND (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))-1) IS FALSE
+           AND (floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1) IS NOT FALSE
+           AND floor(exp(least(session_length, 10))) BETWEEN floor(exp(least(session_length, 10)))-1 AND floor(exp(least(session_length, 10)))+1
+           AND floor(exp(least(session_length, 10))) NOT BETWEEN floor(exp(least(session_length, 10))) AND floor(exp(least(session_length, 10)))-1
+           AND floor(exp(least(session_length, 10))) like '%'
+           AND floor(exp(least(session_length, 10))) not like '__DOES_NOT_EXIST__%'
+           AND floor(exp(least(session_length, 10))) IN (floor(exp(least(session_length, 10)))-1,
+                                                                                              floor(exp(least(session_length, 10)))+0,
+                                                                                              floor(exp(least(session_length, 10)))+1)
+           AND floor(exp(least(session_length, 10))) NOT IN (floor(exp(least(session_length, 10)))-1,
+                                                                                                  floor(exp(least(session_length, 10)))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(exp(least(session_length, 10))) IS NULL
+       OR floor(exp(least(session_length, 10))) IN
+         (SELECT floor(exp(least(session_length, 10)))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(exp(least(session_length, 10))) IS NULL
+                 OR (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))+0
+                     AND floor(exp(least(session_length, 10))) IS NOT DISTINCT
+                     FROM floor(exp(least(session_length, 10)))+0
+                     AND floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1
+                     AND (floor(exp(least(session_length, 10))) IS DISTINCT
+                          FROM floor(exp(least(session_length, 10)))-1)
+                     AND floor(exp(least(session_length, 10))) > floor(exp(least(session_length, 10)))-1
+                     AND floor(exp(least(session_length, 10))) >= floor(exp(least(session_length, 10)))-1
+                     AND floor(exp(least(session_length, 10))) < floor(exp(least(session_length, 10)))+1
+                     AND floor(exp(least(session_length, 10))) <= floor(exp(least(session_length, 10)))+1
+                     AND (floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1) IS TRUE
+                     AND (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))-1) IS NOT TRUE
+                     AND (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))-1) IS FALSE
+                     AND (floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1) IS NOT FALSE
+                     AND floor(exp(least(session_length, 10))) BETWEEN floor(exp(least(session_length, 10)))-1 AND floor(exp(least(session_length, 10)))+1
+                     AND floor(exp(least(session_length, 10))) NOT BETWEEN floor(exp(least(session_length, 10))) AND floor(exp(least(session_length, 10)))-1
+                     AND floor(exp(least(session_length, 10))) like '%'
+                     AND floor(exp(least(session_length, 10))) not like '__DOES_NOT_EXIST__%'
+                     AND floor(exp(least(session_length, 10))) IN (floor(exp(least(session_length, 10)))-1,
+                                                                                                        floor(exp(least(session_length, 10)))+0,
+                                                                                                        floor(exp(least(session_length, 10)))+1)
+                     AND floor(exp(least(session_length, 10))) NOT IN (floor(exp(least(session_length, 10)))-1,
+                                                                                                            floor(exp(least(session_length, 10)))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(exp(least(session_length, 10))),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(exp(least(session_length, 10))) IS NULL
+          OR (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))+0
+              AND floor(exp(least(session_length, 10))) IS NOT DISTINCT
+              FROM floor(exp(least(session_length, 10)))+0
+              AND floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1
+              AND (floor(exp(least(session_length, 10))) IS DISTINCT
+                   FROM floor(exp(least(session_length, 10)))-1)
+              AND floor(exp(least(session_length, 10))) > floor(exp(least(session_length, 10)))-1
+              AND floor(exp(least(session_length, 10))) >= floor(exp(least(session_length, 10)))-1
+              AND floor(exp(least(session_length, 10))) < floor(exp(least(session_length, 10)))+1
+              AND floor(exp(least(session_length, 10))) <= floor(exp(least(session_length, 10)))+1
+              AND (floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1) IS TRUE
+              AND (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))-1) IS NOT TRUE
+              AND (floor(exp(least(session_length, 10))) = floor(exp(least(session_length, 10)))-1) IS FALSE
+              AND (floor(exp(least(session_length, 10))) <> floor(exp(least(session_length, 10)))-1) IS NOT FALSE
+              AND floor(exp(least(session_length, 10))) BETWEEN floor(exp(least(session_length, 10)))-1 AND floor(exp(least(session_length, 10)))+1
+              AND floor(exp(least(session_length, 10))) NOT BETWEEN floor(exp(least(session_length, 10))) AND floor(exp(least(session_length, 10)))-1
+              AND floor(exp(least(session_length, 10))) like '%'
+              AND floor(exp(least(session_length, 10))) not like '__DOES_NOT_EXIST__%'
+              AND floor(exp(least(session_length, 10))) IN (floor(exp(least(session_length, 10)))-1,
+                                                                                                 floor(exp(least(session_length, 10)))+0,
+                                                                                                 floor(exp(least(session_length, 10)))+1)
+              AND floor(exp(least(session_length, 10))) NOT IN (floor(exp(least(session_length, 10)))-1,
+                                                                                                     floor(exp(least(session_length, 10)))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A6: floor
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(session_length) IS NULL
+       OR (floor(session_length) = floor(session_length)+0
+           AND floor(session_length) IS NOT DISTINCT
+           FROM floor(session_length)+0
+           AND floor(session_length) <> floor(session_length)-1
+           AND (floor(session_length) IS DISTINCT
+                FROM floor(session_length)-1)
+           AND floor(session_length) > floor(session_length)-1
+           AND floor(session_length) >= floor(session_length)-1
+           AND floor(session_length) < floor(session_length)+1
+           AND floor(session_length) <= floor(session_length)+1
+           AND (floor(session_length) <> floor(session_length)-1) IS TRUE
+           AND (floor(session_length) = floor(session_length)-1) IS NOT TRUE
+           AND (floor(session_length) = floor(session_length)-1) IS FALSE
+           AND (floor(session_length) <> floor(session_length)-1) IS NOT FALSE
+           AND floor(session_length) BETWEEN floor(session_length)-1 AND floor(session_length)+1
+           AND floor(session_length) NOT BETWEEN floor(session_length) AND floor(session_length)-1
+           AND floor(session_length) like '%'
+           AND floor(session_length) not like '__DOES_NOT_EXIST__%'
+           AND floor(session_length) IN (floor(session_length)-1,
+                                                              floor(session_length)+0,
+                                                              floor(session_length)+1)
+           AND floor(session_length) NOT IN (floor(session_length)-1,
+                                                                  floor(session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(session_length) IS NULL
+       OR floor(session_length) IN
+         (SELECT floor(session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(session_length) IS NULL
+                 OR (floor(session_length) = floor(session_length)+0
+                     AND floor(session_length) IS NOT DISTINCT
+                     FROM floor(session_length)+0
+                     AND floor(session_length) <> floor(session_length)-1
+                     AND (floor(session_length) IS DISTINCT
+                          FROM floor(session_length)-1)
+                     AND floor(session_length) > floor(session_length)-1
+                     AND floor(session_length) >= floor(session_length)-1
+                     AND floor(session_length) < floor(session_length)+1
+                     AND floor(session_length) <= floor(session_length)+1
+                     AND (floor(session_length) <> floor(session_length)-1) IS TRUE
+                     AND (floor(session_length) = floor(session_length)-1) IS NOT TRUE
+                     AND (floor(session_length) = floor(session_length)-1) IS FALSE
+                     AND (floor(session_length) <> floor(session_length)-1) IS NOT FALSE
+                     AND floor(session_length) BETWEEN floor(session_length)-1 AND floor(session_length)+1
+                     AND floor(session_length) NOT BETWEEN floor(session_length) AND floor(session_length)-1
+                     AND floor(session_length) like '%'
+                     AND floor(session_length) not like '__DOES_NOT_EXIST__%'
+                     AND floor(session_length) IN (floor(session_length)-1,
+                                                                        floor(session_length)+0,
+                                                                        floor(session_length)+1)
+                     AND floor(session_length) NOT IN (floor(session_length)-1,
+                                                                            floor(session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(session_length) IS NULL
+          OR (floor(session_length) = floor(session_length)+0
+              AND floor(session_length) IS NOT DISTINCT
+              FROM floor(session_length)+0
+              AND floor(session_length) <> floor(session_length)-1
+              AND (floor(session_length) IS DISTINCT
+                   FROM floor(session_length)-1)
+              AND floor(session_length) > floor(session_length)-1
+              AND floor(session_length) >= floor(session_length)-1
+              AND floor(session_length) < floor(session_length)+1
+              AND floor(session_length) <= floor(session_length)+1
+              AND (floor(session_length) <> floor(session_length)-1) IS TRUE
+              AND (floor(session_length) = floor(session_length)-1) IS NOT TRUE
+              AND (floor(session_length) = floor(session_length)-1) IS FALSE
+              AND (floor(session_length) <> floor(session_length)-1) IS NOT FALSE
+              AND floor(session_length) BETWEEN floor(session_length)-1 AND floor(session_length)+1
+              AND floor(session_length) NOT BETWEEN floor(session_length) AND floor(session_length)-1
+              AND floor(session_length) like '%'
+              AND floor(session_length) not like '__DOES_NOT_EXIST__%'
+              AND floor(session_length) IN (floor(session_length)-1,
+                                                                 floor(session_length)+0,
+                                                                 floor(session_length)+1)
+              AND floor(session_length) NOT IN (floor(session_length)-1,
+                                                                     floor(session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A7: ln
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(ln(greatest(least(session_length, 100), 1))) IS NULL
+       OR (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))+0
+           AND floor(ln(greatest(least(session_length, 100), 1))) IS NOT DISTINCT
+           FROM floor(ln(greatest(least(session_length, 100), 1)))+0
+           AND floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1
+           AND (floor(ln(greatest(least(session_length, 100), 1))) IS DISTINCT
+                FROM floor(ln(greatest(least(session_length, 100), 1)))-1)
+           AND floor(ln(greatest(least(session_length, 100), 1))) > floor(ln(greatest(least(session_length, 100), 1)))-1
+           AND floor(ln(greatest(least(session_length, 100), 1))) >= floor(ln(greatest(least(session_length, 100), 1)))-1
+           AND floor(ln(greatest(least(session_length, 100), 1))) < floor(ln(greatest(least(session_length, 100), 1)))+1
+           AND floor(ln(greatest(least(session_length, 100), 1))) <= floor(ln(greatest(least(session_length, 100), 1)))+1
+           AND (floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1) IS TRUE
+           AND (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))-1) IS NOT TRUE
+           AND (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))-1) IS FALSE
+           AND (floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1) IS NOT FALSE
+           AND floor(ln(greatest(least(session_length, 100), 1))) BETWEEN floor(ln(greatest(least(session_length, 100), 1)))-1 AND floor(ln(greatest(least(session_length, 100), 1)))+1
+           AND floor(ln(greatest(least(session_length, 100), 1))) NOT BETWEEN floor(ln(greatest(least(session_length, 100), 1))) AND floor(ln(greatest(least(session_length, 100), 1)))-1
+           AND floor(ln(greatest(least(session_length, 100), 1))) like '%'
+           AND floor(ln(greatest(least(session_length, 100), 1))) not like '__DOES_NOT_EXIST__%'
+           AND floor(ln(greatest(least(session_length, 100), 1))) IN (floor(ln(greatest(least(session_length, 100), 1)))-1,
+                                                                                                                        floor(ln(greatest(least(session_length, 100), 1)))+0,
+                                                                                                                        floor(ln(greatest(least(session_length, 100), 1)))+1)
+           AND floor(ln(greatest(least(session_length, 100), 1))) NOT IN (floor(ln(greatest(least(session_length, 100), 1)))-1,
+                                                                                                                            floor(ln(greatest(least(session_length, 100), 1)))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(ln(greatest(least(session_length, 100), 1))) IS NULL
+       OR floor(ln(greatest(least(session_length, 100), 1))) IN
+         (SELECT floor(ln(greatest(least(session_length, 100), 1)))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(ln(greatest(least(session_length, 100), 1))) IS NULL
+                 OR (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))+0
+                     AND floor(ln(greatest(least(session_length, 100), 1))) IS NOT DISTINCT
+                     FROM floor(ln(greatest(least(session_length, 100), 1)))+0
+                     AND floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1
+                     AND (floor(ln(greatest(least(session_length, 100), 1))) IS DISTINCT
+                          FROM floor(ln(greatest(least(session_length, 100), 1)))-1)
+                     AND floor(ln(greatest(least(session_length, 100), 1))) > floor(ln(greatest(least(session_length, 100), 1)))-1
+                     AND floor(ln(greatest(least(session_length, 100), 1))) >= floor(ln(greatest(least(session_length, 100), 1)))-1
+                     AND floor(ln(greatest(least(session_length, 100), 1))) < floor(ln(greatest(least(session_length, 100), 1)))+1
+                     AND floor(ln(greatest(least(session_length, 100), 1))) <= floor(ln(greatest(least(session_length, 100), 1)))+1
+                     AND (floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1) IS TRUE
+                     AND (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))-1) IS NOT TRUE
+                     AND (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))-1) IS FALSE
+                     AND (floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1) IS NOT FALSE
+                     AND floor(ln(greatest(least(session_length, 100), 1))) BETWEEN floor(ln(greatest(least(session_length, 100), 1)))-1 AND floor(ln(greatest(least(session_length, 100), 1)))+1
+                     AND floor(ln(greatest(least(session_length, 100), 1))) NOT BETWEEN floor(ln(greatest(least(session_length, 100), 1))) AND floor(ln(greatest(least(session_length, 100), 1)))-1
+                     AND floor(ln(greatest(least(session_length, 100), 1))) like '%'
+                     AND floor(ln(greatest(least(session_length, 100), 1))) not like '__DOES_NOT_EXIST__%'
+                     AND floor(ln(greatest(least(session_length, 100), 1))) IN (floor(ln(greatest(least(session_length, 100), 1)))-1,
+                                                                                                                                  floor(ln(greatest(least(session_length, 100), 1)))+0,
+                                                                                                                                  floor(ln(greatest(least(session_length, 100), 1)))+1)
+                     AND floor(ln(greatest(least(session_length, 100), 1))) NOT IN (floor(ln(greatest(least(session_length, 100), 1)))-1,
+                                                                                                                                      floor(ln(greatest(least(session_length, 100), 1)))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(ln(greatest(least(session_length, 100), 1))),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(ln(greatest(least(session_length, 100), 1))) IS NULL
+          OR (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))+0
+              AND floor(ln(greatest(least(session_length, 100), 1))) IS NOT DISTINCT
+              FROM floor(ln(greatest(least(session_length, 100), 1)))+0
+              AND floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1
+              AND (floor(ln(greatest(least(session_length, 100), 1))) IS DISTINCT
+                   FROM floor(ln(greatest(least(session_length, 100), 1)))-1)
+              AND floor(ln(greatest(least(session_length, 100), 1))) > floor(ln(greatest(least(session_length, 100), 1)))-1
+              AND floor(ln(greatest(least(session_length, 100), 1))) >= floor(ln(greatest(least(session_length, 100), 1)))-1
+              AND floor(ln(greatest(least(session_length, 100), 1))) < floor(ln(greatest(least(session_length, 100), 1)))+1
+              AND floor(ln(greatest(least(session_length, 100), 1))) <= floor(ln(greatest(least(session_length, 100), 1)))+1
+              AND (floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1) IS TRUE
+              AND (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))-1) IS NOT TRUE
+              AND (floor(ln(greatest(least(session_length, 100), 1))) = floor(ln(greatest(least(session_length, 100), 1)))-1) IS FALSE
+              AND (floor(ln(greatest(least(session_length, 100), 1))) <> floor(ln(greatest(least(session_length, 100), 1)))-1) IS NOT FALSE
+              AND floor(ln(greatest(least(session_length, 100), 1))) BETWEEN floor(ln(greatest(least(session_length, 100), 1)))-1 AND floor(ln(greatest(least(session_length, 100), 1)))+1
+              AND floor(ln(greatest(least(session_length, 100), 1))) NOT BETWEEN floor(ln(greatest(least(session_length, 100), 1))) AND floor(ln(greatest(least(session_length, 100), 1)))-1
+              AND floor(ln(greatest(least(session_length, 100), 1))) like '%'
+              AND floor(ln(greatest(least(session_length, 100), 1))) not like '__DOES_NOT_EXIST__%'
+              AND floor(ln(greatest(least(session_length, 100), 1))) IN (floor(ln(greatest(least(session_length, 100), 1)))-1,
+                                                                                                                           floor(ln(greatest(least(session_length, 100), 1)))+0,
+                                                                                                                           floor(ln(greatest(least(session_length, 100), 1)))+1)
+              AND floor(ln(greatest(least(session_length, 100), 1))) NOT IN (floor(ln(greatest(least(session_length, 100), 1)))-1,
+                                                                                                                               floor(ln(greatest(least(session_length, 100), 1)))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A8: log10
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(log10(greatest(session_length, 1))) IS NULL
+       OR (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))+0
+           AND floor(log10(greatest(session_length, 1))) IS NOT DISTINCT
+           FROM floor(log10(greatest(session_length, 1)))+0
+           AND floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1
+           AND (floor(log10(greatest(session_length, 1))) IS DISTINCT
+                FROM floor(log10(greatest(session_length, 1)))-1)
+           AND floor(log10(greatest(session_length, 1))) > floor(log10(greatest(session_length, 1)))-1
+           AND floor(log10(greatest(session_length, 1))) >= floor(log10(greatest(session_length, 1)))-1
+           AND floor(log10(greatest(session_length, 1))) < floor(log10(greatest(session_length, 1)))+1
+           AND floor(log10(greatest(session_length, 1))) <= floor(log10(greatest(session_length, 1)))+1
+           AND (floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1) IS TRUE
+           AND (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))-1) IS NOT TRUE
+           AND (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))-1) IS FALSE
+           AND (floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1) IS NOT FALSE
+           AND floor(log10(greatest(session_length, 1))) BETWEEN floor(log10(greatest(session_length, 1)))-1 AND floor(log10(greatest(session_length, 1)))+1
+           AND floor(log10(greatest(session_length, 1))) NOT BETWEEN floor(log10(greatest(session_length, 1))) AND floor(log10(greatest(session_length, 1)))-1
+           AND floor(log10(greatest(session_length, 1))) like '%'
+           AND floor(log10(greatest(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+           AND floor(log10(greatest(session_length, 1))) IN (floor(log10(greatest(session_length, 1)))-1,
+                                                                                                      floor(log10(greatest(session_length, 1)))+0,
+                                                                                                      floor(log10(greatest(session_length, 1)))+1)
+           AND floor(log10(greatest(session_length, 1))) NOT IN (floor(log10(greatest(session_length, 1)))-1,
+                                                                                                          floor(log10(greatest(session_length, 1)))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(log10(greatest(session_length, 1))) IS NULL
+       OR floor(log10(greatest(session_length, 1))) IN
+         (SELECT floor(log10(greatest(session_length, 1)))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(log10(greatest(session_length, 1))) IS NULL
+                 OR (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))+0
+                     AND floor(log10(greatest(session_length, 1))) IS NOT DISTINCT
+                     FROM floor(log10(greatest(session_length, 1)))+0
+                     AND floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1
+                     AND (floor(log10(greatest(session_length, 1))) IS DISTINCT
+                          FROM floor(log10(greatest(session_length, 1)))-1)
+                     AND floor(log10(greatest(session_length, 1))) > floor(log10(greatest(session_length, 1)))-1
+                     AND floor(log10(greatest(session_length, 1))) >= floor(log10(greatest(session_length, 1)))-1
+                     AND floor(log10(greatest(session_length, 1))) < floor(log10(greatest(session_length, 1)))+1
+                     AND floor(log10(greatest(session_length, 1))) <= floor(log10(greatest(session_length, 1)))+1
+                     AND (floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1) IS TRUE
+                     AND (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))-1) IS NOT TRUE
+                     AND (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))-1) IS FALSE
+                     AND (floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1) IS NOT FALSE
+                     AND floor(log10(greatest(session_length, 1))) BETWEEN floor(log10(greatest(session_length, 1)))-1 AND floor(log10(greatest(session_length, 1)))+1
+                     AND floor(log10(greatest(session_length, 1))) NOT BETWEEN floor(log10(greatest(session_length, 1))) AND floor(log10(greatest(session_length, 1)))-1
+                     AND floor(log10(greatest(session_length, 1))) like '%'
+                     AND floor(log10(greatest(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+                     AND floor(log10(greatest(session_length, 1))) IN (floor(log10(greatest(session_length, 1)))-1,
+                                                                                                                floor(log10(greatest(session_length, 1)))+0,
+                                                                                                                floor(log10(greatest(session_length, 1)))+1)
+                     AND floor(log10(greatest(session_length, 1))) NOT IN (floor(log10(greatest(session_length, 1)))-1,
+                                                                                                                    floor(log10(greatest(session_length, 1)))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(log10(greatest(session_length, 1))),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(log10(greatest(session_length, 1))) IS NULL
+          OR (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))+0
+              AND floor(log10(greatest(session_length, 1))) IS NOT DISTINCT
+              FROM floor(log10(greatest(session_length, 1)))+0
+              AND floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1
+              AND (floor(log10(greatest(session_length, 1))) IS DISTINCT
+                   FROM floor(log10(greatest(session_length, 1)))-1)
+              AND floor(log10(greatest(session_length, 1))) > floor(log10(greatest(session_length, 1)))-1
+              AND floor(log10(greatest(session_length, 1))) >= floor(log10(greatest(session_length, 1)))-1
+              AND floor(log10(greatest(session_length, 1))) < floor(log10(greatest(session_length, 1)))+1
+              AND floor(log10(greatest(session_length, 1))) <= floor(log10(greatest(session_length, 1)))+1
+              AND (floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1) IS TRUE
+              AND (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))-1) IS NOT TRUE
+              AND (floor(log10(greatest(session_length, 1))) = floor(log10(greatest(session_length, 1)))-1) IS FALSE
+              AND (floor(log10(greatest(session_length, 1))) <> floor(log10(greatest(session_length, 1)))-1) IS NOT FALSE
+              AND floor(log10(greatest(session_length, 1))) BETWEEN floor(log10(greatest(session_length, 1)))-1 AND floor(log10(greatest(session_length, 1)))+1
+              AND floor(log10(greatest(session_length, 1))) NOT BETWEEN floor(log10(greatest(session_length, 1))) AND floor(log10(greatest(session_length, 1)))-1
+              AND floor(log10(greatest(session_length, 1))) like '%'
+              AND floor(log10(greatest(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+              AND floor(log10(greatest(session_length, 1))) IN (floor(log10(greatest(session_length, 1)))-1,
+                                                                                                         floor(log10(greatest(session_length, 1)))+0,
+                                                                                                         floor(log10(greatest(session_length, 1)))+1)
+              AND floor(log10(greatest(session_length, 1))) NOT IN (floor(log10(greatest(session_length, 1)))-1,
+                                                                                                             floor(log10(greatest(session_length, 1)))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A9: power
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (power(session_length, 1) IS NULL
+       OR (power(session_length, 1) = power(session_length, 1)+0
+           AND power(session_length, 1) IS NOT DISTINCT
+           FROM power(session_length, 1)+0
+           AND power(session_length, 1) <> power(session_length, 1)-1
+           AND (power(session_length, 1) IS DISTINCT
+                FROM power(session_length, 1)-1)
+           AND power(session_length, 1) > power(session_length, 1)-1
+           AND power(session_length, 1) >= power(session_length, 1)-1
+           AND power(session_length, 1) < power(session_length, 1)+1
+           AND power(session_length, 1) <= power(session_length, 1)+1
+           AND (power(session_length, 1) <> power(session_length, 1)-1) IS TRUE
+           AND (power(session_length, 1) = power(session_length, 1)-1) IS NOT TRUE
+           AND (power(session_length, 1) = power(session_length, 1)-1) IS FALSE
+           AND (power(session_length, 1) <> power(session_length, 1)-1) IS NOT FALSE
+           AND power(session_length, 1) BETWEEN power(session_length, 1)-1 AND power(session_length, 1)+1
+           AND power(session_length, 1) NOT BETWEEN power(session_length, 1) AND power(session_length, 1)-1
+           AND power(session_length, 1) like '%'
+           AND power(session_length, 1) not like '__DOES_NOT_EXIST__%'
+           AND power(session_length, 1) IN (power(session_length, 1)-1,
+                                                                    power(session_length, 1)+0,
+                                                                    power(session_length, 1)+1)
+           AND power(session_length, 1) NOT IN (power(session_length, 1)-1,
+                                                                        power(session_length, 1)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (power(session_length, 1) IS NULL
+       OR power(session_length, 1) IN
+         (SELECT power(session_length, 1)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (power(session_length, 1) IS NULL
+                 OR (power(session_length, 1) = power(session_length, 1)+0
+                     AND power(session_length, 1) IS NOT DISTINCT
+                     FROM power(session_length, 1)+0
+                     AND power(session_length, 1) <> power(session_length, 1)-1
+                     AND (power(session_length, 1) IS DISTINCT
+                          FROM power(session_length, 1)-1)
+                     AND power(session_length, 1) > power(session_length, 1)-1
+                     AND power(session_length, 1) >= power(session_length, 1)-1
+                     AND power(session_length, 1) < power(session_length, 1)+1
+                     AND power(session_length, 1) <= power(session_length, 1)+1
+                     AND (power(session_length, 1) <> power(session_length, 1)-1) IS TRUE
+                     AND (power(session_length, 1) = power(session_length, 1)-1) IS NOT TRUE
+                     AND (power(session_length, 1) = power(session_length, 1)-1) IS FALSE
+                     AND (power(session_length, 1) <> power(session_length, 1)-1) IS NOT FALSE
+                     AND power(session_length, 1) BETWEEN power(session_length, 1)-1 AND power(session_length, 1)+1
+                     AND power(session_length, 1) NOT BETWEEN power(session_length, 1) AND power(session_length, 1)-1
+                     AND power(session_length, 1) like '%'
+                     AND power(session_length, 1) not like '__DOES_NOT_EXIST__%'
+                     AND power(session_length, 1) IN (power(session_length, 1)-1,
+                                                                              power(session_length, 1)+0,
+                                                                              power(session_length, 1)+1)
+                     AND power(session_length, 1) NOT IN (power(session_length, 1)-1,
+                                                                                  power(session_length, 1)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          power(session_length, 1),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (power(session_length, 1) IS NULL
+          OR (power(session_length, 1) = power(session_length, 1)+0
+              AND power(session_length, 1) IS NOT DISTINCT
+              FROM power(session_length, 1)+0
+              AND power(session_length, 1) <> power(session_length, 1)-1
+              AND (power(session_length, 1) IS DISTINCT
+                   FROM power(session_length, 1)-1)
+              AND power(session_length, 1) > power(session_length, 1)-1
+              AND power(session_length, 1) >= power(session_length, 1)-1
+              AND power(session_length, 1) < power(session_length, 1)+1
+              AND power(session_length, 1) <= power(session_length, 1)+1
+              AND (power(session_length, 1) <> power(session_length, 1)-1) IS TRUE
+              AND (power(session_length, 1) = power(session_length, 1)-1) IS NOT TRUE
+              AND (power(session_length, 1) = power(session_length, 1)-1) IS FALSE
+              AND (power(session_length, 1) <> power(session_length, 1)-1) IS NOT FALSE
+              AND power(session_length, 1) BETWEEN power(session_length, 1)-1 AND power(session_length, 1)+1
+              AND power(session_length, 1) NOT BETWEEN power(session_length, 1) AND power(session_length, 1)-1
+              AND power(session_length, 1) like '%'
+              AND power(session_length, 1) not like '__DOES_NOT_EXIST__%'
+              AND power(session_length, 1) IN (power(session_length, 1)-1,
+                                                                       power(session_length, 1)+0,
+                                                                       power(session_length, 1)+1)
+              AND power(session_length, 1) NOT IN (power(session_length, 1)-1,
+                                                                           power(session_length, 1)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A10: sqrt
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(sqrt(session_length)) IS NULL
+       OR (floor(sqrt(session_length)) = floor(sqrt(session_length))+0
+           AND floor(sqrt(session_length)) IS NOT DISTINCT
+           FROM floor(sqrt(session_length))+0
+           AND floor(sqrt(session_length)) <> floor(sqrt(session_length))-1
+           AND (floor(sqrt(session_length)) IS DISTINCT
+                FROM floor(sqrt(session_length))-1)
+           AND floor(sqrt(session_length)) > floor(sqrt(session_length))-1
+           AND floor(sqrt(session_length)) >= floor(sqrt(session_length))-1
+           AND floor(sqrt(session_length)) < floor(sqrt(session_length))+1
+           AND floor(sqrt(session_length)) <= floor(sqrt(session_length))+1
+           AND (floor(sqrt(session_length)) <> floor(sqrt(session_length))-1) IS TRUE
+           AND (floor(sqrt(session_length)) = floor(sqrt(session_length))-1) IS NOT TRUE
+           AND (floor(sqrt(session_length)) = floor(sqrt(session_length))-1) IS FALSE
+           AND (floor(sqrt(session_length)) <> floor(sqrt(session_length))-1) IS NOT FALSE
+           AND floor(sqrt(session_length)) BETWEEN floor(sqrt(session_length))-1 AND floor(sqrt(session_length))+1
+           AND floor(sqrt(session_length)) NOT BETWEEN floor(sqrt(session_length)) AND floor(sqrt(session_length))-1
+           AND floor(sqrt(session_length)) like '%'
+           AND floor(sqrt(session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(sqrt(session_length)) IN (floor(sqrt(session_length))-1,
+                                                                          floor(sqrt(session_length))+0,
+                                                                          floor(sqrt(session_length))+1)
+           AND floor(sqrt(session_length)) NOT IN (floor(sqrt(session_length))-1,
+                                                                              floor(sqrt(session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(sqrt(session_length)) IS NULL
+       OR floor(sqrt(session_length)) IN
+         (SELECT floor(sqrt(session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(sqrt(session_length)) IS NULL
+                 OR (floor(sqrt(session_length)) = floor(sqrt(session_length))+0
+                     AND floor(sqrt(session_length)) IS NOT DISTINCT
+                     FROM floor(sqrt(session_length))+0
+                     AND floor(sqrt(session_length)) <> floor(sqrt(session_length))-1
+                     AND (floor(sqrt(session_length)) IS DISTINCT
+                          FROM floor(sqrt(session_length))-1)
+                     AND floor(sqrt(session_length)) > floor(sqrt(session_length))-1
+                     AND floor(sqrt(session_length)) >= floor(sqrt(session_length))-1
+                     AND floor(sqrt(session_length)) < floor(sqrt(session_length))+1
+                     AND floor(sqrt(session_length)) <= floor(sqrt(session_length))+1
+                     AND (floor(sqrt(session_length)) <> floor(sqrt(session_length))-1) IS TRUE
+                     AND (floor(sqrt(session_length)) = floor(sqrt(session_length))-1) IS NOT TRUE
+                     AND (floor(sqrt(session_length)) = floor(sqrt(session_length))-1) IS FALSE
+                     AND (floor(sqrt(session_length)) <> floor(sqrt(session_length))-1) IS NOT FALSE
+                     AND floor(sqrt(session_length)) BETWEEN floor(sqrt(session_length))-1 AND floor(sqrt(session_length))+1
+                     AND floor(sqrt(session_length)) NOT BETWEEN floor(sqrt(session_length)) AND floor(sqrt(session_length))-1
+                     AND floor(sqrt(session_length)) like '%'
+                     AND floor(sqrt(session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(sqrt(session_length)) IN (floor(sqrt(session_length))-1,
+                                                                                    floor(sqrt(session_length))+0,
+                                                                                    floor(sqrt(session_length))+1)
+                     AND floor(sqrt(session_length)) NOT IN (floor(sqrt(session_length))-1,
+                                                                                        floor(sqrt(session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(sqrt(session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(sqrt(session_length)) IS NULL
+          OR (floor(sqrt(session_length)) = floor(sqrt(session_length))+0
+              AND floor(sqrt(session_length)) IS NOT DISTINCT
+              FROM floor(sqrt(session_length))+0
+              AND floor(sqrt(session_length)) <> floor(sqrt(session_length))-1
+              AND (floor(sqrt(session_length)) IS DISTINCT
+                   FROM floor(sqrt(session_length))-1)
+              AND floor(sqrt(session_length)) > floor(sqrt(session_length))-1
+              AND floor(sqrt(session_length)) >= floor(sqrt(session_length))-1
+              AND floor(sqrt(session_length)) < floor(sqrt(session_length))+1
+              AND floor(sqrt(session_length)) <= floor(sqrt(session_length))+1
+              AND (floor(sqrt(session_length)) <> floor(sqrt(session_length))-1) IS TRUE
+              AND (floor(sqrt(session_length)) = floor(sqrt(session_length))-1) IS NOT TRUE
+              AND (floor(sqrt(session_length)) = floor(sqrt(session_length))-1) IS FALSE
+              AND (floor(sqrt(session_length)) <> floor(sqrt(session_length))-1) IS NOT FALSE
+              AND floor(sqrt(session_length)) BETWEEN floor(sqrt(session_length))-1 AND floor(sqrt(session_length))+1
+              AND floor(sqrt(session_length)) NOT BETWEEN floor(sqrt(session_length)) AND floor(sqrt(session_length))-1
+              AND floor(sqrt(session_length)) like '%'
+              AND floor(sqrt(session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(sqrt(session_length)) IN (floor(sqrt(session_length))-1,
+                                                                             floor(sqrt(session_length))+0,
+                                                                             floor(sqrt(session_length))+1)
+              AND floor(sqrt(session_length)) NOT IN (floor(sqrt(session_length))-1,
+                                                                                 floor(sqrt(session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A11: truncate
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(truncate(session_length, -1)) IS NULL
+       OR (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))+0
+           AND floor(truncate(session_length, -1)) IS NOT DISTINCT
+           FROM floor(truncate(session_length, -1))+0
+           AND floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1
+           AND (floor(truncate(session_length, -1)) IS DISTINCT
+                FROM floor(truncate(session_length, -1))-1)
+           AND floor(truncate(session_length, -1)) > floor(truncate(session_length, -1))-1
+           AND floor(truncate(session_length, -1)) >= floor(truncate(session_length, -1))-1
+           AND floor(truncate(session_length, -1)) < floor(truncate(session_length, -1))+1
+           AND floor(truncate(session_length, -1)) <= floor(truncate(session_length, -1))+1
+           AND (floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1) IS TRUE
+           AND (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))-1) IS NOT TRUE
+           AND (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))-1) IS FALSE
+           AND (floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1) IS NOT FALSE
+           AND floor(truncate(session_length, -1)) BETWEEN floor(truncate(session_length, -1))-1 AND floor(truncate(session_length, -1))+1
+           AND floor(truncate(session_length, -1)) NOT BETWEEN floor(truncate(session_length, -1)) AND floor(truncate(session_length, -1))-1
+           AND floor(truncate(session_length, -1)) like '%'
+           AND floor(truncate(session_length, -1)) not like '__DOES_NOT_EXIST__%'
+           AND floor(truncate(session_length, -1)) IN (floor(truncate(session_length, -1))-1,
+                                                                                          floor(truncate(session_length, -1))+0,
+                                                                                          floor(truncate(session_length, -1))+1)
+           AND floor(truncate(session_length, -1)) NOT IN (floor(truncate(session_length, -1))-1,
+                                                                                              floor(truncate(session_length, -1))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(truncate(session_length, -1)) IS NULL
+       OR floor(truncate(session_length, -1)) IN
+         (SELECT floor(truncate(session_length, -1))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(truncate(session_length, -1)) IS NULL
+                 OR (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))+0
+                     AND floor(truncate(session_length, -1)) IS NOT DISTINCT
+                     FROM floor(truncate(session_length, -1))+0
+                     AND floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1
+                     AND (floor(truncate(session_length, -1)) IS DISTINCT
+                          FROM floor(truncate(session_length, -1))-1)
+                     AND floor(truncate(session_length, -1)) > floor(truncate(session_length, -1))-1
+                     AND floor(truncate(session_length, -1)) >= floor(truncate(session_length, -1))-1
+                     AND floor(truncate(session_length, -1)) < floor(truncate(session_length, -1))+1
+                     AND floor(truncate(session_length, -1)) <= floor(truncate(session_length, -1))+1
+                     AND (floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1) IS TRUE
+                     AND (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))-1) IS NOT TRUE
+                     AND (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))-1) IS FALSE
+                     AND (floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1) IS NOT FALSE
+                     AND floor(truncate(session_length, -1)) BETWEEN floor(truncate(session_length, -1))-1 AND floor(truncate(session_length, -1))+1
+                     AND floor(truncate(session_length, -1)) NOT BETWEEN floor(truncate(session_length, -1)) AND floor(truncate(session_length, -1))-1
+                     AND floor(truncate(session_length, -1)) like '%'
+                     AND floor(truncate(session_length, -1)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(truncate(session_length, -1)) IN (floor(truncate(session_length, -1))-1,
+                                                                                                    floor(truncate(session_length, -1))+0,
+                                                                                                    floor(truncate(session_length, -1))+1)
+                     AND floor(truncate(session_length, -1)) NOT IN (floor(truncate(session_length, -1))-1,
+                                                                                                        floor(truncate(session_length, -1))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(truncate(session_length, -1)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(truncate(session_length, -1)) IS NULL
+          OR (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))+0
+              AND floor(truncate(session_length, -1)) IS NOT DISTINCT
+              FROM floor(truncate(session_length, -1))+0
+              AND floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1
+              AND (floor(truncate(session_length, -1)) IS DISTINCT
+                   FROM floor(truncate(session_length, -1))-1)
+              AND floor(truncate(session_length, -1)) > floor(truncate(session_length, -1))-1
+              AND floor(truncate(session_length, -1)) >= floor(truncate(session_length, -1))-1
+              AND floor(truncate(session_length, -1)) < floor(truncate(session_length, -1))+1
+              AND floor(truncate(session_length, -1)) <= floor(truncate(session_length, -1))+1
+              AND (floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1) IS TRUE
+              AND (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))-1) IS NOT TRUE
+              AND (floor(truncate(session_length, -1)) = floor(truncate(session_length, -1))-1) IS FALSE
+              AND (floor(truncate(session_length, -1)) <> floor(truncate(session_length, -1))-1) IS NOT FALSE
+              AND floor(truncate(session_length, -1)) BETWEEN floor(truncate(session_length, -1))-1 AND floor(truncate(session_length, -1))+1
+              AND floor(truncate(session_length, -1)) NOT BETWEEN floor(truncate(session_length, -1)) AND floor(truncate(session_length, -1))-1
+              AND floor(truncate(session_length, -1)) like '%'
+              AND floor(truncate(session_length, -1)) not like '__DOES_NOT_EXIST__%'
+              AND floor(truncate(session_length, -1)) IN (floor(truncate(session_length, -1))-1,
+                                                                                             floor(truncate(session_length, -1))+0,
+                                                                                             floor(truncate(session_length, -1))+1)
+              AND floor(truncate(session_length, -1)) NOT IN (floor(truncate(session_length, -1))-1,
+                                                                                                 floor(truncate(session_length, -1))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A12: trunc
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(trunc(session_length, -1)) IS NULL
+       OR (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))+0
+           AND floor(trunc(session_length, -1)) IS NOT DISTINCT
+           FROM floor(trunc(session_length, -1))+0
+           AND floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1
+           AND (floor(trunc(session_length, -1)) IS DISTINCT
+                FROM floor(trunc(session_length, -1))-1)
+           AND floor(trunc(session_length, -1)) > floor(trunc(session_length, -1))-1
+           AND floor(trunc(session_length, -1)) >= floor(trunc(session_length, -1))-1
+           AND floor(trunc(session_length, -1)) < floor(trunc(session_length, -1))+1
+           AND floor(trunc(session_length, -1)) <= floor(trunc(session_length, -1))+1
+           AND (floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1) IS TRUE
+           AND (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))-1) IS NOT TRUE
+           AND (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))-1) IS FALSE
+           AND (floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1) IS NOT FALSE
+           AND floor(trunc(session_length, -1)) BETWEEN floor(trunc(session_length, -1))-1 AND floor(trunc(session_length, -1))+1
+           AND floor(trunc(session_length, -1)) NOT BETWEEN floor(trunc(session_length, -1)) AND floor(trunc(session_length, -1))-1
+           AND floor(trunc(session_length, -1)) like '%'
+           AND floor(trunc(session_length, -1)) not like '__DOES_NOT_EXIST__%'
+           AND floor(trunc(session_length, -1)) IN (floor(trunc(session_length, -1))-1,
+                                                                                    floor(trunc(session_length, -1))+0,
+                                                                                    floor(trunc(session_length, -1))+1)
+           AND floor(trunc(session_length, -1)) NOT IN (floor(trunc(session_length, -1))-1,
+                                                                                        floor(trunc(session_length, -1))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(trunc(session_length, -1)) IS NULL
+       OR floor(trunc(session_length, -1)) IN
+         (SELECT floor(trunc(session_length, -1))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(trunc(session_length, -1)) IS NULL
+                 OR (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))+0
+                     AND floor(trunc(session_length, -1)) IS NOT DISTINCT
+                     FROM floor(trunc(session_length, -1))+0
+                     AND floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1
+                     AND (floor(trunc(session_length, -1)) IS DISTINCT
+                          FROM floor(trunc(session_length, -1))-1)
+                     AND floor(trunc(session_length, -1)) > floor(trunc(session_length, -1))-1
+                     AND floor(trunc(session_length, -1)) >= floor(trunc(session_length, -1))-1
+                     AND floor(trunc(session_length, -1)) < floor(trunc(session_length, -1))+1
+                     AND floor(trunc(session_length, -1)) <= floor(trunc(session_length, -1))+1
+                     AND (floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1) IS TRUE
+                     AND (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))-1) IS NOT TRUE
+                     AND (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))-1) IS FALSE
+                     AND (floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1) IS NOT FALSE
+                     AND floor(trunc(session_length, -1)) BETWEEN floor(trunc(session_length, -1))-1 AND floor(trunc(session_length, -1))+1
+                     AND floor(trunc(session_length, -1)) NOT BETWEEN floor(trunc(session_length, -1)) AND floor(trunc(session_length, -1))-1
+                     AND floor(trunc(session_length, -1)) like '%'
+                     AND floor(trunc(session_length, -1)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(trunc(session_length, -1)) IN (floor(trunc(session_length, -1))-1,
+                                                                                              floor(trunc(session_length, -1))+0,
+                                                                                              floor(trunc(session_length, -1))+1)
+                     AND floor(trunc(session_length, -1)) NOT IN (floor(trunc(session_length, -1))-1,
+                                                                                                  floor(trunc(session_length, -1))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(trunc(session_length, -1)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(trunc(session_length, -1)) IS NULL
+          OR (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))+0
+              AND floor(trunc(session_length, -1)) IS NOT DISTINCT
+              FROM floor(trunc(session_length, -1))+0
+              AND floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1
+              AND (floor(trunc(session_length, -1)) IS DISTINCT
+                   FROM floor(trunc(session_length, -1))-1)
+              AND floor(trunc(session_length, -1)) > floor(trunc(session_length, -1))-1
+              AND floor(trunc(session_length, -1)) >= floor(trunc(session_length, -1))-1
+              AND floor(trunc(session_length, -1)) < floor(trunc(session_length, -1))+1
+              AND floor(trunc(session_length, -1)) <= floor(trunc(session_length, -1))+1
+              AND (floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1) IS TRUE
+              AND (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))-1) IS NOT TRUE
+              AND (floor(trunc(session_length, -1)) = floor(trunc(session_length, -1))-1) IS FALSE
+              AND (floor(trunc(session_length, -1)) <> floor(trunc(session_length, -1))-1) IS NOT FALSE
+              AND floor(trunc(session_length, -1)) BETWEEN floor(trunc(session_length, -1))-1 AND floor(trunc(session_length, -1))+1
+              AND floor(trunc(session_length, -1)) NOT BETWEEN floor(trunc(session_length, -1)) AND floor(trunc(session_length, -1))-1
+              AND floor(trunc(session_length, -1)) like '%'
+              AND floor(trunc(session_length, -1)) not like '__DOES_NOT_EXIST__%'
+              AND floor(trunc(session_length, -1)) IN (floor(trunc(session_length, -1))-1,
+                                                                                       floor(trunc(session_length, -1))+0,
+                                                                                       floor(trunc(session_length, -1))+1)
+              AND floor(trunc(session_length, -1)) NOT IN (floor(trunc(session_length, -1))-1,
+                                                                                           floor(trunc(session_length, -1))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A13: round
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (round(session_length, 2) IS NULL
+       OR (round(session_length, 2) = round(session_length, 2)+0
+           AND round(session_length, 2) IS NOT DISTINCT
+           FROM round(session_length, 2)+0
+           AND round(session_length, 2) <> round(session_length, 2)-1
+           AND (round(session_length, 2) IS DISTINCT
+                FROM round(session_length, 2)-1)
+           AND round(session_length, 2) > round(session_length, 2)-1
+           AND round(session_length, 2) >= round(session_length, 2)-1
+           AND round(session_length, 2) < round(session_length, 2)+1
+           AND round(session_length, 2) <= round(session_length, 2)+1
+           AND (round(session_length, 2) <> round(session_length, 2)-1) IS TRUE
+           AND (round(session_length, 2) = round(session_length, 2)-1) IS NOT TRUE
+           AND (round(session_length, 2) = round(session_length, 2)-1) IS FALSE
+           AND (round(session_length, 2) <> round(session_length, 2)-1) IS NOT FALSE
+           AND round(session_length, 2) BETWEEN round(session_length, 2)-1 AND round(session_length, 2)+1
+           AND round(session_length, 2) NOT BETWEEN round(session_length, 2) AND round(session_length, 2)-1
+           AND round(session_length, 2) like '%'
+           AND round(session_length, 2) not like '__DOES_NOT_EXIST__%'
+           AND round(session_length, 2) IN (round(session_length, 2)-1,
+                                                                    round(session_length, 2)+0,
+                                                                    round(session_length, 2)+1)
+           AND round(session_length, 2) NOT IN (round(session_length, 2)-1,
+                                                                        round(session_length, 2)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (round(session_length, 2) IS NULL
+       OR round(session_length, 2) IN
+         (SELECT round(session_length, 2)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (round(session_length, 2) IS NULL
+                 OR (round(session_length, 2) = round(session_length, 2)+0
+                     AND round(session_length, 2) IS NOT DISTINCT
+                     FROM round(session_length, 2)+0
+                     AND round(session_length, 2) <> round(session_length, 2)-1
+                     AND (round(session_length, 2) IS DISTINCT
+                          FROM round(session_length, 2)-1)
+                     AND round(session_length, 2) > round(session_length, 2)-1
+                     AND round(session_length, 2) >= round(session_length, 2)-1
+                     AND round(session_length, 2) < round(session_length, 2)+1
+                     AND round(session_length, 2) <= round(session_length, 2)+1
+                     AND (round(session_length, 2) <> round(session_length, 2)-1) IS TRUE
+                     AND (round(session_length, 2) = round(session_length, 2)-1) IS NOT TRUE
+                     AND (round(session_length, 2) = round(session_length, 2)-1) IS FALSE
+                     AND (round(session_length, 2) <> round(session_length, 2)-1) IS NOT FALSE
+                     AND round(session_length, 2) BETWEEN round(session_length, 2)-1 AND round(session_length, 2)+1
+                     AND round(session_length, 2) NOT BETWEEN round(session_length, 2) AND round(session_length, 2)-1
+                     AND round(session_length, 2) like '%'
+                     AND round(session_length, 2) not like '__DOES_NOT_EXIST__%'
+                     AND round(session_length, 2) IN (round(session_length, 2)-1,
+                                                                              round(session_length, 2)+0,
+                                                                              round(session_length, 2)+1)
+                     AND round(session_length, 2) NOT IN (round(session_length, 2)-1,
+                                                                                  round(session_length, 2)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          round(session_length, 2),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (round(session_length, 2) IS NULL
+          OR (round(session_length, 2) = round(session_length, 2)+0
+              AND round(session_length, 2) IS NOT DISTINCT
+              FROM round(session_length, 2)+0
+              AND round(session_length, 2) <> round(session_length, 2)-1
+              AND (round(session_length, 2) IS DISTINCT
+                   FROM round(session_length, 2)-1)
+              AND round(session_length, 2) > round(session_length, 2)-1
+              AND round(session_length, 2) >= round(session_length, 2)-1
+              AND round(session_length, 2) < round(session_length, 2)+1
+              AND round(session_length, 2) <= round(session_length, 2)+1
+              AND (round(session_length, 2) <> round(session_length, 2)-1) IS TRUE
+              AND (round(session_length, 2) = round(session_length, 2)-1) IS NOT TRUE
+              AND (round(session_length, 2) = round(session_length, 2)-1) IS FALSE
+              AND (round(session_length, 2) <> round(session_length, 2)-1) IS NOT FALSE
+              AND round(session_length, 2) BETWEEN round(session_length, 2)-1 AND round(session_length, 2)+1
+              AND round(session_length, 2) NOT BETWEEN round(session_length, 2) AND round(session_length, 2)-1
+              AND round(session_length, 2) like '%'
+              AND round(session_length, 2) not like '__DOES_NOT_EXIST__%'
+              AND round(session_length, 2) IN (round(session_length, 2)-1,
+                                                                       round(session_length, 2)+0,
+                                                                       round(session_length, 2)+1)
+              AND round(session_length, 2) NOT IN (round(session_length, 2)-1,
+                                                                           round(session_length, 2)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A14: mod
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (mod(session_length, 2) IS NULL
+       OR (mod(session_length, 2) = mod(session_length, 2)+0
+           AND mod(session_length, 2) IS NOT DISTINCT
+           FROM mod(session_length, 2)+0
+           AND mod(session_length, 2) <> mod(session_length, 2)-1
+           AND (mod(session_length, 2) IS DISTINCT
+                FROM mod(session_length, 2)-1)
+           AND mod(session_length, 2) > mod(session_length, 2)-1
+           AND mod(session_length, 2) >= mod(session_length, 2)-1
+           AND mod(session_length, 2) < mod(session_length, 2)+1
+           AND mod(session_length, 2) <= mod(session_length, 2)+1
+           AND (mod(session_length, 2) <> mod(session_length, 2)-1) IS TRUE
+           AND (mod(session_length, 2) = mod(session_length, 2)-1) IS NOT TRUE
+           AND (mod(session_length, 2) = mod(session_length, 2)-1) IS FALSE
+           AND (mod(session_length, 2) <> mod(session_length, 2)-1) IS NOT FALSE
+           AND mod(session_length, 2) BETWEEN mod(session_length, 2)-1 AND mod(session_length, 2)+1
+           AND mod(session_length, 2) NOT BETWEEN mod(session_length, 2) AND mod(session_length, 2)-1
+           AND mod(session_length, 2) like '%'
+           AND mod(session_length, 2) not like '__DOES_NOT_EXIST__%'
+           AND mod(session_length, 2) IN (mod(session_length, 2)-1,
+                                                                mod(session_length, 2)+0,
+                                                                mod(session_length, 2)+1)
+           AND mod(session_length, 2) NOT IN (mod(session_length, 2)-1,
+                                                                    mod(session_length, 2)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (mod(session_length, 2) IS NULL
+       OR mod(session_length, 2) IN
+         (SELECT mod(session_length, 2)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (mod(session_length, 2) IS NULL
+                 OR (mod(session_length, 2) = mod(session_length, 2)+0
+                     AND mod(session_length, 2) IS NOT DISTINCT
+                     FROM mod(session_length, 2)+0
+                     AND mod(session_length, 2) <> mod(session_length, 2)-1
+                     AND (mod(session_length, 2) IS DISTINCT
+                          FROM mod(session_length, 2)-1)
+                     AND mod(session_length, 2) > mod(session_length, 2)-1
+                     AND mod(session_length, 2) >= mod(session_length, 2)-1
+                     AND mod(session_length, 2) < mod(session_length, 2)+1
+                     AND mod(session_length, 2) <= mod(session_length, 2)+1
+                     AND (mod(session_length, 2) <> mod(session_length, 2)-1) IS TRUE
+                     AND (mod(session_length, 2) = mod(session_length, 2)-1) IS NOT TRUE
+                     AND (mod(session_length, 2) = mod(session_length, 2)-1) IS FALSE
+                     AND (mod(session_length, 2) <> mod(session_length, 2)-1) IS NOT FALSE
+                     AND mod(session_length, 2) BETWEEN mod(session_length, 2)-1 AND mod(session_length, 2)+1
+                     AND mod(session_length, 2) NOT BETWEEN mod(session_length, 2) AND mod(session_length, 2)-1
+                     AND mod(session_length, 2) like '%'
+                     AND mod(session_length, 2) not like '__DOES_NOT_EXIST__%'
+                     AND mod(session_length, 2) IN (mod(session_length, 2)-1,
+                                                                          mod(session_length, 2)+0,
+                                                                          mod(session_length, 2)+1)
+                     AND mod(session_length, 2) NOT IN (mod(session_length, 2)-1,
+                                                                              mod(session_length, 2)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          mod(session_length, 2),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (mod(session_length, 2) IS NULL
+          OR (mod(session_length, 2) = mod(session_length, 2)+0
+              AND mod(session_length, 2) IS NOT DISTINCT
+              FROM mod(session_length, 2)+0
+              AND mod(session_length, 2) <> mod(session_length, 2)-1
+              AND (mod(session_length, 2) IS DISTINCT
+                   FROM mod(session_length, 2)-1)
+              AND mod(session_length, 2) > mod(session_length, 2)-1
+              AND mod(session_length, 2) >= mod(session_length, 2)-1
+              AND mod(session_length, 2) < mod(session_length, 2)+1
+              AND mod(session_length, 2) <= mod(session_length, 2)+1
+              AND (mod(session_length, 2) <> mod(session_length, 2)-1) IS TRUE
+              AND (mod(session_length, 2) = mod(session_length, 2)-1) IS NOT TRUE
+              AND (mod(session_length, 2) = mod(session_length, 2)-1) IS FALSE
+              AND (mod(session_length, 2) <> mod(session_length, 2)-1) IS NOT FALSE
+              AND mod(session_length, 2) BETWEEN mod(session_length, 2)-1 AND mod(session_length, 2)+1
+              AND mod(session_length, 2) NOT BETWEEN mod(session_length, 2) AND mod(session_length, 2)-1
+              AND mod(session_length, 2) like '%'
+              AND mod(session_length, 2) not like '__DOES_NOT_EXIST__%'
+              AND mod(session_length, 2) IN (mod(session_length, 2)-1,
+                                                                   mod(session_length, 2)+0,
+                                                                   mod(session_length, 2)+1)
+              AND mod(session_length, 2) NOT IN (mod(session_length, 2)-1,
+                                                                       mod(session_length, 2)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A15: sin
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(sin(session_length)) IS NULL
+       OR (floor(sin(session_length)) = floor(sin(session_length))+0
+           AND floor(sin(session_length)) IS NOT DISTINCT
+           FROM floor(sin(session_length))+0
+           AND floor(sin(session_length)) <> floor(sin(session_length))-1
+           AND (floor(sin(session_length)) IS DISTINCT
+                FROM floor(sin(session_length))-1)
+           AND floor(sin(session_length)) > floor(sin(session_length))-1
+           AND floor(sin(session_length)) >= floor(sin(session_length))-1
+           AND floor(sin(session_length)) < floor(sin(session_length))+1
+           AND floor(sin(session_length)) <= floor(sin(session_length))+1
+           AND (floor(sin(session_length)) <> floor(sin(session_length))-1) IS TRUE
+           AND (floor(sin(session_length)) = floor(sin(session_length))-1) IS NOT TRUE
+           AND (floor(sin(session_length)) = floor(sin(session_length))-1) IS FALSE
+           AND (floor(sin(session_length)) <> floor(sin(session_length))-1) IS NOT FALSE
+           AND floor(sin(session_length)) BETWEEN floor(sin(session_length))-1 AND floor(sin(session_length))+1
+           AND floor(sin(session_length)) NOT BETWEEN floor(sin(session_length)) AND floor(sin(session_length))-1
+           AND floor(sin(session_length)) like '%'
+           AND floor(sin(session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(sin(session_length)) IN (floor(sin(session_length))-1,
+                                                                        floor(sin(session_length))+0,
+                                                                        floor(sin(session_length))+1)
+           AND floor(sin(session_length)) NOT IN (floor(sin(session_length))-1,
+                                                                            floor(sin(session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(sin(session_length)) IS NULL
+       OR floor(sin(session_length)) IN
+         (SELECT floor(sin(session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(sin(session_length)) IS NULL
+                 OR (floor(sin(session_length)) = floor(sin(session_length))+0
+                     AND floor(sin(session_length)) IS NOT DISTINCT
+                     FROM floor(sin(session_length))+0
+                     AND floor(sin(session_length)) <> floor(sin(session_length))-1
+                     AND (floor(sin(session_length)) IS DISTINCT
+                          FROM floor(sin(session_length))-1)
+                     AND floor(sin(session_length)) > floor(sin(session_length))-1
+                     AND floor(sin(session_length)) >= floor(sin(session_length))-1
+                     AND floor(sin(session_length)) < floor(sin(session_length))+1
+                     AND floor(sin(session_length)) <= floor(sin(session_length))+1
+                     AND (floor(sin(session_length)) <> floor(sin(session_length))-1) IS TRUE
+                     AND (floor(sin(session_length)) = floor(sin(session_length))-1) IS NOT TRUE
+                     AND (floor(sin(session_length)) = floor(sin(session_length))-1) IS FALSE
+                     AND (floor(sin(session_length)) <> floor(sin(session_length))-1) IS NOT FALSE
+                     AND floor(sin(session_length)) BETWEEN floor(sin(session_length))-1 AND floor(sin(session_length))+1
+                     AND floor(sin(session_length)) NOT BETWEEN floor(sin(session_length)) AND floor(sin(session_length))-1
+                     AND floor(sin(session_length)) like '%'
+                     AND floor(sin(session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(sin(session_length)) IN (floor(sin(session_length))-1,
+                                                                                  floor(sin(session_length))+0,
+                                                                                  floor(sin(session_length))+1)
+                     AND floor(sin(session_length)) NOT IN (floor(sin(session_length))-1,
+                                                                                      floor(sin(session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(sin(session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(sin(session_length)) IS NULL
+          OR (floor(sin(session_length)) = floor(sin(session_length))+0
+              AND floor(sin(session_length)) IS NOT DISTINCT
+              FROM floor(sin(session_length))+0
+              AND floor(sin(session_length)) <> floor(sin(session_length))-1
+              AND (floor(sin(session_length)) IS DISTINCT
+                   FROM floor(sin(session_length))-1)
+              AND floor(sin(session_length)) > floor(sin(session_length))-1
+              AND floor(sin(session_length)) >= floor(sin(session_length))-1
+              AND floor(sin(session_length)) < floor(sin(session_length))+1
+              AND floor(sin(session_length)) <= floor(sin(session_length))+1
+              AND (floor(sin(session_length)) <> floor(sin(session_length))-1) IS TRUE
+              AND (floor(sin(session_length)) = floor(sin(session_length))-1) IS NOT TRUE
+              AND (floor(sin(session_length)) = floor(sin(session_length))-1) IS FALSE
+              AND (floor(sin(session_length)) <> floor(sin(session_length))-1) IS NOT FALSE
+              AND floor(sin(session_length)) BETWEEN floor(sin(session_length))-1 AND floor(sin(session_length))+1
+              AND floor(sin(session_length)) NOT BETWEEN floor(sin(session_length)) AND floor(sin(session_length))-1
+              AND floor(sin(session_length)) like '%'
+              AND floor(sin(session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(sin(session_length)) IN (floor(sin(session_length))-1,
+                                                                           floor(sin(session_length))+0,
+                                                                           floor(sin(session_length))+1)
+              AND floor(sin(session_length)) NOT IN (floor(sin(session_length))-1,
+                                                                               floor(sin(session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A16: cos
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(cos(session_length)) IS NULL
+       OR (floor(cos(session_length)) = floor(cos(session_length))+0
+           AND floor(cos(session_length)) IS NOT DISTINCT
+           FROM floor(cos(session_length))+0
+           AND floor(cos(session_length)) <> floor(cos(session_length))-1
+           AND (floor(cos(session_length)) IS DISTINCT
+                FROM floor(cos(session_length))-1)
+           AND floor(cos(session_length)) > floor(cos(session_length))-1
+           AND floor(cos(session_length)) >= floor(cos(session_length))-1
+           AND floor(cos(session_length)) < floor(cos(session_length))+1
+           AND floor(cos(session_length)) <= floor(cos(session_length))+1
+           AND (floor(cos(session_length)) <> floor(cos(session_length))-1) IS TRUE
+           AND (floor(cos(session_length)) = floor(cos(session_length))-1) IS NOT TRUE
+           AND (floor(cos(session_length)) = floor(cos(session_length))-1) IS FALSE
+           AND (floor(cos(session_length)) <> floor(cos(session_length))-1) IS NOT FALSE
+           AND floor(cos(session_length)) BETWEEN floor(cos(session_length))-1 AND floor(cos(session_length))+1
+           AND floor(cos(session_length)) NOT BETWEEN floor(cos(session_length)) AND floor(cos(session_length))-1
+           AND floor(cos(session_length)) like '%'
+           AND floor(cos(session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(cos(session_length)) IN (floor(cos(session_length))-1,
+                                                                        floor(cos(session_length))+0,
+                                                                        floor(cos(session_length))+1)
+           AND floor(cos(session_length)) NOT IN (floor(cos(session_length))-1,
+                                                                            floor(cos(session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(cos(session_length)) IS NULL
+       OR floor(cos(session_length)) IN
+         (SELECT floor(cos(session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(cos(session_length)) IS NULL
+                 OR (floor(cos(session_length)) = floor(cos(session_length))+0
+                     AND floor(cos(session_length)) IS NOT DISTINCT
+                     FROM floor(cos(session_length))+0
+                     AND floor(cos(session_length)) <> floor(cos(session_length))-1
+                     AND (floor(cos(session_length)) IS DISTINCT
+                          FROM floor(cos(session_length))-1)
+                     AND floor(cos(session_length)) > floor(cos(session_length))-1
+                     AND floor(cos(session_length)) >= floor(cos(session_length))-1
+                     AND floor(cos(session_length)) < floor(cos(session_length))+1
+                     AND floor(cos(session_length)) <= floor(cos(session_length))+1
+                     AND (floor(cos(session_length)) <> floor(cos(session_length))-1) IS TRUE
+                     AND (floor(cos(session_length)) = floor(cos(session_length))-1) IS NOT TRUE
+                     AND (floor(cos(session_length)) = floor(cos(session_length))-1) IS FALSE
+                     AND (floor(cos(session_length)) <> floor(cos(session_length))-1) IS NOT FALSE
+                     AND floor(cos(session_length)) BETWEEN floor(cos(session_length))-1 AND floor(cos(session_length))+1
+                     AND floor(cos(session_length)) NOT BETWEEN floor(cos(session_length)) AND floor(cos(session_length))-1
+                     AND floor(cos(session_length)) like '%'
+                     AND floor(cos(session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(cos(session_length)) IN (floor(cos(session_length))-1,
+                                                                                  floor(cos(session_length))+0,
+                                                                                  floor(cos(session_length))+1)
+                     AND floor(cos(session_length)) NOT IN (floor(cos(session_length))-1,
+                                                                                      floor(cos(session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(cos(session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(cos(session_length)) IS NULL
+          OR (floor(cos(session_length)) = floor(cos(session_length))+0
+              AND floor(cos(session_length)) IS NOT DISTINCT
+              FROM floor(cos(session_length))+0
+              AND floor(cos(session_length)) <> floor(cos(session_length))-1
+              AND (floor(cos(session_length)) IS DISTINCT
+                   FROM floor(cos(session_length))-1)
+              AND floor(cos(session_length)) > floor(cos(session_length))-1
+              AND floor(cos(session_length)) >= floor(cos(session_length))-1
+              AND floor(cos(session_length)) < floor(cos(session_length))+1
+              AND floor(cos(session_length)) <= floor(cos(session_length))+1
+              AND (floor(cos(session_length)) <> floor(cos(session_length))-1) IS TRUE
+              AND (floor(cos(session_length)) = floor(cos(session_length))-1) IS NOT TRUE
+              AND (floor(cos(session_length)) = floor(cos(session_length))-1) IS FALSE
+              AND (floor(cos(session_length)) <> floor(cos(session_length))-1) IS NOT FALSE
+              AND floor(cos(session_length)) BETWEEN floor(cos(session_length))-1 AND floor(cos(session_length))+1
+              AND floor(cos(session_length)) NOT BETWEEN floor(cos(session_length)) AND floor(cos(session_length))-1
+              AND floor(cos(session_length)) like '%'
+              AND floor(cos(session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(cos(session_length)) IN (floor(cos(session_length))-1,
+                                                                           floor(cos(session_length))+0,
+                                                                           floor(cos(session_length))+1)
+              AND floor(cos(session_length)) NOT IN (floor(cos(session_length))-1,
+                                                                               floor(cos(session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A17: tan
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(tan(session_length)) IS NULL
+       OR (floor(tan(session_length)) = floor(tan(session_length))+0
+           AND floor(tan(session_length)) IS NOT DISTINCT
+           FROM floor(tan(session_length))+0
+           AND floor(tan(session_length)) <> floor(tan(session_length))-1
+           AND (floor(tan(session_length)) IS DISTINCT
+                FROM floor(tan(session_length))-1)
+           AND floor(tan(session_length)) > floor(tan(session_length))-1
+           AND floor(tan(session_length)) >= floor(tan(session_length))-1
+           AND floor(tan(session_length)) < floor(tan(session_length))+1
+           AND floor(tan(session_length)) <= floor(tan(session_length))+1
+           AND (floor(tan(session_length)) <> floor(tan(session_length))-1) IS TRUE
+           AND (floor(tan(session_length)) = floor(tan(session_length))-1) IS NOT TRUE
+           AND (floor(tan(session_length)) = floor(tan(session_length))-1) IS FALSE
+           AND (floor(tan(session_length)) <> floor(tan(session_length))-1) IS NOT FALSE
+           AND floor(tan(session_length)) BETWEEN floor(tan(session_length))-1 AND floor(tan(session_length))+1
+           AND floor(tan(session_length)) NOT BETWEEN floor(tan(session_length)) AND floor(tan(session_length))-1
+           AND floor(tan(session_length)) like '%'
+           AND floor(tan(session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(tan(session_length)) IN (floor(tan(session_length))-1,
+                                                                        floor(tan(session_length))+0,
+                                                                        floor(tan(session_length))+1)
+           AND floor(tan(session_length)) NOT IN (floor(tan(session_length))-1,
+                                                                            floor(tan(session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(tan(session_length)) IS NULL
+       OR floor(tan(session_length)) IN
+         (SELECT floor(tan(session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(tan(session_length)) IS NULL
+                 OR (floor(tan(session_length)) = floor(tan(session_length))+0
+                     AND floor(tan(session_length)) IS NOT DISTINCT
+                     FROM floor(tan(session_length))+0
+                     AND floor(tan(session_length)) <> floor(tan(session_length))-1
+                     AND (floor(tan(session_length)) IS DISTINCT
+                          FROM floor(tan(session_length))-1)
+                     AND floor(tan(session_length)) > floor(tan(session_length))-1
+                     AND floor(tan(session_length)) >= floor(tan(session_length))-1
+                     AND floor(tan(session_length)) < floor(tan(session_length))+1
+                     AND floor(tan(session_length)) <= floor(tan(session_length))+1
+                     AND (floor(tan(session_length)) <> floor(tan(session_length))-1) IS TRUE
+                     AND (floor(tan(session_length)) = floor(tan(session_length))-1) IS NOT TRUE
+                     AND (floor(tan(session_length)) = floor(tan(session_length))-1) IS FALSE
+                     AND (floor(tan(session_length)) <> floor(tan(session_length))-1) IS NOT FALSE
+                     AND floor(tan(session_length)) BETWEEN floor(tan(session_length))-1 AND floor(tan(session_length))+1
+                     AND floor(tan(session_length)) NOT BETWEEN floor(tan(session_length)) AND floor(tan(session_length))-1
+                     AND floor(tan(session_length)) like '%'
+                     AND floor(tan(session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(tan(session_length)) IN (floor(tan(session_length))-1,
+                                                                                  floor(tan(session_length))+0,
+                                                                                  floor(tan(session_length))+1)
+                     AND floor(tan(session_length)) NOT IN (floor(tan(session_length))-1,
+                                                                                      floor(tan(session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(tan(session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(tan(session_length)) IS NULL
+          OR (floor(tan(session_length)) = floor(tan(session_length))+0
+              AND floor(tan(session_length)) IS NOT DISTINCT
+              FROM floor(tan(session_length))+0
+              AND floor(tan(session_length)) <> floor(tan(session_length))-1
+              AND (floor(tan(session_length)) IS DISTINCT
+                   FROM floor(tan(session_length))-1)
+              AND floor(tan(session_length)) > floor(tan(session_length))-1
+              AND floor(tan(session_length)) >= floor(tan(session_length))-1
+              AND floor(tan(session_length)) < floor(tan(session_length))+1
+              AND floor(tan(session_length)) <= floor(tan(session_length))+1
+              AND (floor(tan(session_length)) <> floor(tan(session_length))-1) IS TRUE
+              AND (floor(tan(session_length)) = floor(tan(session_length))-1) IS NOT TRUE
+              AND (floor(tan(session_length)) = floor(tan(session_length))-1) IS FALSE
+              AND (floor(tan(session_length)) <> floor(tan(session_length))-1) IS NOT FALSE
+              AND floor(tan(session_length)) BETWEEN floor(tan(session_length))-1 AND floor(tan(session_length))+1
+              AND floor(tan(session_length)) NOT BETWEEN floor(tan(session_length)) AND floor(tan(session_length))-1
+              AND floor(tan(session_length)) like '%'
+              AND floor(tan(session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(tan(session_length)) IN (floor(tan(session_length))-1,
+                                                                           floor(tan(session_length))+0,
+                                                                           floor(tan(session_length))+1)
+              AND floor(tan(session_length)) NOT IN (floor(tan(session_length))-1,
+                                                                               floor(tan(session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A18: cot
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(cot(greatest(session_length, 1))) IS NULL
+       OR (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))+0
+           AND floor(cot(greatest(session_length, 1))) IS NOT DISTINCT
+           FROM floor(cot(greatest(session_length, 1)))+0
+           AND floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1
+           AND (floor(cot(greatest(session_length, 1))) IS DISTINCT
+                FROM floor(cot(greatest(session_length, 1)))-1)
+           AND floor(cot(greatest(session_length, 1))) > floor(cot(greatest(session_length, 1)))-1
+           AND floor(cot(greatest(session_length, 1))) >= floor(cot(greatest(session_length, 1)))-1
+           AND floor(cot(greatest(session_length, 1))) < floor(cot(greatest(session_length, 1)))+1
+           AND floor(cot(greatest(session_length, 1))) <= floor(cot(greatest(session_length, 1)))+1
+           AND (floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1) IS TRUE
+           AND (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))-1) IS NOT TRUE
+           AND (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))-1) IS FALSE
+           AND (floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1) IS NOT FALSE
+           AND floor(cot(greatest(session_length, 1))) BETWEEN floor(cot(greatest(session_length, 1)))-1 AND floor(cot(greatest(session_length, 1)))+1
+           AND floor(cot(greatest(session_length, 1))) NOT BETWEEN floor(cot(greatest(session_length, 1))) AND floor(cot(greatest(session_length, 1)))-1
+           AND floor(cot(greatest(session_length, 1))) like '%'
+           AND floor(cot(greatest(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+           AND floor(cot(greatest(session_length, 1))) IN (floor(cot(greatest(session_length, 1)))-1,
+                                                                                                  floor(cot(greatest(session_length, 1)))+0,
+                                                                                                  floor(cot(greatest(session_length, 1)))+1)
+           AND floor(cot(greatest(session_length, 1))) NOT IN (floor(cot(greatest(session_length, 1)))-1,
+                                                                                                      floor(cot(greatest(session_length, 1)))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(cot(greatest(session_length, 1))) IS NULL
+       OR floor(cot(greatest(session_length, 1))) IN
+         (SELECT floor(cot(greatest(session_length, 1)))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(cot(greatest(session_length, 1))) IS NULL
+                 OR (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))+0
+                     AND floor(cot(greatest(session_length, 1))) IS NOT DISTINCT
+                     FROM floor(cot(greatest(session_length, 1)))+0
+                     AND floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1
+                     AND (floor(cot(greatest(session_length, 1))) IS DISTINCT
+                          FROM floor(cot(greatest(session_length, 1)))-1)
+                     AND floor(cot(greatest(session_length, 1))) > floor(cot(greatest(session_length, 1)))-1
+                     AND floor(cot(greatest(session_length, 1))) >= floor(cot(greatest(session_length, 1)))-1
+                     AND floor(cot(greatest(session_length, 1))) < floor(cot(greatest(session_length, 1)))+1
+                     AND floor(cot(greatest(session_length, 1))) <= floor(cot(greatest(session_length, 1)))+1
+                     AND (floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1) IS TRUE
+                     AND (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))-1) IS NOT TRUE
+                     AND (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))-1) IS FALSE
+                     AND (floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1) IS NOT FALSE
+                     AND floor(cot(greatest(session_length, 1))) BETWEEN floor(cot(greatest(session_length, 1)))-1 AND floor(cot(greatest(session_length, 1)))+1
+                     AND floor(cot(greatest(session_length, 1))) NOT BETWEEN floor(cot(greatest(session_length, 1))) AND floor(cot(greatest(session_length, 1)))-1
+                     AND floor(cot(greatest(session_length, 1))) like '%'
+                     AND floor(cot(greatest(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+                     AND floor(cot(greatest(session_length, 1))) IN (floor(cot(greatest(session_length, 1)))-1,
+                                                                                                            floor(cot(greatest(session_length, 1)))+0,
+                                                                                                            floor(cot(greatest(session_length, 1)))+1)
+                     AND floor(cot(greatest(session_length, 1))) NOT IN (floor(cot(greatest(session_length, 1)))-1,
+                                                                                                                floor(cot(greatest(session_length, 1)))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(cot(greatest(session_length, 1))),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(cot(greatest(session_length, 1))) IS NULL
+          OR (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))+0
+              AND floor(cot(greatest(session_length, 1))) IS NOT DISTINCT
+              FROM floor(cot(greatest(session_length, 1)))+0
+              AND floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1
+              AND (floor(cot(greatest(session_length, 1))) IS DISTINCT
+                   FROM floor(cot(greatest(session_length, 1)))-1)
+              AND floor(cot(greatest(session_length, 1))) > floor(cot(greatest(session_length, 1)))-1
+              AND floor(cot(greatest(session_length, 1))) >= floor(cot(greatest(session_length, 1)))-1
+              AND floor(cot(greatest(session_length, 1))) < floor(cot(greatest(session_length, 1)))+1
+              AND floor(cot(greatest(session_length, 1))) <= floor(cot(greatest(session_length, 1)))+1
+              AND (floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1) IS TRUE
+              AND (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))-1) IS NOT TRUE
+              AND (floor(cot(greatest(session_length, 1))) = floor(cot(greatest(session_length, 1)))-1) IS FALSE
+              AND (floor(cot(greatest(session_length, 1))) <> floor(cot(greatest(session_length, 1)))-1) IS NOT FALSE
+              AND floor(cot(greatest(session_length, 1))) BETWEEN floor(cot(greatest(session_length, 1)))-1 AND floor(cot(greatest(session_length, 1)))+1
+              AND floor(cot(greatest(session_length, 1))) NOT BETWEEN floor(cot(greatest(session_length, 1))) AND floor(cot(greatest(session_length, 1)))-1
+              AND floor(cot(greatest(session_length, 1))) like '%'
+              AND floor(cot(greatest(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+              AND floor(cot(greatest(session_length, 1))) IN (floor(cot(greatest(session_length, 1)))-1,
+                                                                                                     floor(cot(greatest(session_length, 1)))+0,
+                                                                                                     floor(cot(greatest(session_length, 1)))+1)
+              AND floor(cot(greatest(session_length, 1))) NOT IN (floor(cot(greatest(session_length, 1)))-1,
+                                                                                                         floor(cot(greatest(session_length, 1)))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A19: asin
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(asin(least(session_length, 1))) IS NULL
+       OR (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))+0
+           AND floor(asin(least(session_length, 1))) IS NOT DISTINCT
+           FROM floor(asin(least(session_length, 1)))+0
+           AND floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1
+           AND (floor(asin(least(session_length, 1))) IS DISTINCT
+                FROM floor(asin(least(session_length, 1)))-1)
+           AND floor(asin(least(session_length, 1))) > floor(asin(least(session_length, 1)))-1
+           AND floor(asin(least(session_length, 1))) >= floor(asin(least(session_length, 1)))-1
+           AND floor(asin(least(session_length, 1))) < floor(asin(least(session_length, 1)))+1
+           AND floor(asin(least(session_length, 1))) <= floor(asin(least(session_length, 1)))+1
+           AND (floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1) IS TRUE
+           AND (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))-1) IS NOT TRUE
+           AND (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))-1) IS FALSE
+           AND (floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1) IS NOT FALSE
+           AND floor(asin(least(session_length, 1))) BETWEEN floor(asin(least(session_length, 1)))-1 AND floor(asin(least(session_length, 1)))+1
+           AND floor(asin(least(session_length, 1))) NOT BETWEEN floor(asin(least(session_length, 1))) AND floor(asin(least(session_length, 1)))-1
+           AND floor(asin(least(session_length, 1))) like '%'
+           AND floor(asin(least(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+           AND floor(asin(least(session_length, 1))) IN (floor(asin(least(session_length, 1)))-1,
+                                                                                              floor(asin(least(session_length, 1)))+0,
+                                                                                              floor(asin(least(session_length, 1)))+1)
+           AND floor(asin(least(session_length, 1))) NOT IN (floor(asin(least(session_length, 1)))-1,
+                                                                                                  floor(asin(least(session_length, 1)))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(asin(least(session_length, 1))) IS NULL
+       OR floor(asin(least(session_length, 1))) IN
+         (SELECT floor(asin(least(session_length, 1)))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(asin(least(session_length, 1))) IS NULL
+                 OR (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))+0
+                     AND floor(asin(least(session_length, 1))) IS NOT DISTINCT
+                     FROM floor(asin(least(session_length, 1)))+0
+                     AND floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1
+                     AND (floor(asin(least(session_length, 1))) IS DISTINCT
+                          FROM floor(asin(least(session_length, 1)))-1)
+                     AND floor(asin(least(session_length, 1))) > floor(asin(least(session_length, 1)))-1
+                     AND floor(asin(least(session_length, 1))) >= floor(asin(least(session_length, 1)))-1
+                     AND floor(asin(least(session_length, 1))) < floor(asin(least(session_length, 1)))+1
+                     AND floor(asin(least(session_length, 1))) <= floor(asin(least(session_length, 1)))+1
+                     AND (floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1) IS TRUE
+                     AND (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))-1) IS NOT TRUE
+                     AND (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))-1) IS FALSE
+                     AND (floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1) IS NOT FALSE
+                     AND floor(asin(least(session_length, 1))) BETWEEN floor(asin(least(session_length, 1)))-1 AND floor(asin(least(session_length, 1)))+1
+                     AND floor(asin(least(session_length, 1))) NOT BETWEEN floor(asin(least(session_length, 1))) AND floor(asin(least(session_length, 1)))-1
+                     AND floor(asin(least(session_length, 1))) like '%'
+                     AND floor(asin(least(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+                     AND floor(asin(least(session_length, 1))) IN (floor(asin(least(session_length, 1)))-1,
+                                                                                                        floor(asin(least(session_length, 1)))+0,
+                                                                                                        floor(asin(least(session_length, 1)))+1)
+                     AND floor(asin(least(session_length, 1))) NOT IN (floor(asin(least(session_length, 1)))-1,
+                                                                                                            floor(asin(least(session_length, 1)))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(asin(least(session_length, 1))),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(asin(least(session_length, 1))) IS NULL
+          OR (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))+0
+              AND floor(asin(least(session_length, 1))) IS NOT DISTINCT
+              FROM floor(asin(least(session_length, 1)))+0
+              AND floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1
+              AND (floor(asin(least(session_length, 1))) IS DISTINCT
+                   FROM floor(asin(least(session_length, 1)))-1)
+              AND floor(asin(least(session_length, 1))) > floor(asin(least(session_length, 1)))-1
+              AND floor(asin(least(session_length, 1))) >= floor(asin(least(session_length, 1)))-1
+              AND floor(asin(least(session_length, 1))) < floor(asin(least(session_length, 1)))+1
+              AND floor(asin(least(session_length, 1))) <= floor(asin(least(session_length, 1)))+1
+              AND (floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1) IS TRUE
+              AND (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))-1) IS NOT TRUE
+              AND (floor(asin(least(session_length, 1))) = floor(asin(least(session_length, 1)))-1) IS FALSE
+              AND (floor(asin(least(session_length, 1))) <> floor(asin(least(session_length, 1)))-1) IS NOT FALSE
+              AND floor(asin(least(session_length, 1))) BETWEEN floor(asin(least(session_length, 1)))-1 AND floor(asin(least(session_length, 1)))+1
+              AND floor(asin(least(session_length, 1))) NOT BETWEEN floor(asin(least(session_length, 1))) AND floor(asin(least(session_length, 1)))-1
+              AND floor(asin(least(session_length, 1))) like '%'
+              AND floor(asin(least(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+              AND floor(asin(least(session_length, 1))) IN (floor(asin(least(session_length, 1)))-1,
+                                                                                                 floor(asin(least(session_length, 1)))+0,
+                                                                                                 floor(asin(least(session_length, 1)))+1)
+              AND floor(asin(least(session_length, 1))) NOT IN (floor(asin(least(session_length, 1)))-1,
+                                                                                                     floor(asin(least(session_length, 1)))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A20: acos
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(acos(least(session_length, 1))) IS NULL
+       OR (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))+0
+           AND floor(acos(least(session_length, 1))) IS NOT DISTINCT
+           FROM floor(acos(least(session_length, 1)))+0
+           AND floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1
+           AND (floor(acos(least(session_length, 1))) IS DISTINCT
+                FROM floor(acos(least(session_length, 1)))-1)
+           AND floor(acos(least(session_length, 1))) > floor(acos(least(session_length, 1)))-1
+           AND floor(acos(least(session_length, 1))) >= floor(acos(least(session_length, 1)))-1
+           AND floor(acos(least(session_length, 1))) < floor(acos(least(session_length, 1)))+1
+           AND floor(acos(least(session_length, 1))) <= floor(acos(least(session_length, 1)))+1
+           AND (floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1) IS TRUE
+           AND (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))-1) IS NOT TRUE
+           AND (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))-1) IS FALSE
+           AND (floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1) IS NOT FALSE
+           AND floor(acos(least(session_length, 1))) BETWEEN floor(acos(least(session_length, 1)))-1 AND floor(acos(least(session_length, 1)))+1
+           AND floor(acos(least(session_length, 1))) NOT BETWEEN floor(acos(least(session_length, 1))) AND floor(acos(least(session_length, 1)))-1
+           AND floor(acos(least(session_length, 1))) like '%'
+           AND floor(acos(least(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+           AND floor(acos(least(session_length, 1))) IN (floor(acos(least(session_length, 1)))-1,
+                                                                                              floor(acos(least(session_length, 1)))+0,
+                                                                                              floor(acos(least(session_length, 1)))+1)
+           AND floor(acos(least(session_length, 1))) NOT IN (floor(acos(least(session_length, 1)))-1,
+                                                                                                  floor(acos(least(session_length, 1)))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(acos(least(session_length, 1))) IS NULL
+       OR floor(acos(least(session_length, 1))) IN
+         (SELECT floor(acos(least(session_length, 1)))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(acos(least(session_length, 1))) IS NULL
+                 OR (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))+0
+                     AND floor(acos(least(session_length, 1))) IS NOT DISTINCT
+                     FROM floor(acos(least(session_length, 1)))+0
+                     AND floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1
+                     AND (floor(acos(least(session_length, 1))) IS DISTINCT
+                          FROM floor(acos(least(session_length, 1)))-1)
+                     AND floor(acos(least(session_length, 1))) > floor(acos(least(session_length, 1)))-1
+                     AND floor(acos(least(session_length, 1))) >= floor(acos(least(session_length, 1)))-1
+                     AND floor(acos(least(session_length, 1))) < floor(acos(least(session_length, 1)))+1
+                     AND floor(acos(least(session_length, 1))) <= floor(acos(least(session_length, 1)))+1
+                     AND (floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1) IS TRUE
+                     AND (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))-1) IS NOT TRUE
+                     AND (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))-1) IS FALSE
+                     AND (floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1) IS NOT FALSE
+                     AND floor(acos(least(session_length, 1))) BETWEEN floor(acos(least(session_length, 1)))-1 AND floor(acos(least(session_length, 1)))+1
+                     AND floor(acos(least(session_length, 1))) NOT BETWEEN floor(acos(least(session_length, 1))) AND floor(acos(least(session_length, 1)))-1
+                     AND floor(acos(least(session_length, 1))) like '%'
+                     AND floor(acos(least(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+                     AND floor(acos(least(session_length, 1))) IN (floor(acos(least(session_length, 1)))-1,
+                                                                                                        floor(acos(least(session_length, 1)))+0,
+                                                                                                        floor(acos(least(session_length, 1)))+1)
+                     AND floor(acos(least(session_length, 1))) NOT IN (floor(acos(least(session_length, 1)))-1,
+                                                                                                            floor(acos(least(session_length, 1)))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(acos(least(session_length, 1))),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(acos(least(session_length, 1))) IS NULL
+          OR (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))+0
+              AND floor(acos(least(session_length, 1))) IS NOT DISTINCT
+              FROM floor(acos(least(session_length, 1)))+0
+              AND floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1
+              AND (floor(acos(least(session_length, 1))) IS DISTINCT
+                   FROM floor(acos(least(session_length, 1)))-1)
+              AND floor(acos(least(session_length, 1))) > floor(acos(least(session_length, 1)))-1
+              AND floor(acos(least(session_length, 1))) >= floor(acos(least(session_length, 1)))-1
+              AND floor(acos(least(session_length, 1))) < floor(acos(least(session_length, 1)))+1
+              AND floor(acos(least(session_length, 1))) <= floor(acos(least(session_length, 1)))+1
+              AND (floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1) IS TRUE
+              AND (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))-1) IS NOT TRUE
+              AND (floor(acos(least(session_length, 1))) = floor(acos(least(session_length, 1)))-1) IS FALSE
+              AND (floor(acos(least(session_length, 1))) <> floor(acos(least(session_length, 1)))-1) IS NOT FALSE
+              AND floor(acos(least(session_length, 1))) BETWEEN floor(acos(least(session_length, 1)))-1 AND floor(acos(least(session_length, 1)))+1
+              AND floor(acos(least(session_length, 1))) NOT BETWEEN floor(acos(least(session_length, 1))) AND floor(acos(least(session_length, 1)))-1
+              AND floor(acos(least(session_length, 1))) like '%'
+              AND floor(acos(least(session_length, 1))) not like '__DOES_NOT_EXIST__%'
+              AND floor(acos(least(session_length, 1))) IN (floor(acos(least(session_length, 1)))-1,
+                                                                                                 floor(acos(least(session_length, 1)))+0,
+                                                                                                 floor(acos(least(session_length, 1)))+1)
+              AND floor(acos(least(session_length, 1))) NOT IN (floor(acos(least(session_length, 1)))-1,
+                                                                                                     floor(acos(least(session_length, 1)))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A21: atan
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(atan(session_length)) IS NULL
+       OR (floor(atan(session_length)) = floor(atan(session_length))+0
+           AND floor(atan(session_length)) IS NOT DISTINCT
+           FROM floor(atan(session_length))+0
+           AND floor(atan(session_length)) <> floor(atan(session_length))-1
+           AND (floor(atan(session_length)) IS DISTINCT
+                FROM floor(atan(session_length))-1)
+           AND floor(atan(session_length)) > floor(atan(session_length))-1
+           AND floor(atan(session_length)) >= floor(atan(session_length))-1
+           AND floor(atan(session_length)) < floor(atan(session_length))+1
+           AND floor(atan(session_length)) <= floor(atan(session_length))+1
+           AND (floor(atan(session_length)) <> floor(atan(session_length))-1) IS TRUE
+           AND (floor(atan(session_length)) = floor(atan(session_length))-1) IS NOT TRUE
+           AND (floor(atan(session_length)) = floor(atan(session_length))-1) IS FALSE
+           AND (floor(atan(session_length)) <> floor(atan(session_length))-1) IS NOT FALSE
+           AND floor(atan(session_length)) BETWEEN floor(atan(session_length))-1 AND floor(atan(session_length))+1
+           AND floor(atan(session_length)) NOT BETWEEN floor(atan(session_length)) AND floor(atan(session_length))-1
+           AND floor(atan(session_length)) like '%'
+           AND floor(atan(session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(atan(session_length)) IN (floor(atan(session_length))-1,
+                                                                          floor(atan(session_length))+0,
+                                                                          floor(atan(session_length))+1)
+           AND floor(atan(session_length)) NOT IN (floor(atan(session_length))-1,
+                                                                              floor(atan(session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(atan(session_length)) IS NULL
+       OR floor(atan(session_length)) IN
+         (SELECT floor(atan(session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(atan(session_length)) IS NULL
+                 OR (floor(atan(session_length)) = floor(atan(session_length))+0
+                     AND floor(atan(session_length)) IS NOT DISTINCT
+                     FROM floor(atan(session_length))+0
+                     AND floor(atan(session_length)) <> floor(atan(session_length))-1
+                     AND (floor(atan(session_length)) IS DISTINCT
+                          FROM floor(atan(session_length))-1)
+                     AND floor(atan(session_length)) > floor(atan(session_length))-1
+                     AND floor(atan(session_length)) >= floor(atan(session_length))-1
+                     AND floor(atan(session_length)) < floor(atan(session_length))+1
+                     AND floor(atan(session_length)) <= floor(atan(session_length))+1
+                     AND (floor(atan(session_length)) <> floor(atan(session_length))-1) IS TRUE
+                     AND (floor(atan(session_length)) = floor(atan(session_length))-1) IS NOT TRUE
+                     AND (floor(atan(session_length)) = floor(atan(session_length))-1) IS FALSE
+                     AND (floor(atan(session_length)) <> floor(atan(session_length))-1) IS NOT FALSE
+                     AND floor(atan(session_length)) BETWEEN floor(atan(session_length))-1 AND floor(atan(session_length))+1
+                     AND floor(atan(session_length)) NOT BETWEEN floor(atan(session_length)) AND floor(atan(session_length))-1
+                     AND floor(atan(session_length)) like '%'
+                     AND floor(atan(session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(atan(session_length)) IN (floor(atan(session_length))-1,
+                                                                                    floor(atan(session_length))+0,
+                                                                                    floor(atan(session_length))+1)
+                     AND floor(atan(session_length)) NOT IN (floor(atan(session_length))-1,
+                                                                                        floor(atan(session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(atan(session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(atan(session_length)) IS NULL
+          OR (floor(atan(session_length)) = floor(atan(session_length))+0
+              AND floor(atan(session_length)) IS NOT DISTINCT
+              FROM floor(atan(session_length))+0
+              AND floor(atan(session_length)) <> floor(atan(session_length))-1
+              AND (floor(atan(session_length)) IS DISTINCT
+                   FROM floor(atan(session_length))-1)
+              AND floor(atan(session_length)) > floor(atan(session_length))-1
+              AND floor(atan(session_length)) >= floor(atan(session_length))-1
+              AND floor(atan(session_length)) < floor(atan(session_length))+1
+              AND floor(atan(session_length)) <= floor(atan(session_length))+1
+              AND (floor(atan(session_length)) <> floor(atan(session_length))-1) IS TRUE
+              AND (floor(atan(session_length)) = floor(atan(session_length))-1) IS NOT TRUE
+              AND (floor(atan(session_length)) = floor(atan(session_length))-1) IS FALSE
+              AND (floor(atan(session_length)) <> floor(atan(session_length))-1) IS NOT FALSE
+              AND floor(atan(session_length)) BETWEEN floor(atan(session_length))-1 AND floor(atan(session_length))+1
+              AND floor(atan(session_length)) NOT BETWEEN floor(atan(session_length)) AND floor(atan(session_length))-1
+              AND floor(atan(session_length)) like '%'
+              AND floor(atan(session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(atan(session_length)) IN (floor(atan(session_length))-1,
+                                                                             floor(atan(session_length))+0,
+                                                                             floor(atan(session_length))+1)
+              AND floor(atan(session_length)) NOT IN (floor(atan(session_length))-1,
+                                                                                 floor(atan(session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A22: atan2
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(atan2(session_length, 1)) IS NULL
+       OR (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))+0
+           AND floor(atan2(session_length, 1)) IS NOT DISTINCT
+           FROM floor(atan2(session_length, 1))+0
+           AND floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1
+           AND (floor(atan2(session_length, 1)) IS DISTINCT
+                FROM floor(atan2(session_length, 1))-1)
+           AND floor(atan2(session_length, 1)) > floor(atan2(session_length, 1))-1
+           AND floor(atan2(session_length, 1)) >= floor(atan2(session_length, 1))-1
+           AND floor(atan2(session_length, 1)) < floor(atan2(session_length, 1))+1
+           AND floor(atan2(session_length, 1)) <= floor(atan2(session_length, 1))+1
+           AND (floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1) IS TRUE
+           AND (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))-1) IS NOT TRUE
+           AND (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))-1) IS FALSE
+           AND (floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1) IS NOT FALSE
+           AND floor(atan2(session_length, 1)) BETWEEN floor(atan2(session_length, 1))-1 AND floor(atan2(session_length, 1))+1
+           AND floor(atan2(session_length, 1)) NOT BETWEEN floor(atan2(session_length, 1)) AND floor(atan2(session_length, 1))-1
+           AND floor(atan2(session_length, 1)) like '%'
+           AND floor(atan2(session_length, 1)) not like '__DOES_NOT_EXIST__%'
+           AND floor(atan2(session_length, 1)) IN (floor(atan2(session_length, 1))-1,
+                                                                                  floor(atan2(session_length, 1))+0,
+                                                                                  floor(atan2(session_length, 1))+1)
+           AND floor(atan2(session_length, 1)) NOT IN (floor(atan2(session_length, 1))-1,
+                                                                                      floor(atan2(session_length, 1))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(atan2(session_length, 1)) IS NULL
+       OR floor(atan2(session_length, 1)) IN
+         (SELECT floor(atan2(session_length, 1))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(atan2(session_length, 1)) IS NULL
+                 OR (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))+0
+                     AND floor(atan2(session_length, 1)) IS NOT DISTINCT
+                     FROM floor(atan2(session_length, 1))+0
+                     AND floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1
+                     AND (floor(atan2(session_length, 1)) IS DISTINCT
+                          FROM floor(atan2(session_length, 1))-1)
+                     AND floor(atan2(session_length, 1)) > floor(atan2(session_length, 1))-1
+                     AND floor(atan2(session_length, 1)) >= floor(atan2(session_length, 1))-1
+                     AND floor(atan2(session_length, 1)) < floor(atan2(session_length, 1))+1
+                     AND floor(atan2(session_length, 1)) <= floor(atan2(session_length, 1))+1
+                     AND (floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1) IS TRUE
+                     AND (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))-1) IS NOT TRUE
+                     AND (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))-1) IS FALSE
+                     AND (floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1) IS NOT FALSE
+                     AND floor(atan2(session_length, 1)) BETWEEN floor(atan2(session_length, 1))-1 AND floor(atan2(session_length, 1))+1
+                     AND floor(atan2(session_length, 1)) NOT BETWEEN floor(atan2(session_length, 1)) AND floor(atan2(session_length, 1))-1
+                     AND floor(atan2(session_length, 1)) like '%'
+                     AND floor(atan2(session_length, 1)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(atan2(session_length, 1)) IN (floor(atan2(session_length, 1))-1,
+                                                                                            floor(atan2(session_length, 1))+0,
+                                                                                            floor(atan2(session_length, 1))+1)
+                     AND floor(atan2(session_length, 1)) NOT IN (floor(atan2(session_length, 1))-1,
+                                                                                                floor(atan2(session_length, 1))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(atan2(session_length, 1)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(atan2(session_length, 1)) IS NULL
+          OR (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))+0
+              AND floor(atan2(session_length, 1)) IS NOT DISTINCT
+              FROM floor(atan2(session_length, 1))+0
+              AND floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1
+              AND (floor(atan2(session_length, 1)) IS DISTINCT
+                   FROM floor(atan2(session_length, 1))-1)
+              AND floor(atan2(session_length, 1)) > floor(atan2(session_length, 1))-1
+              AND floor(atan2(session_length, 1)) >= floor(atan2(session_length, 1))-1
+              AND floor(atan2(session_length, 1)) < floor(atan2(session_length, 1))+1
+              AND floor(atan2(session_length, 1)) <= floor(atan2(session_length, 1))+1
+              AND (floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1) IS TRUE
+              AND (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))-1) IS NOT TRUE
+              AND (floor(atan2(session_length, 1)) = floor(atan2(session_length, 1))-1) IS FALSE
+              AND (floor(atan2(session_length, 1)) <> floor(atan2(session_length, 1))-1) IS NOT FALSE
+              AND floor(atan2(session_length, 1)) BETWEEN floor(atan2(session_length, 1))-1 AND floor(atan2(session_length, 1))+1
+              AND floor(atan2(session_length, 1)) NOT BETWEEN floor(atan2(session_length, 1)) AND floor(atan2(session_length, 1))-1
+              AND floor(atan2(session_length, 1)) like '%'
+              AND floor(atan2(session_length, 1)) not like '__DOES_NOT_EXIST__%'
+              AND floor(atan2(session_length, 1)) IN (floor(atan2(session_length, 1))-1,
+                                                                                     floor(atan2(session_length, 1))+0,
+                                                                                     floor(atan2(session_length, 1))+1)
+              AND floor(atan2(session_length, 1)) NOT IN (floor(atan2(session_length, 1))-1,
+                                                                                         floor(atan2(session_length, 1))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A23: degrees
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(degrees(session_length)) IS NULL
+       OR (floor(degrees(session_length)) = floor(degrees(session_length))+0
+           AND floor(degrees(session_length)) IS NOT DISTINCT
+           FROM floor(degrees(session_length))+0
+           AND floor(degrees(session_length)) <> floor(degrees(session_length))-1
+           AND (floor(degrees(session_length)) IS DISTINCT
+                FROM floor(degrees(session_length))-1)
+           AND floor(degrees(session_length)) > floor(degrees(session_length))-1
+           AND floor(degrees(session_length)) >= floor(degrees(session_length))-1
+           AND floor(degrees(session_length)) < floor(degrees(session_length))+1
+           AND floor(degrees(session_length)) <= floor(degrees(session_length))+1
+           AND (floor(degrees(session_length)) <> floor(degrees(session_length))-1) IS TRUE
+           AND (floor(degrees(session_length)) = floor(degrees(session_length))-1) IS NOT TRUE
+           AND (floor(degrees(session_length)) = floor(degrees(session_length))-1) IS FALSE
+           AND (floor(degrees(session_length)) <> floor(degrees(session_length))-1) IS NOT FALSE
+           AND floor(degrees(session_length)) BETWEEN floor(degrees(session_length))-1 AND floor(degrees(session_length))+1
+           AND floor(degrees(session_length)) NOT BETWEEN floor(degrees(session_length)) AND floor(degrees(session_length))-1
+           AND floor(degrees(session_length)) like '%'
+           AND floor(degrees(session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(degrees(session_length)) IN (floor(degrees(session_length))-1,
+                                                                                floor(degrees(session_length))+0,
+                                                                                floor(degrees(session_length))+1)
+           AND floor(degrees(session_length)) NOT IN (floor(degrees(session_length))-1,
+                                                                                    floor(degrees(session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(degrees(session_length)) IS NULL
+       OR floor(degrees(session_length)) IN
+         (SELECT floor(degrees(session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(degrees(session_length)) IS NULL
+                 OR (floor(degrees(session_length)) = floor(degrees(session_length))+0
+                     AND floor(degrees(session_length)) IS NOT DISTINCT
+                     FROM floor(degrees(session_length))+0
+                     AND floor(degrees(session_length)) <> floor(degrees(session_length))-1
+                     AND (floor(degrees(session_length)) IS DISTINCT
+                          FROM floor(degrees(session_length))-1)
+                     AND floor(degrees(session_length)) > floor(degrees(session_length))-1
+                     AND floor(degrees(session_length)) >= floor(degrees(session_length))-1
+                     AND floor(degrees(session_length)) < floor(degrees(session_length))+1
+                     AND floor(degrees(session_length)) <= floor(degrees(session_length))+1
+                     AND (floor(degrees(session_length)) <> floor(degrees(session_length))-1) IS TRUE
+                     AND (floor(degrees(session_length)) = floor(degrees(session_length))-1) IS NOT TRUE
+                     AND (floor(degrees(session_length)) = floor(degrees(session_length))-1) IS FALSE
+                     AND (floor(degrees(session_length)) <> floor(degrees(session_length))-1) IS NOT FALSE
+                     AND floor(degrees(session_length)) BETWEEN floor(degrees(session_length))-1 AND floor(degrees(session_length))+1
+                     AND floor(degrees(session_length)) NOT BETWEEN floor(degrees(session_length)) AND floor(degrees(session_length))-1
+                     AND floor(degrees(session_length)) like '%'
+                     AND floor(degrees(session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(degrees(session_length)) IN (floor(degrees(session_length))-1,
+                                                                                          floor(degrees(session_length))+0,
+                                                                                          floor(degrees(session_length))+1)
+                     AND floor(degrees(session_length)) NOT IN (floor(degrees(session_length))-1,
+                                                                                              floor(degrees(session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(degrees(session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(degrees(session_length)) IS NULL
+          OR (floor(degrees(session_length)) = floor(degrees(session_length))+0
+              AND floor(degrees(session_length)) IS NOT DISTINCT
+              FROM floor(degrees(session_length))+0
+              AND floor(degrees(session_length)) <> floor(degrees(session_length))-1
+              AND (floor(degrees(session_length)) IS DISTINCT
+                   FROM floor(degrees(session_length))-1)
+              AND floor(degrees(session_length)) > floor(degrees(session_length))-1
+              AND floor(degrees(session_length)) >= floor(degrees(session_length))-1
+              AND floor(degrees(session_length)) < floor(degrees(session_length))+1
+              AND floor(degrees(session_length)) <= floor(degrees(session_length))+1
+              AND (floor(degrees(session_length)) <> floor(degrees(session_length))-1) IS TRUE
+              AND (floor(degrees(session_length)) = floor(degrees(session_length))-1) IS NOT TRUE
+              AND (floor(degrees(session_length)) = floor(degrees(session_length))-1) IS FALSE
+              AND (floor(degrees(session_length)) <> floor(degrees(session_length))-1) IS NOT FALSE
+              AND floor(degrees(session_length)) BETWEEN floor(degrees(session_length))-1 AND floor(degrees(session_length))+1
+              AND floor(degrees(session_length)) NOT BETWEEN floor(degrees(session_length)) AND floor(degrees(session_length))-1
+              AND floor(degrees(session_length)) like '%'
+              AND floor(degrees(session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(degrees(session_length)) IN (floor(degrees(session_length))-1,
+                                                                                   floor(degrees(session_length))+0,
+                                                                                   floor(degrees(session_length))+1)
+              AND floor(degrees(session_length)) NOT IN (floor(degrees(session_length))-1,
+                                                                                       floor(degrees(session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A24: radians
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(radians(session_length)) IS NULL
+       OR (floor(radians(session_length)) = floor(radians(session_length))+0
+           AND floor(radians(session_length)) IS NOT DISTINCT
+           FROM floor(radians(session_length))+0
+           AND floor(radians(session_length)) <> floor(radians(session_length))-1
+           AND (floor(radians(session_length)) IS DISTINCT
+                FROM floor(radians(session_length))-1)
+           AND floor(radians(session_length)) > floor(radians(session_length))-1
+           AND floor(radians(session_length)) >= floor(radians(session_length))-1
+           AND floor(radians(session_length)) < floor(radians(session_length))+1
+           AND floor(radians(session_length)) <= floor(radians(session_length))+1
+           AND (floor(radians(session_length)) <> floor(radians(session_length))-1) IS TRUE
+           AND (floor(radians(session_length)) = floor(radians(session_length))-1) IS NOT TRUE
+           AND (floor(radians(session_length)) = floor(radians(session_length))-1) IS FALSE
+           AND (floor(radians(session_length)) <> floor(radians(session_length))-1) IS NOT FALSE
+           AND floor(radians(session_length)) BETWEEN floor(radians(session_length))-1 AND floor(radians(session_length))+1
+           AND floor(radians(session_length)) NOT BETWEEN floor(radians(session_length)) AND floor(radians(session_length))-1
+           AND floor(radians(session_length)) like '%'
+           AND floor(radians(session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(radians(session_length)) IN (floor(radians(session_length))-1,
+                                                                                floor(radians(session_length))+0,
+                                                                                floor(radians(session_length))+1)
+           AND floor(radians(session_length)) NOT IN (floor(radians(session_length))-1,
+                                                                                    floor(radians(session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(radians(session_length)) IS NULL
+       OR floor(radians(session_length)) IN
+         (SELECT floor(radians(session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(radians(session_length)) IS NULL
+                 OR (floor(radians(session_length)) = floor(radians(session_length))+0
+                     AND floor(radians(session_length)) IS NOT DISTINCT
+                     FROM floor(radians(session_length))+0
+                     AND floor(radians(session_length)) <> floor(radians(session_length))-1
+                     AND (floor(radians(session_length)) IS DISTINCT
+                          FROM floor(radians(session_length))-1)
+                     AND floor(radians(session_length)) > floor(radians(session_length))-1
+                     AND floor(radians(session_length)) >= floor(radians(session_length))-1
+                     AND floor(radians(session_length)) < floor(radians(session_length))+1
+                     AND floor(radians(session_length)) <= floor(radians(session_length))+1
+                     AND (floor(radians(session_length)) <> floor(radians(session_length))-1) IS TRUE
+                     AND (floor(radians(session_length)) = floor(radians(session_length))-1) IS NOT TRUE
+                     AND (floor(radians(session_length)) = floor(radians(session_length))-1) IS FALSE
+                     AND (floor(radians(session_length)) <> floor(radians(session_length))-1) IS NOT FALSE
+                     AND floor(radians(session_length)) BETWEEN floor(radians(session_length))-1 AND floor(radians(session_length))+1
+                     AND floor(radians(session_length)) NOT BETWEEN floor(radians(session_length)) AND floor(radians(session_length))-1
+                     AND floor(radians(session_length)) like '%'
+                     AND floor(radians(session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(radians(session_length)) IN (floor(radians(session_length))-1,
+                                                                                          floor(radians(session_length))+0,
+                                                                                          floor(radians(session_length))+1)
+                     AND floor(radians(session_length)) NOT IN (floor(radians(session_length))-1,
+                                                                                              floor(radians(session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(radians(session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(radians(session_length)) IS NULL
+          OR (floor(radians(session_length)) = floor(radians(session_length))+0
+              AND floor(radians(session_length)) IS NOT DISTINCT
+              FROM floor(radians(session_length))+0
+              AND floor(radians(session_length)) <> floor(radians(session_length))-1
+              AND (floor(radians(session_length)) IS DISTINCT
+                   FROM floor(radians(session_length))-1)
+              AND floor(radians(session_length)) > floor(radians(session_length))-1
+              AND floor(radians(session_length)) >= floor(radians(session_length))-1
+              AND floor(radians(session_length)) < floor(radians(session_length))+1
+              AND floor(radians(session_length)) <= floor(radians(session_length))+1
+              AND (floor(radians(session_length)) <> floor(radians(session_length))-1) IS TRUE
+              AND (floor(radians(session_length)) = floor(radians(session_length))-1) IS NOT TRUE
+              AND (floor(radians(session_length)) = floor(radians(session_length))-1) IS FALSE
+              AND (floor(radians(session_length)) <> floor(radians(session_length))-1) IS NOT FALSE
+              AND floor(radians(session_length)) BETWEEN floor(radians(session_length))-1 AND floor(radians(session_length))+1
+              AND floor(radians(session_length)) NOT BETWEEN floor(radians(session_length)) AND floor(radians(session_length))-1
+              AND floor(radians(session_length)) like '%'
+              AND floor(radians(session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(radians(session_length)) IN (floor(radians(session_length))-1,
+                                                                                   floor(radians(session_length))+0,
+                                                                                   floor(radians(session_length))+1)
+              AND floor(radians(session_length)) NOT IN (floor(radians(session_length))-1,
+                                                                                       floor(radians(session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A25: bitwise_and
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_and(session_length, session_length) IS NULL
+       OR (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)+0
+           AND bitwise_and(session_length, session_length) IS NOT DISTINCT
+           FROM bitwise_and(session_length, session_length)+0
+           AND bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1
+           AND (bitwise_and(session_length, session_length) IS DISTINCT
+                FROM bitwise_and(session_length, session_length)-1)
+           AND bitwise_and(session_length, session_length) > bitwise_and(session_length, session_length)-1
+           AND bitwise_and(session_length, session_length) >= bitwise_and(session_length, session_length)-1
+           AND bitwise_and(session_length, session_length) < bitwise_and(session_length, session_length)+1
+           AND bitwise_and(session_length, session_length) <= bitwise_and(session_length, session_length)+1
+           AND (bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1) IS TRUE
+           AND (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)-1) IS NOT TRUE
+           AND (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)-1) IS FALSE
+           AND (bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1) IS NOT FALSE
+           AND bitwise_and(session_length, session_length) BETWEEN bitwise_and(session_length, session_length)-1 AND bitwise_and(session_length, session_length)+1
+           AND bitwise_and(session_length, session_length) NOT BETWEEN bitwise_and(session_length, session_length) AND bitwise_and(session_length, session_length)-1
+           AND bitwise_and(session_length, session_length) like '%'
+           AND bitwise_and(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_and(session_length, session_length) IN (bitwise_and(session_length, session_length)-1,
+                                                                                                          bitwise_and(session_length, session_length)+0,
+                                                                                                          bitwise_and(session_length, session_length)+1)
+           AND bitwise_and(session_length, session_length) NOT IN (bitwise_and(session_length, session_length)-1,
+                                                                                                              bitwise_and(session_length, session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_and(session_length, session_length) IS NULL
+       OR bitwise_and(session_length, session_length) IN
+         (SELECT bitwise_and(session_length, session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_and(session_length, session_length) IS NULL
+                 OR (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)+0
+                     AND bitwise_and(session_length, session_length) IS NOT DISTINCT
+                     FROM bitwise_and(session_length, session_length)+0
+                     AND bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1
+                     AND (bitwise_and(session_length, session_length) IS DISTINCT
+                          FROM bitwise_and(session_length, session_length)-1)
+                     AND bitwise_and(session_length, session_length) > bitwise_and(session_length, session_length)-1
+                     AND bitwise_and(session_length, session_length) >= bitwise_and(session_length, session_length)-1
+                     AND bitwise_and(session_length, session_length) < bitwise_and(session_length, session_length)+1
+                     AND bitwise_and(session_length, session_length) <= bitwise_and(session_length, session_length)+1
+                     AND (bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1) IS TRUE
+                     AND (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)-1) IS NOT TRUE
+                     AND (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)-1) IS FALSE
+                     AND (bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1) IS NOT FALSE
+                     AND bitwise_and(session_length, session_length) BETWEEN bitwise_and(session_length, session_length)-1 AND bitwise_and(session_length, session_length)+1
+                     AND bitwise_and(session_length, session_length) NOT BETWEEN bitwise_and(session_length, session_length) AND bitwise_and(session_length, session_length)-1
+                     AND bitwise_and(session_length, session_length) like '%'
+                     AND bitwise_and(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_and(session_length, session_length) IN (bitwise_and(session_length, session_length)-1,
+                                                                                                                    bitwise_and(session_length, session_length)+0,
+                                                                                                                    bitwise_and(session_length, session_length)+1)
+                     AND bitwise_and(session_length, session_length) NOT IN (bitwise_and(session_length, session_length)-1,
+                                                                                                                        bitwise_and(session_length, session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_and(session_length, session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_and(session_length, session_length) IS NULL
+          OR (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)+0
+              AND bitwise_and(session_length, session_length) IS NOT DISTINCT
+              FROM bitwise_and(session_length, session_length)+0
+              AND bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1
+              AND (bitwise_and(session_length, session_length) IS DISTINCT
+                   FROM bitwise_and(session_length, session_length)-1)
+              AND bitwise_and(session_length, session_length) > bitwise_and(session_length, session_length)-1
+              AND bitwise_and(session_length, session_length) >= bitwise_and(session_length, session_length)-1
+              AND bitwise_and(session_length, session_length) < bitwise_and(session_length, session_length)+1
+              AND bitwise_and(session_length, session_length) <= bitwise_and(session_length, session_length)+1
+              AND (bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1) IS TRUE
+              AND (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)-1) IS NOT TRUE
+              AND (bitwise_and(session_length, session_length) = bitwise_and(session_length, session_length)-1) IS FALSE
+              AND (bitwise_and(session_length, session_length) <> bitwise_and(session_length, session_length)-1) IS NOT FALSE
+              AND bitwise_and(session_length, session_length) BETWEEN bitwise_and(session_length, session_length)-1 AND bitwise_and(session_length, session_length)+1
+              AND bitwise_and(session_length, session_length) NOT BETWEEN bitwise_and(session_length, session_length) AND bitwise_and(session_length, session_length)-1
+              AND bitwise_and(session_length, session_length) like '%'
+              AND bitwise_and(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_and(session_length, session_length) IN (bitwise_and(session_length, session_length)-1,
+                                                                                                             bitwise_and(session_length, session_length)+0,
+                                                                                                             bitwise_and(session_length, session_length)+1)
+              AND bitwise_and(session_length, session_length) NOT IN (bitwise_and(session_length, session_length)-1,
+                                                                                                                 bitwise_and(session_length, session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A26: bitwise_complement
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_complement(session_length) IS NULL
+       OR (bitwise_complement(session_length) = bitwise_complement(session_length)+0
+           AND bitwise_complement(session_length) IS NOT DISTINCT
+           FROM bitwise_complement(session_length)+0
+           AND bitwise_complement(session_length) <> bitwise_complement(session_length)-1
+           AND (bitwise_complement(session_length) IS DISTINCT
+                FROM bitwise_complement(session_length)-1)
+           AND bitwise_complement(session_length) > bitwise_complement(session_length)-1
+           AND bitwise_complement(session_length) >= bitwise_complement(session_length)-1
+           AND bitwise_complement(session_length) < bitwise_complement(session_length)+1
+           AND bitwise_complement(session_length) <= bitwise_complement(session_length)+1
+           AND (bitwise_complement(session_length) <> bitwise_complement(session_length)-1) IS TRUE
+           AND (bitwise_complement(session_length) = bitwise_complement(session_length)-1) IS NOT TRUE
+           AND (bitwise_complement(session_length) = bitwise_complement(session_length)-1) IS FALSE
+           AND (bitwise_complement(session_length) <> bitwise_complement(session_length)-1) IS NOT FALSE
+           AND bitwise_complement(session_length) BETWEEN bitwise_complement(session_length)-1 AND bitwise_complement(session_length)+1
+           AND bitwise_complement(session_length) NOT BETWEEN bitwise_complement(session_length) AND bitwise_complement(session_length)-1
+           AND bitwise_complement(session_length) like '%'
+           AND bitwise_complement(session_length) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_complement(session_length) IN (bitwise_complement(session_length)-1,
+                                                                                        bitwise_complement(session_length)+0,
+                                                                                        bitwise_complement(session_length)+1)
+           AND bitwise_complement(session_length) NOT IN (bitwise_complement(session_length)-1,
+                                                                                            bitwise_complement(session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_complement(session_length) IS NULL
+       OR bitwise_complement(session_length) IN
+         (SELECT bitwise_complement(session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_complement(session_length) IS NULL
+                 OR (bitwise_complement(session_length) = bitwise_complement(session_length)+0
+                     AND bitwise_complement(session_length) IS NOT DISTINCT
+                     FROM bitwise_complement(session_length)+0
+                     AND bitwise_complement(session_length) <> bitwise_complement(session_length)-1
+                     AND (bitwise_complement(session_length) IS DISTINCT
+                          FROM bitwise_complement(session_length)-1)
+                     AND bitwise_complement(session_length) > bitwise_complement(session_length)-1
+                     AND bitwise_complement(session_length) >= bitwise_complement(session_length)-1
+                     AND bitwise_complement(session_length) < bitwise_complement(session_length)+1
+                     AND bitwise_complement(session_length) <= bitwise_complement(session_length)+1
+                     AND (bitwise_complement(session_length) <> bitwise_complement(session_length)-1) IS TRUE
+                     AND (bitwise_complement(session_length) = bitwise_complement(session_length)-1) IS NOT TRUE
+                     AND (bitwise_complement(session_length) = bitwise_complement(session_length)-1) IS FALSE
+                     AND (bitwise_complement(session_length) <> bitwise_complement(session_length)-1) IS NOT FALSE
+                     AND bitwise_complement(session_length) BETWEEN bitwise_complement(session_length)-1 AND bitwise_complement(session_length)+1
+                     AND bitwise_complement(session_length) NOT BETWEEN bitwise_complement(session_length) AND bitwise_complement(session_length)-1
+                     AND bitwise_complement(session_length) like '%'
+                     AND bitwise_complement(session_length) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_complement(session_length) IN (bitwise_complement(session_length)-1,
+                                                                                                  bitwise_complement(session_length)+0,
+                                                                                                  bitwise_complement(session_length)+1)
+                     AND bitwise_complement(session_length) NOT IN (bitwise_complement(session_length)-1,
+                                                                                                      bitwise_complement(session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_complement(session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_complement(session_length) IS NULL
+          OR (bitwise_complement(session_length) = bitwise_complement(session_length)+0
+              AND bitwise_complement(session_length) IS NOT DISTINCT
+              FROM bitwise_complement(session_length)+0
+              AND bitwise_complement(session_length) <> bitwise_complement(session_length)-1
+              AND (bitwise_complement(session_length) IS DISTINCT
+                   FROM bitwise_complement(session_length)-1)
+              AND bitwise_complement(session_length) > bitwise_complement(session_length)-1
+              AND bitwise_complement(session_length) >= bitwise_complement(session_length)-1
+              AND bitwise_complement(session_length) < bitwise_complement(session_length)+1
+              AND bitwise_complement(session_length) <= bitwise_complement(session_length)+1
+              AND (bitwise_complement(session_length) <> bitwise_complement(session_length)-1) IS TRUE
+              AND (bitwise_complement(session_length) = bitwise_complement(session_length)-1) IS NOT TRUE
+              AND (bitwise_complement(session_length) = bitwise_complement(session_length)-1) IS FALSE
+              AND (bitwise_complement(session_length) <> bitwise_complement(session_length)-1) IS NOT FALSE
+              AND bitwise_complement(session_length) BETWEEN bitwise_complement(session_length)-1 AND bitwise_complement(session_length)+1
+              AND bitwise_complement(session_length) NOT BETWEEN bitwise_complement(session_length) AND bitwise_complement(session_length)-1
+              AND bitwise_complement(session_length) like '%'
+              AND bitwise_complement(session_length) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_complement(session_length) IN (bitwise_complement(session_length)-1,
+                                                                                           bitwise_complement(session_length)+0,
+                                                                                           bitwise_complement(session_length)+1)
+              AND bitwise_complement(session_length) NOT IN (bitwise_complement(session_length)-1,
+                                                                                               bitwise_complement(session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A27: bitwise_convert_double_to_long_bits
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_convert_double_to_long_bits(session_length) IS NULL
+       OR (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)+0
+           AND bitwise_convert_double_to_long_bits(session_length) IS NOT DISTINCT
+           FROM bitwise_convert_double_to_long_bits(session_length)+0
+           AND bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1
+           AND (bitwise_convert_double_to_long_bits(session_length) IS DISTINCT
+                FROM bitwise_convert_double_to_long_bits(session_length)-1)
+           AND bitwise_convert_double_to_long_bits(session_length) > bitwise_convert_double_to_long_bits(session_length)-1
+           AND bitwise_convert_double_to_long_bits(session_length) >= bitwise_convert_double_to_long_bits(session_length)-1
+           AND bitwise_convert_double_to_long_bits(session_length) < bitwise_convert_double_to_long_bits(session_length)+1
+           AND bitwise_convert_double_to_long_bits(session_length) <= bitwise_convert_double_to_long_bits(session_length)+1
+           AND (bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1) IS TRUE
+           AND (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)-1) IS NOT TRUE
+           AND (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)-1) IS FALSE
+           AND (bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1) IS NOT FALSE
+           AND bitwise_convert_double_to_long_bits(session_length) BETWEEN bitwise_convert_double_to_long_bits(session_length)-1 AND bitwise_convert_double_to_long_bits(session_length)+1
+           AND bitwise_convert_double_to_long_bits(session_length) NOT BETWEEN bitwise_convert_double_to_long_bits(session_length) AND bitwise_convert_double_to_long_bits(session_length)-1
+           AND bitwise_convert_double_to_long_bits(session_length) like '%'
+           AND bitwise_convert_double_to_long_bits(session_length) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_convert_double_to_long_bits(session_length) IN (bitwise_convert_double_to_long_bits(session_length)-1,
+                                                                                                                          bitwise_convert_double_to_long_bits(session_length)+0,
+                                                                                                                          bitwise_convert_double_to_long_bits(session_length)+1)
+           AND bitwise_convert_double_to_long_bits(session_length) NOT IN (bitwise_convert_double_to_long_bits(session_length)-1,
+                                                                                                                              bitwise_convert_double_to_long_bits(session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_convert_double_to_long_bits(session_length) IS NULL
+       OR bitwise_convert_double_to_long_bits(session_length) IN
+         (SELECT bitwise_convert_double_to_long_bits(session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_convert_double_to_long_bits(session_length) IS NULL
+                 OR (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)+0
+                     AND bitwise_convert_double_to_long_bits(session_length) IS NOT DISTINCT
+                     FROM bitwise_convert_double_to_long_bits(session_length)+0
+                     AND bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1
+                     AND (bitwise_convert_double_to_long_bits(session_length) IS DISTINCT
+                          FROM bitwise_convert_double_to_long_bits(session_length)-1)
+                     AND bitwise_convert_double_to_long_bits(session_length) > bitwise_convert_double_to_long_bits(session_length)-1
+                     AND bitwise_convert_double_to_long_bits(session_length) >= bitwise_convert_double_to_long_bits(session_length)-1
+                     AND bitwise_convert_double_to_long_bits(session_length) < bitwise_convert_double_to_long_bits(session_length)+1
+                     AND bitwise_convert_double_to_long_bits(session_length) <= bitwise_convert_double_to_long_bits(session_length)+1
+                     AND (bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1) IS TRUE
+                     AND (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)-1) IS NOT TRUE
+                     AND (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)-1) IS FALSE
+                     AND (bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1) IS NOT FALSE
+                     AND bitwise_convert_double_to_long_bits(session_length) BETWEEN bitwise_convert_double_to_long_bits(session_length)-1 AND bitwise_convert_double_to_long_bits(session_length)+1
+                     AND bitwise_convert_double_to_long_bits(session_length) NOT BETWEEN bitwise_convert_double_to_long_bits(session_length) AND bitwise_convert_double_to_long_bits(session_length)-1
+                     AND bitwise_convert_double_to_long_bits(session_length) like '%'
+                     AND bitwise_convert_double_to_long_bits(session_length) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_convert_double_to_long_bits(session_length) IN (bitwise_convert_double_to_long_bits(session_length)-1,
+                                                                                                                                    bitwise_convert_double_to_long_bits(session_length)+0,
+                                                                                                                                    bitwise_convert_double_to_long_bits(session_length)+1)
+                     AND bitwise_convert_double_to_long_bits(session_length) NOT IN (bitwise_convert_double_to_long_bits(session_length)-1,
+                                                                                                                                        bitwise_convert_double_to_long_bits(session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_convert_double_to_long_bits(session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_convert_double_to_long_bits(session_length) IS NULL
+          OR (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)+0
+              AND bitwise_convert_double_to_long_bits(session_length) IS NOT DISTINCT
+              FROM bitwise_convert_double_to_long_bits(session_length)+0
+              AND bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1
+              AND (bitwise_convert_double_to_long_bits(session_length) IS DISTINCT
+                   FROM bitwise_convert_double_to_long_bits(session_length)-1)
+              AND bitwise_convert_double_to_long_bits(session_length) > bitwise_convert_double_to_long_bits(session_length)-1
+              AND bitwise_convert_double_to_long_bits(session_length) >= bitwise_convert_double_to_long_bits(session_length)-1
+              AND bitwise_convert_double_to_long_bits(session_length) < bitwise_convert_double_to_long_bits(session_length)+1
+              AND bitwise_convert_double_to_long_bits(session_length) <= bitwise_convert_double_to_long_bits(session_length)+1
+              AND (bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1) IS TRUE
+              AND (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)-1) IS NOT TRUE
+              AND (bitwise_convert_double_to_long_bits(session_length) = bitwise_convert_double_to_long_bits(session_length)-1) IS FALSE
+              AND (bitwise_convert_double_to_long_bits(session_length) <> bitwise_convert_double_to_long_bits(session_length)-1) IS NOT FALSE
+              AND bitwise_convert_double_to_long_bits(session_length) BETWEEN bitwise_convert_double_to_long_bits(session_length)-1 AND bitwise_convert_double_to_long_bits(session_length)+1
+              AND bitwise_convert_double_to_long_bits(session_length) NOT BETWEEN bitwise_convert_double_to_long_bits(session_length) AND bitwise_convert_double_to_long_bits(session_length)-1
+              AND bitwise_convert_double_to_long_bits(session_length) like '%'
+              AND bitwise_convert_double_to_long_bits(session_length) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_convert_double_to_long_bits(session_length) IN (bitwise_convert_double_to_long_bits(session_length)-1,
+                                                                                                                             bitwise_convert_double_to_long_bits(session_length)+0,
+                                                                                                                             bitwise_convert_double_to_long_bits(session_length)+1)
+              AND bitwise_convert_double_to_long_bits(session_length) NOT IN (bitwise_convert_double_to_long_bits(session_length)-1,
+                                                                                                                                 bitwise_convert_double_to_long_bits(session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A28: bitwise_convert_long_bits_to_double
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_convert_long_bits_to_double(session_length) IS NULL
+       OR (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)+0
+           AND bitwise_convert_long_bits_to_double(session_length) IS NOT DISTINCT
+           FROM bitwise_convert_long_bits_to_double(session_length)+0
+           AND bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1
+           AND (bitwise_convert_long_bits_to_double(session_length) IS DISTINCT
+                FROM bitwise_convert_long_bits_to_double(session_length)-1)
+           AND bitwise_convert_long_bits_to_double(session_length) > bitwise_convert_long_bits_to_double(session_length)-1
+           AND bitwise_convert_long_bits_to_double(session_length) >= bitwise_convert_long_bits_to_double(session_length)-1
+           AND bitwise_convert_long_bits_to_double(session_length) < bitwise_convert_long_bits_to_double(session_length)+1
+           AND bitwise_convert_long_bits_to_double(session_length) <= bitwise_convert_long_bits_to_double(session_length)+1
+           AND (bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1) IS TRUE
+           AND (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)-1) IS NOT TRUE
+           AND (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)-1) IS FALSE
+           AND (bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1) IS NOT FALSE
+           AND bitwise_convert_long_bits_to_double(session_length) BETWEEN bitwise_convert_long_bits_to_double(session_length)-1 AND bitwise_convert_long_bits_to_double(session_length)+1
+           AND bitwise_convert_long_bits_to_double(session_length) NOT BETWEEN bitwise_convert_long_bits_to_double(session_length) AND bitwise_convert_long_bits_to_double(session_length)-1
+           AND bitwise_convert_long_bits_to_double(session_length) like '%'
+           AND bitwise_convert_long_bits_to_double(session_length) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_convert_long_bits_to_double(session_length) IN (bitwise_convert_long_bits_to_double(session_length)-1,
+                                                                                                                          bitwise_convert_long_bits_to_double(session_length)+0,
+                                                                                                                          bitwise_convert_long_bits_to_double(session_length)+1)
+           AND bitwise_convert_long_bits_to_double(session_length) NOT IN (bitwise_convert_long_bits_to_double(session_length)-1,
+                                                                                                                              bitwise_convert_long_bits_to_double(session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_convert_long_bits_to_double(session_length) IS NULL
+       OR bitwise_convert_long_bits_to_double(session_length) IN
+         (SELECT bitwise_convert_long_bits_to_double(session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_convert_long_bits_to_double(session_length) IS NULL
+                 OR (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)+0
+                     AND bitwise_convert_long_bits_to_double(session_length) IS NOT DISTINCT
+                     FROM bitwise_convert_long_bits_to_double(session_length)+0
+                     AND bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1
+                     AND (bitwise_convert_long_bits_to_double(session_length) IS DISTINCT
+                          FROM bitwise_convert_long_bits_to_double(session_length)-1)
+                     AND bitwise_convert_long_bits_to_double(session_length) > bitwise_convert_long_bits_to_double(session_length)-1
+                     AND bitwise_convert_long_bits_to_double(session_length) >= bitwise_convert_long_bits_to_double(session_length)-1
+                     AND bitwise_convert_long_bits_to_double(session_length) < bitwise_convert_long_bits_to_double(session_length)+1
+                     AND bitwise_convert_long_bits_to_double(session_length) <= bitwise_convert_long_bits_to_double(session_length)+1
+                     AND (bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1) IS TRUE
+                     AND (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)-1) IS NOT TRUE
+                     AND (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)-1) IS FALSE
+                     AND (bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1) IS NOT FALSE
+                     AND bitwise_convert_long_bits_to_double(session_length) BETWEEN bitwise_convert_long_bits_to_double(session_length)-1 AND bitwise_convert_long_bits_to_double(session_length)+1
+                     AND bitwise_convert_long_bits_to_double(session_length) NOT BETWEEN bitwise_convert_long_bits_to_double(session_length) AND bitwise_convert_long_bits_to_double(session_length)-1
+                     AND bitwise_convert_long_bits_to_double(session_length) like '%'
+                     AND bitwise_convert_long_bits_to_double(session_length) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_convert_long_bits_to_double(session_length) IN (bitwise_convert_long_bits_to_double(session_length)-1,
+                                                                                                                                    bitwise_convert_long_bits_to_double(session_length)+0,
+                                                                                                                                    bitwise_convert_long_bits_to_double(session_length)+1)
+                     AND bitwise_convert_long_bits_to_double(session_length) NOT IN (bitwise_convert_long_bits_to_double(session_length)-1,
+                                                                                                                                        bitwise_convert_long_bits_to_double(session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_convert_long_bits_to_double(session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_convert_long_bits_to_double(session_length) IS NULL
+          OR (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)+0
+              AND bitwise_convert_long_bits_to_double(session_length) IS NOT DISTINCT
+              FROM bitwise_convert_long_bits_to_double(session_length)+0
+              AND bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1
+              AND (bitwise_convert_long_bits_to_double(session_length) IS DISTINCT
+                   FROM bitwise_convert_long_bits_to_double(session_length)-1)
+              AND bitwise_convert_long_bits_to_double(session_length) > bitwise_convert_long_bits_to_double(session_length)-1
+              AND bitwise_convert_long_bits_to_double(session_length) >= bitwise_convert_long_bits_to_double(session_length)-1
+              AND bitwise_convert_long_bits_to_double(session_length) < bitwise_convert_long_bits_to_double(session_length)+1
+              AND bitwise_convert_long_bits_to_double(session_length) <= bitwise_convert_long_bits_to_double(session_length)+1
+              AND (bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1) IS TRUE
+              AND (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)-1) IS NOT TRUE
+              AND (bitwise_convert_long_bits_to_double(session_length) = bitwise_convert_long_bits_to_double(session_length)-1) IS FALSE
+              AND (bitwise_convert_long_bits_to_double(session_length) <> bitwise_convert_long_bits_to_double(session_length)-1) IS NOT FALSE
+              AND bitwise_convert_long_bits_to_double(session_length) BETWEEN bitwise_convert_long_bits_to_double(session_length)-1 AND bitwise_convert_long_bits_to_double(session_length)+1
+              AND bitwise_convert_long_bits_to_double(session_length) NOT BETWEEN bitwise_convert_long_bits_to_double(session_length) AND bitwise_convert_long_bits_to_double(session_length)-1
+              AND bitwise_convert_long_bits_to_double(session_length) like '%'
+              AND bitwise_convert_long_bits_to_double(session_length) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_convert_long_bits_to_double(session_length) IN (bitwise_convert_long_bits_to_double(session_length)-1,
+                                                                                                                             bitwise_convert_long_bits_to_double(session_length)+0,
+                                                                                                                             bitwise_convert_long_bits_to_double(session_length)+1)
+              AND bitwise_convert_long_bits_to_double(session_length) NOT IN (bitwise_convert_long_bits_to_double(session_length)-1,
+                                                                                                                                 bitwise_convert_long_bits_to_double(session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A29: bitwise_or
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_or(session_length, session_length) IS NULL
+       OR (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)+0
+           AND bitwise_or(session_length, session_length) IS NOT DISTINCT
+           FROM bitwise_or(session_length, session_length)+0
+           AND bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1
+           AND (bitwise_or(session_length, session_length) IS DISTINCT
+                FROM bitwise_or(session_length, session_length)-1)
+           AND bitwise_or(session_length, session_length) > bitwise_or(session_length, session_length)-1
+           AND bitwise_or(session_length, session_length) >= bitwise_or(session_length, session_length)-1
+           AND bitwise_or(session_length, session_length) < bitwise_or(session_length, session_length)+1
+           AND bitwise_or(session_length, session_length) <= bitwise_or(session_length, session_length)+1
+           AND (bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1) IS TRUE
+           AND (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)-1) IS NOT TRUE
+           AND (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)-1) IS FALSE
+           AND (bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1) IS NOT FALSE
+           AND bitwise_or(session_length, session_length) BETWEEN bitwise_or(session_length, session_length)-1 AND bitwise_or(session_length, session_length)+1
+           AND bitwise_or(session_length, session_length) NOT BETWEEN bitwise_or(session_length, session_length) AND bitwise_or(session_length, session_length)-1
+           AND bitwise_or(session_length, session_length) like '%'
+           AND bitwise_or(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_or(session_length, session_length) IN (bitwise_or(session_length, session_length)-1,
+                                                                                                        bitwise_or(session_length, session_length)+0,
+                                                                                                        bitwise_or(session_length, session_length)+1)
+           AND bitwise_or(session_length, session_length) NOT IN (bitwise_or(session_length, session_length)-1,
+                                                                                                            bitwise_or(session_length, session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_or(session_length, session_length) IS NULL
+       OR bitwise_or(session_length, session_length) IN
+         (SELECT bitwise_or(session_length, session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_or(session_length, session_length) IS NULL
+                 OR (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)+0
+                     AND bitwise_or(session_length, session_length) IS NOT DISTINCT
+                     FROM bitwise_or(session_length, session_length)+0
+                     AND bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1
+                     AND (bitwise_or(session_length, session_length) IS DISTINCT
+                          FROM bitwise_or(session_length, session_length)-1)
+                     AND bitwise_or(session_length, session_length) > bitwise_or(session_length, session_length)-1
+                     AND bitwise_or(session_length, session_length) >= bitwise_or(session_length, session_length)-1
+                     AND bitwise_or(session_length, session_length) < bitwise_or(session_length, session_length)+1
+                     AND bitwise_or(session_length, session_length) <= bitwise_or(session_length, session_length)+1
+                     AND (bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1) IS TRUE
+                     AND (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)-1) IS NOT TRUE
+                     AND (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)-1) IS FALSE
+                     AND (bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1) IS NOT FALSE
+                     AND bitwise_or(session_length, session_length) BETWEEN bitwise_or(session_length, session_length)-1 AND bitwise_or(session_length, session_length)+1
+                     AND bitwise_or(session_length, session_length) NOT BETWEEN bitwise_or(session_length, session_length) AND bitwise_or(session_length, session_length)-1
+                     AND bitwise_or(session_length, session_length) like '%'
+                     AND bitwise_or(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_or(session_length, session_length) IN (bitwise_or(session_length, session_length)-1,
+                                                                                                                  bitwise_or(session_length, session_length)+0,
+                                                                                                                  bitwise_or(session_length, session_length)+1)
+                     AND bitwise_or(session_length, session_length) NOT IN (bitwise_or(session_length, session_length)-1,
+                                                                                                                      bitwise_or(session_length, session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_or(session_length, session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_or(session_length, session_length) IS NULL
+          OR (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)+0
+              AND bitwise_or(session_length, session_length) IS NOT DISTINCT
+              FROM bitwise_or(session_length, session_length)+0
+              AND bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1
+              AND (bitwise_or(session_length, session_length) IS DISTINCT
+                   FROM bitwise_or(session_length, session_length)-1)
+              AND bitwise_or(session_length, session_length) > bitwise_or(session_length, session_length)-1
+              AND bitwise_or(session_length, session_length) >= bitwise_or(session_length, session_length)-1
+              AND bitwise_or(session_length, session_length) < bitwise_or(session_length, session_length)+1
+              AND bitwise_or(session_length, session_length) <= bitwise_or(session_length, session_length)+1
+              AND (bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1) IS TRUE
+              AND (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)-1) IS NOT TRUE
+              AND (bitwise_or(session_length, session_length) = bitwise_or(session_length, session_length)-1) IS FALSE
+              AND (bitwise_or(session_length, session_length) <> bitwise_or(session_length, session_length)-1) IS NOT FALSE
+              AND bitwise_or(session_length, session_length) BETWEEN bitwise_or(session_length, session_length)-1 AND bitwise_or(session_length, session_length)+1
+              AND bitwise_or(session_length, session_length) NOT BETWEEN bitwise_or(session_length, session_length) AND bitwise_or(session_length, session_length)-1
+              AND bitwise_or(session_length, session_length) like '%'
+              AND bitwise_or(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_or(session_length, session_length) IN (bitwise_or(session_length, session_length)-1,
+                                                                                                           bitwise_or(session_length, session_length)+0,
+                                                                                                           bitwise_or(session_length, session_length)+1)
+              AND bitwise_or(session_length, session_length) NOT IN (bitwise_or(session_length, session_length)-1,
+                                                                                                               bitwise_or(session_length, session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A30: bitwise_shift_left
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_shift_left(session_length, 2) IS NULL
+       OR (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)+0
+           AND bitwise_shift_left(session_length, 2) IS NOT DISTINCT
+           FROM bitwise_shift_left(session_length, 2)+0
+           AND bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1
+           AND (bitwise_shift_left(session_length, 2) IS DISTINCT
+                FROM bitwise_shift_left(session_length, 2)-1)
+           AND bitwise_shift_left(session_length, 2) > bitwise_shift_left(session_length, 2)-1
+           AND bitwise_shift_left(session_length, 2) >= bitwise_shift_left(session_length, 2)-1
+           AND bitwise_shift_left(session_length, 2) < bitwise_shift_left(session_length, 2)+1
+           AND bitwise_shift_left(session_length, 2) <= bitwise_shift_left(session_length, 2)+1
+           AND (bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1) IS TRUE
+           AND (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)-1) IS NOT TRUE
+           AND (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)-1) IS FALSE
+           AND (bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1) IS NOT FALSE
+           AND bitwise_shift_left(session_length, 2) BETWEEN bitwise_shift_left(session_length, 2)-1 AND bitwise_shift_left(session_length, 2)+1
+           AND bitwise_shift_left(session_length, 2) NOT BETWEEN bitwise_shift_left(session_length, 2) AND bitwise_shift_left(session_length, 2)-1
+           AND bitwise_shift_left(session_length, 2) like '%'
+           AND bitwise_shift_left(session_length, 2) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_shift_left(session_length, 2) IN (bitwise_shift_left(session_length, 2)-1,
+                                                                                              bitwise_shift_left(session_length, 2)+0,
+                                                                                              bitwise_shift_left(session_length, 2)+1)
+           AND bitwise_shift_left(session_length, 2) NOT IN (bitwise_shift_left(session_length, 2)-1,
+                                                                                                  bitwise_shift_left(session_length, 2)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_shift_left(session_length, 2) IS NULL
+       OR bitwise_shift_left(session_length, 2) IN
+         (SELECT bitwise_shift_left(session_length, 2)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_shift_left(session_length, 2) IS NULL
+                 OR (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)+0
+                     AND bitwise_shift_left(session_length, 2) IS NOT DISTINCT
+                     FROM bitwise_shift_left(session_length, 2)+0
+                     AND bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1
+                     AND (bitwise_shift_left(session_length, 2) IS DISTINCT
+                          FROM bitwise_shift_left(session_length, 2)-1)
+                     AND bitwise_shift_left(session_length, 2) > bitwise_shift_left(session_length, 2)-1
+                     AND bitwise_shift_left(session_length, 2) >= bitwise_shift_left(session_length, 2)-1
+                     AND bitwise_shift_left(session_length, 2) < bitwise_shift_left(session_length, 2)+1
+                     AND bitwise_shift_left(session_length, 2) <= bitwise_shift_left(session_length, 2)+1
+                     AND (bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1) IS TRUE
+                     AND (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)-1) IS NOT TRUE
+                     AND (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)-1) IS FALSE
+                     AND (bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1) IS NOT FALSE
+                     AND bitwise_shift_left(session_length, 2) BETWEEN bitwise_shift_left(session_length, 2)-1 AND bitwise_shift_left(session_length, 2)+1
+                     AND bitwise_shift_left(session_length, 2) NOT BETWEEN bitwise_shift_left(session_length, 2) AND bitwise_shift_left(session_length, 2)-1
+                     AND bitwise_shift_left(session_length, 2) like '%'
+                     AND bitwise_shift_left(session_length, 2) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_shift_left(session_length, 2) IN (bitwise_shift_left(session_length, 2)-1,
+                                                                                                        bitwise_shift_left(session_length, 2)+0,
+                                                                                                        bitwise_shift_left(session_length, 2)+1)
+                     AND bitwise_shift_left(session_length, 2) NOT IN (bitwise_shift_left(session_length, 2)-1,
+                                                                                                            bitwise_shift_left(session_length, 2)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_shift_left(session_length, 2),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_shift_left(session_length, 2) IS NULL
+          OR (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)+0
+              AND bitwise_shift_left(session_length, 2) IS NOT DISTINCT
+              FROM bitwise_shift_left(session_length, 2)+0
+              AND bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1
+              AND (bitwise_shift_left(session_length, 2) IS DISTINCT
+                   FROM bitwise_shift_left(session_length, 2)-1)
+              AND bitwise_shift_left(session_length, 2) > bitwise_shift_left(session_length, 2)-1
+              AND bitwise_shift_left(session_length, 2) >= bitwise_shift_left(session_length, 2)-1
+              AND bitwise_shift_left(session_length, 2) < bitwise_shift_left(session_length, 2)+1
+              AND bitwise_shift_left(session_length, 2) <= bitwise_shift_left(session_length, 2)+1
+              AND (bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1) IS TRUE
+              AND (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)-1) IS NOT TRUE
+              AND (bitwise_shift_left(session_length, 2) = bitwise_shift_left(session_length, 2)-1) IS FALSE
+              AND (bitwise_shift_left(session_length, 2) <> bitwise_shift_left(session_length, 2)-1) IS NOT FALSE
+              AND bitwise_shift_left(session_length, 2) BETWEEN bitwise_shift_left(session_length, 2)-1 AND bitwise_shift_left(session_length, 2)+1
+              AND bitwise_shift_left(session_length, 2) NOT BETWEEN bitwise_shift_left(session_length, 2) AND bitwise_shift_left(session_length, 2)-1
+              AND bitwise_shift_left(session_length, 2) like '%'
+              AND bitwise_shift_left(session_length, 2) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_shift_left(session_length, 2) IN (bitwise_shift_left(session_length, 2)-1,
+                                                                                                 bitwise_shift_left(session_length, 2)+0,
+                                                                                                 bitwise_shift_left(session_length, 2)+1)
+              AND bitwise_shift_left(session_length, 2) NOT IN (bitwise_shift_left(session_length, 2)-1,
+                                                                                                     bitwise_shift_left(session_length, 2)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A31: bitwise_shift_right
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_shift_right(session_length, 2) IS NULL
+       OR (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)+0
+           AND bitwise_shift_right(session_length, 2) IS NOT DISTINCT
+           FROM bitwise_shift_right(session_length, 2)+0
+           AND bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1
+           AND (bitwise_shift_right(session_length, 2) IS DISTINCT
+                FROM bitwise_shift_right(session_length, 2)-1)
+           AND bitwise_shift_right(session_length, 2) > bitwise_shift_right(session_length, 2)-1
+           AND bitwise_shift_right(session_length, 2) >= bitwise_shift_right(session_length, 2)-1
+           AND bitwise_shift_right(session_length, 2) < bitwise_shift_right(session_length, 2)+1
+           AND bitwise_shift_right(session_length, 2) <= bitwise_shift_right(session_length, 2)+1
+           AND (bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1) IS TRUE
+           AND (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)-1) IS NOT TRUE
+           AND (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)-1) IS FALSE
+           AND (bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1) IS NOT FALSE
+           AND bitwise_shift_right(session_length, 2) BETWEEN bitwise_shift_right(session_length, 2)-1 AND bitwise_shift_right(session_length, 2)+1
+           AND bitwise_shift_right(session_length, 2) NOT BETWEEN bitwise_shift_right(session_length, 2) AND bitwise_shift_right(session_length, 2)-1
+           AND bitwise_shift_right(session_length, 2) like '%'
+           AND bitwise_shift_right(session_length, 2) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_shift_right(session_length, 2) IN (bitwise_shift_right(session_length, 2)-1,
+                                                                                                bitwise_shift_right(session_length, 2)+0,
+                                                                                                bitwise_shift_right(session_length, 2)+1)
+           AND bitwise_shift_right(session_length, 2) NOT IN (bitwise_shift_right(session_length, 2)-1,
+                                                                                                    bitwise_shift_right(session_length, 2)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_shift_right(session_length, 2) IS NULL
+       OR bitwise_shift_right(session_length, 2) IN
+         (SELECT bitwise_shift_right(session_length, 2)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_shift_right(session_length, 2) IS NULL
+                 OR (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)+0
+                     AND bitwise_shift_right(session_length, 2) IS NOT DISTINCT
+                     FROM bitwise_shift_right(session_length, 2)+0
+                     AND bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1
+                     AND (bitwise_shift_right(session_length, 2) IS DISTINCT
+                          FROM bitwise_shift_right(session_length, 2)-1)
+                     AND bitwise_shift_right(session_length, 2) > bitwise_shift_right(session_length, 2)-1
+                     AND bitwise_shift_right(session_length, 2) >= bitwise_shift_right(session_length, 2)-1
+                     AND bitwise_shift_right(session_length, 2) < bitwise_shift_right(session_length, 2)+1
+                     AND bitwise_shift_right(session_length, 2) <= bitwise_shift_right(session_length, 2)+1
+                     AND (bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1) IS TRUE
+                     AND (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)-1) IS NOT TRUE
+                     AND (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)-1) IS FALSE
+                     AND (bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1) IS NOT FALSE
+                     AND bitwise_shift_right(session_length, 2) BETWEEN bitwise_shift_right(session_length, 2)-1 AND bitwise_shift_right(session_length, 2)+1
+                     AND bitwise_shift_right(session_length, 2) NOT BETWEEN bitwise_shift_right(session_length, 2) AND bitwise_shift_right(session_length, 2)-1
+                     AND bitwise_shift_right(session_length, 2) like '%'
+                     AND bitwise_shift_right(session_length, 2) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_shift_right(session_length, 2) IN (bitwise_shift_right(session_length, 2)-1,
+                                                                                                          bitwise_shift_right(session_length, 2)+0,
+                                                                                                          bitwise_shift_right(session_length, 2)+1)
+                     AND bitwise_shift_right(session_length, 2) NOT IN (bitwise_shift_right(session_length, 2)-1,
+                                                                                                              bitwise_shift_right(session_length, 2)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_shift_right(session_length, 2),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_shift_right(session_length, 2) IS NULL
+          OR (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)+0
+              AND bitwise_shift_right(session_length, 2) IS NOT DISTINCT
+              FROM bitwise_shift_right(session_length, 2)+0
+              AND bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1
+              AND (bitwise_shift_right(session_length, 2) IS DISTINCT
+                   FROM bitwise_shift_right(session_length, 2)-1)
+              AND bitwise_shift_right(session_length, 2) > bitwise_shift_right(session_length, 2)-1
+              AND bitwise_shift_right(session_length, 2) >= bitwise_shift_right(session_length, 2)-1
+              AND bitwise_shift_right(session_length, 2) < bitwise_shift_right(session_length, 2)+1
+              AND bitwise_shift_right(session_length, 2) <= bitwise_shift_right(session_length, 2)+1
+              AND (bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1) IS TRUE
+              AND (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)-1) IS NOT TRUE
+              AND (bitwise_shift_right(session_length, 2) = bitwise_shift_right(session_length, 2)-1) IS FALSE
+              AND (bitwise_shift_right(session_length, 2) <> bitwise_shift_right(session_length, 2)-1) IS NOT FALSE
+              AND bitwise_shift_right(session_length, 2) BETWEEN bitwise_shift_right(session_length, 2)-1 AND bitwise_shift_right(session_length, 2)+1
+              AND bitwise_shift_right(session_length, 2) NOT BETWEEN bitwise_shift_right(session_length, 2) AND bitwise_shift_right(session_length, 2)-1
+              AND bitwise_shift_right(session_length, 2) like '%'
+              AND bitwise_shift_right(session_length, 2) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_shift_right(session_length, 2) IN (bitwise_shift_right(session_length, 2)-1,
+                                                                                                   bitwise_shift_right(session_length, 2)+0,
+                                                                                                   bitwise_shift_right(session_length, 2)+1)
+              AND bitwise_shift_right(session_length, 2) NOT IN (bitwise_shift_right(session_length, 2)-1,
+                                                                                                       bitwise_shift_right(session_length, 2)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A32: bitwise_xor
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_xor(session_length, session_length) IS NULL
+       OR (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)+0
+           AND bitwise_xor(session_length, session_length) IS NOT DISTINCT
+           FROM bitwise_xor(session_length, session_length)+0
+           AND bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1
+           AND (bitwise_xor(session_length, session_length) IS DISTINCT
+                FROM bitwise_xor(session_length, session_length)-1)
+           AND bitwise_xor(session_length, session_length) > bitwise_xor(session_length, session_length)-1
+           AND bitwise_xor(session_length, session_length) >= bitwise_xor(session_length, session_length)-1
+           AND bitwise_xor(session_length, session_length) < bitwise_xor(session_length, session_length)+1
+           AND bitwise_xor(session_length, session_length) <= bitwise_xor(session_length, session_length)+1
+           AND (bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1) IS TRUE
+           AND (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)-1) IS NOT TRUE
+           AND (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)-1) IS FALSE
+           AND (bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1) IS NOT FALSE
+           AND bitwise_xor(session_length, session_length) BETWEEN bitwise_xor(session_length, session_length)-1 AND bitwise_xor(session_length, session_length)+1
+           AND bitwise_xor(session_length, session_length) NOT BETWEEN bitwise_xor(session_length, session_length) AND bitwise_xor(session_length, session_length)-1
+           AND bitwise_xor(session_length, session_length) like '%'
+           AND bitwise_xor(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+           AND bitwise_xor(session_length, session_length) IN (bitwise_xor(session_length, session_length)-1,
+                                                                                                          bitwise_xor(session_length, session_length)+0,
+                                                                                                          bitwise_xor(session_length, session_length)+1)
+           AND bitwise_xor(session_length, session_length) NOT IN (bitwise_xor(session_length, session_length)-1,
+                                                                                                              bitwise_xor(session_length, session_length)+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (bitwise_xor(session_length, session_length) IS NULL
+       OR bitwise_xor(session_length, session_length) IN
+         (SELECT bitwise_xor(session_length, session_length)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (bitwise_xor(session_length, session_length) IS NULL
+                 OR (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)+0
+                     AND bitwise_xor(session_length, session_length) IS NOT DISTINCT
+                     FROM bitwise_xor(session_length, session_length)+0
+                     AND bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1
+                     AND (bitwise_xor(session_length, session_length) IS DISTINCT
+                          FROM bitwise_xor(session_length, session_length)-1)
+                     AND bitwise_xor(session_length, session_length) > bitwise_xor(session_length, session_length)-1
+                     AND bitwise_xor(session_length, session_length) >= bitwise_xor(session_length, session_length)-1
+                     AND bitwise_xor(session_length, session_length) < bitwise_xor(session_length, session_length)+1
+                     AND bitwise_xor(session_length, session_length) <= bitwise_xor(session_length, session_length)+1
+                     AND (bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1) IS TRUE
+                     AND (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)-1) IS NOT TRUE
+                     AND (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)-1) IS FALSE
+                     AND (bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1) IS NOT FALSE
+                     AND bitwise_xor(session_length, session_length) BETWEEN bitwise_xor(session_length, session_length)-1 AND bitwise_xor(session_length, session_length)+1
+                     AND bitwise_xor(session_length, session_length) NOT BETWEEN bitwise_xor(session_length, session_length) AND bitwise_xor(session_length, session_length)-1
+                     AND bitwise_xor(session_length, session_length) like '%'
+                     AND bitwise_xor(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+                     AND bitwise_xor(session_length, session_length) IN (bitwise_xor(session_length, session_length)-1,
+                                                                                                                    bitwise_xor(session_length, session_length)+0,
+                                                                                                                    bitwise_xor(session_length, session_length)+1)
+                     AND bitwise_xor(session_length, session_length) NOT IN (bitwise_xor(session_length, session_length)-1,
+                                                                                                                        bitwise_xor(session_length, session_length)+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          bitwise_xor(session_length, session_length),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (bitwise_xor(session_length, session_length) IS NULL
+          OR (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)+0
+              AND bitwise_xor(session_length, session_length) IS NOT DISTINCT
+              FROM bitwise_xor(session_length, session_length)+0
+              AND bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1
+              AND (bitwise_xor(session_length, session_length) IS DISTINCT
+                   FROM bitwise_xor(session_length, session_length)-1)
+              AND bitwise_xor(session_length, session_length) > bitwise_xor(session_length, session_length)-1
+              AND bitwise_xor(session_length, session_length) >= bitwise_xor(session_length, session_length)-1
+              AND bitwise_xor(session_length, session_length) < bitwise_xor(session_length, session_length)+1
+              AND bitwise_xor(session_length, session_length) <= bitwise_xor(session_length, session_length)+1
+              AND (bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1) IS TRUE
+              AND (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)-1) IS NOT TRUE
+              AND (bitwise_xor(session_length, session_length) = bitwise_xor(session_length, session_length)-1) IS FALSE
+              AND (bitwise_xor(session_length, session_length) <> bitwise_xor(session_length, session_length)-1) IS NOT FALSE
+              AND bitwise_xor(session_length, session_length) BETWEEN bitwise_xor(session_length, session_length)-1 AND bitwise_xor(session_length, session_length)+1
+              AND bitwise_xor(session_length, session_length) NOT BETWEEN bitwise_xor(session_length, session_length) AND bitwise_xor(session_length, session_length)-1
+              AND bitwise_xor(session_length, session_length) like '%'
+              AND bitwise_xor(session_length, session_length) not like '__DOES_NOT_EXIST__%'
+              AND bitwise_xor(session_length, session_length) IN (bitwise_xor(session_length, session_length)-1,
+                                                                                                             bitwise_xor(session_length, session_length)+0,
+                                                                                                             bitwise_xor(session_length, session_length)+1)
+              AND bitwise_xor(session_length, session_length) NOT IN (bitwise_xor(session_length, session_length)-1,
+                                                                                                                 bitwise_xor(session_length, session_length)+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A33: human_readable_binary_byte_format
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||human_readable_binary_byte_format(session_length, 1) IS NULL
+       OR ('1'||human_readable_binary_byte_format(session_length, 1) = 1||human_readable_binary_byte_format(session_length, 1)
+           AND '1'||human_readable_binary_byte_format(session_length, 1) IS NOT DISTINCT
+           FROM 1||human_readable_binary_byte_format(session_length, 1)
+           AND '1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)
+           AND ('1'||human_readable_binary_byte_format(session_length, 1) IS DISTINCT
+                FROM '0'||human_readable_binary_byte_format(session_length, 1))
+           AND '1'||human_readable_binary_byte_format(session_length, 1) > '0'||human_readable_binary_byte_format(session_length, 1)
+           AND '1'||human_readable_binary_byte_format(session_length, 1) >= '0'||human_readable_binary_byte_format(session_length, 1)
+           AND '1'||human_readable_binary_byte_format(session_length, 1) < 2||human_readable_binary_byte_format(session_length, 1)
+           AND '1'||human_readable_binary_byte_format(session_length, 1) <= 2||human_readable_binary_byte_format(session_length, 1)
+           AND ('1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)) IS TRUE
+           AND ('1'||human_readable_binary_byte_format(session_length, 1) = '0'||human_readable_binary_byte_format(session_length, 1)) IS NOT TRUE
+           AND ('1'||human_readable_binary_byte_format(session_length, 1) = '0'||human_readable_binary_byte_format(session_length, 1)) IS FALSE
+           AND ('1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)) IS NOT FALSE
+           AND '1'||human_readable_binary_byte_format(session_length, 1) BETWEEN '0'||human_readable_binary_byte_format(session_length, 1) AND 2||human_readable_binary_byte_format(session_length, 1)
+           AND '1'||human_readable_binary_byte_format(session_length, 1) NOT BETWEEN '1'||human_readable_binary_byte_format(session_length, 1) AND '0'||human_readable_binary_byte_format(session_length, 1)
+           AND '1'||human_readable_binary_byte_format(session_length, 1) like '%'
+           AND '1'||human_readable_binary_byte_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+           AND '1'||human_readable_binary_byte_format(session_length, 1) IN ('0'||human_readable_binary_byte_format(session_length, 1),
+                                                                             1||human_readable_binary_byte_format(session_length, 1),
+                                                                             2||human_readable_binary_byte_format(session_length, 1))
+           AND '1'||human_readable_binary_byte_format(session_length, 1) NOT IN ('0'||human_readable_binary_byte_format(session_length, 1),
+                                                                                 2||human_readable_binary_byte_format(session_length, 1)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||human_readable_binary_byte_format(session_length, 1) IS NULL
+       OR '1'||human_readable_binary_byte_format(session_length, 1) IN
+         (SELECT '1'||human_readable_binary_byte_format(session_length, 1)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||human_readable_binary_byte_format(session_length, 1) IS NULL
+                 OR ('1'||human_readable_binary_byte_format(session_length, 1) = 1||human_readable_binary_byte_format(session_length, 1)
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) IS NOT DISTINCT
+                     FROM 1||human_readable_binary_byte_format(session_length, 1)
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)
+                     AND ('1'||human_readable_binary_byte_format(session_length, 1) IS DISTINCT
+                          FROM '0'||human_readable_binary_byte_format(session_length, 1))
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) > '0'||human_readable_binary_byte_format(session_length, 1)
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) >= '0'||human_readable_binary_byte_format(session_length, 1)
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) < 2||human_readable_binary_byte_format(session_length, 1)
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) <= 2||human_readable_binary_byte_format(session_length, 1)
+                     AND ('1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)) IS TRUE
+                     AND ('1'||human_readable_binary_byte_format(session_length, 1) = '0'||human_readable_binary_byte_format(session_length, 1)) IS NOT TRUE
+                     AND ('1'||human_readable_binary_byte_format(session_length, 1) = '0'||human_readable_binary_byte_format(session_length, 1)) IS FALSE
+                     AND ('1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)) IS NOT FALSE
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) BETWEEN '0'||human_readable_binary_byte_format(session_length, 1) AND 2||human_readable_binary_byte_format(session_length, 1)
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) NOT BETWEEN '1'||human_readable_binary_byte_format(session_length, 1) AND '0'||human_readable_binary_byte_format(session_length, 1)
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) like '%'
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) IN ('0'||human_readable_binary_byte_format(session_length, 1),
+                                                                                       1||human_readable_binary_byte_format(session_length, 1),
+                                                                                       2||human_readable_binary_byte_format(session_length, 1))
+                     AND '1'||human_readable_binary_byte_format(session_length, 1) NOT IN ('0'||human_readable_binary_byte_format(session_length, 1),
+                                                                                           2||human_readable_binary_byte_format(session_length, 1))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||human_readable_binary_byte_format(session_length, 1),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||human_readable_binary_byte_format(session_length, 1) IS NULL
+          OR ('1'||human_readable_binary_byte_format(session_length, 1) = 1||human_readable_binary_byte_format(session_length, 1)
+              AND '1'||human_readable_binary_byte_format(session_length, 1) IS NOT DISTINCT
+              FROM 1||human_readable_binary_byte_format(session_length, 1)
+              AND '1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)
+              AND ('1'||human_readable_binary_byte_format(session_length, 1) IS DISTINCT
+                   FROM '0'||human_readable_binary_byte_format(session_length, 1))
+              AND '1'||human_readable_binary_byte_format(session_length, 1) > '0'||human_readable_binary_byte_format(session_length, 1)
+              AND '1'||human_readable_binary_byte_format(session_length, 1) >= '0'||human_readable_binary_byte_format(session_length, 1)
+              AND '1'||human_readable_binary_byte_format(session_length, 1) < 2||human_readable_binary_byte_format(session_length, 1)
+              AND '1'||human_readable_binary_byte_format(session_length, 1) <= 2||human_readable_binary_byte_format(session_length, 1)
+              AND ('1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)) IS TRUE
+              AND ('1'||human_readable_binary_byte_format(session_length, 1) = '0'||human_readable_binary_byte_format(session_length, 1)) IS NOT TRUE
+              AND ('1'||human_readable_binary_byte_format(session_length, 1) = '0'||human_readable_binary_byte_format(session_length, 1)) IS FALSE
+              AND ('1'||human_readable_binary_byte_format(session_length, 1) <> '0'||human_readable_binary_byte_format(session_length, 1)) IS NOT FALSE
+              AND '1'||human_readable_binary_byte_format(session_length, 1) BETWEEN '0'||human_readable_binary_byte_format(session_length, 1) AND 2||human_readable_binary_byte_format(session_length, 1)
+              AND '1'||human_readable_binary_byte_format(session_length, 1) NOT BETWEEN '1'||human_readable_binary_byte_format(session_length, 1) AND '0'||human_readable_binary_byte_format(session_length, 1)
+              AND '1'||human_readable_binary_byte_format(session_length, 1) like '%'
+              AND '1'||human_readable_binary_byte_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+              AND '1'||human_readable_binary_byte_format(session_length, 1) IN ('0'||human_readable_binary_byte_format(session_length, 1),
+                                                                                1||human_readable_binary_byte_format(session_length, 1),
+                                                                                2||human_readable_binary_byte_format(session_length, 1))
+              AND '1'||human_readable_binary_byte_format(session_length, 1) NOT IN ('0'||human_readable_binary_byte_format(session_length, 1),
+                                                                                    2||human_readable_binary_byte_format(session_length, 1))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A34: human_readable_decimal_byte_format
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||human_readable_decimal_byte_format(session_length, 1) IS NULL
+       OR ('1'||human_readable_decimal_byte_format(session_length, 1) = 1||human_readable_decimal_byte_format(session_length, 1)
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) IS NOT DISTINCT
+           FROM 1||human_readable_decimal_byte_format(session_length, 1)
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)
+           AND ('1'||human_readable_decimal_byte_format(session_length, 1) IS DISTINCT
+                FROM '0'||human_readable_decimal_byte_format(session_length, 1))
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) > '0'||human_readable_decimal_byte_format(session_length, 1)
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) >= '0'||human_readable_decimal_byte_format(session_length, 1)
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) < 2||human_readable_decimal_byte_format(session_length, 1)
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) <= 2||human_readable_decimal_byte_format(session_length, 1)
+           AND ('1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)) IS TRUE
+           AND ('1'||human_readable_decimal_byte_format(session_length, 1) = '0'||human_readable_decimal_byte_format(session_length, 1)) IS NOT TRUE
+           AND ('1'||human_readable_decimal_byte_format(session_length, 1) = '0'||human_readable_decimal_byte_format(session_length, 1)) IS FALSE
+           AND ('1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)) IS NOT FALSE
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) BETWEEN '0'||human_readable_decimal_byte_format(session_length, 1) AND 2||human_readable_decimal_byte_format(session_length, 1)
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) NOT BETWEEN '1'||human_readable_decimal_byte_format(session_length, 1) AND '0'||human_readable_decimal_byte_format(session_length, 1)
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) like '%'
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) IN ('0'||human_readable_decimal_byte_format(session_length, 1),
+                                                                              1||human_readable_decimal_byte_format(session_length, 1),
+                                                                              2||human_readable_decimal_byte_format(session_length, 1))
+           AND '1'||human_readable_decimal_byte_format(session_length, 1) NOT IN ('0'||human_readable_decimal_byte_format(session_length, 1),
+                                                                                  2||human_readable_decimal_byte_format(session_length, 1)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||human_readable_decimal_byte_format(session_length, 1) IS NULL
+       OR '1'||human_readable_decimal_byte_format(session_length, 1) IN
+         (SELECT '1'||human_readable_decimal_byte_format(session_length, 1)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||human_readable_decimal_byte_format(session_length, 1) IS NULL
+                 OR ('1'||human_readable_decimal_byte_format(session_length, 1) = 1||human_readable_decimal_byte_format(session_length, 1)
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) IS NOT DISTINCT
+                     FROM 1||human_readable_decimal_byte_format(session_length, 1)
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)
+                     AND ('1'||human_readable_decimal_byte_format(session_length, 1) IS DISTINCT
+                          FROM '0'||human_readable_decimal_byte_format(session_length, 1))
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) > '0'||human_readable_decimal_byte_format(session_length, 1)
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) >= '0'||human_readable_decimal_byte_format(session_length, 1)
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) < 2||human_readable_decimal_byte_format(session_length, 1)
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) <= 2||human_readable_decimal_byte_format(session_length, 1)
+                     AND ('1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)) IS TRUE
+                     AND ('1'||human_readable_decimal_byte_format(session_length, 1) = '0'||human_readable_decimal_byte_format(session_length, 1)) IS NOT TRUE
+                     AND ('1'||human_readable_decimal_byte_format(session_length, 1) = '0'||human_readable_decimal_byte_format(session_length, 1)) IS FALSE
+                     AND ('1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)) IS NOT FALSE
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) BETWEEN '0'||human_readable_decimal_byte_format(session_length, 1) AND 2||human_readable_decimal_byte_format(session_length, 1)
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) NOT BETWEEN '1'||human_readable_decimal_byte_format(session_length, 1) AND '0'||human_readable_decimal_byte_format(session_length, 1)
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) like '%'
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) IN ('0'||human_readable_decimal_byte_format(session_length, 1),
+                                                                                        1||human_readable_decimal_byte_format(session_length, 1),
+                                                                                        2||human_readable_decimal_byte_format(session_length, 1))
+                     AND '1'||human_readable_decimal_byte_format(session_length, 1) NOT IN ('0'||human_readable_decimal_byte_format(session_length, 1),
+                                                                                            2||human_readable_decimal_byte_format(session_length, 1))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||human_readable_decimal_byte_format(session_length, 1),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||human_readable_decimal_byte_format(session_length, 1) IS NULL
+          OR ('1'||human_readable_decimal_byte_format(session_length, 1) = 1||human_readable_decimal_byte_format(session_length, 1)
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) IS NOT DISTINCT
+              FROM 1||human_readable_decimal_byte_format(session_length, 1)
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)
+              AND ('1'||human_readable_decimal_byte_format(session_length, 1) IS DISTINCT
+                   FROM '0'||human_readable_decimal_byte_format(session_length, 1))
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) > '0'||human_readable_decimal_byte_format(session_length, 1)
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) >= '0'||human_readable_decimal_byte_format(session_length, 1)
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) < 2||human_readable_decimal_byte_format(session_length, 1)
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) <= 2||human_readable_decimal_byte_format(session_length, 1)
+              AND ('1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)) IS TRUE
+              AND ('1'||human_readable_decimal_byte_format(session_length, 1) = '0'||human_readable_decimal_byte_format(session_length, 1)) IS NOT TRUE
+              AND ('1'||human_readable_decimal_byte_format(session_length, 1) = '0'||human_readable_decimal_byte_format(session_length, 1)) IS FALSE
+              AND ('1'||human_readable_decimal_byte_format(session_length, 1) <> '0'||human_readable_decimal_byte_format(session_length, 1)) IS NOT FALSE
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) BETWEEN '0'||human_readable_decimal_byte_format(session_length, 1) AND 2||human_readable_decimal_byte_format(session_length, 1)
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) NOT BETWEEN '1'||human_readable_decimal_byte_format(session_length, 1) AND '0'||human_readable_decimal_byte_format(session_length, 1)
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) like '%'
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) IN ('0'||human_readable_decimal_byte_format(session_length, 1),
+                                                                                 1||human_readable_decimal_byte_format(session_length, 1),
+                                                                                 2||human_readable_decimal_byte_format(session_length, 1))
+              AND '1'||human_readable_decimal_byte_format(session_length, 1) NOT IN ('0'||human_readable_decimal_byte_format(session_length, 1),
+                                                                                     2||human_readable_decimal_byte_format(session_length, 1))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A35: human_readable_decimal_format
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||human_readable_decimal_format(session_length, 1) IS NULL
+       OR ('1'||human_readable_decimal_format(session_length, 1) = 1||human_readable_decimal_format(session_length, 1)
+           AND '1'||human_readable_decimal_format(session_length, 1) IS NOT DISTINCT
+           FROM 1||human_readable_decimal_format(session_length, 1)
+           AND '1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)
+           AND ('1'||human_readable_decimal_format(session_length, 1) IS DISTINCT
+                FROM '0'||human_readable_decimal_format(session_length, 1))
+           AND '1'||human_readable_decimal_format(session_length, 1) > '0'||human_readable_decimal_format(session_length, 1)
+           AND '1'||human_readable_decimal_format(session_length, 1) >= '0'||human_readable_decimal_format(session_length, 1)
+           AND '1'||human_readable_decimal_format(session_length, 1) < 2||human_readable_decimal_format(session_length, 1)
+           AND '1'||human_readable_decimal_format(session_length, 1) <= 2||human_readable_decimal_format(session_length, 1)
+           AND ('1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)) IS TRUE
+           AND ('1'||human_readable_decimal_format(session_length, 1) = '0'||human_readable_decimal_format(session_length, 1)) IS NOT TRUE
+           AND ('1'||human_readable_decimal_format(session_length, 1) = '0'||human_readable_decimal_format(session_length, 1)) IS FALSE
+           AND ('1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)) IS NOT FALSE
+           AND '1'||human_readable_decimal_format(session_length, 1) BETWEEN '0'||human_readable_decimal_format(session_length, 1) AND 2||human_readable_decimal_format(session_length, 1)
+           AND '1'||human_readable_decimal_format(session_length, 1) NOT BETWEEN '1'||human_readable_decimal_format(session_length, 1) AND '0'||human_readable_decimal_format(session_length, 1)
+           AND '1'||human_readable_decimal_format(session_length, 1) like '%'
+           AND '1'||human_readable_decimal_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+           AND '1'||human_readable_decimal_format(session_length, 1) IN ('0'||human_readable_decimal_format(session_length, 1),
+                                                                         1||human_readable_decimal_format(session_length, 1),
+                                                                         2||human_readable_decimal_format(session_length, 1))
+           AND '1'||human_readable_decimal_format(session_length, 1) NOT IN ('0'||human_readable_decimal_format(session_length, 1),
+                                                                             2||human_readable_decimal_format(session_length, 1)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||human_readable_decimal_format(session_length, 1) IS NULL
+       OR '1'||human_readable_decimal_format(session_length, 1) IN
+         (SELECT '1'||human_readable_decimal_format(session_length, 1)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||human_readable_decimal_format(session_length, 1) IS NULL
+                 OR ('1'||human_readable_decimal_format(session_length, 1) = 1||human_readable_decimal_format(session_length, 1)
+                     AND '1'||human_readable_decimal_format(session_length, 1) IS NOT DISTINCT
+                     FROM 1||human_readable_decimal_format(session_length, 1)
+                     AND '1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)
+                     AND ('1'||human_readable_decimal_format(session_length, 1) IS DISTINCT
+                          FROM '0'||human_readable_decimal_format(session_length, 1))
+                     AND '1'||human_readable_decimal_format(session_length, 1) > '0'||human_readable_decimal_format(session_length, 1)
+                     AND '1'||human_readable_decimal_format(session_length, 1) >= '0'||human_readable_decimal_format(session_length, 1)
+                     AND '1'||human_readable_decimal_format(session_length, 1) < 2||human_readable_decimal_format(session_length, 1)
+                     AND '1'||human_readable_decimal_format(session_length, 1) <= 2||human_readable_decimal_format(session_length, 1)
+                     AND ('1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)) IS TRUE
+                     AND ('1'||human_readable_decimal_format(session_length, 1) = '0'||human_readable_decimal_format(session_length, 1)) IS NOT TRUE
+                     AND ('1'||human_readable_decimal_format(session_length, 1) = '0'||human_readable_decimal_format(session_length, 1)) IS FALSE
+                     AND ('1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)) IS NOT FALSE
+                     AND '1'||human_readable_decimal_format(session_length, 1) BETWEEN '0'||human_readable_decimal_format(session_length, 1) AND 2||human_readable_decimal_format(session_length, 1)
+                     AND '1'||human_readable_decimal_format(session_length, 1) NOT BETWEEN '1'||human_readable_decimal_format(session_length, 1) AND '0'||human_readable_decimal_format(session_length, 1)
+                     AND '1'||human_readable_decimal_format(session_length, 1) like '%'
+                     AND '1'||human_readable_decimal_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||human_readable_decimal_format(session_length, 1) IN ('0'||human_readable_decimal_format(session_length, 1),
+                                                                                   1||human_readable_decimal_format(session_length, 1),
+                                                                                   2||human_readable_decimal_format(session_length, 1))
+                     AND '1'||human_readable_decimal_format(session_length, 1) NOT IN ('0'||human_readable_decimal_format(session_length, 1),
+                                                                                       2||human_readable_decimal_format(session_length, 1))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||human_readable_decimal_format(session_length, 1),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||human_readable_decimal_format(session_length, 1) IS NULL
+          OR ('1'||human_readable_decimal_format(session_length, 1) = 1||human_readable_decimal_format(session_length, 1)
+              AND '1'||human_readable_decimal_format(session_length, 1) IS NOT DISTINCT
+              FROM 1||human_readable_decimal_format(session_length, 1)
+              AND '1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)
+              AND ('1'||human_readable_decimal_format(session_length, 1) IS DISTINCT
+                   FROM '0'||human_readable_decimal_format(session_length, 1))
+              AND '1'||human_readable_decimal_format(session_length, 1) > '0'||human_readable_decimal_format(session_length, 1)
+              AND '1'||human_readable_decimal_format(session_length, 1) >= '0'||human_readable_decimal_format(session_length, 1)
+              AND '1'||human_readable_decimal_format(session_length, 1) < 2||human_readable_decimal_format(session_length, 1)
+              AND '1'||human_readable_decimal_format(session_length, 1) <= 2||human_readable_decimal_format(session_length, 1)
+              AND ('1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)) IS TRUE
+              AND ('1'||human_readable_decimal_format(session_length, 1) = '0'||human_readable_decimal_format(session_length, 1)) IS NOT TRUE
+              AND ('1'||human_readable_decimal_format(session_length, 1) = '0'||human_readable_decimal_format(session_length, 1)) IS FALSE
+              AND ('1'||human_readable_decimal_format(session_length, 1) <> '0'||human_readable_decimal_format(session_length, 1)) IS NOT FALSE
+              AND '1'||human_readable_decimal_format(session_length, 1) BETWEEN '0'||human_readable_decimal_format(session_length, 1) AND 2||human_readable_decimal_format(session_length, 1)
+              AND '1'||human_readable_decimal_format(session_length, 1) NOT BETWEEN '1'||human_readable_decimal_format(session_length, 1) AND '0'||human_readable_decimal_format(session_length, 1)
+              AND '1'||human_readable_decimal_format(session_length, 1) like '%'
+              AND '1'||human_readable_decimal_format(session_length, 1) not like '__DOES_NOT_EXIST__%'
+              AND '1'||human_readable_decimal_format(session_length, 1) IN ('0'||human_readable_decimal_format(session_length, 1),
+                                                                            1||human_readable_decimal_format(session_length, 1),
+                                                                            2||human_readable_decimal_format(session_length, 1))
+              AND '1'||human_readable_decimal_format(session_length, 1) NOT IN ('0'||human_readable_decimal_format(session_length, 1),
+                                                                                2||human_readable_decimal_format(session_length, 1))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A36: safe_divide
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(safe_divide(session_length, session_length)) IS NULL
+       OR (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))+0
+           AND floor(safe_divide(session_length, session_length)) IS NOT DISTINCT
+           FROM floor(safe_divide(session_length, session_length))+0
+           AND floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1
+           AND (floor(safe_divide(session_length, session_length)) IS DISTINCT
+                FROM floor(safe_divide(session_length, session_length))-1)
+           AND floor(safe_divide(session_length, session_length)) > floor(safe_divide(session_length, session_length))-1
+           AND floor(safe_divide(session_length, session_length)) >= floor(safe_divide(session_length, session_length))-1
+           AND floor(safe_divide(session_length, session_length)) < floor(safe_divide(session_length, session_length))+1
+           AND floor(safe_divide(session_length, session_length)) <= floor(safe_divide(session_length, session_length))+1
+           AND (floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1) IS TRUE
+           AND (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))-1) IS NOT TRUE
+           AND (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))-1) IS FALSE
+           AND (floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1) IS NOT FALSE
+           AND floor(safe_divide(session_length, session_length)) BETWEEN floor(safe_divide(session_length, session_length))-1 AND floor(safe_divide(session_length, session_length))+1
+           AND floor(safe_divide(session_length, session_length)) NOT BETWEEN floor(safe_divide(session_length, session_length)) AND floor(safe_divide(session_length, session_length))-1
+           AND floor(safe_divide(session_length, session_length)) like '%'
+           AND floor(safe_divide(session_length, session_length)) not like '__DOES_NOT_EXIST__%'
+           AND floor(safe_divide(session_length, session_length)) IN (floor(safe_divide(session_length, session_length))-1,
+                                                                                                                        floor(safe_divide(session_length, session_length))+0,
+                                                                                                                        floor(safe_divide(session_length, session_length))+1)
+           AND floor(safe_divide(session_length, session_length)) NOT IN (floor(safe_divide(session_length, session_length))-1,
+                                                                                                                            floor(safe_divide(session_length, session_length))+1))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (floor(safe_divide(session_length, session_length)) IS NULL
+       OR floor(safe_divide(session_length, session_length)) IN
+         (SELECT floor(safe_divide(session_length, session_length))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (floor(safe_divide(session_length, session_length)) IS NULL
+                 OR (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))+0
+                     AND floor(safe_divide(session_length, session_length)) IS NOT DISTINCT
+                     FROM floor(safe_divide(session_length, session_length))+0
+                     AND floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1
+                     AND (floor(safe_divide(session_length, session_length)) IS DISTINCT
+                          FROM floor(safe_divide(session_length, session_length))-1)
+                     AND floor(safe_divide(session_length, session_length)) > floor(safe_divide(session_length, session_length))-1
+                     AND floor(safe_divide(session_length, session_length)) >= floor(safe_divide(session_length, session_length))-1
+                     AND floor(safe_divide(session_length, session_length)) < floor(safe_divide(session_length, session_length))+1
+                     AND floor(safe_divide(session_length, session_length)) <= floor(safe_divide(session_length, session_length))+1
+                     AND (floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1) IS TRUE
+                     AND (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))-1) IS NOT TRUE
+                     AND (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))-1) IS FALSE
+                     AND (floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1) IS NOT FALSE
+                     AND floor(safe_divide(session_length, session_length)) BETWEEN floor(safe_divide(session_length, session_length))-1 AND floor(safe_divide(session_length, session_length))+1
+                     AND floor(safe_divide(session_length, session_length)) NOT BETWEEN floor(safe_divide(session_length, session_length)) AND floor(safe_divide(session_length, session_length))-1
+                     AND floor(safe_divide(session_length, session_length)) like '%'
+                     AND floor(safe_divide(session_length, session_length)) not like '__DOES_NOT_EXIST__%'
+                     AND floor(safe_divide(session_length, session_length)) IN (floor(safe_divide(session_length, session_length))-1,
+                                                                                                                                  floor(safe_divide(session_length, session_length))+0,
+                                                                                                                                  floor(safe_divide(session_length, session_length))+1)
+                     AND floor(safe_divide(session_length, session_length)) NOT IN (floor(safe_divide(session_length, session_length))-1,
+                                                                                                                                      floor(safe_divide(session_length, session_length))+1)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          floor(safe_divide(session_length, session_length)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (floor(safe_divide(session_length, session_length)) IS NULL
+          OR (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))+0
+              AND floor(safe_divide(session_length, session_length)) IS NOT DISTINCT
+              FROM floor(safe_divide(session_length, session_length))+0
+              AND floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1
+              AND (floor(safe_divide(session_length, session_length)) IS DISTINCT
+                   FROM floor(safe_divide(session_length, session_length))-1)
+              AND floor(safe_divide(session_length, session_length)) > floor(safe_divide(session_length, session_length))-1
+              AND floor(safe_divide(session_length, session_length)) >= floor(safe_divide(session_length, session_length))-1
+              AND floor(safe_divide(session_length, session_length)) < floor(safe_divide(session_length, session_length))+1
+              AND floor(safe_divide(session_length, session_length)) <= floor(safe_divide(session_length, session_length))+1
+              AND (floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1) IS TRUE
+              AND (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))-1) IS NOT TRUE
+              AND (floor(safe_divide(session_length, session_length)) = floor(safe_divide(session_length, session_length))-1) IS FALSE
+              AND (floor(safe_divide(session_length, session_length)) <> floor(safe_divide(session_length, session_length))-1) IS NOT FALSE
+              AND floor(safe_divide(session_length, session_length)) BETWEEN floor(safe_divide(session_length, session_length))-1 AND floor(safe_divide(session_length, session_length))+1
+              AND floor(safe_divide(session_length, session_length)) NOT BETWEEN floor(safe_divide(session_length, session_length)) AND floor(safe_divide(session_length, session_length))-1
+              AND floor(safe_divide(session_length, session_length)) like '%'
+              AND floor(safe_divide(session_length, session_length)) not like '__DOES_NOT_EXIST__%'
+              AND floor(safe_divide(session_length, session_length)) IN (floor(safe_divide(session_length, session_length))-1,
+                                                                                                                           floor(safe_divide(session_length, session_length))+0,
+                                                                                                                           floor(safe_divide(session_length, session_length))+1)
+              AND floor(safe_divide(session_length, session_length)) NOT IN (floor(safe_divide(session_length, session_length))-1,
+                                                                                                                               floor(safe_divide(session_length, session_length))+1)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# Total query count 109
+#-------------------------------------------------------------------------

--- a/quidem-ut/src/test/quidem/org.apache.druid.quidem.QTest/qaSQL_scalar_string.iq
+++ b/quidem-ut/src/test/quidem/org.apache.druid.quidem.QTest/qaSQL_scalar_string.iq
@@ -1,0 +1,4606 @@
+!set useApproximateCountDistinct false
+!use druidtest:///?componentSupplier=KttmNestedComponentSupplier
+!set outputformat mysql
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00';
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A1: plain_value_string
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||loaded_image IS NULL
+       OR ('1'||loaded_image = 1||loaded_image
+           AND '1'||loaded_image IS NOT DISTINCT
+           FROM 1||loaded_image
+           AND '1'||loaded_image <> '0'||loaded_image
+           AND ('1'||loaded_image IS DISTINCT
+                FROM '0'||loaded_image)
+           AND '1'||loaded_image > '0'||loaded_image
+           AND '1'||loaded_image >= '0'||loaded_image
+           AND '1'||loaded_image < 2||loaded_image
+           AND '1'||loaded_image <= 2||loaded_image
+           AND ('1'||loaded_image <> '0'||loaded_image) IS TRUE
+           AND ('1'||loaded_image = '0'||loaded_image) IS NOT TRUE
+           AND ('1'||loaded_image = '0'||loaded_image) IS FALSE
+           AND ('1'||loaded_image <> '0'||loaded_image) IS NOT FALSE
+           AND '1'||loaded_image BETWEEN '0'||loaded_image AND 2||loaded_image
+           AND '1'||loaded_image NOT BETWEEN '1'||loaded_image AND '0'||loaded_image
+           AND '1'||loaded_image like '%'
+           AND '1'||loaded_image not like '__DOES_NOT_EXIST__%'
+           AND '1'||loaded_image IN ('0'||loaded_image,
+                                     1||loaded_image,
+                                     2||loaded_image)
+           AND '1'||loaded_image NOT IN ('0'||loaded_image,
+                                         2||loaded_image))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||loaded_image IS NULL
+       OR '1'||loaded_image IN
+         (SELECT '1'||loaded_image
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||loaded_image IS NULL
+                 OR ('1'||loaded_image = 1||loaded_image
+                     AND '1'||loaded_image IS NOT DISTINCT
+                     FROM 1||loaded_image
+                     AND '1'||loaded_image <> '0'||loaded_image
+                     AND ('1'||loaded_image IS DISTINCT
+                          FROM '0'||loaded_image)
+                     AND '1'||loaded_image > '0'||loaded_image
+                     AND '1'||loaded_image >= '0'||loaded_image
+                     AND '1'||loaded_image < 2||loaded_image
+                     AND '1'||loaded_image <= 2||loaded_image
+                     AND ('1'||loaded_image <> '0'||loaded_image) IS TRUE
+                     AND ('1'||loaded_image = '0'||loaded_image) IS NOT TRUE
+                     AND ('1'||loaded_image = '0'||loaded_image) IS FALSE
+                     AND ('1'||loaded_image <> '0'||loaded_image) IS NOT FALSE
+                     AND '1'||loaded_image BETWEEN '0'||loaded_image AND 2||loaded_image
+                     AND '1'||loaded_image NOT BETWEEN '1'||loaded_image AND '0'||loaded_image
+                     AND '1'||loaded_image like '%'
+                     AND '1'||loaded_image not like '__DOES_NOT_EXIST__%'
+                     AND '1'||loaded_image IN ('0'||loaded_image,
+                                               1||loaded_image,
+                                               2||loaded_image)
+                     AND '1'||loaded_image NOT IN ('0'||loaded_image,
+                                                   2||loaded_image)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||loaded_image,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||loaded_image IS NULL
+          OR ('1'||loaded_image = 1||loaded_image
+              AND '1'||loaded_image IS NOT DISTINCT
+              FROM 1||loaded_image
+              AND '1'||loaded_image <> '0'||loaded_image
+              AND ('1'||loaded_image IS DISTINCT
+                   FROM '0'||loaded_image)
+              AND '1'||loaded_image > '0'||loaded_image
+              AND '1'||loaded_image >= '0'||loaded_image
+              AND '1'||loaded_image < 2||loaded_image
+              AND '1'||loaded_image <= 2||loaded_image
+              AND ('1'||loaded_image <> '0'||loaded_image) IS TRUE
+              AND ('1'||loaded_image = '0'||loaded_image) IS NOT TRUE
+              AND ('1'||loaded_image = '0'||loaded_image) IS FALSE
+              AND ('1'||loaded_image <> '0'||loaded_image) IS NOT FALSE
+              AND '1'||loaded_image BETWEEN '0'||loaded_image AND 2||loaded_image
+              AND '1'||loaded_image NOT BETWEEN '1'||loaded_image AND '0'||loaded_image
+              AND '1'||loaded_image like '%'
+              AND '1'||loaded_image not like '__DOES_NOT_EXIST__%'
+              AND '1'||loaded_image IN ('0'||loaded_image,
+                                        1||loaded_image,
+                                        2||loaded_image)
+              AND '1'||loaded_image NOT IN ('0'||loaded_image,
+                                            2||loaded_image)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A2: ||
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||loaded_image||loaded_image IS NULL
+       OR ('1'||loaded_image||loaded_image = 1||loaded_image||loaded_image
+           AND '1'||loaded_image||loaded_image IS NOT DISTINCT
+           FROM 1||loaded_image||loaded_image
+           AND '1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image
+           AND ('1'||loaded_image||loaded_image IS DISTINCT
+                FROM '0'||loaded_image||loaded_image)
+           AND '1'||loaded_image||loaded_image > '0'||loaded_image||loaded_image
+           AND '1'||loaded_image||loaded_image >= '0'||loaded_image||loaded_image
+           AND '1'||loaded_image||loaded_image < 2||loaded_image||loaded_image
+           AND '1'||loaded_image||loaded_image <= 2||loaded_image||loaded_image
+           AND ('1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image) IS TRUE
+           AND ('1'||loaded_image||loaded_image = '0'||loaded_image||loaded_image) IS NOT TRUE
+           AND ('1'||loaded_image||loaded_image = '0'||loaded_image||loaded_image) IS FALSE
+           AND ('1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image) IS NOT FALSE
+           AND '1'||loaded_image||loaded_image BETWEEN '0'||loaded_image||loaded_image AND 2||loaded_image||loaded_image
+           AND '1'||loaded_image||loaded_image NOT BETWEEN '1'||loaded_image||loaded_image AND '0'||loaded_image||loaded_image
+           AND '1'||loaded_image||loaded_image like '%'
+           AND '1'||loaded_image||loaded_image not like '__DOES_NOT_EXIST__%'
+           AND '1'||loaded_image||loaded_image IN ('0'||loaded_image||loaded_image,
+                                                   1||loaded_image||loaded_image,
+                                                   2||loaded_image||loaded_image)
+           AND '1'||loaded_image||loaded_image NOT IN ('0'||loaded_image||loaded_image,
+                                                       2||loaded_image||loaded_image))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||loaded_image||loaded_image IS NULL
+       OR '1'||loaded_image||loaded_image IN
+         (SELECT '1'||loaded_image||loaded_image
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||loaded_image||loaded_image IS NULL
+                 OR ('1'||loaded_image||loaded_image = 1||loaded_image||loaded_image
+                     AND '1'||loaded_image||loaded_image IS NOT DISTINCT
+                     FROM 1||loaded_image||loaded_image
+                     AND '1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image
+                     AND ('1'||loaded_image||loaded_image IS DISTINCT
+                          FROM '0'||loaded_image||loaded_image)
+                     AND '1'||loaded_image||loaded_image > '0'||loaded_image||loaded_image
+                     AND '1'||loaded_image||loaded_image >= '0'||loaded_image||loaded_image
+                     AND '1'||loaded_image||loaded_image < 2||loaded_image||loaded_image
+                     AND '1'||loaded_image||loaded_image <= 2||loaded_image||loaded_image
+                     AND ('1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image) IS TRUE
+                     AND ('1'||loaded_image||loaded_image = '0'||loaded_image||loaded_image) IS NOT TRUE
+                     AND ('1'||loaded_image||loaded_image = '0'||loaded_image||loaded_image) IS FALSE
+                     AND ('1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image) IS NOT FALSE
+                     AND '1'||loaded_image||loaded_image BETWEEN '0'||loaded_image||loaded_image AND 2||loaded_image||loaded_image
+                     AND '1'||loaded_image||loaded_image NOT BETWEEN '1'||loaded_image||loaded_image AND '0'||loaded_image||loaded_image
+                     AND '1'||loaded_image||loaded_image like '%'
+                     AND '1'||loaded_image||loaded_image not like '__DOES_NOT_EXIST__%'
+                     AND '1'||loaded_image||loaded_image IN ('0'||loaded_image||loaded_image,
+                                                             1||loaded_image||loaded_image,
+                                                             2||loaded_image||loaded_image)
+                     AND '1'||loaded_image||loaded_image NOT IN ('0'||loaded_image||loaded_image,
+                                                                 2||loaded_image||loaded_image)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||loaded_image||loaded_image,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||loaded_image||loaded_image IS NULL
+          OR ('1'||loaded_image||loaded_image = 1||loaded_image||loaded_image
+              AND '1'||loaded_image||loaded_image IS NOT DISTINCT
+              FROM 1||loaded_image||loaded_image
+              AND '1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image
+              AND ('1'||loaded_image||loaded_image IS DISTINCT
+                   FROM '0'||loaded_image||loaded_image)
+              AND '1'||loaded_image||loaded_image > '0'||loaded_image||loaded_image
+              AND '1'||loaded_image||loaded_image >= '0'||loaded_image||loaded_image
+              AND '1'||loaded_image||loaded_image < 2||loaded_image||loaded_image
+              AND '1'||loaded_image||loaded_image <= 2||loaded_image||loaded_image
+              AND ('1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image) IS TRUE
+              AND ('1'||loaded_image||loaded_image = '0'||loaded_image||loaded_image) IS NOT TRUE
+              AND ('1'||loaded_image||loaded_image = '0'||loaded_image||loaded_image) IS FALSE
+              AND ('1'||loaded_image||loaded_image <> '0'||loaded_image||loaded_image) IS NOT FALSE
+              AND '1'||loaded_image||loaded_image BETWEEN '0'||loaded_image||loaded_image AND 2||loaded_image||loaded_image
+              AND '1'||loaded_image||loaded_image NOT BETWEEN '1'||loaded_image||loaded_image AND '0'||loaded_image||loaded_image
+              AND '1'||loaded_image||loaded_image like '%'
+              AND '1'||loaded_image||loaded_image not like '__DOES_NOT_EXIST__%'
+              AND '1'||loaded_image||loaded_image IN ('0'||loaded_image||loaded_image,
+                                                      1||loaded_image||loaded_image,
+                                                      2||loaded_image||loaded_image)
+              AND '1'||loaded_image||loaded_image NOT IN ('0'||loaded_image||loaded_image,
+                                                          2||loaded_image||loaded_image)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A3: concat
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (concat('1', loaded_image, loaded_image) IS NULL
+       OR (concat('1', loaded_image, loaded_image) = concat('1', loaded_image, loaded_image)
+           AND concat('1', loaded_image, loaded_image) IS NOT DISTINCT
+           FROM concat('1', loaded_image, loaded_image)
+           AND concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)
+           AND (concat('1', loaded_image, loaded_image) IS DISTINCT
+                FROM concat('0', loaded_image, loaded_image))
+           AND concat('1', loaded_image, loaded_image) > concat('0', loaded_image, loaded_image)
+           AND concat('1', loaded_image, loaded_image) >= concat('0', loaded_image, loaded_image)
+           AND concat('1', loaded_image, loaded_image) < concat('2', loaded_image, loaded_image)
+           AND concat('1', loaded_image, loaded_image) <= concat('2', loaded_image, loaded_image)
+           AND (concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)) IS TRUE
+           AND (concat('1', loaded_image, loaded_image) = concat('0', loaded_image, loaded_image)) IS NOT TRUE
+           AND (concat('1', loaded_image, loaded_image) = concat('0', loaded_image, loaded_image)) IS FALSE
+           AND (concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)) IS NOT FALSE
+           AND concat('1', loaded_image, loaded_image) BETWEEN concat('0', loaded_image, loaded_image) AND concat('2', loaded_image, loaded_image)
+           AND concat('1', loaded_image, loaded_image) NOT BETWEEN concat('1', loaded_image, loaded_image) AND concat('0', loaded_image, loaded_image)
+           AND concat('1', loaded_image, loaded_image) like '%'
+           AND concat('1', loaded_image, loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND concat('1', loaded_image, loaded_image) IN (concat('0', loaded_image, loaded_image),
+                                                           concat('1', loaded_image, loaded_image),
+                                                           concat('2', loaded_image, loaded_image))
+           AND concat('1', loaded_image, loaded_image) NOT IN (concat('0', loaded_image, loaded_image),
+                                                               concat('2', loaded_image, loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (concat('1', loaded_image, loaded_image) IS NULL
+       OR concat('1', loaded_image, loaded_image) IN
+         (SELECT concat('1', loaded_image, loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (concat('1', loaded_image, loaded_image) IS NULL
+                 OR (concat('1', loaded_image, loaded_image) = concat('1', loaded_image, loaded_image)
+                     AND concat('1', loaded_image, loaded_image) IS NOT DISTINCT
+                     FROM concat('1', loaded_image, loaded_image)
+                     AND concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)
+                     AND (concat('1', loaded_image, loaded_image) IS DISTINCT
+                          FROM concat('0', loaded_image, loaded_image))
+                     AND concat('1', loaded_image, loaded_image) > concat('0', loaded_image, loaded_image)
+                     AND concat('1', loaded_image, loaded_image) >= concat('0', loaded_image, loaded_image)
+                     AND concat('1', loaded_image, loaded_image) < concat('2', loaded_image, loaded_image)
+                     AND concat('1', loaded_image, loaded_image) <= concat('2', loaded_image, loaded_image)
+                     AND (concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)) IS TRUE
+                     AND (concat('1', loaded_image, loaded_image) = concat('0', loaded_image, loaded_image)) IS NOT TRUE
+                     AND (concat('1', loaded_image, loaded_image) = concat('0', loaded_image, loaded_image)) IS FALSE
+                     AND (concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)) IS NOT FALSE
+                     AND concat('1', loaded_image, loaded_image) BETWEEN concat('0', loaded_image, loaded_image) AND concat('2', loaded_image, loaded_image)
+                     AND concat('1', loaded_image, loaded_image) NOT BETWEEN concat('1', loaded_image, loaded_image) AND concat('0', loaded_image, loaded_image)
+                     AND concat('1', loaded_image, loaded_image) like '%'
+                     AND concat('1', loaded_image, loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND concat('1', loaded_image, loaded_image) IN (concat('0', loaded_image, loaded_image),
+                                                                     concat('1', loaded_image, loaded_image),
+                                                                     concat('2', loaded_image, loaded_image))
+                     AND concat('1', loaded_image, loaded_image) NOT IN (concat('0', loaded_image, loaded_image),
+                                                                         concat('2', loaded_image, loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          concat('1', loaded_image, loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (concat('1', loaded_image, loaded_image) IS NULL
+          OR (concat('1', loaded_image, loaded_image) = concat('1', loaded_image, loaded_image)
+              AND concat('1', loaded_image, loaded_image) IS NOT DISTINCT
+              FROM concat('1', loaded_image, loaded_image)
+              AND concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)
+              AND (concat('1', loaded_image, loaded_image) IS DISTINCT
+                   FROM concat('0', loaded_image, loaded_image))
+              AND concat('1', loaded_image, loaded_image) > concat('0', loaded_image, loaded_image)
+              AND concat('1', loaded_image, loaded_image) >= concat('0', loaded_image, loaded_image)
+              AND concat('1', loaded_image, loaded_image) < concat('2', loaded_image, loaded_image)
+              AND concat('1', loaded_image, loaded_image) <= concat('2', loaded_image, loaded_image)
+              AND (concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)) IS TRUE
+              AND (concat('1', loaded_image, loaded_image) = concat('0', loaded_image, loaded_image)) IS NOT TRUE
+              AND (concat('1', loaded_image, loaded_image) = concat('0', loaded_image, loaded_image)) IS FALSE
+              AND (concat('1', loaded_image, loaded_image) <> concat('0', loaded_image, loaded_image)) IS NOT FALSE
+              AND concat('1', loaded_image, loaded_image) BETWEEN concat('0', loaded_image, loaded_image) AND concat('2', loaded_image, loaded_image)
+              AND concat('1', loaded_image, loaded_image) NOT BETWEEN concat('1', loaded_image, loaded_image) AND concat('0', loaded_image, loaded_image)
+              AND concat('1', loaded_image, loaded_image) like '%'
+              AND concat('1', loaded_image, loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND concat('1', loaded_image, loaded_image) IN (concat('0', loaded_image, loaded_image),
+                                                              concat('1', loaded_image, loaded_image),
+                                                              concat('2', loaded_image, loaded_image))
+              AND concat('1', loaded_image, loaded_image) NOT IN (concat('0', loaded_image, loaded_image),
+                                                                  concat('2', loaded_image, loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A4: textcat
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (textcat('1', loaded_image) IS NULL
+       OR (textcat('1', loaded_image) = textcat('1', loaded_image)
+           AND textcat('1', loaded_image) IS NOT DISTINCT
+           FROM textcat('1', loaded_image)
+           AND textcat('1', loaded_image) <> textcat('0', loaded_image)
+           AND (textcat('1', loaded_image) IS DISTINCT
+                FROM textcat('0', loaded_image))
+           AND textcat('1', loaded_image) > textcat('0', loaded_image)
+           AND textcat('1', loaded_image) >= textcat('0', loaded_image)
+           AND textcat('1', loaded_image) < textcat('2', loaded_image)
+           AND textcat('1', loaded_image) <= textcat('2', loaded_image)
+           AND (textcat('1', loaded_image) <> textcat('0', loaded_image)) IS TRUE
+           AND (textcat('1', loaded_image) = textcat('0', loaded_image)) IS NOT TRUE
+           AND (textcat('1', loaded_image) = textcat('0', loaded_image)) IS FALSE
+           AND (textcat('1', loaded_image) <> textcat('0', loaded_image)) IS NOT FALSE
+           AND textcat('1', loaded_image) BETWEEN textcat('0', loaded_image) AND textcat('2', loaded_image)
+           AND textcat('1', loaded_image) NOT BETWEEN textcat('1', loaded_image) AND textcat('0', loaded_image)
+           AND textcat('1', loaded_image) like '%'
+           AND textcat('1', loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND textcat('1', loaded_image) IN (textcat('0', loaded_image),
+                                              textcat('1', loaded_image),
+                                              textcat('2', loaded_image))
+           AND textcat('1', loaded_image) NOT IN (textcat('0', loaded_image),
+                                                  textcat('2', loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (textcat('1', loaded_image) IS NULL
+       OR textcat('1', loaded_image) IN
+         (SELECT textcat('1', loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (textcat('1', loaded_image) IS NULL
+                 OR (textcat('1', loaded_image) = textcat('1', loaded_image)
+                     AND textcat('1', loaded_image) IS NOT DISTINCT
+                     FROM textcat('1', loaded_image)
+                     AND textcat('1', loaded_image) <> textcat('0', loaded_image)
+                     AND (textcat('1', loaded_image) IS DISTINCT
+                          FROM textcat('0', loaded_image))
+                     AND textcat('1', loaded_image) > textcat('0', loaded_image)
+                     AND textcat('1', loaded_image) >= textcat('0', loaded_image)
+                     AND textcat('1', loaded_image) < textcat('2', loaded_image)
+                     AND textcat('1', loaded_image) <= textcat('2', loaded_image)
+                     AND (textcat('1', loaded_image) <> textcat('0', loaded_image)) IS TRUE
+                     AND (textcat('1', loaded_image) = textcat('0', loaded_image)) IS NOT TRUE
+                     AND (textcat('1', loaded_image) = textcat('0', loaded_image)) IS FALSE
+                     AND (textcat('1', loaded_image) <> textcat('0', loaded_image)) IS NOT FALSE
+                     AND textcat('1', loaded_image) BETWEEN textcat('0', loaded_image) AND textcat('2', loaded_image)
+                     AND textcat('1', loaded_image) NOT BETWEEN textcat('1', loaded_image) AND textcat('0', loaded_image)
+                     AND textcat('1', loaded_image) like '%'
+                     AND textcat('1', loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND textcat('1', loaded_image) IN (textcat('0', loaded_image),
+                                                        textcat('1', loaded_image),
+                                                        textcat('2', loaded_image))
+                     AND textcat('1', loaded_image) NOT IN (textcat('0', loaded_image),
+                                                            textcat('2', loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          textcat('1', loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (textcat('1', loaded_image) IS NULL
+          OR (textcat('1', loaded_image) = textcat('1', loaded_image)
+              AND textcat('1', loaded_image) IS NOT DISTINCT
+              FROM textcat('1', loaded_image)
+              AND textcat('1', loaded_image) <> textcat('0', loaded_image)
+              AND (textcat('1', loaded_image) IS DISTINCT
+                   FROM textcat('0', loaded_image))
+              AND textcat('1', loaded_image) > textcat('0', loaded_image)
+              AND textcat('1', loaded_image) >= textcat('0', loaded_image)
+              AND textcat('1', loaded_image) < textcat('2', loaded_image)
+              AND textcat('1', loaded_image) <= textcat('2', loaded_image)
+              AND (textcat('1', loaded_image) <> textcat('0', loaded_image)) IS TRUE
+              AND (textcat('1', loaded_image) = textcat('0', loaded_image)) IS NOT TRUE
+              AND (textcat('1', loaded_image) = textcat('0', loaded_image)) IS FALSE
+              AND (textcat('1', loaded_image) <> textcat('0', loaded_image)) IS NOT FALSE
+              AND textcat('1', loaded_image) BETWEEN textcat('0', loaded_image) AND textcat('2', loaded_image)
+              AND textcat('1', loaded_image) NOT BETWEEN textcat('1', loaded_image) AND textcat('0', loaded_image)
+              AND textcat('1', loaded_image) like '%'
+              AND textcat('1', loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND textcat('1', loaded_image) IN (textcat('0', loaded_image),
+                                                 textcat('1', loaded_image),
+                                                 textcat('2', loaded_image))
+              AND textcat('1', loaded_image) NOT IN (textcat('0', loaded_image),
+                                                     textcat('2', loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A5: string_format
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (string_format('1 %s', loaded_image) IS NULL
+       OR (string_format('1 %s', loaded_image) = string_format('1 %s', loaded_image)
+           AND string_format('1 %s', loaded_image) IS NOT DISTINCT
+           FROM string_format('1 %s', loaded_image)
+           AND string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)
+           AND (string_format('1 %s', loaded_image) IS DISTINCT
+                FROM string_format('0 %s', loaded_image))
+           AND string_format('1 %s', loaded_image) > string_format('0 %s', loaded_image)
+           AND string_format('1 %s', loaded_image) >= string_format('0 %s', loaded_image)
+           AND string_format('1 %s', loaded_image) < string_format('2 %s', loaded_image)
+           AND string_format('1 %s', loaded_image) <= string_format('2 %s', loaded_image)
+           AND (string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)) IS TRUE
+           AND (string_format('1 %s', loaded_image) = string_format('0 %s', loaded_image)) IS NOT TRUE
+           AND (string_format('1 %s', loaded_image) = string_format('0 %s', loaded_image)) IS FALSE
+           AND (string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)) IS NOT FALSE
+           AND string_format('1 %s', loaded_image) BETWEEN string_format('0 %s', loaded_image) AND string_format('2 %s', loaded_image)
+           AND string_format('1 %s', loaded_image) NOT BETWEEN string_format('1 %s', loaded_image) AND string_format('0 %s', loaded_image)
+           AND string_format('1 %s', loaded_image) like '%'
+           AND string_format('1 %s', loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND string_format('1 %s', loaded_image) IN (string_format('0 %s', loaded_image),
+                                                       string_format('1 %s', loaded_image),
+                                                       string_format('2 %s', loaded_image))
+           AND string_format('1 %s', loaded_image) NOT IN (string_format('0 %s', loaded_image),
+                                                           string_format('2 %s', loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (string_format('1 %s', loaded_image) IS NULL
+       OR string_format('1 %s', loaded_image) IN
+         (SELECT string_format('1 %s', loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (string_format('1 %s', loaded_image) IS NULL
+                 OR (string_format('1 %s', loaded_image) = string_format('1 %s', loaded_image)
+                     AND string_format('1 %s', loaded_image) IS NOT DISTINCT
+                     FROM string_format('1 %s', loaded_image)
+                     AND string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)
+                     AND (string_format('1 %s', loaded_image) IS DISTINCT
+                          FROM string_format('0 %s', loaded_image))
+                     AND string_format('1 %s', loaded_image) > string_format('0 %s', loaded_image)
+                     AND string_format('1 %s', loaded_image) >= string_format('0 %s', loaded_image)
+                     AND string_format('1 %s', loaded_image) < string_format('2 %s', loaded_image)
+                     AND string_format('1 %s', loaded_image) <= string_format('2 %s', loaded_image)
+                     AND (string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)) IS TRUE
+                     AND (string_format('1 %s', loaded_image) = string_format('0 %s', loaded_image)) IS NOT TRUE
+                     AND (string_format('1 %s', loaded_image) = string_format('0 %s', loaded_image)) IS FALSE
+                     AND (string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)) IS NOT FALSE
+                     AND string_format('1 %s', loaded_image) BETWEEN string_format('0 %s', loaded_image) AND string_format('2 %s', loaded_image)
+                     AND string_format('1 %s', loaded_image) NOT BETWEEN string_format('1 %s', loaded_image) AND string_format('0 %s', loaded_image)
+                     AND string_format('1 %s', loaded_image) like '%'
+                     AND string_format('1 %s', loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND string_format('1 %s', loaded_image) IN (string_format('0 %s', loaded_image),
+                                                                 string_format('1 %s', loaded_image),
+                                                                 string_format('2 %s', loaded_image))
+                     AND string_format('1 %s', loaded_image) NOT IN (string_format('0 %s', loaded_image),
+                                                                     string_format('2 %s', loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          string_format('1 %s', loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (string_format('1 %s', loaded_image) IS NULL
+          OR (string_format('1 %s', loaded_image) = string_format('1 %s', loaded_image)
+              AND string_format('1 %s', loaded_image) IS NOT DISTINCT
+              FROM string_format('1 %s', loaded_image)
+              AND string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)
+              AND (string_format('1 %s', loaded_image) IS DISTINCT
+                   FROM string_format('0 %s', loaded_image))
+              AND string_format('1 %s', loaded_image) > string_format('0 %s', loaded_image)
+              AND string_format('1 %s', loaded_image) >= string_format('0 %s', loaded_image)
+              AND string_format('1 %s', loaded_image) < string_format('2 %s', loaded_image)
+              AND string_format('1 %s', loaded_image) <= string_format('2 %s', loaded_image)
+              AND (string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)) IS TRUE
+              AND (string_format('1 %s', loaded_image) = string_format('0 %s', loaded_image)) IS NOT TRUE
+              AND (string_format('1 %s', loaded_image) = string_format('0 %s', loaded_image)) IS FALSE
+              AND (string_format('1 %s', loaded_image) <> string_format('0 %s', loaded_image)) IS NOT FALSE
+              AND string_format('1 %s', loaded_image) BETWEEN string_format('0 %s', loaded_image) AND string_format('2 %s', loaded_image)
+              AND string_format('1 %s', loaded_image) NOT BETWEEN string_format('1 %s', loaded_image) AND string_format('0 %s', loaded_image)
+              AND string_format('1 %s', loaded_image) like '%'
+              AND string_format('1 %s', loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND string_format('1 %s', loaded_image) IN (string_format('0 %s', loaded_image),
+                                                          string_format('1 %s', loaded_image),
+                                                          string_format('2 %s', loaded_image))
+              AND string_format('1 %s', loaded_image) NOT IN (string_format('0 %s', loaded_image),
+                                                              string_format('2 %s', loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A6: length
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||length(loaded_image) IS NULL
+       OR ('1'||length(loaded_image) = 1||length(loaded_image)
+           AND '1'||length(loaded_image) IS NOT DISTINCT
+           FROM 1||length(loaded_image)
+           AND '1'||length(loaded_image) <> '0'||length(loaded_image)
+           AND ('1'||length(loaded_image) IS DISTINCT
+                FROM '0'||length(loaded_image))
+           AND '1'||length(loaded_image) > '0'||length(loaded_image)
+           AND '1'||length(loaded_image) >= '0'||length(loaded_image)
+           AND '1'||length(loaded_image) < 2||length(loaded_image)
+           AND '1'||length(loaded_image) <= 2||length(loaded_image)
+           AND ('1'||length(loaded_image) <> '0'||length(loaded_image)) IS TRUE
+           AND ('1'||length(loaded_image) = '0'||length(loaded_image)) IS NOT TRUE
+           AND ('1'||length(loaded_image) = '0'||length(loaded_image)) IS FALSE
+           AND ('1'||length(loaded_image) <> '0'||length(loaded_image)) IS NOT FALSE
+           AND '1'||length(loaded_image) BETWEEN '0'||length(loaded_image) AND 2||length(loaded_image)
+           AND '1'||length(loaded_image) NOT BETWEEN '1'||length(loaded_image) AND '0'||length(loaded_image)
+           AND '1'||length(loaded_image) like '%'
+           AND '1'||length(loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||length(loaded_image) IN ('0'||length(loaded_image),
+                                             1||length(loaded_image),
+                                             2||length(loaded_image))
+           AND '1'||length(loaded_image) NOT IN ('0'||length(loaded_image),
+                                                 2||length(loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||length(loaded_image) IS NULL
+       OR '1'||length(loaded_image) IN
+         (SELECT '1'||length(loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||length(loaded_image) IS NULL
+                 OR ('1'||length(loaded_image) = 1||length(loaded_image)
+                     AND '1'||length(loaded_image) IS NOT DISTINCT
+                     FROM 1||length(loaded_image)
+                     AND '1'||length(loaded_image) <> '0'||length(loaded_image)
+                     AND ('1'||length(loaded_image) IS DISTINCT
+                          FROM '0'||length(loaded_image))
+                     AND '1'||length(loaded_image) > '0'||length(loaded_image)
+                     AND '1'||length(loaded_image) >= '0'||length(loaded_image)
+                     AND '1'||length(loaded_image) < 2||length(loaded_image)
+                     AND '1'||length(loaded_image) <= 2||length(loaded_image)
+                     AND ('1'||length(loaded_image) <> '0'||length(loaded_image)) IS TRUE
+                     AND ('1'||length(loaded_image) = '0'||length(loaded_image)) IS NOT TRUE
+                     AND ('1'||length(loaded_image) = '0'||length(loaded_image)) IS FALSE
+                     AND ('1'||length(loaded_image) <> '0'||length(loaded_image)) IS NOT FALSE
+                     AND '1'||length(loaded_image) BETWEEN '0'||length(loaded_image) AND 2||length(loaded_image)
+                     AND '1'||length(loaded_image) NOT BETWEEN '1'||length(loaded_image) AND '0'||length(loaded_image)
+                     AND '1'||length(loaded_image) like '%'
+                     AND '1'||length(loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||length(loaded_image) IN ('0'||length(loaded_image),
+                                                       1||length(loaded_image),
+                                                       2||length(loaded_image))
+                     AND '1'||length(loaded_image) NOT IN ('0'||length(loaded_image),
+                                                           2||length(loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||length(loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||length(loaded_image) IS NULL
+          OR ('1'||length(loaded_image) = 1||length(loaded_image)
+              AND '1'||length(loaded_image) IS NOT DISTINCT
+              FROM 1||length(loaded_image)
+              AND '1'||length(loaded_image) <> '0'||length(loaded_image)
+              AND ('1'||length(loaded_image) IS DISTINCT
+                   FROM '0'||length(loaded_image))
+              AND '1'||length(loaded_image) > '0'||length(loaded_image)
+              AND '1'||length(loaded_image) >= '0'||length(loaded_image)
+              AND '1'||length(loaded_image) < 2||length(loaded_image)
+              AND '1'||length(loaded_image) <= 2||length(loaded_image)
+              AND ('1'||length(loaded_image) <> '0'||length(loaded_image)) IS TRUE
+              AND ('1'||length(loaded_image) = '0'||length(loaded_image)) IS NOT TRUE
+              AND ('1'||length(loaded_image) = '0'||length(loaded_image)) IS FALSE
+              AND ('1'||length(loaded_image) <> '0'||length(loaded_image)) IS NOT FALSE
+              AND '1'||length(loaded_image) BETWEEN '0'||length(loaded_image) AND 2||length(loaded_image)
+              AND '1'||length(loaded_image) NOT BETWEEN '1'||length(loaded_image) AND '0'||length(loaded_image)
+              AND '1'||length(loaded_image) like '%'
+              AND '1'||length(loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||length(loaded_image) IN ('0'||length(loaded_image),
+                                                1||length(loaded_image),
+                                                2||length(loaded_image))
+              AND '1'||length(loaded_image) NOT IN ('0'||length(loaded_image),
+                                                    2||length(loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A7: char_length
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||char_length(loaded_image) IS NULL
+       OR ('1'||char_length(loaded_image) = 1||char_length(loaded_image)
+           AND '1'||char_length(loaded_image) IS NOT DISTINCT
+           FROM 1||char_length(loaded_image)
+           AND '1'||char_length(loaded_image) <> '0'||char_length(loaded_image)
+           AND ('1'||char_length(loaded_image) IS DISTINCT
+                FROM '0'||char_length(loaded_image))
+           AND '1'||char_length(loaded_image) > '0'||char_length(loaded_image)
+           AND '1'||char_length(loaded_image) >= '0'||char_length(loaded_image)
+           AND '1'||char_length(loaded_image) < 2||char_length(loaded_image)
+           AND '1'||char_length(loaded_image) <= 2||char_length(loaded_image)
+           AND ('1'||char_length(loaded_image) <> '0'||char_length(loaded_image)) IS TRUE
+           AND ('1'||char_length(loaded_image) = '0'||char_length(loaded_image)) IS NOT TRUE
+           AND ('1'||char_length(loaded_image) = '0'||char_length(loaded_image)) IS FALSE
+           AND ('1'||char_length(loaded_image) <> '0'||char_length(loaded_image)) IS NOT FALSE
+           AND '1'||char_length(loaded_image) BETWEEN '0'||char_length(loaded_image) AND 2||char_length(loaded_image)
+           AND '1'||char_length(loaded_image) NOT BETWEEN '1'||char_length(loaded_image) AND '0'||char_length(loaded_image)
+           AND '1'||char_length(loaded_image) like '%'
+           AND '1'||char_length(loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||char_length(loaded_image) IN ('0'||char_length(loaded_image),
+                                                  1||char_length(loaded_image),
+                                                  2||char_length(loaded_image))
+           AND '1'||char_length(loaded_image) NOT IN ('0'||char_length(loaded_image),
+                                                      2||char_length(loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||char_length(loaded_image) IS NULL
+       OR '1'||char_length(loaded_image) IN
+         (SELECT '1'||char_length(loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||char_length(loaded_image) IS NULL
+                 OR ('1'||char_length(loaded_image) = 1||char_length(loaded_image)
+                     AND '1'||char_length(loaded_image) IS NOT DISTINCT
+                     FROM 1||char_length(loaded_image)
+                     AND '1'||char_length(loaded_image) <> '0'||char_length(loaded_image)
+                     AND ('1'||char_length(loaded_image) IS DISTINCT
+                          FROM '0'||char_length(loaded_image))
+                     AND '1'||char_length(loaded_image) > '0'||char_length(loaded_image)
+                     AND '1'||char_length(loaded_image) >= '0'||char_length(loaded_image)
+                     AND '1'||char_length(loaded_image) < 2||char_length(loaded_image)
+                     AND '1'||char_length(loaded_image) <= 2||char_length(loaded_image)
+                     AND ('1'||char_length(loaded_image) <> '0'||char_length(loaded_image)) IS TRUE
+                     AND ('1'||char_length(loaded_image) = '0'||char_length(loaded_image)) IS NOT TRUE
+                     AND ('1'||char_length(loaded_image) = '0'||char_length(loaded_image)) IS FALSE
+                     AND ('1'||char_length(loaded_image) <> '0'||char_length(loaded_image)) IS NOT FALSE
+                     AND '1'||char_length(loaded_image) BETWEEN '0'||char_length(loaded_image) AND 2||char_length(loaded_image)
+                     AND '1'||char_length(loaded_image) NOT BETWEEN '1'||char_length(loaded_image) AND '0'||char_length(loaded_image)
+                     AND '1'||char_length(loaded_image) like '%'
+                     AND '1'||char_length(loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||char_length(loaded_image) IN ('0'||char_length(loaded_image),
+                                                            1||char_length(loaded_image),
+                                                            2||char_length(loaded_image))
+                     AND '1'||char_length(loaded_image) NOT IN ('0'||char_length(loaded_image),
+                                                                2||char_length(loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||char_length(loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||char_length(loaded_image) IS NULL
+          OR ('1'||char_length(loaded_image) = 1||char_length(loaded_image)
+              AND '1'||char_length(loaded_image) IS NOT DISTINCT
+              FROM 1||char_length(loaded_image)
+              AND '1'||char_length(loaded_image) <> '0'||char_length(loaded_image)
+              AND ('1'||char_length(loaded_image) IS DISTINCT
+                   FROM '0'||char_length(loaded_image))
+              AND '1'||char_length(loaded_image) > '0'||char_length(loaded_image)
+              AND '1'||char_length(loaded_image) >= '0'||char_length(loaded_image)
+              AND '1'||char_length(loaded_image) < 2||char_length(loaded_image)
+              AND '1'||char_length(loaded_image) <= 2||char_length(loaded_image)
+              AND ('1'||char_length(loaded_image) <> '0'||char_length(loaded_image)) IS TRUE
+              AND ('1'||char_length(loaded_image) = '0'||char_length(loaded_image)) IS NOT TRUE
+              AND ('1'||char_length(loaded_image) = '0'||char_length(loaded_image)) IS FALSE
+              AND ('1'||char_length(loaded_image) <> '0'||char_length(loaded_image)) IS NOT FALSE
+              AND '1'||char_length(loaded_image) BETWEEN '0'||char_length(loaded_image) AND 2||char_length(loaded_image)
+              AND '1'||char_length(loaded_image) NOT BETWEEN '1'||char_length(loaded_image) AND '0'||char_length(loaded_image)
+              AND '1'||char_length(loaded_image) like '%'
+              AND '1'||char_length(loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||char_length(loaded_image) IN ('0'||char_length(loaded_image),
+                                                     1||char_length(loaded_image),
+                                                     2||char_length(loaded_image))
+              AND '1'||char_length(loaded_image) NOT IN ('0'||char_length(loaded_image),
+                                                         2||char_length(loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A8: character_length
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||character_length(loaded_image) IS NULL
+       OR ('1'||character_length(loaded_image) = 1||character_length(loaded_image)
+           AND '1'||character_length(loaded_image) IS NOT DISTINCT
+           FROM 1||character_length(loaded_image)
+           AND '1'||character_length(loaded_image) <> '0'||character_length(loaded_image)
+           AND ('1'||character_length(loaded_image) IS DISTINCT
+                FROM '0'||character_length(loaded_image))
+           AND '1'||character_length(loaded_image) > '0'||character_length(loaded_image)
+           AND '1'||character_length(loaded_image) >= '0'||character_length(loaded_image)
+           AND '1'||character_length(loaded_image) < 2||character_length(loaded_image)
+           AND '1'||character_length(loaded_image) <= 2||character_length(loaded_image)
+           AND ('1'||character_length(loaded_image) <> '0'||character_length(loaded_image)) IS TRUE
+           AND ('1'||character_length(loaded_image) = '0'||character_length(loaded_image)) IS NOT TRUE
+           AND ('1'||character_length(loaded_image) = '0'||character_length(loaded_image)) IS FALSE
+           AND ('1'||character_length(loaded_image) <> '0'||character_length(loaded_image)) IS NOT FALSE
+           AND '1'||character_length(loaded_image) BETWEEN '0'||character_length(loaded_image) AND 2||character_length(loaded_image)
+           AND '1'||character_length(loaded_image) NOT BETWEEN '1'||character_length(loaded_image) AND '0'||character_length(loaded_image)
+           AND '1'||character_length(loaded_image) like '%'
+           AND '1'||character_length(loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||character_length(loaded_image) IN ('0'||character_length(loaded_image),
+                                                       1||character_length(loaded_image),
+                                                       2||character_length(loaded_image))
+           AND '1'||character_length(loaded_image) NOT IN ('0'||character_length(loaded_image),
+                                                           2||character_length(loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||character_length(loaded_image) IS NULL
+       OR '1'||character_length(loaded_image) IN
+         (SELECT '1'||character_length(loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||character_length(loaded_image) IS NULL
+                 OR ('1'||character_length(loaded_image) = 1||character_length(loaded_image)
+                     AND '1'||character_length(loaded_image) IS NOT DISTINCT
+                     FROM 1||character_length(loaded_image)
+                     AND '1'||character_length(loaded_image) <> '0'||character_length(loaded_image)
+                     AND ('1'||character_length(loaded_image) IS DISTINCT
+                          FROM '0'||character_length(loaded_image))
+                     AND '1'||character_length(loaded_image) > '0'||character_length(loaded_image)
+                     AND '1'||character_length(loaded_image) >= '0'||character_length(loaded_image)
+                     AND '1'||character_length(loaded_image) < 2||character_length(loaded_image)
+                     AND '1'||character_length(loaded_image) <= 2||character_length(loaded_image)
+                     AND ('1'||character_length(loaded_image) <> '0'||character_length(loaded_image)) IS TRUE
+                     AND ('1'||character_length(loaded_image) = '0'||character_length(loaded_image)) IS NOT TRUE
+                     AND ('1'||character_length(loaded_image) = '0'||character_length(loaded_image)) IS FALSE
+                     AND ('1'||character_length(loaded_image) <> '0'||character_length(loaded_image)) IS NOT FALSE
+                     AND '1'||character_length(loaded_image) BETWEEN '0'||character_length(loaded_image) AND 2||character_length(loaded_image)
+                     AND '1'||character_length(loaded_image) NOT BETWEEN '1'||character_length(loaded_image) AND '0'||character_length(loaded_image)
+                     AND '1'||character_length(loaded_image) like '%'
+                     AND '1'||character_length(loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||character_length(loaded_image) IN ('0'||character_length(loaded_image),
+                                                                 1||character_length(loaded_image),
+                                                                 2||character_length(loaded_image))
+                     AND '1'||character_length(loaded_image) NOT IN ('0'||character_length(loaded_image),
+                                                                     2||character_length(loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||character_length(loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||character_length(loaded_image) IS NULL
+          OR ('1'||character_length(loaded_image) = 1||character_length(loaded_image)
+              AND '1'||character_length(loaded_image) IS NOT DISTINCT
+              FROM 1||character_length(loaded_image)
+              AND '1'||character_length(loaded_image) <> '0'||character_length(loaded_image)
+              AND ('1'||character_length(loaded_image) IS DISTINCT
+                   FROM '0'||character_length(loaded_image))
+              AND '1'||character_length(loaded_image) > '0'||character_length(loaded_image)
+              AND '1'||character_length(loaded_image) >= '0'||character_length(loaded_image)
+              AND '1'||character_length(loaded_image) < 2||character_length(loaded_image)
+              AND '1'||character_length(loaded_image) <= 2||character_length(loaded_image)
+              AND ('1'||character_length(loaded_image) <> '0'||character_length(loaded_image)) IS TRUE
+              AND ('1'||character_length(loaded_image) = '0'||character_length(loaded_image)) IS NOT TRUE
+              AND ('1'||character_length(loaded_image) = '0'||character_length(loaded_image)) IS FALSE
+              AND ('1'||character_length(loaded_image) <> '0'||character_length(loaded_image)) IS NOT FALSE
+              AND '1'||character_length(loaded_image) BETWEEN '0'||character_length(loaded_image) AND 2||character_length(loaded_image)
+              AND '1'||character_length(loaded_image) NOT BETWEEN '1'||character_length(loaded_image) AND '0'||character_length(loaded_image)
+              AND '1'||character_length(loaded_image) like '%'
+              AND '1'||character_length(loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||character_length(loaded_image) IN ('0'||character_length(loaded_image),
+                                                          1||character_length(loaded_image),
+                                                          2||character_length(loaded_image))
+              AND '1'||character_length(loaded_image) NOT IN ('0'||character_length(loaded_image),
+                                                              2||character_length(loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A9: strlen
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||strlen(loaded_image) IS NULL
+       OR ('1'||strlen(loaded_image) = 1||strlen(loaded_image)
+           AND '1'||strlen(loaded_image) IS NOT DISTINCT
+           FROM 1||strlen(loaded_image)
+           AND '1'||strlen(loaded_image) <> '0'||strlen(loaded_image)
+           AND ('1'||strlen(loaded_image) IS DISTINCT
+                FROM '0'||strlen(loaded_image))
+           AND '1'||strlen(loaded_image) > '0'||strlen(loaded_image)
+           AND '1'||strlen(loaded_image) >= '0'||strlen(loaded_image)
+           AND '1'||strlen(loaded_image) < 2||strlen(loaded_image)
+           AND '1'||strlen(loaded_image) <= 2||strlen(loaded_image)
+           AND ('1'||strlen(loaded_image) <> '0'||strlen(loaded_image)) IS TRUE
+           AND ('1'||strlen(loaded_image) = '0'||strlen(loaded_image)) IS NOT TRUE
+           AND ('1'||strlen(loaded_image) = '0'||strlen(loaded_image)) IS FALSE
+           AND ('1'||strlen(loaded_image) <> '0'||strlen(loaded_image)) IS NOT FALSE
+           AND '1'||strlen(loaded_image) BETWEEN '0'||strlen(loaded_image) AND 2||strlen(loaded_image)
+           AND '1'||strlen(loaded_image) NOT BETWEEN '1'||strlen(loaded_image) AND '0'||strlen(loaded_image)
+           AND '1'||strlen(loaded_image) like '%'
+           AND '1'||strlen(loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||strlen(loaded_image) IN ('0'||strlen(loaded_image),
+                                             1||strlen(loaded_image),
+                                             2||strlen(loaded_image))
+           AND '1'||strlen(loaded_image) NOT IN ('0'||strlen(loaded_image),
+                                                 2||strlen(loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||strlen(loaded_image) IS NULL
+       OR '1'||strlen(loaded_image) IN
+         (SELECT '1'||strlen(loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||strlen(loaded_image) IS NULL
+                 OR ('1'||strlen(loaded_image) = 1||strlen(loaded_image)
+                     AND '1'||strlen(loaded_image) IS NOT DISTINCT
+                     FROM 1||strlen(loaded_image)
+                     AND '1'||strlen(loaded_image) <> '0'||strlen(loaded_image)
+                     AND ('1'||strlen(loaded_image) IS DISTINCT
+                          FROM '0'||strlen(loaded_image))
+                     AND '1'||strlen(loaded_image) > '0'||strlen(loaded_image)
+                     AND '1'||strlen(loaded_image) >= '0'||strlen(loaded_image)
+                     AND '1'||strlen(loaded_image) < 2||strlen(loaded_image)
+                     AND '1'||strlen(loaded_image) <= 2||strlen(loaded_image)
+                     AND ('1'||strlen(loaded_image) <> '0'||strlen(loaded_image)) IS TRUE
+                     AND ('1'||strlen(loaded_image) = '0'||strlen(loaded_image)) IS NOT TRUE
+                     AND ('1'||strlen(loaded_image) = '0'||strlen(loaded_image)) IS FALSE
+                     AND ('1'||strlen(loaded_image) <> '0'||strlen(loaded_image)) IS NOT FALSE
+                     AND '1'||strlen(loaded_image) BETWEEN '0'||strlen(loaded_image) AND 2||strlen(loaded_image)
+                     AND '1'||strlen(loaded_image) NOT BETWEEN '1'||strlen(loaded_image) AND '0'||strlen(loaded_image)
+                     AND '1'||strlen(loaded_image) like '%'
+                     AND '1'||strlen(loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||strlen(loaded_image) IN ('0'||strlen(loaded_image),
+                                                       1||strlen(loaded_image),
+                                                       2||strlen(loaded_image))
+                     AND '1'||strlen(loaded_image) NOT IN ('0'||strlen(loaded_image),
+                                                           2||strlen(loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||strlen(loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||strlen(loaded_image) IS NULL
+          OR ('1'||strlen(loaded_image) = 1||strlen(loaded_image)
+              AND '1'||strlen(loaded_image) IS NOT DISTINCT
+              FROM 1||strlen(loaded_image)
+              AND '1'||strlen(loaded_image) <> '0'||strlen(loaded_image)
+              AND ('1'||strlen(loaded_image) IS DISTINCT
+                   FROM '0'||strlen(loaded_image))
+              AND '1'||strlen(loaded_image) > '0'||strlen(loaded_image)
+              AND '1'||strlen(loaded_image) >= '0'||strlen(loaded_image)
+              AND '1'||strlen(loaded_image) < 2||strlen(loaded_image)
+              AND '1'||strlen(loaded_image) <= 2||strlen(loaded_image)
+              AND ('1'||strlen(loaded_image) <> '0'||strlen(loaded_image)) IS TRUE
+              AND ('1'||strlen(loaded_image) = '0'||strlen(loaded_image)) IS NOT TRUE
+              AND ('1'||strlen(loaded_image) = '0'||strlen(loaded_image)) IS FALSE
+              AND ('1'||strlen(loaded_image) <> '0'||strlen(loaded_image)) IS NOT FALSE
+              AND '1'||strlen(loaded_image) BETWEEN '0'||strlen(loaded_image) AND 2||strlen(loaded_image)
+              AND '1'||strlen(loaded_image) NOT BETWEEN '1'||strlen(loaded_image) AND '0'||strlen(loaded_image)
+              AND '1'||strlen(loaded_image) like '%'
+              AND '1'||strlen(loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||strlen(loaded_image) IN ('0'||strlen(loaded_image),
+                                                1||strlen(loaded_image),
+                                                2||strlen(loaded_image))
+              AND '1'||strlen(loaded_image) NOT IN ('0'||strlen(loaded_image),
+                                                    2||strlen(loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A10: lower
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||lower(loaded_image) IS NULL
+       OR ('1'||lower(loaded_image) = 1||lower(loaded_image)
+           AND '1'||lower(loaded_image) IS NOT DISTINCT
+           FROM 1||lower(loaded_image)
+           AND '1'||lower(loaded_image) <> '0'||lower(loaded_image)
+           AND ('1'||lower(loaded_image) IS DISTINCT
+                FROM '0'||lower(loaded_image))
+           AND '1'||lower(loaded_image) > '0'||lower(loaded_image)
+           AND '1'||lower(loaded_image) >= '0'||lower(loaded_image)
+           AND '1'||lower(loaded_image) < 2||lower(loaded_image)
+           AND '1'||lower(loaded_image) <= 2||lower(loaded_image)
+           AND ('1'||lower(loaded_image) <> '0'||lower(loaded_image)) IS TRUE
+           AND ('1'||lower(loaded_image) = '0'||lower(loaded_image)) IS NOT TRUE
+           AND ('1'||lower(loaded_image) = '0'||lower(loaded_image)) IS FALSE
+           AND ('1'||lower(loaded_image) <> '0'||lower(loaded_image)) IS NOT FALSE
+           AND '1'||lower(loaded_image) BETWEEN '0'||lower(loaded_image) AND 2||lower(loaded_image)
+           AND '1'||lower(loaded_image) NOT BETWEEN '1'||lower(loaded_image) AND '0'||lower(loaded_image)
+           AND '1'||lower(loaded_image) like '%'
+           AND '1'||lower(loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||lower(loaded_image) IN ('0'||lower(loaded_image),
+                                            1||lower(loaded_image),
+                                            2||lower(loaded_image))
+           AND '1'||lower(loaded_image) NOT IN ('0'||lower(loaded_image),
+                                                2||lower(loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||lower(loaded_image) IS NULL
+       OR '1'||lower(loaded_image) IN
+         (SELECT '1'||lower(loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||lower(loaded_image) IS NULL
+                 OR ('1'||lower(loaded_image) = 1||lower(loaded_image)
+                     AND '1'||lower(loaded_image) IS NOT DISTINCT
+                     FROM 1||lower(loaded_image)
+                     AND '1'||lower(loaded_image) <> '0'||lower(loaded_image)
+                     AND ('1'||lower(loaded_image) IS DISTINCT
+                          FROM '0'||lower(loaded_image))
+                     AND '1'||lower(loaded_image) > '0'||lower(loaded_image)
+                     AND '1'||lower(loaded_image) >= '0'||lower(loaded_image)
+                     AND '1'||lower(loaded_image) < 2||lower(loaded_image)
+                     AND '1'||lower(loaded_image) <= 2||lower(loaded_image)
+                     AND ('1'||lower(loaded_image) <> '0'||lower(loaded_image)) IS TRUE
+                     AND ('1'||lower(loaded_image) = '0'||lower(loaded_image)) IS NOT TRUE
+                     AND ('1'||lower(loaded_image) = '0'||lower(loaded_image)) IS FALSE
+                     AND ('1'||lower(loaded_image) <> '0'||lower(loaded_image)) IS NOT FALSE
+                     AND '1'||lower(loaded_image) BETWEEN '0'||lower(loaded_image) AND 2||lower(loaded_image)
+                     AND '1'||lower(loaded_image) NOT BETWEEN '1'||lower(loaded_image) AND '0'||lower(loaded_image)
+                     AND '1'||lower(loaded_image) like '%'
+                     AND '1'||lower(loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||lower(loaded_image) IN ('0'||lower(loaded_image),
+                                                      1||lower(loaded_image),
+                                                      2||lower(loaded_image))
+                     AND '1'||lower(loaded_image) NOT IN ('0'||lower(loaded_image),
+                                                          2||lower(loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||lower(loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||lower(loaded_image) IS NULL
+          OR ('1'||lower(loaded_image) = 1||lower(loaded_image)
+              AND '1'||lower(loaded_image) IS NOT DISTINCT
+              FROM 1||lower(loaded_image)
+              AND '1'||lower(loaded_image) <> '0'||lower(loaded_image)
+              AND ('1'||lower(loaded_image) IS DISTINCT
+                   FROM '0'||lower(loaded_image))
+              AND '1'||lower(loaded_image) > '0'||lower(loaded_image)
+              AND '1'||lower(loaded_image) >= '0'||lower(loaded_image)
+              AND '1'||lower(loaded_image) < 2||lower(loaded_image)
+              AND '1'||lower(loaded_image) <= 2||lower(loaded_image)
+              AND ('1'||lower(loaded_image) <> '0'||lower(loaded_image)) IS TRUE
+              AND ('1'||lower(loaded_image) = '0'||lower(loaded_image)) IS NOT TRUE
+              AND ('1'||lower(loaded_image) = '0'||lower(loaded_image)) IS FALSE
+              AND ('1'||lower(loaded_image) <> '0'||lower(loaded_image)) IS NOT FALSE
+              AND '1'||lower(loaded_image) BETWEEN '0'||lower(loaded_image) AND 2||lower(loaded_image)
+              AND '1'||lower(loaded_image) NOT BETWEEN '1'||lower(loaded_image) AND '0'||lower(loaded_image)
+              AND '1'||lower(loaded_image) like '%'
+              AND '1'||lower(loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||lower(loaded_image) IN ('0'||lower(loaded_image),
+                                               1||lower(loaded_image),
+                                               2||lower(loaded_image))
+              AND '1'||lower(loaded_image) NOT IN ('0'||lower(loaded_image),
+                                                   2||lower(loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A11: upper
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||upper(loaded_image) IS NULL
+       OR ('1'||upper(loaded_image) = 1||upper(loaded_image)
+           AND '1'||upper(loaded_image) IS NOT DISTINCT
+           FROM 1||upper(loaded_image)
+           AND '1'||upper(loaded_image) <> '0'||upper(loaded_image)
+           AND ('1'||upper(loaded_image) IS DISTINCT
+                FROM '0'||upper(loaded_image))
+           AND '1'||upper(loaded_image) > '0'||upper(loaded_image)
+           AND '1'||upper(loaded_image) >= '0'||upper(loaded_image)
+           AND '1'||upper(loaded_image) < 2||upper(loaded_image)
+           AND '1'||upper(loaded_image) <= 2||upper(loaded_image)
+           AND ('1'||upper(loaded_image) <> '0'||upper(loaded_image)) IS TRUE
+           AND ('1'||upper(loaded_image) = '0'||upper(loaded_image)) IS NOT TRUE
+           AND ('1'||upper(loaded_image) = '0'||upper(loaded_image)) IS FALSE
+           AND ('1'||upper(loaded_image) <> '0'||upper(loaded_image)) IS NOT FALSE
+           AND '1'||upper(loaded_image) BETWEEN '0'||upper(loaded_image) AND 2||upper(loaded_image)
+           AND '1'||upper(loaded_image) NOT BETWEEN '1'||upper(loaded_image) AND '0'||upper(loaded_image)
+           AND '1'||upper(loaded_image) like '%'
+           AND '1'||upper(loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||upper(loaded_image) IN ('0'||upper(loaded_image),
+                                            1||upper(loaded_image),
+                                            2||upper(loaded_image))
+           AND '1'||upper(loaded_image) NOT IN ('0'||upper(loaded_image),
+                                                2||upper(loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||upper(loaded_image) IS NULL
+       OR '1'||upper(loaded_image) IN
+         (SELECT '1'||upper(loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||upper(loaded_image) IS NULL
+                 OR ('1'||upper(loaded_image) = 1||upper(loaded_image)
+                     AND '1'||upper(loaded_image) IS NOT DISTINCT
+                     FROM 1||upper(loaded_image)
+                     AND '1'||upper(loaded_image) <> '0'||upper(loaded_image)
+                     AND ('1'||upper(loaded_image) IS DISTINCT
+                          FROM '0'||upper(loaded_image))
+                     AND '1'||upper(loaded_image) > '0'||upper(loaded_image)
+                     AND '1'||upper(loaded_image) >= '0'||upper(loaded_image)
+                     AND '1'||upper(loaded_image) < 2||upper(loaded_image)
+                     AND '1'||upper(loaded_image) <= 2||upper(loaded_image)
+                     AND ('1'||upper(loaded_image) <> '0'||upper(loaded_image)) IS TRUE
+                     AND ('1'||upper(loaded_image) = '0'||upper(loaded_image)) IS NOT TRUE
+                     AND ('1'||upper(loaded_image) = '0'||upper(loaded_image)) IS FALSE
+                     AND ('1'||upper(loaded_image) <> '0'||upper(loaded_image)) IS NOT FALSE
+                     AND '1'||upper(loaded_image) BETWEEN '0'||upper(loaded_image) AND 2||upper(loaded_image)
+                     AND '1'||upper(loaded_image) NOT BETWEEN '1'||upper(loaded_image) AND '0'||upper(loaded_image)
+                     AND '1'||upper(loaded_image) like '%'
+                     AND '1'||upper(loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||upper(loaded_image) IN ('0'||upper(loaded_image),
+                                                      1||upper(loaded_image),
+                                                      2||upper(loaded_image))
+                     AND '1'||upper(loaded_image) NOT IN ('0'||upper(loaded_image),
+                                                          2||upper(loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||upper(loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||upper(loaded_image) IS NULL
+          OR ('1'||upper(loaded_image) = 1||upper(loaded_image)
+              AND '1'||upper(loaded_image) IS NOT DISTINCT
+              FROM 1||upper(loaded_image)
+              AND '1'||upper(loaded_image) <> '0'||upper(loaded_image)
+              AND ('1'||upper(loaded_image) IS DISTINCT
+                   FROM '0'||upper(loaded_image))
+              AND '1'||upper(loaded_image) > '0'||upper(loaded_image)
+              AND '1'||upper(loaded_image) >= '0'||upper(loaded_image)
+              AND '1'||upper(loaded_image) < 2||upper(loaded_image)
+              AND '1'||upper(loaded_image) <= 2||upper(loaded_image)
+              AND ('1'||upper(loaded_image) <> '0'||upper(loaded_image)) IS TRUE
+              AND ('1'||upper(loaded_image) = '0'||upper(loaded_image)) IS NOT TRUE
+              AND ('1'||upper(loaded_image) = '0'||upper(loaded_image)) IS FALSE
+              AND ('1'||upper(loaded_image) <> '0'||upper(loaded_image)) IS NOT FALSE
+              AND '1'||upper(loaded_image) BETWEEN '0'||upper(loaded_image) AND 2||upper(loaded_image)
+              AND '1'||upper(loaded_image) NOT BETWEEN '1'||upper(loaded_image) AND '0'||upper(loaded_image)
+              AND '1'||upper(loaded_image) like '%'
+              AND '1'||upper(loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||upper(loaded_image) IN ('0'||upper(loaded_image),
+                                               1||upper(loaded_image),
+                                               2||upper(loaded_image))
+              AND '1'||upper(loaded_image) NOT IN ('0'||upper(loaded_image),
+                                                   2||upper(loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A12: parse_long
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (parse_long(number, 10)+1 IS NULL
+       OR (parse_long(number, 10)+1 = parse_long(number, 10)+1
+           AND parse_long(number, 10)+1 IS NOT DISTINCT
+           FROM parse_long(number, 10)+1
+           AND parse_long(number, 10)+1 <> parse_long(number, 10)
+           AND (parse_long(number, 10)+1 IS DISTINCT
+                FROM parse_long(number, 10))
+           AND parse_long(number, 10)+1 > parse_long(number, 10)
+           AND parse_long(number, 10)+1 >= parse_long(number, 10)
+           AND parse_long(number, 10)+1 < parse_long(number, 10)+2
+           AND parse_long(number, 10)+1 <= parse_long(number, 10)+2
+           AND (parse_long(number, 10)+1 <> parse_long(number, 10)) IS TRUE
+           AND (parse_long(number, 10)+1 = parse_long(number, 10)) IS NOT TRUE
+           AND (parse_long(number, 10)+1 = parse_long(number, 10)) IS FALSE
+           AND (parse_long(number, 10)+1 <> parse_long(number, 10)) IS NOT FALSE
+           AND parse_long(number, 10)+1 BETWEEN parse_long(number, 10) AND parse_long(number, 10)+2
+           AND parse_long(number, 10)+1 NOT BETWEEN parse_long(number, 10)+1 AND parse_long(number, 10)
+           AND parse_long(number, 10)+1 like '%'
+           AND parse_long(number, 10)+1 not like '__DOES_NOT_EXIST__%'
+           AND parse_long(number, 10)+1 IN (parse_long(number, 10),
+                                            parse_long(number, 10)+1,
+                                            parse_long(number, 10)+2)
+           AND parse_long(number, 10)+1 NOT IN (parse_long(number, 10),
+                                                parse_long(number, 10)+2))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (parse_long(number, 10)+1 IS NULL
+       OR parse_long(number, 10)+1 IN
+         (SELECT parse_long(number, 10)+1
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (parse_long(number, 10)+1 IS NULL
+                 OR (parse_long(number, 10)+1 = parse_long(number, 10)+1
+                     AND parse_long(number, 10)+1 IS NOT DISTINCT
+                     FROM parse_long(number, 10)+1
+                     AND parse_long(number, 10)+1 <> parse_long(number, 10)
+                     AND (parse_long(number, 10)+1 IS DISTINCT
+                          FROM parse_long(number, 10))
+                     AND parse_long(number, 10)+1 > parse_long(number, 10)
+                     AND parse_long(number, 10)+1 >= parse_long(number, 10)
+                     AND parse_long(number, 10)+1 < parse_long(number, 10)+2
+                     AND parse_long(number, 10)+1 <= parse_long(number, 10)+2
+                     AND (parse_long(number, 10)+1 <> parse_long(number, 10)) IS TRUE
+                     AND (parse_long(number, 10)+1 = parse_long(number, 10)) IS NOT TRUE
+                     AND (parse_long(number, 10)+1 = parse_long(number, 10)) IS FALSE
+                     AND (parse_long(number, 10)+1 <> parse_long(number, 10)) IS NOT FALSE
+                     AND parse_long(number, 10)+1 BETWEEN parse_long(number, 10) AND parse_long(number, 10)+2
+                     AND parse_long(number, 10)+1 NOT BETWEEN parse_long(number, 10)+1 AND parse_long(number, 10)
+                     AND parse_long(number, 10)+1 like '%'
+                     AND parse_long(number, 10)+1 not like '__DOES_NOT_EXIST__%'
+                     AND parse_long(number, 10)+1 IN (parse_long(number, 10),
+                                                      parse_long(number, 10)+1,
+                                                      parse_long(number, 10)+2)
+                     AND parse_long(number, 10)+1 NOT IN (parse_long(number, 10),
+                                                          parse_long(number, 10)+2)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          parse_long(number, 10)+1,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (parse_long(number, 10)+1 IS NULL
+          OR (parse_long(number, 10)+1 = parse_long(number, 10)+1
+              AND parse_long(number, 10)+1 IS NOT DISTINCT
+              FROM parse_long(number, 10)+1
+              AND parse_long(number, 10)+1 <> parse_long(number, 10)
+              AND (parse_long(number, 10)+1 IS DISTINCT
+                   FROM parse_long(number, 10))
+              AND parse_long(number, 10)+1 > parse_long(number, 10)
+              AND parse_long(number, 10)+1 >= parse_long(number, 10)
+              AND parse_long(number, 10)+1 < parse_long(number, 10)+2
+              AND parse_long(number, 10)+1 <= parse_long(number, 10)+2
+              AND (parse_long(number, 10)+1 <> parse_long(number, 10)) IS TRUE
+              AND (parse_long(number, 10)+1 = parse_long(number, 10)) IS NOT TRUE
+              AND (parse_long(number, 10)+1 = parse_long(number, 10)) IS FALSE
+              AND (parse_long(number, 10)+1 <> parse_long(number, 10)) IS NOT FALSE
+              AND parse_long(number, 10)+1 BETWEEN parse_long(number, 10) AND parse_long(number, 10)+2
+              AND parse_long(number, 10)+1 NOT BETWEEN parse_long(number, 10)+1 AND parse_long(number, 10)
+              AND parse_long(number, 10)+1 like '%'
+              AND parse_long(number, 10)+1 not like '__DOES_NOT_EXIST__%'
+              AND parse_long(number, 10)+1 IN (parse_long(number, 10),
+                                               parse_long(number, 10)+1,
+                                               parse_long(number, 10)+2)
+              AND parse_long(number, 10)+1 NOT IN (parse_long(number, 10),
+                                                   parse_long(number, 10)+2)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A13: position
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (position('a' IN loaded_image
+                FROM 3)+1 IS NULL
+       OR (position('a' IN loaded_image
+                    FROM 3)+1 = position('a' IN loaded_image
+                                         FROM 3)+1
+           AND position('a' IN loaded_image
+                        FROM 3)+1 IS NOT DISTINCT
+           FROM position('a' IN loaded_image
+                         FROM 3)+1
+           AND position('a' IN loaded_image
+                        FROM 3)+1 <> position('a' IN loaded_image
+                                              FROM 3)
+           AND (position('a' IN loaded_image
+                         FROM 3)+1 IS DISTINCT
+                FROM position('a' IN loaded_image
+                              FROM 3))
+           AND position('a' IN loaded_image
+                        FROM 3)+1 > position('a' IN loaded_image
+                                             FROM 3)
+           AND position('a' IN loaded_image
+                        FROM 3)+1 >= position('a' IN loaded_image
+                                              FROM 3)
+           AND position('a' IN loaded_image
+                        FROM 3)+1 < position('a' IN loaded_image
+                                             FROM 3)+2
+           AND position('a' IN loaded_image
+                        FROM 3)+1 <= position('a' IN loaded_image
+                                              FROM 3)+2
+           AND (position('a' IN loaded_image
+                         FROM 3)+1 <> position('a' IN loaded_image
+                                               FROM 3)) IS TRUE
+           AND (position('a' IN loaded_image
+                         FROM 3)+1 = position('a' IN loaded_image
+                                              FROM 3)) IS NOT TRUE
+           AND (position('a' IN loaded_image
+                         FROM 3)+1 = position('a' IN loaded_image
+                                              FROM 3)) IS FALSE
+           AND (position('a' IN loaded_image
+                         FROM 3)+1 <> position('a' IN loaded_image
+                                               FROM 3)) IS NOT FALSE
+           AND position('a' IN loaded_image
+                        FROM 3)+1 BETWEEN position('a' IN loaded_image
+                                                   FROM 3) AND position('a' IN loaded_image
+                                                                        FROM 3)+2
+           AND position('a' IN loaded_image
+                        FROM 3)+1 NOT BETWEEN position('a' IN loaded_image
+                                                       FROM 3)+1 AND position('a' IN loaded_image
+                                                                              FROM 3)
+           AND position('a' IN loaded_image
+                        FROM 3)+1 like '%'
+           AND position('a' IN loaded_image
+                        FROM 3)+1 not like '__DOES_NOT_EXIST__%'
+           AND position('a' IN loaded_image
+                        FROM 3)+1 IN (position('a' IN loaded_image
+                                               FROM 3),
+                                      position('a' IN loaded_image
+                                               FROM 3)+1,
+                                      position('a' IN loaded_image
+                                               FROM 3)+2)
+           AND position('a' IN loaded_image
+                        FROM 3)+1 NOT IN (position('a' IN loaded_image
+                                                   FROM 3),
+                                          position('a' IN loaded_image
+                                                   FROM 3)+2))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (position('a' IN loaded_image
+                FROM 3)+1 IS NULL
+       OR position('a' IN loaded_image
+                   FROM 3)+1 IN
+         (SELECT position('a' IN loaded_image
+                          FROM 3)+1
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (position('a' IN loaded_image
+                          FROM 3)+1 IS NULL
+                 OR (position('a' IN loaded_image
+                              FROM 3)+1 = position('a' IN loaded_image
+                                                   FROM 3)+1
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 IS NOT DISTINCT
+                     FROM position('a' IN loaded_image
+                                   FROM 3)+1
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 <> position('a' IN loaded_image
+                                                        FROM 3)
+                     AND (position('a' IN loaded_image
+                                   FROM 3)+1 IS DISTINCT
+                          FROM position('a' IN loaded_image
+                                        FROM 3))
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 > position('a' IN loaded_image
+                                                       FROM 3)
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 >= position('a' IN loaded_image
+                                                        FROM 3)
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 < position('a' IN loaded_image
+                                                       FROM 3)+2
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 <= position('a' IN loaded_image
+                                                        FROM 3)+2
+                     AND (position('a' IN loaded_image
+                                   FROM 3)+1 <> position('a' IN loaded_image
+                                                         FROM 3)) IS TRUE
+                     AND (position('a' IN loaded_image
+                                   FROM 3)+1 = position('a' IN loaded_image
+                                                        FROM 3)) IS NOT TRUE
+                     AND (position('a' IN loaded_image
+                                   FROM 3)+1 = position('a' IN loaded_image
+                                                        FROM 3)) IS FALSE
+                     AND (position('a' IN loaded_image
+                                   FROM 3)+1 <> position('a' IN loaded_image
+                                                         FROM 3)) IS NOT FALSE
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 BETWEEN position('a' IN loaded_image
+                                                             FROM 3) AND position('a' IN loaded_image
+                                                                                  FROM 3)+2
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 NOT BETWEEN position('a' IN loaded_image
+                                                                 FROM 3)+1 AND position('a' IN loaded_image
+                                                                                        FROM 3)
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 like '%'
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 not like '__DOES_NOT_EXIST__%'
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 IN (position('a' IN loaded_image
+                                                         FROM 3),
+                                                position('a' IN loaded_image
+                                                         FROM 3)+1,
+                                                position('a' IN loaded_image
+                                                         FROM 3)+2)
+                     AND position('a' IN loaded_image
+                                  FROM 3)+1 NOT IN (position('a' IN loaded_image
+                                                             FROM 3),
+                                                    position('a' IN loaded_image
+                                                             FROM 3)+2)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          position('a' IN loaded_image
+                                   FROM 3)+1,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (position('a' IN loaded_image
+                   FROM 3)+1 IS NULL
+          OR (position('a' IN loaded_image
+                       FROM 3)+1 = position('a' IN loaded_image
+                                            FROM 3)+1
+              AND position('a' IN loaded_image
+                           FROM 3)+1 IS NOT DISTINCT
+              FROM position('a' IN loaded_image
+                            FROM 3)+1
+              AND position('a' IN loaded_image
+                           FROM 3)+1 <> position('a' IN loaded_image
+                                                 FROM 3)
+              AND (position('a' IN loaded_image
+                            FROM 3)+1 IS DISTINCT
+                   FROM position('a' IN loaded_image
+                                 FROM 3))
+              AND position('a' IN loaded_image
+                           FROM 3)+1 > position('a' IN loaded_image
+                                                FROM 3)
+              AND position('a' IN loaded_image
+                           FROM 3)+1 >= position('a' IN loaded_image
+                                                 FROM 3)
+              AND position('a' IN loaded_image
+                           FROM 3)+1 < position('a' IN loaded_image
+                                                FROM 3)+2
+              AND position('a' IN loaded_image
+                           FROM 3)+1 <= position('a' IN loaded_image
+                                                 FROM 3)+2
+              AND (position('a' IN loaded_image
+                            FROM 3)+1 <> position('a' IN loaded_image
+                                                  FROM 3)) IS TRUE
+              AND (position('a' IN loaded_image
+                            FROM 3)+1 = position('a' IN loaded_image
+                                                 FROM 3)) IS NOT TRUE
+              AND (position('a' IN loaded_image
+                            FROM 3)+1 = position('a' IN loaded_image
+                                                 FROM 3)) IS FALSE
+              AND (position('a' IN loaded_image
+                            FROM 3)+1 <> position('a' IN loaded_image
+                                                  FROM 3)) IS NOT FALSE
+              AND position('a' IN loaded_image
+                           FROM 3)+1 BETWEEN position('a' IN loaded_image
+                                                      FROM 3) AND position('a' IN loaded_image
+                                                                           FROM 3)+2
+              AND position('a' IN loaded_image
+                           FROM 3)+1 NOT BETWEEN position('a' IN loaded_image
+                                                          FROM 3)+1 AND position('a' IN loaded_image
+                                                                                 FROM 3)
+              AND position('a' IN loaded_image
+                           FROM 3)+1 like '%'
+              AND position('a' IN loaded_image
+                           FROM 3)+1 not like '__DOES_NOT_EXIST__%'
+              AND position('a' IN loaded_image
+                           FROM 3)+1 IN (position('a' IN loaded_image
+                                                  FROM 3),
+                                         position('a' IN loaded_image
+                                                  FROM 3)+1,
+                                         position('a' IN loaded_image
+                                                  FROM 3)+2)
+              AND position('a' IN loaded_image
+                           FROM 3)+1 NOT IN (position('a' IN loaded_image
+                                                      FROM 3),
+                                             position('a' IN loaded_image
+                                                      FROM 3)+2)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A14: regexp_extract
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||regexp_extract(loaded_image, '.*') IS NULL
+       OR ('1'||regexp_extract(loaded_image, '.*') = 1||regexp_extract(loaded_image, '.*')
+           AND '1'||regexp_extract(loaded_image, '.*') IS NOT DISTINCT
+           FROM 1||regexp_extract(loaded_image, '.*')
+           AND '1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')
+           AND ('1'||regexp_extract(loaded_image, '.*') IS DISTINCT
+                FROM '0'||regexp_extract(loaded_image, '.*'))
+           AND '1'||regexp_extract(loaded_image, '.*') > '0'||regexp_extract(loaded_image, '.*')
+           AND '1'||regexp_extract(loaded_image, '.*') >= '0'||regexp_extract(loaded_image, '.*')
+           AND '1'||regexp_extract(loaded_image, '.*') < 2||regexp_extract(loaded_image, '.*')
+           AND '1'||regexp_extract(loaded_image, '.*') <= 2||regexp_extract(loaded_image, '.*')
+           AND ('1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')) IS TRUE
+           AND ('1'||regexp_extract(loaded_image, '.*') = '0'||regexp_extract(loaded_image, '.*')) IS NOT TRUE
+           AND ('1'||regexp_extract(loaded_image, '.*') = '0'||regexp_extract(loaded_image, '.*')) IS FALSE
+           AND ('1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')) IS NOT FALSE
+           AND '1'||regexp_extract(loaded_image, '.*') BETWEEN '0'||regexp_extract(loaded_image, '.*') AND 2||regexp_extract(loaded_image, '.*')
+           AND '1'||regexp_extract(loaded_image, '.*') NOT BETWEEN '1'||regexp_extract(loaded_image, '.*') AND '0'||regexp_extract(loaded_image, '.*')
+           AND '1'||regexp_extract(loaded_image, '.*') like '%'
+           AND '1'||regexp_extract(loaded_image, '.*') not like '__DOES_NOT_EXIST__%'
+           AND '1'||regexp_extract(loaded_image, '.*') IN ('0'||regexp_extract(loaded_image, '.*'),
+                                                           1||regexp_extract(loaded_image, '.*'),
+                                                           2||regexp_extract(loaded_image, '.*'))
+           AND '1'||regexp_extract(loaded_image, '.*') NOT IN ('0'||regexp_extract(loaded_image, '.*'),
+                                                               2||regexp_extract(loaded_image, '.*')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||regexp_extract(loaded_image, '.*') IS NULL
+       OR '1'||regexp_extract(loaded_image, '.*') IN
+         (SELECT '1'||regexp_extract(loaded_image, '.*')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||regexp_extract(loaded_image, '.*') IS NULL
+                 OR ('1'||regexp_extract(loaded_image, '.*') = 1||regexp_extract(loaded_image, '.*')
+                     AND '1'||regexp_extract(loaded_image, '.*') IS NOT DISTINCT
+                     FROM 1||regexp_extract(loaded_image, '.*')
+                     AND '1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')
+                     AND ('1'||regexp_extract(loaded_image, '.*') IS DISTINCT
+                          FROM '0'||regexp_extract(loaded_image, '.*'))
+                     AND '1'||regexp_extract(loaded_image, '.*') > '0'||regexp_extract(loaded_image, '.*')
+                     AND '1'||regexp_extract(loaded_image, '.*') >= '0'||regexp_extract(loaded_image, '.*')
+                     AND '1'||regexp_extract(loaded_image, '.*') < 2||regexp_extract(loaded_image, '.*')
+                     AND '1'||regexp_extract(loaded_image, '.*') <= 2||regexp_extract(loaded_image, '.*')
+                     AND ('1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')) IS TRUE
+                     AND ('1'||regexp_extract(loaded_image, '.*') = '0'||regexp_extract(loaded_image, '.*')) IS NOT TRUE
+                     AND ('1'||regexp_extract(loaded_image, '.*') = '0'||regexp_extract(loaded_image, '.*')) IS FALSE
+                     AND ('1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')) IS NOT FALSE
+                     AND '1'||regexp_extract(loaded_image, '.*') BETWEEN '0'||regexp_extract(loaded_image, '.*') AND 2||regexp_extract(loaded_image, '.*')
+                     AND '1'||regexp_extract(loaded_image, '.*') NOT BETWEEN '1'||regexp_extract(loaded_image, '.*') AND '0'||regexp_extract(loaded_image, '.*')
+                     AND '1'||regexp_extract(loaded_image, '.*') like '%'
+                     AND '1'||regexp_extract(loaded_image, '.*') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||regexp_extract(loaded_image, '.*') IN ('0'||regexp_extract(loaded_image, '.*'),
+                                                                     1||regexp_extract(loaded_image, '.*'),
+                                                                     2||regexp_extract(loaded_image, '.*'))
+                     AND '1'||regexp_extract(loaded_image, '.*') NOT IN ('0'||regexp_extract(loaded_image, '.*'),
+                                                                         2||regexp_extract(loaded_image, '.*'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||regexp_extract(loaded_image, '.*'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||regexp_extract(loaded_image, '.*') IS NULL
+          OR ('1'||regexp_extract(loaded_image, '.*') = 1||regexp_extract(loaded_image, '.*')
+              AND '1'||regexp_extract(loaded_image, '.*') IS NOT DISTINCT
+              FROM 1||regexp_extract(loaded_image, '.*')
+              AND '1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')
+              AND ('1'||regexp_extract(loaded_image, '.*') IS DISTINCT
+                   FROM '0'||regexp_extract(loaded_image, '.*'))
+              AND '1'||regexp_extract(loaded_image, '.*') > '0'||regexp_extract(loaded_image, '.*')
+              AND '1'||regexp_extract(loaded_image, '.*') >= '0'||regexp_extract(loaded_image, '.*')
+              AND '1'||regexp_extract(loaded_image, '.*') < 2||regexp_extract(loaded_image, '.*')
+              AND '1'||regexp_extract(loaded_image, '.*') <= 2||regexp_extract(loaded_image, '.*')
+              AND ('1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')) IS TRUE
+              AND ('1'||regexp_extract(loaded_image, '.*') = '0'||regexp_extract(loaded_image, '.*')) IS NOT TRUE
+              AND ('1'||regexp_extract(loaded_image, '.*') = '0'||regexp_extract(loaded_image, '.*')) IS FALSE
+              AND ('1'||regexp_extract(loaded_image, '.*') <> '0'||regexp_extract(loaded_image, '.*')) IS NOT FALSE
+              AND '1'||regexp_extract(loaded_image, '.*') BETWEEN '0'||regexp_extract(loaded_image, '.*') AND 2||regexp_extract(loaded_image, '.*')
+              AND '1'||regexp_extract(loaded_image, '.*') NOT BETWEEN '1'||regexp_extract(loaded_image, '.*') AND '0'||regexp_extract(loaded_image, '.*')
+              AND '1'||regexp_extract(loaded_image, '.*') like '%'
+              AND '1'||regexp_extract(loaded_image, '.*') not like '__DOES_NOT_EXIST__%'
+              AND '1'||regexp_extract(loaded_image, '.*') IN ('0'||regexp_extract(loaded_image, '.*'),
+                                                              1||regexp_extract(loaded_image, '.*'),
+                                                              2||regexp_extract(loaded_image, '.*'))
+              AND '1'||regexp_extract(loaded_image, '.*') NOT IN ('0'||regexp_extract(loaded_image, '.*'),
+                                                                  2||regexp_extract(loaded_image, '.*'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A15: regexp_like
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (CASE
+           WHEN regexp_like(loaded_image, '.*') THEN 1
+           ELSE 101
+       END IS NULL
+       OR (CASE
+               WHEN regexp_like(loaded_image, '.*') THEN 1
+               ELSE 101
+           END = CASE
+                     WHEN regexp_like(loaded_image, '.*') THEN 1
+                     ELSE 101
+                 END
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END IS NOT DISTINCT
+           FROM CASE
+                    WHEN regexp_like(loaded_image, '.*') THEN 1
+                    ELSE 101
+                END
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END <> CASE
+                          WHEN regexp_like(loaded_image, '.*') THEN 0
+                          ELSE 100
+                      END
+           AND (CASE
+                    WHEN regexp_like(loaded_image, '.*') THEN 1
+                    ELSE 101
+                END IS DISTINCT
+                FROM CASE
+                         WHEN regexp_like(loaded_image, '.*') THEN 0
+                         ELSE 100
+                     END)
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END > CASE
+                         WHEN regexp_like(loaded_image, '.*') THEN 0
+                         ELSE 100
+                     END
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END >= CASE
+                          WHEN regexp_like(loaded_image, '.*') THEN 0
+                          ELSE 100
+                      END
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END < CASE
+                         WHEN regexp_like(loaded_image, '.*') THEN 2
+                         ELSE 102
+                     END
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END <= CASE
+                          WHEN regexp_like(loaded_image, '.*') THEN 2
+                          ELSE 102
+                      END
+           AND (CASE
+                    WHEN regexp_like(loaded_image, '.*') THEN 1
+                    ELSE 101
+                END <> CASE
+                           WHEN regexp_like(loaded_image, '.*') THEN 0
+                           ELSE 100
+                       END) IS TRUE
+           AND (CASE
+                    WHEN regexp_like(loaded_image, '.*') THEN 1
+                    ELSE 101
+                END = CASE
+                          WHEN regexp_like(loaded_image, '.*') THEN 0
+                          ELSE 100
+                      END) IS NOT TRUE
+           AND (CASE
+                    WHEN regexp_like(loaded_image, '.*') THEN 1
+                    ELSE 101
+                END = CASE
+                          WHEN regexp_like(loaded_image, '.*') THEN 0
+                          ELSE 100
+                      END) IS FALSE
+           AND (CASE
+                    WHEN regexp_like(loaded_image, '.*') THEN 1
+                    ELSE 101
+                END <> CASE
+                           WHEN regexp_like(loaded_image, '.*') THEN 0
+                           ELSE 100
+                       END) IS NOT FALSE
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END BETWEEN CASE
+                               WHEN regexp_like(loaded_image, '.*') THEN 0
+                               ELSE 100
+                           END AND CASE
+                                       WHEN regexp_like(loaded_image, '.*') THEN 2
+                                       ELSE 102
+                                   END
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END NOT BETWEEN CASE
+                                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                                   ELSE 101
+                               END AND CASE
+                                           WHEN regexp_like(loaded_image, '.*') THEN 0
+                                           ELSE 100
+                                       END
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END like '%'
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END not like '__DOES_NOT_EXIST__%'
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END IN (CASE
+                           WHEN regexp_like(loaded_image, '.*') THEN 0
+                           ELSE 100
+                       END,
+                       CASE
+                           WHEN regexp_like(loaded_image, '.*') THEN 1
+                           ELSE 101
+                       END,
+                       CASE
+                           WHEN regexp_like(loaded_image, '.*') THEN 2
+                           ELSE 102
+                       END)
+           AND CASE
+                   WHEN regexp_like(loaded_image, '.*') THEN 1
+                   ELSE 101
+               END NOT IN (CASE
+                               WHEN regexp_like(loaded_image, '.*') THEN 0
+                               ELSE 100
+                           END,
+                           CASE
+                               WHEN regexp_like(loaded_image, '.*') THEN 2
+                               ELSE 102
+                           END))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (CASE
+           WHEN regexp_like(loaded_image, '.*') THEN 1
+           ELSE 101
+       END IS NULL
+       OR CASE
+              WHEN regexp_like(loaded_image, '.*') THEN 1
+              ELSE 101
+          END IN
+         (SELECT CASE
+                     WHEN regexp_like(loaded_image, '.*') THEN 1
+                     ELSE 101
+                 END
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (CASE
+                     WHEN regexp_like(loaded_image, '.*') THEN 1
+                     ELSE 101
+                 END IS NULL
+                 OR (CASE
+                         WHEN regexp_like(loaded_image, '.*') THEN 1
+                         ELSE 101
+                     END = CASE
+                               WHEN regexp_like(loaded_image, '.*') THEN 1
+                               ELSE 101
+                           END
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END IS NOT DISTINCT
+                     FROM CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END <> CASE
+                                    WHEN regexp_like(loaded_image, '.*') THEN 0
+                                    ELSE 100
+                                END
+                     AND (CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END IS DISTINCT
+                          FROM CASE
+                                   WHEN regexp_like(loaded_image, '.*') THEN 0
+                                   ELSE 100
+                               END)
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END > CASE
+                                   WHEN regexp_like(loaded_image, '.*') THEN 0
+                                   ELSE 100
+                               END
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END >= CASE
+                                    WHEN regexp_like(loaded_image, '.*') THEN 0
+                                    ELSE 100
+                                END
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END < CASE
+                                   WHEN regexp_like(loaded_image, '.*') THEN 2
+                                   ELSE 102
+                               END
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END <= CASE
+                                    WHEN regexp_like(loaded_image, '.*') THEN 2
+                                    ELSE 102
+                                END
+                     AND (CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END <> CASE
+                                     WHEN regexp_like(loaded_image, '.*') THEN 0
+                                     ELSE 100
+                                 END) IS TRUE
+                     AND (CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END = CASE
+                                    WHEN regexp_like(loaded_image, '.*') THEN 0
+                                    ELSE 100
+                                END) IS NOT TRUE
+                     AND (CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END = CASE
+                                    WHEN regexp_like(loaded_image, '.*') THEN 0
+                                    ELSE 100
+                                END) IS FALSE
+                     AND (CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END <> CASE
+                                     WHEN regexp_like(loaded_image, '.*') THEN 0
+                                     ELSE 100
+                                 END) IS NOT FALSE
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END BETWEEN CASE
+                                         WHEN regexp_like(loaded_image, '.*') THEN 0
+                                         ELSE 100
+                                     END AND CASE
+                                                 WHEN regexp_like(loaded_image, '.*') THEN 2
+                                                 ELSE 102
+                                             END
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END NOT BETWEEN CASE
+                                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                                             ELSE 101
+                                         END AND CASE
+                                                     WHEN regexp_like(loaded_image, '.*') THEN 0
+                                                     ELSE 100
+                                                 END
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END like '%'
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END not like '__DOES_NOT_EXIST__%'
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END IN (CASE
+                                     WHEN regexp_like(loaded_image, '.*') THEN 0
+                                     ELSE 100
+                                 END,
+                                 CASE
+                                     WHEN regexp_like(loaded_image, '.*') THEN 1
+                                     ELSE 101
+                                 END,
+                                 CASE
+                                     WHEN regexp_like(loaded_image, '.*') THEN 2
+                                     ELSE 102
+                                 END)
+                     AND CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 1
+                             ELSE 101
+                         END NOT IN (CASE
+                                         WHEN regexp_like(loaded_image, '.*') THEN 0
+                                         ELSE 100
+                                     END,
+                                     CASE
+                                         WHEN regexp_like(loaded_image, '.*') THEN 2
+                                         ELSE 102
+                                     END)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (CASE
+              WHEN regexp_like(loaded_image, '.*') THEN 1
+              ELSE 101
+          END IS NULL
+          OR (CASE
+                  WHEN regexp_like(loaded_image, '.*') THEN 1
+                  ELSE 101
+              END = CASE
+                        WHEN regexp_like(loaded_image, '.*') THEN 1
+                        ELSE 101
+                    END
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END IS NOT DISTINCT
+              FROM CASE
+                       WHEN regexp_like(loaded_image, '.*') THEN 1
+                       ELSE 101
+                   END
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END <> CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 0
+                             ELSE 100
+                         END
+              AND (CASE
+                       WHEN regexp_like(loaded_image, '.*') THEN 1
+                       ELSE 101
+                   END IS DISTINCT
+                   FROM CASE
+                            WHEN regexp_like(loaded_image, '.*') THEN 0
+                            ELSE 100
+                        END)
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END > CASE
+                            WHEN regexp_like(loaded_image, '.*') THEN 0
+                            ELSE 100
+                        END
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END >= CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 0
+                             ELSE 100
+                         END
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END < CASE
+                            WHEN regexp_like(loaded_image, '.*') THEN 2
+                            ELSE 102
+                        END
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END <= CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 2
+                             ELSE 102
+                         END
+              AND (CASE
+                       WHEN regexp_like(loaded_image, '.*') THEN 1
+                       ELSE 101
+                   END <> CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 0
+                              ELSE 100
+                          END) IS TRUE
+              AND (CASE
+                       WHEN regexp_like(loaded_image, '.*') THEN 1
+                       ELSE 101
+                   END = CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 0
+                             ELSE 100
+                         END) IS NOT TRUE
+              AND (CASE
+                       WHEN regexp_like(loaded_image, '.*') THEN 1
+                       ELSE 101
+                   END = CASE
+                             WHEN regexp_like(loaded_image, '.*') THEN 0
+                             ELSE 100
+                         END) IS FALSE
+              AND (CASE
+                       WHEN regexp_like(loaded_image, '.*') THEN 1
+                       ELSE 101
+                   END <> CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 0
+                              ELSE 100
+                          END) IS NOT FALSE
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END BETWEEN CASE
+                                  WHEN regexp_like(loaded_image, '.*') THEN 0
+                                  ELSE 100
+                              END AND CASE
+                                          WHEN regexp_like(loaded_image, '.*') THEN 2
+                                          ELSE 102
+                                      END
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END NOT BETWEEN CASE
+                                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                                      ELSE 101
+                                  END AND CASE
+                                              WHEN regexp_like(loaded_image, '.*') THEN 0
+                                              ELSE 100
+                                          END
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END like '%'
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END not like '__DOES_NOT_EXIST__%'
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END IN (CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 0
+                              ELSE 100
+                          END,
+                          CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 1
+                              ELSE 101
+                          END,
+                          CASE
+                              WHEN regexp_like(loaded_image, '.*') THEN 2
+                              ELSE 102
+                          END)
+              AND CASE
+                      WHEN regexp_like(loaded_image, '.*') THEN 1
+                      ELSE 101
+                  END NOT IN (CASE
+                                  WHEN regexp_like(loaded_image, '.*') THEN 0
+                                  ELSE 100
+                              END,
+                              CASE
+                                  WHEN regexp_like(loaded_image, '.*') THEN 2
+                                  ELSE 102
+                              END)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A16: regexp_replace
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (regexp_replace(loaded_image, '.', '1') IS NULL
+       OR (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '1')
+           AND regexp_replace(loaded_image, '.', '1') IS NOT DISTINCT
+           FROM regexp_replace(loaded_image, '.', '1')
+           AND regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')
+           AND (regexp_replace(loaded_image, '.', '1') IS DISTINCT
+                FROM regexp_replace(loaded_image, '.', '0'))
+           AND regexp_replace(loaded_image, '.', '1') > regexp_replace(loaded_image, '.', '0')
+           AND regexp_replace(loaded_image, '.', '1') >= regexp_replace(loaded_image, '.', '0')
+           AND regexp_replace(loaded_image, '.', '1') < regexp_replace(loaded_image, '.', '2')
+           AND regexp_replace(loaded_image, '.', '1') <= regexp_replace(loaded_image, '.', '2')
+           AND (regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')) IS TRUE
+           AND (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '0')) IS NOT TRUE
+           AND (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '0')) IS FALSE
+           AND (regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')) IS NOT FALSE
+           AND regexp_replace(loaded_image, '.', '1') BETWEEN regexp_replace(loaded_image, '.', '0') AND regexp_replace(loaded_image, '.', '2')
+           AND regexp_replace(loaded_image, '.', '1') NOT BETWEEN regexp_replace(loaded_image, '.', '1') AND regexp_replace(loaded_image, '.', '0')
+           AND regexp_replace(loaded_image, '.', '1') like '%'
+           AND regexp_replace(loaded_image, '.', '1') not like '__DOES_NOT_EXIST__%'
+           AND regexp_replace(loaded_image, '.', '1') IN (regexp_replace(loaded_image, '.', '0'),
+                                                          regexp_replace(loaded_image, '.', '1'),
+                                                          regexp_replace(loaded_image, '.', '2'))
+           AND regexp_replace(loaded_image, '.', '1') NOT IN (regexp_replace(loaded_image, '.', '0'),
+                                                              regexp_replace(loaded_image, '.', '2')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (regexp_replace(loaded_image, '.', '1') IS NULL
+       OR regexp_replace(loaded_image, '.', '1') IN
+         (SELECT regexp_replace(loaded_image, '.', '1')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (regexp_replace(loaded_image, '.', '1') IS NULL
+                 OR (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '1')
+                     AND regexp_replace(loaded_image, '.', '1') IS NOT DISTINCT
+                     FROM regexp_replace(loaded_image, '.', '1')
+                     AND regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')
+                     AND (regexp_replace(loaded_image, '.', '1') IS DISTINCT
+                          FROM regexp_replace(loaded_image, '.', '0'))
+                     AND regexp_replace(loaded_image, '.', '1') > regexp_replace(loaded_image, '.', '0')
+                     AND regexp_replace(loaded_image, '.', '1') >= regexp_replace(loaded_image, '.', '0')
+                     AND regexp_replace(loaded_image, '.', '1') < regexp_replace(loaded_image, '.', '2')
+                     AND regexp_replace(loaded_image, '.', '1') <= regexp_replace(loaded_image, '.', '2')
+                     AND (regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')) IS TRUE
+                     AND (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '0')) IS NOT TRUE
+                     AND (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '0')) IS FALSE
+                     AND (regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')) IS NOT FALSE
+                     AND regexp_replace(loaded_image, '.', '1') BETWEEN regexp_replace(loaded_image, '.', '0') AND regexp_replace(loaded_image, '.', '2')
+                     AND regexp_replace(loaded_image, '.', '1') NOT BETWEEN regexp_replace(loaded_image, '.', '1') AND regexp_replace(loaded_image, '.', '0')
+                     AND regexp_replace(loaded_image, '.', '1') like '%'
+                     AND regexp_replace(loaded_image, '.', '1') not like '__DOES_NOT_EXIST__%'
+                     AND regexp_replace(loaded_image, '.', '1') IN (regexp_replace(loaded_image, '.', '0'),
+                                                                    regexp_replace(loaded_image, '.', '1'),
+                                                                    regexp_replace(loaded_image, '.', '2'))
+                     AND regexp_replace(loaded_image, '.', '1') NOT IN (regexp_replace(loaded_image, '.', '0'),
+                                                                        regexp_replace(loaded_image, '.', '2'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          regexp_replace(loaded_image, '.', '1'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (regexp_replace(loaded_image, '.', '1') IS NULL
+          OR (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '1')
+              AND regexp_replace(loaded_image, '.', '1') IS NOT DISTINCT
+              FROM regexp_replace(loaded_image, '.', '1')
+              AND regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')
+              AND (regexp_replace(loaded_image, '.', '1') IS DISTINCT
+                   FROM regexp_replace(loaded_image, '.', '0'))
+              AND regexp_replace(loaded_image, '.', '1') > regexp_replace(loaded_image, '.', '0')
+              AND regexp_replace(loaded_image, '.', '1') >= regexp_replace(loaded_image, '.', '0')
+              AND regexp_replace(loaded_image, '.', '1') < regexp_replace(loaded_image, '.', '2')
+              AND regexp_replace(loaded_image, '.', '1') <= regexp_replace(loaded_image, '.', '2')
+              AND (regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')) IS TRUE
+              AND (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '0')) IS NOT TRUE
+              AND (regexp_replace(loaded_image, '.', '1') = regexp_replace(loaded_image, '.', '0')) IS FALSE
+              AND (regexp_replace(loaded_image, '.', '1') <> regexp_replace(loaded_image, '.', '0')) IS NOT FALSE
+              AND regexp_replace(loaded_image, '.', '1') BETWEEN regexp_replace(loaded_image, '.', '0') AND regexp_replace(loaded_image, '.', '2')
+              AND regexp_replace(loaded_image, '.', '1') NOT BETWEEN regexp_replace(loaded_image, '.', '1') AND regexp_replace(loaded_image, '.', '0')
+              AND regexp_replace(loaded_image, '.', '1') like '%'
+              AND regexp_replace(loaded_image, '.', '1') not like '__DOES_NOT_EXIST__%'
+              AND regexp_replace(loaded_image, '.', '1') IN (regexp_replace(loaded_image, '.', '0'),
+                                                             regexp_replace(loaded_image, '.', '1'),
+                                                             regexp_replace(loaded_image, '.', '2'))
+              AND regexp_replace(loaded_image, '.', '1') NOT IN (regexp_replace(loaded_image, '.', '0'),
+                                                                 regexp_replace(loaded_image, '.', '2'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A17: contains_string
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||contains_string(loaded_image, 'a') IS NULL
+       OR ('1'||contains_string(loaded_image, 'a') = 1||contains_string(loaded_image, 'a')
+           AND '1'||contains_string(loaded_image, 'a') IS NOT DISTINCT
+           FROM 1||contains_string(loaded_image, 'a')
+           AND '1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')
+           AND ('1'||contains_string(loaded_image, 'a') IS DISTINCT
+                FROM '0'||contains_string(loaded_image, 'a'))
+           AND '1'||contains_string(loaded_image, 'a') > '0'||contains_string(loaded_image, 'a')
+           AND '1'||contains_string(loaded_image, 'a') >= '0'||contains_string(loaded_image, 'a')
+           AND '1'||contains_string(loaded_image, 'a') < 2||contains_string(loaded_image, 'a')
+           AND '1'||contains_string(loaded_image, 'a') <= 2||contains_string(loaded_image, 'a')
+           AND ('1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')) IS TRUE
+           AND ('1'||contains_string(loaded_image, 'a') = '0'||contains_string(loaded_image, 'a')) IS NOT TRUE
+           AND ('1'||contains_string(loaded_image, 'a') = '0'||contains_string(loaded_image, 'a')) IS FALSE
+           AND ('1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')) IS NOT FALSE
+           AND '1'||contains_string(loaded_image, 'a') BETWEEN '0'||contains_string(loaded_image, 'a') AND 2||contains_string(loaded_image, 'a')
+           AND '1'||contains_string(loaded_image, 'a') NOT BETWEEN '1'||contains_string(loaded_image, 'a') AND '0'||contains_string(loaded_image, 'a')
+           AND '1'||contains_string(loaded_image, 'a') like '%'
+           AND '1'||contains_string(loaded_image, 'a') not like '__DOES_NOT_EXIST__%'
+           AND '1'||contains_string(loaded_image, 'a') IN ('0'||contains_string(loaded_image, 'a'),
+                                                           1||contains_string(loaded_image, 'a'),
+                                                           2||contains_string(loaded_image, 'a'))
+           AND '1'||contains_string(loaded_image, 'a') NOT IN ('0'||contains_string(loaded_image, 'a'),
+                                                               2||contains_string(loaded_image, 'a')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||contains_string(loaded_image, 'a') IS NULL
+       OR '1'||contains_string(loaded_image, 'a') IN
+         (SELECT '1'||contains_string(loaded_image, 'a')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||contains_string(loaded_image, 'a') IS NULL
+                 OR ('1'||contains_string(loaded_image, 'a') = 1||contains_string(loaded_image, 'a')
+                     AND '1'||contains_string(loaded_image, 'a') IS NOT DISTINCT
+                     FROM 1||contains_string(loaded_image, 'a')
+                     AND '1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')
+                     AND ('1'||contains_string(loaded_image, 'a') IS DISTINCT
+                          FROM '0'||contains_string(loaded_image, 'a'))
+                     AND '1'||contains_string(loaded_image, 'a') > '0'||contains_string(loaded_image, 'a')
+                     AND '1'||contains_string(loaded_image, 'a') >= '0'||contains_string(loaded_image, 'a')
+                     AND '1'||contains_string(loaded_image, 'a') < 2||contains_string(loaded_image, 'a')
+                     AND '1'||contains_string(loaded_image, 'a') <= 2||contains_string(loaded_image, 'a')
+                     AND ('1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')) IS TRUE
+                     AND ('1'||contains_string(loaded_image, 'a') = '0'||contains_string(loaded_image, 'a')) IS NOT TRUE
+                     AND ('1'||contains_string(loaded_image, 'a') = '0'||contains_string(loaded_image, 'a')) IS FALSE
+                     AND ('1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')) IS NOT FALSE
+                     AND '1'||contains_string(loaded_image, 'a') BETWEEN '0'||contains_string(loaded_image, 'a') AND 2||contains_string(loaded_image, 'a')
+                     AND '1'||contains_string(loaded_image, 'a') NOT BETWEEN '1'||contains_string(loaded_image, 'a') AND '0'||contains_string(loaded_image, 'a')
+                     AND '1'||contains_string(loaded_image, 'a') like '%'
+                     AND '1'||contains_string(loaded_image, 'a') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||contains_string(loaded_image, 'a') IN ('0'||contains_string(loaded_image, 'a'),
+                                                                     1||contains_string(loaded_image, 'a'),
+                                                                     2||contains_string(loaded_image, 'a'))
+                     AND '1'||contains_string(loaded_image, 'a') NOT IN ('0'||contains_string(loaded_image, 'a'),
+                                                                         2||contains_string(loaded_image, 'a'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||contains_string(loaded_image, 'a'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||contains_string(loaded_image, 'a') IS NULL
+          OR ('1'||contains_string(loaded_image, 'a') = 1||contains_string(loaded_image, 'a')
+              AND '1'||contains_string(loaded_image, 'a') IS NOT DISTINCT
+              FROM 1||contains_string(loaded_image, 'a')
+              AND '1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')
+              AND ('1'||contains_string(loaded_image, 'a') IS DISTINCT
+                   FROM '0'||contains_string(loaded_image, 'a'))
+              AND '1'||contains_string(loaded_image, 'a') > '0'||contains_string(loaded_image, 'a')
+              AND '1'||contains_string(loaded_image, 'a') >= '0'||contains_string(loaded_image, 'a')
+              AND '1'||contains_string(loaded_image, 'a') < 2||contains_string(loaded_image, 'a')
+              AND '1'||contains_string(loaded_image, 'a') <= 2||contains_string(loaded_image, 'a')
+              AND ('1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')) IS TRUE
+              AND ('1'||contains_string(loaded_image, 'a') = '0'||contains_string(loaded_image, 'a')) IS NOT TRUE
+              AND ('1'||contains_string(loaded_image, 'a') = '0'||contains_string(loaded_image, 'a')) IS FALSE
+              AND ('1'||contains_string(loaded_image, 'a') <> '0'||contains_string(loaded_image, 'a')) IS NOT FALSE
+              AND '1'||contains_string(loaded_image, 'a') BETWEEN '0'||contains_string(loaded_image, 'a') AND 2||contains_string(loaded_image, 'a')
+              AND '1'||contains_string(loaded_image, 'a') NOT BETWEEN '1'||contains_string(loaded_image, 'a') AND '0'||contains_string(loaded_image, 'a')
+              AND '1'||contains_string(loaded_image, 'a') like '%'
+              AND '1'||contains_string(loaded_image, 'a') not like '__DOES_NOT_EXIST__%'
+              AND '1'||contains_string(loaded_image, 'a') IN ('0'||contains_string(loaded_image, 'a'),
+                                                              1||contains_string(loaded_image, 'a'),
+                                                              2||contains_string(loaded_image, 'a'))
+              AND '1'||contains_string(loaded_image, 'a') NOT IN ('0'||contains_string(loaded_image, 'a'),
+                                                                  2||contains_string(loaded_image, 'a'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A18: icontains_string
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||icontains_string(loaded_image, 'a') IS NULL
+       OR ('1'||icontains_string(loaded_image, 'a') = 1||icontains_string(loaded_image, 'a')
+           AND '1'||icontains_string(loaded_image, 'a') IS NOT DISTINCT
+           FROM 1||icontains_string(loaded_image, 'a')
+           AND '1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')
+           AND ('1'||icontains_string(loaded_image, 'a') IS DISTINCT
+                FROM '0'||icontains_string(loaded_image, 'a'))
+           AND '1'||icontains_string(loaded_image, 'a') > '0'||icontains_string(loaded_image, 'a')
+           AND '1'||icontains_string(loaded_image, 'a') >= '0'||icontains_string(loaded_image, 'a')
+           AND '1'||icontains_string(loaded_image, 'a') < 2||icontains_string(loaded_image, 'a')
+           AND '1'||icontains_string(loaded_image, 'a') <= 2||icontains_string(loaded_image, 'a')
+           AND ('1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')) IS TRUE
+           AND ('1'||icontains_string(loaded_image, 'a') = '0'||icontains_string(loaded_image, 'a')) IS NOT TRUE
+           AND ('1'||icontains_string(loaded_image, 'a') = '0'||icontains_string(loaded_image, 'a')) IS FALSE
+           AND ('1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')) IS NOT FALSE
+           AND '1'||icontains_string(loaded_image, 'a') BETWEEN '0'||icontains_string(loaded_image, 'a') AND 2||icontains_string(loaded_image, 'a')
+           AND '1'||icontains_string(loaded_image, 'a') NOT BETWEEN '1'||icontains_string(loaded_image, 'a') AND '0'||icontains_string(loaded_image, 'a')
+           AND '1'||icontains_string(loaded_image, 'a') like '%'
+           AND '1'||icontains_string(loaded_image, 'a') not like '__DOES_NOT_EXIST__%'
+           AND '1'||icontains_string(loaded_image, 'a') IN ('0'||icontains_string(loaded_image, 'a'),
+                                                            1||icontains_string(loaded_image, 'a'),
+                                                            2||icontains_string(loaded_image, 'a'))
+           AND '1'||icontains_string(loaded_image, 'a') NOT IN ('0'||icontains_string(loaded_image, 'a'),
+                                                                2||icontains_string(loaded_image, 'a')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||icontains_string(loaded_image, 'a') IS NULL
+       OR '1'||icontains_string(loaded_image, 'a') IN
+         (SELECT '1'||icontains_string(loaded_image, 'a')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||icontains_string(loaded_image, 'a') IS NULL
+                 OR ('1'||icontains_string(loaded_image, 'a') = 1||icontains_string(loaded_image, 'a')
+                     AND '1'||icontains_string(loaded_image, 'a') IS NOT DISTINCT
+                     FROM 1||icontains_string(loaded_image, 'a')
+                     AND '1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')
+                     AND ('1'||icontains_string(loaded_image, 'a') IS DISTINCT
+                          FROM '0'||icontains_string(loaded_image, 'a'))
+                     AND '1'||icontains_string(loaded_image, 'a') > '0'||icontains_string(loaded_image, 'a')
+                     AND '1'||icontains_string(loaded_image, 'a') >= '0'||icontains_string(loaded_image, 'a')
+                     AND '1'||icontains_string(loaded_image, 'a') < 2||icontains_string(loaded_image, 'a')
+                     AND '1'||icontains_string(loaded_image, 'a') <= 2||icontains_string(loaded_image, 'a')
+                     AND ('1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')) IS TRUE
+                     AND ('1'||icontains_string(loaded_image, 'a') = '0'||icontains_string(loaded_image, 'a')) IS NOT TRUE
+                     AND ('1'||icontains_string(loaded_image, 'a') = '0'||icontains_string(loaded_image, 'a')) IS FALSE
+                     AND ('1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')) IS NOT FALSE
+                     AND '1'||icontains_string(loaded_image, 'a') BETWEEN '0'||icontains_string(loaded_image, 'a') AND 2||icontains_string(loaded_image, 'a')
+                     AND '1'||icontains_string(loaded_image, 'a') NOT BETWEEN '1'||icontains_string(loaded_image, 'a') AND '0'||icontains_string(loaded_image, 'a')
+                     AND '1'||icontains_string(loaded_image, 'a') like '%'
+                     AND '1'||icontains_string(loaded_image, 'a') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||icontains_string(loaded_image, 'a') IN ('0'||icontains_string(loaded_image, 'a'),
+                                                                      1||icontains_string(loaded_image, 'a'),
+                                                                      2||icontains_string(loaded_image, 'a'))
+                     AND '1'||icontains_string(loaded_image, 'a') NOT IN ('0'||icontains_string(loaded_image, 'a'),
+                                                                          2||icontains_string(loaded_image, 'a'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||icontains_string(loaded_image, 'a'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||icontains_string(loaded_image, 'a') IS NULL
+          OR ('1'||icontains_string(loaded_image, 'a') = 1||icontains_string(loaded_image, 'a')
+              AND '1'||icontains_string(loaded_image, 'a') IS NOT DISTINCT
+              FROM 1||icontains_string(loaded_image, 'a')
+              AND '1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')
+              AND ('1'||icontains_string(loaded_image, 'a') IS DISTINCT
+                   FROM '0'||icontains_string(loaded_image, 'a'))
+              AND '1'||icontains_string(loaded_image, 'a') > '0'||icontains_string(loaded_image, 'a')
+              AND '1'||icontains_string(loaded_image, 'a') >= '0'||icontains_string(loaded_image, 'a')
+              AND '1'||icontains_string(loaded_image, 'a') < 2||icontains_string(loaded_image, 'a')
+              AND '1'||icontains_string(loaded_image, 'a') <= 2||icontains_string(loaded_image, 'a')
+              AND ('1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')) IS TRUE
+              AND ('1'||icontains_string(loaded_image, 'a') = '0'||icontains_string(loaded_image, 'a')) IS NOT TRUE
+              AND ('1'||icontains_string(loaded_image, 'a') = '0'||icontains_string(loaded_image, 'a')) IS FALSE
+              AND ('1'||icontains_string(loaded_image, 'a') <> '0'||icontains_string(loaded_image, 'a')) IS NOT FALSE
+              AND '1'||icontains_string(loaded_image, 'a') BETWEEN '0'||icontains_string(loaded_image, 'a') AND 2||icontains_string(loaded_image, 'a')
+              AND '1'||icontains_string(loaded_image, 'a') NOT BETWEEN '1'||icontains_string(loaded_image, 'a') AND '0'||icontains_string(loaded_image, 'a')
+              AND '1'||icontains_string(loaded_image, 'a') like '%'
+              AND '1'||icontains_string(loaded_image, 'a') not like '__DOES_NOT_EXIST__%'
+              AND '1'||icontains_string(loaded_image, 'a') IN ('0'||icontains_string(loaded_image, 'a'),
+                                                               1||icontains_string(loaded_image, 'a'),
+                                                               2||icontains_string(loaded_image, 'a'))
+              AND '1'||icontains_string(loaded_image, 'a') NOT IN ('0'||icontains_string(loaded_image, 'a'),
+                                                                   2||icontains_string(loaded_image, 'a'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A19: replace
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||replace(loaded_image, 'a', 'z') IS NULL
+       OR ('1'||replace(loaded_image, 'a', 'z') = 1||replace(loaded_image, 'a', 'z')
+           AND '1'||replace(loaded_image, 'a', 'z') IS NOT DISTINCT
+           FROM 1||replace(loaded_image, 'a', 'z')
+           AND '1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')
+           AND ('1'||replace(loaded_image, 'a', 'z') IS DISTINCT
+                FROM '0'||replace(loaded_image, 'a', 'z'))
+           AND '1'||replace(loaded_image, 'a', 'z') > '0'||replace(loaded_image, 'a', 'z')
+           AND '1'||replace(loaded_image, 'a', 'z') >= '0'||replace(loaded_image, 'a', 'z')
+           AND '1'||replace(loaded_image, 'a', 'z') < 2||replace(loaded_image, 'a', 'z')
+           AND '1'||replace(loaded_image, 'a', 'z') <= 2||replace(loaded_image, 'a', 'z')
+           AND ('1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')) IS TRUE
+           AND ('1'||replace(loaded_image, 'a', 'z') = '0'||replace(loaded_image, 'a', 'z')) IS NOT TRUE
+           AND ('1'||replace(loaded_image, 'a', 'z') = '0'||replace(loaded_image, 'a', 'z')) IS FALSE
+           AND ('1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')) IS NOT FALSE
+           AND '1'||replace(loaded_image, 'a', 'z') BETWEEN '0'||replace(loaded_image, 'a', 'z') AND 2||replace(loaded_image, 'a', 'z')
+           AND '1'||replace(loaded_image, 'a', 'z') NOT BETWEEN '1'||replace(loaded_image, 'a', 'z') AND '0'||replace(loaded_image, 'a', 'z')
+           AND '1'||replace(loaded_image, 'a', 'z') like '%'
+           AND '1'||replace(loaded_image, 'a', 'z') not like '__DOES_NOT_EXIST__%'
+           AND '1'||replace(loaded_image, 'a', 'z') IN ('0'||replace(loaded_image, 'a', 'z'),
+                                                        1||replace(loaded_image, 'a', 'z'),
+                                                        2||replace(loaded_image, 'a', 'z'))
+           AND '1'||replace(loaded_image, 'a', 'z') NOT IN ('0'||replace(loaded_image, 'a', 'z'),
+                                                            2||replace(loaded_image, 'a', 'z')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||replace(loaded_image, 'a', 'z') IS NULL
+       OR '1'||replace(loaded_image, 'a', 'z') IN
+         (SELECT '1'||replace(loaded_image, 'a', 'z')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||replace(loaded_image, 'a', 'z') IS NULL
+                 OR ('1'||replace(loaded_image, 'a', 'z') = 1||replace(loaded_image, 'a', 'z')
+                     AND '1'||replace(loaded_image, 'a', 'z') IS NOT DISTINCT
+                     FROM 1||replace(loaded_image, 'a', 'z')
+                     AND '1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')
+                     AND ('1'||replace(loaded_image, 'a', 'z') IS DISTINCT
+                          FROM '0'||replace(loaded_image, 'a', 'z'))
+                     AND '1'||replace(loaded_image, 'a', 'z') > '0'||replace(loaded_image, 'a', 'z')
+                     AND '1'||replace(loaded_image, 'a', 'z') >= '0'||replace(loaded_image, 'a', 'z')
+                     AND '1'||replace(loaded_image, 'a', 'z') < 2||replace(loaded_image, 'a', 'z')
+                     AND '1'||replace(loaded_image, 'a', 'z') <= 2||replace(loaded_image, 'a', 'z')
+                     AND ('1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')) IS TRUE
+                     AND ('1'||replace(loaded_image, 'a', 'z') = '0'||replace(loaded_image, 'a', 'z')) IS NOT TRUE
+                     AND ('1'||replace(loaded_image, 'a', 'z') = '0'||replace(loaded_image, 'a', 'z')) IS FALSE
+                     AND ('1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')) IS NOT FALSE
+                     AND '1'||replace(loaded_image, 'a', 'z') BETWEEN '0'||replace(loaded_image, 'a', 'z') AND 2||replace(loaded_image, 'a', 'z')
+                     AND '1'||replace(loaded_image, 'a', 'z') NOT BETWEEN '1'||replace(loaded_image, 'a', 'z') AND '0'||replace(loaded_image, 'a', 'z')
+                     AND '1'||replace(loaded_image, 'a', 'z') like '%'
+                     AND '1'||replace(loaded_image, 'a', 'z') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||replace(loaded_image, 'a', 'z') IN ('0'||replace(loaded_image, 'a', 'z'),
+                                                                  1||replace(loaded_image, 'a', 'z'),
+                                                                  2||replace(loaded_image, 'a', 'z'))
+                     AND '1'||replace(loaded_image, 'a', 'z') NOT IN ('0'||replace(loaded_image, 'a', 'z'),
+                                                                      2||replace(loaded_image, 'a', 'z'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||replace(loaded_image, 'a', 'z'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||replace(loaded_image, 'a', 'z') IS NULL
+          OR ('1'||replace(loaded_image, 'a', 'z') = 1||replace(loaded_image, 'a', 'z')
+              AND '1'||replace(loaded_image, 'a', 'z') IS NOT DISTINCT
+              FROM 1||replace(loaded_image, 'a', 'z')
+              AND '1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')
+              AND ('1'||replace(loaded_image, 'a', 'z') IS DISTINCT
+                   FROM '0'||replace(loaded_image, 'a', 'z'))
+              AND '1'||replace(loaded_image, 'a', 'z') > '0'||replace(loaded_image, 'a', 'z')
+              AND '1'||replace(loaded_image, 'a', 'z') >= '0'||replace(loaded_image, 'a', 'z')
+              AND '1'||replace(loaded_image, 'a', 'z') < 2||replace(loaded_image, 'a', 'z')
+              AND '1'||replace(loaded_image, 'a', 'z') <= 2||replace(loaded_image, 'a', 'z')
+              AND ('1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')) IS TRUE
+              AND ('1'||replace(loaded_image, 'a', 'z') = '0'||replace(loaded_image, 'a', 'z')) IS NOT TRUE
+              AND ('1'||replace(loaded_image, 'a', 'z') = '0'||replace(loaded_image, 'a', 'z')) IS FALSE
+              AND ('1'||replace(loaded_image, 'a', 'z') <> '0'||replace(loaded_image, 'a', 'z')) IS NOT FALSE
+              AND '1'||replace(loaded_image, 'a', 'z') BETWEEN '0'||replace(loaded_image, 'a', 'z') AND 2||replace(loaded_image, 'a', 'z')
+              AND '1'||replace(loaded_image, 'a', 'z') NOT BETWEEN '1'||replace(loaded_image, 'a', 'z') AND '0'||replace(loaded_image, 'a', 'z')
+              AND '1'||replace(loaded_image, 'a', 'z') like '%'
+              AND '1'||replace(loaded_image, 'a', 'z') not like '__DOES_NOT_EXIST__%'
+              AND '1'||replace(loaded_image, 'a', 'z') IN ('0'||replace(loaded_image, 'a', 'z'),
+                                                           1||replace(loaded_image, 'a', 'z'),
+                                                           2||replace(loaded_image, 'a', 'z'))
+              AND '1'||replace(loaded_image, 'a', 'z') NOT IN ('0'||replace(loaded_image, 'a', 'z'),
+                                                               2||replace(loaded_image, 'a', 'z'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A20: strpos
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (strpos(loaded_image, 'a')+1 IS NULL
+       OR (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')+1
+           AND strpos(loaded_image, 'a')+1 IS NOT DISTINCT
+           FROM strpos(loaded_image, 'a')+1
+           AND strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')
+           AND (strpos(loaded_image, 'a')+1 IS DISTINCT
+                FROM strpos(loaded_image, 'a'))
+           AND strpos(loaded_image, 'a')+1 > strpos(loaded_image, 'a')
+           AND strpos(loaded_image, 'a')+1 >= strpos(loaded_image, 'a')
+           AND strpos(loaded_image, 'a')+1 < strpos(loaded_image, 'a')+2
+           AND strpos(loaded_image, 'a')+1 <= strpos(loaded_image, 'a')+2
+           AND (strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')) IS TRUE
+           AND (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')) IS NOT TRUE
+           AND (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')) IS FALSE
+           AND (strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')) IS NOT FALSE
+           AND strpos(loaded_image, 'a')+1 BETWEEN strpos(loaded_image, 'a') AND strpos(loaded_image, 'a')+2
+           AND strpos(loaded_image, 'a')+1 NOT BETWEEN strpos(loaded_image, 'a')+1 AND strpos(loaded_image, 'a')
+           AND strpos(loaded_image, 'a')+1 like '%'
+           AND strpos(loaded_image, 'a')+1 not like '__DOES_NOT_EXIST__%'
+           AND strpos(loaded_image, 'a')+1 IN (strpos(loaded_image, 'a'),
+                                               strpos(loaded_image, 'a')+1,
+                                               strpos(loaded_image, 'a')+2)
+           AND strpos(loaded_image, 'a')+1 NOT IN (strpos(loaded_image, 'a'),
+                                                   strpos(loaded_image, 'a')+2))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND (strpos(loaded_image, 'a')+1 IS NULL
+       OR strpos(loaded_image, 'a')+1 IN
+         (SELECT strpos(loaded_image, 'a')+1
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND (strpos(loaded_image, 'a')+1 IS NULL
+                 OR (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')+1
+                     AND strpos(loaded_image, 'a')+1 IS NOT DISTINCT
+                     FROM strpos(loaded_image, 'a')+1
+                     AND strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')
+                     AND (strpos(loaded_image, 'a')+1 IS DISTINCT
+                          FROM strpos(loaded_image, 'a'))
+                     AND strpos(loaded_image, 'a')+1 > strpos(loaded_image, 'a')
+                     AND strpos(loaded_image, 'a')+1 >= strpos(loaded_image, 'a')
+                     AND strpos(loaded_image, 'a')+1 < strpos(loaded_image, 'a')+2
+                     AND strpos(loaded_image, 'a')+1 <= strpos(loaded_image, 'a')+2
+                     AND (strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')) IS TRUE
+                     AND (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')) IS NOT TRUE
+                     AND (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')) IS FALSE
+                     AND (strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')) IS NOT FALSE
+                     AND strpos(loaded_image, 'a')+1 BETWEEN strpos(loaded_image, 'a') AND strpos(loaded_image, 'a')+2
+                     AND strpos(loaded_image, 'a')+1 NOT BETWEEN strpos(loaded_image, 'a')+1 AND strpos(loaded_image, 'a')
+                     AND strpos(loaded_image, 'a')+1 like '%'
+                     AND strpos(loaded_image, 'a')+1 not like '__DOES_NOT_EXIST__%'
+                     AND strpos(loaded_image, 'a')+1 IN (strpos(loaded_image, 'a'),
+                                                         strpos(loaded_image, 'a')+1,
+                                                         strpos(loaded_image, 'a')+2)
+                     AND strpos(loaded_image, 'a')+1 NOT IN (strpos(loaded_image, 'a'),
+                                                             strpos(loaded_image, 'a')+2)))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          strpos(loaded_image, 'a')+1,
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND (strpos(loaded_image, 'a')+1 IS NULL
+          OR (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')+1
+              AND strpos(loaded_image, 'a')+1 IS NOT DISTINCT
+              FROM strpos(loaded_image, 'a')+1
+              AND strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')
+              AND (strpos(loaded_image, 'a')+1 IS DISTINCT
+                   FROM strpos(loaded_image, 'a'))
+              AND strpos(loaded_image, 'a')+1 > strpos(loaded_image, 'a')
+              AND strpos(loaded_image, 'a')+1 >= strpos(loaded_image, 'a')
+              AND strpos(loaded_image, 'a')+1 < strpos(loaded_image, 'a')+2
+              AND strpos(loaded_image, 'a')+1 <= strpos(loaded_image, 'a')+2
+              AND (strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')) IS TRUE
+              AND (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')) IS NOT TRUE
+              AND (strpos(loaded_image, 'a')+1 = strpos(loaded_image, 'a')) IS FALSE
+              AND (strpos(loaded_image, 'a')+1 <> strpos(loaded_image, 'a')) IS NOT FALSE
+              AND strpos(loaded_image, 'a')+1 BETWEEN strpos(loaded_image, 'a') AND strpos(loaded_image, 'a')+2
+              AND strpos(loaded_image, 'a')+1 NOT BETWEEN strpos(loaded_image, 'a')+1 AND strpos(loaded_image, 'a')
+              AND strpos(loaded_image, 'a')+1 like '%'
+              AND strpos(loaded_image, 'a')+1 not like '__DOES_NOT_EXIST__%'
+              AND strpos(loaded_image, 'a')+1 IN (strpos(loaded_image, 'a'),
+                                                  strpos(loaded_image, 'a')+1,
+                                                  strpos(loaded_image, 'a')+2)
+              AND strpos(loaded_image, 'a')+1 NOT IN (strpos(loaded_image, 'a'),
+                                                      strpos(loaded_image, 'a')+2)))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A21: substring
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||substring(loaded_image, 1, length(loaded_image)) IS NULL
+       OR ('1'||substring(loaded_image, 1, length(loaded_image)) = 1||substring(loaded_image, 1, length(loaded_image))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) IS NOT DISTINCT
+           FROM 1||substring(loaded_image, 1, length(loaded_image))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))
+           AND ('1'||substring(loaded_image, 1, length(loaded_image)) IS DISTINCT
+                FROM '0'||substring(loaded_image, 1, length(loaded_image)))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) > '0'||substring(loaded_image, 1, length(loaded_image))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) >= '0'||substring(loaded_image, 1, length(loaded_image))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) < 2||substring(loaded_image, 1, length(loaded_image))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) <= 2||substring(loaded_image, 1, length(loaded_image))
+           AND ('1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))) IS TRUE
+           AND ('1'||substring(loaded_image, 1, length(loaded_image)) = '0'||substring(loaded_image, 1, length(loaded_image))) IS NOT TRUE
+           AND ('1'||substring(loaded_image, 1, length(loaded_image)) = '0'||substring(loaded_image, 1, length(loaded_image))) IS FALSE
+           AND ('1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))) IS NOT FALSE
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) BETWEEN '0'||substring(loaded_image, 1, length(loaded_image)) AND 2||substring(loaded_image, 1, length(loaded_image))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) NOT BETWEEN '1'||substring(loaded_image, 1, length(loaded_image)) AND '0'||substring(loaded_image, 1, length(loaded_image))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) like '%'
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) not like '__DOES_NOT_EXIST__%'
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) IN ('0'||substring(loaded_image, 1, length(loaded_image)),
+                                                                         1||substring(loaded_image, 1, length(loaded_image)),
+                                                                         2||substring(loaded_image, 1, length(loaded_image)))
+           AND '1'||substring(loaded_image, 1, length(loaded_image)) NOT IN ('0'||substring(loaded_image, 1, length(loaded_image)),
+                                                                             2||substring(loaded_image, 1, length(loaded_image))))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||substring(loaded_image, 1, length(loaded_image)) IS NULL
+       OR '1'||substring(loaded_image, 1, length(loaded_image)) IN
+         (SELECT '1'||substring(loaded_image, 1, length(loaded_image))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||substring(loaded_image, 1, length(loaded_image)) IS NULL
+                 OR ('1'||substring(loaded_image, 1, length(loaded_image)) = 1||substring(loaded_image, 1, length(loaded_image))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) IS NOT DISTINCT
+                     FROM 1||substring(loaded_image, 1, length(loaded_image))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))
+                     AND ('1'||substring(loaded_image, 1, length(loaded_image)) IS DISTINCT
+                          FROM '0'||substring(loaded_image, 1, length(loaded_image)))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) > '0'||substring(loaded_image, 1, length(loaded_image))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) >= '0'||substring(loaded_image, 1, length(loaded_image))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) < 2||substring(loaded_image, 1, length(loaded_image))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) <= 2||substring(loaded_image, 1, length(loaded_image))
+                     AND ('1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))) IS TRUE
+                     AND ('1'||substring(loaded_image, 1, length(loaded_image)) = '0'||substring(loaded_image, 1, length(loaded_image))) IS NOT TRUE
+                     AND ('1'||substring(loaded_image, 1, length(loaded_image)) = '0'||substring(loaded_image, 1, length(loaded_image))) IS FALSE
+                     AND ('1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))) IS NOT FALSE
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) BETWEEN '0'||substring(loaded_image, 1, length(loaded_image)) AND 2||substring(loaded_image, 1, length(loaded_image))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) NOT BETWEEN '1'||substring(loaded_image, 1, length(loaded_image)) AND '0'||substring(loaded_image, 1, length(loaded_image))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) like '%'
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) IN ('0'||substring(loaded_image, 1, length(loaded_image)),
+                                                                                   1||substring(loaded_image, 1, length(loaded_image)),
+                                                                                   2||substring(loaded_image, 1, length(loaded_image)))
+                     AND '1'||substring(loaded_image, 1, length(loaded_image)) NOT IN ('0'||substring(loaded_image, 1, length(loaded_image)),
+                                                                                       2||substring(loaded_image, 1, length(loaded_image)))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||substring(loaded_image, 1, length(loaded_image)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||substring(loaded_image, 1, length(loaded_image)) IS NULL
+          OR ('1'||substring(loaded_image, 1, length(loaded_image)) = 1||substring(loaded_image, 1, length(loaded_image))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) IS NOT DISTINCT
+              FROM 1||substring(loaded_image, 1, length(loaded_image))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))
+              AND ('1'||substring(loaded_image, 1, length(loaded_image)) IS DISTINCT
+                   FROM '0'||substring(loaded_image, 1, length(loaded_image)))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) > '0'||substring(loaded_image, 1, length(loaded_image))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) >= '0'||substring(loaded_image, 1, length(loaded_image))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) < 2||substring(loaded_image, 1, length(loaded_image))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) <= 2||substring(loaded_image, 1, length(loaded_image))
+              AND ('1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))) IS TRUE
+              AND ('1'||substring(loaded_image, 1, length(loaded_image)) = '0'||substring(loaded_image, 1, length(loaded_image))) IS NOT TRUE
+              AND ('1'||substring(loaded_image, 1, length(loaded_image)) = '0'||substring(loaded_image, 1, length(loaded_image))) IS FALSE
+              AND ('1'||substring(loaded_image, 1, length(loaded_image)) <> '0'||substring(loaded_image, 1, length(loaded_image))) IS NOT FALSE
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) BETWEEN '0'||substring(loaded_image, 1, length(loaded_image)) AND 2||substring(loaded_image, 1, length(loaded_image))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) NOT BETWEEN '1'||substring(loaded_image, 1, length(loaded_image)) AND '0'||substring(loaded_image, 1, length(loaded_image))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) like '%'
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) not like '__DOES_NOT_EXIST__%'
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) IN ('0'||substring(loaded_image, 1, length(loaded_image)),
+                                                                            1||substring(loaded_image, 1, length(loaded_image)),
+                                                                            2||substring(loaded_image, 1, length(loaded_image)))
+              AND '1'||substring(loaded_image, 1, length(loaded_image)) NOT IN ('0'||substring(loaded_image, 1, length(loaded_image)),
+                                                                                2||substring(loaded_image, 1, length(loaded_image)))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A22: right
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||right(loaded_image, 2) IS NULL
+       OR ('1'||right(loaded_image, 2) = 1||right(loaded_image, 2)
+           AND '1'||right(loaded_image, 2) IS NOT DISTINCT
+           FROM 1||right(loaded_image, 2)
+           AND '1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)
+           AND ('1'||right(loaded_image, 2) IS DISTINCT
+                FROM '0'||right(loaded_image, 2))
+           AND '1'||right(loaded_image, 2) > '0'||right(loaded_image, 2)
+           AND '1'||right(loaded_image, 2) >= '0'||right(loaded_image, 2)
+           AND '1'||right(loaded_image, 2) < 2||right(loaded_image, 2)
+           AND '1'||right(loaded_image, 2) <= 2||right(loaded_image, 2)
+           AND ('1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)) IS TRUE
+           AND ('1'||right(loaded_image, 2) = '0'||right(loaded_image, 2)) IS NOT TRUE
+           AND ('1'||right(loaded_image, 2) = '0'||right(loaded_image, 2)) IS FALSE
+           AND ('1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)) IS NOT FALSE
+           AND '1'||right(loaded_image, 2) BETWEEN '0'||right(loaded_image, 2) AND 2||right(loaded_image, 2)
+           AND '1'||right(loaded_image, 2) NOT BETWEEN '1'||right(loaded_image, 2) AND '0'||right(loaded_image, 2)
+           AND '1'||right(loaded_image, 2) like '%'
+           AND '1'||right(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+           AND '1'||right(loaded_image, 2) IN ('0'||right(loaded_image, 2),
+                                               1||right(loaded_image, 2),
+                                               2||right(loaded_image, 2))
+           AND '1'||right(loaded_image, 2) NOT IN ('0'||right(loaded_image, 2),
+                                                   2||right(loaded_image, 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||right(loaded_image, 2) IS NULL
+       OR '1'||right(loaded_image, 2) IN
+         (SELECT '1'||right(loaded_image, 2)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||right(loaded_image, 2) IS NULL
+                 OR ('1'||right(loaded_image, 2) = 1||right(loaded_image, 2)
+                     AND '1'||right(loaded_image, 2) IS NOT DISTINCT
+                     FROM 1||right(loaded_image, 2)
+                     AND '1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)
+                     AND ('1'||right(loaded_image, 2) IS DISTINCT
+                          FROM '0'||right(loaded_image, 2))
+                     AND '1'||right(loaded_image, 2) > '0'||right(loaded_image, 2)
+                     AND '1'||right(loaded_image, 2) >= '0'||right(loaded_image, 2)
+                     AND '1'||right(loaded_image, 2) < 2||right(loaded_image, 2)
+                     AND '1'||right(loaded_image, 2) <= 2||right(loaded_image, 2)
+                     AND ('1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)) IS TRUE
+                     AND ('1'||right(loaded_image, 2) = '0'||right(loaded_image, 2)) IS NOT TRUE
+                     AND ('1'||right(loaded_image, 2) = '0'||right(loaded_image, 2)) IS FALSE
+                     AND ('1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)) IS NOT FALSE
+                     AND '1'||right(loaded_image, 2) BETWEEN '0'||right(loaded_image, 2) AND 2||right(loaded_image, 2)
+                     AND '1'||right(loaded_image, 2) NOT BETWEEN '1'||right(loaded_image, 2) AND '0'||right(loaded_image, 2)
+                     AND '1'||right(loaded_image, 2) like '%'
+                     AND '1'||right(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||right(loaded_image, 2) IN ('0'||right(loaded_image, 2),
+                                                         1||right(loaded_image, 2),
+                                                         2||right(loaded_image, 2))
+                     AND '1'||right(loaded_image, 2) NOT IN ('0'||right(loaded_image, 2),
+                                                             2||right(loaded_image, 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||right(loaded_image, 2),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||right(loaded_image, 2) IS NULL
+          OR ('1'||right(loaded_image, 2) = 1||right(loaded_image, 2)
+              AND '1'||right(loaded_image, 2) IS NOT DISTINCT
+              FROM 1||right(loaded_image, 2)
+              AND '1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)
+              AND ('1'||right(loaded_image, 2) IS DISTINCT
+                   FROM '0'||right(loaded_image, 2))
+              AND '1'||right(loaded_image, 2) > '0'||right(loaded_image, 2)
+              AND '1'||right(loaded_image, 2) >= '0'||right(loaded_image, 2)
+              AND '1'||right(loaded_image, 2) < 2||right(loaded_image, 2)
+              AND '1'||right(loaded_image, 2) <= 2||right(loaded_image, 2)
+              AND ('1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)) IS TRUE
+              AND ('1'||right(loaded_image, 2) = '0'||right(loaded_image, 2)) IS NOT TRUE
+              AND ('1'||right(loaded_image, 2) = '0'||right(loaded_image, 2)) IS FALSE
+              AND ('1'||right(loaded_image, 2) <> '0'||right(loaded_image, 2)) IS NOT FALSE
+              AND '1'||right(loaded_image, 2) BETWEEN '0'||right(loaded_image, 2) AND 2||right(loaded_image, 2)
+              AND '1'||right(loaded_image, 2) NOT BETWEEN '1'||right(loaded_image, 2) AND '0'||right(loaded_image, 2)
+              AND '1'||right(loaded_image, 2) like '%'
+              AND '1'||right(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+              AND '1'||right(loaded_image, 2) IN ('0'||right(loaded_image, 2),
+                                                  1||right(loaded_image, 2),
+                                                  2||right(loaded_image, 2))
+              AND '1'||right(loaded_image, 2) NOT IN ('0'||right(loaded_image, 2),
+                                                      2||right(loaded_image, 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A23: left
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||left(loaded_image, 2) IS NULL
+       OR ('1'||left(loaded_image, 2) = 1||left(loaded_image, 2)
+           AND '1'||left(loaded_image, 2) IS NOT DISTINCT
+           FROM 1||left(loaded_image, 2)
+           AND '1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)
+           AND ('1'||left(loaded_image, 2) IS DISTINCT
+                FROM '0'||left(loaded_image, 2))
+           AND '1'||left(loaded_image, 2) > '0'||left(loaded_image, 2)
+           AND '1'||left(loaded_image, 2) >= '0'||left(loaded_image, 2)
+           AND '1'||left(loaded_image, 2) < 2||left(loaded_image, 2)
+           AND '1'||left(loaded_image, 2) <= 2||left(loaded_image, 2)
+           AND ('1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)) IS TRUE
+           AND ('1'||left(loaded_image, 2) = '0'||left(loaded_image, 2)) IS NOT TRUE
+           AND ('1'||left(loaded_image, 2) = '0'||left(loaded_image, 2)) IS FALSE
+           AND ('1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)) IS NOT FALSE
+           AND '1'||left(loaded_image, 2) BETWEEN '0'||left(loaded_image, 2) AND 2||left(loaded_image, 2)
+           AND '1'||left(loaded_image, 2) NOT BETWEEN '1'||left(loaded_image, 2) AND '0'||left(loaded_image, 2)
+           AND '1'||left(loaded_image, 2) like '%'
+           AND '1'||left(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+           AND '1'||left(loaded_image, 2) IN ('0'||left(loaded_image, 2),
+                                              1||left(loaded_image, 2),
+                                              2||left(loaded_image, 2))
+           AND '1'||left(loaded_image, 2) NOT IN ('0'||left(loaded_image, 2),
+                                                  2||left(loaded_image, 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||left(loaded_image, 2) IS NULL
+       OR '1'||left(loaded_image, 2) IN
+         (SELECT '1'||left(loaded_image, 2)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||left(loaded_image, 2) IS NULL
+                 OR ('1'||left(loaded_image, 2) = 1||left(loaded_image, 2)
+                     AND '1'||left(loaded_image, 2) IS NOT DISTINCT
+                     FROM 1||left(loaded_image, 2)
+                     AND '1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)
+                     AND ('1'||left(loaded_image, 2) IS DISTINCT
+                          FROM '0'||left(loaded_image, 2))
+                     AND '1'||left(loaded_image, 2) > '0'||left(loaded_image, 2)
+                     AND '1'||left(loaded_image, 2) >= '0'||left(loaded_image, 2)
+                     AND '1'||left(loaded_image, 2) < 2||left(loaded_image, 2)
+                     AND '1'||left(loaded_image, 2) <= 2||left(loaded_image, 2)
+                     AND ('1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)) IS TRUE
+                     AND ('1'||left(loaded_image, 2) = '0'||left(loaded_image, 2)) IS NOT TRUE
+                     AND ('1'||left(loaded_image, 2) = '0'||left(loaded_image, 2)) IS FALSE
+                     AND ('1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)) IS NOT FALSE
+                     AND '1'||left(loaded_image, 2) BETWEEN '0'||left(loaded_image, 2) AND 2||left(loaded_image, 2)
+                     AND '1'||left(loaded_image, 2) NOT BETWEEN '1'||left(loaded_image, 2) AND '0'||left(loaded_image, 2)
+                     AND '1'||left(loaded_image, 2) like '%'
+                     AND '1'||left(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||left(loaded_image, 2) IN ('0'||left(loaded_image, 2),
+                                                        1||left(loaded_image, 2),
+                                                        2||left(loaded_image, 2))
+                     AND '1'||left(loaded_image, 2) NOT IN ('0'||left(loaded_image, 2),
+                                                            2||left(loaded_image, 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||left(loaded_image, 2),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||left(loaded_image, 2) IS NULL
+          OR ('1'||left(loaded_image, 2) = 1||left(loaded_image, 2)
+              AND '1'||left(loaded_image, 2) IS NOT DISTINCT
+              FROM 1||left(loaded_image, 2)
+              AND '1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)
+              AND ('1'||left(loaded_image, 2) IS DISTINCT
+                   FROM '0'||left(loaded_image, 2))
+              AND '1'||left(loaded_image, 2) > '0'||left(loaded_image, 2)
+              AND '1'||left(loaded_image, 2) >= '0'||left(loaded_image, 2)
+              AND '1'||left(loaded_image, 2) < 2||left(loaded_image, 2)
+              AND '1'||left(loaded_image, 2) <= 2||left(loaded_image, 2)
+              AND ('1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)) IS TRUE
+              AND ('1'||left(loaded_image, 2) = '0'||left(loaded_image, 2)) IS NOT TRUE
+              AND ('1'||left(loaded_image, 2) = '0'||left(loaded_image, 2)) IS FALSE
+              AND ('1'||left(loaded_image, 2) <> '0'||left(loaded_image, 2)) IS NOT FALSE
+              AND '1'||left(loaded_image, 2) BETWEEN '0'||left(loaded_image, 2) AND 2||left(loaded_image, 2)
+              AND '1'||left(loaded_image, 2) NOT BETWEEN '1'||left(loaded_image, 2) AND '0'||left(loaded_image, 2)
+              AND '1'||left(loaded_image, 2) like '%'
+              AND '1'||left(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+              AND '1'||left(loaded_image, 2) IN ('0'||left(loaded_image, 2),
+                                                 1||left(loaded_image, 2),
+                                                 2||left(loaded_image, 2))
+              AND '1'||left(loaded_image, 2) NOT IN ('0'||left(loaded_image, 2),
+                                                     2||left(loaded_image, 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A24: substr
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||substr(loaded_image, 1, length(loaded_image)) IS NULL
+       OR ('1'||substr(loaded_image, 1, length(loaded_image)) = 1||substr(loaded_image, 1, length(loaded_image))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) IS NOT DISTINCT
+           FROM 1||substr(loaded_image, 1, length(loaded_image))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))
+           AND ('1'||substr(loaded_image, 1, length(loaded_image)) IS DISTINCT
+                FROM '0'||substr(loaded_image, 1, length(loaded_image)))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) > '0'||substr(loaded_image, 1, length(loaded_image))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) >= '0'||substr(loaded_image, 1, length(loaded_image))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) < 2||substr(loaded_image, 1, length(loaded_image))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) <= 2||substr(loaded_image, 1, length(loaded_image))
+           AND ('1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))) IS TRUE
+           AND ('1'||substr(loaded_image, 1, length(loaded_image)) = '0'||substr(loaded_image, 1, length(loaded_image))) IS NOT TRUE
+           AND ('1'||substr(loaded_image, 1, length(loaded_image)) = '0'||substr(loaded_image, 1, length(loaded_image))) IS FALSE
+           AND ('1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))) IS NOT FALSE
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) BETWEEN '0'||substr(loaded_image, 1, length(loaded_image)) AND 2||substr(loaded_image, 1, length(loaded_image))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) NOT BETWEEN '1'||substr(loaded_image, 1, length(loaded_image)) AND '0'||substr(loaded_image, 1, length(loaded_image))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) like '%'
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) not like '__DOES_NOT_EXIST__%'
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) IN ('0'||substr(loaded_image, 1, length(loaded_image)),
+                                                                      1||substr(loaded_image, 1, length(loaded_image)),
+                                                                      2||substr(loaded_image, 1, length(loaded_image)))
+           AND '1'||substr(loaded_image, 1, length(loaded_image)) NOT IN ('0'||substr(loaded_image, 1, length(loaded_image)),
+                                                                          2||substr(loaded_image, 1, length(loaded_image))))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||substr(loaded_image, 1, length(loaded_image)) IS NULL
+       OR '1'||substr(loaded_image, 1, length(loaded_image)) IN
+         (SELECT '1'||substr(loaded_image, 1, length(loaded_image))
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||substr(loaded_image, 1, length(loaded_image)) IS NULL
+                 OR ('1'||substr(loaded_image, 1, length(loaded_image)) = 1||substr(loaded_image, 1, length(loaded_image))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) IS NOT DISTINCT
+                     FROM 1||substr(loaded_image, 1, length(loaded_image))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))
+                     AND ('1'||substr(loaded_image, 1, length(loaded_image)) IS DISTINCT
+                          FROM '0'||substr(loaded_image, 1, length(loaded_image)))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) > '0'||substr(loaded_image, 1, length(loaded_image))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) >= '0'||substr(loaded_image, 1, length(loaded_image))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) < 2||substr(loaded_image, 1, length(loaded_image))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) <= 2||substr(loaded_image, 1, length(loaded_image))
+                     AND ('1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))) IS TRUE
+                     AND ('1'||substr(loaded_image, 1, length(loaded_image)) = '0'||substr(loaded_image, 1, length(loaded_image))) IS NOT TRUE
+                     AND ('1'||substr(loaded_image, 1, length(loaded_image)) = '0'||substr(loaded_image, 1, length(loaded_image))) IS FALSE
+                     AND ('1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))) IS NOT FALSE
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) BETWEEN '0'||substr(loaded_image, 1, length(loaded_image)) AND 2||substr(loaded_image, 1, length(loaded_image))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) NOT BETWEEN '1'||substr(loaded_image, 1, length(loaded_image)) AND '0'||substr(loaded_image, 1, length(loaded_image))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) like '%'
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) IN ('0'||substr(loaded_image, 1, length(loaded_image)),
+                                                                                1||substr(loaded_image, 1, length(loaded_image)),
+                                                                                2||substr(loaded_image, 1, length(loaded_image)))
+                     AND '1'||substr(loaded_image, 1, length(loaded_image)) NOT IN ('0'||substr(loaded_image, 1, length(loaded_image)),
+                                                                                    2||substr(loaded_image, 1, length(loaded_image)))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||substr(loaded_image, 1, length(loaded_image)),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||substr(loaded_image, 1, length(loaded_image)) IS NULL
+          OR ('1'||substr(loaded_image, 1, length(loaded_image)) = 1||substr(loaded_image, 1, length(loaded_image))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) IS NOT DISTINCT
+              FROM 1||substr(loaded_image, 1, length(loaded_image))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))
+              AND ('1'||substr(loaded_image, 1, length(loaded_image)) IS DISTINCT
+                   FROM '0'||substr(loaded_image, 1, length(loaded_image)))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) > '0'||substr(loaded_image, 1, length(loaded_image))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) >= '0'||substr(loaded_image, 1, length(loaded_image))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) < 2||substr(loaded_image, 1, length(loaded_image))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) <= 2||substr(loaded_image, 1, length(loaded_image))
+              AND ('1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))) IS TRUE
+              AND ('1'||substr(loaded_image, 1, length(loaded_image)) = '0'||substr(loaded_image, 1, length(loaded_image))) IS NOT TRUE
+              AND ('1'||substr(loaded_image, 1, length(loaded_image)) = '0'||substr(loaded_image, 1, length(loaded_image))) IS FALSE
+              AND ('1'||substr(loaded_image, 1, length(loaded_image)) <> '0'||substr(loaded_image, 1, length(loaded_image))) IS NOT FALSE
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) BETWEEN '0'||substr(loaded_image, 1, length(loaded_image)) AND 2||substr(loaded_image, 1, length(loaded_image))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) NOT BETWEEN '1'||substr(loaded_image, 1, length(loaded_image)) AND '0'||substr(loaded_image, 1, length(loaded_image))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) like '%'
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) not like '__DOES_NOT_EXIST__%'
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) IN ('0'||substr(loaded_image, 1, length(loaded_image)),
+                                                                         1||substr(loaded_image, 1, length(loaded_image)),
+                                                                         2||substr(loaded_image, 1, length(loaded_image)))
+              AND '1'||substr(loaded_image, 1, length(loaded_image)) NOT IN ('0'||substr(loaded_image, 1, length(loaded_image)),
+                                                                             2||substr(loaded_image, 1, length(loaded_image)))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A25: trim
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||trim(BOTH 'A'
+                 FROM loaded_image) IS NULL
+       OR ('1'||trim(BOTH 'A'
+                     FROM loaded_image) = 1||trim(BOTH 'A'
+                                                  FROM loaded_image)
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) IS NOT DISTINCT
+           FROM 1||trim(BOTH 'A'
+                        FROM loaded_image)
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                         FROM loaded_image)
+           AND ('1'||trim(BOTH 'A'
+                          FROM loaded_image) IS DISTINCT
+                FROM '0'||trim(BOTH 'A'
+                               FROM loaded_image))
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) > '0'||trim(BOTH 'A'
+                                                        FROM loaded_image)
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) >= '0'||trim(BOTH 'A'
+                                                         FROM loaded_image)
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) < 2||trim(BOTH 'A'
+                                                      FROM loaded_image)
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) <= 2||trim(BOTH 'A'
+                                                       FROM loaded_image)
+           AND ('1'||trim(BOTH 'A'
+                          FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                          FROM loaded_image)) IS TRUE
+           AND ('1'||trim(BOTH 'A'
+                          FROM loaded_image) = '0'||trim(BOTH 'A'
+                                                         FROM loaded_image)) IS NOT TRUE
+           AND ('1'||trim(BOTH 'A'
+                          FROM loaded_image) = '0'||trim(BOTH 'A'
+                                                         FROM loaded_image)) IS FALSE
+           AND ('1'||trim(BOTH 'A'
+                          FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                          FROM loaded_image)) IS NOT FALSE
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) BETWEEN '0'||trim(BOTH 'A'
+                                                              FROM loaded_image) AND 2||trim(BOTH 'A'
+                                                                                             FROM loaded_image)
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) NOT BETWEEN '1'||trim(BOTH 'A'
+                                                                  FROM loaded_image) AND '0'||trim(BOTH 'A'
+                                                                                                   FROM loaded_image)
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) like '%'
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) IN ('0'||trim(BOTH 'A'
+                                                          FROM loaded_image),
+                                                1||trim(BOTH 'A'
+                                                        FROM loaded_image),
+                                                2||trim(BOTH 'A'
+                                                        FROM loaded_image))
+           AND '1'||trim(BOTH 'A'
+                         FROM loaded_image) NOT IN ('0'||trim(BOTH 'A'
+                                                              FROM loaded_image),
+                                                    2||trim(BOTH 'A'
+                                                            FROM loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||trim(BOTH 'A'
+                 FROM loaded_image) IS NULL
+       OR '1'||trim(BOTH 'A'
+                    FROM loaded_image) IN
+         (SELECT '1'||trim(BOTH 'A'
+                           FROM loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||trim(BOTH 'A'
+                           FROM loaded_image) IS NULL
+                 OR ('1'||trim(BOTH 'A'
+                               FROM loaded_image) = 1||trim(BOTH 'A'
+                                                            FROM loaded_image)
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) IS NOT DISTINCT
+                     FROM 1||trim(BOTH 'A'
+                                  FROM loaded_image)
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                                   FROM loaded_image)
+                     AND ('1'||trim(BOTH 'A'
+                                    FROM loaded_image) IS DISTINCT
+                          FROM '0'||trim(BOTH 'A'
+                                         FROM loaded_image))
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) > '0'||trim(BOTH 'A'
+                                                                  FROM loaded_image)
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) >= '0'||trim(BOTH 'A'
+                                                                   FROM loaded_image)
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) < 2||trim(BOTH 'A'
+                                                                FROM loaded_image)
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) <= 2||trim(BOTH 'A'
+                                                                 FROM loaded_image)
+                     AND ('1'||trim(BOTH 'A'
+                                    FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                                    FROM loaded_image)) IS TRUE
+                     AND ('1'||trim(BOTH 'A'
+                                    FROM loaded_image) = '0'||trim(BOTH 'A'
+                                                                   FROM loaded_image)) IS NOT TRUE
+                     AND ('1'||trim(BOTH 'A'
+                                    FROM loaded_image) = '0'||trim(BOTH 'A'
+                                                                   FROM loaded_image)) IS FALSE
+                     AND ('1'||trim(BOTH 'A'
+                                    FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                                    FROM loaded_image)) IS NOT FALSE
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) BETWEEN '0'||trim(BOTH 'A'
+                                                                        FROM loaded_image) AND 2||trim(BOTH 'A'
+                                                                                                       FROM loaded_image)
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) NOT BETWEEN '1'||trim(BOTH 'A'
+                                                                            FROM loaded_image) AND '0'||trim(BOTH 'A'
+                                                                                                             FROM loaded_image)
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) like '%'
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) IN ('0'||trim(BOTH 'A'
+                                                                    FROM loaded_image),
+                                                          1||trim(BOTH 'A'
+                                                                  FROM loaded_image),
+                                                          2||trim(BOTH 'A'
+                                                                  FROM loaded_image))
+                     AND '1'||trim(BOTH 'A'
+                                   FROM loaded_image) NOT IN ('0'||trim(BOTH 'A'
+                                                                        FROM loaded_image),
+                                                              2||trim(BOTH 'A'
+                                                                      FROM loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||trim(BOTH 'A'
+                                    FROM loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||trim(BOTH 'A'
+                    FROM loaded_image) IS NULL
+          OR ('1'||trim(BOTH 'A'
+                        FROM loaded_image) = 1||trim(BOTH 'A'
+                                                     FROM loaded_image)
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) IS NOT DISTINCT
+              FROM 1||trim(BOTH 'A'
+                           FROM loaded_image)
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                            FROM loaded_image)
+              AND ('1'||trim(BOTH 'A'
+                             FROM loaded_image) IS DISTINCT
+                   FROM '0'||trim(BOTH 'A'
+                                  FROM loaded_image))
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) > '0'||trim(BOTH 'A'
+                                                           FROM loaded_image)
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) >= '0'||trim(BOTH 'A'
+                                                            FROM loaded_image)
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) < 2||trim(BOTH 'A'
+                                                         FROM loaded_image)
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) <= 2||trim(BOTH 'A'
+                                                          FROM loaded_image)
+              AND ('1'||trim(BOTH 'A'
+                             FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                             FROM loaded_image)) IS TRUE
+              AND ('1'||trim(BOTH 'A'
+                             FROM loaded_image) = '0'||trim(BOTH 'A'
+                                                            FROM loaded_image)) IS NOT TRUE
+              AND ('1'||trim(BOTH 'A'
+                             FROM loaded_image) = '0'||trim(BOTH 'A'
+                                                            FROM loaded_image)) IS FALSE
+              AND ('1'||trim(BOTH 'A'
+                             FROM loaded_image) <> '0'||trim(BOTH 'A'
+                                                             FROM loaded_image)) IS NOT FALSE
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) BETWEEN '0'||trim(BOTH 'A'
+                                                                 FROM loaded_image) AND 2||trim(BOTH 'A'
+                                                                                                FROM loaded_image)
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) NOT BETWEEN '1'||trim(BOTH 'A'
+                                                                     FROM loaded_image) AND '0'||trim(BOTH 'A'
+                                                                                                      FROM loaded_image)
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) like '%'
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) IN ('0'||trim(BOTH 'A'
+                                                             FROM loaded_image),
+                                                   1||trim(BOTH 'A'
+                                                           FROM loaded_image),
+                                                   2||trim(BOTH 'A'
+                                                           FROM loaded_image))
+              AND '1'||trim(BOTH 'A'
+                            FROM loaded_image) NOT IN ('0'||trim(BOTH 'A'
+                                                                 FROM loaded_image),
+                                                       2||trim(BOTH 'A'
+                                                               FROM loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A26: btrim
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||btrim(loaded_image, 'A') IS NULL
+       OR ('1'||btrim(loaded_image, 'A') = 1||btrim(loaded_image, 'A')
+           AND '1'||btrim(loaded_image, 'A') IS NOT DISTINCT
+           FROM 1||btrim(loaded_image, 'A')
+           AND '1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')
+           AND ('1'||btrim(loaded_image, 'A') IS DISTINCT
+                FROM '0'||btrim(loaded_image, 'A'))
+           AND '1'||btrim(loaded_image, 'A') > '0'||btrim(loaded_image, 'A')
+           AND '1'||btrim(loaded_image, 'A') >= '0'||btrim(loaded_image, 'A')
+           AND '1'||btrim(loaded_image, 'A') < 2||btrim(loaded_image, 'A')
+           AND '1'||btrim(loaded_image, 'A') <= 2||btrim(loaded_image, 'A')
+           AND ('1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')) IS TRUE
+           AND ('1'||btrim(loaded_image, 'A') = '0'||btrim(loaded_image, 'A')) IS NOT TRUE
+           AND ('1'||btrim(loaded_image, 'A') = '0'||btrim(loaded_image, 'A')) IS FALSE
+           AND ('1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')) IS NOT FALSE
+           AND '1'||btrim(loaded_image, 'A') BETWEEN '0'||btrim(loaded_image, 'A') AND 2||btrim(loaded_image, 'A')
+           AND '1'||btrim(loaded_image, 'A') NOT BETWEEN '1'||btrim(loaded_image, 'A') AND '0'||btrim(loaded_image, 'A')
+           AND '1'||btrim(loaded_image, 'A') like '%'
+           AND '1'||btrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+           AND '1'||btrim(loaded_image, 'A') IN ('0'||btrim(loaded_image, 'A'),
+                                                 1||btrim(loaded_image, 'A'),
+                                                 2||btrim(loaded_image, 'A'))
+           AND '1'||btrim(loaded_image, 'A') NOT IN ('0'||btrim(loaded_image, 'A'),
+                                                     2||btrim(loaded_image, 'A')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||btrim(loaded_image, 'A') IS NULL
+       OR '1'||btrim(loaded_image, 'A') IN
+         (SELECT '1'||btrim(loaded_image, 'A')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||btrim(loaded_image, 'A') IS NULL
+                 OR ('1'||btrim(loaded_image, 'A') = 1||btrim(loaded_image, 'A')
+                     AND '1'||btrim(loaded_image, 'A') IS NOT DISTINCT
+                     FROM 1||btrim(loaded_image, 'A')
+                     AND '1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')
+                     AND ('1'||btrim(loaded_image, 'A') IS DISTINCT
+                          FROM '0'||btrim(loaded_image, 'A'))
+                     AND '1'||btrim(loaded_image, 'A') > '0'||btrim(loaded_image, 'A')
+                     AND '1'||btrim(loaded_image, 'A') >= '0'||btrim(loaded_image, 'A')
+                     AND '1'||btrim(loaded_image, 'A') < 2||btrim(loaded_image, 'A')
+                     AND '1'||btrim(loaded_image, 'A') <= 2||btrim(loaded_image, 'A')
+                     AND ('1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')) IS TRUE
+                     AND ('1'||btrim(loaded_image, 'A') = '0'||btrim(loaded_image, 'A')) IS NOT TRUE
+                     AND ('1'||btrim(loaded_image, 'A') = '0'||btrim(loaded_image, 'A')) IS FALSE
+                     AND ('1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')) IS NOT FALSE
+                     AND '1'||btrim(loaded_image, 'A') BETWEEN '0'||btrim(loaded_image, 'A') AND 2||btrim(loaded_image, 'A')
+                     AND '1'||btrim(loaded_image, 'A') NOT BETWEEN '1'||btrim(loaded_image, 'A') AND '0'||btrim(loaded_image, 'A')
+                     AND '1'||btrim(loaded_image, 'A') like '%'
+                     AND '1'||btrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||btrim(loaded_image, 'A') IN ('0'||btrim(loaded_image, 'A'),
+                                                           1||btrim(loaded_image, 'A'),
+                                                           2||btrim(loaded_image, 'A'))
+                     AND '1'||btrim(loaded_image, 'A') NOT IN ('0'||btrim(loaded_image, 'A'),
+                                                               2||btrim(loaded_image, 'A'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||btrim(loaded_image, 'A'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||btrim(loaded_image, 'A') IS NULL
+          OR ('1'||btrim(loaded_image, 'A') = 1||btrim(loaded_image, 'A')
+              AND '1'||btrim(loaded_image, 'A') IS NOT DISTINCT
+              FROM 1||btrim(loaded_image, 'A')
+              AND '1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')
+              AND ('1'||btrim(loaded_image, 'A') IS DISTINCT
+                   FROM '0'||btrim(loaded_image, 'A'))
+              AND '1'||btrim(loaded_image, 'A') > '0'||btrim(loaded_image, 'A')
+              AND '1'||btrim(loaded_image, 'A') >= '0'||btrim(loaded_image, 'A')
+              AND '1'||btrim(loaded_image, 'A') < 2||btrim(loaded_image, 'A')
+              AND '1'||btrim(loaded_image, 'A') <= 2||btrim(loaded_image, 'A')
+              AND ('1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')) IS TRUE
+              AND ('1'||btrim(loaded_image, 'A') = '0'||btrim(loaded_image, 'A')) IS NOT TRUE
+              AND ('1'||btrim(loaded_image, 'A') = '0'||btrim(loaded_image, 'A')) IS FALSE
+              AND ('1'||btrim(loaded_image, 'A') <> '0'||btrim(loaded_image, 'A')) IS NOT FALSE
+              AND '1'||btrim(loaded_image, 'A') BETWEEN '0'||btrim(loaded_image, 'A') AND 2||btrim(loaded_image, 'A')
+              AND '1'||btrim(loaded_image, 'A') NOT BETWEEN '1'||btrim(loaded_image, 'A') AND '0'||btrim(loaded_image, 'A')
+              AND '1'||btrim(loaded_image, 'A') like '%'
+              AND '1'||btrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+              AND '1'||btrim(loaded_image, 'A') IN ('0'||btrim(loaded_image, 'A'),
+                                                    1||btrim(loaded_image, 'A'),
+                                                    2||btrim(loaded_image, 'A'))
+              AND '1'||btrim(loaded_image, 'A') NOT IN ('0'||btrim(loaded_image, 'A'),
+                                                        2||btrim(loaded_image, 'A'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A27: ltrim
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||ltrim(loaded_image, 'A') IS NULL
+       OR ('1'||ltrim(loaded_image, 'A') = 1||ltrim(loaded_image, 'A')
+           AND '1'||ltrim(loaded_image, 'A') IS NOT DISTINCT
+           FROM 1||ltrim(loaded_image, 'A')
+           AND '1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')
+           AND ('1'||ltrim(loaded_image, 'A') IS DISTINCT
+                FROM '0'||ltrim(loaded_image, 'A'))
+           AND '1'||ltrim(loaded_image, 'A') > '0'||ltrim(loaded_image, 'A')
+           AND '1'||ltrim(loaded_image, 'A') >= '0'||ltrim(loaded_image, 'A')
+           AND '1'||ltrim(loaded_image, 'A') < 2||ltrim(loaded_image, 'A')
+           AND '1'||ltrim(loaded_image, 'A') <= 2||ltrim(loaded_image, 'A')
+           AND ('1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')) IS TRUE
+           AND ('1'||ltrim(loaded_image, 'A') = '0'||ltrim(loaded_image, 'A')) IS NOT TRUE
+           AND ('1'||ltrim(loaded_image, 'A') = '0'||ltrim(loaded_image, 'A')) IS FALSE
+           AND ('1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')) IS NOT FALSE
+           AND '1'||ltrim(loaded_image, 'A') BETWEEN '0'||ltrim(loaded_image, 'A') AND 2||ltrim(loaded_image, 'A')
+           AND '1'||ltrim(loaded_image, 'A') NOT BETWEEN '1'||ltrim(loaded_image, 'A') AND '0'||ltrim(loaded_image, 'A')
+           AND '1'||ltrim(loaded_image, 'A') like '%'
+           AND '1'||ltrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+           AND '1'||ltrim(loaded_image, 'A') IN ('0'||ltrim(loaded_image, 'A'),
+                                                 1||ltrim(loaded_image, 'A'),
+                                                 2||ltrim(loaded_image, 'A'))
+           AND '1'||ltrim(loaded_image, 'A') NOT IN ('0'||ltrim(loaded_image, 'A'),
+                                                     2||ltrim(loaded_image, 'A')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||ltrim(loaded_image, 'A') IS NULL
+       OR '1'||ltrim(loaded_image, 'A') IN
+         (SELECT '1'||ltrim(loaded_image, 'A')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||ltrim(loaded_image, 'A') IS NULL
+                 OR ('1'||ltrim(loaded_image, 'A') = 1||ltrim(loaded_image, 'A')
+                     AND '1'||ltrim(loaded_image, 'A') IS NOT DISTINCT
+                     FROM 1||ltrim(loaded_image, 'A')
+                     AND '1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')
+                     AND ('1'||ltrim(loaded_image, 'A') IS DISTINCT
+                          FROM '0'||ltrim(loaded_image, 'A'))
+                     AND '1'||ltrim(loaded_image, 'A') > '0'||ltrim(loaded_image, 'A')
+                     AND '1'||ltrim(loaded_image, 'A') >= '0'||ltrim(loaded_image, 'A')
+                     AND '1'||ltrim(loaded_image, 'A') < 2||ltrim(loaded_image, 'A')
+                     AND '1'||ltrim(loaded_image, 'A') <= 2||ltrim(loaded_image, 'A')
+                     AND ('1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')) IS TRUE
+                     AND ('1'||ltrim(loaded_image, 'A') = '0'||ltrim(loaded_image, 'A')) IS NOT TRUE
+                     AND ('1'||ltrim(loaded_image, 'A') = '0'||ltrim(loaded_image, 'A')) IS FALSE
+                     AND ('1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')) IS NOT FALSE
+                     AND '1'||ltrim(loaded_image, 'A') BETWEEN '0'||ltrim(loaded_image, 'A') AND 2||ltrim(loaded_image, 'A')
+                     AND '1'||ltrim(loaded_image, 'A') NOT BETWEEN '1'||ltrim(loaded_image, 'A') AND '0'||ltrim(loaded_image, 'A')
+                     AND '1'||ltrim(loaded_image, 'A') like '%'
+                     AND '1'||ltrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||ltrim(loaded_image, 'A') IN ('0'||ltrim(loaded_image, 'A'),
+                                                           1||ltrim(loaded_image, 'A'),
+                                                           2||ltrim(loaded_image, 'A'))
+                     AND '1'||ltrim(loaded_image, 'A') NOT IN ('0'||ltrim(loaded_image, 'A'),
+                                                               2||ltrim(loaded_image, 'A'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||ltrim(loaded_image, 'A'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||ltrim(loaded_image, 'A') IS NULL
+          OR ('1'||ltrim(loaded_image, 'A') = 1||ltrim(loaded_image, 'A')
+              AND '1'||ltrim(loaded_image, 'A') IS NOT DISTINCT
+              FROM 1||ltrim(loaded_image, 'A')
+              AND '1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')
+              AND ('1'||ltrim(loaded_image, 'A') IS DISTINCT
+                   FROM '0'||ltrim(loaded_image, 'A'))
+              AND '1'||ltrim(loaded_image, 'A') > '0'||ltrim(loaded_image, 'A')
+              AND '1'||ltrim(loaded_image, 'A') >= '0'||ltrim(loaded_image, 'A')
+              AND '1'||ltrim(loaded_image, 'A') < 2||ltrim(loaded_image, 'A')
+              AND '1'||ltrim(loaded_image, 'A') <= 2||ltrim(loaded_image, 'A')
+              AND ('1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')) IS TRUE
+              AND ('1'||ltrim(loaded_image, 'A') = '0'||ltrim(loaded_image, 'A')) IS NOT TRUE
+              AND ('1'||ltrim(loaded_image, 'A') = '0'||ltrim(loaded_image, 'A')) IS FALSE
+              AND ('1'||ltrim(loaded_image, 'A') <> '0'||ltrim(loaded_image, 'A')) IS NOT FALSE
+              AND '1'||ltrim(loaded_image, 'A') BETWEEN '0'||ltrim(loaded_image, 'A') AND 2||ltrim(loaded_image, 'A')
+              AND '1'||ltrim(loaded_image, 'A') NOT BETWEEN '1'||ltrim(loaded_image, 'A') AND '0'||ltrim(loaded_image, 'A')
+              AND '1'||ltrim(loaded_image, 'A') like '%'
+              AND '1'||ltrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+              AND '1'||ltrim(loaded_image, 'A') IN ('0'||ltrim(loaded_image, 'A'),
+                                                    1||ltrim(loaded_image, 'A'),
+                                                    2||ltrim(loaded_image, 'A'))
+              AND '1'||ltrim(loaded_image, 'A') NOT IN ('0'||ltrim(loaded_image, 'A'),
+                                                        2||ltrim(loaded_image, 'A'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A28: rtrim
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||rtrim(loaded_image, 'A') IS NULL
+       OR ('1'||rtrim(loaded_image, 'A') = 1||rtrim(loaded_image, 'A')
+           AND '1'||rtrim(loaded_image, 'A') IS NOT DISTINCT
+           FROM 1||rtrim(loaded_image, 'A')
+           AND '1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')
+           AND ('1'||rtrim(loaded_image, 'A') IS DISTINCT
+                FROM '0'||rtrim(loaded_image, 'A'))
+           AND '1'||rtrim(loaded_image, 'A') > '0'||rtrim(loaded_image, 'A')
+           AND '1'||rtrim(loaded_image, 'A') >= '0'||rtrim(loaded_image, 'A')
+           AND '1'||rtrim(loaded_image, 'A') < 2||rtrim(loaded_image, 'A')
+           AND '1'||rtrim(loaded_image, 'A') <= 2||rtrim(loaded_image, 'A')
+           AND ('1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')) IS TRUE
+           AND ('1'||rtrim(loaded_image, 'A') = '0'||rtrim(loaded_image, 'A')) IS NOT TRUE
+           AND ('1'||rtrim(loaded_image, 'A') = '0'||rtrim(loaded_image, 'A')) IS FALSE
+           AND ('1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')) IS NOT FALSE
+           AND '1'||rtrim(loaded_image, 'A') BETWEEN '0'||rtrim(loaded_image, 'A') AND 2||rtrim(loaded_image, 'A')
+           AND '1'||rtrim(loaded_image, 'A') NOT BETWEEN '1'||rtrim(loaded_image, 'A') AND '0'||rtrim(loaded_image, 'A')
+           AND '1'||rtrim(loaded_image, 'A') like '%'
+           AND '1'||rtrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+           AND '1'||rtrim(loaded_image, 'A') IN ('0'||rtrim(loaded_image, 'A'),
+                                                 1||rtrim(loaded_image, 'A'),
+                                                 2||rtrim(loaded_image, 'A'))
+           AND '1'||rtrim(loaded_image, 'A') NOT IN ('0'||rtrim(loaded_image, 'A'),
+                                                     2||rtrim(loaded_image, 'A')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||rtrim(loaded_image, 'A') IS NULL
+       OR '1'||rtrim(loaded_image, 'A') IN
+         (SELECT '1'||rtrim(loaded_image, 'A')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||rtrim(loaded_image, 'A') IS NULL
+                 OR ('1'||rtrim(loaded_image, 'A') = 1||rtrim(loaded_image, 'A')
+                     AND '1'||rtrim(loaded_image, 'A') IS NOT DISTINCT
+                     FROM 1||rtrim(loaded_image, 'A')
+                     AND '1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')
+                     AND ('1'||rtrim(loaded_image, 'A') IS DISTINCT
+                          FROM '0'||rtrim(loaded_image, 'A'))
+                     AND '1'||rtrim(loaded_image, 'A') > '0'||rtrim(loaded_image, 'A')
+                     AND '1'||rtrim(loaded_image, 'A') >= '0'||rtrim(loaded_image, 'A')
+                     AND '1'||rtrim(loaded_image, 'A') < 2||rtrim(loaded_image, 'A')
+                     AND '1'||rtrim(loaded_image, 'A') <= 2||rtrim(loaded_image, 'A')
+                     AND ('1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')) IS TRUE
+                     AND ('1'||rtrim(loaded_image, 'A') = '0'||rtrim(loaded_image, 'A')) IS NOT TRUE
+                     AND ('1'||rtrim(loaded_image, 'A') = '0'||rtrim(loaded_image, 'A')) IS FALSE
+                     AND ('1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')) IS NOT FALSE
+                     AND '1'||rtrim(loaded_image, 'A') BETWEEN '0'||rtrim(loaded_image, 'A') AND 2||rtrim(loaded_image, 'A')
+                     AND '1'||rtrim(loaded_image, 'A') NOT BETWEEN '1'||rtrim(loaded_image, 'A') AND '0'||rtrim(loaded_image, 'A')
+                     AND '1'||rtrim(loaded_image, 'A') like '%'
+                     AND '1'||rtrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||rtrim(loaded_image, 'A') IN ('0'||rtrim(loaded_image, 'A'),
+                                                           1||rtrim(loaded_image, 'A'),
+                                                           2||rtrim(loaded_image, 'A'))
+                     AND '1'||rtrim(loaded_image, 'A') NOT IN ('0'||rtrim(loaded_image, 'A'),
+                                                               2||rtrim(loaded_image, 'A'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||rtrim(loaded_image, 'A'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||rtrim(loaded_image, 'A') IS NULL
+          OR ('1'||rtrim(loaded_image, 'A') = 1||rtrim(loaded_image, 'A')
+              AND '1'||rtrim(loaded_image, 'A') IS NOT DISTINCT
+              FROM 1||rtrim(loaded_image, 'A')
+              AND '1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')
+              AND ('1'||rtrim(loaded_image, 'A') IS DISTINCT
+                   FROM '0'||rtrim(loaded_image, 'A'))
+              AND '1'||rtrim(loaded_image, 'A') > '0'||rtrim(loaded_image, 'A')
+              AND '1'||rtrim(loaded_image, 'A') >= '0'||rtrim(loaded_image, 'A')
+              AND '1'||rtrim(loaded_image, 'A') < 2||rtrim(loaded_image, 'A')
+              AND '1'||rtrim(loaded_image, 'A') <= 2||rtrim(loaded_image, 'A')
+              AND ('1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')) IS TRUE
+              AND ('1'||rtrim(loaded_image, 'A') = '0'||rtrim(loaded_image, 'A')) IS NOT TRUE
+              AND ('1'||rtrim(loaded_image, 'A') = '0'||rtrim(loaded_image, 'A')) IS FALSE
+              AND ('1'||rtrim(loaded_image, 'A') <> '0'||rtrim(loaded_image, 'A')) IS NOT FALSE
+              AND '1'||rtrim(loaded_image, 'A') BETWEEN '0'||rtrim(loaded_image, 'A') AND 2||rtrim(loaded_image, 'A')
+              AND '1'||rtrim(loaded_image, 'A') NOT BETWEEN '1'||rtrim(loaded_image, 'A') AND '0'||rtrim(loaded_image, 'A')
+              AND '1'||rtrim(loaded_image, 'A') like '%'
+              AND '1'||rtrim(loaded_image, 'A') not like '__DOES_NOT_EXIST__%'
+              AND '1'||rtrim(loaded_image, 'A') IN ('0'||rtrim(loaded_image, 'A'),
+                                                    1||rtrim(loaded_image, 'A'),
+                                                    2||rtrim(loaded_image, 'A'))
+              AND '1'||rtrim(loaded_image, 'A') NOT IN ('0'||rtrim(loaded_image, 'A'),
+                                                        2||rtrim(loaded_image, 'A'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A29: reverse
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||reverse(loaded_image) IS NULL
+       OR ('1'||reverse(loaded_image) = 1||reverse(loaded_image)
+           AND '1'||reverse(loaded_image) IS NOT DISTINCT
+           FROM 1||reverse(loaded_image)
+           AND '1'||reverse(loaded_image) <> '0'||reverse(loaded_image)
+           AND ('1'||reverse(loaded_image) IS DISTINCT
+                FROM '0'||reverse(loaded_image))
+           AND '1'||reverse(loaded_image) > '0'||reverse(loaded_image)
+           AND '1'||reverse(loaded_image) >= '0'||reverse(loaded_image)
+           AND '1'||reverse(loaded_image) < 2||reverse(loaded_image)
+           AND '1'||reverse(loaded_image) <= 2||reverse(loaded_image)
+           AND ('1'||reverse(loaded_image) <> '0'||reverse(loaded_image)) IS TRUE
+           AND ('1'||reverse(loaded_image) = '0'||reverse(loaded_image)) IS NOT TRUE
+           AND ('1'||reverse(loaded_image) = '0'||reverse(loaded_image)) IS FALSE
+           AND ('1'||reverse(loaded_image) <> '0'||reverse(loaded_image)) IS NOT FALSE
+           AND '1'||reverse(loaded_image) BETWEEN '0'||reverse(loaded_image) AND 2||reverse(loaded_image)
+           AND '1'||reverse(loaded_image) NOT BETWEEN '1'||reverse(loaded_image) AND '0'||reverse(loaded_image)
+           AND '1'||reverse(loaded_image) like '%'
+           AND '1'||reverse(loaded_image) not like '__DOES_NOT_EXIST__%'
+           AND '1'||reverse(loaded_image) IN ('0'||reverse(loaded_image),
+                                              1||reverse(loaded_image),
+                                              2||reverse(loaded_image))
+           AND '1'||reverse(loaded_image) NOT IN ('0'||reverse(loaded_image),
+                                                  2||reverse(loaded_image)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||reverse(loaded_image) IS NULL
+       OR '1'||reverse(loaded_image) IN
+         (SELECT '1'||reverse(loaded_image)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||reverse(loaded_image) IS NULL
+                 OR ('1'||reverse(loaded_image) = 1||reverse(loaded_image)
+                     AND '1'||reverse(loaded_image) IS NOT DISTINCT
+                     FROM 1||reverse(loaded_image)
+                     AND '1'||reverse(loaded_image) <> '0'||reverse(loaded_image)
+                     AND ('1'||reverse(loaded_image) IS DISTINCT
+                          FROM '0'||reverse(loaded_image))
+                     AND '1'||reverse(loaded_image) > '0'||reverse(loaded_image)
+                     AND '1'||reverse(loaded_image) >= '0'||reverse(loaded_image)
+                     AND '1'||reverse(loaded_image) < 2||reverse(loaded_image)
+                     AND '1'||reverse(loaded_image) <= 2||reverse(loaded_image)
+                     AND ('1'||reverse(loaded_image) <> '0'||reverse(loaded_image)) IS TRUE
+                     AND ('1'||reverse(loaded_image) = '0'||reverse(loaded_image)) IS NOT TRUE
+                     AND ('1'||reverse(loaded_image) = '0'||reverse(loaded_image)) IS FALSE
+                     AND ('1'||reverse(loaded_image) <> '0'||reverse(loaded_image)) IS NOT FALSE
+                     AND '1'||reverse(loaded_image) BETWEEN '0'||reverse(loaded_image) AND 2||reverse(loaded_image)
+                     AND '1'||reverse(loaded_image) NOT BETWEEN '1'||reverse(loaded_image) AND '0'||reverse(loaded_image)
+                     AND '1'||reverse(loaded_image) like '%'
+                     AND '1'||reverse(loaded_image) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||reverse(loaded_image) IN ('0'||reverse(loaded_image),
+                                                        1||reverse(loaded_image),
+                                                        2||reverse(loaded_image))
+                     AND '1'||reverse(loaded_image) NOT IN ('0'||reverse(loaded_image),
+                                                            2||reverse(loaded_image))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||reverse(loaded_image),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||reverse(loaded_image) IS NULL
+          OR ('1'||reverse(loaded_image) = 1||reverse(loaded_image)
+              AND '1'||reverse(loaded_image) IS NOT DISTINCT
+              FROM 1||reverse(loaded_image)
+              AND '1'||reverse(loaded_image) <> '0'||reverse(loaded_image)
+              AND ('1'||reverse(loaded_image) IS DISTINCT
+                   FROM '0'||reverse(loaded_image))
+              AND '1'||reverse(loaded_image) > '0'||reverse(loaded_image)
+              AND '1'||reverse(loaded_image) >= '0'||reverse(loaded_image)
+              AND '1'||reverse(loaded_image) < 2||reverse(loaded_image)
+              AND '1'||reverse(loaded_image) <= 2||reverse(loaded_image)
+              AND ('1'||reverse(loaded_image) <> '0'||reverse(loaded_image)) IS TRUE
+              AND ('1'||reverse(loaded_image) = '0'||reverse(loaded_image)) IS NOT TRUE
+              AND ('1'||reverse(loaded_image) = '0'||reverse(loaded_image)) IS FALSE
+              AND ('1'||reverse(loaded_image) <> '0'||reverse(loaded_image)) IS NOT FALSE
+              AND '1'||reverse(loaded_image) BETWEEN '0'||reverse(loaded_image) AND 2||reverse(loaded_image)
+              AND '1'||reverse(loaded_image) NOT BETWEEN '1'||reverse(loaded_image) AND '0'||reverse(loaded_image)
+              AND '1'||reverse(loaded_image) like '%'
+              AND '1'||reverse(loaded_image) not like '__DOES_NOT_EXIST__%'
+              AND '1'||reverse(loaded_image) IN ('0'||reverse(loaded_image),
+                                                 1||reverse(loaded_image),
+                                                 2||reverse(loaded_image))
+              AND '1'||reverse(loaded_image) NOT IN ('0'||reverse(loaded_image),
+                                                     2||reverse(loaded_image))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A30: repeat
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||repeat(loaded_image, 2) IS NULL
+       OR ('1'||repeat(loaded_image, 2) = 1||repeat(loaded_image, 2)
+           AND '1'||repeat(loaded_image, 2) IS NOT DISTINCT
+           FROM 1||repeat(loaded_image, 2)
+           AND '1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)
+           AND ('1'||repeat(loaded_image, 2) IS DISTINCT
+                FROM '0'||repeat(loaded_image, 2))
+           AND '1'||repeat(loaded_image, 2) > '0'||repeat(loaded_image, 2)
+           AND '1'||repeat(loaded_image, 2) >= '0'||repeat(loaded_image, 2)
+           AND '1'||repeat(loaded_image, 2) < 2||repeat(loaded_image, 2)
+           AND '1'||repeat(loaded_image, 2) <= 2||repeat(loaded_image, 2)
+           AND ('1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)) IS TRUE
+           AND ('1'||repeat(loaded_image, 2) = '0'||repeat(loaded_image, 2)) IS NOT TRUE
+           AND ('1'||repeat(loaded_image, 2) = '0'||repeat(loaded_image, 2)) IS FALSE
+           AND ('1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)) IS NOT FALSE
+           AND '1'||repeat(loaded_image, 2) BETWEEN '0'||repeat(loaded_image, 2) AND 2||repeat(loaded_image, 2)
+           AND '1'||repeat(loaded_image, 2) NOT BETWEEN '1'||repeat(loaded_image, 2) AND '0'||repeat(loaded_image, 2)
+           AND '1'||repeat(loaded_image, 2) like '%'
+           AND '1'||repeat(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+           AND '1'||repeat(loaded_image, 2) IN ('0'||repeat(loaded_image, 2),
+                                                1||repeat(loaded_image, 2),
+                                                2||repeat(loaded_image, 2))
+           AND '1'||repeat(loaded_image, 2) NOT IN ('0'||repeat(loaded_image, 2),
+                                                    2||repeat(loaded_image, 2)))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||repeat(loaded_image, 2) IS NULL
+       OR '1'||repeat(loaded_image, 2) IN
+         (SELECT '1'||repeat(loaded_image, 2)
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||repeat(loaded_image, 2) IS NULL
+                 OR ('1'||repeat(loaded_image, 2) = 1||repeat(loaded_image, 2)
+                     AND '1'||repeat(loaded_image, 2) IS NOT DISTINCT
+                     FROM 1||repeat(loaded_image, 2)
+                     AND '1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)
+                     AND ('1'||repeat(loaded_image, 2) IS DISTINCT
+                          FROM '0'||repeat(loaded_image, 2))
+                     AND '1'||repeat(loaded_image, 2) > '0'||repeat(loaded_image, 2)
+                     AND '1'||repeat(loaded_image, 2) >= '0'||repeat(loaded_image, 2)
+                     AND '1'||repeat(loaded_image, 2) < 2||repeat(loaded_image, 2)
+                     AND '1'||repeat(loaded_image, 2) <= 2||repeat(loaded_image, 2)
+                     AND ('1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)) IS TRUE
+                     AND ('1'||repeat(loaded_image, 2) = '0'||repeat(loaded_image, 2)) IS NOT TRUE
+                     AND ('1'||repeat(loaded_image, 2) = '0'||repeat(loaded_image, 2)) IS FALSE
+                     AND ('1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)) IS NOT FALSE
+                     AND '1'||repeat(loaded_image, 2) BETWEEN '0'||repeat(loaded_image, 2) AND 2||repeat(loaded_image, 2)
+                     AND '1'||repeat(loaded_image, 2) NOT BETWEEN '1'||repeat(loaded_image, 2) AND '0'||repeat(loaded_image, 2)
+                     AND '1'||repeat(loaded_image, 2) like '%'
+                     AND '1'||repeat(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+                     AND '1'||repeat(loaded_image, 2) IN ('0'||repeat(loaded_image, 2),
+                                                          1||repeat(loaded_image, 2),
+                                                          2||repeat(loaded_image, 2))
+                     AND '1'||repeat(loaded_image, 2) NOT IN ('0'||repeat(loaded_image, 2),
+                                                              2||repeat(loaded_image, 2))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||repeat(loaded_image, 2),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||repeat(loaded_image, 2) IS NULL
+          OR ('1'||repeat(loaded_image, 2) = 1||repeat(loaded_image, 2)
+              AND '1'||repeat(loaded_image, 2) IS NOT DISTINCT
+              FROM 1||repeat(loaded_image, 2)
+              AND '1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)
+              AND ('1'||repeat(loaded_image, 2) IS DISTINCT
+                   FROM '0'||repeat(loaded_image, 2))
+              AND '1'||repeat(loaded_image, 2) > '0'||repeat(loaded_image, 2)
+              AND '1'||repeat(loaded_image, 2) >= '0'||repeat(loaded_image, 2)
+              AND '1'||repeat(loaded_image, 2) < 2||repeat(loaded_image, 2)
+              AND '1'||repeat(loaded_image, 2) <= 2||repeat(loaded_image, 2)
+              AND ('1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)) IS TRUE
+              AND ('1'||repeat(loaded_image, 2) = '0'||repeat(loaded_image, 2)) IS NOT TRUE
+              AND ('1'||repeat(loaded_image, 2) = '0'||repeat(loaded_image, 2)) IS FALSE
+              AND ('1'||repeat(loaded_image, 2) <> '0'||repeat(loaded_image, 2)) IS NOT FALSE
+              AND '1'||repeat(loaded_image, 2) BETWEEN '0'||repeat(loaded_image, 2) AND 2||repeat(loaded_image, 2)
+              AND '1'||repeat(loaded_image, 2) NOT BETWEEN '1'||repeat(loaded_image, 2) AND '0'||repeat(loaded_image, 2)
+              AND '1'||repeat(loaded_image, 2) like '%'
+              AND '1'||repeat(loaded_image, 2) not like '__DOES_NOT_EXIST__%'
+              AND '1'||repeat(loaded_image, 2) IN ('0'||repeat(loaded_image, 2),
+                                                   1||repeat(loaded_image, 2),
+                                                   2||repeat(loaded_image, 2))
+              AND '1'||repeat(loaded_image, 2) NOT IN ('0'||repeat(loaded_image, 2),
+                                                       2||repeat(loaded_image, 2))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A31: lpad
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||lpad(loaded_image, 10, 'z') IS NULL
+       OR ('1'||lpad(loaded_image, 10, 'z') = 1||lpad(loaded_image, 10, 'z')
+           AND '1'||lpad(loaded_image, 10, 'z') IS NOT DISTINCT
+           FROM 1||lpad(loaded_image, 10, 'z')
+           AND '1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')
+           AND ('1'||lpad(loaded_image, 10, 'z') IS DISTINCT
+                FROM '0'||lpad(loaded_image, 10, 'z'))
+           AND '1'||lpad(loaded_image, 10, 'z') > '0'||lpad(loaded_image, 10, 'z')
+           AND '1'||lpad(loaded_image, 10, 'z') >= '0'||lpad(loaded_image, 10, 'z')
+           AND '1'||lpad(loaded_image, 10, 'z') < 2||lpad(loaded_image, 10, 'z')
+           AND '1'||lpad(loaded_image, 10, 'z') <= 2||lpad(loaded_image, 10, 'z')
+           AND ('1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')) IS TRUE
+           AND ('1'||lpad(loaded_image, 10, 'z') = '0'||lpad(loaded_image, 10, 'z')) IS NOT TRUE
+           AND ('1'||lpad(loaded_image, 10, 'z') = '0'||lpad(loaded_image, 10, 'z')) IS FALSE
+           AND ('1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')) IS NOT FALSE
+           AND '1'||lpad(loaded_image, 10, 'z') BETWEEN '0'||lpad(loaded_image, 10, 'z') AND 2||lpad(loaded_image, 10, 'z')
+           AND '1'||lpad(loaded_image, 10, 'z') NOT BETWEEN '1'||lpad(loaded_image, 10, 'z') AND '0'||lpad(loaded_image, 10, 'z')
+           AND '1'||lpad(loaded_image, 10, 'z') like '%'
+           AND '1'||lpad(loaded_image, 10, 'z') not like '__DOES_NOT_EXIST__%'
+           AND '1'||lpad(loaded_image, 10, 'z') IN ('0'||lpad(loaded_image, 10, 'z'),
+                                                    1||lpad(loaded_image, 10, 'z'),
+                                                    2||lpad(loaded_image, 10, 'z'))
+           AND '1'||lpad(loaded_image, 10, 'z') NOT IN ('0'||lpad(loaded_image, 10, 'z'),
+                                                        2||lpad(loaded_image, 10, 'z')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||lpad(loaded_image, 10, 'z') IS NULL
+       OR '1'||lpad(loaded_image, 10, 'z') IN
+         (SELECT '1'||lpad(loaded_image, 10, 'z')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||lpad(loaded_image, 10, 'z') IS NULL
+                 OR ('1'||lpad(loaded_image, 10, 'z') = 1||lpad(loaded_image, 10, 'z')
+                     AND '1'||lpad(loaded_image, 10, 'z') IS NOT DISTINCT
+                     FROM 1||lpad(loaded_image, 10, 'z')
+                     AND '1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')
+                     AND ('1'||lpad(loaded_image, 10, 'z') IS DISTINCT
+                          FROM '0'||lpad(loaded_image, 10, 'z'))
+                     AND '1'||lpad(loaded_image, 10, 'z') > '0'||lpad(loaded_image, 10, 'z')
+                     AND '1'||lpad(loaded_image, 10, 'z') >= '0'||lpad(loaded_image, 10, 'z')
+                     AND '1'||lpad(loaded_image, 10, 'z') < 2||lpad(loaded_image, 10, 'z')
+                     AND '1'||lpad(loaded_image, 10, 'z') <= 2||lpad(loaded_image, 10, 'z')
+                     AND ('1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')) IS TRUE
+                     AND ('1'||lpad(loaded_image, 10, 'z') = '0'||lpad(loaded_image, 10, 'z')) IS NOT TRUE
+                     AND ('1'||lpad(loaded_image, 10, 'z') = '0'||lpad(loaded_image, 10, 'z')) IS FALSE
+                     AND ('1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')) IS NOT FALSE
+                     AND '1'||lpad(loaded_image, 10, 'z') BETWEEN '0'||lpad(loaded_image, 10, 'z') AND 2||lpad(loaded_image, 10, 'z')
+                     AND '1'||lpad(loaded_image, 10, 'z') NOT BETWEEN '1'||lpad(loaded_image, 10, 'z') AND '0'||lpad(loaded_image, 10, 'z')
+                     AND '1'||lpad(loaded_image, 10, 'z') like '%'
+                     AND '1'||lpad(loaded_image, 10, 'z') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||lpad(loaded_image, 10, 'z') IN ('0'||lpad(loaded_image, 10, 'z'),
+                                                              1||lpad(loaded_image, 10, 'z'),
+                                                              2||lpad(loaded_image, 10, 'z'))
+                     AND '1'||lpad(loaded_image, 10, 'z') NOT IN ('0'||lpad(loaded_image, 10, 'z'),
+                                                                  2||lpad(loaded_image, 10, 'z'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||lpad(loaded_image, 10, 'z'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||lpad(loaded_image, 10, 'z') IS NULL
+          OR ('1'||lpad(loaded_image, 10, 'z') = 1||lpad(loaded_image, 10, 'z')
+              AND '1'||lpad(loaded_image, 10, 'z') IS NOT DISTINCT
+              FROM 1||lpad(loaded_image, 10, 'z')
+              AND '1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')
+              AND ('1'||lpad(loaded_image, 10, 'z') IS DISTINCT
+                   FROM '0'||lpad(loaded_image, 10, 'z'))
+              AND '1'||lpad(loaded_image, 10, 'z') > '0'||lpad(loaded_image, 10, 'z')
+              AND '1'||lpad(loaded_image, 10, 'z') >= '0'||lpad(loaded_image, 10, 'z')
+              AND '1'||lpad(loaded_image, 10, 'z') < 2||lpad(loaded_image, 10, 'z')
+              AND '1'||lpad(loaded_image, 10, 'z') <= 2||lpad(loaded_image, 10, 'z')
+              AND ('1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')) IS TRUE
+              AND ('1'||lpad(loaded_image, 10, 'z') = '0'||lpad(loaded_image, 10, 'z')) IS NOT TRUE
+              AND ('1'||lpad(loaded_image, 10, 'z') = '0'||lpad(loaded_image, 10, 'z')) IS FALSE
+              AND ('1'||lpad(loaded_image, 10, 'z') <> '0'||lpad(loaded_image, 10, 'z')) IS NOT FALSE
+              AND '1'||lpad(loaded_image, 10, 'z') BETWEEN '0'||lpad(loaded_image, 10, 'z') AND 2||lpad(loaded_image, 10, 'z')
+              AND '1'||lpad(loaded_image, 10, 'z') NOT BETWEEN '1'||lpad(loaded_image, 10, 'z') AND '0'||lpad(loaded_image, 10, 'z')
+              AND '1'||lpad(loaded_image, 10, 'z') like '%'
+              AND '1'||lpad(loaded_image, 10, 'z') not like '__DOES_NOT_EXIST__%'
+              AND '1'||lpad(loaded_image, 10, 'z') IN ('0'||lpad(loaded_image, 10, 'z'),
+                                                       1||lpad(loaded_image, 10, 'z'),
+                                                       2||lpad(loaded_image, 10, 'z'))
+              AND '1'||lpad(loaded_image, 10, 'z') NOT IN ('0'||lpad(loaded_image, 10, 'z'),
+                                                           2||lpad(loaded_image, 10, 'z'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# TEST_ID: A32: rpad
+#-------------------------------------------------------------------------
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||rpad(loaded_image, 10, 'z') IS NULL
+       OR ('1'||rpad(loaded_image, 10, 'z') = 1||rpad(loaded_image, 10, 'z')
+           AND '1'||rpad(loaded_image, 10, 'z') IS NOT DISTINCT
+           FROM 1||rpad(loaded_image, 10, 'z')
+           AND '1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')
+           AND ('1'||rpad(loaded_image, 10, 'z') IS DISTINCT
+                FROM '0'||rpad(loaded_image, 10, 'z'))
+           AND '1'||rpad(loaded_image, 10, 'z') > '0'||rpad(loaded_image, 10, 'z')
+           AND '1'||rpad(loaded_image, 10, 'z') >= '0'||rpad(loaded_image, 10, 'z')
+           AND '1'||rpad(loaded_image, 10, 'z') < 2||rpad(loaded_image, 10, 'z')
+           AND '1'||rpad(loaded_image, 10, 'z') <= 2||rpad(loaded_image, 10, 'z')
+           AND ('1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')) IS TRUE
+           AND ('1'||rpad(loaded_image, 10, 'z') = '0'||rpad(loaded_image, 10, 'z')) IS NOT TRUE
+           AND ('1'||rpad(loaded_image, 10, 'z') = '0'||rpad(loaded_image, 10, 'z')) IS FALSE
+           AND ('1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')) IS NOT FALSE
+           AND '1'||rpad(loaded_image, 10, 'z') BETWEEN '0'||rpad(loaded_image, 10, 'z') AND 2||rpad(loaded_image, 10, 'z')
+           AND '1'||rpad(loaded_image, 10, 'z') NOT BETWEEN '1'||rpad(loaded_image, 10, 'z') AND '0'||rpad(loaded_image, 10, 'z')
+           AND '1'||rpad(loaded_image, 10, 'z') like '%'
+           AND '1'||rpad(loaded_image, 10, 'z') not like '__DOES_NOT_EXIST__%'
+           AND '1'||rpad(loaded_image, 10, 'z') IN ('0'||rpad(loaded_image, 10, 'z'),
+                                                    1||rpad(loaded_image, 10, 'z'),
+                                                    2||rpad(loaded_image, 10, 'z'))
+           AND '1'||rpad(loaded_image, 10, 'z') NOT IN ('0'||rpad(loaded_image, 10, 'z'),
+                                                        2||rpad(loaded_image, 10, 'z')))) ;
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM kttm_nested
+WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+  AND ('1'||rpad(loaded_image, 10, 'z') IS NULL
+       OR '1'||rpad(loaded_image, 10, 'z') IN
+         (SELECT '1'||rpad(loaded_image, 10, 'z')
+          FROM kttm_nested
+          WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+            AND ('1'||rpad(loaded_image, 10, 'z') IS NULL
+                 OR ('1'||rpad(loaded_image, 10, 'z') = 1||rpad(loaded_image, 10, 'z')
+                     AND '1'||rpad(loaded_image, 10, 'z') IS NOT DISTINCT
+                     FROM 1||rpad(loaded_image, 10, 'z')
+                     AND '1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')
+                     AND ('1'||rpad(loaded_image, 10, 'z') IS DISTINCT
+                          FROM '0'||rpad(loaded_image, 10, 'z'))
+                     AND '1'||rpad(loaded_image, 10, 'z') > '0'||rpad(loaded_image, 10, 'z')
+                     AND '1'||rpad(loaded_image, 10, 'z') >= '0'||rpad(loaded_image, 10, 'z')
+                     AND '1'||rpad(loaded_image, 10, 'z') < 2||rpad(loaded_image, 10, 'z')
+                     AND '1'||rpad(loaded_image, 10, 'z') <= 2||rpad(loaded_image, 10, 'z')
+                     AND ('1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')) IS TRUE
+                     AND ('1'||rpad(loaded_image, 10, 'z') = '0'||rpad(loaded_image, 10, 'z')) IS NOT TRUE
+                     AND ('1'||rpad(loaded_image, 10, 'z') = '0'||rpad(loaded_image, 10, 'z')) IS FALSE
+                     AND ('1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')) IS NOT FALSE
+                     AND '1'||rpad(loaded_image, 10, 'z') BETWEEN '0'||rpad(loaded_image, 10, 'z') AND 2||rpad(loaded_image, 10, 'z')
+                     AND '1'||rpad(loaded_image, 10, 'z') NOT BETWEEN '1'||rpad(loaded_image, 10, 'z') AND '0'||rpad(loaded_image, 10, 'z')
+                     AND '1'||rpad(loaded_image, 10, 'z') like '%'
+                     AND '1'||rpad(loaded_image, 10, 'z') not like '__DOES_NOT_EXIST__%'
+                     AND '1'||rpad(loaded_image, 10, 'z') IN ('0'||rpad(loaded_image, 10, 'z'),
+                                                              1||rpad(loaded_image, 10, 'z'),
+                                                              2||rpad(loaded_image, 10, 'z'))
+                     AND '1'||rpad(loaded_image, 10, 'z') NOT IN ('0'||rpad(loaded_image, 10, 'z'),
+                                                                  2||rpad(loaded_image, 10, 'z'))))));
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+SELECT count(*) cnt
+FROM
+  (SELECT __time, number, client_ip,
+                          '1'||rpad(loaded_image, 10, 'z'),
+                          count(*)
+   FROM kttm_nested
+   WHERE time_floor(__time, 'PT1H') BETWEEN timestamp '2019-08-25 00:00:00' AND timestamp '2019-08-25 06:00:00'
+     AND ('1'||rpad(loaded_image, 10, 'z') IS NULL
+          OR ('1'||rpad(loaded_image, 10, 'z') = 1||rpad(loaded_image, 10, 'z')
+              AND '1'||rpad(loaded_image, 10, 'z') IS NOT DISTINCT
+              FROM 1||rpad(loaded_image, 10, 'z')
+              AND '1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')
+              AND ('1'||rpad(loaded_image, 10, 'z') IS DISTINCT
+                   FROM '0'||rpad(loaded_image, 10, 'z'))
+              AND '1'||rpad(loaded_image, 10, 'z') > '0'||rpad(loaded_image, 10, 'z')
+              AND '1'||rpad(loaded_image, 10, 'z') >= '0'||rpad(loaded_image, 10, 'z')
+              AND '1'||rpad(loaded_image, 10, 'z') < 2||rpad(loaded_image, 10, 'z')
+              AND '1'||rpad(loaded_image, 10, 'z') <= 2||rpad(loaded_image, 10, 'z')
+              AND ('1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')) IS TRUE
+              AND ('1'||rpad(loaded_image, 10, 'z') = '0'||rpad(loaded_image, 10, 'z')) IS NOT TRUE
+              AND ('1'||rpad(loaded_image, 10, 'z') = '0'||rpad(loaded_image, 10, 'z')) IS FALSE
+              AND ('1'||rpad(loaded_image, 10, 'z') <> '0'||rpad(loaded_image, 10, 'z')) IS NOT FALSE
+              AND '1'||rpad(loaded_image, 10, 'z') BETWEEN '0'||rpad(loaded_image, 10, 'z') AND 2||rpad(loaded_image, 10, 'z')
+              AND '1'||rpad(loaded_image, 10, 'z') NOT BETWEEN '1'||rpad(loaded_image, 10, 'z') AND '0'||rpad(loaded_image, 10, 'z')
+              AND '1'||rpad(loaded_image, 10, 'z') like '%'
+              AND '1'||rpad(loaded_image, 10, 'z') not like '__DOES_NOT_EXIST__%'
+              AND '1'||rpad(loaded_image, 10, 'z') IN ('0'||rpad(loaded_image, 10, 'z'),
+                                                       1||rpad(loaded_image, 10, 'z'),
+                                                       2||rpad(loaded_image, 10, 'z'))
+              AND '1'||rpad(loaded_image, 10, 'z') NOT IN ('0'||rpad(loaded_image, 10, 'z'),
+                                                           2||rpad(loaded_image, 10, 'z'))))
+   GROUP BY 1,
+            2,
+            3,
+            4);
++-------+
+| cnt   |
++-------+
+| 78197 |
++-------+
+(1 row)
+
+!ok
+
+#-------------------------------------------------------------------------
+# Total query count 97
+#-------------------------------------------------------------------------


### PR DESCRIPTION
### Description
Migrate the initial 3 sets of SQL tests to quidem.  These 3 sets cover numeric, string, and datetime scalar functions. These tests use the existing kttm dataset.  They aim to exercise SQL queries in a more comprehensive way:
- Each scalar function is exercised in 3 different query shapes:
  simple query
  query with subquery
  group-by query
- Each query covers all operators in its predicates. 
- All queries are select count(*) queries.  The predicates are designed for all queries to return the same result for easy maintenance and debugging.

These are the initial sets of tests.  More tests will be added to cover the rest of the scalar and aggregation functions.

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
