### PR TITLE
Web console: add suggestions for table status filtering.

### DIFF
--- a/web-console/src/components/menu-boolean/menu-boolean.tsx
+++ b/web-console/src/components/menu-boolean/menu-boolean.tsx
@@ -31,9 +31,9 @@ function toKey(value: boolean | undefined) {
 
 const DEFAULT_OPTIONS_TEXT: Partial<Record<TrueFalseUndefined, string>> = { undefined: 'Auto' };
 
-export const ENABLE_DISABLE_OPTIONS_TEXT: Partial<Record<TrueFalseUndefined, string>> = {
-  true: 'Enable',
-  false: 'Disable',
+export const ENABLED_DISABLED_OPTIONS_TEXT: Partial<Record<TrueFalseUndefined, string>> = {
+  true: 'Enabled',
+  false: 'Disabled',
   undefined: 'Auto',
 };
 

--- a/web-console/src/components/segment-timeline/segment-bar-chart-render.tsx
+++ b/web-console/src/components/segment-timeline/segment-bar-chart-render.tsx
@@ -644,8 +644,8 @@ export const SegmentBarChartRender = function SegmentBarChartRender(
         className={classNames('load-rule', loadRuleToBaseType(loadRule))}
         data-tooltip={title}
         style={{
-          left: xWidth.x,
-          width: xWidth.width,
+          left: clamp(xWidth.x, 0, innerStage.width),
+          width: clamp(xWidth.width, 0, innerStage.width),
         }}
       >
         {title}

--- a/web-console/src/react-table/react-table-inputs.tsx
+++ b/web-console/src/react-table/react-table-inputs.tsx
@@ -22,6 +22,8 @@ import classNames from 'classnames';
 import { useEffect, useState } from 'react';
 import type { Column, ReactTableFunction } from 'react-table';
 
+import { filterMap, toggle } from '../utils';
+
 import {
   combineModeAndNeedle,
   FILTER_MODES,
@@ -111,6 +113,57 @@ export function GenericFilterInput({ column, filter, onChange, key }: FilterRend
       }}
     />
   );
+}
+
+export function suggestibleFilterInput(suggestions: string[]) {
+  return function SuggestibleFilterInput({ filter, onChange, key, ...rest }: FilterRendererProps) {
+    let valuesFilteredOn: string[] | undefined;
+    if (filter) {
+      const modeAndNeedle = parseFilterModeAndNeedle(filter, true);
+      if (modeAndNeedle && modeAndNeedle.mode === '=') {
+        valuesFilteredOn = modeAndNeedle.needleParts;
+      }
+    }
+    return (
+      <Popover
+        key={key}
+        placement="bottom-start"
+        minimal
+        content={
+          <Menu>
+            {filterMap(suggestions, (suggestion, i) => {
+              return (
+                <MenuItem
+                  key={i}
+                  icon={
+                    valuesFilteredOn
+                      ? valuesFilteredOn.includes(suggestion)
+                        ? IconNames.MINUS
+                        : IconNames.PLUS
+                      : IconNames.EQUALS
+                  }
+                  text={suggestion}
+                  onClick={() =>
+                    onChange(
+                      combineModeAndNeedle(
+                        '=',
+                        valuesFilteredOn
+                          ? toggle(valuesFilteredOn, suggestion).join('|')
+                          : suggestion,
+                        true,
+                      ),
+                    )
+                  }
+                />
+              );
+            })}
+          </Menu>
+        }
+      >
+        <GenericFilterInput filter={filter} onChange={onChange} {...rest} />
+      </Popover>
+    );
+  };
 }
 
 export function BooleanFilterInput({ filter, onChange, key }: FilterRendererProps) {

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -686,3 +686,8 @@ export function offsetToRowColumn(str: string, offset: number): RowColumn | unde
 export function xor(a: unknown, b: unknown): boolean {
   return Boolean(a ? !b : b);
 }
+
+export function toggle<T>(xs: readonly T[], x: T, eq?: (a: T, b: T) => boolean): T[] {
+  const e = eq || ((a, b) => a === b);
+  return xs.find(_ => e(_, x)) ? xs.filter(d => !e(d, x)) : xs.concat([x]);
+}

--- a/web-console/src/views/datasources-view/datasources-view.tsx
+++ b/web-console/src/views/datasources-view/datasources-view.tsx
@@ -70,6 +70,7 @@ import {
   compact,
   countBy,
   deepGet,
+  findMap,
   formatBytes,
   formatInteger,
   formatMillions,
@@ -1709,7 +1710,7 @@ GROUP BY 1, 2`;
   }
 
   render() {
-    const { capabilities, goToSegments } = this.props;
+    const { capabilities, filters, goToSegments } = this.props;
     const {
       showUnused,
       visibleColumns,
@@ -1737,7 +1738,16 @@ GROUP BY 1, 2`;
             label="Show segment timeline"
             onChange={() =>
               this.setState({
-                showSegmentTimeline: showSegmentTimeline ? undefined : { capabilities },
+                showSegmentTimeline: showSegmentTimeline
+                  ? undefined
+                  : {
+                      capabilities,
+                      datasource: findMap(filters, filter =>
+                        filter.id === 'datasource' && /^=[^=|]+$/.exec(String(filter.value))
+                          ? filter.value.slice(1)
+                          : undefined,
+                      ),
+                    },
               })
             }
             disabled={!capabilities.hasSqlOrCoordinatorAccess()}

--- a/web-console/src/views/explore-view/components/filter-pane/filter-menu/values-filter-control/values-filter-control.tsx
+++ b/web-console/src/views/explore-view/components/filter-pane/filter-menu/values-filter-control/values-filter-control.tsx
@@ -25,9 +25,8 @@ import React, { useMemo, useState } from 'react';
 
 import { ClearableInput } from '../../../../../../components';
 import { useQueryManager } from '../../../../../../hooks';
-import { caseInsensitiveContains, filterMap } from '../../../../../../utils';
+import { caseInsensitiveContains, filterMap, toggle } from '../../../../../../utils';
 import type { QuerySource } from '../../../../models';
-import { toggle } from '../../../../utils';
 import { ColumnValue } from '../../../column-value/column-value';
 
 import './values-filter-control.scss';

--- a/web-console/src/views/explore-view/components/helper-table/helper-table.tsx
+++ b/web-console/src/views/explore-view/components/helper-table/helper-table.tsx
@@ -37,11 +37,12 @@ import {
   checkedCircleIcon,
   filterMap,
   formatNumber,
+  toggle,
   without,
   xor,
 } from '../../../../utils';
 import type { ExpressionMeta, QuerySource } from '../../models';
-import { addOrUpdatePattern, toggle } from '../../utils';
+import { addOrUpdatePattern } from '../../utils';
 import { ColumnValue } from '../column-value/column-value';
 
 import './helper-table.scss';

--- a/web-console/src/views/explore-view/components/resource-pane/nested-column-dialog/nested-column-dialog.tsx
+++ b/web-console/src/views/explore-view/components/resource-pane/nested-column-dialog/nested-column-dialog.tsx
@@ -33,10 +33,15 @@ import React, { useState } from 'react';
 
 import { ClearableInput, Loader, MenuCheckbox } from '../../../../../components';
 import { useQueryManager } from '../../../../../hooks';
-import { caseInsensitiveContains, filterMap, pluralIfNeeded, wait } from '../../../../../utils';
+import {
+  caseInsensitiveContains,
+  filterMap,
+  pluralIfNeeded,
+  toggle,
+  wait,
+} from '../../../../../utils';
 import type { QuerySource } from '../../../models';
 import { ExpressionMeta } from '../../../models';
-import { toggle } from '../../../utils';
 
 import './nested-column-dialog.scss';
 

--- a/web-console/src/views/explore-view/utils/misc.ts
+++ b/web-console/src/views/explore-view/utils/misc.ts
@@ -19,11 +19,6 @@
 import { nonEmptyArray } from '../../../utils';
 import type { ParameterDefinition } from '../models';
 
-export function toggle<T>(xs: readonly T[], x: T, eq?: (a: T, b: T) => boolean): T[] {
-  const e = eq || ((a, b) => a === b);
-  return xs.find(_ => e(_, x)) ? xs.filter(d => !e(d, x)) : xs.concat([x]);
-}
-
 export function normalizeType(paramType: ParameterDefinition['type']): ParameterDefinition['type'] {
   switch (paramType) {
     case 'expressions':

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -62,6 +62,7 @@ import {
   compact,
   countBy,
   filterMap,
+  findMap,
   formatBytes,
   formatInteger,
   getApiArray,
@@ -1004,7 +1005,7 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
   }
 
   render() {
-    const { capabilities, onFiltersChange } = this.props;
+    const { capabilities, filters, onFiltersChange } = this.props;
     const {
       segmentTableActionDialogId,
       datasourceTableActionDialogId,
@@ -1047,7 +1048,16 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
             label="Show segment timeline"
             onChange={() =>
               this.setState({
-                showSegmentTimeline: showSegmentTimeline ? undefined : { capabilities },
+                showSegmentTimeline: showSegmentTimeline
+                  ? undefined
+                  : {
+                      capabilities,
+                      datasource: findMap(filters, filter =>
+                        filter.id === 'datasource' && /^=[^=|]+$/.exec(String(filter.value))
+                          ? filter.value.slice(1)
+                          : undefined,
+                      ),
+                    },
               })
             }
             disabled={!capabilities.hasSqlOrCoordinatorAccess()}

--- a/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
+++ b/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
@@ -132,6 +132,7 @@ exports[`ServicesView renders data 1`] = `
         },
         {
           "Cell": [Function],
+          "Filter": [Function],
           "Header": "Type",
           "accessor": "service_type",
           "show": true,

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -38,7 +38,11 @@ import {
 import { AsyncActionDialog } from '../../dialogs';
 import type { QueryWithContext } from '../../druid-models';
 import type { Capabilities, CapabilitiesMode } from '../../helpers';
-import { STANDARD_TABLE_PAGE_SIZE, STANDARD_TABLE_PAGE_SIZE_OPTIONS } from '../../react-table';
+import {
+  STANDARD_TABLE_PAGE_SIZE,
+  STANDARD_TABLE_PAGE_SIZE_OPTIONS,
+  suggestibleFilterInput,
+} from '../../react-table';
 import { Api, AppToaster } from '../../singletons';
 import type { AuxiliaryQueryFn, NumberLike } from '../../utils';
 import {
@@ -417,6 +421,16 @@ ORDER BY
           {
             Header: 'Type',
             show: visibleColumns.shown('Type'),
+            Filter: suggestibleFilterInput([
+              'coordinator',
+              'overlord',
+              'router',
+              'broker',
+              'historical',
+              'indexer',
+              'middle_manager',
+              'peon',
+            ]),
             accessor: 'service_type',
             width: 150,
             Cell: this.renderFilterableCell('service_type'),

--- a/web-console/src/views/sql-data-loader-view/schema-step/schema-step.tsx
+++ b/web-console/src/views/sql-data-loader-view/schema-step/schema-step.tsx
@@ -48,7 +48,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import {
   ClearableInput,
-  ENABLE_DISABLE_OPTIONS_TEXT,
+  ENABLED_DISABLED_OPTIONS_TEXT,
   LearnMore,
   Loader,
   MenuBoolean,
@@ -694,7 +694,7 @@ export const SchemaStep = function SchemaStep(props: SchemaStepProps) {
                     text="Force segment sort by time"
                     value={forceSegmentSortByTime}
                     onValueChange={v => changeForceSegmentSortByTime(Boolean(v))}
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                     optionsLabelElement={{ false: EXPERIMENTAL_ICON }}
                   />
                 </Menu>

--- a/web-console/src/views/supervisors-view/__snapshots__/supervisors-view.spec.tsx.snap
+++ b/web-console/src/views/supervisors-view/__snapshots__/supervisors-view.spec.tsx.snap
@@ -183,6 +183,7 @@ exports[`SupervisorsView matches snapshot 1`] = `
         },
         {
           "Cell": [Function],
+          "Filter": [Function],
           "Header": "Status",
           "accessor": "detailed_state",
           "id": "detailed_state",

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -58,6 +58,7 @@ import {
   SMALL_TABLE_PAGE_SIZE,
   SMALL_TABLE_PAGE_SIZE_OPTIONS,
   sqlQueryCustomTableFilters,
+  suggestibleFilterInput,
 } from '../../react-table';
 import { Api, AppToaster } from '../../singletons';
 import type { AuxiliaryQueryFn, TableState } from '../../utils';
@@ -741,6 +742,20 @@ export class SupervisorsView extends React.PureComponent<
             Header: 'Status',
             id: 'detailed_state',
             width: 150,
+            Filter: suggestibleFilterInput([
+              'CONNECTING_TO_STREAM',
+              'CREATING_TASKS',
+              'DISCOVERING_INITIAL_TASKS',
+              'IDLE',
+              'LOST_CONTACT_WITH_STREAM',
+              'PENDING',
+              'RUNNING',
+              'STOPPING',
+              'SUSPENDED',
+              'UNABLE_TO_CONNECT_TO_STREAM',
+              'UNHEALTHY_SUPERVISOR',
+              'UNHEALTHY_TASKS',
+            ]),
             accessor: 'detailed_state',
             Cell: ({ value }) => (
               <TableFilterableCell

--- a/web-console/src/views/tasks-view/__snapshots__/tasks-view.spec.tsx.snap
+++ b/web-console/src/views/tasks-view/__snapshots__/tasks-view.spec.tsx.snap
@@ -174,6 +174,7 @@ exports[`TasksView matches snapshot 1`] = `
         },
         {
           "Cell": [Function],
+          "Filter": [Function],
           "Header": "Status",
           "accessor": [Function],
           "id": "status",

--- a/web-console/src/views/tasks-view/tasks-view.tsx
+++ b/web-console/src/views/tasks-view/tasks-view.tsx
@@ -38,7 +38,11 @@ import { AlertDialog, AsyncActionDialog, SpecDialog, TaskTableActionDialog } fro
 import type { QueryWithContext } from '../../druid-models';
 import { TASK_CANCELED_ERROR_MESSAGES, TASK_CANCELED_PREDICATE } from '../../druid-models';
 import type { Capabilities } from '../../helpers';
-import { SMALL_TABLE_PAGE_SIZE, SMALL_TABLE_PAGE_SIZE_OPTIONS } from '../../react-table';
+import {
+  SMALL_TABLE_PAGE_SIZE,
+  SMALL_TABLE_PAGE_SIZE_OPTIONS,
+  suggestibleFilterInput,
+} from '../../react-table';
 import { Api, AppToaster } from '../../singletons';
 import {
   formatDuration,
@@ -408,6 +412,14 @@ ORDER BY
             Header: 'Status',
             id: 'status',
             width: 110,
+            Filter: suggestibleFilterInput([
+              'CANCELED',
+              'FAILED',
+              'PENDING',
+              'RUNNING',
+              'SUCCESS',
+              'WAITING',
+            ]),
             accessor: row => ({
               status: row.status,
               created_time: row.created_time,

--- a/web-console/src/views/workbench-view/run-panel/run-panel.tsx
+++ b/web-console/src/views/workbench-view/run-panel/run-panel.tsx
@@ -34,7 +34,7 @@ import type { JSX } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import {
-  ENABLE_DISABLE_OPTIONS_TEXT,
+  ENABLED_DISABLED_OPTIONS_TEXT,
   MenuBoolean,
   MenuCheckbox,
   TimezoneMenuItems,
@@ -414,7 +414,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                         useApproximateCountDistinct,
                       })
                     }
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                   />
                 )}
                 {show('approximate-top-n') && (
@@ -428,7 +428,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                         useApproximateTopN,
                       })
                     }
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                   />
                 )}
                 {show('join-algorithm') && (
@@ -465,7 +465,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                       onValueChange={failOnEmptyInsert =>
                         changeQueryContext({ ...queryContext, failOnEmptyInsert })
                       }
-                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                     />
                     <MenuBoolean
                       text="Wait until segments have loaded"
@@ -475,7 +475,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                       onValueChange={waitUntilSegmentsLoad =>
                         changeQueryContext({ ...queryContext, waitUntilSegmentsLoad })
                       }
-                      optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                      optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                     />
                     <MenuItem text="Max parse exceptions" label={String(maxParseExceptions)}>
                       {[0, 1, 5, 10, 1000, 10000, -1].map(v => (
@@ -511,7 +511,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                     onValueChange={finalizeAggregations =>
                       changeQueryContext({ ...queryContext, finalizeAggregations })
                     }
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                   />
                 )}
                 {show('group-by-enable-multi-value-unnesting') && (
@@ -524,7 +524,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                     onValueChange={groupByEnableMultiValueUnnesting =>
                       changeQueryContext({ ...queryContext, groupByEnableMultiValueUnnesting })
                     }
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                   />
                 )}
 
@@ -540,7 +540,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                         populateCache: useCache,
                       })
                     }
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                   />
                 )}
                 {show('limit-inline-results') && (
@@ -568,7 +568,7 @@ export const RunPanel = React.memo(function RunPanel(props: RunPanelProps) {
                         durableShuffleStorage,
                       })
                     }
-                    optionsText={ENABLE_DISABLE_OPTIONS_TEXT}
+                    optionsText={ENABLED_DISABLED_OPTIONS_TEXT}
                   />
                 )}
                 {show('select-destination') && (


### PR DESCRIPTION
Added the ability to multi-select in table filters and added suggestions to the Status field for tasks and supervisors, also added it for service type

![image](https://github.com/user-attachments/assets/44c73e7d-3bc7-4dc7-8cbc-e0eaba997c15)

![image](https://github.com/user-attachments/assets/e2809928-7896-4c53-9453-859326dfe5e9)

![image](https://github.com/user-attachments/assets/5068168b-2168-4d88-9a33-f51154ecddab)

Finally, based on user feedback, changed the verbs "Enable" and "Disable" to adjectives "Enabled" and "Disabled" to be less confusion about whether they are indicating a state or an action

![image](https://github.com/user-attachments/assets/734d3e7b-4908-42fc-8e38-2fe879059c30)
