### PR TITLE
Fix condition for uploading artifacts in worker.yml

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
-        if: ${{ failure() }} || ${{ inputs.artifact_prefix != '' }}
+        if: ${{ failure() || inputs.artifact_prefix != '' }}
         with:
           name: "${{ inputs.artifact_prefix }}-${{ env.HASH }}"
           path: |


### PR DESCRIPTION
### Description

The `if: ${{ failure() }} || ${{ inputs.artifact_prefix != '' }}` condition in always seems to be evaluating to `true`, as can be seen here where the upload artifact step was run even though no prior step failed: https://github.com/implydata/druid/actions/runs/13199722965/job/36850130824?pr=3053

This is also the reason why this job failed on the weekly cron: https://github.com/apache/druid/actions/runs/13211720628/job/36886496050

This PR fixes it.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
