### PR TITLE
Update Kafka Emitter Documentation

### DIFF
--- a/docs/development/extensions-contrib/kafka-emitter.md
+++ b/docs/development/extensions-contrib/kafka-emitter.md
@@ -53,7 +53,7 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 
 ```
 druid.emitter.kafka.bootstrap.servers=hostname1:9092,hostname2:9092
-druid.emitter.kafka.event.types=["metrics", alerts", "requests", "segment_metadata"]
+druid.emitter.kafka.event.types=["metrics", "alerts", "requests", "segment_metadata"]
 druid.emitter.kafka.metric.topic=druid-metric
 druid.emitter.kafka.alert.topic=druid-alert
 druid.emitter.kafka.request.topic=druid-request-logs


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
* The example configuration in `kafka-emitter` documentation is missing a `"`, which causes the below exception if it is used verbatim in Kafka Emitter configuration. 
* This PR fixes the issue, and verified that, with this fix in place, the Druid processes come up fine. 
```
 Exception in thread "main" com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException
         at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2085)
         at com.google.common.cache.LocalCache.get(LocalCache.java:4011)
         at com.google.common.cache.LocalCache.getOrLoad(LocalCache.java:4034)
         at com.google.common.cache.LocalCache$LocalLoadingCache.get(LocalCache.java:5010)
         at com.google.common.cache.LocalCache$LocalLoadingCache.getUnchecked(LocalCache.java:5017)
         at com.google.inject.internal.util.StackTraceElements.forMember(StackTraceElements.java:70)
         at com.google.inject.internal.Errors.formatParameter(Errors.java:859)
         at com.google.inject.internal.Errors.formatInjectionPoint(Errors.java:846)
         at com.google.inject.internal.Errors.formatSource(Errors.java:805)
         at com.google.inject.internal.Errors.formatSource(Errors.java:796)
         at com.google.inject.internal.Errors.format(Errors.java:590)
         at com.google.inject.CreationException.getMessage(CreationException.java:50)
         at java.base/java.lang.Throwable.getLocalizedMessage(Throwable.java:397)
         at java.base/java.lang.Throwable.toString(Throwable.java:496)
         at java.base/java.lang.Throwable.<init>(Throwable.java:317)
         at java.base/java.lang.Exception.<init>(Exception.java:103)
         at java.base/java.lang.RuntimeException.<init>(RuntimeException.java:97)
         at org.apache.druid.cli.GuiceRunnable.makeInjector(GuiceRunnable.java:88)
         at org.apache.druid.cli.ServerRunnable.run(ServerRunnable.java:69)
         at org.apache.druid.cli.Main.main(Main.java:112)
 Caused by: java.lang.IllegalArgumentException
         at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
         at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
         at com.google.inject.internal.asm.$ClassReader.<init>(Unknown Source)
         at com.google.inject.internal.util.LineNumbers.<init>(LineNumbers.java:66)
         at com.google.inject.internal.util.StackTraceElements$1.load(StackTraceElements.java:46)
         at com.google.inject.internal.util.StackTraceElements$1.load(StackTraceElements.java:43)
         at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3570)
         at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2312)
         at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2189)
         at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2079)
         ... 19 more
```


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>



<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
