### PR TITLE
Shutdown exec on KubernetesTaskRunner stop

### DIFF
--- a/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -399,6 +399,8 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
   public void stop()
   {
     log.debug("Stopping KubernetesTaskRunner");
+    // Stop managing the running k8s jobs
+    exec.shutdownNow();
     cleanupExecutor.shutdownNow();
     log.debug("Stopped KubernetesTaskRunner");
   }

--- a/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
+++ b/extensions-contrib/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerTest.java
@@ -59,6 +59,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
@@ -758,5 +759,21 @@ public class KubernetesTaskRunnerTest extends EasyMockSupport
     Assert.assertEquals(1, runner.getUsedCapacity());
     runner.tasks.remove(task.getId());
     Assert.assertEquals(0, runner.getUsedCapacity());
+  }
+
+  @Test
+  public void test_stop()
+  {
+
+    KubernetesTaskRunner kubernetesTaskRunner = new KubernetesTaskRunner(
+        taskAdapter,
+        config,
+        peonClient,
+        httpClient,
+        new TestPeonLifecycleFactory(kubernetesPeonLifecycle),
+        emitter
+    );
+    kubernetesTaskRunner.stop();
+    Assert.assertThrows(RejectedExecutionException.class, () -> kubernetesTaskRunner.run(task));
   }
 }


### PR DESCRIPTION
Fixes a issue where the KubernetesTaskRunner still tracks task status after the overlord it is running on has lost leadership.

### Description
The KubernetesTaskRunner doesn't actually do anything to stop watching running tasks in its stop method(), so the threads watching each task continue running doTask(). In this situation, the task queue is already shutdown, so the only thing that happens is the 'phantom' KubernetesTaskRunner sending notifications to its task queue that get ignored and potentially task logs getting double uploaded.

This is still not ideal, so we should shutdown the exec Executor in the stop method. This won't stop any of the tasks (they're running on k8s), but will stop the overlord's management of these tasks, which is the correct behavior.

#### Fixed the bug ...
#### Renamed the class ...
#### Added a forbidden-apis entry ...
Fixed a bug with overlord shutdown in mmless mode.

#### Release note
Bugfix with mmless ingestion.

##### Key changed/added classes in this PR
 * `KubernetesTaskRunner`


This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
