### PR TITLE
Bump async-http-client to 3.0.1

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2003,7 +2003,7 @@ name: AsyncHttpClient asynchttpclient
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.5.3
+version: 3.0.1
 libraries:
   - org.asynchttpclient: async-http-client
   - org.asynchttpclient: async-http-client-netty-utils

--- a/pom.xml
+++ b/pom.xml
@@ -1010,8 +1010,7 @@
             <dependency>
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
-                <!-- Uses Netty 4.1.x -->
-                <version>2.5.3</version>
+                <version>3.0.1</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>

--- a/processing/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
+++ b/processing/src/main/java/org/apache/druid/java/util/emitter/core/HttpPostEmitter.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.primitives.Ints;
 import io.netty.handler.codec.http.HttpHeaders;
 import org.apache.druid.concurrent.ConcurrentAwaitableCounter;
 import org.apache.druid.java.util.common.ISE;
@@ -45,6 +44,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -773,7 +773,7 @@ public class HttpPostEmitter implements Flushable, Closeable, Emitter
         request.setHeader(HttpHeaders.Names.AUTHORIZATION, "Basic " + encoded);
       }
 
-      request.setRequestTimeout(Ints.saturatedCast(timeoutMillis));
+      request.setRequestTimeout(Duration.ofMillis(timeoutMillis));
 
       ListenableFuture<Response> future = client.executeRequest(request);
       Response response;

--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/HttpEmitterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/HttpEmitterTest.java
@@ -30,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class HttpEmitterTest
@@ -56,8 +57,8 @@ public class HttpEmitterTest
       @Override
       protected ListenableFuture<Response> go(Request request)
       {
-        int timeout = request.getRequestTimeout();
-        timeoutUsed.set(timeout);
+        Duration timeout = request.getRequestTimeout();
+        timeoutUsed.set(timeout.toMillis());
         return GoHandlers.immediateFuture(EmitterTest.okResponse());
       }
     });

--- a/processing/src/test/java/org/apache/druid/java/util/http/client/AsyncHttpClientTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/http/client/AsyncHttpClientTest.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -81,7 +82,7 @@ public class AsyncHttpClientTest
       requestStart = System.currentTimeMillis();
       Future<?> future = client
           .prepareGet(StringUtils.format("http://localhost:%d/", serverSocket.getLocalPort()))
-          .setRequestTimeout(2000)
+          .setRequestTimeout(Duration.ofMillis(2000))
           .execute();
       System.out.println("created future in: " + (System.currentTimeMillis() - requestStart));
       future.get(3000, TimeUnit.MILLISECONDS);
@@ -103,7 +104,7 @@ public class AsyncHttpClientTest
     try {
       Future<?> future = client
           .prepareGet(StringUtils.format("http://localhost:%d/", serverSocket.getLocalPort()))
-          .setRequestTimeout(100)
+          .setRequestTimeout(Duration.ofMillis(100))
           .execute();
       future.get();
     }


### PR DESCRIPTION
### Description

Bump async-http-client to 3.0.1 to resolve [CVE-2024-53990](https://github.com/AsyncHttpClient/async-http-client/security/advisories/GHSA-mfj5-cf8g-g2fv).

#### Release note

<hr>

##### General Changes
 * Bump async-http-client to 3.0.1 to resolve CVE-2024-53990.
<hr>

This PR has:

- [X] been self-reviewed.
- [] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
