### PR TITLE
Fix Hadoop Indexing CLI for versions JDK v9+

### DIFF
--- a/services/src/main/java/org/apache/druid/cli/CliHadoopIndexer.java
+++ b/services/src/main/java/org/apache/druid/cli/CliHadoopIndexer.java
@@ -29,6 +29,7 @@ import org.apache.druid.guice.ExtensionsLoader;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.Initialization;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.utils.JvmUtils;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -39,6 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
+ *
  */
 @Command(
     name = "hadoop",
@@ -55,12 +57,12 @@ public class CliHadoopIndexer implements Runnable
   private String argumentSpec;
 
   @Option(name = {"-c", "--coordinate", "hadoopDependencies"},
-          description = "extra dependencies to pull down (e.g. non-default hadoop coordinates or extra hadoop jars)")
+      description = "extra dependencies to pull down (e.g. non-default hadoop coordinates or extra hadoop jars)")
   @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
   private List<String> coordinates;
 
   @Option(name = "--no-default-hadoop",
-          description = "don't pull down the default hadoop version")
+      description = "don't pull down the default hadoop version")
   public boolean noDefaultHadoop;
 
   @Inject
@@ -84,9 +86,7 @@ public class CliHadoopIndexer implements Runnable
         extensionURLs.addAll(Arrays.asList(extensionLoader.getURLs()));
       }
 
-      final List<URL> nonHadoopURLs = Arrays.asList(
-          ((URLClassLoader) CliHadoopIndexer.class.getClassLoader()).getURLs()
-      );
+      final List<URL> nonHadoopURLs = JvmUtils.systemClassPath();
 
       final List<URL> driverURLs = new ArrayList<>(nonHadoopURLs);
       // put hadoop dependencies last to avoid jets3t & apache.httpcore version conflicts
@@ -95,7 +95,10 @@ public class CliHadoopIndexer implements Runnable
         driverURLs.addAll(Arrays.asList(hadoopLoader.getURLs()));
       }
 
-      final URLClassLoader loader = new URLClassLoader(driverURLs.toArray(new URL[0]), null);
+      final URLClassLoader loader = new URLClassLoader(
+          driverURLs.toArray(new URL[0]),
+          ClassLoader.getSystemClassLoader()
+      );
       Thread.currentThread().setContextClassLoader(loader);
 
       final List<URL> jobUrls = new ArrayList<>();


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #17574.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

For JDK v9+ this job will fail as URLClassloader is no longer the default classloader. Additionally, with the introduction of the jmod system, the job failed to find the correct JDK-included modules because the new classloader constructed for the job didn't reference the system classloader. Adding ClassLoader.getSystemClassLoader() as the parent classloader fixes this.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note

Fix Hadoop Indexing CLI for versions JDK v9+


<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `services/src/main/java/org/apache/druid/cli/CliHadoopIndexer.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
