### PR TITLE
[Docs] Move T-Digest function docs

### DIFF
--- a/docs/development/extensions-contrib/tdigestsketch-quantiles.md
+++ b/docs/development/extensions-contrib/tdigestsketch-quantiles.md
@@ -162,7 +162,7 @@ Higher compression provides higher accuracy but requires more storage space.
 
 * **Syntax**: `TDIGEST_GENERATE_SKETCH(expr, [compression])`
 * **Default**: Empty Base64-encoded T-Digest sketch string
-* **Function type**: [Aggregation](sql-aggregations.md)
+* **Function type**: [Aggregation](../../querying/sql-aggregations.md)
 
 #### TDIGEST_QUANTILE
 
@@ -172,4 +172,4 @@ Higher compression provides higher accuracy but requires more storage space.
 
 * **Syntax**: `TDIGEST_QUANTILE(expr, quantileFraction, [compression])`
 * **Default**: `Double.NaN`
-* **Function type**: [Aggregation](sql-aggregations.md)
+* **Function type**: [Aggregation](../../querying/sql-aggregations.md)

--- a/docs/development/extensions-contrib/tdigestsketch-quantiles.md
+++ b/docs/development/extensions-contrib/tdigestsketch-quantiles.md
@@ -149,3 +149,27 @@ Similar to quantilesFromTDigestSketch except it takes in a single fraction for c
 |name|A String for the output (result) name of the calculation.|yes|
 |field|A field reference pointing to the field aggregated/combined T-Digest sketch.|yes|
 |fraction|Decimal value between 0 and 1|yes|
+
+### SQL functions
+
+Once you load the T-Digest extension, you can use the following SQL functions.
+
+#### TDIGEST_GENERATE_SKETCH
+
+Builds a T-Digest sketch on values produced by an expression.
+Compression parameter (default value 100) determines the accuracy and size of the sketch.
+Higher compression provides higher accuracy but requires more storage space.
+
+* **Syntax**: `TDIGEST_GENERATE_SKETCH(expr, [compression])`
+* **Default**: Empty Base64-encoded T-Digest sketch string
+* **Function type**: [Aggregation](sql-aggregations.md)
+
+#### TDIGEST_QUANTILE
+
+Builds a T-Digest sketch on values produced by an expression and returns the value for the quantile.
+Compression parameter (default value 100) determines the accuracy and size of the sketch.
+Higher compression provides higher accuracy but requires more storage space.
+
+* **Syntax**: `TDIGEST_QUANTILE(expr, quantileFraction, [compression])`
+* **Default**: `Double.NaN`
+* **Function type**: [Aggregation](sql-aggregations.md)

--- a/docs/querying/sql-functions.md
+++ b/docs/querying/sql-functions.md
@@ -1468,22 +1468,6 @@ Calculates the sum of a set of values.
 
 Calculates the trigonometric tangent of an angle expressed in radians.
 
-## TDIGEST_GENERATE_SKETCH
-
-`TDIGEST_GENERATE_SKETCH(expr, [compression])`
-
-**Function type:** [Aggregation](sql-aggregations.md)
-
-Generates a T-digest sketch from values of the specified expression.
-
-## TDIGEST_QUANTILE
-
-`TDIGEST_QUANTILE(expr, quantileFraction, [compression])`
-
-**Function type:** [Aggregation](sql-aggregations.md)
-
-Returns the quantile for the specified fraction from a T-Digest sketch constructed from values of the expression.
-
 ## TEXTCAT
 
 `TEXTCAT(<CHARACTER>, <CHARACTER>)`


### PR DESCRIPTION
Moves docs for T-Digest functions from `sql-functions.md` to `tdigestsketch-quantiles.md`.

This PR has:
- [x] been self-reviewed.
