### PR TITLE
Docs - Fix links in sorting section of partitioning page

### DIFF
--- a/docs/ingestion/partitioning.md
+++ b/docs/ingestion/partitioning.md
@@ -81,8 +81,8 @@ The following table describes how to configure sorting.
 |Method|Configuration|
 |------|------------|
 |[SQL](../multi-stage-query/index.md)|Uses order of fields in [`CLUSTERED BY`](../multi-stage-query/concepts.md#clustering) or [`segmentSortOrder`](../multi-stage-query/reference.md#context) in the query context|
-|[Kafka](../ingestion/kafka-ingestion.md) or [Kinesis](../ingestion/kinesis-ingestion.md)|Uses order of fields in [`dimensionsSpec`](ingestion-spec.md#granularityspec)|
-|[Native batch](native-batch.md) or [Hadoop](hadoop.md)|Uses order of fields in [`dimensionsSpec`](ingestion-spec.md#granularityspec)|
+|[Kafka](../ingestion/kafka-ingestion.md) or [Kinesis](../ingestion/kinesis-ingestion.md)|Uses order of fields in [`dimensionsSpec`](ingestion-spec.md#dimensionsspec)|
+|[Native batch](native-batch.md) or [Hadoop](hadoop.md)|Uses order of fields in [`dimensionsSpec`](ingestion-spec.md#dimensionsspec)|
 
 :::info
 Druid implicitly sorts rows within a segment by `__time` first before any `dimensions` or `CLUSTERED BY` fields, unless


### PR DESCRIPTION
Quick fix to point the links to `dimensionsSpec` in the "sorting" section to the correct header in the ingestion spec doc.

<hr>

This PR has:

- [X] been self-reviewed.
- [ ] a release note entry in the PR description.
- [ ] been tested in a test Druid cluster.