### PR TITLE
fix missing required columns of CursorBuildSpec from RowFilterPolicy

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/policy/Policy.java
+++ b/processing/src/main/java/org/apache/druid/query/policy/Policy.java
@@ -39,6 +39,11 @@ public interface Policy
   /**
    * Apply this policy to a {@link CursorBuildSpec} to seamlessly enforce policies for cursor-based queries. The
    * application must encapsulate 100% of the requirements of this policy.
+   * <p>
+   * Any transforms done to the spec must be sure to update {@link CursorBuildSpec#getPhysicalColumns()} and
+   * {@link CursorBuildSpec#getVirtualColumns()} as needed to ensure the underlying
+   * {@link org.apache.druid.segment.CursorHolder} that is being restricted has accurate information about the set of
+   * required columns.
    */
   CursorBuildSpec visit(CursorBuildSpec spec);
 

--- a/processing/src/main/java/org/apache/druid/query/policy/RowFilterPolicy.java
+++ b/processing/src/main/java/org/apache/druid/query/policy/RowFilterPolicy.java
@@ -23,12 +23,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import org.apache.druid.query.filter.DimFilter;
-import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.CursorBuildSpec;
-import org.apache.druid.segment.filter.Filters;
+import org.apache.druid.segment.FilteredCursorFactory;
 
 import javax.annotation.Nonnull;
-import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -58,12 +56,7 @@ public class RowFilterPolicy implements Policy
   @Override
   public CursorBuildSpec visit(CursorBuildSpec spec)
   {
-    CursorBuildSpec.CursorBuildSpecBuilder builder = CursorBuildSpec.builder(spec);
-    final Filter filter = spec.getFilter();
-    final Filter policyFilter = this.rowFilter.toFilter();
-
-    builder.setFilter(Filters.and(Arrays.asList(policyFilter, filter)));
-    return builder.build();
+    return FilteredCursorFactory.addFilter(spec, rowFilter);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/CursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/CursorFactory.java
@@ -26,6 +26,10 @@ import javax.annotation.Nullable;
 
 public interface CursorFactory extends ColumnInspector
 {
+  /**
+   * Creates a {@link CursorHolder} for a given {@link CursorBuildSpec} which describes how the reader is going to
+   * scan, filter, transform, group and aggregate, and/or order the data.
+   */
   CursorHolder makeCursorHolder(CursorBuildSpec spec);
 
   /**

--- a/processing/src/main/java/org/apache/druid/segment/CursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/CursorHolder.java
@@ -31,6 +31,22 @@ import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Provides {@link Cursor} and if available, {@link VectorCursor} which readers can use to scan a set of rows defined
+ * originally from a {@link CursorBuildSpec} which describes how data is to be scanned, transformed, filter, grouped and
+ * aggregated, and/or ordered.
+ * <p>
+ * If {@link #canVectorize()} then {@link #asVectorCursor()} will return a non-null value allowing for processing rows
+ * in batches instead of individually.
+ * <p>
+ * If {@link #isPreAggregated()} is true, readers which are aggregating must call
+ * {@link #getAggregatorsForPreAggregated()} to get the updated set of {@link AggregatorFactory} to correctly process
+ * results
+ * <p>
+ * {@link #getOrdering()} defines how the data is ordered in the {@link Cursor} or {@link VectorCursor}, allowing
+ * readers to compare to their own desired ordering and potentially skip ordering their own results if it is
+ * pre-ordered.
+ */
 public interface CursorHolder extends Closeable
 {
   /**
@@ -60,8 +76,9 @@ public interface CursorHolder extends Closeable
   }
 
   /**
-   * Returns true if the {@link Cursor} or {@link VectorCursor} contains pre-aggregated columns for all
-   * {@link AggregatorFactory} specified in {@link CursorBuildSpec#getAggregators()}.
+   * Returns true if the {@link Cursor} or {@link VectorCursor} contains pre-aggregated columns for all grouping columns
+   * specified in {@link CursorBuildSpec#getGroupingColumns()} and all {@link AggregatorFactory} specified in
+   * {@link CursorBuildSpec#getAggregators()}.
    * <p>
    * If this method returns true, {@link ColumnSelectorFactory} and
    * {@link org.apache.druid.segment.vector.VectorColumnSelectorFactory} created from {@link Cursor} and
@@ -90,7 +107,7 @@ public interface CursorHolder extends Closeable
   /**
    * Returns cursor ordering, which may or may not match {@link CursorBuildSpec#getPreferredOrdering()}. If returns
    * an empty list then the cursor has no defined ordering.
-   *
+   * <p>
    * Cursors associated with this holder return rows in this ordering, using the natural comparator for the column type.
    * Includes {@link ColumnHolder#TIME_COLUMN_NAME} if appropriate.
    */


### PR DESCRIPTION
### Description
changes:
* RowFilterPolicy.visit now uses new method FilteredCursorFactory.addFilter to re-use the CursorBuildSpec transform of FilteredCursorFactory of adding a filter and its required columns to a CursorBuildSpec
* Added javadoc to CursorFactory, CursorHolder, and CursorBuildSpec to clarify usage


<hr>

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] been tested in a test Druid cluster.
