### PR TITLE
Add check to see if druid is running in kubernetes

### DIFF
--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -138,8 +138,15 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-0}
-if [ "${DRUID_SET_HOST_IP}" = "1" ]
+if [ -z ${KUBERNETES_SERVICE_HOST} ]
+then
+  DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+else
+  # Running in kubernetes
+  DRUID_SET_HOST=${DRUID_SET_HOST:-0}
+fi
+
+if [ "${DRUID_SET_HOST}" = "1" ]
 then
     setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
 fi

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -138,15 +138,16 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-if [ -z ${KUBERNETES_SERVICE_HOST} ]
+if [ -z "${KUBERNETES_SERVICE_HOST}" ]
 then
-  DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+  # Running outside kubernetes, use IP addresses
+  DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-1}
 else
-  # Running in kubernetes
-  DRUID_SET_HOST=${DRUID_SET_HOST:-0}
+  # Running in kubernetes, so use canonical names
+  DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-0}
 fi
 
-if [ "${DRUID_SET_HOST}" = "1" ]
+if [ "${DRUID_SET_HOST_IP}" = "1" ]
 then
     setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
 fi

--- a/distribution/docker/peon.sh
+++ b/distribution/docker/peon.sh
@@ -97,15 +97,16 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-if [ -z ${KUBERNETES_SERVICE_HOST} ]
+if [ -z "${KUBERNETES_SERVICE_HOST}" ]
 then
-  DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+  # Running outside kubernetes, use IP addresses
+  DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-1}
 else
-  # Running in kubernetes
-  DRUID_SET_HOST=${DRUID_SET_HOST:-0}
+  # Running in kubernetes, so use canonical names
+  DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-0}
 fi
 
-if [ "${DRUID_SET_HOST}" = "1" ]
+if [ "${DRUID_SET_HOST_IP}" = "1" ]
 then
     setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
 fi

--- a/distribution/docker/peon.sh
+++ b/distribution/docker/peon.sh
@@ -97,8 +97,15 @@ then
     setKey _common druid.zk.service.host "${ZOOKEEPER}"
 fi
 
-DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-0}
-if [ "${DRUID_SET_HOST_IP}" = "1" ]
+if [ -z ${KUBERNETES_SERVICE_HOST} ]
+then
+  DRUID_SET_HOST=${DRUID_SET_HOST:-1}
+else
+  # Running in kubernetes
+  DRUID_SET_HOST=${DRUID_SET_HOST:-0}
+fi
+
+if [ "${DRUID_SET_HOST}" = "1" ]
 then
     setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
 fi


### PR DESCRIPTION
The PR https://github.com/apache/druid/pull/16386 changed the docker file to use the canonical hostname instead of ip by default. This was an attempt to fix `druid.indexer.task.restoreTasksOnRestart `, as it does not work on kubernetes without the canonical hostname. 

This change is not backward compatible, as switching to canonical names would not work with docker. This PR attempts to fix this by adding a check to see if the deployment is in a kubernetes environment by checking `${KUBERNETES_SERVICE_HOST}` and using canonical hostnames instead of IP addresses only in that case.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
