### PR TITLE
Fix deterministic server selection in balancer by adding tie-breaking logic

### DIFF
--- a/server/src/main/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategy.java
+++ b/server/src/main/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategy.java
@@ -30,11 +30,15 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class ConnectionCountServerSelectorStrategy implements ServerSelectorStrategy
 {
   private static final Comparator<QueryableDruidServer> COMPARATOR =
-      Comparator.comparingInt(s -> ((DirectDruidClient) s.getQueryRunner()).getNumOpenConnections());
+      Comparator.comparingDouble(s ->
+                                     ((DirectDruidClient) s.getQueryRunner()).getNumOpenConnections()
+                                     + ThreadLocalRandom.current().nextDouble()
+      );
 
   @Nullable
   @Override

--- a/server/src/test/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/client/selector/ConnectionCountServerSelectorStrategyTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client.selector;
+
+import org.apache.druid.client.DirectDruidClient;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.client.QueryableDruidServer;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ConnectionCountServerSelectorStrategyTest
+{
+  @Test
+  public void testDifferentConnectionCount()
+  {
+    QueryableDruidServer s1 = mockServer("test1", 2);
+    QueryableDruidServer s2 = mockServer("test2", 1);
+    QueryableDruidServer s3 = mockServer("test3", 4);
+    ServerSelector serverSelector = initSelector(s1, s2, s3);
+
+    for (int i = 0; i < 100; ++i) {
+      Assert.assertEquals(s2, serverSelector.pick(null));
+    }
+  }
+
+  @Test
+  public void testBalancerTieBreaking()
+  {
+    QueryableDruidServer s1 = mockServer("test1", 100);
+    QueryableDruidServer s2 = mockServer("test2", 100);
+    ServerSelector serverSelector = initSelector(s1, s2);
+
+    Set<String> pickedServers = new HashSet<>();
+    for (int i = 0; i < 100; ++i) {
+      pickedServers.add(serverSelector.pick(null).getServer().getName());
+    }
+    Assert.assertTrue(
+        "Multiple servers should be selected when the number of connections is equal.",
+        pickedServers.size() > 1
+    );
+  }
+
+  private QueryableDruidServer mockServer(String name, int openConnections)
+  {
+    DirectDruidClient client = EasyMock.createMock(DirectDruidClient.class);
+    EasyMock.expect(client.getNumOpenConnections()).andReturn(openConnections).anyTimes();
+    EasyMock.replay(client);
+    return new QueryableDruidServer(
+        new DruidServer(
+            name,
+            "localhost",
+            null,
+            0,
+            ServerType.HISTORICAL,
+            DruidServer.DEFAULT_TIER,
+            0
+        ), client
+    );
+  }
+
+  private ServerSelector initSelector(QueryableDruidServer... servers)
+  {
+    TierSelectorStrategy strategy = new HighestPriorityTierSelectorStrategy(new ConnectionCountServerSelectorStrategy());
+    ServerSelector selector = new ServerSelector(
+        new DataSegment(
+            "test",
+            Intervals.of("2025-01-01/2025-01-02"),
+            DateTimes.of("2025-01-01").toString(),
+            new HashMap<>(),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new NumberedShardSpec(0, 0),
+            0,
+            0L
+        ), strategy
+    );
+    List<QueryableDruidServer> serverList = new ArrayList<>(Arrays.asList(servers));
+    Collections.shuffle(serverList);
+    for (QueryableDruidServer server : serverList) {
+      selector.addServerAndUpdateSegment(server, selector.getSegment());
+    }
+    return selector;
+  }
+}


### PR DESCRIPTION
### Description

The current connection count query balancer (when `druid.broker.balancer.type=connectionCount`) behavior in Apache Druid has a deterministic server selection mechanism when multiple servers have the same number of active connections. This results in uneven query distribution, particularly in the following cases:
- A single query always targets the same node.
- If the nodes have the same number of connections, a single Historical is always "preferred".
- If the number of queries surpasses the number of active connections on Historicals, the Broker may end up targeting only one Historical node, leading to potential performance bottlenecks.

Likely the same problem is described in an old issue here: https://github.com/apache/druid/issues/3777

### Proposed Fix

This PR introduces a simple tie-breaking mechanism in the balancer to prevent deterministic selection when multiple servers have the same connection count. This will improve overall load balancing by:
- Keeping the behavior unchanged when the nodes have different number of active connections (the process with the fewest number of active connections is always picked).
- Falling back to random query balancing when the processes have the same number of connections.
- Ensuring that when query volume increases beyond active connections on Historicals, the Broker does not repeatedly select the same Historical.

### Impact:

The fix only impacts clusters with `druid.broker.balancer.type=connectionCount` set (by default it is set to `random`):
- Improves query distribution across servers, reducing load imbalance.
- Prevents performance degradation due to overloading a single Historical.

### Testing:
- Added unit tests to validate improved balancing behavior.
- Manually tested in a clustered setup to ensure even query distribution.

#### Related Issues:
- https://github.com/apache/druid/issues/3777

---

Let me know if any additional details should be included!


#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

-->


<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
