### PR TITLE
Support Lazy Loading of Pod Templates

### DIFF
--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -39,9 +39,13 @@
       <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
       <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="true" />
     </inspection_tool>
+    <inspection_tool class="ConstantValue" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="true" />
+    </inspection_tool>
     <inspection_tool class="Contract" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CopyConstructorMissesField" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CovariantEquals" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="DataFlowIssueMerged" />
     <inspection_tool class="DuplicateBooleanBranch" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="DuplicateCondition" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="ignoreSideEffectConditions" value="true" />
@@ -70,7 +74,6 @@
       </option>
       <option name="IGNORE_FIELDS_USED_IN_MULTIPLE_METHODS" value="true" />
     </inspection_tool>
-    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FinalStaticMethod" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="FlowJSError" enabled="false" level="Non-TeamCity Error" enabled_by_default="false" />
     <inspection_tool class="ForCanBeForeach" enabled="true" level="WARNING" enabled_by_default="true">
@@ -82,7 +85,6 @@
       <option name="ignoreUntypedCollections" value="false" />
     </inspection_tool>
     <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HashCodeUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ImplicitArrayToString" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IndexOfReplaceableByContains" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -154,6 +156,7 @@
     </inspection_tool>
     <inspection_tool class="ObjectEqualsNull" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ObjectToString" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="OptionalOfNullableMisuseMerged" />
     <inspection_tool class="OverwrittenKey" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -167,6 +170,7 @@
     <inspection_tool class="ReplaceAllDot" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ReplaceInefficientStreamCount" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WARNING" enabled="false" />
       <scope name="Production" level="ERROR" enabled="true" />
     </inspection_tool>
     <inspection_tool class="ResultSetIndexZero" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -373,15 +377,15 @@
         <constraint name="l" within="" contains="" />
         <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="Assign an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" >
+      <searchConfiguration name="Assign an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" within="" contains="" />
         <constraint name="x" nameOfExprType="java\.util\.concurrent\.Executor" within="" contains="" />
         <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="Intialize an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="Executor $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" >
+      <searchConfiguration name="Intialize an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="Executor $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
         <constraint name="__context__" within="" contains="" />
-        <constraint name="x"  within="" contains="" />
-        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true"  within="" contains="" />
+        <constraint name="x" within="" contains="" />
+        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="Create a simple ExecutorService (not scheduled)" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
         <constraint name="__context__" within="" contains="" />
@@ -481,8 +485,8 @@
     <inspection_tool class="XmlHighlighting" enabled="true" level="Non-TeamCity Warning" enabled_by_default="true" />
     <inspection_tool class="XmlInvalidId" enabled="true" level="Non-TeamCity Error" enabled_by_default="true" />
     <inspection_tool class="XmlPathReference" enabled="true" level="Non-TeamCity Error" enabled_by_default="true" />
-    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" isSelected="false">
-      <scope name="UnusedInspectionsScope" level="ERROR" enabled="true" isSelected="false">
+    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" checkParameterExcludingHierarchy="false">
+      <scope name="UnusedInspectionsScope" level="ERROR" enabled="true" checkParameterExcludingHierarchy="false">
         <option name="LOCAL_VARIABLE" value="true" />
         <option name="FIELD" value="true" />
         <option name="METHOD" value="true" />

--- a/.idea/inspectionProfiles/Druid.xml
+++ b/.idea/inspectionProfiles/Druid.xml
@@ -39,13 +39,9 @@
       <option name="SUGGEST_NULLABLE_ANNOTATIONS" value="false" />
       <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="true" />
     </inspection_tool>
-    <inspection_tool class="ConstantValue" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="DONT_REPORT_TRUE_ASSERT_STATEMENTS" value="true" />
-    </inspection_tool>
     <inspection_tool class="Contract" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CopyConstructorMissesField" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="CovariantEquals" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="DataFlowIssueMerged" />
     <inspection_tool class="DuplicateBooleanBranch" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="DuplicateCondition" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="ignoreSideEffectConditions" value="true" />
@@ -74,6 +70,7 @@
       </option>
       <option name="IGNORE_FIELDS_USED_IN_MULTIPLE_METHODS" value="true" />
     </inspection_tool>
+    <inspection_tool class="FieldMayBeFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="FinalStaticMethod" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="FlowJSError" enabled="false" level="Non-TeamCity Error" enabled_by_default="false" />
     <inspection_tool class="ForCanBeForeach" enabled="true" level="WARNING" enabled_by_default="true">
@@ -85,6 +82,7 @@
       <option name="ignoreUntypedCollections" value="false" />
     </inspection_tool>
     <inspection_tool class="ForLoopThatDoesntUseLoopVariable" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="Guava" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="HashCodeUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ImplicitArrayToString" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="IndexOfReplaceableByContains" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -156,7 +154,6 @@
     </inspection_tool>
     <inspection_tool class="ObjectEqualsNull" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ObjectToString" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="OptionalOfNullableMisuseMerged" />
     <inspection_tool class="OverwrittenKey" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PointlessIndexOfComparison" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="PrimitiveArrayArgumentToVariableArgMethod" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -170,7 +167,6 @@
     <inspection_tool class="ReplaceAllDot" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ReplaceInefficientStreamCount" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Tests" level="WARNING" enabled="false" />
       <scope name="Production" level="ERROR" enabled="true" />
     </inspection_tool>
     <inspection_tool class="ResultSetIndexZero" enabled="true" level="ERROR" enabled_by_default="true" />
@@ -377,15 +373,15 @@
         <constraint name="l" within="" contains="" />
         <constraint name="y" minCount="0" maxCount="2147483647" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="Assign an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
+      <searchConfiguration name="Assign an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" >
         <constraint name="__context__" within="" contains="" />
         <constraint name="x" nameOfExprType="java\.util\.concurrent\.Executor" within="" contains="" />
         <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
       </searchConfiguration>
-      <searchConfiguration name="Intialize an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="Executor $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA">
+      <searchConfiguration name="Intialize an ExecutorService instance to an ExecutorService variable, not an Executor variable" text="Executor $x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" >
         <constraint name="__context__" within="" contains="" />
-        <constraint name="x" within="" contains="" />
-        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true" within="" contains="" />
+        <constraint name="x"  within="" contains="" />
+        <constraint name="y" nameOfExprType="java\.util\.concurrent\.ExecutorService" exprTypeWithinHierarchy="true"  within="" contains="" />
       </searchConfiguration>
       <searchConfiguration name="Create a simple ExecutorService (not scheduled)" text="$x$ = $y$;" recursive="true" caseInsensitive="true" type="JAVA" pattern_context="default">
         <constraint name="__context__" within="" contains="" />
@@ -485,8 +481,8 @@
     <inspection_tool class="XmlHighlighting" enabled="true" level="Non-TeamCity Warning" enabled_by_default="true" />
     <inspection_tool class="XmlInvalidId" enabled="true" level="Non-TeamCity Error" enabled_by_default="true" />
     <inspection_tool class="XmlPathReference" enabled="true" level="Non-TeamCity Error" enabled_by_default="true" />
-    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" checkParameterExcludingHierarchy="false">
-      <scope name="UnusedInspectionsScope" level="ERROR" enabled="true" checkParameterExcludingHierarchy="false">
+    <inspection_tool class="unused" enabled="true" level="WARNING" enabled_by_default="true" isSelected="false">
+      <scope name="UnusedInspectionsScope" level="ERROR" enabled="true" isSelected="false">
         <option name="LOCAL_VARIABLE" value="true" />
         <option name="FIELD" value="true" />
         <option name="METHOD" value="true" />

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -374,7 +374,7 @@ druid.indexer.runner.type=k8s
 druid.indexer.task.encapsulatedTask=true
 ```
 
-#### Example 1: Using a PodTemplate that retrieves values from a ConfigMap 
+#### Example 1: Using a Pod Template that retrieves values from a ConfigMap 
 
 <details>
 <summary>Example Pod Template that uses the regular druid docker image</summary>
@@ -496,9 +496,9 @@ data:
 ```
 </details>
 
-#### Example 2: Using a ConfigMap to upload the PodTemplate file
+#### Example 2: Using a ConfigMap to upload the Pod Template file
 
-Alternatively, we can mount the ConfigMap onto the Overlord services, and use the ConfigMap to generate the PodTemplate files we want.
+Alternatively, we can mount the ConfigMap onto the Overlord services, and use the ConfigMap to generate the pod template files we want.
 
 <details>
 <summary>Mounting to Overlord deployment</summary>

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -536,7 +536,7 @@ data:
       spec:
         containers:
         - name: main
-          image: apache/druid:32.0.0
+          image: apache/druid:{{DRUIDVERSION}}
           command:
             - sh
             - -c

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -547,6 +547,8 @@ data:
               value: 8100
             - name: druid_plaintextPort
               value: 8100
+            - name: druid_tlsPort
+              value: 8091
             - name: druid_peon_mode
               value: remote
             - name: druid_service

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -593,7 +593,7 @@ data:
 
 #### Lazy Loading of Pod Templates
 
-Whenever the Overlord wants to spin up a Kubernetes task pod, it will first read the relevant pod template files, and then create a task pod according to the specifications of the pod template file. This is helpful when you want to make configuration changes to the task pods (e.g. increase/decrease CPU limit or resources). You can edit the pod template files directly, and the next task pod spun up by the Overlord will reflect these changes in its configurations.
+Whenever the Overlord wants to spin up a Kubernetes task pod, it will first read the relevant pod template file, and then create a task pod according to the specifications of the pod template file. This is helpful when you want to make configuration changes to the task pods (e.g. increase/decrease CPU limit or resources). You can edit the pod template files directly, and the next task pod spun up by the Overlord will reflect these changes in its configurations.
 
 #### Pod template selection
 

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -498,7 +498,7 @@ data:
 
 #### Example 2: Using a ConfigMap to upload the Pod Template file
 
-Alternatively, we can mount the ConfigMap onto the Overlord services, and use the ConfigMap to generate the pod template files we want.
+Alternatively, we can mount the ConfigMap onto Overlord services, and use the ConfigMap to generate the pod template files we want.
 
 <details>
 <summary>Mounting to Overlord deployment</summary>

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/PodTemplateSelectStrategy.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/PodTemplateSelectStrategy.java
@@ -21,6 +21,7 @@ package org.apache.druid.k8s.overlord.execution;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.base.Supplier;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.k8s.overlord.taskadapter.PodTemplateWithName;
@@ -45,5 +46,5 @@ public interface PodTemplateSelectStrategy
    * @param task The task for which the Pod template is determined.
    * @return The PodTemplateWithName POJO that contains the name of the template selected and the template itself.
    */
-  @NotNull PodTemplateWithName getPodTemplateForTask(Task task, Map<String, PodTemplate> templates);
+  @NotNull PodTemplateWithName getPodTemplateForTask(Task task, Map<String, Supplier<PodTemplate>> templates);
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategy.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategy.java
@@ -22,6 +22,7 @@ package org.apache.druid.k8s.overlord.execution;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Supplier;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
@@ -55,7 +56,7 @@ public class SelectorBasedPodTemplateSelectStrategy implements PodTemplateSelect
    * @return the template if a selector matches, otherwise fallback to base template
    */
   @Override
-  public PodTemplateWithName getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
+  public PodTemplateWithName getPodTemplateForTask(Task task, Map<String, Supplier<PodTemplate>> templates)
   {
     String templateKey = selectors.stream()
                                   .filter(selector -> selector.evaluate(task))
@@ -66,7 +67,8 @@ public class SelectorBasedPodTemplateSelectStrategy implements PodTemplateSelect
     if (!templates.containsKey(templateKey)) {
       templateKey = DruidK8sConstants.BASE_TEMPLATE_NAME;
     }
-    return new PodTemplateWithName(templateKey, templates.get(templateKey));
+    Supplier<PodTemplate> podTemplateSupplier = templates.get(templateKey);
+    return new PodTemplateWithName(templateKey, podTemplateSupplier.get());
   }
 
   @JsonProperty

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/TaskTypePodTemplateSelectStrategy.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/execution/TaskTypePodTemplateSelectStrategy.java
@@ -20,6 +20,7 @@
 package org.apache.druid.k8s.overlord.execution;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.base.Supplier;
 import io.fabric8.kubernetes.api.model.PodTemplate;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
@@ -42,10 +43,11 @@ public class TaskTypePodTemplateSelectStrategy implements PodTemplateSelectStrat
   }
 
   @Override
-  public PodTemplateWithName getPodTemplateForTask(Task task, Map<String, PodTemplate> templates)
+  public PodTemplateWithName getPodTemplateForTask(Task task, Map<String, Supplier<PodTemplate>> templates)
   {
     String templateKey = templates.containsKey(task.getType()) ? task.getType() : DruidK8sConstants.BASE_TEMPLATE_NAME;
-    return new PodTemplateWithName(templateKey, templates.get(templateKey));
+    Supplier<PodTemplate> podSupplier = templates.get(templateKey);
+    return new PodTemplateWithName(templateKey, podSupplier.get());
   }
 
   @Override

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
@@ -111,7 +111,8 @@ public class DynamicConfigPodTemplateSelector implements PodTemplateSelector
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
-  private void validateTemplateSupplier(Supplier<PodTemplate> templateSupplier) throws IAE {
+  private void validateTemplateSupplier(Supplier<PodTemplate> templateSupplier) throws IAE
+  {
     templateSupplier.get();
   }
 

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
@@ -44,6 +44,7 @@ public class DynamicConfigPodTemplateSelector implements PodTemplateSelector
 
   private final Properties properties;
   private final Supplier<KubernetesTaskRunnerDynamicConfig> dynamicConfigRef;
+  // Supplier allows Overlord to read the most recent pod template file without calling initializeTemplatesFromFileSystem() again.
   private HashMap<String, Supplier<PodTemplate>> podTemplates;
 
   public DynamicConfigPodTemplateSelector(

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelector.java
@@ -43,8 +43,8 @@ public class DynamicConfigPodTemplateSelector implements PodTemplateSelector
                                               + ".k8s.podTemplate.";
 
   private final Properties properties;
-  private HashMap<String, PodTemplate> podTemplates;
-  private Supplier<KubernetesTaskRunnerDynamicConfig> dynamicConfigRef;
+  private final Supplier<KubernetesTaskRunnerDynamicConfig> dynamicConfigRef;
+  private HashMap<String, Supplier<PodTemplate>> podTemplates;
 
   public DynamicConfigPodTemplateSelector(
       Properties properties,
@@ -56,25 +56,25 @@ public class DynamicConfigPodTemplateSelector implements PodTemplateSelector
     initializeTemplatesFromFileSystem();
   }
 
-  private void initializeTemplatesFromFileSystem()
+  private void initializeTemplatesFromFileSystem() throws IAE
   {
-    Set<String> taskAdapterTemplateKeys = getTaskAdapterTemplates(properties);
+    Set<String> taskAdapterTemplateKeys = getTaskAdapterTemplatesKeys(properties);
     if (!taskAdapterTemplateKeys.contains("base")) {
       throw new IAE(
           "Pod template task adapter requires a base pod template to be specified under druid.indexer.runner.k8s.podTemplate.base");
     }
 
-    HashMap<String, PodTemplate> podTemplateMap = new HashMap<>();
+    HashMap<String, Supplier<PodTemplate>> podTemplateMap = new HashMap<>();
     for (String taskAdapterTemplateKey : taskAdapterTemplateKeys) {
-      Optional<PodTemplate> template = loadPodTemplate(taskAdapterTemplateKey, properties);
-      if (template.isPresent()) {
-        podTemplateMap.put(taskAdapterTemplateKey, template.get());
-      }
+      Supplier<PodTemplate> templateSupplier = () -> loadPodTemplate(taskAdapterTemplateKey, properties);
+      validateTemplateSupplier(templateSupplier);
+      podTemplateMap.put(taskAdapterTemplateKey, templateSupplier);
     }
+
     podTemplates = podTemplateMap;
   }
 
-  private Set<String> getTaskAdapterTemplates(Properties properties)
+  private Set<String> getTaskAdapterTemplatesKeys(Properties properties)
   {
     Set<String> taskAdapterTemplates = new HashSet<>();
 
@@ -88,23 +88,31 @@ public class DynamicConfigPodTemplateSelector implements PodTemplateSelector
     return taskAdapterTemplates;
   }
 
-  private Optional<PodTemplate> loadPodTemplate(String key, Properties properties)
+  private PodTemplate loadPodTemplate(String key, Properties properties) throws IAE
   {
     String property = TASK_PROPERTY + key;
     String podTemplateFile = properties.getProperty(property);
     if (podTemplateFile == null) {
       throw new IAE("Pod template file not specified for [%s]", property);
-
     }
+
     try {
-      return Optional.of(Serialization.unmarshal(
+      // Use Optional to assert unmarshal result is non-null.
+      Optional<PodTemplate> maybeTemplate = Optional.of(Serialization.unmarshal(
           Files.newInputStream(new File(podTemplateFile).toPath()),
           PodTemplate.class
       ));
+
+      return maybeTemplate.get();
     }
     catch (Exception e) {
       throw new IAE(e, "Failed to load pod template file for [%s] at [%s]", property, podTemplateFile);
     }
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  private void validateTemplateSupplier(Supplier<PodTemplate> templateSupplier) throws IAE {
+    templateSupplier.get();
   }
 
   @Override

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -120,7 +120,7 @@ public class PodTemplateTaskAdapter implements TaskAdapter
           task.getId()
       );
     }
-    PodTemplateWithName podTemplateWithName = podTemplateSelector.getPodTemplateForTask(task).get();
+    PodTemplateWithName podTemplateWithName = selectedPodTemplate.get();
 
     return new JobBuilder()
         .withNewMetadata()

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/execution/SelectorBasedPodTemplateSelectStrategyTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.k8s.overlord.execution;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -41,14 +42,14 @@ import java.util.Set;
 
 public class SelectorBasedPodTemplateSelectStrategyTest
 {
-  private Map<String, PodTemplate> templates;
+  private Map<String, Supplier<PodTemplate>> templates;
 
   @Before
   public void setup()
   {
     templates = ImmutableMap.of(
         "mock",
-        new PodTemplate(null, null, new ObjectMeta()
+        () -> new PodTemplate(null, null, new ObjectMeta()
         {
           @Override
           public String getName()
@@ -57,7 +58,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
           }
         }, null),
         "no_match",
-        new PodTemplate(null, null, new ObjectMeta()
+        () -> new PodTemplate(null, null, new ObjectMeta()
         {
           @Override
           public String getName()
@@ -66,7 +67,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
           }
         }, null),
         "match",
-        new PodTemplate(null, null, new ObjectMeta()
+        () -> new PodTemplate(null, null, new ObjectMeta()
         {
           @Override
           public String getName()
@@ -75,7 +76,7 @@ public class SelectorBasedPodTemplateSelectStrategyTest
           }
         }, null),
         "base",
-        new PodTemplate(null, "base", new ObjectMeta()
+        () -> new PodTemplate(null, "base", new ObjectMeta()
         {
           @Override
           public String getName()

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelectorTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DynamicConfigPodTemplateSelectorTest.java
@@ -70,10 +70,14 @@ public class DynamicConfigPodTemplateSelectorTest
         "No base prop should throw an IAE",
         IAE.class,
         () -> new DynamicConfigPodTemplateSelector(
-        new Properties(),
-        dynamicConfigRef
-    ));
-    Assertions.assertEquals(exception.getMessage(), "Pod template task adapter requires a base pod template to be specified under druid.indexer.runner.k8s.podTemplate.base");
+            new Properties(),
+            dynamicConfigRef
+        )
+    );
+    Assertions.assertEquals(
+        exception.getMessage(),
+        "Pod template task adapter requires a base pod template to be specified under druid.indexer.runner.k8s.podTemplate.base"
+    );
   }
 
   @Test
@@ -90,7 +94,8 @@ public class DynamicConfigPodTemplateSelectorTest
         () -> new DynamicConfigPodTemplateSelector(
             props,
             dynamicConfigRef
-    ));
+        )
+    );
 
     Assertions.assertTrue(exception.getMessage().contains("Failed to load pod template file for"));
   }
@@ -144,7 +149,8 @@ public class DynamicConfigPodTemplateSelectorTest
         dynamicConfigRef
     );
 
-    Task kafkaTask = new NoopTask("id", "id", "datasource", 0, 0, null) {
+    Task kafkaTask = new NoopTask("id", "id", "datasource", 0, 0, null)
+    {
       @Override
       public String getType()
       {
@@ -155,13 +161,21 @@ public class DynamicConfigPodTemplateSelectorTest
     Task noopTask = new NoopTask("id", "id", "datasource", 0, 0, null);
     Optional<PodTemplateWithName> podTemplateWithName = selector.getPodTemplateForTask(kafkaTask);
     Assertions.assertTrue(podTemplateWithName.isPresent());
-    Assertions.assertEquals(1, podTemplateWithName.get().getPodTemplate().getTemplate().getSpec().getVolumes().size(), 1);
+    Assertions.assertEquals(
+        1,
+        podTemplateWithName.get().getPodTemplate().getTemplate().getSpec().getVolumes().size(),
+        1
+    );
     Assertions.assertEquals("index_kafka", podTemplateWithName.get().getName());
 
 
     podTemplateWithName = selector.getPodTemplateForTask(noopTask);
     Assertions.assertTrue(podTemplateWithName.isPresent());
-    Assertions.assertEquals(0, podTemplateWithName.get().getPodTemplate().getTemplate().getSpec().getVolumes().size(), 1);
+    Assertions.assertEquals(
+        0,
+        podTemplateWithName.get().getPodTemplate().getTemplate().getSpec().getVolumes().size(),
+        1
+    );
     Assertions.assertEquals("base", podTemplateWithName.get().getName());
   }
 
@@ -230,7 +244,7 @@ public class DynamicConfigPodTemplateSelectorTest
     props.setProperty("druid.indexer.runner.k8s.podTemplate.lowThroughput", lowThroughputTemplatePath.toString());
     dynamicConfigRef = () -> new DefaultKubernetesTaskRunnerDynamicConfig(new SelectorBasedPodTemplateSelectStrategy(
         Collections.singletonList(
-            new Selector("lowThrougput", null, null, Sets.newSet(dataSource)
+            new Selector("lowThroughput", null, null, Sets.newSet(dataSource)
             )
         )
     ));
@@ -249,5 +263,39 @@ public class DynamicConfigPodTemplateSelectorTest
     actual = podTemplateSelector.getPodTemplateForTask(noopTask);
     Assertions.assertTrue(actual.isPresent());
     Assertions.assertEquals(0, actual.get().getPodTemplate().getTemplate().getSpec().getVolumes().size(), 1);
+  }
+
+  @Test
+  public void test_fromTask_LazyLoadPodTemplate() throws IOException
+  {
+    Path baseTemplatePath = Files.createFile(tempDir.resolve("base.yaml"));
+    mapper.writeValue(baseTemplatePath.toFile(), podTemplateSpec);
+
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.k8s.podTemplate.base", baseTemplatePath.toString());
+
+    DynamicConfigPodTemplateSelector adapter = new DynamicConfigPodTemplateSelector(
+        props,
+        dynamicConfigRef
+    );
+
+    Task task = new NoopTask("id", "id", "datasource", 0, 0, null);
+    Optional<PodTemplateWithName> actual = adapter.getPodTemplateForTask(task);
+    PodTemplate expected = K8sTestUtils.fileToResource("expectedNoopPodTemplate.yaml", PodTemplate.class);
+
+    Assertions.assertTrue(actual.isPresent());
+    Assertions.assertEquals("base", actual.get().getName());
+    Assertions.assertEquals(expected, actual.get().getPodTemplate());
+
+    // Now we change the file to an empty file, and expect an assertion.
+    mapper.writeValue(baseTemplatePath.toFile(), null);
+
+    Exception exception = Assert.assertThrows(
+        "Empty base pod template should throw a exception",
+        IAE.class,
+        () -> adapter.getPodTemplateForTask(task)
+    );
+
+    Assertions.assertTrue(exception.getMessage().contains("Failed to load pod template file for"));
   }
 }


### PR DESCRIPTION
### Description

There may be some circumstances where we want to change the config of the task pod, such as changing the cpu requests/limits of default task pods by editing the base YAML pod template file. In my case, I am editing something that looks like this [example ConfigMap](https://druid.apache.org/docs/latest/development/extensions-contrib/k8s-jobs/#custom-template-pod-adapter), to directly make changes to the pod templates. 

However, since the code only updates `HashMap<String, PodTemplate> templates` during Overlord initialization, the changes are not immediately reflected.

This PR aims to solve this problem and make Druid more adaptable in Kubernetes environments. Instead of internally keeping track of the deserialized PodTemplates we have read from all template files, we will now run the deserialization process whenever a new Task Pod is to be created. Do note this PR does not support reading from newly created pod template files. (e.g. If we create a `newPodTemplate.yaml`, we will still need to let the Overlord run template initialization for the new file to take effect).

The original intention of fail-fast for invalid pod templates is retained by validating all of the pod templates defined during initialization. 

#### Performance Considerations
Given that a ingestion task will create `n` task pods, and we have `k` pod templates defined, we will be reading from the pod template `n + k` times instead of just `k` times. 

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

You can now configure Kubernetes task pod specifications by directly editing existing pod templates.

##### Key changed/added classes in this PR
 * `PodTemplateSelectStrategy.java`
 * `SelectorBasedPodTemplateSelectStrategy.java`
 * `TaskTypePodTemplateSelectStrategy.java`
 * `DynamicConfigPodTemplateSelector.java`
 * `PodTemplateTaskAdapter.java`
 * `SelectorBasedPodTemplateSelectStrategyTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
