### PR TITLE
[Docs] Add styling for HTTP request methods

### DIFF
--- a/docs/api-reference/automatic-compaction-api.md
+++ b/docs/api-reference/automatic-compaction-api.md
@@ -49,7 +49,7 @@ Note that this endpoint returns an HTTP `200 OK` message code even if the dataso
 
 #### URL
 
-`POST` `/druid/coordinator/v1/config/compaction`
+<code class="postAPI">POST</code> <code>/druid/coordinator/v1/config/compaction</code>
 
 #### Responses
 
@@ -138,7 +138,7 @@ Removes the automatic compaction configuration for a datasource. This updates th
 
 #### URL
 
-`DELETE` `/druid/coordinator/v1/config/compaction/{dataSource}`
+<code class="deleteAPI">DELETE</code> <code>/druid/coordinator/v1/config/compaction/&#123;dataSource&#125;</code>
 
 #### Responses
 
@@ -196,7 +196,7 @@ Note that while the max compaction tasks can theoretically be set to 2147483647,
 
 #### URL
 
-`POST` `/druid/coordinator/v1/config/compaction/taskslots`
+<code class="postAPI">POST</code> <code>/druid/coordinator/v1/config/compaction/taskslots</code>
 
 #### Query parameters
 
@@ -268,7 +268,7 @@ You can use this endpoint to retrieve `compactionTaskSlotRatio` and `maxCompacti
 
 #### URL
 
-`GET` `/druid/coordinator/v1/config/compaction`
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/config/compaction</code>
 
 #### Responses
 
@@ -417,7 +417,7 @@ Retrieves the automatic compaction configuration for a datasource.
 
 #### URL
 
-`GET` `/druid/coordinator/v1/config/compaction/{dataSource}`
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/config/compaction/&#123;dataSource&#125;</code>
 
 #### Responses
 
@@ -529,7 +529,7 @@ The response contains a list of objects with the following keys:
 
 #### URL
 
-`GET` `/druid/coordinator/v1/config/compaction/{dataSource}/history`
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/config/compaction/&#123;dataSource&#125;/history</code>
 
 #### Query parameters
 * `interval` (optional)
@@ -689,7 +689,7 @@ Returns the total size of segments awaiting compaction for a given datasource. R
 
 #### URL
 
-`GET` `/druid/coordinator/v1/compaction/progress?dataSource={dataSource}`
+<code class="getAPI">GET</code> <code>druid/coordinator/v1/compaction/progress?dataSource=&#123;dataSource&#125;</code>
 
 #### Query parameter
 * `dataSource` (required)
@@ -773,7 +773,7 @@ The `latestStatus` object has the following properties:
 
 #### URL
 
-`GET` `/druid/coordinator/v1/compaction/status`
+<code class="getAPI">GET</code> <code>/druid/coordinator/v1/compaction/status</code>
 
 #### Query parameters
 * `dataSource` (optional)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -33,7 +33,8 @@ module.exports={
   ],
   "stylesheets": [
     "https://use.fontawesome.com/releases/v5.7.2/css/all.css",
-    "/css/code-block-buttons.css"
+    "/css/code-block-buttons.css",
+    "/css/api.css"
   ],
   "favicon": "img/favicon.png",
   "customFields": {

--- a/website/static/css/api.css
+++ b/website/static/css/api.css
@@ -21,11 +21,11 @@
     color: #0073e6; 
     font-weight: bold;
   }
-  .postAPI {
+.postAPI {
     color: #00bf7d; 
     font-weight: bold;
   }
-  .deleteAPI {
+.deleteAPI {
     color: #f49200; 
     font-weight: bold;
   }

--- a/website/static/css/api.css
+++ b/website/static/css/api.css
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* API docs css */
+.getAPI {
+    color: #0073e6; 
+    font-weight: bold;
+  }
+  .postAPI {
+    color: #00bf7d; 
+    font-weight: bold;
+  }
+  .deleteAPI {
+    color: #f49200; 
+    font-weight: bold;
+  }


### PR DESCRIPTION
### Description

@demo-kratia added css to style the HTTP request methods in : https://github.com/apache/druid-website-src/pull/409 .
For Docusaurus, you need to add the css into the `docusaurus.config.js` to load it.
This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
