### PR TITLE
Update central maven repo to speed up building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
         <jdk.security.manager.allow.argLine><!-- empty placeholder --></jdk.security.manager.allow.argLine>
         <repoOrgId>maven.org</repoOrgId>
         <repoOrgName>Maven Central Repository</repoOrgName>
-        <repoOrgUrl>https://repo1.maven.org/maven2/</repoOrgUrl>
+        <repoOrgUrl>https://repo.maven.apache.org/maven2/</repoOrgUrl>
 
         <!-- Allow the handful of flaky tests with transient failures to pass. -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>


### PR DESCRIPTION
### Description

The maven central repo address was changed from `https://repository.apache.org/snapshots` to `https://repo1.maven.org/maven2/` in #13921 

However, the `https://repo1.maven.org/maven2/` address is extremely slow. 

I'm accessing this address from Singapore, it shows that the latency to repo1 is up to 600 milliseconds, which is unacceptable and it takes extremely long time to download a dependency during building.

```text
ping repo1.maven.org
PING dualstack.sonatype.map.fastly.net (151.101.196.209): 56 data bytes
64 bytes from 151.101.196.209: icmp_seq=0 ttl=51 time=586.089 ms
64 bytes from 151.101.196.209: icmp_seq=1 ttl=51 time=608.747 ms
64 bytes from 151.101.196.209: icmp_seq=2 ttl=51 time=627.263 ms
64 bytes from 151.101.196.209: icmp_seq=3 ttl=51 time=548.446 ms
^C
--- dualstack.sonatype.map.fastly.net ping statistics ---
5 packets transmitted, 4 packets received, 20.0% packet loss
round-trip min/avg/max/stddev = 548.446/592.636/627.263/29.386 ms

ping  repo.maven.apache.org
PING maven.map.fastly.net (199.232.44.215): 56 data bytes
64 bytes from 199.232.44.215: icmp_seq=0 ttl=58 time=7.065 ms
64 bytes from 199.232.44.215: icmp_seq=1 ttl=58 time=6.096 ms
64 bytes from 199.232.44.215: icmp_seq=2 ttl=58 time=10.391 ms
64 bytes from 199.232.44.215: icmp_seq=3 ttl=58 time=10.639 ms
--- maven.map.fastly.net ping statistics ---
4 packets transmitted, 4 packets received, 0.0% packet loss
round-trip min/avg/max/stddev = 6.096/8.548/10.639/1.999 ms
```

GitHub Action does not suffer this problem, I guess that CDN for repo1 address does not work for locations outside of the US.

After switching to the new address, I noticed a max download speed of 17 MB/s.
And building of the entire project a refresh Mac M4 environment(no .m2 directory cache) by the following command takes about 2:30 minutes, which is normal.
```
mvn clean package -DskipTests -T 2C
```


This PR has:

- [X] been self-reviewed.
