### PR TITLE
Revert "Fix error where communication failures to k8s can lead to stuck tasks (#17431)

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
@@ -42,7 +42,6 @@ import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.tasklogs.TaskLogs;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -351,20 +350,23 @@ public class KubernetesPeonLifecycle
   protected void saveLogs()
   {
     try {
-      final Path file = Files.createTempFile(taskId.getOriginalTaskId(), "log");
+      Path file = Files.createTempFile(taskId.getOriginalTaskId(), "log");
       try {
-        final InputStream logStream;
+        startWatchingLogs();
         if (logWatch != null) {
-          logStream = logWatch.getOutput();
+          FileUtils.copyInputStreamToFile(logWatch.getOutput(), file.toFile());
         } else {
-          logStream = kubernetesClient.getPeonLogs(taskId).or(
-              new ByteArrayInputStream(StringUtils.format(
+          log.debug("Log stream not found for %s", taskId.getOriginalTaskId());
+          FileUtils.writeStringToFile(
+              file.toFile(),
+              StringUtils.format(
                   "Peon for task [%s] did not report any logs. Check k8s metrics and events for the pod to see what happened.",
                   taskId
-              ).getBytes(StandardCharsets.UTF_8))
+              ),
+              Charset.defaultCharset()
           );
+
         }
-        FileUtils.copyInputStreamToFile(logStream, file.toFile());
         taskLogs.pushTaskLog(taskId.getOriginalTaskId(), file.toFile());
       }
       catch (IOException e) {

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
@@ -25,7 +25,6 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
-import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.common.task.IndexTaskUtils;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.java.util.common.RetryUtils;
@@ -267,7 +266,7 @@ public class KubernetesPeonClient
       );
     }
     catch (Exception e) {
-      throw DruidException.defensive(e, "Error when looking for K8s pod with label: job-name=%s", jobName);
+      throw new KubernetesResourceNotFoundException("K8s pod with label: job-name=" + jobName + " not found");
     }
   }
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
@@ -30,7 +30,6 @@ import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
@@ -526,7 +525,7 @@ public class KubernetesPeonClientTest
   void test_getPeonPodWithRetries_withoutPod_raisesKubernetesResourceNotFoundException()
   {
     Assertions.assertThrows(
-        DruidException.class,
+        KubernetesResourceNotFoundException.class,
         () -> instance.getPeonPodWithRetries(clientApi.getClient(), new K8sTaskId(ID).getK8sJobName(), 1, 1),
         StringUtils.format("K8s pod with label: job-name=%s not found", ID)
     );


### PR DESCRIPTION
Reasoning : https://github.com/apache/druid/pull/17431#issuecomment-2672191532

Revert "Fix error where communication failures to k8s can lead to stuck tasks (#17431)
This reverts commit 8850023811b27eeb25095fa9d4ce96ede9081b52.
