### PR TITLE
doc: add missing catalog info

### DIFF
--- a/docs/configuration/extensions.md
+++ b/docs/configuration/extensions.md
@@ -39,6 +39,7 @@ Core extensions are maintained by Druid committers.
 |druid-azure-extensions|Microsoft Azure deep storage.|[link](../development/extensions-core/azure.md)|
 |druid-basic-security|Support for Basic HTTP authentication and role-based access control.|[link](../development/extensions-core/druid-basic-security.md)|
 |druid-bloom-filter|Support for providing Bloom filters in druid queries.|[link](../development/extensions-core/bloom-filter.md)|
+|druid-catalog|This extension allows users to configure, update, retrieve, and manage metadata stored in Druid's catalog. |[link](../development/extensions-core/catalog.md)|
 |druid-datasketches|Support for approximate counts and set operations with [Apache DataSketches](https://datasketches.apache.org/).|[link](../development/extensions-core/datasketches-extension.md)|
 |druid-google-extensions|Google Cloud Storage deep storage.|[link](../development/extensions-core/google.md)|
 |druid-hdfs-storage|HDFS deep storage.|[link](../development/extensions-core/hdfs.md)|

--- a/docs/development/extensions-core/catalog.md
+++ b/docs/development/extensions-core/catalog.md
@@ -1,4 +1,7 @@
-
+---
+id: catalog
+title: Catalog
+---
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The catalog page was missing frontmatter so it was falling back to the filename. It was also missing from the extensions index page

This PR has:

- [x] been self-reviewed.
