### PR TITLE
Avoid OOM-killing query if result-level caching fails

### DIFF
--- a/processing/src/main/java/org/apache/druid/io/LimitedOutputStream.java
+++ b/processing/src/main/java/org/apache/druid/io/LimitedOutputStream.java
@@ -22,13 +22,14 @@ package org.apache.druid.io;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.IOE;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.Function;
 
 /**
  * An {@link OutputStream} that limits how many bytes can be written. Throws {@link IOException} if the limit
- * is exceeded.
+ * is exceeded. *Not* thread-safe.
  */
 public class LimitedOutputStream extends OutputStream
 {
@@ -86,6 +87,14 @@ public class LimitedOutputStream extends OutputStream
   public void close() throws IOException
   {
     out.close();
+  }
+
+  public byte[] toByteArray()
+  {
+    if (!(out instanceof ByteArrayOutputStream)) {
+      throw new UnsupportedOperationException(out.getClass().getName() + "does not implement toByteArray()");
+    }
+    return ((ByteArrayOutputStream) out).toByteArray();
   }
 
   private void plus(final int n) throws IOException

--- a/processing/src/test/java/org/apache/druid/io/LimitedOutputStreamTest.java
+++ b/processing/src/test/java/org/apache/druid/io/LimitedOutputStreamTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 
 import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -62,6 +63,26 @@ public class LimitedOutputStreamTest
       );
 
       MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Limit[3] exceeded")));
+    }
+  }
+
+  @Test
+  public void test_toByteArray() throws IOException
+  {
+    try (final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         final LimitedOutputStream stream =
+             new LimitedOutputStream(baos, 3, LimitedOutputStreamTest::makeErrorMessage)) {
+      stream.write('a');
+      stream.write(new byte[]{'b'});
+      stream.write(new byte[]{'c'}, 0, 1);
+
+      MatcherAssert.assertThat(stream.toByteArray(), CoreMatchers.equalTo(new byte[]{'a', 'b', 'c'}));
+    }
+
+    try (final DataOutputStream dos = new DataOutputStream(new ByteArrayOutputStream());
+         final LimitedOutputStream stream =
+             new LimitedOutputStream(dos, 3, LimitedOutputStreamTest::makeErrorMessage)) {
+      Assert.assertThrows(UnsupportedOperationException.class, stream::toByteArray);
     }
   }
 

--- a/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
@@ -30,6 +30,7 @@ import org.apache.druid.client.CacheUtil;
 import org.apache.druid.client.cache.Cache;
 import org.apache.druid.client.cache.Cache.NamedKey;
 import org.apache.druid.client.cache.CacheConfig;
+import org.apache.druid.io.LimitedOutputStream;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -152,6 +153,8 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
                   // The resultset identifier and its length is cached along with the resultset
                   resultLevelCachePopulator.populateResults();
                   log.debug("Cache population complete for query %s", query.getId());
+                } else { // thrown == null && !resultLevelCachePopulator.isShouldPopulate()
+                  log.error("Failed (gracefully) to populate result level cache for query %s", query.getId());
                 }
                 resultLevelCachePopulator.stopPopulating();
               }
@@ -233,8 +236,8 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
       try {
         //   Save the resultSetId and its length
         resultLevelCachePopulator.cacheObjectStream.write(ByteBuffer.allocate(Integer.BYTES)
-                                                                    .putInt(resultSetId.length())
-                                                                    .array());
+                                                              .putInt(resultSetId.length())
+                                                              .array());
         resultLevelCachePopulator.cacheObjectStream.write(StringUtils.toUtf8(resultSetId));
       }
       catch (IOException ioe) {
@@ -255,7 +258,7 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
     private final Cache.NamedKey key;
     private final CacheConfig cacheConfig;
     @Nullable
-    private ByteArrayOutputStream cacheObjectStream;
+    private LimitedOutputStream cacheObjectStream;
 
     private ResultLevelCachePopulator(
         Cache cache,
@@ -270,7 +273,14 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
       this.serialiers = mapper.getSerializerProviderInstance();
       this.key = key;
       this.cacheConfig = cacheConfig;
-      this.cacheObjectStream = shouldPopulate ? new ByteArrayOutputStream() : null;
+      this.cacheObjectStream = shouldPopulate ? new LimitedOutputStream(
+          new ByteArrayOutputStream(),
+          cacheConfig.getResultLevelCacheLimit(), limit -> StringUtils.format(
+          "resultLevelCacheLimit[%,d] exceeded. "
+          + "Max ResultLevelCacheLimit for cache exceeded. Result caching failed.",
+          limit
+      )
+      ) : null;
     }
 
     boolean isShouldPopulate()
@@ -289,12 +299,8 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
     )
     {
       Preconditions.checkNotNull(cacheObjectStream, "cacheObjectStream");
-      int cacheLimit = cacheConfig.getResultLevelCacheLimit();
       try (JsonGenerator gen = mapper.getFactory().createGenerator(cacheObjectStream)) {
         JacksonUtils.writeObjectUsingSerializerProvider(gen, serialiers, cacheFn.apply(resultEntry));
-        if (cacheLimit > 0 && cacheObjectStream.size() > cacheLimit) {
-          stopPopulating();
-        }
       }
       catch (IOException ex) {
         log.error(ex, "Failed to retrieve entry to be cached. Result Level caching will not be performed!");

--- a/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase
 {
   private Cache cache;
+  private static final int DEFAULT_CACHE_ENTRY_MAX_SIZE = Integer.MAX_VALUE;
 
   @Before
   public void setup()
@@ -58,7 +59,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     prepareCluster(10);
     final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
-        newCacheConfig(false, false),
+        newCacheConfig(false, false, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -72,7 +73,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     Assert.assertEquals(0, cache.getStats().getNumMisses());
 
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
-        newCacheConfig(false, false),
+        newCacheConfig(false, false, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -93,7 +94,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     prepareCluster(10);
     final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
-        newCacheConfig(true, false),
+        newCacheConfig(true, false, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -107,7 +108,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     Assert.assertEquals(0, cache.getStats().getNumMisses());
 
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
-        newCacheConfig(true, false),
+        newCacheConfig(true, false, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -128,7 +129,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     prepareCluster(10);
     final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
-        newCacheConfig(false, false),
+        newCacheConfig(false, false, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -142,7 +143,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     Assert.assertEquals(0, cache.getStats().getNumMisses());
 
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
-        newCacheConfig(false, true),
+        newCacheConfig(false, true, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -163,7 +164,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     prepareCluster(10);
     final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
-        newCacheConfig(true, true),
+        newCacheConfig(true, true, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -177,7 +178,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     Assert.assertEquals(1, cache.getStats().getNumMisses());
 
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
-        newCacheConfig(true, true),
+        newCacheConfig(true, true, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -190,6 +191,41 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     Assert.assertEquals(1, cache.getStats().getNumHits());
     Assert.assertEquals(1, cache.getStats().getNumEntries());
     Assert.assertEquals(1, cache.getStats().getNumMisses());
+  }
+
+  @Test
+  public void testNoPopulateIfEntrySizeExceedsMaximum()
+  {
+    prepareCluster(10);
+    final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner1 = createQueryRunner(
+        newCacheConfig(true, true, 128),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence1 = queryRunner1.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results1 = sequence1.toList();
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+    Assert.assertEquals(0, cache.getStats().getNumEntries());
+    Assert.assertEquals(1, cache.getStats().getNumMisses());
+
+    final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner2 = createQueryRunner(
+        newCacheConfig(true, true, DEFAULT_CACHE_ENTRY_MAX_SIZE),
+        query
+    );
+
+    final Sequence<Result<TimeseriesResultValue>> sequence2 = queryRunner2.run(
+        QueryPlus.wrap(query),
+        responseContext()
+    );
+    final List<Result<TimeseriesResultValue>> results2 = sequence2.toList();
+    Assert.assertEquals(results1, results2);
+    Assert.assertEquals(0, cache.getStats().getNumHits());
+    Assert.assertEquals(1, cache.getStats().getNumEntries());
+    Assert.assertEquals(2, cache.getStats().getNumMisses());
   }
 
   @Test
@@ -206,7 +242,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
 
     final Query<Result<TimeseriesResultValue>> query = timeseriesQuery(BASE_SCHEMA_INFO.getDataInterval());
     final ResultLevelCachingQueryRunner<Result<TimeseriesResultValue>> queryRunner = createQueryRunner(
-        newCacheConfig(true, false),
+        newCacheConfig(true, false, DEFAULT_CACHE_ENTRY_MAX_SIZE),
         query
     );
 
@@ -249,7 +285,11 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
     );
   }
 
-  private CacheConfig newCacheConfig(boolean populateResultLevelCache, boolean useResultLevelCache)
+  private CacheConfig newCacheConfig(
+      boolean populateResultLevelCache,
+      boolean useResultLevelCache,
+      int resultLevelCacheLimit
+  )
   {
     return new CacheConfig()
     {
@@ -263,6 +303,12 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
       public boolean isUseResultLevelCache()
       {
         return useResultLevelCache;
+      }
+
+      @Override
+      public int getResultLevelCacheLimit()
+      {
+        return resultLevelCacheLimit;
       }
     };
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #17651.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Currently, result-level caching which attempts to allocate a large enough buffer to store query results will overflow the Integer.MAX_INT capacity. `ByteArrayOutputStream` materializes this case as an `OutOfMemoryError`, which is not caught and terminates the query. This limits the allocated buffer for storing query results to whatever is set in `CacheConfig.getResultLevelCacheLimit()`. Although we do a check comparing buffer size to `CacheConfig.getResultLevelCacheLimit()` [here](https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java#L295), this comes after the exception is thrown and is too late to gracefully catch the issue.

##  **Important Note**
I opted to use `LimitedOutputStream` here as it is already used with `ByteArrayOutputStream`. While ok in QueryRunners (single-threaded), this still is less-than-ideal in the general case because it doesn't guarantee strict consistency between overflow exception delivery and ordering of writes to the buffer(see another example below). As such, this class in general is \*not\* thread-safe and I think should be refactored to account for this. This is because every case of `LimitedOutputStream` already uses `ByteArrayOutputStream`, which \*is\* already using locks, we should suffer no performance hit by synchronizing `LimitedOutputStream::write` methods. This is just in the general spirit of future-proofing code, given that we're already using locks, we might as well avoid as many future races as we can : ). Given that this would take some changes to the `LimitedOutputStream` API (from extending `ByteArrayOutputStream` directly) I've opted to not change these APIs here, but in a separate PR.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Changes to `LimitedOutputStream`
- Expose an public `LimitedOutputStream::toByteArray()` which returns the underlying byte array for stream-specific operations.

```
T1: write():
T1: read written = INT_MAX - 1
INT
T2: write():
T2: read written = INT_MAX - 1
T2: write written += 1
T2: write() succeeds
INT
T1: write written += 1
T1: write() succeeds
FIN
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Avoid OOM-killing query if large result-level cache population fails for query

<hr>

##### Key changed/added classes in this PR
* `processing/src/main/java/org/apache/druid/io/LimitedOutputStream.java`
* `server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java`
* `server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
