### PR TITLE
Re-visit previously disabled spotbugs patterns and enable them

### DIFF
--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -139,11 +139,10 @@
     <Bug pattern="URF_UNREAD_FIELD"/>
     <Bug pattern="CT_CONSTRUCTOR_THROW"/>
     <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
-    <!-- The following patterns have been excluded as part of upgrading to Java 17 as there were 100s of occurrences.
-         We should revisit these later.  -->
     <Bug pattern="SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE"/>
     <Bug pattern="MS_EXPOSE_REP"/>
-    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <!-- The following patterns have been excluded as part of upgrading to Java 17 as there were 100s of occurrences.
+         We should revisit these later.  -->
     <Bug pattern="EI_EXPOSE_STATIC_REP2"/>
     <Bug pattern="SS_SHOULD_BE_STATIC"/>
     <Bug pattern="SING_SINGLETON_IMPLEMENTS_SERIALIZABLE"/>

--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -143,6 +143,5 @@
     <Bug pattern="MS_EXPOSE_REP"/>
     <!-- The following patterns have been excluded as part of upgrading to Java 17 as there were 100s of occurrences.
          We should revisit these later.  -->
-    <Bug pattern="SS_SHOULD_BE_STATIC"/>
     <Bug pattern="SING_SINGLETON_IMPLEMENTS_SERIALIZABLE"/>
 </FindBugsFilter>

--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -143,7 +143,6 @@
     <Bug pattern="MS_EXPOSE_REP"/>
     <!-- The following patterns have been excluded as part of upgrading to Java 17 as there were 100s of occurrences.
          We should revisit these later.  -->
-    <Bug pattern="EI_EXPOSE_STATIC_REP2"/>
     <Bug pattern="SS_SHOULD_BE_STATIC"/>
     <Bug pattern="SING_SINGLETON_IMPLEMENTS_SERIALIZABLE"/>
 </FindBugsFilter>

--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -137,11 +137,10 @@
     <Bug pattern="SWL_SLEEP_WITH_LOCK_HELD"/>
     <Bug pattern="UL_UNRELEASED_LOCK_EXCEPTION_PATH"/>
     <Bug pattern="URF_UNREAD_FIELD"/>
-    <!-- The following patterns have been excluded as part of upgrading to Java 17 as there were 100s of occurrences.
-         We should revisit these later.  -->
     <Bug pattern="CT_CONSTRUCTOR_THROW"/>
     <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
-    <Bug pattern="DCN_NULLPOINTER_EXCEPTION"/>
+    <!-- The following patterns have been excluded as part of upgrading to Java 17 as there were 100s of occurrences.
+         We should revisit these later.  -->
     <Bug pattern="SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE"/>
     <Bug pattern="MS_EXPOSE_REP"/>
     <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>

--- a/codestyle/spotbugs-exclude.xml
+++ b/codestyle/spotbugs-exclude.xml
@@ -141,7 +141,5 @@
     <Bug pattern="SING_SINGLETON_HAS_NONPRIVATE_CONSTRUCTOR"/>
     <Bug pattern="SING_SINGLETON_INDIRECTLY_IMPLEMENTS_CLONEABLE"/>
     <Bug pattern="MS_EXPOSE_REP"/>
-    <!-- The following patterns have been excluded as part of upgrading to Java 17 as there were 100s of occurrences.
-         We should revisit these later.  -->
     <Bug pattern="SING_SINGLETON_IMPLEMENTS_SERIALIZABLE"/>
 </FindBugsFilter>

--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerConfig.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesAndWorkerTaskRunnerConfig.java
@@ -31,8 +31,8 @@ import javax.annotation.Nullable;
 public class KubernetesAndWorkerTaskRunnerConfig
 {
 
-  private final String RUNNER_STRATEGY_TYPE = "runnerStrategy.type";
-  private final String RUNNER_STRATEGY_WORKER_TYPE = "runnerStrategy.workerType";
+  private static final String RUNNER_STRATEGY_TYPE = "runnerStrategy.type";
+  private static final String RUNNER_STRATEGY_WORKER_TYPE = "runnerStrategy.workerType";
   /**
    * Select which runner type a task would run on, options are k8s or worker.
    */

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/updater/CoordinatorBasicAuthenticatorMetadataStorageUpdater.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/updater/CoordinatorBasicAuthenticatorMetadataStorageUpdater.java
@@ -74,7 +74,7 @@ public class CoordinatorBasicAuthenticatorMetadataStorageUpdater implements Basi
   private final BasicAuthCommonCacheConfig commonCacheConfig;
   private final ObjectMapper objectMapper;
   private final BasicAuthenticatorCacheNotifier cacheNotifier;
-  private static final int numRetries = 5;
+  private static final int NUM_RETRIES = 5;
 
   private final Map<String, BasicAuthenticatorUserMapBundle> cachedUserMaps;
   private final Set<String> authenticatorPrefixes;
@@ -294,7 +294,7 @@ public class CoordinatorBasicAuthenticatorMetadataStorageUpdater implements Basi
   private void createUserInternal(String prefix, String userName)
   {
     int attempts = 0;
-    while (attempts < numRetries) {
+    while (attempts < NUM_RETRIES) {
       if (createUserOnce(prefix, userName)) {
         return;
       } else {
@@ -308,7 +308,7 @@ public class CoordinatorBasicAuthenticatorMetadataStorageUpdater implements Basi
   private void deleteUserInternal(String prefix, String userName)
   {
     int attempts = 0;
-    while (attempts < numRetries) {
+    while (attempts < NUM_RETRIES) {
       if (deleteUserOnce(prefix, userName)) {
         return;
       } else {
@@ -349,7 +349,7 @@ public class CoordinatorBasicAuthenticatorMetadataStorageUpdater implements Basi
     }
 
     int attempts = 0;
-    while (attempts < numRetries) {
+    while (attempts < NUM_RETRIES) {
       if (setUserCredentialOnce(prefix, userName, credentials)) {
         return;
       } else {

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/updater/CoordinatorBasicAuthenticatorMetadataStorageUpdater.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authentication/db/updater/CoordinatorBasicAuthenticatorMetadataStorageUpdater.java
@@ -74,7 +74,7 @@ public class CoordinatorBasicAuthenticatorMetadataStorageUpdater implements Basi
   private final BasicAuthCommonCacheConfig commonCacheConfig;
   private final ObjectMapper objectMapper;
   private final BasicAuthenticatorCacheNotifier cacheNotifier;
-  private final int numRetries = 5;
+  private static final int numRetries = 5;
 
   private final Map<String, BasicAuthenticatorUserMapBundle> cachedUserMaps;
   private final Set<String> authenticatorPrefixes;

--- a/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/updater/CoordinatorBasicAuthorizerMetadataStorageUpdater.java
+++ b/extensions-core/druid-basic-security/src/main/java/org/apache/druid/security/basic/authorization/db/updater/CoordinatorBasicAuthorizerMetadataStorageUpdater.java
@@ -91,7 +91,7 @@ public class CoordinatorBasicAuthorizerMetadataStorageUpdater implements BasicAu
   private final BasicAuthorizerCacheNotifier cacheNotifier;
   private final BasicAuthCommonCacheConfig commonCacheConfig;
   private final ObjectMapper objectMapper;
-  private final int numRetries = 5;
+  private static final int numRetries = 5;
 
   private final Map<String, BasicAuthorizerUserMapBundle> cachedUserMaps;
   private final Map<String, BasicAuthorizerGroupMappingMapBundle> cachedGroupMappingMaps;

--- a/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/OIDCConfig.java
+++ b/extensions-core/druid-pac4j/src/main/java/org/apache/druid/security/pac4j/OIDCConfig.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 
 public class OIDCConfig
 {
-  private final String DEFAULT_SCOPE = "name";
+  private static final String DEFAULT_SCOPE = "name";
   @JsonProperty
   private final String clientID;
 

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogram.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogram.java
@@ -41,8 +41,8 @@ public class ApproximateHistogram
   // max size of the histogram (number of bincount/position pairs)
   int size;
 
-  public float[] positions;
-  public long[] bins;
+  protected float[] positions;
+  private long[] bins;
 
   // used bincount
   int binCount;

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogram.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogram.java
@@ -42,7 +42,7 @@ public class ApproximateHistogram
   int size;
 
   protected float[] positions;
-  private long[] bins;
+  protected long[] bins;
 
   // used bincount
   int binCount;

--- a/processing/src/main/java/org/apache/druid/query/aggregation/Histogram.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/Histogram.java
@@ -27,11 +27,11 @@ import java.util.Arrays;
 
 public class Histogram
 {
-  public float[] breaks;
-  public long[] bins;
-  public transient long count;
-  public float min;
-  public float max;
+  private float[] breaks;
+  protected long[] bins;
+  protected transient long count;
+  private float min;
+  private float max;
 
   public Histogram(float[] breaks)
   {

--- a/processing/src/main/java/org/apache/druid/query/aggregation/Histogram.java
+++ b/processing/src/main/java/org/apache/druid/query/aggregation/Histogram.java
@@ -27,11 +27,11 @@ import java.util.Arrays;
 
 public class Histogram
 {
-  private float[] breaks;
+  protected float[] breaks;
   protected long[] bins;
   protected transient long count;
-  private float min;
-  private float max;
+  protected float min;
+  protected float max;
 
   public Histogram(float[] breaks)
   {

--- a/processing/src/main/java/org/apache/druid/query/extraction/BucketExtractionFn.java
+++ b/processing/src/main/java/org/apache/druid/query/extraction/BucketExtractionFn.java
@@ -81,7 +81,7 @@ public class BucketExtractionFn implements ExtractionFn
     try {
       return bucket(Double.parseDouble(value));
     }
-    catch (NumberFormatException | NullPointerException ex) {
+    catch (NumberFormatException ex) {
       return null;
     }
   }

--- a/processing/src/main/java/org/apache/druid/segment/incremental/SpatialDimensionRowTransformer.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/SpatialDimensionRowTransformer.java
@@ -213,10 +213,14 @@ public class SpatialDimensionRowTransformer implements Function<InputRow, InputR
   @Nullable
   private static Float tryParseFloat(String val)
   {
+    if (val == null) {
+      return null;
+    }
+
     try {
       return Float.parseFloat(val);
     }
-    catch (NullPointerException | NumberFormatException e) {
+    catch (NumberFormatException e) {
       return null;
     }
   }

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
@@ -597,7 +597,7 @@ public class JettyServerModule extends JerseyServletModule
   }
 
   @VisibleForTesting
-  public static void setJettyServerThreadPool(QueuedThreadPool threadPool)
+  protected static void setJettyServerThreadPool(QueuedThreadPool threadPool)
   {
     jettyServerThreadPool = threadPool;
   }


### PR DESCRIPTION
### Description

With #17466, we excluded a bunch of spotbugs patterns to avoid irrelevant changes to that PR, and decided to revisit them as a follow-up action item.

This PR re-visits all the spotbugs patterns we disabled at that time, and enables some of them. The ones which are still kept disabled are mostly either false alarms, or would require a wider scoped design change.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
