### PR TITLE
fix time column seeking for time ordered projections

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorHolder.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexCursorHolder.java
@@ -178,6 +178,7 @@ public class QueryableIndexCursorHolder implements CursorHolder
 
     final long timeStart = Math.max(interval.getStartMillis(), minDataTimestamp);
     final long timeEnd = interval.getEndMillis();
+    final Offset offset;
 
     if (timeOrder == Order.ASCENDING) {
       for (; baseOffset.withinBounds(); baseOffset.increment()) {
@@ -185,17 +186,6 @@ public class QueryableIndexCursorHolder implements CursorHolder
           break;
         }
       }
-    } else if (timeOrder == Order.DESCENDING) {
-      for (; baseOffset.withinBounds(); baseOffset.increment()) {
-        if (resources.getTimestampsColumn().getLongSingleValueRow(baseOffset.getOffset()) < timeEnd) {
-          break;
-        }
-      }
-    }
-
-    final Offset offset;
-
-    if (timeOrder == Order.ASCENDING) {
       offset = new AscendingTimestampCheckingOffset(
           baseOffset,
           resources.getTimestampsColumn(),
@@ -203,6 +193,11 @@ public class QueryableIndexCursorHolder implements CursorHolder
           maxDataTimestamp < timeEnd
       );
     } else if (timeOrder == Order.DESCENDING) {
+      for (; baseOffset.withinBounds(); baseOffset.increment()) {
+        if (resources.getTimestampsColumn().getLongSingleValueRow(baseOffset.getOffset()) < timeEnd) {
+          break;
+        }
+      }
       offset = new DescendingTimestampCheckingOffset(
           baseOffset,
           resources.getTimestampsColumn(),


### PR DESCRIPTION
### Description
Fixes a bug in time ordered projections resulting from #17397. The changes in that PR resulted in a `QueryableIndexCursorHolder` of a projection using a `QueryableIndexTimeBoundaryInspector` that was pointing to the base table __time column instead of the projections time column, which could result in seeking to the incorrect the starting offset when the time column of a projection is transformed due to the code checking the time column against the 'start' timestamp of the base table instead of the projection table.

For example, imagine we have a base table which has a first row with a `__time` value of `2025-02-10T00:01:01Z` or whatever, and a time ordered projection exists which does `TIME_FLOOR(__time, 'PT1H')`, so the first value of the projection time column would be `2025-02-10T00:00:00Z`. The seek logic in the `asCursor` method of `QueryableIndexCursorHolder` would be reading `2025-02-10T00:00:00Z` from the projection time column, but moving the offset ahead checking for a value greater than or equal to `2025-02-10T00:01:01Z` which it got from the `QueryableIndexTimeBoundaryInspector` of the base table, instead of the correct value it would have from using an inspector of the projection. As a result, the offset is moved forward until the row with next granularity bucket that is larger than __time.

Existing tests missed this because the test data starting timestamp lined up evenly with the granularity buckets, so the first row of the __time column was always identical to the first row of projection time columns, so added a new one that targets this scenario specifically and fails without the change to make the projection cursor holder use a projection time boundary inspector.
