### PR TITLE
Docs: Add SQL query example

### DIFF
--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -92,7 +92,7 @@ The request body takes the following properties:
     ```json
     {
         "query": "SELECT \"arrayDouble\" FROM \"array_example\" WHERE ARRAY_CONTAINS(\"arrayDouble\", ?)",
-        "parameters": [{"type": "ARRAY", "value": [999, null, 5.5]}]
+        "parameters": [{"type": "ARRAY", "value": [999.0, null, 5.5]},{"type":"VARCHAR","value":"bar"}]
     }
     ```
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -85,20 +85,15 @@ The request body takes the following properties:
 
 * `context`: JSON object containing optional [SQL query context parameters](../querying/sql-query-context.md), such as to set the query ID, time zone, and whether to use an approximation algorithm for distinct count.
 
-* `parameters`: List of query parameters for parameterized queries. Each parameter in the array should be a JSON object containing the parameter's SQL data type and parameter value. For a list of supported SQL types, see [Data types](../querying/sql-data-types.md).
+* `parameters`: List of query parameters for parameterized queries. Each parameter in the array should be a JSON object containing the parameter's SQL data type and parameter value. For more information on using dynamic parameters, see [Dynamic parameters](../querying/sql.md#dynamic-parameters). For a list of supported SQL types, see [Data types](../querying/sql-data-types.md).
 
     For example:
+
     ```json
-    "parameters": [
-        {
-            "type": "VARCHAR",
-            "value": "bar"
-        },
-        {
-            "type": "ARRAY",
-            "value": [-25.7, null, 36.85]
-        }
-    ]
+    {
+        "query": "SELECT \"arrayDouble\" FROM \"array_example\" WHERE ARRAY_CONTAINS(\"arrayDouble\", ?)",
+        "parameters": [{"type": "ARRAY", "value": [999, null, 5.5]}]
+    }
     ```
 
 #### Responses
@@ -154,7 +149,6 @@ For line-oriented formats, Druid includes a newline character as the final chara
 If you detect a truncated response, treat it as an error.
 
 ---
-
 
 #### Sample request
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -94,7 +94,7 @@ The request body takes the following properties:
         "query": "SELECT \"arrayDouble\", \"stringColumn\" FROM \"array_example\" WHERE ARRAY_CONTAINS(\"arrayDouble\", ?) AND \"stringColumn\" = ?",
         "parameters": [
             {"type": "ARRAY", "value": [999.0, null, 5.5]},
-            {"type":"VARCHAR","value":"bar"}
+            {"type": "VARCHAR", "value": "bar"}
             ]
     }
     ```

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -91,8 +91,11 @@ The request body takes the following properties:
 
     ```json
     {
-        "query": "SELECT \"arrayDouble\" FROM \"array_example\" WHERE ARRAY_CONTAINS(\"arrayDouble\", ?)",
-        "parameters": [{"type": "ARRAY", "value": [999.0, null, 5.5]},{"type":"VARCHAR","value":"bar"}]
+        "query": "SELECT \"arrayDouble\", \"stringColumn\" FROM \"array_example\" WHERE ARRAY_CONTAINS(\"arrayDouble\", ?) AND \"stringColumn\" = ?",
+        "parameters": [
+            {"type": "ARRAY", "value": [999.0, null, 5.5]},
+            {"type":"VARCHAR","value":"bar"}
+            ]
     }
     ```
 

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -432,7 +432,7 @@ SELECT arrayColumn from druid.table where ARRAY_CONTAINS(arrayColumn, ?)
 ```
 
 You can replace an IN filter with many values by dynamically passing a parameter into [SCALAR_IN_ARRAY](sql-functions.md#scalar_in_array).
-For sample java queries, see [Dynamic parameters](../api-reference/sql-jdbc.md#dynamic-parameters).
+For example Java queries, see [Dynamic parameters](../api-reference/sql-jdbc.md#dynamic-parameters).
 
 ```sql
 SELECT count(city) from druid.table where SCALAR_IN_ARRAY(city, ?)

--- a/docs/querying/sql.md
+++ b/docs/querying/sql.md
@@ -403,7 +403,7 @@ The following example query uses the [ARRAY_CONTAINS](./sql-functions.md#array_c
 
 ```sql
 {
-   "query": "SELECT doubleArrayColumn from druid.table where ARRAY_CONTAINS(?, doubleArrayColumn)",
+   "query": "SELECT doubleArrayColumn from druid.table where ARRAY_CONTAINS(doubleArrayColumn, ?)",
    "parameters": [
       {
         "type": "ARRAY",
@@ -428,16 +428,15 @@ SELECT * FROM druid.foo WHERE dim1 like CONCAT('%', CAST (? AS VARCHAR), '%')
 Dynamic parameters can even replace arrays, reducing the parsing time. Refer to the parameters in the [API request body](../api-reference/sql-api.md#request-body) for usage.
 
 ```sql
-SELECT arrayColumn from druid.table where ARRAY_CONTAINS(?, arrayColumn)
+SELECT arrayColumn from druid.table where ARRAY_CONTAINS(arrayColumn, ?)
 ```
 
-With this, an IN filter being supplied with a lot of values, can be replaced by a dynamic parameter passed inside [SCALAR_IN_ARRAY](sql-functions.md#scalar_in_array)
+You can replace an IN filter with many values by dynamically passing a parameter into [SCALAR_IN_ARRAY](sql-functions.md#scalar_in_array).
+For sample java queries, see [Dynamic parameters](../api-reference/sql-jdbc.md#dynamic-parameters).
 
 ```sql
 SELECT count(city) from druid.table where SCALAR_IN_ARRAY(city, ?)
 ```
-
-sample java code using dynamic parameters is provided [here](../api-reference/sql-jdbc.md#dynamic-parameters).
 
 ## Reserved keywords
 


### PR DESCRIPTION
Add a SQL query example showing how to pass dynamic parameters.

Tested using CURL:

```
curl "http://localhost:8888/druid/v2/sql" \
--header 'Content-Type: application/json' \
--data '{
    "query": "SELECT \"arrayDouble\" FROM \"array_example\" WHERE ARRAY_CONTAINS(\"arrayDouble\", ?)",
    "parameters": [{"type": "ARRAY", "value": [999, null, 5.5]}] 
}'
```

Returns:

`[{"arrayDouble":"[999.0,null,5.5]"}]`

This PR has:

- [x] been self-reviewed.