### PR TITLE
Update release guide and update cron-job-unit-tests to run on PRs to release branches

### DIFF
--- a/.github/workflows/cron-job-unit-tests.yml
+++ b/.github/workflows/cron-job-unit-tests.yml
@@ -17,11 +17,15 @@ name: "Cron Job Unit Tests"
 on:
   schedule: # Runs by default on master branch
     - cron: '0 3 * * 6' # Runs every Saturday at 03:00 AM UTC
+  pull_request:
+    branches:
+      - '[0-9]+.[0-9]+.[0-9]+' # release branches
+      - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
 
 jobs:
   run-unit-tests:
     name: "unit tests"
-    if: (github.event_name == 'schedule' && github.repository == 'apache/druid')
+    if: github.repository == 'apache/druid'
     strategy:
       fail-fast: false
       matrix:

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -128,7 +128,7 @@ To check the CI status on a release branch, you can go to the commits page e.g. 
 a green &#10004; in the commit description. If the commit has a failed build, please click on red &#10005; icon in the commit description to go to travis build job and investigate. 
 You can restart a failed build via travis if it is flaky. 
 
-The release manager should also keep an eye-out for `Cron Job Unit Tests` failures: https://github.com/apache/druid/actions/workflows/cron-job-unit-tests.yml
+The release manager should also keep an eye-out for `Cron Job Unit Tests` failures: https://github.com/apache/druid/actions/workflows/cron-job-unit-tests.yml. If there are failures, we need to fix them before creating an RC.
 
 Once all issues and PRs that are still tagged with the release milestone have been merged, closed, or removed from the milestone and CI on branch is green, the next step is to put together a release candidate.
 

--- a/distribution/asf-release-process-guide.md
+++ b/distribution/asf-release-process-guide.md
@@ -128,6 +128,8 @@ To check the CI status on a release branch, you can go to the commits page e.g. 
 a green &#10004; in the commit description. If the commit has a failed build, please click on red &#10005; icon in the commit description to go to travis build job and investigate. 
 You can restart a failed build via travis if it is flaky. 
 
+The release manager should also keep an eye-out for `Cron Job Unit Tests` failures: https://github.com/apache/druid/actions/workflows/cron-job-unit-tests.yml
+
 Once all issues and PRs that are still tagged with the release milestone have been merged, closed, or removed from the milestone and CI on branch is green, the next step is to put together a release candidate.
 
 ## Initial setup to create a release candidate


### PR DESCRIPTION
### Description

Since we have moved unit tests phase (2) to a weekly cron workflow, this PR updates the ASF release process guide so that the release manager checks if there are any failures on the weekly cron workflow as well.

This PR also updates the workflow to also run on any PRs made to any release branches.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
