### PR TITLE
Docs: Mark use concurrent locks as GA

### DIFF
--- a/docs/data-management/automatic-compaction.md
+++ b/docs/data-management/automatic-compaction.md
@@ -173,7 +173,7 @@ You can use concurrent append and replace to safely replace the existing data in
 To do this, you need to update your datasource to allow concurrent append and replace tasks:
 
 * If you're using the API, include the following `taskContext` property in your API call: `"useConcurrentLocks": true`
-* If you're using the UI, enable **Use concurrent locks (experimental)** in the **Compaction config** for your datasource.
+* If you're using the UI, enable **Use concurrent locks** in the **Compaction config** for your datasource.
 
 You'll also need to update your ingestion jobs for the datasource to include the task context `"useConcurrentLocks": true`.
 

--- a/docs/ingestion/concurrent-append-replace.md
+++ b/docs/ingestion/concurrent-append-replace.md
@@ -22,21 +22,21 @@ title: Concurrent append and replace
   ~ under the License.
   -->
 
-Concurrent append and replace safely replaces the existing data in an interval of a datasource while new data is being appended to that interval. One of the most common applications of this feature is appending new data (such as with streaming ingestion) to an interval while compaction of that interval is already in progress. Druid segments the data ingested during this time dynamically. The subsequent compaction run segments the data into the  granularity you specified.
+Concurrent append and replace safely replaces the existing data in an interval of a datasource while new data is being appended to that interval. One of the most common applications of this feature is appending new data (such as with streaming ingestion) to an interval while compaction of that interval is already in progress. Druid partitions the data ingested during this time using `dynamic` partitioning. The subsequent compaction run would partition the data into the granularity you specified in the compaction config.
 
 To set up concurrent append and replace, use the context flag `useConcurrentLocks`. Druid will then determine the correct lock type for you, either append or replace. Although you can set the type of lock manually, we don't recommend it. 
 
-## Update the compaction settings 
+## Update compaction config to use concurrent locks
 
 If you want to append data to a datasource while compaction is running, you need to enable concurrent append and replace for the datasource by updating the compaction settings.
 
-### Update the compaction settings with the UI
+### Update compaction config from the Druid web-console
 
-In the **Compaction config** for a datasource, enable  **Use concurrent locks (experimental)**.
+In the **Compaction config** for a datasource, enable  **Use concurrent locks**.
 
 For details on accessing the compaction config in the UI, see [Enable automatic compaction with the web console](../data-management/automatic-compaction.md#manage-auto-compaction-using-the-web-console).
 
-### Update the compaction settings with the API
+### Update compaction config using REST API
  
 Add the `taskContext` like you would any other automatic compaction setting through the API:
 
@@ -51,17 +51,17 @@ curl --location --request POST 'http://localhost:8081/druid/coordinator/v1/confi
 }'
 ```
 
-## Configure a task lock type for your ingestion job
+## Use concurrent locks in ingestion jobs
 
-You also need to configure the ingestion job to allow concurrent tasks.
+You also need to configure the ingestion job to allow concurrent locks.
 
 You can provide the context parameter like any other parameter for ingestion jobs through the API or the UI.
 
-### Add a task lock using the Druid console
+### Use concurrent locks in the Druid web-console
 
-As part of the  **Load data** wizard for classic batch (JSON-based ingestion) and streaming ingestion, enable the following config on the **Publish** step: **Use concurrent locks (experimental)**.
+As part of the  **Load data** wizard for classic batch (JSON-based) ingestion and streaming ingestion, enable the following config on the **Publish** step: **Use concurrent locks**.
 
-### Add the task lock through the API
+### Use concurrent locks in the REST APIs
 
 Add the following JSON snippet to your supervisor or ingestion spec if you're using the API:
 
@@ -70,7 +70,14 @@ Add the following JSON snippet to your supervisor or ingestion spec if you're us
    "useConcurrentLocks": true
 }
 ```
- 
+
+## Update Overlord properties to use concurrent locks for all ingestion and compaction jobs
+
+Updating the compaction config and ingestion job for each data source can be cumbersome if you have several data sources in your cluster. You can instead set the following config in the `runtime.properties` of the Overlord service to use concurrent locks across all ingestion and compaction jobs.
+
+```bash
+druid.indexer.task.default.context={"useConcurrentLocks":true}
+```
 
 ## Task lock types
 

--- a/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
@@ -372,7 +372,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -782,7 +782,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -1192,7 +1192,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -1602,7 +1602,7 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>

--- a/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
@@ -35,15 +35,15 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
             },
             {
               "info": <p>
-                For perfect rollup, you should use either 
+                For perfect rollup, you should use either
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or 
+                 (partitioning based on the hash of dimensions in each row) or
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use 
+                 (based on several dimensions). For best-effort rollup, you should use
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -86,27 +86,27 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -128,33 +128,33 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to 
+                   renamed to
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -175,11 +175,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -224,11 +224,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -247,11 +247,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -358,7 +358,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
             </p>
             <p>
               For more information refer to the
-               
+
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -372,7 +372,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -445,15 +445,15 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
             },
             {
               "info": <p>
-                For perfect rollup, you should use either 
+                For perfect rollup, you should use either
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or 
+                 (partitioning based on the hash of dimensions in each row) or
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use 
+                 (based on several dimensions). For best-effort rollup, you should use
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -496,27 +496,27 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -538,33 +538,33 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to 
+                   renamed to
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -585,11 +585,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -634,11 +634,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -657,11 +657,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -768,7 +768,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
             </p>
             <p>
               For more information refer to the
-               
+
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -782,7 +782,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -855,15 +855,15 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
             },
             {
               "info": <p>
-                For perfect rollup, you should use either 
+                For perfect rollup, you should use either
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or 
+                 (partitioning based on the hash of dimensions in each row) or
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use 
+                 (based on several dimensions). For best-effort rollup, you should use
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -906,27 +906,27 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -948,33 +948,33 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to 
+                   renamed to
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -995,11 +995,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1044,11 +1044,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1067,11 +1067,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1178,7 +1178,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
             </p>
             <p>
               For more information refer to the
-               
+
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -1192,7 +1192,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -1265,15 +1265,15 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
             },
             {
               "info": <p>
-                For perfect rollup, you should use either 
+                For perfect rollup, you should use either
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or 
+                 (partitioning based on the hash of dimensions in each row) or
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use 
+                 (based on several dimensions). For best-effort rollup, you should use
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -1316,27 +1316,27 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1358,33 +1358,33 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to 
+                   renamed to
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If 
+                  If
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-                   
+
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by 
+                   automatically by
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1405,11 +1405,11 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1454,11 +1454,11 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1477,11 +1477,11 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either 
+                  Note that either
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or 
+                   or
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1588,7 +1588,7 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
             </p>
             <p>
               For more information refer to the
-               
+
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -1602,7 +1602,7 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks (experimental)"
+          label="Use concurrent locks"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>

--- a/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/compaction-config-dialog/__snapshots__/compaction-config-dialog.spec.tsx.snap
@@ -35,15 +35,15 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
             },
             {
               "info": <p>
-                For perfect rollup, you should use either
+                For perfect rollup, you should use either 
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or
+                 (partitioning based on the hash of dimensions in each row) or 
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use
+                 (based on several dimensions). For best-effort rollup, you should use 
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -86,27 +86,27 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -128,33 +128,33 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to
+                   renamed to 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -175,11 +175,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -224,11 +224,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -247,11 +247,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -358,7 +358,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
             </p>
             <p>
               For more information refer to the
-
+               
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -372,7 +372,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (dynamic 
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks"
+          label="Use concurrent locks (experimental)"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -445,15 +445,15 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
             },
             {
               "info": <p>
-                For perfect rollup, you should use either
+                For perfect rollup, you should use either 
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or
+                 (partitioning based on the hash of dimensions in each row) or 
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use
+                 (based on several dimensions). For best-effort rollup, you should use 
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -496,27 +496,27 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -538,33 +538,33 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to
+                   renamed to 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -585,11 +585,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -634,11 +634,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -657,11 +657,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -768,7 +768,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
             </p>
             <p>
               For more information refer to the
-
+               
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -782,7 +782,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (hashed p
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks"
+          label="Use concurrent locks (experimental)"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -855,15 +855,15 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
             },
             {
               "info": <p>
-                For perfect rollup, you should use either
+                For perfect rollup, you should use either 
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or
+                 (partitioning based on the hash of dimensions in each row) or 
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use
+                 (based on several dimensions). For best-effort rollup, you should use 
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -906,27 +906,27 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -948,33 +948,33 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to
+                   renamed to 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -995,11 +995,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1044,11 +1044,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1067,11 +1067,11 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1178,7 +1178,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
             </p>
             <p>
               For more information refer to the
-
+               
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -1192,7 +1192,7 @@ exports[`CompactionConfigDialog matches snapshot with compactionConfig (range pa
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks"
+          label="Use concurrent locks (experimental)"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>
@@ -1265,15 +1265,15 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
             },
             {
               "info": <p>
-                For perfect rollup, you should use either
+                For perfect rollup, you should use either 
                 <ForwardRef>
                   hashed
                 </ForwardRef>
-                 (partitioning based on the hash of dimensions in each row) or
+                 (partitioning based on the hash of dimensions in each row) or 
                 <ForwardRef>
                   range
                 </ForwardRef>
-                 (based on several dimensions). For best-effort rollup, you should use
+                 (based on several dimensions). For best-effort rollup, you should use 
                 <ForwardRef>
                   dynamic
                 </ForwardRef>
@@ -1316,27 +1316,27 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   A target row count for each partition. Each partition will have a row count close to the target assuming evenly distributed keys. Defaults to 5 million if numShards is null.
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1358,33 +1358,33 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
-                   renamed to
+                   renamed to 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                 </p>
                 <p>
-                  If
+                  If 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
                    is left unspecified, the Parallel task will determine
-
+                   
                   <ForwardRef>
                     numShards
                   </ForwardRef>
-                   automatically by
+                   automatically by 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
                   .
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1405,11 +1405,11 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   Directly specify the number of shards to create. If this is specified and 'intervals' is specified in the granularitySpec, the index task can skip the determine intervals/partitions pass through the data.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     numShards
                   </ForwardRef>
@@ -1454,11 +1454,11 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   Target number of rows to include in a partition, should be a number that targets segments of 500MB~1GB.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1477,11 +1477,11 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
                   Maximum number of rows to include in a partition.
                 </p>
                 <p>
-                  Note that either
+                  Note that either 
                   <ForwardRef>
                     targetRowsPerSegment
                   </ForwardRef>
-                   or
+                   or 
                   <ForwardRef>
                     maxRowsPerSegment
                   </ForwardRef>
@@ -1588,7 +1588,7 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
             </p>
             <p>
               For more information refer to the
-
+               
               <Memo(ExternalLink)
                 href="https://druid.apache.org/docs/latest/ingestion/concurrent-append-replace"
               >
@@ -1602,7 +1602,7 @@ exports[`CompactionConfigDialog matches snapshot without compactionConfig 1`] = 
       >
         <Blueprint5.Switch
           checked={false}
-          label="Use concurrent locks"
+          label="Use concurrent locks (experimental)"
           onChange={[Function]}
         />
       </Memo(FormGroupWithInfo)>

--- a/web-console/src/dialogs/compaction-config-dialog/compaction-config-dialog.tsx
+++ b/web-console/src/dialogs/compaction-config-dialog/compaction-config-dialog.tsx
@@ -130,7 +130,7 @@ export const CompactionConfigDialog = React.memo(function CompactionConfigDialog
               }
             >
               <Switch
-                label="Use concurrent locks (experimental)"
+                label="Use concurrent locks"
                 checked={Boolean(deepGet(currentConfig, 'taskContext.useConcurrentLocks'))}
                 onChange={() => {
                   setCurrentConfig(

--- a/web-console/src/views/load-data-view/load-data-view.tsx
+++ b/web-console/src/views/load-data-view/load-data-view.tsx
@@ -3443,7 +3443,7 @@ export class LoadDataView extends React.PureComponent<LoadDataViewProps, LoadDat
             }
           >
             <Switch
-              label="Use concurrent locks (experimental)"
+              label="Use concurrent locks"
               checked={Boolean(deepGet(spec, 'context.useConcurrentLocks'))}
               onChange={() => {
                 this.updateSpec(


### PR DESCRIPTION
### Changes

- Update documentation
- Update web-console label for `Use concurrent locks`
- Update snapshots after running `npm run jest -- -u`