### PR TITLE
Adjust pre-commit/pre-push hooks to be compatible with git-worktree

### DIFF
--- a/hooks/install-hooks.sh
+++ b/hooks/install-hooks.sh
@@ -32,9 +32,9 @@ if [ $# != 1 ]
 fi
 
 DRUID_ROOT=$1
-
-cp_if_not_exist ${DRUID_ROOT}/hooks/run-all-in-dir.py ${DRUID_ROOT}/.git/hooks/run-all-in-dir.py
-cp_if_not_exist ${DRUID_ROOT}/hooks/pre-commit ${DRUID_ROOT}/.git/hooks/pre-commit
-cp_if_not_exist ${DRUID_ROOT}/hooks/pre-push ${DRUID_ROOT}/.git/hooks/pre-push
-cp_if_not_exist ${DRUID_ROOT}/hooks/pre-commits ${DRUID_ROOT}/.git/hooks/pre-commits
-cp_if_not_exist ${DRUID_ROOT}/hooks/pre-pushes ${DRUID_ROOT}/.git/hooks/pre-pushes
+GIT_COMMON_DIR=$(eval "git -C $DRUID_ROOT rev-parse --path-format=absolute --git-common-dir")
+cp_if_not_exist ${DRUID_ROOT}/hooks/run-all-in-dir.py ${GIT_COMMON_DIR}/hooks/run-all-in-dir.py
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-commit ${GIT_COMMON_DIR}/hooks/pre-commit
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-push ${GIT_COMMON_DIR}/hooks/pre-push
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-commits ${GIT_COMMON_DIR}/hooks/pre-commits
+cp_if_not_exist ${DRUID_ROOT}/hooks/pre-pushes ${GIT_COMMON_DIR}/hooks/pre-pushes

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -15,4 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.git/hooks/run-all-in-dir.py .git/hooks/pre-commits
+GIT_COMMON_DIR=$(eval "git rev-parse --path-format=absolute --git-common-dir")
+$GIT_COMMON_DIR/hooks/run-all-in-dir.py $GIT_COMMON_DIR/hooks/pre-commits

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -19,4 +19,5 @@
 # under the License.
 #
 
-.git/hooks/run-all-in-dir.py .git/hooks/pre-pushes $1 $2
+GIT_COMMON_DIR=$(eval "git rev-parse --path-format=absolute --git-common-dir")
+$GIT_COMMON_DIR/hooks/run-all-in-dir.py $GIT_COMMON_DIR/hooks/pre-pushes $1 $2


### PR DESCRIPTION
 
### Description

Updates pre-commit/pre-push hooks to work with [git-worktree](https://git-scm.com/docs/git-worktree). 

`git-worktree` doesn't have `.git` folder. The `.git` in a git worktree directory is a file, e.g. this is the content of the `hooks-config` worktree in my local env:
> gitdir: /Users/cecemei/codespace/oss-druid/.git/worktrees/hooks-config

The content in this `gitdir` is less compared with a regular git directory.
```
❯ ls -l /Users/cecemei/codespace/oss-druid/.git/worktrees/hooks-config
total 4560
-rw-r--r--@ 1 cecemei  staff      403 Feb  7 14:40 COMMIT_EDITMSG
-rw-r--r--@ 1 cecemei  staff       29 Feb  7 14:35 HEAD
-rw-r--r--@ 1 cecemei  staff       41 Feb  7 14:35 ORIG_HEAD
-rw-r--r--@ 1 cecemei  staff        6 Feb  7 14:35 commondir
drwxr-xr-x@ 3 cecemei  staff       96 Feb  7 14:35 fsmonitor--daemon
srwxr-xr-x@ 1 cecemei  staff        0 Feb  7 14:35 fsmonitor--daemon.ipc
-rw-r--r--@ 1 cecemei  staff       43 Feb  7 14:35 gitdir
-rw-r--r--@ 1 cecemei  staff  2313883 Feb  7 14:40 index
drwxr-xr-x@ 3 cecemei  staff       96 Feb  7 14:35 logs
❯ ls -l /Users/cecemei/codespace/oss-druid/.git
total 4728
-rw-r--r--@   1 cecemei  staff       99 Jan 24 16:25 COMMIT_EDITMSG
-rw-r--r--@   1 cecemei  staff    14333 Feb  7 13:56 FETCH_HEAD
-rw-r--r--@   1 cecemei  staff       23 Feb  7 13:56 HEAD
-rw-r--r--@   1 cecemei  staff       41 Feb  7 13:57 ORIG_HEAD
-rw-r--r--@   1 cecemei  staff     1623 Feb  7 14:36 config
-rw-r--r--@   1 cecemei  staff       73 Dec 11 11:28 description
drwxr-xr-x@   3 cecemei  staff       96 Jan 26 19:45 fsmonitor--daemon
srwxr-xr-x@   1 cecemei  staff        0 Feb  7 13:56 fsmonitor--daemon.ipc
drwxr-xr-x@   7 cecemei  staff      224 Feb  7 14:40 hooks
-rw-r--r--@   1 cecemei  staff  2313883 Feb  7 14:20 index
drwxr-xr-x@   4 cecemei  staff      128 Feb  6 14:30 info
drwxr-xr-x@   4 cecemei  staff      128 Dec 11 11:34 logs
drwxr-xr-x@ 260 cecemei  staff     8320 Feb  7 14:40 objects
-rw-r--r--@   1 cecemei  staff    62249 Feb  7 13:57 packed-refs
drwxr-xr-x@   6 cecemei  staff      192 Jan 26 20:51 refs
-rw-r--r--@   1 cecemei  staff      174 Jan 23 08:21 sourcetreeconfig
drwxr-xr-x@  13 cecemei  staff      416 Feb  7 14:35 worktrees
```

The git layout in a worktree doesn't have `refs`, `objects`, `hooks`. The [hooks](https://git-scm.com/docs/gitrepository-layout#Documentation/gitrepository-layout.txt-hooks) would still be triggered when working in a `git-worktree`, since it looks up the `GIT_COMMON_DIR`, which is `/Users/cecemei/codespace/oss-druid/.git`.

Note that for a regular git directory, `GIT_COMMON_DIR` is not set, thus `git rev-parse --path-format=absolute --git-common-dir` just returns `GIT_DIR` (e.x. /Users/cecemei/codespace/oss-druid/.git).



<br>
 
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
