### PR TITLE
Remove duplicate context from Request Logging

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -133,7 +133,6 @@ public class SqlExecutionReporter
         statsMap.put("identity", plannerContext.getAuthenticationResult().getIdentity());
         queryContext.put("nativeQueryIds", plannerContext.getNativeQueryIds().toString());
       }
-      statsMap.put("context", queryContext);
       if (e != null) {
         statsMap.put("exception", e.toString());
 

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -1905,7 +1905,7 @@ public class SqlResourceTest extends CalciteTestBase
     Assert.assertEquals(1, testRequestLogger.getSqlQueryLogs().size());
 
     final Map<String, Object> stats = testRequestLogger.getSqlQueryLogs().get(0).getQueryStats().getStats();
-    final Map<String, Object> queryContext = (Map<String, Object>) stats.get("context");
+    final Map<String, Object> queryContext = (Map<String, Object>) testRequestLogger.getSqlQueryLogs().get(0).getSqlQueryContext();
     Assert.assertEquals(success, stats.get("success"));
     Assert.assertEquals(CalciteTests.REGULAR_USER_AUTH_RESULT.getIdentity(), stats.get("identity"));
     Assert.assertTrue(stats.containsKey("sqlQuery/time"));


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
* Currently, for SQL queries, whenever we output the Request Log, we are printing the `context` map twice on the same log line, once in the query stats map, and other during the request log line's queryContext.
* This causes unnecessary duplication of data in the request log, and also increases the volume of data that we send to our logging systems like Splunk, or File based loggers. 
* Steps to Reproduce:
  *  Using quick-start scripts, start the Druid cluster
  * Load the `wikipedia` dataset (https://druid.apache.org/docs/latest/tutorials/tutorial-kafka/) 
  * Update `apache-druid-31.0.0/conf/druid/auto/_common/common.runtime.properties` to include the following and run any sample SQL query on the console: 

 
```
druid.request.logging.type=file
druid.request.logging.dir=/tmp/druidLogs
```
* The request logger will output lines as: 
```
2024-12-10T23:41:10.909Z	127.0.0.1		{"sqlQuery/time":440,"sqlQuery/planningTimeMs":357,"sqlQuery/bytes":326208,"success":true,"identity":"allowAll","context":{"sqlQueryId":"95f73480-0916-48c9-bd1c-5c24a439c528","sqlOuterLimit":1001,"maxNumTasks":2,"priority":1,"sqlStringifyArrays":false,"queryId":"95f73480-0916-48c9-bd1c-5c24a439c528","nativeQueryIds":"[95f73480-0916-48c9-bd1c-5c24a439c528]"}}	{"query":"SELECT *\nFROM \"wikipedia\"","context":{"sqlQueryId":"95f73480-0916-48c9-bd1c-5c24a439c528","sqlOuterLimit":1001,"maxNumTasks":2,"priority":1,"sqlStringifyArrays":false,"queryId":"95f73480-0916-48c9-bd1c-5c24a439c528","nativeQueryIds":"[95f73480-0916-48c9-bd1c-5c24a439c528]"}}
```
* Formatted JSON looks like, which shows that we have the same information being printed on the same log line: 
```
{
  "sqlQuery/time": 440,
  "sqlQuery/planningTimeMs": 357,
  "sqlQuery/bytes": 326208,
  "success": true,
  "identity": "allowAll",
  "context": {
    "sqlQueryId": "95f73480-0916-48c9-bd1c-5c24a439c528",
    "sqlOuterLimit": 1001,
    "maxNumTasks": 2,
    "priority": 1,
    "sqlStringifyArrays": false,
    "queryId": "95f73480-0916-48c9-bd1c-5c24a439c528",
    "nativeQueryIds": "[95f73480-0916-48c9-bd1c-5c24a439c528]"
  }
}

{
  "query": "SELECT *\nFROM \"wikipedia\"",
  "context": {
    "sqlQueryId": "95f73480-0916-48c9-bd1c-5c24a439c528",
    "sqlOuterLimit": 1001,
    "maxNumTasks": 2,
    "priority": 1,
    "sqlStringifyArrays": false,
    "queryId": "95f73480-0916-48c9-bd1c-5c24a439c528",
    "nativeQueryIds": "[95f73480-0916-48c9-bd1c-5c24a439c528]"
  }
}
```

* **Proposal**:  Remove the context from the `statsMap`, and print it only in the request log line. The new log line will look like: 
```
{
  "sqlQuery/time": 440,
  "sqlQuery/planningTimeMs": 357,
  "sqlQuery/bytes": 326208,
  "success": true,
  "identity": "allowAll"
}

{
  "query": "SELECT *\nFROM \"wikipedia\"",
  "context": {
    "sqlQueryId": "95f73480-0916-48c9-bd1c-5c24a439c528",
    "sqlOuterLimit": 1001,
    "maxNumTasks": 2,
    "priority": 1,
    "sqlStringifyArrays": false,
    "queryId": "95f73480-0916-48c9-bd1c-5c24a439c528",
    "nativeQueryIds": "[95f73480-0916-48c9-bd1c-5c24a439c528]"
  }
}
```
* https://github.com/apache/druid/blob/8b81c919792edbb78c7050d63e326cbbc6e2752a/docs/configuration/index.md?plain=1#L293 documentation already captures this behavior.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
* Changed: The SQL request logger now does not print the query context twice. Previously, it printed query context twice on the same log line, once in the query statistics, and other in the request log line.
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `SqlExecutionReporter.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
