### PR TITLE
DataSourceMetadataQuery: Use TimeBoundaryInspector as a fallback.

### DIFF
--- a/docs/querying/datasourcemetadataquery.md
+++ b/docs/querying/datasourcemetadataquery.md
@@ -31,7 +31,7 @@ sidebar_label: "DatasourceMetadata"
 
 Data Source Metadata queries return metadata information for a dataSource.  These queries return information about:
 
-* The timestamp of the latest ingested event for the dataSource. This is the ingested event without any consideration of rollup.
+* `maxIngestedEventTime`: The timestamp of the latest ingested event for the dataSource. For realtime datasources, this may be later than `MAX(__time)` if `queryGranularity` is being used. For non-realtime datasources, this is equivalent to `MAX(__time)`.
 
 The grammar for these queries is:
 


### PR DESCRIPTION
PR #16849 changed the behavior such that maxIngestedEventTime is not updated for non-real-time data. This patch restores the old behavior for non-real-time data by using a TimeBoundaryInspector when MaxIngestedEventTimeInspector is not present.