### PR TITLE
Cleanup unreachable Java 8 code flows

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -173,15 +173,13 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
       localClassLoaderURLs.addAll(Arrays.asList(hadoopLoader.getURLs()));
     }
 
-    ClassLoader parent = null;
-    if (JvmUtils.isIsJava9Compatible()) {
-      try {
-        // See also https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E
-        parent = (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
-      }
-      catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-        throw new RuntimeException(e);
-      }
+    ClassLoader parent;
+    try {
+      // See also https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E
+      parent = (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
+    }
+    catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new RuntimeException(e);
     }
     final ClassLoader classLoader = new URLClassLoader(
         localClassLoaderURLs.toArray(new URL[0]),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopTask.java
@@ -173,14 +173,7 @@ public abstract class HadoopTask extends AbstractBatchIndexTask
       localClassLoaderURLs.addAll(Arrays.asList(hadoopLoader.getURLs()));
     }
 
-    ClassLoader parent;
-    try {
-      // See also https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E
-      parent = (ClassLoader) ClassLoader.class.getMethod("getPlatformClassLoader").invoke(null);
-    }
-    catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-      throw new RuntimeException(e);
-    }
+    ClassLoader parent = ClassLoader.getPlatformClassLoader();
     final ClassLoader classLoader = new URLClassLoader(
         localClassLoaderURLs.toArray(new URL[0]),
         parent

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -244,9 +244,7 @@ public class ForkingTaskRunner
 
                         command.add(config.getJavaCommand());
 
-                        if (JvmUtils.majorVersion() >= 11) {
-                          command.addAll(STRONG_ENCAPSULATION_PROPERTIES);
-                        }
+                        command.addAll(STRONG_ENCAPSULATION_PROPERTIES);
 
                         command.add("-cp");
                         command.add(taskClasspath);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/HadoopTaskTest.java
@@ -30,7 +30,6 @@ import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.timeline.DataSegment;
-import org.apache.druid.utils.JvmUtils;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -131,13 +130,8 @@ public class HadoopTaskTest
 
   public static void assertClassLoaderIsSingular(ClassLoader classLoader)
   {
-    if (JvmUtils.isIsJava9Compatible()) {
-      // See also https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E
-      Assert.assertEquals("PlatformClassLoader", classLoader.getParent().getClass().getSimpleName());
-    } else {
-      // This is a check against the current HadoopTask which creates a single URLClassLoader with null parent
-      Assert.assertNull(classLoader.getParent());
-    }
+    // See also https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-A868D0B9-026F-4D46-B979-901834343F9E
+    Assert.assertEquals("PlatformClassLoader", classLoader.getParent().getClass().getSimpleName());
     Assert.assertFalse(classLoader.getClass().getSimpleName().equals("ApplicationClassLoader"));
     Assert.assertTrue(classLoader instanceof URLClassLoader);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1666,6 +1666,9 @@
                                 <ignore>sun.misc.Unsafe</ignore>
                                 <!-- ignore java reflection polymorphic api signatures -->
                                 <ignore>java.lang.invoke.MethodHandle</ignore>
+                                <!-- For ignoring java.lang.ClassLoader#getPlatformClassLoader since that's present in java 9+.
+                                Need to be added since animal sniffer is using JDK8 signature currently. -->
+                                <ignore>java.lang.ClassLoader</ignore>
                                 <!--
                                  For the following java.nio.* classes, we get errors like: "Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.clear()"
                                  GitHub issue: https://github.com/mojohaus/animal-sniffer/issues/4

--- a/processing/src/main/java/org/apache/druid/utils/JvmUtils.java
+++ b/processing/src/main/java/org/apache/druid/utils/JvmUtils.java
@@ -71,11 +71,6 @@ public class JvmUtils
     return MAJOR_VERSION;
   }
 
-  public static boolean isIsJava9Compatible()
-  {
-    return MAJOR_VERSION >= 9;
-  }
-
   public static RuntimeInfo getRuntimeInfo()
   {
     return RUNTIME_INFO;

--- a/processing/src/main/java/org/apache/druid/utils/RuntimeInfo.java
+++ b/processing/src/main/java/org/apache/druid/utils/RuntimeInfo.java
@@ -50,7 +50,7 @@ public class RuntimeInfo
   public long getDirectMemorySizeBytes()
   {
     try {
-      Class<?> vmClass = Class.forName(JvmUtils.majorVersion() >= 9 ? "jdk.internal.misc.VM" : "sun.misc.VM");
+      Class<?> vmClass = Class.forName("jdk.internal.misc.VM");
       Object maxDirectMemoryObj = vmClass.getMethod("maxDirectMemory").invoke(null);
 
       if (maxDirectMemoryObj == null || !(maxDirectMemoryObj instanceof Number)) {


### PR DESCRIPTION
### Description

As a follow-up to #17466, some Java 8 specific flows are unreachable now.

This PR cleans such code flows, majorly the flows corresponding to `JvmUtils.isIsJava9Compatible()` being `false`.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
