### PR TITLE
Add ingest/processed/bytes metric

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -993,6 +993,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler, Pe
         emitMetric(toolbox.getEmitter(), "ingest/segments/count",
                    published.getSegments().size() + tombStones.size()
         );
+        emitMetric(toolbox.getEmitter(), "ingest/processed/bytes", buildSegmentsMeters.getProcessedBytes());
 
         log.debugSegments(published.getSegments(), "Published segments");
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -1633,6 +1633,14 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
     );
     buildSegmentsRowStats.addRowIngestionMetersTotals(rowStatsForRunningTasks);
 
+    // Emit the processed bytes metric
+    try {
+      emitMetric(toolbox.getEmitter(), "ingest/processed/bytes", rowStatsForRunningTasks.getProcessedBytes());
+    }
+    catch (Exception e) {
+      LOG.warn(e, "Unable to emit processed bytes metric");
+    }
+
     return createStatsAndErrorsReport(buildSegmentsRowStats.getTotals(), unparseableEvents);
   }
 


### PR DESCRIPTION
A new metric `ingest/processed/bytes` is added to track the total number of bytes processed during ingestion tasks. 

#### Key changed/added classes in this PR
This metric was added in three key ingestion task classes:

- IndexTask: A sequential ingestion task. The processed bytes were retrieved from the RowIngestionMetersTotals object (buildSegmentsMeters) and emitted directly after segment publication.
- ParallelIndexSupervisorTask: A task that supervises parallel ingestion. Processed bytes were aggregated from subtasks' ingestion metrics (RowIngestionMetersTotals) and emitted safely with exception handling to ensure robustness.
- SeekableStreamIndexTaskRunner: A runner for ingestion tasks that consume data from seekable streams (e.g., Kafka). The processed bytes were calculated based on the size of the data buffers (e.g., ByteEntity buffers) being processed for each record. The metric was emitted for each processed record.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
