### PR TITLE
Various fixes for large columns.

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/BaseColumnarLongsBenchmark.java
@@ -318,7 +318,7 @@ public class BaseColumnarLongsBenchmark
       case "none-longs":
       case "zstd-auto":
       case "zstd-longs":
-        return CompressedColumnarLongsSupplier.fromByteBuffer(buffer, ByteOrder.LITTLE_ENDIAN).get();
+        return CompressedColumnarLongsSupplier.fromByteBuffer(buffer, ByteOrder.LITTLE_ENDIAN, null).get();
     }
 
     throw new IllegalArgumentException("unknown encoding");

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/CompressedColumnarIntsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/CompressedColumnarIntsBenchmark.java
@@ -82,7 +82,8 @@ public class CompressedColumnarIntsBenchmark
     );
     this.compressed = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
         bufferCompressed,
-        ByteOrder.nativeOrder()
+        ByteOrder.nativeOrder(),
+        null
     ).get();
 
     final ByteBuffer bufferUncompressed = serialize(VSizeColumnarInts.fromArray(vals));

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/CompressedVSizeColumnarMultiIntsBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/CompressedVSizeColumnarMultiIntsBenchmark.java
@@ -95,7 +95,8 @@ public class CompressedVSizeColumnarMultiIntsBenchmark
     );
     this.compressed = CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
         bufferCompressed,
-        ByteOrder.nativeOrder()
+        ByteOrder.nativeOrder(),
+        null
     ).get();
 
     final ByteBuffer bufferUncompressed = serialize(

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/FloatCompressionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/FloatCompressionBenchmark.java
@@ -75,7 +75,7 @@ public class FloatCompressionBenchmark
     File compFile = new File(dir, file + "-" + strategy);
     bufferHandler = FileUtils.map(compFile);
     ByteBuffer buffer = bufferHandler.get();
-    supplier = CompressedColumnarFloatsSupplier.fromByteBuffer(buffer, ByteOrder.nativeOrder());
+    supplier = CompressedColumnarFloatsSupplier.fromByteBuffer(buffer, ByteOrder.nativeOrder(), null);
   }
 
   @TearDown

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/compression/LongCompressionBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/compression/LongCompressionBenchmark.java
@@ -79,7 +79,7 @@ public class LongCompressionBenchmark
     File compFile = new File(dir, file + "-" + strategy + "-" + format);
     bufferHandler = FileUtils.map(compFile);
     ByteBuffer buffer = bufferHandler.get();
-    supplier = CompressedColumnarLongsSupplier.fromByteBuffer(buffer, ByteOrder.nativeOrder());
+    supplier = CompressedColumnarLongsSupplier.fromByteBuffer(buffer, ByteOrder.nativeOrder(), null);
   }
 
   @TearDown

--- a/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalColumnPartSupplier.java
+++ b/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalColumnPartSupplier.java
@@ -22,6 +22,7 @@ package org.apache.druid.compressedbigdecimal;
 
 import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.column.ComplexColumn;
 import org.apache.druid.segment.data.CompressedVSizeColumnarIntsSupplier;
@@ -40,10 +41,12 @@ public class CompressedBigDecimalColumnPartSupplier implements Supplier<ComplexC
    * Compressed.
    *
    * @param buffer Byte buffer
+   * @param smooshMapper mapper for secondary files, in case of large columns
    * @return new instance of CompressedBigDecimalColumnPartSupplier
    */
   public static CompressedBigDecimalColumnPartSupplier fromByteBuffer(
-      ByteBuffer buffer
+      ByteBuffer buffer,
+      SmooshedFileMapper smooshMapper
   )
   {
     byte versionFromBuffer = buffer.get();
@@ -53,11 +56,12 @@ public class CompressedBigDecimalColumnPartSupplier implements Supplier<ComplexC
 
       CompressedVSizeColumnarIntsSupplier scaleSupplier = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
           buffer,
-          IndexIO.BYTE_ORDER
+          IndexIO.BYTE_ORDER,
+          smooshMapper
       );
 
       V3CompressedVSizeColumnarMultiIntsSupplier magnitudeSupplier =
-          V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(buffer, IndexIO.BYTE_ORDER);
+          V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(buffer, IndexIO.BYTE_ORDER, smooshMapper);
 
       return new CompressedBigDecimalColumnPartSupplier(
           buffer.position() - positionStart,

--- a/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalLongColumnSerializer.java
+++ b/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalLongColumnSerializer.java
@@ -25,6 +25,7 @@ import org.apache.druid.segment.GenericColumnSerializer;
 import org.apache.druid.segment.data.ArrayBasedIndexedInts;
 import org.apache.druid.segment.data.CompressedVSizeColumnarIntsSerializer;
 import org.apache.druid.segment.data.CompressionStrategy;
+import org.apache.druid.segment.data.GenericIndexedWriter;
 import org.apache.druid.segment.data.V3CompressedVSizeColumnarMultiIntsSerializer;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
@@ -66,7 +67,8 @@ public class CompressedBigDecimalLongColumnSerializer implements GenericColumnSe
             segmentWriteOutMedium,
             String.format(Locale.ROOT, "%s.magnitude", filenameBase),
             Integer.MAX_VALUE,
-            CompressionStrategy.LZ4
+            CompressionStrategy.LZ4,
+            GenericIndexedWriter.MAX_FILE_SIZE
         )
     );
   }

--- a/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalMetricSerde.java
+++ b/extensions-contrib/compressed-bigdecimal/src/main/java/org/apache/druid/compressedbigdecimal/CompressedBigDecimalMetricSerde.java
@@ -74,7 +74,7 @@ public class CompressedBigDecimalMetricSerde extends ComplexMetricSerde
   public void deserializeColumn(ByteBuffer buffer, ColumnBuilder builder)
   {
     builder.setComplexColumnSupplier(
-        CompressedBigDecimalColumnPartSupplier.fromByteBuffer(buffer)
+        CompressedBigDecimalColumnPartSupplier.fromByteBuffer(buffer, builder.getFileMapper())
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
+++ b/processing/src/main/java/org/apache/druid/segment/DictionaryEncodedColumnMerger.java
@@ -461,7 +461,8 @@ public abstract class DictionaryEncodedColumnMerger<T extends Comparable<T>> imp
             segmentWriteOutMedium,
             filenameBase,
             cardinality,
-            compressionStrategy
+            compressionStrategy,
+            GenericIndexedWriter.MAX_FILE_SIZE
         );
       } else {
         encodedValueSerializer =

--- a/processing/src/main/java/org/apache/druid/segment/IndexIO.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexIO.java
@@ -357,7 +357,8 @@ public class IndexIO
 
       CompressedColumnarLongsSupplier timestamps = CompressedColumnarLongsSupplier.fromByteBuffer(
           smooshedFiles.mapFile(makeTimeFile(inDir, BYTE_ORDER).getName()),
-          BYTE_ORDER
+          BYTE_ORDER,
+          smooshedFiles
       );
 
       Map<String, MetricHolder> metrics = Maps.newLinkedHashMap();
@@ -385,7 +386,10 @@ public class IndexIO
             fileDimensionName
         );
 
-        dimValueUtf8Lookups.put(dimension, GenericIndexed.read(dimBuffer, GenericIndexed.UTF8_STRATEGY));
+        dimValueUtf8Lookups.put(
+            dimension,
+            GenericIndexed.read(dimBuffer, GenericIndexed.UTF8_STRATEGY, smooshedFiles)
+        );
         dimColumns.put(dimension, VSizeColumnarMultiInts.readFromByteBuffer(dimBuffer));
       }
 
@@ -393,7 +397,7 @@ public class IndexIO
       for (int i = 0; i < availableDimensions.size(); ++i) {
         bitmaps.put(
             SERIALIZER_UTILS.readString(invertedBuffer),
-            GenericIndexed.read(invertedBuffer, bitmapSerdeFactory.getObjectStrategy())
+            GenericIndexed.read(invertedBuffer, bitmapSerdeFactory.getObjectStrategy(), smooshedFiles)
         );
       }
 

--- a/processing/src/main/java/org/apache/druid/segment/MetricHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/MetricHolder.java
@@ -38,6 +38,9 @@ public class MetricHolder
   private static final byte[] VERSION = new byte[]{0x0};
   private static final SerializerUtils SERIALIZER_UTILS = new SerializerUtils();
 
+  /**
+   * Read a metric column from a legacy (v8) segment.
+   */
   public static MetricHolder fromByteBuffer(ByteBuffer buf)
   {
     final byte ver = buf.get();
@@ -51,7 +54,11 @@ public class MetricHolder
 
     switch (holder.type) {
       case FLOAT:
-        holder.floatType = CompressedColumnarFloatsSupplier.fromByteBuffer(buf, ByteOrder.nativeOrder());
+        holder.floatType = CompressedColumnarFloatsSupplier.fromByteBuffer(
+            buf,
+            ByteOrder.nativeOrder(),
+            null // OK since this method is only used for legacy segments, which always use version 1 indexed
+        );
         break;
       case COMPLEX:
         final ComplexMetricSerde serdeForType = ComplexMetrics.getSerdeForType(holder.getTypeName());
@@ -72,7 +79,7 @@ public class MetricHolder
 
   private static <T> GenericIndexed<T> read(ByteBuffer buf, ComplexMetricSerde serde)
   {
-    return GenericIndexed.read(buf, serde.getObjectStrategy());
+    return GenericIndexed.read(buf, serde.getObjectStrategy(), null);
   }
 
   public enum MetricType

--- a/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarDoublesSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarDoublesSerializer.java
@@ -26,7 +26,6 @@ import org.apache.druid.segment.serde.MetaSerdeHelper;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 
 import javax.annotation.Nullable;
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -57,6 +56,7 @@ public class BlockLayoutColumnarDoublesSerializer implements ColumnarDoublesSeri
       String filenameBase,
       ByteOrder byteOrder,
       CompressionStrategy compression,
+      int fileSizeLimit,
       Closer closer
   )
   {
@@ -66,6 +66,7 @@ public class BlockLayoutColumnarDoublesSerializer implements ColumnarDoublesSeri
         filenameBase,
         compression,
         CompressedPools.BUFFER_SIZE,
+        fileSizeLimit,
         closer
     );
     this.compression = compression;

--- a/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarDoublesSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarDoublesSupplier.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.data;
 
 import com.google.common.base.Supplier;
 import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -43,11 +44,16 @@ public class BlockLayoutColumnarDoublesSupplier implements Supplier<ColumnarDoub
       int sizePer,
       ByteBuffer fromBuffer,
       ByteOrder byteOrder,
-      CompressionStrategy strategy
+      CompressionStrategy strategy,
+      SmooshedFileMapper smooshMapper
   )
   {
     this.strategy = strategy;
-    this.baseDoubleBuffers = GenericIndexed.read(fromBuffer, DecompressingByteBufferObjectStrategy.of(byteOrder, strategy));
+    this.baseDoubleBuffers = GenericIndexed.read(
+        fromBuffer,
+        DecompressingByteBufferObjectStrategy.of(byteOrder, strategy),
+        smooshMapper
+    );
     this.totalSize = totalSize;
     this.sizePer = sizePer;
   }

--- a/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarFloatsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarFloatsSerializer.java
@@ -57,6 +57,7 @@ public class BlockLayoutColumnarFloatsSerializer implements ColumnarFloatsSerial
       String filenameBase,
       ByteOrder byteOrder,
       CompressionStrategy compression,
+      int fileSizeLimit,
       Closer closer
   )
   {
@@ -66,6 +67,7 @@ public class BlockLayoutColumnarFloatsSerializer implements ColumnarFloatsSerial
         filenameBase,
         compression,
         CompressedPools.BUFFER_SIZE,
+        fileSizeLimit,
         closer
     );
     this.compression = compression;

--- a/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarFloatsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarFloatsSupplier.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.data;
 
 import com.google.common.base.Supplier;
 import org.apache.druid.collections.ResourceHolder;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -42,10 +43,15 @@ public class BlockLayoutColumnarFloatsSupplier implements Supplier<ColumnarFloat
       int sizePer,
       ByteBuffer fromBuffer,
       ByteOrder byteOrder,
-      CompressionStrategy strategy
+      CompressionStrategy strategy,
+      @Nullable SmooshedFileMapper smooshMapper
   )
   {
-    baseFloatBuffers = GenericIndexed.read(fromBuffer, DecompressingByteBufferObjectStrategy.of(byteOrder, strategy));
+    baseFloatBuffers = GenericIndexed.read(
+        fromBuffer,
+        DecompressingByteBufferObjectStrategy.of(byteOrder, strategy),
+        smooshMapper
+    );
     this.totalSize = totalSize;
     this.sizePer = sizePer;
   }

--- a/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarLongsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarLongsSerializer.java
@@ -60,6 +60,7 @@ public class BlockLayoutColumnarLongsSerializer implements ColumnarLongsSerializ
       ByteOrder byteOrder,
       CompressionFactory.LongEncodingWriter writer,
       CompressionStrategy compression,
+      int fileSizeLimit,
       Closer closer
   )
   {
@@ -71,6 +72,7 @@ public class BlockLayoutColumnarLongsSerializer implements ColumnarLongsSerializ
         filenameBase,
         compression,
         bufferSize,
+        fileSizeLimit,
         closer
     );
     this.writer = writer;

--- a/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarLongsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/BlockLayoutColumnarLongsSupplier.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.data;
 import com.google.common.base.Supplier;
 import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.common.semantic.SemanticUtils;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -51,11 +52,16 @@ public class BlockLayoutColumnarLongsSupplier implements Supplier<ColumnarLongs>
       ByteBuffer fromBuffer,
       ByteOrder order,
       CompressionFactory.LongEncodingReader reader,
-      CompressionStrategy strategy
+      CompressionStrategy strategy,
+      SmooshedFileMapper smooshMapper
   )
   {
     this.strategy = strategy;
-    this.baseLongBuffers = GenericIndexed.read(fromBuffer, DecompressingByteBufferObjectStrategy.of(order, strategy));
+    this.baseLongBuffers = GenericIndexed.read(
+        fromBuffer,
+        DecompressingByteBufferObjectStrategy.of(order, strategy),
+        smooshMapper
+    );
     this.totalSize = totalSize;
     this.sizePer = sizePer;
     this.baseReader = reader;

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarDoublesSuppliers.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarDoublesSuppliers.java
@@ -21,6 +21,7 @@ package org.apache.druid.segment.data;
 
 import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -34,9 +35,19 @@ public class CompressedColumnarDoublesSuppliers
   {
   }
 
+  /**
+   * Reads a column from a {@link ByteBuffer}, possibly using additional secondary files from a
+   * {@link SmooshedFileMapper}.
+   *
+   * @param buffer       primary buffer to read from
+   * @param order        byte order
+   * @param smooshMapper required for reading version 2 (multi-file) indexed. May be null if you know you are reading
+   *                     a single-file column. Generally, this should only be null in tests, not production code.
+   */
   public static Supplier<ColumnarDoubles> fromByteBuffer(
       ByteBuffer buffer,
-      ByteOrder order
+      ByteOrder order,
+      SmooshedFileMapper smooshMapper
   )
   {
     byte versionFromBuffer = buffer.get();
@@ -54,7 +65,8 @@ public class CompressedColumnarDoublesSuppliers
           sizePer,
           buffer.asReadOnlyBuffer(),
           order,
-          compression
+          compression,
+          smooshMapper
       );
     }
     throw new IAE("Unknown version[%s]", versionFromBuffer);

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializer.java
@@ -59,6 +59,7 @@ public class CompressedColumnarIntsSerializer extends SingleValueColumnarIntsSer
       final int chunkFactor,
       final ByteOrder byteOrder,
       final CompressionStrategy compression,
+      final int fileSizeLimit,
       final Closer closer
   )
   {
@@ -72,6 +73,7 @@ public class CompressedColumnarIntsSerializer extends SingleValueColumnarIntsSer
             filenameBase,
             compression,
             chunkFactor * Integer.BYTES,
+            fileSizeLimit,
             closer
         ),
         closer

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplier.java
@@ -114,25 +114,6 @@ public class CompressedColumnarIntsSupplier implements WritableSupplier<Columnar
     return baseIntBuffers;
   }
 
-  public static CompressedColumnarIntsSupplier fromByteBuffer(ByteBuffer buffer, ByteOrder order)
-  {
-    byte versionFromBuffer = buffer.get();
-
-    if (versionFromBuffer == VERSION) {
-      final int totalSize = buffer.getInt();
-      final int sizePer = buffer.getInt();
-      final CompressionStrategy compression = CompressionStrategy.forId(buffer.get());
-      return new CompressedColumnarIntsSupplier(
-          totalSize,
-          sizePer,
-          GenericIndexed.read(buffer, DecompressingByteBufferObjectStrategy.of(order, compression)),
-          compression
-      );
-    }
-
-    throw new IAE("Unknown version[%s]", versionFromBuffer);
-  }
-
   public static CompressedColumnarIntsSupplier fromByteBuffer(
       ByteBuffer buffer,
       ByteOrder order,

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarLongsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedColumnarLongsSupplier.java
@@ -23,9 +23,11 @@ import com.google.common.base.Supplier;
 import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.segment.serde.MetaSerdeHelper;
 import org.apache.druid.segment.serde.Serializer;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -97,7 +99,20 @@ public class CompressedColumnarLongsSupplier implements Supplier<ColumnarLongs>,
     Channels.writeFully(channel, buffer.asReadOnlyBuffer());
   }
 
-  public static CompressedColumnarLongsSupplier fromByteBuffer(ByteBuffer buffer, ByteOrder order)
+  /**
+   * Reads a column from a {@link ByteBuffer}, possibly using additional secondary files from a
+   * {@link SmooshedFileMapper}.
+   *
+   * @param buffer       primary buffer to read from
+   * @param order        byte order
+   * @param smooshMapper required for reading version 2 (multi-file) indexed. May be null if you know you are reading
+   *                     a single-file column. Generally, this should only be null in tests, not production code.
+   */
+  public static CompressedColumnarLongsSupplier fromByteBuffer(
+      ByteBuffer buffer,
+      ByteOrder order,
+      @Nullable SmooshedFileMapper smooshMapper
+  )
   {
     byte versionFromBuffer = buffer.get();
 
@@ -120,7 +135,8 @@ public class CompressedColumnarLongsSupplier implements Supplier<ColumnarLongs>,
           buffer.asReadOnlyBuffer(),
           order,
           encoding,
-          compression
+          compression,
+          smooshMapper
       );
       return new CompressedColumnarLongsSupplier(
           totalSize,

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializer.java
@@ -63,6 +63,7 @@ public class CompressedVSizeColumnarIntsSerializer extends SingleValueColumnarIn
         CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForValue(maxValue),
         IndexIO.BYTE_ORDER,
         compression,
+        GenericIndexedWriter.MAX_FILE_SIZE,
         closer
     );
   }
@@ -87,6 +88,7 @@ public class CompressedVSizeColumnarIntsSerializer extends SingleValueColumnarIn
       final int chunkFactor,
       final ByteOrder byteOrder,
       final CompressionStrategy compression,
+      final int fileSizeLimit,
       final Closer closer
   )
   {
@@ -101,6 +103,7 @@ public class CompressedVSizeColumnarIntsSerializer extends SingleValueColumnarIn
             filenameBase,
             compression,
             sizePer(maxValue, chunkFactor),
+            fileSizeLimit,
             closer
         ),
         closer

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplier.java
@@ -142,33 +142,6 @@ public class CompressedVSizeColumnarIntsSupplier implements WritableSupplier<Col
 
   public static CompressedVSizeColumnarIntsSupplier fromByteBuffer(
       ByteBuffer buffer,
-      ByteOrder order
-  )
-  {
-    byte versionFromBuffer = buffer.get();
-
-    if (versionFromBuffer == VERSION) {
-      final int numBytes = buffer.get();
-      final int totalSize = buffer.getInt();
-      final int sizePer = buffer.getInt();
-
-      final CompressionStrategy compression = CompressionStrategy.forId(buffer.get());
-
-      return new CompressedVSizeColumnarIntsSupplier(
-          totalSize,
-          sizePer,
-          numBytes,
-          GenericIndexed.read(buffer, DecompressingByteBufferObjectStrategy.of(order, compression)),
-          compression
-      );
-
-    }
-
-    throw new IAE("Unknown version[%s]", versionFromBuffer);
-  }
-
-  public static CompressedVSizeColumnarIntsSupplier fromByteBuffer(
-      ByteBuffer buffer,
       ByteOrder order,
       SmooshedFileMapper mapper
   )

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplier.java
@@ -26,6 +26,7 @@ import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.query.monomorphicprocessing.RuntimeShapeInspector;
 
 import java.io.IOException;
@@ -78,18 +79,24 @@ public class CompressedVSizeColumnarMultiIntsSupplier implements WritableSupplie
     valueSupplier.writeTo(channel, smoosher);
   }
 
-  public static CompressedVSizeColumnarMultiIntsSupplier fromByteBuffer(ByteBuffer buffer, ByteOrder order)
+  public static CompressedVSizeColumnarMultiIntsSupplier fromByteBuffer(
+      ByteBuffer buffer,
+      ByteOrder order,
+      SmooshedFileMapper smooshMapper
+  )
   {
     byte versionFromBuffer = buffer.get();
 
     if (versionFromBuffer == VERSION) {
       CompressedVSizeColumnarIntsSupplier offsetSupplier = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
           buffer,
-          order
+          order,
+          smooshMapper
       );
       CompressedVSizeColumnarIntsSupplier valueSupplier = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
           buffer,
-          order
+          order,
+          smooshMapper
       );
       return new CompressedVSizeColumnarMultiIntsSupplier(offsetSupplier, valueSupplier);
     }

--- a/processing/src/main/java/org/apache/druid/segment/data/CompressionFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/CompressionFactory.java
@@ -25,10 +25,12 @@ import com.google.common.base.Supplier;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.segment.serde.MetaSerdeHelper;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.WriteOutBytes;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -306,13 +308,27 @@ public class CompressionFactory
     LongEncodingStrategy getStrategy();
   }
 
+  /**
+   * Reads a column from a {@link ByteBuffer}, possibly using additional secondary files from a
+   * {@link SmooshedFileMapper}.
+   *
+   * @param totalSize      number of rows in the column
+   * @param sizePer        number of values per compression buffer, for compressed columns
+   * @param fromBuffer     primary buffer to read from
+   * @param order          byte order
+   * @param encodingFormat encoding of each long value
+   * @param strategy       compression strategy, for compressed columns
+   * @param smooshMapper   required for reading version 2 (multi-file) indexed. May be null if you know you are reading
+   *                       a single-file column. Generally, this should only be null in tests, not production code.
+   */
   public static Supplier<ColumnarLongs> getLongSupplier(
       int totalSize,
       int sizePer,
       ByteBuffer fromBuffer,
       ByteOrder order,
       LongEncodingFormat encodingFormat,
-      CompressionStrategy strategy
+      CompressionStrategy strategy,
+      @Nullable SmooshedFileMapper smooshMapper
   )
   {
     if (strategy == CompressionStrategy.NONE) {
@@ -324,7 +340,8 @@ public class CompressionFactory
           fromBuffer,
           order,
           encodingFormat.getReader(fromBuffer, order),
-          strategy
+          strategy,
+          smooshMapper
       );
     }
   }
@@ -363,6 +380,7 @@ public class CompressionFactory
             order,
             new LongsLongEncodingWriter(order),
             compressionStrategy,
+            GenericIndexedWriter.MAX_FILE_SIZE,
             closer
         );
       }
@@ -373,18 +391,31 @@ public class CompressionFactory
 
   // Float currently does not support any encoding types, and stores values as 4 byte float
 
+  /**
+   * Reads a column from a {@link ByteBuffer}, possibly using additional secondary files from a
+   * {@link SmooshedFileMapper}.
+   *
+   * @param totalSize    number of rows in the column
+   * @param sizePer      number of values per compression buffer, for compressed columns
+   * @param fromBuffer   primary buffer to read from
+   * @param order        byte order
+   * @param strategy     compression strategy, for compressed columns
+   * @param smooshMapper required for reading version 2 (multi-file) indexed. May be null if you know you are reading
+   *                     a single-file column. Generally, this should only be null in tests, not production code.
+   */
   public static Supplier<ColumnarFloats> getFloatSupplier(
       int totalSize,
       int sizePer,
       ByteBuffer fromBuffer,
       ByteOrder order,
-      CompressionStrategy strategy
+      CompressionStrategy strategy,
+      @Nullable SmooshedFileMapper smooshMapper
   )
   {
     if (strategy == CompressionStrategy.NONE) {
       return new EntireLayoutColumnarFloatsSupplier(totalSize, fromBuffer, order);
     } else {
-      return new BlockLayoutColumnarFloatsSupplier(totalSize, sizePer, fromBuffer, order, strategy);
+      return new BlockLayoutColumnarFloatsSupplier(totalSize, sizePer, fromBuffer, order, strategy, smooshMapper);
     }
   }
 
@@ -406,26 +437,45 @@ public class CompressionFactory
           filenameBase,
           order,
           compressionStrategy,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           closer
       );
     }
   }
 
+  /**
+   * Reads a column from a {@link ByteBuffer}, possibly using additional secondary files from a
+   * {@link SmooshedFileMapper}.
+   *
+   * @param totalSize    number of rows in the column
+   * @param sizePer      number of values per compression buffer, for compressed columns
+   * @param fromBuffer   primary buffer to read from
+   * @param byteOrder    byte order
+   * @param strategy     compression strategy, for compressed columns
+   * @param smooshMapper required for reading version 2 (multi-file) indexed. May be null if you know you are reading
+   *                     a single-file column. Generally, this should only be null in tests, not production code.
+   */
   public static Supplier<ColumnarDoubles> getDoubleSupplier(
       int totalSize,
       int sizePer,
       ByteBuffer fromBuffer,
       ByteOrder byteOrder,
-      CompressionStrategy strategy
+      CompressionStrategy strategy,
+      SmooshedFileMapper smooshMapper
   )
   {
-    switch (strategy) {
-      case NONE:
-        return new EntireLayoutColumnarDoublesSupplier(totalSize, fromBuffer, byteOrder);
-      default:
-        return new BlockLayoutColumnarDoublesSupplier(totalSize, sizePer, fromBuffer, byteOrder, strategy);
+    if (strategy == CompressionStrategy.NONE) {
+      return new EntireLayoutColumnarDoublesSupplier(totalSize, fromBuffer, byteOrder);
+    } else {
+      return new BlockLayoutColumnarDoublesSupplier(
+          totalSize,
+          sizePer,
+          fromBuffer,
+          byteOrder,
+          strategy,
+          smooshMapper
+      );
     }
-
   }
 
   public static ColumnarDoublesSerializer getDoubleSerializer(
@@ -446,6 +496,7 @@ public class CompressionFactory
           filenameBase,
           byteOrder,
           compression,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           closer
       );
     }

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexed.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.data;
 import com.google.common.primitives.Ints;
 import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.common.utils.SerializerUtils;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.ByteBufferUtils;
 import org.apache.druid.java.util.common.IAE;
@@ -174,32 +175,36 @@ public abstract class GenericIndexed<T> implements CloseableIndexed<T>, Serializ
     }
   };
 
-  public static <T> GenericIndexed<T> read(ByteBuffer buffer, ObjectStrategy<T> strategy)
+  /**
+   * Reads a GenericIndexed from a {@link ByteBuffer}, possibly using additional secondary files from a
+   * {@link SmooshedFileMapper}.
+   *
+   * @param buffer     primary buffer to read from
+   * @param strategy   deserialization strategy
+   * @param fileMapper required for reading version 2 (multi-file) indexed. May be null if you know you are reading
+   *                   a version 1 indexed.
+   */
+  public static <T> GenericIndexed<T> read(
+      ByteBuffer buffer,
+      ObjectStrategy<T> strategy,
+      @Nullable SmooshedFileMapper fileMapper
+  )
   {
     byte versionFromBuffer = buffer.get();
 
     if (VERSION_ONE == versionFromBuffer) {
       return createGenericIndexedVersionOne(buffer, strategy);
     } else if (VERSION_TWO == versionFromBuffer) {
-      throw new IAE(
-          "use read(ByteBuffer buffer, ObjectStrategy<T> strategy, SmooshedFileMapper fileMapper)"
-          + " to read version 2 indexed."
-      );
-    }
-    throw new IAE("Unknown version[%d]", (int) versionFromBuffer);
-  }
-
-  public static <T> GenericIndexed<T> read(ByteBuffer buffer, ObjectStrategy<T> strategy, SmooshedFileMapper fileMapper)
-  {
-    byte versionFromBuffer = buffer.get();
-
-    if (VERSION_ONE == versionFromBuffer) {
-      return createGenericIndexedVersionOne(buffer, strategy);
-    } else if (VERSION_TWO == versionFromBuffer) {
+      if (fileMapper == null) {
+        throw DruidException.defensive(
+            "use read(ByteBuffer buffer, ObjectStrategy<T> strategy, SmooshedFileMapper fileMapper)"
+            + " with non-null fileMapper to read version 2 indexed."
+        );
+      }
       return createGenericIndexedVersionTwo(buffer, strategy, fileMapper);
     }
 
-    throw new IAE("Unknown version [%s]", versionFromBuffer);
+    throw new IAE("Unknown version[%s]", versionFromBuffer);
   }
 
   public static <T> GenericIndexed<T> fromArray(T[] objects, ObjectStrategy<T> strategy)

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexedWriter.java
@@ -73,6 +73,17 @@ public class GenericIndexedWriter<T> implements DictionaryWriter<T>
       .writeByteArray(x -> x.fileNameByteArray);
 
 
+  /**
+   * Creates a new writer that accepts byte buffers and compresses them.
+   *
+   * @param segmentWriteOutMedium supplier of temporary files
+   * @param filenameBase          base filename to be used for secondary files, if multiple files are needed
+   * @param compressionStrategy   compression strategy to apply
+   * @param bufferSize            size of the buffers that will be passed in
+   * @param fileSizeLimit         limit for files created by the writer. In production code, this should always be
+   *                              {@link GenericIndexedWriter#MAX_FILE_SIZE}. The parameter is exposed only for testing.
+   * @param closer                closer to attach temporary compression buffers to
+   */
   public static GenericIndexedWriter<ByteBuffer> ofCompressedByteBuffers(
       final SegmentWriteOutMedium segmentWriteOutMedium,
       final String filenameBase,

--- a/processing/src/main/java/org/apache/druid/segment/data/GenericIndexedWriter.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/GenericIndexedWriter.java
@@ -52,6 +52,7 @@ import java.nio.channels.WritableByteChannel;
 public class GenericIndexedWriter<T> implements DictionaryWriter<T>
 {
   private static final int PAGE_SIZE = 4096;
+  public static final int MAX_FILE_SIZE = Integer.MAX_VALUE - PAGE_SIZE;
 
   private static final MetaSerdeHelper<GenericIndexedWriter> SINGLE_FILE_META_SERDE_HELPER = MetaSerdeHelper
       .firstWriteByte((GenericIndexedWriter x) -> GenericIndexed.VERSION_ONE)
@@ -77,13 +78,15 @@ public class GenericIndexedWriter<T> implements DictionaryWriter<T>
       final String filenameBase,
       final CompressionStrategy compressionStrategy,
       final int bufferSize,
+      final int fileSizeLimit,
       final Closer closer
   )
   {
     GenericIndexedWriter<ByteBuffer> writer = new GenericIndexedWriter<>(
         segmentWriteOutMedium,
         filenameBase,
-        compressedByteBuffersWriteObjectStrategy(compressionStrategy, bufferSize, closer)
+        compressedByteBuffersWriteObjectStrategy(compressionStrategy, bufferSize, closer),
+        fileSizeLimit
     );
     writer.objectsSorted = false;
     return writer;
@@ -169,7 +172,7 @@ public class GenericIndexedWriter<T> implements DictionaryWriter<T>
       ObjectStrategy<T> strategy
   )
   {
-    this(segmentWriteOutMedium, filenameBase, strategy, Integer.MAX_VALUE & ~PAGE_SIZE);
+    this(segmentWriteOutMedium, filenameBase, strategy, MAX_FILE_SIZE);
   }
 
   public GenericIndexedWriter(

--- a/processing/src/main/java/org/apache/druid/segment/data/IntermediateColumnarLongsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/IntermediateColumnarLongsSerializer.java
@@ -145,6 +145,7 @@ public class IntermediateColumnarLongsSerializer implements ColumnarLongsSeriali
           order,
           writer,
           compression,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           closer
       );
     }

--- a/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializer.java
@@ -40,7 +40,8 @@ public class V3CompressedVSizeColumnarMultiIntsSerializer extends ColumnarMultiI
       final SegmentWriteOutMedium segmentWriteOutMedium,
       final String filenameBase,
       final int maxValue,
-      final CompressionStrategy compression
+      final CompressionStrategy compression,
+      final int fileSizeLimit
   )
   {
     return new V3CompressedVSizeColumnarMultiIntsSerializer(
@@ -48,20 +49,22 @@ public class V3CompressedVSizeColumnarMultiIntsSerializer extends ColumnarMultiI
         new CompressedColumnarIntsSerializer(
             columnName,
             segmentWriteOutMedium,
-            filenameBase,
+            filenameBase + ".offsets",
             CompressedColumnarIntsSupplier.MAX_INTS_IN_BUFFER,
             IndexIO.BYTE_ORDER,
             compression,
+            fileSizeLimit,
             segmentWriteOutMedium.getCloser()
         ),
         new CompressedVSizeColumnarIntsSerializer(
             columnName,
             segmentWriteOutMedium,
-            filenameBase,
+            filenameBase + ".values",
             maxValue,
             CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForValue(maxValue),
             IndexIO.BYTE_ORDER,
             compression,
+            fileSizeLimit,
             segmentWriteOutMedium.getCloser()
         )
     );

--- a/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializer.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializer.java
@@ -35,6 +35,17 @@ public class V3CompressedVSizeColumnarMultiIntsSerializer extends ColumnarMultiI
 {
   private static final byte VERSION = V3CompressedVSizeColumnarMultiIntsSupplier.VERSION;
 
+  /**
+   * Creates a new serializer.
+   *
+   * @param columnName            name of the column to write
+   * @param segmentWriteOutMedium supplier of temporary files
+   * @param filenameBase          base filename to be used for secondary files, if multiple files are needed
+   * @param maxValue              maximum integer value that will be written to the column
+   * @param compression           compression strategy to apply
+   * @param fileSizeLimit         limit for files created by the writer. In production code, this should always be
+   *                              {@link GenericIndexedWriter#MAX_FILE_SIZE}. The parameter is exposed only for testing.
+   */
   public static V3CompressedVSizeColumnarMultiIntsSerializer create(
       final String columnName,
       final SegmentWriteOutMedium segmentWriteOutMedium,

--- a/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSupplier.java
@@ -56,24 +56,6 @@ public class V3CompressedVSizeColumnarMultiIntsSupplier implements WritableSuppl
     this.valueSupplier = valueSupplier;
   }
 
-  public static V3CompressedVSizeColumnarMultiIntsSupplier fromByteBuffer(ByteBuffer buffer, ByteOrder order)
-  {
-    byte versionFromBuffer = buffer.get();
-
-    if (versionFromBuffer == VERSION) {
-      CompressedColumnarIntsSupplier offsetSupplier = CompressedColumnarIntsSupplier.fromByteBuffer(
-          buffer,
-          order
-      );
-      CompressedVSizeColumnarIntsSupplier valueSupplier = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
-          buffer,
-          order
-      );
-      return new V3CompressedVSizeColumnarMultiIntsSupplier(offsetSupplier, valueSupplier);
-    }
-    throw new IAE("Unknown version[%s]", versionFromBuffer);
-  }
-
   public static V3CompressedVSizeColumnarMultiIntsSupplier fromByteBuffer(ByteBuffer buffer, ByteOrder order, SmooshedFileMapper mapper)
   {
     byte versionFromBuffer = buffer.get();

--- a/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
@@ -968,18 +968,20 @@ public abstract class CompressedNestedDataComplexColumn<TStringDictionary extend
       int pos = dataBuffer.position();
       final Supplier<ColumnarLongs> longs = longsLength > 0 ? CompressedColumnarLongsSupplier.fromByteBuffer(
           dataBuffer,
-          byteOrder
+          byteOrder,
+          columnBuilder.getFileMapper()
       ) : () -> null;
       dataBuffer.position(pos + longsLength);
       pos = dataBuffer.position();
       final Supplier<ColumnarDoubles> doubles = doublesLength > 0 ? CompressedColumnarDoublesSuppliers.fromByteBuffer(
           dataBuffer,
-          byteOrder
+          byteOrder,
+          columnBuilder.getFileMapper()
       ) : () -> null;
       dataBuffer.position(pos + doublesLength);
       final WritableSupplier<ColumnarInts> ints;
       if (version == DictionaryEncodedColumnPartSerde.VERSION.COMPRESSED) {
-        ints = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(dataBuffer, byteOrder);
+        ints = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(dataBuffer, byteOrder, columnBuilder.getFileMapper());
       } else {
         ints = VSizeColumnarInts.readFromByteBuffer(dataBuffer);
       }

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarDoubleColumnAndIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarDoubleColumnAndIndexSupplier.java
@@ -142,7 +142,8 @@ public class ScalarDoubleColumnAndIndexSupplier implements Supplier<NestedCommon
 
         final Supplier<ColumnarDoubles> doubles = CompressedColumnarDoublesSuppliers.fromByteBuffer(
             doublesValueColumn,
-            byteOrder
+            byteOrder,
+            columnBuilder.getFileMapper()
         );
         final ByteBuffer valueIndexBuffer = NestedCommonFormatColumnPartSerde.loadInternalFile(
             mapper,

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarLongColumnAndIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarLongColumnAndIndexSupplier.java
@@ -151,7 +151,8 @@ public class ScalarLongColumnAndIndexSupplier implements Supplier<NestedCommonFo
 
         final Supplier<ColumnarLongs> longs = CompressedColumnarLongsSupplier.fromByteBuffer(
             longsValueColumn,
-            byteOrder
+            byteOrder,
+            columnBuilder.getFileMapper()
         );
         return new ScalarLongColumnAndIndexSupplier(
             longDictionarySupplier,

--- a/processing/src/main/java/org/apache/druid/segment/nested/ScalarStringColumnAndIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/ScalarStringColumnAndIndexSupplier.java
@@ -85,7 +85,8 @@ public class ScalarStringColumnAndIndexSupplier implements Supplier<NestedCommon
         );
         final CompressedVSizeColumnarIntsSupplier ints = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
             encodedValueColumn,
-            byteOrder
+            byteOrder,
+            columnBuilder.getFileMapper()
         );
         final ByteBuffer valueIndexBuffer = NestedCommonFormatColumnPartSerde.loadInternalFile(
             mapper,

--- a/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnAndIndexSupplier.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/VariantColumnAndIndexSupplier.java
@@ -163,7 +163,8 @@ public class VariantColumnAndIndexSupplier implements Supplier<NestedCommonForma
         );
         final CompressedVSizeColumnarIntsSupplier ints = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
             encodedValueColumn,
-            byteOrder
+            byteOrder,
+            fileMapper
         );
         final ByteBuffer valueIndexBuffer = NestedCommonFormatColumnPartSerde.loadInternalFile(
             fileMapper,

--- a/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DictionaryEncodedColumnPartSerde.java
@@ -29,6 +29,7 @@ import org.apache.druid.collections.spatial.ImmutableRTree;
 import org.apache.druid.io.Channels;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
 import org.apache.druid.segment.column.BaseColumn;
 import org.apache.druid.segment.column.ColumnBuilder;
 import org.apache.druid.segment.column.ColumnConfig;
@@ -332,10 +333,10 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
         final WritableSupplier<ColumnarMultiInts> rMultiValuedColumn;
 
         if (hasMultipleValues) {
-          rMultiValuedColumn = readMultiValuedColumn(rVersion, buffer, rFlags);
+          rMultiValuedColumn = readMultiValuedColumn(rVersion, buffer, rFlags, builder.getFileMapper());
           rSingleValuedColumn = null;
         } else {
-          rSingleValuedColumn = readSingleValuedColumn(rVersion, buffer);
+          rSingleValuedColumn = readSingleValuedColumn(rVersion, buffer, builder.getFileMapper());
           rMultiValuedColumn = null;
         }
 
@@ -381,20 +382,29 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
         }
       }
 
-      private WritableSupplier<ColumnarInts> readSingleValuedColumn(VERSION version, ByteBuffer buffer)
+      private WritableSupplier<ColumnarInts> readSingleValuedColumn(
+          VERSION version,
+          ByteBuffer buffer,
+          SmooshedFileMapper smooshReader
+      )
       {
         switch (version) {
           case UNCOMPRESSED_SINGLE_VALUE:
           case UNCOMPRESSED_WITH_FLAGS:
             return VSizeColumnarInts.readFromByteBuffer(buffer);
           case COMPRESSED:
-            return CompressedVSizeColumnarIntsSupplier.fromByteBuffer(buffer, byteOrder);
+            return CompressedVSizeColumnarIntsSupplier.fromByteBuffer(buffer, byteOrder, smooshReader);
           default:
             throw new IAE("Unsupported single-value version[%s]", version);
         }
       }
 
-      private WritableSupplier<ColumnarMultiInts> readMultiValuedColumn(VERSION version, ByteBuffer buffer, int flags)
+      private WritableSupplier<ColumnarMultiInts> readMultiValuedColumn(
+          VERSION version,
+          ByteBuffer buffer,
+          int flags,
+          SmooshedFileMapper smooshReader
+      )
       {
         switch (version) {
           case UNCOMPRESSED_MULTI_VALUE: {
@@ -409,9 +419,9 @@ public class DictionaryEncodedColumnPartSerde implements ColumnPartSerde
           }
           case COMPRESSED: {
             if (Feature.MULTI_VALUE.isSet(flags)) {
-              return CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(buffer, byteOrder);
+              return CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(buffer, byteOrder, smooshReader);
             } else if (Feature.MULTI_VALUE_V3.isSet(flags)) {
-              return V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(buffer, byteOrder);
+              return V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(buffer, byteOrder, smooshReader);
             } else {
               throw new IAE("Unrecognized multi-value flag[%d] for version[%s]", flags, version);
             }

--- a/processing/src/main/java/org/apache/druid/segment/serde/DoubleNumericColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DoubleNumericColumnPartSerde.java
@@ -99,7 +99,8 @@ public class DoubleNumericColumnPartSerde implements ColumnPartSerde
     return (buffer, builder, columnConfig, parent) -> {
       final Supplier<ColumnarDoubles> column = CompressedColumnarDoublesSuppliers.fromByteBuffer(
           buffer,
-          byteOrder
+          byteOrder,
+          builder.getFileMapper()
       );
       DoubleNumericColumnSupplier columnSupplier = new DoubleNumericColumnSupplier(
           column,

--- a/processing/src/main/java/org/apache/druid/segment/serde/DoubleNumericColumnPartSerdeV2.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/DoubleNumericColumnPartSerdeV2.java
@@ -147,7 +147,8 @@ public class DoubleNumericColumnPartSerdeV2 implements ColumnPartSerde
       int initialPos = buffer.position();
       final Supplier<ColumnarDoubles> column = CompressedColumnarDoublesSuppliers.fromByteBuffer(
           buffer,
-          byteOrder
+          byteOrder,
+          builder.getFileMapper()
       );
 
       buffer.position(initialPos + offset);

--- a/processing/src/main/java/org/apache/druid/segment/serde/FloatNumericColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/FloatNumericColumnPartSerde.java
@@ -99,7 +99,8 @@ public class FloatNumericColumnPartSerde implements ColumnPartSerde
     return (buffer, builder, columnConfig, parent) -> {
       final CompressedColumnarFloatsSupplier column = CompressedColumnarFloatsSupplier.fromByteBuffer(
           buffer,
-          byteOrder
+          byteOrder,
+          builder.getFileMapper()
       );
       FloatNumericColumnSupplier columnSupplier = new FloatNumericColumnSupplier(
           column,

--- a/processing/src/main/java/org/apache/druid/segment/serde/FloatNumericColumnPartSerdeV2.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/FloatNumericColumnPartSerdeV2.java
@@ -145,7 +145,8 @@ public class FloatNumericColumnPartSerdeV2 implements ColumnPartSerde
       int initialPos = buffer.position();
       final CompressedColumnarFloatsSupplier column = CompressedColumnarFloatsSupplier.fromByteBuffer(
           buffer,
-          byteOrder
+          byteOrder,
+          builder.getFileMapper()
       );
       buffer.position(initialPos + offset);
       final ImmutableBitmap bitmap;

--- a/processing/src/main/java/org/apache/druid/segment/serde/LongNumericColumnPartSerde.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/LongNumericColumnPartSerde.java
@@ -99,7 +99,8 @@ public class LongNumericColumnPartSerde implements ColumnPartSerde
     return (buffer, builder, columnConfig, parent) -> {
       final CompressedColumnarLongsSupplier column = CompressedColumnarLongsSupplier.fromByteBuffer(
           buffer,
-          byteOrder
+          byteOrder,
+          builder.getFileMapper()
       );
       LongNumericColumnSupplier columnSupplier = new LongNumericColumnSupplier(
           column,

--- a/processing/src/main/java/org/apache/druid/segment/serde/LongNumericColumnPartSerdeV2.java
+++ b/processing/src/main/java/org/apache/druid/segment/serde/LongNumericColumnPartSerdeV2.java
@@ -147,7 +147,8 @@ public class LongNumericColumnPartSerdeV2 implements ColumnPartSerde
       int initialPos = buffer.position();
       final CompressedColumnarLongsSupplier column = CompressedColumnarLongsSupplier.fromByteBuffer(
           buffer,
-          byteOrder
+          byteOrder,
+          builder.getFileMapper()
       );
       buffer.position(initialPos + offset);
       final ImmutableBitmap bitmap;

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -38,6 +38,7 @@ import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.FloatDimensionSchema;
 import org.apache.druid.data.input.impl.LongDimensionSchema;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
+import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.frame.testutil.FrameTestUtil;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.FileUtils;
@@ -94,6 +95,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 public class IndexMergerTestBase extends InitializedNullHandlingTest
@@ -426,6 +428,82 @@ public class IndexMergerTestBase extends InitializedNullHandlingTest
         ),
         index.getMetadata()
     );
+  }
+
+  @Test
+  public void testPersistMergeLargeLongColumn() throws Exception
+  {
+    final DateTime timestamp = DateTimes.nowUtc();
+    final String columnName = "largeColumn";
+    final List<String> dimensions = Collections.singletonList(columnName);
+    final RowSignature signature = RowSignature.builder().add(columnName, ColumnType.LONG).build();
+    final Random random = new Random(0);
+    final long totalRows = 5_000_000L; // Large enough that we can expect to need large columns
+
+    final List<QueryableIndex> toMerge = new ArrayList<>();
+    IncrementalIndex incrementalIndex = null;
+
+    for (long i = 0 ; i < totalRows ; i++) {
+      if (i > 0 && i % 1_000_000 == 0) {
+        System.out.println("Wrote " + i + " rows");
+      }
+
+      if (incrementalIndex != null && !incrementalIndex.canAppendRow()) {
+        toMerge.add(TestIndex.persistAndMemoryMap(incrementalIndex));
+        incrementalIndex.close();
+        incrementalIndex = null;
+      }
+
+      if (incrementalIndex == null) {
+        incrementalIndex = new OnheapIncrementalIndex.Builder()
+            .setIndexSchema(
+                IncrementalIndexSchema
+                    .builder()
+                    .withTimestampSpec(new TimestampSpec("timestamp", "millis", timestamp))
+                    .withDimensionsSpec(
+                        DimensionsSpec.builder()
+                                      .setDimensions(ImmutableList.of(new LongDimensionSchema(columnName)))
+                                      .build()
+                    )
+                    .build()
+            )
+            .setMaxRowCount(5_000_000)
+            .build();
+      }
+
+      final long value = random.nextLong();
+      incrementalIndex.add(new ListBasedInputRow(signature, timestamp, dimensions, Collections.singletonList(value)));
+    }
+
+    final File tempDir = temporaryFolder.newFolder();
+    final File mergedDir = indexMerger.mergeQueryableIndex(
+        toMerge,
+        false,
+        new AggregatorFactory[0],
+        tempDir,
+        indexSpec,
+        null,
+        0
+    );
+
+    final QueryableIndex mergedIndex = closer.closeLater(indexIO.loadIndex(mergedDir));
+
+//    Assert.assertEquals(2, mergedIndex.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+//    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(mergedIndex.getAvailableDimensions()));
+//    Assert.assertEquals(makeOrderBys("__time"), Lists.newArrayList(mergedIndex.getOrdering()));
+//    Assert.assertEquals(3, mergedIndex.getColumnNames().size());
+//
+//    assertDimCompression(mergedIndex, indexSpec.getDimensionCompression());
+//
+//    Assert.assertArrayEquals(
+//        IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
+//        mergedIndex.getMetadata().getAggregators()
+//    );
+//
+//    Assert.assertEquals(
+//        Granularities.NONE,
+//        mergedIndex.getMetadata().getQueryGranularity()
+//    );
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializerTest.java
@@ -165,7 +165,7 @@ public class CompressedColumnarIntsSerializerTest
             TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
         FileSmoosher smoosher = new FileSmoosher(columnDir)
     ) {
-      final Random random = new Random();
+      final Random random = new Random(0);
       final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
       final CompressedColumnarIntsSerializer serializer = new CompressedColumnarIntsSerializer(
           columnName,

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializerTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.data;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
@@ -35,6 +36,8 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.WriteOutBytes;
 import org.apache.druid.utils.CloseableUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -150,6 +153,60 @@ public class CompressedColumnarIntsSerializerTest
     }
   }
 
+  @Test
+  public void testLargeColumn() throws IOException
+  {
+    final File columnDir = temporaryFolder.newFolder();
+    final String columnName = "column";
+    final long numRows = 500_000; // enough values that we expect to switch into large-column mode
+
+    try (
+        SegmentWriteOutMedium segmentWriteOutMedium =
+            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
+        FileSmoosher smoosher = new FileSmoosher(columnDir)
+    ) {
+      final Random random = new Random();
+      final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
+      final CompressedColumnarIntsSerializer serializer = new CompressedColumnarIntsSerializer(
+          columnName,
+          segmentWriteOutMedium,
+          columnName,
+          CompressedColumnarIntsSupplier.MAX_INTS_IN_BUFFER,
+          byteOrder,
+          compressionStrategy,
+          fileSizeLimit,
+          segmentWriteOutMedium.getCloser()
+      );
+      serializer.open();
+
+      for (int i = 0; i < numRows; i++) {
+        serializer.addValue(random.nextInt() ^ Integer.MIN_VALUE);
+      }
+
+      try (SmooshedWriter primaryWriter = smoosher.addWithSmooshedWriter(columnName, serializer.getSerializedSize())) {
+        serializer.writeTo(primaryWriter, smoosher);
+      }
+    }
+
+    try (SmooshedFileMapper smooshMapper = SmooshedFileMapper.load(columnDir)) {
+      MatcherAssert.assertThat(
+          "Number of value parts written", // ensure the column actually ended up multi-part
+          smooshMapper.getInternalFilenames().stream().filter(s -> s.startsWith("column_value_")).count(),
+          Matchers.greaterThan(1L)
+      );
+
+      final Supplier<ColumnarInts> columnSupplier = CompressedColumnarIntsSupplier.fromByteBuffer(
+          smooshMapper.mapFile(columnName),
+          byteOrder,
+          smooshMapper
+      );
+
+      try (final ColumnarInts column = columnSupplier.get()) {
+        Assert.assertEquals(numRows, column.size());
+      }
+    }
+  }
+
   // this test takes ~30 minutes to run
   @Ignore
   @Test
@@ -168,6 +225,7 @@ public class CompressedColumnarIntsSerializerTest
           CompressedColumnarIntsSupplier.MAX_INTS_IN_BUFFER,
           byteOrder,
           compressionStrategy,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           segmentWriteOutMedium.getCloser()
       );
       serializer.open();
@@ -198,6 +256,7 @@ public class CompressedColumnarIntsSerializerTest
         chunkFactor,
         byteOrder,
         compressionStrategy,
+        GenericIndexedWriter.MAX_FILE_SIZE,
         segmentWriteOutMedium.getCloser()
     );
     CompressedColumnarIntsSupplier supplierFromList = CompressedColumnarIntsSupplier.fromList(
@@ -221,7 +280,8 @@ public class CompressedColumnarIntsSerializerTest
     // read from ByteBuffer and check values
     CompressedColumnarIntsSupplier supplierFromByteBuffer = CompressedColumnarIntsSupplier.fromByteBuffer(
         ByteBuffer.wrap(IOUtils.toByteArray(writeOutBytes.asInputStream())),
-        byteOrder
+        byteOrder,
+        null
     );
     ColumnarInts columnarInts = supplierFromByteBuffer.get();
     Assert.assertEquals(vals.length, columnarInts.size());
@@ -247,6 +307,7 @@ public class CompressedColumnarIntsSerializerTest
             "test",
             compressionStrategy,
             Long.BYTES * 10000,
+            GenericIndexedWriter.MAX_FILE_SIZE,
             segmentWriteOutMedium.getCloser()
         ),
         segmentWriteOutMedium.getCloser()
@@ -264,7 +325,8 @@ public class CompressedColumnarIntsSerializerTest
     // read from ByteBuffer and check values
     CompressedColumnarIntsSupplier supplierFromByteBuffer = CompressedColumnarIntsSupplier.fromByteBuffer(
         mapper.mapFile("test"),
-        byteOrder
+        byteOrder,
+        null
     );
     ColumnarInts columnarInts = supplierFromByteBuffer.get();
     Assert.assertEquals(vals.length, columnarInts.size());

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplierTest.java
@@ -109,7 +109,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
     final byte[] bytes = baos.toByteArray();
     Assert.assertEquals(theSupplier.getSerializedSize(), bytes.length);
 
-    supplier = CompressedColumnarIntsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), ByteOrder.nativeOrder());
+    supplier = CompressedColumnarIntsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), ByteOrder.nativeOrder(), null);
     columnarInts = supplier.get();
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedDoublesSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedDoublesSerdeTest.java
@@ -23,11 +23,18 @@ import com.google.common.base.Supplier;
 import com.google.common.primitives.Doubles;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedWriter;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.utils.CloseableUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,12 +44,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -131,6 +140,63 @@ public class CompressedDoublesSerdeTest
     testWithValues(chunk);
   }
 
+  @Test
+  public void testLargeColumn() throws IOException
+  {
+    // This test only makes sense if we can use BlockLayoutColumnarDoubleSerializer directly.
+    // Exclude incompatible compressionStrategy.
+    Assume.assumeThat(compressionStrategy, CoreMatchers.not(CoreMatchers.equalTo(CompressionStrategy.NONE)));
+
+    final File columnDir = temporaryFolder.newFolder();
+    final String columnName = "column";
+    final long numRows = 500_000; // enough values that we expect to switch into large-column mode
+
+    try (
+        SegmentWriteOutMedium segmentWriteOutMedium =
+            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
+        FileSmoosher smoosher = new FileSmoosher(columnDir)
+    ) {
+      final Random random = new Random();
+      final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
+      final ColumnarDoublesSerializer serializer = new BlockLayoutColumnarDoublesSerializer(
+          columnName,
+          segmentWriteOutMedium,
+          columnName,
+          order,
+          compressionStrategy,
+          fileSizeLimit,
+          segmentWriteOutMedium.getCloser()
+      );
+      serializer.open();
+
+      for (int i = 0; i < numRows; i++) {
+        serializer.add(random.nextLong());
+      }
+
+      try (SmooshedWriter primaryWriter = smoosher.addWithSmooshedWriter(columnName, serializer.getSerializedSize())) {
+        serializer.writeTo(primaryWriter, smoosher);
+      }
+    }
+
+    try (SmooshedFileMapper smooshMapper = SmooshedFileMapper.load(columnDir)) {
+      MatcherAssert.assertThat(
+          "Number of value parts written", // ensure the column actually ended up multi-part
+          smooshMapper.getInternalFilenames().stream().filter(s -> s.startsWith("column_value_")).count(),
+          Matchers.greaterThan(1L)
+      );
+
+      final Supplier<ColumnarDoubles> columnSupplier = CompressedColumnarDoublesSuppliers.fromByteBuffer(
+          smooshMapper.mapFile(columnName),
+          order,
+          smooshMapper
+      );
+
+      try (final ColumnarDoubles column = columnSupplier.get()) {
+        Assert.assertEquals(numRows, column.size());
+      }
+    }
+  }
+
   // this test takes ~45 minutes to run
   @Ignore
   @Test
@@ -179,7 +245,7 @@ public class CompressedDoublesSerdeTest
     serializer.writeTo(Channels.newChannel(baos), null);
     Assert.assertEquals(baos.size(), serializer.getSerializedSize());
     Supplier<ColumnarDoubles> supplier = CompressedColumnarDoublesSuppliers
-        .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order);
+        .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     try (ColumnarDoubles doubles = supplier.get()) {
       assertIndexMatchesVals(doubles, values);
       for (int i = 0; i < 10; i++) {

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedDoublesSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedDoublesSerdeTest.java
@@ -156,7 +156,7 @@ public class CompressedDoublesSerdeTest
             TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
         FileSmoosher smoosher = new FileSmoosher(columnDir)
     ) {
-      final Random random = new Random();
+      final Random random = new Random(0);
       final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
       final ColumnarDoublesSerializer serializer = new BlockLayoutColumnarDoublesSerializer(
           columnName,

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
@@ -23,11 +23,18 @@ import com.google.common.base.Supplier;
 import com.google.common.primitives.Floats;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedWriter;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.utils.CloseableUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,12 +44,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -138,6 +147,63 @@ public class CompressedFloatsSerdeTest
     testWithValues(chunk);
   }
 
+  @Test
+  public void testLargeColumn() throws IOException
+  {
+    // This test only makes sense if we can use BlockLayoutColumnarFloatSerializer directly.
+    // Exclude incompatible compressionStrategy.
+    Assume.assumeThat(compressionStrategy, CoreMatchers.not(CoreMatchers.equalTo(CompressionStrategy.NONE)));
+
+    final File columnDir = temporaryFolder.newFolder();
+    final String columnName = "column";
+    final long numRows = 500_000; // enough values that we expect to switch into large-column mode
+
+    try (
+        SegmentWriteOutMedium segmentWriteOutMedium =
+            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
+        FileSmoosher smoosher = new FileSmoosher(columnDir)
+    ) {
+      final Random random = new Random();
+      final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
+      final ColumnarFloatsSerializer serializer = new BlockLayoutColumnarFloatsSerializer(
+          columnName,
+          segmentWriteOutMedium,
+          columnName,
+          order,
+          compressionStrategy,
+          fileSizeLimit,
+          segmentWriteOutMedium.getCloser()
+      );
+      serializer.open();
+
+      for (int i = 0; i < numRows; i++) {
+        serializer.add(random.nextLong());
+      }
+
+      try (SmooshedWriter primaryWriter = smoosher.addWithSmooshedWriter(columnName, serializer.getSerializedSize())) {
+        serializer.writeTo(primaryWriter, smoosher);
+      }
+    }
+
+    try (SmooshedFileMapper smooshMapper = SmooshedFileMapper.load(columnDir)) {
+      MatcherAssert.assertThat(
+          "Number of value parts written", // ensure the column actually ended up multi-part
+          smooshMapper.getInternalFilenames().stream().filter(s -> s.startsWith("column_value_")).count(),
+          Matchers.greaterThan(1L)
+      );
+
+      final Supplier<ColumnarFloats> columnSupplier = CompressedColumnarFloatsSupplier.fromByteBuffer(
+          smooshMapper.mapFile(columnName),
+          order,
+          smooshMapper
+      );
+
+      try (final ColumnarFloats column = columnSupplier.get()) {
+        Assert.assertEquals(numRows, column.size());
+      }
+    }
+  }
+
   // this test takes ~30 minutes to run
   @Ignore
   @Test
@@ -188,7 +254,7 @@ public class CompressedFloatsSerdeTest
     serializer.writeTo(Channels.newChannel(baos), null);
     Assert.assertEquals(baos.size(), serializer.getSerializedSize());
     CompressedColumnarFloatsSupplier supplier = CompressedColumnarFloatsSupplier
-        .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order);
+        .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     try (ColumnarFloats floats = supplier.get()) {
 
       assertIndexMatchesVals(floats, values);
@@ -241,9 +307,8 @@ public class CompressedFloatsSerdeTest
 
     final byte[] bytes = baos.toByteArray();
     Assert.assertEquals(supplier.getSerializedSize(), bytes.length);
-    CompressedColumnarFloatsSupplier anotherSupplier = CompressedColumnarFloatsSupplier.fromByteBuffer(
-        ByteBuffer.wrap(bytes), order
-    );
+    CompressedColumnarFloatsSupplier anotherSupplier =
+        CompressedColumnarFloatsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), order, null);
     try (ColumnarFloats indexed = anotherSupplier.get()) {
       assertIndexMatchesVals(indexed, vals);
     }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
@@ -163,7 +163,7 @@ public class CompressedFloatsSerdeTest
             TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
         FileSmoosher smoosher = new FileSmoosher(columnDir)
     ) {
-      final Random random = new Random();
+      final Random random = new Random(0);
       final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
       final ColumnarFloatsSerializer serializer = new BlockLayoutColumnarFloatsSerializer(
           columnName,

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsAutoEncodingSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsAutoEncodingSerdeTest.java
@@ -115,7 +115,7 @@ public class CompressedLongsAutoEncodingSerdeTest
     serializer.writeTo(Channels.newChannel(baos), null);
     Assert.assertEquals(baos.size(), serializer.getSerializedSize());
     CompressedColumnarLongsSupplier supplier =
-        CompressedColumnarLongsSupplier.fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order);
+        CompressedColumnarLongsSupplier.fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     ColumnarLongs longs = supplier.get();
 
     assertIndexMatchesVals(longs, values);

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
@@ -23,11 +23,18 @@ import com.google.common.base.Supplier;
 import com.google.common.primitives.Longs;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.io.smoosh.FileSmoosher;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedFileMapper;
+import org.apache.druid.java.util.common.io.smoosh.SmooshedWriter;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.utils.CloseableUtils;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,12 +44,14 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -166,6 +175,65 @@ public class CompressedLongsSerdeTest
     }
   }
 
+  @Test
+  public void testLargeColumn() throws IOException
+  {
+    // This test only makes sense if we can use BlockLayoutColumnarLongsSerializer directly. Exclude incompatible
+    // combinations of compressionStrategy, encodingStrategy.
+    Assume.assumeThat(compressionStrategy, CoreMatchers.not(CoreMatchers.equalTo(CompressionStrategy.NONE)));
+    Assume.assumeThat(encodingStrategy, CoreMatchers.equalTo(CompressionFactory.LongEncodingStrategy.LONGS));
+
+    final File columnDir = temporaryFolder.newFolder();
+    final String columnName = "column";
+    final long numRows = 500_000; // enough values that we expect to switch into large-column mode
+
+    try (
+        SegmentWriteOutMedium segmentWriteOutMedium =
+            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
+        FileSmoosher smoosher = new FileSmoosher(columnDir)
+    ) {
+      final Random random = new Random();
+      final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
+      final ColumnarLongsSerializer serializer = new BlockLayoutColumnarLongsSerializer(
+          columnName,
+          segmentWriteOutMedium,
+          columnName,
+          order,
+          new LongsLongEncodingWriter(order),
+          compressionStrategy,
+          fileSizeLimit,
+          segmentWriteOutMedium.getCloser()
+      );
+      serializer.open();
+
+      for (int i = 0; i < numRows; i++) {
+        serializer.add(random.nextLong());
+      }
+
+      try (SmooshedWriter primaryWriter = smoosher.addWithSmooshedWriter(columnName, serializer.getSerializedSize())) {
+        serializer.writeTo(primaryWriter, smoosher);
+      }
+    }
+
+    try (SmooshedFileMapper smooshMapper = SmooshedFileMapper.load(columnDir)) {
+      MatcherAssert.assertThat(
+          "Number of value parts written", // ensure the column actually ended up multi-part
+          smooshMapper.getInternalFilenames().stream().filter(s -> s.startsWith("column_value_")).count(),
+          Matchers.greaterThan(1L)
+      );
+
+      final CompressedColumnarLongsSupplier columnSupplier = CompressedColumnarLongsSupplier.fromByteBuffer(
+          smooshMapper.mapFile(columnName),
+          order,
+          smooshMapper
+      );
+
+      try (final ColumnarLongs column = columnSupplier.get()) {
+        Assert.assertEquals(numRows, column.size());
+      }
+    }
+  }
+
   public void testWithValues(long[] values) throws Exception
   {
     testValues(values);
@@ -193,7 +261,7 @@ public class CompressedLongsSerdeTest
     serializer.writeTo(Channels.newChannel(baos), null);
     Assert.assertEquals(baos.size(), serializer.getSerializedSize());
     CompressedColumnarLongsSupplier supplier = CompressedColumnarLongsSupplier
-        .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order);
+        .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     try (ColumnarLongs longs = supplier.get()) {
 
       assertIndexMatchesVals(longs, values);
@@ -255,10 +323,8 @@ public class CompressedLongsSerdeTest
 
     final byte[] bytes = baos.toByteArray();
     Assert.assertEquals(supplier.getSerializedSize(), bytes.length);
-    CompressedColumnarLongsSupplier anotherSupplier = CompressedColumnarLongsSupplier.fromByteBuffer(
-        ByteBuffer.wrap(bytes),
-        order
-    );
+    CompressedColumnarLongsSupplier anotherSupplier =
+        CompressedColumnarLongsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), order, null);
     try (ColumnarLongs indexed = anotherSupplier.get()) {
       assertIndexMatchesVals(indexed, vals);
     }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
@@ -192,7 +192,7 @@ public class CompressedLongsSerdeTest
             TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
         FileSmoosher smoosher = new FileSmoosher(columnDir)
     ) {
-      final Random random = new Random();
+      final Random random = new Random(0);
       final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
       final ColumnarLongsSerializer serializer = new BlockLayoutColumnarLongsSerializer(
           columnName,

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
@@ -305,7 +305,7 @@ public class CompressedVSizeColumnarIntsSerializerTest
             TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
         FileSmoosher smoosher = new FileSmoosher(columnDir)
     ) {
-      final Random random = new Random();
+      final Random random = new Random(0);
       final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
       final CompressedVSizeColumnarIntsSerializer serializer = new CompressedVSizeColumnarIntsSerializer(
           columnName,

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.data;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
@@ -34,6 +35,8 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.WriteOutBytes;
 import org.apache.druid.utils.CloseableUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -125,6 +128,7 @@ public class CompressedVSizeColumnarIntsSerializerTest
         chunkSize,
         byteOrder,
         compressionStrategy,
+        GenericIndexedWriter.MAX_FILE_SIZE,
         segmentWriteOutMedium.getCloser()
     );
     CompressedVSizeColumnarIntsSupplier supplierFromList = CompressedVSizeColumnarIntsSupplier.fromList(
@@ -149,7 +153,8 @@ public class CompressedVSizeColumnarIntsSerializerTest
     // read from ByteBuffer and check values
     CompressedVSizeColumnarIntsSupplier supplierFromByteBuffer = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
         ByteBuffer.wrap(IOUtils.toByteArray(writeOutBytes.asInputStream())),
-        byteOrder
+        byteOrder,
+        null
     );
     ColumnarInts columnarInts = supplierFromByteBuffer.get();
     for (int i = 0; i < vals.length; ++i) {
@@ -199,6 +204,7 @@ public class CompressedVSizeColumnarIntsSerializerTest
           "test",
           compressionStrategy,
           Long.BYTES * 10000,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           segmentWriteOutMedium.getCloser()
       );
       CompressedVSizeColumnarIntsSerializer serializer = new CompressedVSizeColumnarIntsSerializer(
@@ -236,6 +242,7 @@ public class CompressedVSizeColumnarIntsSerializerTest
         "test",
         compressionStrategy,
         Long.BYTES * 10000,
+        GenericIndexedWriter.MAX_FILE_SIZE,
         segmentWriteOutMedium.getCloser()
     );
     CompressedVSizeColumnarIntsSerializer writer = new CompressedVSizeColumnarIntsSerializer(
@@ -264,7 +271,8 @@ public class CompressedVSizeColumnarIntsSerializerTest
 
     CompressedVSizeColumnarIntsSupplier supplierFromByteBuffer = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
         mapper.mapFile("test"),
-        byteOrder
+        byteOrder,
+        null
     );
 
     ColumnarInts columnarInts = supplierFromByteBuffer.get();
@@ -284,4 +292,59 @@ public class CompressedVSizeColumnarIntsSerializerTest
     }
   }
 
+  @Test
+  public void testLargeColumn() throws IOException
+  {
+    final File columnDir = temporaryFolder.newFolder();
+    final String columnName = "column";
+    final int maxValue = Integer.MAX_VALUE;
+    final long numRows = 500_000; // enough values that we expect to switch into large-column mode
+
+    try (
+        SegmentWriteOutMedium segmentWriteOutMedium =
+            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
+        FileSmoosher smoosher = new FileSmoosher(columnDir)
+    ) {
+      final Random random = new Random();
+      final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
+      final CompressedVSizeColumnarIntsSerializer serializer = new CompressedVSizeColumnarIntsSerializer(
+          columnName,
+          segmentWriteOutMedium,
+          columnName,
+          maxValue,
+          CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForValue(maxValue),
+          byteOrder,
+          compressionStrategy,
+          fileSizeLimit,
+          segmentWriteOutMedium.getCloser()
+      );
+      serializer.open();
+
+      for (int i = 0; i < numRows; i++) {
+        serializer.addValue(random.nextInt() ^ Integer.MIN_VALUE);
+      }
+
+      try (SmooshedWriter primaryWriter = smoosher.addWithSmooshedWriter(columnName, serializer.getSerializedSize())) {
+        serializer.writeTo(primaryWriter, smoosher);
+      }
+    }
+
+    try (SmooshedFileMapper smooshMapper = SmooshedFileMapper.load(columnDir)) {
+      MatcherAssert.assertThat(
+          "Number of value parts written", // ensure the column actually ended up multi-part
+          smooshMapper.getInternalFilenames().stream().filter(s -> s.startsWith("column_value_")).count(),
+          Matchers.greaterThan(1L)
+      );
+
+      final Supplier<ColumnarInts> columnSupplier = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(
+          smooshMapper.mapFile(columnName),
+          byteOrder,
+          smooshMapper
+      );
+
+      try (final ColumnarInts column = columnSupplier.get()) {
+        Assert.assertEquals(numRows, column.size());
+      }
+    }
+  }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSupplierTest.java
@@ -136,7 +136,7 @@ public class CompressedVSizeColumnarIntsSupplierTest extends CompressionStrategy
     final byte[] bytes = baos.toByteArray();
     Assert.assertEquals(theSupplier.getSerializedSize(), bytes.length);
 
-    supplier = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), byteOrder);
+    supplier = CompressedVSizeColumnarIntsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), byteOrder, null);
     columnarInts = supplier.get();
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarMultiIntsSupplierTest.java
@@ -87,7 +87,8 @@ public class CompressedVSizeColumnarMultiIntsSupplierTest extends CompressedVSiz
     return wrapSupplier(
         CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
             buffer,
-            ByteOrder.nativeOrder()
+            ByteOrder.nativeOrder(),
+            null
         ),
         closer
     );

--- a/processing/src/test/java/org/apache/druid/segment/data/GenericIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/GenericIndexedTest.java
@@ -126,7 +126,7 @@ public class GenericIndexedTest extends InitializedNullHandlingTest
 
     final ByteBuffer byteBuffer = ByteBuffer.wrap(baos.toByteArray());
     Assert.assertEquals(indexed.getSerializedSize(), byteBuffer.remaining());
-    GenericIndexed<String> deserialized = GenericIndexed.read(byteBuffer, GenericIndexed.STRING_STRATEGY);
+    GenericIndexed<String> deserialized = GenericIndexed.read(byteBuffer, GenericIndexed.STRING_STRATEGY, null);
     Assert.assertEquals(0, byteBuffer.remaining());
     return deserialized;
   }

--- a/processing/src/test/java/org/apache/druid/segment/data/TestColumnCompression.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/TestColumnCompression.java
@@ -92,7 +92,8 @@ public class TestColumnCompression
     );
     this.compressed = CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
         buffer,
-        ByteOrder.nativeOrder()
+        ByteOrder.nativeOrder(),
+        null
     ).get();
 
     filter = new BitSet();

--- a/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.data;
 
 import com.google.common.base.Function;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.IOUtils;
@@ -34,6 +35,8 @@ import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.WriteOutBytes;
 import org.apache.druid.utils.CloseableUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -45,6 +48,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -151,6 +155,65 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
     }
   }
 
+  @Test
+  public void testLargeColumn() throws IOException
+  {
+    final File columnDir = temporaryFolder.newFolder();
+    final String columnName = "column";
+    final long numRows = 500_000; // enough values that we expect to switch into large-column mode
+
+    try (
+        SegmentWriteOutMedium segmentWriteOutMedium =
+            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
+        FileSmoosher smoosher = new FileSmoosher(columnDir)
+    ) {
+      final Random random = new Random();
+      final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
+      final V3CompressedVSizeColumnarMultiIntsSerializer serializer =
+          V3CompressedVSizeColumnarMultiIntsSerializer.create(
+              columnName,
+              segmentWriteOutMedium,
+              columnName,
+              Integer.MAX_VALUE,
+              compressionStrategy,
+              fileSizeLimit
+          );
+      serializer.open();
+
+      for (int i = 0; i < numRows; i++) {
+        serializer.addValues(new ArrayBasedIndexedInts(new int[]{random.nextInt() ^ Integer.MIN_VALUE}));
+      }
+
+      try (SmooshedWriter primaryWriter = smoosher.addWithSmooshedWriter(columnName, serializer.getSerializedSize())) {
+        serializer.writeTo(primaryWriter, smoosher);
+      }
+    }
+
+    try (SmooshedFileMapper smooshMapper = SmooshedFileMapper.load(columnDir)) {
+      MatcherAssert.assertThat(
+          "Number of offset parts written", // ensure the offsets subcolumn actually ended up multi-part
+          smooshMapper.getInternalFilenames().stream().filter(s -> s.startsWith("column.offsets_value_")).count(),
+          Matchers.greaterThan(1L)
+      );
+
+      MatcherAssert.assertThat(
+          "Number of value parts written", // ensure the values subcolumn actually ended up multi-part
+          smooshMapper.getInternalFilenames().stream().filter(s -> s.startsWith("column.values_value_")).count(),
+          Matchers.greaterThan(1L)
+      );
+
+      final Supplier<ColumnarMultiInts> columnSupplier = V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
+          smooshMapper.mapFile(columnName),
+          byteOrder,
+          smooshMapper
+      );
+
+      try (final ColumnarMultiInts column = columnSupplier.get()) {
+        Assert.assertEquals(numRows, column.size());
+      }
+    }
+  }
+
   // this test takes ~30 minutes to run
   @Ignore
   @Test
@@ -207,6 +270,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
           offsetChunkFactor,
           byteOrder,
           compressionStrategy,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           segmentWriteOutMedium.getCloser()
       );
       CompressedVSizeColumnarIntsSerializer valueWriter = new CompressedVSizeColumnarIntsSerializer(
@@ -217,6 +281,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
           valueChunkFactor,
           byteOrder,
           compressionStrategy,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           segmentWriteOutMedium.getCloser()
       );
       V3CompressedVSizeColumnarMultiIntsSerializer writer =
@@ -244,7 +309,8 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       // read from ByteBuffer and check values
       V3CompressedVSizeColumnarMultiIntsSupplier supplierFromByteBuffer = V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
           ByteBuffer.wrap(IOUtils.toByteArray(writeOutBytes.asInputStream())),
-          byteOrder
+          byteOrder,
+          null
       );
 
       try (final ColumnarMultiInts columnarMultiInts = supplierFromByteBuffer.get()) {
@@ -281,6 +347,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
               "offset",
               compressionStrategy,
               Long.BYTES * 250000,
+              GenericIndexedWriter.MAX_FILE_SIZE,
               segmentWriteOutMedium.getCloser()
           ),
           segmentWriteOutMedium.getCloser()
@@ -291,6 +358,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
           "value",
           compressionStrategy,
           Long.BYTES * 250000,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           segmentWriteOutMedium.getCloser()
       );
       CompressedVSizeColumnarIntsSerializer valueWriter = new CompressedVSizeColumnarIntsSerializer(
@@ -316,7 +384,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       SmooshedFileMapper mapper = Smoosh.map(tmpDirectory);
 
       V3CompressedVSizeColumnarMultiIntsSupplier supplierFromByteBuffer =
-          V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(mapper.mapFile("test"), byteOrder);
+          V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(mapper.mapFile("test"), byteOrder, null);
       ColumnarMultiInts columnarMultiInts = supplierFromByteBuffer.get();
       Assert.assertEquals(columnarMultiInts.size(), vals.size());
       for (int i = 0; i < vals.size(); ++i) {
@@ -359,6 +427,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
               "offset",
               compressionStrategy,
               Long.BYTES * 250000,
+              GenericIndexedWriter.MAX_FILE_SIZE,
               segmentWriteOutMedium.getCloser()
           ),
           segmentWriteOutMedium.getCloser()
@@ -369,6 +438,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
           "value",
           compressionStrategy,
           Long.BYTES * 250000,
+          GenericIndexedWriter.MAX_FILE_SIZE,
           segmentWriteOutMedium.getCloser()
       );
       CompressedVSizeColumnarIntsSerializer valueWriter = new CompressedVSizeColumnarIntsSerializer(

--- a/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
@@ -167,7 +167,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
             TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder());
         FileSmoosher smoosher = new FileSmoosher(columnDir)
     ) {
-      final Random random = new Random();
+      final Random random = new Random(0);
       final int fileSizeLimit = 128_000; // limit to 128KB so we switch to large-column mode sooner
       final V3CompressedVSizeColumnarMultiIntsSerializer serializer =
           V3CompressedVSizeColumnarMultiIntsSerializer.create(

--- a/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSupplierTest.java
@@ -85,7 +85,8 @@ public class V3CompressedVSizeColumnarMultiIntsSupplierTest extends CompressedVS
     return wrapSupplier(
         V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
             buffer,
-            ByteOrder.nativeOrder()
+            ByteOrder.nativeOrder(),
+            null
         ),
         closer
     );

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldColumnIndexSupplierTest.java
@@ -146,7 +146,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     arrayWriter.open();
     writeToBuffer(arrayBuffer, arrayWriter);
 
-    GenericIndexed<ByteBuffer> strings = GenericIndexed.read(stringBuffer, GenericIndexed.UTF8_STRATEGY);
+    GenericIndexed<ByteBuffer> strings = GenericIndexed.read(stringBuffer, GenericIndexed.UTF8_STRATEGY, null);
     globalStrings = () -> strings.singleThreaded();
     globalLongs = FixedIndexed.read(longBuffer, TypeStrategies.LONG, ByteOrder.nativeOrder(), Long.BYTES);
     globalDoubles = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES);
@@ -1241,7 +1241,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     doubleWriter.open();
     writeToBuffer(doubleBuffer, doubleWriter);
 
-    GenericIndexed<ByteBuffer> strings = GenericIndexed.read(stringBuffer, GenericIndexed.UTF8_STRATEGY);
+    GenericIndexed<ByteBuffer> strings = GenericIndexed.read(stringBuffer, GenericIndexed.UTF8_STRATEGY, null);
     Supplier<Indexed<ByteBuffer>> stringIndexed = () -> strings.singleThreaded();
     Supplier<FixedIndexed<Long>> longIndexed = FixedIndexed.read(longBuffer, TypeStrategies.LONG, ByteOrder.nativeOrder(), Long.BYTES);
     Supplier<FixedIndexed<Double>> doubleIndexed = FixedIndexed.read(doubleBuffer, TypeStrategies.DOUBLE, ByteOrder.nativeOrder(), Double.BYTES);
@@ -1293,7 +1293,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     NestedFieldColumnIndexSupplier<?> indexSupplier = new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(
@@ -1397,7 +1398,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     return new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(
@@ -1481,7 +1483,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     return new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(
@@ -1561,7 +1564,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     return new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(
@@ -1646,7 +1650,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     return new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(
@@ -1726,7 +1731,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     return new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(
@@ -1811,7 +1817,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     return new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(
@@ -1903,7 +1910,8 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
         Integer.BYTES
     );
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
 
     return new NestedFieldColumnIndexSupplier<>(
         new FieldTypeInfo.TypeSet(

--- a/processing/src/test/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/serde/DictionaryEncodedStringIndexSupplierTest.java
@@ -157,10 +157,11 @@ public class DictionaryEncodedStringIndexSupplierTest extends InitializedNullHan
     writeToBuffer(byteBuffer, stringWriter);
     writeToBuffer(bitmapsBuffer, bitmapWriter);
 
-    GenericIndexed<ImmutableBitmap> bitmaps = GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy());
+    GenericIndexed<ImmutableBitmap> bitmaps =
+        GenericIndexed.read(bitmapsBuffer, roaringFactory.getObjectStrategy(), null);
     return new StringUtf8ColumnIndexSupplier<>(
         roaringFactory.getBitmapFactory(),
-        GenericIndexed.read(byteBuffer, GenericIndexed.UTF8_STRATEGY)::singleThreaded,
+        GenericIndexed.read(byteBuffer, GenericIndexed.UTF8_STRATEGY, null)::singleThreaded,
         bitmaps,
         null
     );

--- a/processing/src/test/java/org/apache/druid/segment/serde/HyperUniquesSerdeForTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/serde/HyperUniquesSerdeForTest.java
@@ -93,7 +93,7 @@ public class HyperUniquesSerdeForTest extends ComplexMetricSerde
   {
     final GenericIndexed column;
     if (columnBuilder.getFileMapper() == null) {
-      column = GenericIndexed.read(byteBuffer, getObjectStrategy());
+      column = GenericIndexed.read(byteBuffer, getObjectStrategy(), null);
     } else {
       column = GenericIndexed.read(byteBuffer, getObjectStrategy(), columnBuilder.getFileMapper());
     }


### PR DESCRIPTION
This patch fixes a class of bugs where various primitive column readers were not providing a SmooshedFileMapper to GenericIndexed, even though the corresponding writer could potentially write multi-file columns. For example, #7943 is an instance of this bug.

This patch also includes a fix for an issue on the writer for compressed multi-value string columns, V3CompressedVSizeColumnarMultiIntsSerializer, where it would use the same base filename for both the offset and values sections. This bug would only be triggered for segments in excess of 500 million rows. When a segment has fewer rows than that, it could potentially have a values section that needs to be split over multiple files, but the offset is never more than 4 bytes per row. This bug was triggered by the new tests, which use a smaller fileSizeLimit.

This patch also removes the 2-arg overload of `GenericIndexed#read` (which doesn't accept a `SmooshedFileMapper`). The 3-arg one can be used with the `SmooshedFileMapper` arg set to `null` if the caller really doesn't want to use a mapper. However, production callers generally do.