### PR TITLE
Enable actions-timeline for testruns

### DIFF
--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -220,3 +220,10 @@ jobs:
       DRUID_PREVIOUS_VERSION: ${{ needs.set-env-var.outputs.DRUID_PREVIOUS_VERSION }}
       DRUID_PREVIOUS_VERSION_DOWNLOAD_URL: ${{ needs.set-env-var.outputs.DRUID_PREVIOUS_VERSION_DOWNLOAD_URL }}
       DRUID_PREVIOUS_IT_IMAGE_NAME: ${{ needs.set-env-var.outputs.DRUID_PREVIOUS_IT_IMAGE_NAME }}
+
+  actions-timeline:
+    needs: [build, unit-tests-approved, unit-tests-unapproved, revised-its, standard-its]
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - uses: Kesin11/actions-timeline@v2.2.3


### PR DESCRIPTION
Configures Kesin11/actions-timeline@v2.2.3 to create a gnatt diagram of the job executions