### PR TITLE
Do not use deprecated Jackson API ObjectMapper.writerWithType()

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -2,6 +2,7 @@ com.fasterxml.jackson.databind.ObjectMapper#reader(com.fasterxml.jackson.core.ty
 com.fasterxml.jackson.databind.ObjectMapper#reader(com.fasterxml.jackson.databind.JavaType) @ Use ObjectMapper#readerFor instead
 com.fasterxml.jackson.databind.ObjectMapper#reader(java.lang.Class) @ Use ObjectMapper#readerFor instead
 com.fasterxml.jackson.databind.ObjectMapper#writeValue(com.fasterxml.jackson.core.JsonGenerator, java.lang.Object) @ Use JacksonUtils#writeObjectUsingSerializerProvider to allow SerializerProvider reuse
+com.fasterxml.jackson.databind.ObjectMapper#writerWithType(com.fasterxml.jackson.core.type.TypeReference) @ Use ObjectMapper#writeFor instead
 com.fasterxml.jackson.core.JsonGenerator#writeObject(java.lang.Object) @ Use JacksonUtils#writeObjectUsingSerializerProvider to allow SerializerProvider reuse
 com.google.common.base.Charsets @ Use java.nio.charset.StandardCharsets instead
 com.google.common.collect.Iterators#emptyIterator() @ Use java.util.Collections#emptyIterator()

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DetermineHashedPartitionsJob.java
@@ -412,7 +412,7 @@ public class DetermineHashedPartitionsJob implements Jobby
 
       try {
         HadoopDruidIndexerConfig.JSON_MAPPER
-            .writerWithType(Long.class)
+            .writerFor(Long.class)
             .writeValue(out, aggregate.estimateCardinalityRound());
       }
       finally {
@@ -430,7 +430,7 @@ public class DetermineHashedPartitionsJob implements Jobby
         final OutputStream out = Utils.makePathAndOutputStream(context, outPath, config.isOverwriteFiles());
 
         try {
-          HadoopDruidIndexerConfig.JSON_MAPPER.writerWithType(
+          HadoopDruidIndexerConfig.JSON_MAPPER.writerFor(
               new TypeReference<List<Interval>>()
               {
               }

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/DeterminePartitionsJob.java
@@ -920,7 +920,7 @@ public class DeterminePartitionsJob implements Jobby
 
       try {
         HadoopDruidIndexerConfig.JSON_MAPPER
-            .writerWithType(
+            .writerFor(
                 new TypeReference<List<ShardSpec>>()
                 {
                 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/TaskManagementResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/http/TaskManagementResource.java
@@ -167,7 +167,7 @@ public class TaskManagementResource
             try {
               HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
               response.setStatus(HttpServletResponse.SC_OK);
-              context.inputMapper.writerWithType(WorkerHolder.WORKER_SYNC_RESP_TYPE_REF)
+              context.inputMapper.writerFor(WorkerHolder.WORKER_SYNC_RESP_TYPE_REF)
                                  .writeValue(asyncContext.getResponse().getOutputStream(), result);
               asyncContext.complete();
             }

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
@@ -132,7 +132,7 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
   )
   {
     this.jsonMapper = jsonMapper;
-    this.requestBodyWriter = jsonMapper.writerWithType(REQUEST_ENTITY_TYPE_REF);
+    this.requestBodyWriter = jsonMapper.writerFor(REQUEST_ENTITY_TYPE_REF);
     this.httpClient = httpClient;
     this.config = config;
     this.processingExecutor = processingExecutor;

--- a/server/src/main/java/org/apache/druid/server/http/SegmentListerResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/SegmentListerResource.java
@@ -182,7 +182,7 @@ public class SegmentListerResource
             try {
               HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
               response.setStatus(HttpServletResponse.SC_OK);
-              context.inputMapper.writerWithType(HttpServerInventoryView.SEGMENT_LIST_RESP_TYPE_REF)
+              context.inputMapper.writerFor(HttpServerInventoryView.SEGMENT_LIST_RESP_TYPE_REF)
                                  .writeValue(asyncContext.getResponse().getOutputStream(), result);
               asyncContext.complete();
             }
@@ -295,7 +295,7 @@ public class SegmentListerResource
             try {
               HttpServletResponse response = (HttpServletResponse) asyncContext.getResponse();
               response.setStatus(HttpServletResponse.SC_OK);
-              context.inputMapper.writerWithType(HttpLoadQueuePeon.RESPONSE_ENTITY_TYPE_REF)
+              context.inputMapper.writerFor(HttpLoadQueuePeon.RESPONSE_ENTITY_TYPE_REF)
                                  .writeValue(asyncContext.getResponse().getOutputStream(), result);
               asyncContext.complete();
             }

--- a/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/ChangeRequestHttpSyncerTest.java
@@ -60,7 +60,7 @@ public class ChangeRequestHttpSyncerTest
         ImmutableList.of(
             Futures.immediateFuture(
                 new ByteArrayInputStream(
-                    jsonMapper.writerWithType(typeRef).writeValueAsBytes(
+                    jsonMapper.writerFor(typeRef).writeValueAsBytes(
                         new ChangeRequestsSnapshot(
                             false,
                             null,
@@ -72,7 +72,7 @@ public class ChangeRequestHttpSyncerTest
             ),
             Futures.immediateFuture(
                 new ByteArrayInputStream(
-                    jsonMapper.writerWithType(typeRef).writeValueAsBytes(
+                    jsonMapper.writerFor(typeRef).writeValueAsBytes(
                         new ChangeRequestsSnapshot(
                             false,
                             null,
@@ -84,7 +84,7 @@ public class ChangeRequestHttpSyncerTest
             ),
             Futures.immediateFuture(
                 new ByteArrayInputStream(
-                    jsonMapper.writerWithType(typeRef).writeValueAsBytes(
+                    jsonMapper.writerFor(typeRef).writeValueAsBytes(
                         new ChangeRequestsSnapshot(
                             true,
                             "reset the counter",
@@ -96,7 +96,7 @@ public class ChangeRequestHttpSyncerTest
             ),
             Futures.immediateFuture(
                 new ByteArrayInputStream(
-                    jsonMapper.writerWithType(typeRef).writeValueAsBytes(
+                    jsonMapper.writerFor(typeRef).writeValueAsBytes(
                         new ChangeRequestsSnapshot(
                             false,
                             null,
@@ -108,7 +108,7 @@ public class ChangeRequestHttpSyncerTest
             ),
             Futures.immediateFuture(
                 new ByteArrayInputStream(
-                    jsonMapper.writerWithType(typeRef).writeValueAsBytes(
+                    jsonMapper.writerFor(typeRef).writeValueAsBytes(
                         new ChangeRequestsSnapshot(
                             false,
                             null,

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
@@ -363,7 +363,7 @@ public class HttpLoadQueuePeonTest
         return (ListenableFuture<Final>) Futures.immediateFuture(
             new ByteArrayInputStream(
                 MAPPER
-                    .writerWithType(HttpLoadQueuePeon.RESPONSE_ENTITY_TYPE_REF)
+                    .writerFor(HttpLoadQueuePeon.RESPONSE_ENTITY_TYPE_REF)
                     .writeValueAsBytes(statuses)
             )
         );


### PR DESCRIPTION
### Changes

- Replace usages of `ObjectMapper.writeWithType()` with the recommended `ObjectMapper.writerFor()`
- There is no difference between the two implementations but the older method is deprecated
[since jackson version 2.5](https://fasterxml.github.io/jackson-databind/javadoc/2.5/com/fasterxml/jackson/databind/ObjectMapper.html#writerWithType(com.fasterxml.jackson.core.type.TypeReference)) and may be removed in the future