### PR TITLE
remove sql_compatibility from build matrix and only test sql compatible mode

### DIFF
--- a/.github/scripts/unit_tests_script.sh
+++ b/.github/scripts/unit_tests_script.sh
@@ -21,7 +21,7 @@ unset _JAVA_OPTIONS
 
 # Set MAVEN_OPTS for Surefire launcher.
 MAVEN_OPTS='-Xmx2500m' ${MVN} test -pl ${MAVEN_PROJECTS} \
-${MAVEN_SKIP} -Ddruid.generic.useDefaultValueForNull=${DRUID_USE_DEFAULT_VALUE_FOR_NULL} \
+${MAVEN_SKIP} \
 -DjfrProfilerArgLine="${JFR_PROFILER_ARG_LINE}" -Pci
 sh -c "dmesg | egrep -i '(oom|out of memory|kill process|killed).*' -C 1 || exit 0"
 free -m

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -21,11 +21,6 @@ on:
         required: true
         type: string
         description: 'JDK version used to test Druid'
-      sql_compatibility:
-        required: false
-        type: boolean
-        default: true
-        description: 'For SQL compatibility'
       module:
         required: true
         type: string
@@ -84,13 +79,6 @@ jobs:
         run: |
           export base_ref=${{ github.base_ref }}
           echo "GITHUB_BASE_REF=${base_ref}" >> $GITHUB_ENV
-          # If sql_compatibilty is true, we want to set default_value_for_null
-          # which enables compatibility mode
-          if (${{ inputs.sql_compatibility }} == true); then
-            echo "DRUID_USE_DEFAULT_VALUE_FOR_NULL=false" >> $GITHUB_ENV
-          else
-            echo "DRUID_USE_DEFAULT_VALUE_FOR_NULL=true" >> $GITHUB_ENV
-          fi
 
       - name: test profiling
         run: | 

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -163,25 +163,19 @@ jobs:
       matrix:
         # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
         jdk: [ '11', '21.0.4' ]
-    name: "unit tests (jdk${{ matrix.jdk }}, sql-compat=true)"
+    name: "unit tests (jdk${{ matrix.jdk }})"
     uses: ./.github/workflows/unit-tests.yml
     needs: unit-tests
     if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.outputs.continue_tests) }}
     with:
       jdk: ${{ matrix.jdk }}
-      sql_compatibility: true
 
   unit-tests:
-    strategy:
-      fail-fast: false
-      matrix:
-        sql_compatibility: [ false, true ]
-    name: "unit tests (jdk17, sql-compat=${{ matrix.sql_compatibility }})"
+    name: "unit tests (jdk17)"
     uses: ./.github/workflows/unit-tests.yml
     needs: build
     with:
       jdk: 17
-      sql_compatibility: ${{ matrix.sql_compatibility }}
 
   standard-its:
     needs: unit-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,11 +21,6 @@ on:
         required: true
         type: string
         description: 'JDK version used to test Druid'
-      sql_compatibility:
-        required: false
-        type: boolean
-        default: true
-        description: 'For SQL compatibility'
     outputs:
       continue_tests:
         description: 'Flag to decide if next tests need to run incase coverage issue failures'
@@ -72,7 +67,6 @@ jobs:
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       jdk: ${{ inputs.jdk }}
-      sql_compatibility: ${{ inputs.sql_compatibility }}
       module: indexing
       maven_projects: 'indexing-hadoop,indexing-service,extensions-core/kafka-indexing-service,extensions-core/kinesis-indexing-service'
 
@@ -82,7 +76,6 @@ jobs:
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       jdk: ${{ inputs.jdk }}
-      sql_compatibility: ${{ inputs.sql_compatibility }}
       module: processing
       maven_projects: 'processing'
 
@@ -92,7 +85,6 @@ jobs:
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       jdk: ${{ inputs.jdk }}
-      sql_compatibility: ${{ inputs.sql_compatibility }}
       module: server
       maven_projects: 'server'
 
@@ -100,6 +92,5 @@ jobs:
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       jdk: ${{ inputs.jdk }}
-      sql_compatibility: ${{ inputs.sql_compatibility }}
       module: other
       maven_projects: '!processing,!indexing-hadoop,!indexing-service,!extensions-core/kafka-indexing-service,!extensions-core/kinesis-indexing-service,!server,!web-console,!integration-tests,!:druid-it-tools,!:druid-it-image,!:druid-it-cases'


### PR DESCRIPTION
`druid.generic.useDefaultValueForNull` is deprecated and will be removed in the future. This PR removes it from the CI matrix to cut down on overall runtime. I will be opening some follow-up PRs to actually start removing the code and configs for these modes.