### PR TITLE
Run JDK 21 workflows with latest JDK.

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -41,8 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
-        java: [ '11', '17', '21.0.4' ]
+        java: [ '11', '17', '21' ]
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -79,8 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
-        jdk: [ '11', '17', '21.0.4' ]
+        jdk: [ '11', '17', '21' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch
@@ -211,8 +210,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
-        jdk: [ '11', '21.0.4' ]
+        jdk: [ '11', '21' ]
     name: "unit tests (jdk${{ matrix.jdk }})"
     uses: ./.github/workflows/unit-tests.yml
     needs: [unit-tests-unapproved, check-approval]


### PR DESCRIPTION
Reverts PR #17458. There's a new JDK out (21.0.6). Hopefully it does not segfault.