### PR TITLE
Update Apache mirror host to downloads.apache.org

### DIFF
--- a/examples/quickstart/tutorial/hadoop/docker/Dockerfile
+++ b/examples/quickstart/tutorial/hadoop/docker/Dockerfile
@@ -60,8 +60,8 @@ ENV JAVA_HOME=/usr/lib/jvm/zulu17
 ENV PATH $PATH:$JAVA_HOME/bin
 
 # hadoop
-ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
-RUN curl -s ${APACHE_ARCHIVE_MIRROR_HOST}/dist/hadoop/core/hadoop-3.3.6/hadoop-3.3.6.tar.gz | tar -xz -C /usr/local/
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://downloads.apache.org
+RUN curl -s ${APACHE_ARCHIVE_MIRROR_HOST}/hadoop/core/hadoop-3.3.6/hadoop-3.3.6.tar.gz | tar -xz -C /usr/local/
 RUN cd /usr/local && ln -s ./hadoop-3.3.6 hadoop
 
 ENV HADOOP_HOME /usr/local/hadoop

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -46,7 +46,7 @@ environment variable to localhost on your system, as follows:
 export DOCKER_IP=127.0.0.1
 ```
 
-Optionally, you can also set `APACHE_ARCHIVE_MIRROR_HOST` to override `https://archive.apache.org` host. This host is used to download archives such as hadoop and kafka during building docker images:
+Optionally, you can also set `APACHE_ARCHIVE_MIRROR_HOST` to override `https://downloads.apache.org` host. This host is used to download archives such as hadoop and kafka during building docker images:
 
 ```bash
 export APACHE_ARCHIVE_MIRROR_HOST=https://example.com/remote-generic-repo

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -24,7 +24,7 @@ ARG KAFKA_VERSION
 # ZooKeeper version to install in the base image
 # This is passed in by maven at build time to align with the client version we depend on in the pom file
 ARG ZK_VERSION
-ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://downloads.apache.org
 ARG SETUP_RETRIES=3
 # Retry mechanism for running the setup script up to limit of 3 times.
 RUN set -e; \

--- a/integration-tests/docker/base-setup.sh
+++ b/integration-tests/docker/base-setup.sh
@@ -18,7 +18,7 @@ set -e
 set -u
 
 export DEBIAN_FRONTEND=noninteractive
-APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST:-https://archive.apache.org}
+APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST:-https://downloads.apache.org}
 
 apt-get update
 
@@ -34,7 +34,7 @@ apt-get install -y supervisor
 # Zookeeper
 
 install_zk() {
-  wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/dist/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
+  wget -q -O /tmp/$ZK_TAR.tar.gz "$APACHE_ARCHIVE_MIRROR_HOST/zookeeper/zookeeper-$ZK_VERSION/$ZK_TAR.tar.gz"
   tar -xzf /tmp/$ZK_TAR.tar.gz -C /usr/local
   cp /usr/local/$ZK_TAR/conf/zoo_sample.cfg /usr/local/$ZK_TAR/conf/zoo.cfg
   rm /tmp/$ZK_TAR.tar.gz
@@ -46,7 +46,7 @@ ln -s /usr/local/$ZK_TAR /usr/local/zookeeper
 
 # Kafka
 # KAFKA_VERSION is defined by docker build arguments
-wget -q -O /tmp/kafka_2.13-$KAFKA_VERSION.tgz "$APACHE_ARCHIVE_MIRROR_HOST/dist/kafka/$KAFKA_VERSION/kafka_2.13-$KAFKA_VERSION.tgz"
+wget -q -O /tmp/kafka_2.13-$KAFKA_VERSION.tgz "$APACHE_ARCHIVE_MIRROR_HOST/kafka/$KAFKA_VERSION/kafka_2.13-$KAFKA_VERSION.tgz"
 tar -xzf /tmp/kafka_2.13-$KAFKA_VERSION.tgz -C /usr/local
 ln -s /usr/local/kafka_2.13-$KAFKA_VERSION /usr/local/kafka
 rm /tmp/kafka_2.13-$KAFKA_VERSION.tgz


### PR DESCRIPTION
### Description

We currently point `APACHE_ARCHIVE_MIRROR_HOST`  to `https://archive.apache.org/`.

https://archive.apache.org/dist/ says the following: `THEY MAY BE UNSUPPORTED AND UNSAFE TO USE. Current releases can be found on our download server.` (download server being https://downloads.apache.org/)

We had a lot of flaky standard ITs because of transient networking issues, which were surfacing as `Error while posting dynamic config` errors because of a bug introduced recently, discussed [here](https://github.com/apache/druid/pull/17543#discussion_r1893632630).

While switching to https://downloads.apache.org doesn't seem to solve the flakiness issue (as one of the standard ITs on this PR is still failing with `Error while posting dynamic config` error because of exhausting all 3 retries for running base-setup.sh), we should move to it as it's recommended, and might potentially help reduce flakiness to some extent.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
