### PR TITLE
Remove semicolon from example

### DIFF
--- a/docs/operations/segment-optimization.md
+++ b/docs/operations/segment-optimization.md
@@ -83,7 +83,7 @@ WHERE
   datasource = 'your_dataSource' AND
   is_published = 1
 GROUP BY 1, 2, 3
-ORDER BY 1, 2, 3 DESC;
+ORDER BY 1, 2, 3 DESC
 ```
 
 Please note that the query result might include overshadowed segments.


### PR DESCRIPTION
Semicolon is not allowed and supported in Druid, remove it from example.
Also checked the sql.md, there's no such problem. I don't go through all documents

It would be better we handle this situation silently in background without reporting an error. See #17758 


This PR has:

- [X] been self-reviewed.

