### PR TITLE
202502 Docs fix for GROUP BY metrics table

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -122,6 +122,8 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 
 These metrics are reported from broker, historical and real-time nodes 
 
+|Metric|Description|Normal value|
+|------|-----------|------------|
 |`mergeBuffer/pendingRequests`|Number of requests waiting to acquire a batch of buffers from the merge buffer pool.|This metric is only available if the `GroupByStatsMonitor` module is included.|Should be ideally 0, though a higher number isn't representative of a problem.|
 |`mergeBuffer/used`|Number of merge buffers used from the merge buffer pool.|This metric is only available if the `GroupByStatsMonitor` module is included.|Depends on the number of groupBy queries needing merge buffers.|
 |`mergeBuffer/queries`|Number of groupBy queries that acquired a batch of buffers from the merge buffer pool.|This metric is only available if the `GroupByStatsMonitor` module is included.|Depends on the number of groupBy queries needing merge buffers.|


### PR DESCRIPTION
Restored the table header that was causing a markdown render issue.

- [x] been self-reviewed.
- [ ] been tested in a test Druid cluster.
