### PR TITLE
improve exception message for mismatched types when merging CapabilitiesBasedFormat

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/column/CapabilitiesBasedFormat.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/CapabilitiesBasedFormat.java
@@ -28,6 +28,12 @@ import org.apache.druid.segment.DimensionHandlerUtils;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
+/**
+ * Legacy fallback column format used by columns which do not directly implement {@link ColumnFormat}. This should be
+ * avoided if possible in favor of implementing a {@link ColumnFormat} that is specific to the column type and can
+ * accurately capture the physical storage details and have fine-grained control over how {@link #merge(ColumnFormat)},
+ * {@link #getColumnSchema(String)} and {@link #getColumnHandler(String)} behave.
+ */
 public class CapabilitiesBasedFormat implements ColumnFormat
 {
   // merge logic for the state capabilities will be in after incremental index is persisted
@@ -118,10 +124,10 @@ public class CapabilitiesBasedFormat implements ColumnFormat
     merged.setDictionaryEncoded(merged.isDictionaryEncoded().or(otherSnapshot.isDictionaryEncoded()).isTrue());
     merged.setHasMultipleValues(merged.hasMultipleValues().or(otherSnapshot.hasMultipleValues()).isTrue());
     merged.setDictionaryValuesSorted(
-        merged.areDictionaryValuesSorted().or(otherSnapshot.areDictionaryValuesSorted()).isTrue()
+        merged.areDictionaryValuesSorted().and(otherSnapshot.areDictionaryValuesSorted()).isTrue()
     );
     merged.setDictionaryValuesUnique(
-        merged.areDictionaryValuesUnique().or(otherSnapshot.areDictionaryValuesUnique()).isTrue()
+        merged.areDictionaryValuesUnique().and(otherSnapshot.areDictionaryValuesUnique()).isTrue()
     );
     merged.setHasNulls(merged.hasNulls().or(otherSnapshot.hasNulls()).isTrue());
     // when merging persisted queryableIndexes in the same ingestion job, all queryableIndexes should have the exact

--- a/processing/src/main/java/org/apache/druid/segment/column/CapabilitiesBasedFormat.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/CapabilitiesBasedFormat.java
@@ -98,11 +98,10 @@ public class CapabilitiesBasedFormat implements ColumnFormat
 
     ColumnCapabilitiesImpl merged = ColumnCapabilitiesImpl.copyOf(this.toColumnCapabilities());
     ColumnCapabilitiesImpl otherSnapshot = ColumnCapabilitiesImpl.copyOf(otherFormat.toColumnCapabilities());
-
+    final String mergedType = merged.getType() == null ? null : merged.asTypeString();
+    final String otherType = otherSnapshot.getType() == null ? null : otherSnapshot.asTypeString();
     if (!Objects.equals(merged.getType(), otherSnapshot.getType())
         || !Objects.equals(merged.getElementType(), otherSnapshot.getElementType())) {
-      final String mergedType = merged.getType() == null ? null : merged.asTypeString();
-      final String otherType = otherSnapshot.getType() == null ? null : otherSnapshot.asTypeString();
       throw new ISE(
           "Cannot merge columns of type[%s] and [%s]",
           mergedType,
@@ -111,18 +110,18 @@ public class CapabilitiesBasedFormat implements ColumnFormat
     } else if (!Objects.equals(merged.getComplexTypeName(), otherSnapshot.getComplexTypeName())) {
       throw new ISE(
           "Cannot merge columns of type[%s] and [%s]",
-          merged.getComplexTypeName(),
-          otherSnapshot.getComplexTypeName()
+          mergedType,
+          otherType
       );
     }
 
     merged.setDictionaryEncoded(merged.isDictionaryEncoded().or(otherSnapshot.isDictionaryEncoded()).isTrue());
     merged.setHasMultipleValues(merged.hasMultipleValues().or(otherSnapshot.hasMultipleValues()).isTrue());
     merged.setDictionaryValuesSorted(
-        merged.areDictionaryValuesSorted().and(otherSnapshot.areDictionaryValuesSorted()).isTrue()
+        merged.areDictionaryValuesSorted().or(otherSnapshot.areDictionaryValuesSorted()).isTrue()
     );
     merged.setDictionaryValuesUnique(
-        merged.areDictionaryValuesUnique().and(otherSnapshot.areDictionaryValuesUnique()).isTrue()
+        merged.areDictionaryValuesUnique().or(otherSnapshot.areDictionaryValuesUnique()).isTrue()
     );
     merged.setHasNulls(merged.hasNulls().or(otherSnapshot.hasNulls()).isTrue());
     // when merging persisted queryableIndexes in the same ingestion job, all queryableIndexes should have the exact

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnFormat.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnFormat.java
@@ -24,15 +24,35 @@ import org.apache.druid.segment.DimensionHandler;
 
 import javax.annotation.Nullable;
 
+/**
+ * Abstraction for the physical storage components of a column, allowing us to decouple a columns logical type from
+ * how it is actually stored in a segment. Also provides methods to create {@link DimensionHandler} and
+ * {@link DimensionSchema} for creating new columns with identical physical storage components.
+ */
 public interface ColumnFormat
 {
   ColumnType getLogicalType();
 
+  /**
+   * Convert physical column details to generic {@link ColumnCapabilities} for query time analysis
+   */
   ColumnCapabilities toColumnCapabilities();
 
+  /**
+   * Create a {@link DimensionHandler} which can be used to create indexers and mergers to produce a new column with
+   * this format
+   */
   DimensionHandler getColumnHandler(String columnName);
 
+  /**
+   * Creates a {@link DimensionSchema} which can be used to create new segment schemas for ingestion jobs to create
+   * columns with this format
+   */
   DimensionSchema getColumnSchema(String columnName);
 
+  /**
+   * Create a new {@link ColumnFormat} from this format and another format, merging implementation specific physical
+   * storage details as appropriate to determine what the new format should be.
+   */
   ColumnFormat merge(@Nullable ColumnFormat otherFormat);
 }

--- a/processing/src/test/java/org/apache/druid/segment/column/CapabilitiesBasedFormatTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/column/CapabilitiesBasedFormatTest.java
@@ -45,12 +45,14 @@ public class CapabilitiesBasedFormatTest
     ColumnCapabilities mergedCapabilities = format.merge(new CapabilitiesBasedFormat(capabilities2))
                                                   .toColumnCapabilities();
     Assertions.assertTrue(mergedCapabilities.is(ValueType.STRING));
-    // this one is false if either is false
+    // false if either is false
     Assertions.assertFalse(mergedCapabilities.hasBitmapIndexes());
+    // also false if either is false, but these don't have any known implications for segment creation since they are
+    // computed when the segment is loaded and only used at query time
+    Assertions.assertFalse(mergedCapabilities.areDictionaryValuesSorted().isTrue());
+    Assertions.assertFalse(mergedCapabilities.areDictionaryValuesUnique().isTrue());
     // rest are true if either is true
     Assertions.assertTrue(mergedCapabilities.isDictionaryEncoded().isTrue());
-    Assertions.assertTrue(mergedCapabilities.areDictionaryValuesSorted().isTrue());
-    Assertions.assertTrue(mergedCapabilities.areDictionaryValuesUnique().isTrue());
     Assertions.assertTrue(mergedCapabilities.hasMultipleValues().isTrue());
     Assertions.assertTrue(mergedCapabilities.hasNulls().isTrue());
   }

--- a/processing/src/test/java/org/apache/druid/segment/column/CapabilitiesBasedFormatTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/column/CapabilitiesBasedFormatTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.segment.column;
+
+import org.apache.druid.java.util.common.ISE;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CapabilitiesBasedFormatTest
+{
+  @Test
+  public void testMerge()
+  {
+    ColumnCapabilities capabilities = new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                                                  .setHasMultipleValues(true);
+    ColumnCapabilities capabilities2 = new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                                                   .setDictionaryEncoded(true)
+                                                                   .setDictionaryValuesSorted(true)
+                                                                   .setDictionaryValuesUnique(true)
+                                                                   .setHasBitmapIndexes(true)
+                                                                   .setHasNulls(true);
+
+    CapabilitiesBasedFormat format = new CapabilitiesBasedFormat(capabilities);
+
+
+    // merged format should pick up combined capabilities, just check the resulting merged capabilities since they
+    // drive everything in CapabilitiesBasedFormat
+    ColumnCapabilities mergedCapabilities = format.merge(new CapabilitiesBasedFormat(capabilities2))
+                                                  .toColumnCapabilities();
+    Assertions.assertTrue(mergedCapabilities.is(ValueType.STRING));
+    // this one is false if either is false
+    Assertions.assertFalse(mergedCapabilities.hasBitmapIndexes());
+    // rest are true if either is true
+    Assertions.assertTrue(mergedCapabilities.isDictionaryEncoded().isTrue());
+    Assertions.assertTrue(mergedCapabilities.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(mergedCapabilities.areDictionaryValuesUnique().isTrue());
+    Assertions.assertTrue(mergedCapabilities.hasMultipleValues().isTrue());
+    Assertions.assertTrue(mergedCapabilities.hasNulls().isTrue());
+  }
+
+  @Test
+  public void testMergeNullCapabilities()
+  {
+    ColumnCapabilities capabilities = new ColumnCapabilitiesImpl().setType(ColumnType.STRING)
+                                                                  .setHasMultipleValues(true);
+
+    CapabilitiesBasedFormat format = new CapabilitiesBasedFormat(capabilities);
+
+
+    ColumnFormat merged = format.merge(null);
+    // same object since other is null
+    Assertions.assertEquals(format, merged);
+  }
+
+  @Test
+  public void testMergeIncompatibleArray()
+  {
+    ColumnCapabilities arrayString = ColumnCapabilitiesImpl.createSimpleArrayColumnCapabilities(ColumnType.STRING_ARRAY);
+    ColumnCapabilities arrayLong = ColumnCapabilitiesImpl.createSimpleArrayColumnCapabilities(ColumnType.LONG_ARRAY);
+    ColumnCapabilities string = ColumnCapabilitiesImpl.createSimpleSingleValueStringColumnCapabilities();
+
+    ColumnFormat stringArrayFormat = new CapabilitiesBasedFormat(arrayString);
+    ColumnFormat longArrayFormat = new CapabilitiesBasedFormat(arrayLong);
+    CapabilitiesBasedFormat stringFormat = new CapabilitiesBasedFormat(string);
+
+    Throwable t = Assertions.assertThrows(
+        ISE.class,
+        () -> stringArrayFormat.merge(longArrayFormat)
+    );
+    Assertions.assertEquals("Cannot merge columns of type[ARRAY<STRING>] and [ARRAY<LONG>]", t.getMessage());
+
+
+    t = Assertions.assertThrows(
+        ISE.class,
+        () -> stringArrayFormat.merge(stringFormat)
+    );
+    Assertions.assertEquals("Cannot merge columns of type[ARRAY<STRING>] and [STRING]", t.getMessage());
+  }
+
+  @Test
+  public void testMergeIncompatibleComplexType()
+  {
+    ColumnCapabilities complex1 = new ColumnCapabilitiesImpl().setType(ColumnType.ofComplex("someComplex"));
+    ColumnCapabilities complex2 = new ColumnCapabilitiesImpl().setType(ColumnType.ofComplex("otherComplex"));
+    ColumnCapabilities string = ColumnCapabilitiesImpl.createSimpleSingleValueStringColumnCapabilities();
+
+
+    ColumnFormat format1 = new CapabilitiesBasedFormat(complex1);
+    ColumnFormat format2 = new CapabilitiesBasedFormat(complex2);
+    CapabilitiesBasedFormat stringFormat = new CapabilitiesBasedFormat(string);
+
+    Throwable t = Assertions.assertThrows(
+        ISE.class,
+        () -> format1.merge(format2)
+    );
+    Assertions.assertEquals("Cannot merge columns of type[COMPLEX<someComplex>] and [COMPLEX<otherComplex>]", t.getMessage());
+
+
+    t = Assertions.assertThrows(
+        ISE.class,
+        () -> format1.merge(stringFormat)
+    );
+    Assertions.assertEquals("Cannot merge columns of type[COMPLEX<someComplex>] and [STRING]", t.getMessage());
+  }
+}


### PR DESCRIPTION
Improves exception message when merging `CapabilitiesBasedFormat` in `IndexMergerV9` when faced with mismatched complex types. Prior to this change merging a complex type with a string type for example would create an exception message with a message like `Cannot merge columns of type[someComplex] and [null]` since it was using the complex type name of both types, which will be null for non-complex types. After this change this exception message for complex types will be something like `Cannot merge columns of type[COMPLEX<someComplex>] and [STRING]` since it will now use the type strings.

I also modified a merge behavior of `ColumnCapabilities.areDictionaryValuesSorted` and `ColumnCapabilities.areDictionaryValuesUnique` in `CapabilitiesBasedFormat.merge` that probably doesn't really matter since these are computed for query time stuff and they do not actually affect segment persistence but seemed odd behavior considering everything else in the merge, so now it is consistent and uses 'or' instead of 'and'.