### PR TITLE
Support task payload for HDFS

### DIFF
--- a/distribution/docker/peon.sh
+++ b/distribution/docker/peon.sh
@@ -161,4 +161,4 @@ fi
 # If TASK_JSON is not set, CliPeon will pull the task.json file from deep storage.
 mkdir -p ${TASK_DIR}; [ -n "$TASK_JSON" ] && echo ${TASK_JSON} | base64 -d | gzip -d > ${TASK_DIR}/task.json;
 
-exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main internal peon $@
+exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main internal peon --taskId ${TASK_ID} $@

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
@@ -208,33 +208,22 @@ public class HdfsTaskLogs implements TaskLogs
     }
   }
 
-  /**
-   * Save payload into HDFS, so it can be retrieved later.
-   *
-   * @throws IOException When Druid fails to push the task payload.
-   */
   @Override
   public void pushTaskPayload(String taskId, File taskPayloadFile) throws IOException
   {
-    final Path path = getTaskPayloadFromId(taskId);
-    log.info("Pushing task payload [%s] to location [%s]", taskPayloadFile, path);
+    final Path path = getTaskPayloadFileFromId(taskId);
+    log.info("Pushing payload for task[%s] to location[%s]", taskId, path);
     pushTaskFile(path, taskPayloadFile);
   }
 
-  /**
-   * Stream payload from HDFS for a task.
-   *
-   * @return InputStream for this taskPayload, if available.
-   * @throws IOException When Druid fails to read the task payload.
-   */
   @Override
   public Optional<InputStream> streamTaskPayload(String taskId) throws IOException
   {
-    final Path path = getTaskPayloadFromId(taskId);
+    final Path path = getTaskPayloadFileFromId(taskId);
     return streamTaskFile(path, 0);
   }
 
-  private Path getTaskPayloadFromId(String taskId)
+  private Path getTaskPayloadFileFromId(String taskId)
   {
     return new Path(mergePaths(config.getDirectory(), taskId.replace(':', '_') + ".payload.json"));
   }

--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/tasklog/HdfsTaskLogs.java
@@ -207,6 +207,37 @@ public class HdfsTaskLogs implements TaskLogs
       }
     }
   }
+
+  /**
+   * Save payload into HDFS, so it can be retrieved later.
+   *
+   * @throws IOException When Druid fails to push the task payload.
+   */
+  @Override
+  public void pushTaskPayload(String taskId, File taskPayloadFile) throws IOException
+  {
+    final Path path = getTaskPayloadFromId(taskId);
+    log.info("Pushing task payload [%s] to location [%s]", taskPayloadFile, path);
+    pushTaskFile(path, taskPayloadFile);
+  }
+
+  /**
+   * Stream payload from HDFS for a task.
+   *
+   * @return InputStream for this taskPayload, if available.
+   * @throws IOException When Druid fails to read the task payload.
+   */
+  @Override
+  public Optional<InputStream> streamTaskPayload(String taskId) throws IOException
+  {
+    final Path path = getTaskPayloadFromId(taskId);
+    return streamTaskFile(path, 0);
+  }
+
+  private Path getTaskPayloadFromId(String taskId)
+  {
+    return new Path(mergePaths(config.getDirectory(), taskId.replace(':', '_') + ".payload.json"));
+  }
 }
 
 

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -96,6 +96,20 @@ public class HdfsTaskLogsTest
   }
 
   @Test
+  public void test_taskPayload() throws Exception
+  {
+    final File tmpDir = tempFolder.newFolder();
+    final File logDir = new File(tmpDir, "logs");
+    final File payload = new File(tmpDir, "payload.json");
+    final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
+
+    Files.write("{}", payload, StandardCharsets.UTF_8);
+    taskLogs.pushTaskLog("id", payload);
+    Assert.assertEquals("{}",
+                        StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskPayload("id").get())));
+  }
+
+  @Test
   public void testKill() throws Exception
   {
     final File tmpDir = tempFolder.newFolder();

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -50,7 +50,7 @@ public class HdfsTaskLogsTest
     final File tmpDir = tempFolder.newFolder();
     final File logDir = new File(tmpDir, "logs");
     final File logFile = new File(tmpDir, "log");
-    Files.write("blah", logFile, StandardCharsets.UTF_8);
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
     taskLogs.pushTaskLog("foo", logFile);
 
@@ -69,11 +69,11 @@ public class HdfsTaskLogsTest
     final File logFile = new File(tmpDir, "log");
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
 
-    Files.write("blah", logFile, StandardCharsets.UTF_8);
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
     taskLogs.pushTaskLog("foo", logFile);
     Assert.assertEquals("blah", readLog(taskLogs, "foo", 0));
 
-    Files.write("blah blah", logFile, StandardCharsets.UTF_8);
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah blah");
     taskLogs.pushTaskLog("foo", logFile);
     Assert.assertEquals("blah blah", readLog(taskLogs, "foo", 0));
   }
@@ -87,7 +87,7 @@ public class HdfsTaskLogsTest
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
 
 
-    Files.write("{}", statusFile, StandardCharsets.UTF_8);
+    Files.asCharSink(statusFile, StandardCharsets.UTF_8).write("{}");
     taskLogs.pushTaskStatus("id", statusFile);
     Assert.assertEquals(
         "{}",
@@ -103,7 +103,7 @@ public class HdfsTaskLogsTest
     final File payload = new File(tmpDir, "payload.json");
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
 
-    Files.write("{}", payload, StandardCharsets.UTF_8);
+    Files.asCharSink(payload, StandardCharsets.UTF_8).write("{}");
     taskLogs.pushTaskPayload("id", payload);
     Assert.assertEquals("{}", StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskPayload("id").get())));
   }
@@ -120,7 +120,7 @@ public class HdfsTaskLogsTest
 
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
 
-    Files.write("log1content", logFile, StandardCharsets.UTF_8);
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log1content");
     taskLogs.pushTaskLog("log1", logFile);
     Assert.assertEquals("log1content", readLog(taskLogs, "log1", 0));
 
@@ -131,7 +131,7 @@ public class HdfsTaskLogsTest
     long time = (System.currentTimeMillis() / 1000) * 1000;
     Assert.assertTrue(fs.getFileStatus(new Path(logDirPath, "log1")).getModificationTime() < time);
 
-    Files.write("log2content", logFile, StandardCharsets.UTF_8);
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log2content");
     taskLogs.pushTaskLog("log2", logFile);
     Assert.assertEquals("log2content", readLog(taskLogs, "log2", 0));
     Assert.assertTrue(fs.getFileStatus(new Path(logDirPath, "log2")).getModificationTime() >= time);

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -104,9 +104,8 @@ public class HdfsTaskLogsTest
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
 
     Files.write("{}", payload, StandardCharsets.UTF_8);
-    taskLogs.pushTaskLog("id", payload);
-    Assert.assertEquals("{}",
-                        StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskPayload("id").get())));
+    taskLogs.pushTaskPayload("id", payload);
+    Assert.assertEquals("{}", StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskPayload("id").get())));
   }
 
   @Test


### PR DESCRIPTION
### Description

Implement pushTaskPayload/streamTaskPayload as introduced in #14887 for HDFS storage to allow larger mm-less ingestion payloads when using HDFS as the deep storage location.

#### Release note

Support ingestion payloads larger than 128KiB for mm-less ingestion using HDFS as deep storage.

<hr>

##### Key changed/added classes in this PR
 * `HDFSTaskLogs`
 * `HDFSTaskLogsTest`
 * `peon.sh`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
