### PR TITLE
simplify SimpleQueryableIndex constructor

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -1985,8 +1985,7 @@ public class CompactionTaskTest
                 new ListIndexed<>(segment.getDimensions()),
                 null,
                 columnMap,
-                null,
-                false
+                null
             )
             {
               @Override
@@ -2024,8 +2023,7 @@ public class CompactionTaskTest
                 index.getAvailableDimensions(),
                 index.getBitmapFactoryForDimensions(),
                 index.getColumns(),
-                index.getFileMapper(),
-                false
+                index.getFileMapper()
             )
             {
               @Override

--- a/processing/src/main/java/org/apache/druid/segment/IndexIO.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexIO.java
@@ -516,8 +516,7 @@ public class IndexIO
           index.getAvailableDimensions(),
           new ConciseBitmapFactory(),
           columns,
-          index.getFileMapper(),
-          lazy
+          index.getFileMapper()
       )
       {
         @Override
@@ -674,7 +673,6 @@ public class IndexIO
           segmentBitmapSerdeFactory.getBitmapFactory(),
           columns,
           smooshedFiles,
-          lazy,
           metadata,
           projectionsColumns
       )

--- a/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/SimpleQueryableIndex.java
@@ -70,11 +70,10 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
       Indexed<String> dimNames,
       BitmapFactory bitmapFactory,
       Map<String, Supplier<ColumnHolder>> columns,
-      SmooshedFileMapper fileMapper,
-      boolean lazy
+      SmooshedFileMapper fileMapper
   )
   {
-    this(dataInterval, dimNames, bitmapFactory, columns, fileMapper, lazy, null, null);
+    this(dataInterval, dimNames, bitmapFactory, columns, fileMapper, null, null);
   }
 
   public SimpleQueryableIndex(
@@ -83,7 +82,6 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
       BitmapFactory bitmapFactory,
       Map<String, Supplier<ColumnHolder>> columns,
       SmooshedFileMapper fileMapper,
-      boolean lazy,
       @Nullable Metadata metadata,
       @Nullable Map<String, Map<String, Supplier<ColumnHolder>>> projectionColumns
   )
@@ -108,12 +106,8 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
     this.fileMapper = fileMapper;
 
     this.projectionColumns = projectionColumns == null ? Collections.emptyMap() : projectionColumns;
+    this.dimensionHandlers = Suppliers.memoize(() -> initDimensionHandlers(availableDimensions));
 
-    if (lazy) {
-      this.dimensionHandlers = Suppliers.memoize(() -> initDimensionHandlers(availableDimensions));
-    } else {
-      this.dimensionHandlers = () -> initDimensionHandlers(availableDimensions);
-    }
     if (metadata != null) {
       if (metadata.getOrdering() != null) {
         this.ordering = ORDERING_INTERNER.intern(metadata.getOrdering());
@@ -261,7 +255,6 @@ public abstract class SimpleQueryableIndex implements QueryableIndex
         bitmapFactory,
         projectionColumns.get(name),
         fileMapper,
-        true,
         projectionMetadata,
         null
     )

--- a/processing/src/test/java/org/apache/druid/segment/IndexIONullColumnsCompatibilityTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexIONullColumnsCompatibilityTest.java
@@ -237,8 +237,7 @@ public class IndexIONullColumnsCompatibilityTest extends InitializedNullHandling
           dims,
           segmentBitmapSerdeFactory.getBitmapFactory(),
           columns,
-          smooshedFiles,
-          lazy
+          smooshedFiles
       )
       {
         @Override

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerLongestSharedDimOrderTest.java
@@ -166,8 +166,7 @@ public class IndexMergerLongestSharedDimOrderTest
             new ListIndexed<>(dimensions),
             mockBitmapFactory,
             ImmutableMap.of(ColumnHolder.TIME_COLUMN_NAME, mockSupplier),
-            mockSmooshedFileMapper,
-            true
+            mockSmooshedFileMapper
         )
         {
           @Override


### PR DESCRIPTION
### Description
changes:
* remove the 'lazy' parameter to SimpleQueryableIndex constructor in favor of always using the lazy = true path

Prior to https://github.com/apache/druid/pull/12279/files#diff-7f633ed96a4bb0b8fa8362dcd52173c0d9cfe1c7d329e5b0d6184b65317263bcR81 setting lazy = false in the SimpleQueryableIndex constructor would result in eagerl y initializing the dimension handlers, however after that change the meaning was changed to compute them on demand every time they were called. This was likely a mistake, and since eagerly initializing has not been
 happening by default for some time now, we should just drop this flag in favor of using the lazy = true path, which caches the dimension handlers when they are called.
