### PR TITLE
Fix dataSource dimension decoration in SQLExecutionReporter Metrics

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlExecutionReporter.java
@@ -101,14 +101,18 @@ public class SqlExecutionReporter
         // Note: the dimension is "dataSource" (sic), so we log only the SQL resource
         // actions. Even here, for external tables, those actions are not always
         // datasources.
-        metricBuilder.setDimension(
-            "dataSource",
-            stmt.authResult.sqlResourceActions
-                            .stream()
-                            .map(action -> action.getResource().getName())
-                            .collect(Collectors.toList())
-                            .toString()
-        );
+        String dataSourcesResourceNames = stmt.authResult.sqlResourceActions
+                .stream()
+                .map(action -> action.getResource().getName())
+                .collect(Collectors.toList())
+                .toString();
+
+        // Remove enclosing square brackets from String representation of the list,
+        // so that the emitters do not decorate the dataSource dimension with square brackets
+        if (dataSourcesResourceNames != null && !dataSourcesResourceNames.isBlank()) {
+          dataSourcesResourceNames = dataSourcesResourceNames.substring(1, dataSourcesResourceNames.length() - 1);
+        }
+        metricBuilder.setDimension("dataSource", dataSourcesResourceNames);
       }
       metricBuilder.setDimension("remoteAddress", StringUtils.nullToEmptyNonDruidDataString(remoteAddress));
       metricBuilder.setDimension("success", String.valueOf(success));

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -464,6 +464,10 @@ public class SqlResourceTest extends CalciteTestBase
     stubServiceEmitter.verifyEmitted("sqlQuery/time", 1);
     stubServiceEmitter.verifyValue("sqlQuery/bytes", 27L);
     stubServiceEmitter.verifyEmitted("sqlQuery/planningTimeMs", 1);
+    stubServiceEmitter.getEvents().forEach(event -> {
+      Assert.assertEquals("foo", event.toMap().get("dataSource"));
+      Assert.assertEquals("metrics", event.toMap().get("feed"));
+    });
   }
 
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #17743.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
* For the `sqlQuery/*` metrics, `[` and `]` are added when the data source names are being converted from a List to a String. 
* This decorated `dataSource` value gets emitted by the emitters in decorated format as shown in the screenshots on the linked issue. 

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
* In this PR, we are explicitly removing the heading `[` and trailing `]` characters from the `dataSource` name in the `SQLExecutionReporter` itself, so that the decorated values are not carried to the emitters.
  * Side Note: Prometheus Emitter replaces all non-alphanumeric characters with `_`; so `dataSource` names in Prometheus will not contain the heading `_` and trailing `_` automatically!
* We are also adding a test case to cover this scenario, wherein the expected value of `dataSource` should be `foo`. Before making the code change, I ran the unit test on the current codebase, and I can clearly see the actual value was `[foo]`. Attaching reference screenshot here: 
![image](https://github.com/user-attachments/assets/91e7f595-4a0f-4e04-a248-b56efa7286ee)
* With the code changes in this PR, the `dataSource` value is correctly passed as `foo`
 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
* `dataSource` names for `sqlQuery` metrics will not include heading `[` and trailing `]` or any other character decorations; making them consistent across other Druid metrics. 
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `SqlExecutionReporter`
 * `SqlResourceTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [X] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [X] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [X] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
