### PR TITLE
Upgrade maven commit-id plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1729,9 +1729,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.9.10</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>9.0.1</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
old versions of this plugin takes ~2sec to execute; now that jdk11 is minimum it could be upgraded to get a faster versijon