### PR TITLE
Web console: fix processed row formatting

### DIFF
--- a/web-console/src/dialogs/supervisor-table-action-dialog/supervisor-statistics-table/supervisor-statistics-table.tsx
+++ b/web-console/src/dialogs/supervisor-table-action-dialog/supervisor-statistics-table/supervisor-statistics-table.tsx
@@ -76,16 +76,18 @@ export const SupervisorStatisticsTable = React.memo(function SupervisorStatistic
 
     const formatNumber = isRate ? formatRate : formatInteger;
     const formatData = isRate ? formatByteRate : formatBytes;
-    const bytes = c.processedBytes ? ` (${formatData(c.processedBytes)})` : '';
-    return (
+    return c.processedBytes ? (
       <div>
-        <div>{`Processed: ${formatNumber(c.processed)}${bytes}`}</div>
+        <div>{`Input: ${formatData(c.processedBytes)}`}</div>
+        {Boolean(c.processed) && <div>{`Processed: ${formatNumber(c.processed)}`}</div>}
         {Boolean(c.processedWithError) && (
-          <div>Processed with error: {formatNumber(c.processedWithError)}</div>
+          <div>{`Processed with error: ${formatNumber(c.processedWithError)}`}</div>
         )}
-        {Boolean(c.thrownAway) && <div>Thrown away: {formatNumber(c.thrownAway)}</div>}
-        {Boolean(c.unparseable) && <div>Unparseable: {formatNumber(c.unparseable)}</div>}
+        {Boolean(c.thrownAway) && <div>{`Thrown away: ${formatNumber(c.thrownAway)}`}</div>}
+        {Boolean(c.unparseable) && <div>{`Unparseable: ${formatNumber(c.unparseable)}`}</div>}
       </div>
+    ) : (
+      <div>No activity</div>
     );
   }
 

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -875,19 +875,25 @@ export class SupervisorsView extends React.PureComponent<
 
               const c = getTotalSupervisorStats(value, statsKey, activeTaskIds);
               const seconds = getRowStatsKeySeconds(statsKey);
+              const issues =
+                (c.processedWithError || 0) + (c.thrownAway || 0) + (c.unparseable || 0);
               const totalLabel = `Total (past ${statsKey}): `;
-              const bytes = c.processedBytes ? ` (${formatByteRate(c.processedBytes)})` : '';
-              return (
+              return issues ? (
                 <div>
                   <div
-                    data-tooltip={`${totalLabel}${formatInteger(
-                      c.processed * seconds,
-                    )} (${formatBytes(c.processedBytes * seconds)})`}
-                  >{`Processed: ${formatRate(c.processed)}${bytes}`}</div>
+                    data-tooltip={`${totalLabel}${formatBytes(c.processedBytes * seconds)}`}
+                  >{`Input: ${formatByteRate(c.processedBytes)}`}</div>
+                  {Boolean(c.processed) && (
+                    <div
+                      data-tooltip={`${totalLabel}${formatInteger(c.processed * seconds)} events`}
+                    >{`Processed: ${formatRate(c.processed)}`}</div>
+                  )}
                   {Boolean(c.processedWithError) && (
                     <div
                       className="warning-line"
-                      data-tooltip={`${totalLabel}${formatInteger(c.processedWithError * seconds)}`}
+                      data-tooltip={`${totalLabel}${formatInteger(
+                        c.processedWithError * seconds,
+                      )} events`}
                     >
                       Processed with error: {formatRate(c.processedWithError)}
                     </div>
@@ -895,7 +901,7 @@ export class SupervisorsView extends React.PureComponent<
                   {Boolean(c.thrownAway) && (
                     <div
                       className="warning-line"
-                      data-tooltip={`${totalLabel}${formatInteger(c.thrownAway * seconds)}`}
+                      data-tooltip={`${totalLabel}${formatInteger(c.thrownAway * seconds)} events`}
                     >
                       Thrown away: {formatRate(c.thrownAway)}
                     </div>
@@ -903,12 +909,22 @@ export class SupervisorsView extends React.PureComponent<
                   {Boolean(c.unparseable) && (
                     <div
                       className="warning-line"
-                      data-tooltip={`${totalLabel}${formatInteger(c.unparseable * seconds)}`}
+                      data-tooltip={`${totalLabel}${formatInteger(c.unparseable * seconds)} events`}
                     >
                       Unparseable: {formatRate(c.unparseable)}
                     </div>
                   )}
                 </div>
+              ) : c.processedBytes ? (
+                <div
+                  data-tooltip={`${totalLabel}${formatInteger(
+                    c.processed * seconds,
+                  )} events, ${formatBytes(c.processedBytes * seconds)}`}
+                >{`Processed: ${formatRate(c.processed)} (${formatByteRate(
+                  c.processedBytes,
+                )})`}</div>
+              ) : (
+                <div>No activity</div>
               );
             },
             show: visibleColumns.shown('Stats'),


### PR DESCRIPTION
The web console falsely assumed that the `processed` counter includes the "issues" (`processedWithError`, `thrownAway`, and `unparseable`). This PR changes it so that the rendering if there are no issues is the same as before and the rendering if there are issues is more clear and not misleading.

Here are the 3 possible states that there can be (issues, nothing, no issues):

<img width="249" alt="image" src="https://github.com/user-attachments/assets/d840dfc7-6a9b-4059-82bd-d778501c513d" />
