### PR TITLE
Speed up docker image building and switch base image to alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,7 +24,7 @@ dist
 **/target
 
 # To support building the docker image from the distribution file built on host machine,
-# we need to keep binary files under targett directory of distribution module.
+# we need to keep binary files under the target directory of distribution module.
 # This rule MUST be after above '**/target' rule
 !distribution/target/*-bin.tar.gz
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -20,9 +20,14 @@
 **/*.jar
 **/*.class
 dist
+
 **/target
-# Keep the target of distribution since we support to build the docker directly by the distribution file built on host machine
-#!distribution/target
+
+# To support building the docker image from the distribution file built on host machine,
+# we need to keep binary files under targett directory of distribution module.
+# This rule MUST be after above '**/target' rule
+!distribution/target/*-bin.tar.gz
+
 *.iml
 *.ipr
 *.iws

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 #
-#i Licensed to the Apache Software Foundation (ASF) under one
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 #
-# Licensed to the Apache Software Foundation (ASF) under one
+#i Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -20,7 +20,9 @@
 **/*.jar
 **/*.class
 dist
-target
+**/target
+# Keep the target of distribution since we support to build the docker directly by the distribution file built on host machine
+#!distribution/target
 *.iml
 *.ipr
 *.iws
@@ -35,3 +37,4 @@ target
 *.DS_Store
 _site
 dependency-reduced-pom.xml
+**/node_modules

--- a/.github/workflows/distribution-checks.yml
+++ b/.github/workflows/distribution-checks.yml
@@ -22,6 +22,7 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]+' # release branches
     paths:
       - 'distribution/**'
+      - 'web-console/**'
       - '**/pom.xml'
   pull_request:
     branches:

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -30,7 +30,7 @@ ARG BUILD_FROM_SOURCE="true"
 # This is because it's not able to build the distribution on arm64 due to dependency problem of web-console. See: https://github.com/apache/druid/issues/13012
 # Since only java jars are shipped in the final image, it's OK to build the distribution on x64.
 # Once the web-console dependency problem is resolved, we can remove the --platform directive.
-FROM --platform=linux/amd64 node:20.9.0-slim as web-console-builder
+FROM --platform=linux/amd64 node:20.9.0-slim AS web-console-builder
 
 RUN npm install -g npm@10.9.0
 
@@ -61,7 +61,7 @@ RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
 #===============================================================
 # Declare a builder stage to build the Druid distribution
 #===============================================================
-FROM maven:3.9.9-eclipse-temurin-${JDK_VERSION} as builder
+FROM maven:3.9.9-eclipse-temurin-${JDK_VERSION} AS builder
 RUN apt-get -qq update \
     && apt-get -qq -y install --no-install-recommends python3 python3-yaml
 

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -27,9 +27,7 @@ ARG BUILD_FROM_SOURCE="true"
 # This is because it's not able to build the distribution on arm64 due to dependency problem of web-console. See: https://github.com/apache/druid/issues/13012
 # Since only java jars are shipped in the final image, it's OK to build the distribution on x64.
 # Once the web-console dependency problem is resolved, we can remove the --platform directive.
-FROM openjdk:${JDK_VERSION}-jdk-slim as web-console-builder
-RUN apt-get -qq update \
-    && apt-get -qq -y install --no-install-recommends maven
+FROM --platform=linux/amd64 maven:3.9.9-eclipse-temurin-${JDK_VERSION} as web-console-builder
 
 COPY . /src
 
@@ -38,16 +36,15 @@ ARG BUILD_FROM_SOURCE
 
 # Build web-console
 RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-    cd /src/web-console && mvn -B -ff -DskipUTs clean package\
+    cd /src/web-console && mvn -B -ff -Dpmd.skip=true -DskipUTs=true clean package\
 ; fi
 
 #
 # Declare a builder stage to build the Druid distribution
 #
-FROM openjdk:${JDK_VERSION}-jdk-slim as builder
-
+FROM maven:3.9.9-eclipse-temurin-${JDK_VERSION} as builder
 RUN apt-get -qq update \
-    && apt-get -qq -y install --no-install-recommends python3 python3-yaml maven
+    && apt-get -qq -y install --no-install-recommends python3 python3-yaml
 
 COPY . /src
 WORKDIR /src
@@ -61,19 +58,20 @@ ARG BUILD_FROM_SOURCE
 # Note: 'clean' is necessary to make sure distrubution/target is cleared
 # because later we will use 'tar -zxf' to extract tar files under this directory
 RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -B -ff \
+      mvn -B -ff -ntp \
       clean install \
       -Pdist,bundle-contrib-exts \
       -Pskip-static-checks,skip-tests \
       -pl '!org.apache.druid:web-console, !org.apache.druid:druid-benchmarks, !org.apache.druid:druid-integration-tests, !org.apache.druid.integration-tests:druid-it-tools, !org.apache.druid.integration-tests:druid-it-image, !org.apache.druid.integration-tests:druid-it-cases, !org.apache.druid:druid-quidem-ut' \
-    -T1C \
-      ; fi
+      -T1C \
+; fi
 
 RUN DISTRIBUTION=$(ls ./distribution/target/apache-druid-*-bin.tar.gz) \
  && tar -zxf ${DISTRIBUTION} -C /opt \
  && mv /opt/apache-druid-* /opt/druid
 
-
+# The bulding stagings use images based on eclipse-temurin,
+# however here we directly use alpine because eclipse-temurin-alpine for JRE17 does not ship a image with ARM64 architecture.
 FROM alpine:latest
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -23,6 +23,9 @@ ARG JDK_VERSION=17
 # This can be unset if the tarball was already built outside of Docker
 ARG BUILD_FROM_SOURCE="true"
 
+#===============================================================
+# web-console building stage
+#===============================================================
 # The platform is explicitly specified as x64 to build the Druid distribution.
 # This is because it's not able to build the distribution on arm64 due to dependency problem of web-console. See: https://github.com/apache/druid/issues/13012
 # Since only java jars are shipped in the final image, it's OK to build the distribution on x64.
@@ -37,23 +40,27 @@ COPY ./docs /src/docs
 WORKDIR /src/web-console
 
 # Re-declare the ARG to make it available in this stage
-ARG BUILD_FROM_SOURCE="true"
+ARG BUILD_FROM_SOURCE
 
+# Suppress a building error saying error:0308010C:digital envelope routines::unsupported
 ENV NODE_OPTIONS=--openssl-legacy-provider
 
-# The ls command below is just for debug helping us know which files are updated that docker cache are invalidated
+# The directory of output, during the package stage, files will be copied from this directory
+RUN mkdir /output
+
+# The ls command below is just for debug purpose helping us know which files are updated that docker cache are invalidated
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
   ls -l && \
   npm ci \
 ; fi
 RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
    ./script/build \
-   && ./script/cp-to ./target/resources \
+   && ./script/cp-to ./output \
 ; fi
 
-#
+#===============================================================
 # Declare a builder stage to build the Druid distribution
-#
+#===============================================================
 FROM maven:3.9.9-eclipse-temurin-${JDK_VERSION} as builder
 RUN apt-get -qq update \
     && apt-get -qq -y install --no-install-recommends python3 python3-yaml
@@ -62,7 +69,7 @@ COPY . /src
 WORKDIR /src
 
 # Copy the web-console resources from the web-console-builder to include it in this stage to package
-COPY --from=web-console-builder /src/web-console/target/resources /src/web-console/target/resources
+COPY --from=web-console-builder /output /src/web-console/target/resources
 
 # Re-declare the ARG to make it available in this stage
 ARG BUILD_FROM_SOURCE
@@ -80,11 +87,16 @@ RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; th
       -T1C \
 ; fi
 
+
+# RUN ls ./distribution/target
 RUN DISTRIBUTION=$(ls ./distribution/target/apache-druid-*-bin.tar.gz) \
  && tar -zxf ${DISTRIBUTION} -C /opt \
  && mv /opt/apache-druid-* /opt/druid
 
-# The bulding stagings use images based on eclipse-temurin,
+#===============================================================
+# Final stage
+#===============================================================
+# Above bulding staging uses images based on eclipse-temurin,
 # however here we directly use alpine because eclipse-temurin-alpine for JRE17 does not ship a image with ARM64 architecture.
 FROM alpine:latest
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -79,7 +79,6 @@ RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; th
       rm -fr distribution/target/ && \
       mvn -B -ff -ntp \
       install \
-      -s settings.xml \
       -Pdist,bundle-contrib-exts \
       -Pskip-static-checks,skip-tests \
       -Dweb.console.skip=true \

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -19,68 +19,73 @@
 
 ARG JDK_VERSION=17
 
+# By default we build the entire distribution from source in docker
+# This can be unset if the tarball was already built outside of Docker
+ARG BUILD_FROM_SOURCE="true"
+
 # The platform is explicitly specified as x64 to build the Druid distribution.
 # This is because it's not able to build the distribution on arm64 due to dependency problem of web-console. See: https://github.com/apache/druid/issues/13012
 # Since only java jars are shipped in the final image, it's OK to build the distribution on x64.
 # Once the web-console dependency problem is resolved, we can remove the --platform directive.
-FROM --platform=linux/amd64 maven:3.9 as builder
+FROM openjdk:${JDK_VERSION}-jdk-slim as web-console-builder
+RUN apt-get -qq update \
+    && apt-get -qq -y install --no-install-recommends maven
 
-# Rebuild from source in this stage
-# This can be unset if the tarball was already built outside of Docker
-ARG BUILD_FROM_SOURCE="true"
+COPY . /src
 
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -qq update \
-    && apt-get -qq -y install --no-install-recommends python3 python3-yaml
+# Re-declare the ARG to make it available in this stage
+ARG BUILD_FROM_SOURCE
+
+# Build web-console
+RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+    cd /src/web-console && mvn -B -ff -DskipUTs clean package\
+; fi
+
+#
+# Declare a builder stage to build the Druid distribution
+#
+FROM openjdk:${JDK_VERSION}-jdk-slim as builder
+
+RUN apt-get -qq update \
+    && apt-get -qq -y install --no-install-recommends python3 python3-yaml maven
 
 COPY . /src
 WORKDIR /src
+
+# Copy the web-console jar from the web-console-builder to include it in the distribution
+COPY --from=web-console-builder /src/web-console/target/web-console*.jar /src/web-console/target/
+
+# Re-declare the ARG to make it available in this stage
+ARG BUILD_FROM_SOURCE
+
+# Note: 'clean' is necessary to make sure distrubution/target is cleared
+# because later we will use 'tar -zxf' to extract tar files under this directory
 RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-      mvn -B -ff -q \
-      install \
+      mvn -B -ff \
+      clean install \
       -Pdist,bundle-contrib-exts \
       -Pskip-static-checks,skip-tests \
-      -Dmaven.javadoc.skip=true -T1C \
+      -pl '!org.apache.druid:web-console, !org.apache.druid:druid-benchmarks, !org.apache.druid:druid-integration-tests, !org.apache.druid.integration-tests:druid-it-tools, !org.apache.druid.integration-tests:druid-it-image, !org.apache.druid.integration-tests:druid-it-cases, !org.apache.druid:druid-quidem-ut' \
+    -T1C \
       ; fi
 
-RUN --mount=type=cache,target=/root/.m2 VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
-      -Dexpression=project.version -DforceStdout=true \
-    ) \
- && tar -zxf ./distribution/target/apache-druid-${VERSION}-bin.tar.gz -C /opt \
- && mv /opt/apache-druid-${VERSION} /opt/druid
+RUN DISTRIBUTION=$(ls ./distribution/target/apache-druid-*-bin.tar.gz) \
+ && tar -zxf ${DISTRIBUTION} -C /opt \
+ && mv /opt/apache-druid-* /opt/druid
 
-FROM alpine:3 as bash-static
-ARG TARGETARCH
-#
-# Download bash-static binary to execute scripts that require bash.
-# Although bash-static supports multiple platforms, but there's no need for us to support all those platform, amd64 and arm64 are enough.
-#
-ARG BASH_URL_BASE="https://github.com/robxu9/bash-static/releases/download/5.1.016-1.2.3"
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      BASH_URL="${BASH_URL_BASE}/bash-linux-aarch64" ; \
-    elif [ "$TARGETARCH" = "amd64" ]; then \
-      BASH_URL="${BASH_URL_BASE}/bash-linux-x86_64" ; \
-    else \
-      echo "Unsupported architecture ($TARGETARCH)" && exit 1; \
-    fi; \
-    echo "Downloading bash-static from ${BASH_URL}" \
-    && wget ${BASH_URL} -O /bin/bash
 
-FROM busybox:1.35.0-glibc as busybox
-
-FROM gcr.io/distroless/java$JDK_VERSION-debian12
+FROM alpine:latest
 LABEL maintainer="Apache Druid Developers <dev@druid.apache.org>"
 
-COPY --from=busybox /bin/busybox /busybox/busybox
-RUN ["/busybox/busybox", "--install", "/bin"]
+# Re-daclare the ARG to make it available in this stage
+ARG JDK_VERSION
 
-
-RUN addgroup -S -g 1000 druid \
+# Install necessary packages to easier debugging
+RUN apk add --no-cache openjdk${JDK_VERSION}-jre bash curl net-tools strace lsof \
+ && addgroup -S -g 1000 druid \
  && adduser -S -u 1000 -D -H -h /opt/druid -s /bin/sh -g '' -G druid druid
 
-
-COPY --from=bash-static /bin/bash /bin/bash
-RUN chmod 755 /bin/bash
+ENV JAVA_HOME=/usr/lib/jvm/java-${JDK_VERSION}-openjdk
 
 COPY distribution/docker/druid.sh /druid.sh
 COPY distribution/docker/peon.sh /peon.sh

--- a/distribution/docker/Dockerfile
+++ b/distribution/docker/Dockerfile
@@ -27,16 +27,28 @@ ARG BUILD_FROM_SOURCE="true"
 # This is because it's not able to build the distribution on arm64 due to dependency problem of web-console. See: https://github.com/apache/druid/issues/13012
 # Since only java jars are shipped in the final image, it's OK to build the distribution on x64.
 # Once the web-console dependency problem is resolved, we can remove the --platform directive.
-FROM --platform=linux/amd64 maven:3.9.9-eclipse-temurin-${JDK_VERSION} as web-console-builder
+FROM --platform=linux/amd64 node:20.9.0-slim as web-console-builder
 
-COPY . /src
+RUN npm install -g npm@10.9.0
+
+# Only copy necessary files to web-console to build to try the best to use docker cache
+COPY ./web-console /src/web-console
+COPY ./docs /src/docs
+WORKDIR /src/web-console
 
 # Re-declare the ARG to make it available in this stage
-ARG BUILD_FROM_SOURCE
+ARG BUILD_FROM_SOURCE="true"
 
-# Build web-console
-RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
-    cd /src/web-console && mvn -B -ff -Dpmd.skip=true -DskipUTs=true clean package\
+ENV NODE_OPTIONS=--openssl-legacy-provider
+
+# The ls command below is just for debug helping us know which files are updated that docker cache are invalidated
+RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+  ls -l && \
+  npm ci \
+; fi
+RUN if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+   ./script/build \
+   && ./script/cp-to ./target/resources \
 ; fi
 
 #
@@ -49,20 +61,22 @@ RUN apt-get -qq update \
 COPY . /src
 WORKDIR /src
 
-# Copy the web-console jar from the web-console-builder to include it in the distribution
-COPY --from=web-console-builder /src/web-console/target/web-console*.jar /src/web-console/target/
+# Copy the web-console resources from the web-console-builder to include it in this stage to package
+COPY --from=web-console-builder /src/web-console/target/resources /src/web-console/target/resources
 
 # Re-declare the ARG to make it available in this stage
 ARG BUILD_FROM_SOURCE
 
-# Note: 'clean' is necessary to make sure distrubution/target is cleared
-# because later we will use 'tar -zxf' to extract tar files under this directory
+# Note: use web.console.skip to exclude building of web-console but include the package of web-console
 RUN --mount=type=cache,target=/root/.m2 if [ "$BUILD_FROM_SOURCE" = "true" ]; then \
+      rm -fr distribution/target/ && \
       mvn -B -ff -ntp \
-      clean install \
+      install \
+      -s settings.xml \
       -Pdist,bundle-contrib-exts \
       -Pskip-static-checks,skip-tests \
-      -pl '!org.apache.druid:web-console, !org.apache.druid:druid-benchmarks, !org.apache.druid:druid-integration-tests, !org.apache.druid.integration-tests:druid-it-tools, !org.apache.druid.integration-tests:druid-it-image, !org.apache.druid.integration-tests:druid-it-cases, !org.apache.druid:druid-quidem-ut' \
+      -Dweb.console.skip=true \
+      -pl '!org.apache.druid:druid-benchmarks, !org.apache.druid:druid-integration-tests, !org.apache.druid.integration-tests:druid-it-tools, !org.apache.druid.integration-tests:druid-it-image, !org.apache.druid.integration-tests:druid-it-cases' \
       -T1C \
 ; fi
 

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -25,7 +25,7 @@ From the root of the repo, run the following command:
 DOCKER_BUILDKIT=1 docker build -t apache/druid:tag -f distribution/docker/Dockerfile .
 ```
 
-There re two extra build arguments that can be passed to the build command by using `--build-arg` flag.
+There are two extra build arguments that can be passed to the build command by using `--build-arg` flag.
 
 | Building argument | Description                                                                                                                                                                       | Default value |
 |-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -19,23 +19,18 @@
 
 ## Build
 
-From the root of the repo, run following command:
+From the root of the repo, run the following command:
 
 ```bash
 DOCKER_BUILDKIT=1 docker build -t apache/druid:tag -f distribution/docker/Dockerfile .
 ```
 
-### Building images on Apple M1/M2
-To build images on Apple M1/M2, you need to follow the instructions in this section.
+There re two extra build arguments that can be passed to the build command by using `--build-arg` flag.
 
-1. build Druid distribution from the root of the repo
-   ```bash
-   mvn clean package -DskipTests -Pdist
-   ```
-2. build target image
-   ```
-   DOCKER_BUILDKIT=1 docker build -t apache/druid:tag -f distribution/docker/Dockerfile --build-arg BUILD_FROM_SOURCE=false .
-   ```
+| Building argument | Description                                                                                                                                                                       | Default value |
+|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| JDK_VERSION       | The version of JDK to use. By default JDK 17 is used. Use 17 and above.                                                                                                           | 17            |
+| BUILD_FROM_SOURCE | Whether to build Druid from source inside docker.<br/> If you already build the distribution outside the docker, you can manully set this argument to false to speed up building. | true          |
 
 ## Run
 

--- a/distribution/docker/druid.sh
+++ b/distribution/docker/druid.sh
@@ -141,7 +141,13 @@ fi
 DRUID_SET_HOST_IP=${DRUID_SET_HOST_IP:-0}
 if [ "${DRUID_SET_HOST_IP}" = "1" ]
 then
-    setKey $SERVICE druid.host $(ip r get 1 | awk '{print $7;exit}')
+    # Get local ip from the 'ip' tool
+    IP=$(ip r get 1 | awk '{print $7;exit}')
+    if [ -z "$IP" ]; then
+      echo "ERROR: IP address not found."
+      exit 1
+    fi
+    setKey $SERVICE druid.host $IP
 fi
 
 env | grep ^druid_ | while read evar;

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -31,7 +31,7 @@
     "sasslint-fix-changed-only": "npm run sasslint-changed-only -- --fix",
     "prettify": "prettier --write '{src,e2e-tests}/**/*.{ts,tsx,scss}' './*.js'",
     "prettify-check": "prettier --check '{src,e2e-tests}/**/*.{ts,tsx,scss}' './*.js'",
-    "generate-licenses-file": "license-checker --production --json --out licenses.json",
+    "generate-licenses-file": "license-checker --production --json --out target/licenses.json",
     "check-licenses": "license-checker --production --onlyAllow 'Apache-1.1;Apache-2.0;BSD-2-Clause;BSD-3-Clause;0BSD;MIT;ISC;CC0-1.0;OFL-1.1' --summary",
     "start": "webpack serve"
   },

--- a/web-console/pom.xml
+++ b/web-console/pom.xml
@@ -154,7 +154,6 @@
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
           <outputDirectory>${project.build.outputDirectory}/org/apache/druid/console</outputDirectory>
-          <skip>${web.console.skip}</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/web-console/pom.xml
+++ b/web-console/pom.xml
@@ -34,6 +34,10 @@
   <properties>
     <resources.directory>${project.build.directory}/resources</resources.directory>
     <web.console.skip>false</web.console.skip>  <!-- this property is overidden in Travis CI to skip the javascript-related work -->
+
+    <!--
+    NOTE: When changing the following properties, the docker base image specified in distribution/docker/Dockerfile must be updated accordingly
+    -->
     <node.version>v20.9.0</node.version>
     <npm.version>10.9.0</npm.version>
   </properties>
@@ -150,6 +154,9 @@
         </executions>
       </plugin>
       <plugin>
+        <!--
+        The web.console.skip is NOT applied to this stage as this is required for web-console package when building docker image
+        -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
There are several problems in the Dockerfile

### 1. Extreme slow building on Apple Silicon Chips

Previously, to allow building docker on Apple Silicon Chips like M1, the docker file forces the building under the amd64 platform. This is to address the building problem that node-sass does not support ARM, see https://github.com/apache/druid/issues/13012

```
FROM --platform=linux/amd64 maven:3.9 as builder
```

However, this drastically slows down the docker building process on these platforms, like it takes more than **15** minutes to build an image on my M1 laptop.

The main reason is that Apple has to use x86 emulator to run the building process.

### 2. Unfriendly to debug

Currently the distroless base image is used, it's a secure image but it's unfriendly to debug. there's no curl, no wget, no lsof, and nettools. It's painful to debug if we have to debug some live issues.

### 3. web-console is repeatedly built  even if it's not changed

Most of the development does not involve the web-console module, now it's part of the building process of other backend services when using `mvn package` command.
Since the web-console module take time to build, it also slows down the building process

And there're some other problems which are described in the following section.

### Changes Description

1. The entire building process is split into two stages, the web-console build stage which runs under amd64 platform, and the distribution building stage which adapts local development platform. And during the distribution building stage, the web-console will be copied for final distribution package.

   This improves the building process drastically. Now on my laptop, it takes 120 seconds to complete the web-console building stage, and 210 seconds to complete the backend service building stage which are acceptable.

```
 => [web-console-builder 4/4] RUN --mount=type=cache,target=/root/.m2 if [ "true" = "true" ]; then     cd /src/web-console && mvn -B -ff -DskipUTs clean package; fi       126.4s
 => [builder 4/7] WORKDIR /src                                                                                                                                               0.0s
 => [builder 5/7] COPY --from=web-console-builder /src/web-console/target/web-console*.jar /src/web-console/target/                                                          0.0s
 => [builder 6/7] RUN --mount=type=cache,target=/root/.m2 if [ "true" = "true" ]; then       mvn -B -ff       clean install       -Pdist,bundle-contrib-exts       -Pskip  211.5s
```

2. DO NOT use `mvn` to build web-console
This can greatly improve the building performance when contents under web-console directory are not changed by leveraging the docker cache.

To make it, we bulid the web-console in a node image directly. In development, when web-console module is not changed, this reduces the entire building process of web-console

3. Unifed the JDK during building and final run environment

Previously, the `maven:3.9`, which comes with JDK17, is used for building stage. This does NOT respect the `JDK_VERSION` argument in the docker file. This means if we're going to build druid in 21 by specifying the JDK_VERSION, the distribution was still buit under JDK17 but packaged to run in JRE 21 environment.

In this PR, this is fixed. The buliding stage and final image use the SAME version of JDK

4. Switching base from `gcr.io/distroless/java$JDK_VERSION-debian12` to `alpine`

This also drastically simplifies the docker file. Previously, we have to install busybox, download bash from somewhere in the Dockerfile, which makes the Dockerfile very complicated.

Since alpine comes with shell, these steps are eliminated.  The change does NOT involve size bloat of image. On my local it shows that size of alpine based image is 746MB which is a little bit smaller than that of distroless image.

```
druid                         latest                     6eb4ec6dc77f   34 minutes ago   746MB
druid                         distroless                 1daa75c32b0c   7 hours ago      761MB
```

And some command used tools like curl,lsof,netools are packaged in the final docker image.


5. Remove the evaluation of VERSION

Previously we use the following command to evaluate the version, but this step takes VERY LONG time on my laptop

```
RUN --mount=type=cache,target=/root/.m2 VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate \
      -Dexpression=project.version -DforceStdout=true \
    ) \
...
```

We can see that after 254 seconds, the command is still running.

```
 => [builder 7/8] RUN VERSION=$(mvn -B -q org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate       -Dstyle.color=never -Dexpression=project.version -DforceStdout=  254.3s
```

This is eliminated because by applying 'clean' to the maven command, we ensure that there's only one tar file under the distribution and we can use wild match to find the file and decompress it

6. test-related modules are execluded from distribution stage.

7. `druid.sh` is also updated to ensure `druid.host` has value before starting java process. This helps exposing problem more earlier.


#### Release note

The default image is switched from `gcr.io/distroless/java17-debian12` to `alpine`


This PR has:

- [X] been self-reviewed.
- [X] a release note entry in the PR description.
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] been tested in a test Druid cluster.
