### PR TITLE
Fix description typo for sqlserver metadata store

### DIFF
--- a/docs/configuration/extensions.md
+++ b/docs/configuration/extensions.md
@@ -89,7 +89,7 @@ All of these community extensions can be downloaded using [pull-deps](../operati
 |druid-iceberg-extensions|Support for ingesting Iceberg tables.|[link](../development/extensions-contrib/iceberg.md)|
 |druid-redis-cache|A cache implementation for Druid based on Redis.|[link](../development/extensions-contrib/redis-cache.md)|
 |druid-time-min-max|Min/Max aggregator for timestamp.|[link](../development/extensions-contrib/time-min-max.md)|
-|sqlserver-metadata-storage|Microsoft SQLServer deep storage.|[link](../development/extensions-contrib/sqlserver.md)|
+|sqlserver-metadata-storage|Microsoft SQLServer metadata store.|[link](../development/extensions-contrib/sqlserver.md)|
 |graphite-emitter|Graphite metrics emitter|[link](../development/extensions-contrib/graphite.md)|
 |statsd-emitter|StatsD metrics emitter|[link](../development/extensions-contrib/statsd.md)|
 |kafka-emitter|Kafka metrics emitter|[link](../development/extensions-contrib/kafka-emitter.md)|


### PR DESCRIPTION
### Description

This is a small doc fix - The extension `sqlserver-metadata-storage` was mistakenly categories under deep storage instead of metadata store. The PR fixed that.

This PR has:

- [X] been self-reviewed.
- [X] added documentation for new or modified features or behaviors.