### PR TITLE
Fix binding of segment metadata cache on CliOverlord

### DIFF
--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLMetadataStorageModuleTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLMetadataStorageModuleTest.java
@@ -35,6 +35,7 @@ import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.guice.MetadataConfigModule;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.security.EscalatorModule;
+import org.apache.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import org.apache.druid.java.util.emitter.core.NoopEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.junit.Assert;
@@ -137,6 +138,13 @@ public class MySQLMetadataStorageModuleTest
               public DruidLeaderSelector getLeaderSelector()
               {
                 // A provider for DruidLeaderSelector is needed by SqlSegmentMetadataTransactionFactory
+                return null;
+              }
+
+              @Provides
+              public ScheduledExecutorFactory getExecutorFactory()
+              {
+                // Required for HeapMemorySegmentMetadataCache
                 return null;
               }
             }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/DruidOverlord.java
@@ -59,6 +59,7 @@ public class DruidOverlord
 
   private final DruidLeaderSelector overlordLeaderSelector;
   private final DruidLeaderSelector.Listener leadershipListener;
+  private final SegmentMetadataCache segmentMetadataCache;
 
   private final ReentrantLock giant = new ReentrantLock(true);
 
@@ -98,6 +99,7 @@ public class DruidOverlord
   )
   {
     this.overlordLeaderSelector = overlordLeaderSelector;
+    this.segmentMetadataCache = segmentMetadataCache;
 
     final DruidNode node = coordinatorOverlordServiceConfig.getOverlordService() == null ? selfNode :
                            selfNode.withService(coordinatorOverlordServiceConfig.getOverlordService());
@@ -225,6 +227,7 @@ public class DruidOverlord
     giant.lock();
 
     try {
+      segmentMetadataCache.start();
       overlordLeaderSelector.registerListener(leadershipListener);
     }
     finally {
@@ -244,6 +247,7 @@ public class DruidOverlord
     try {
       gracefulStopLeaderLifecycle();
       overlordLeaderSelector.unregisterListener();
+      segmentMetadataCache.stop();
     }
     finally {
       giant.unlock();

--- a/server/src/main/java/org/apache/druid/guice/SQLMetadataStorageDruidModule.java
+++ b/server/src/main/java/org/apache/druid/guice/SQLMetadataStorageDruidModule.java
@@ -105,8 +105,8 @@ public class SQLMetadataStorageDruidModule implements Module
             .to(SQLMetadataRuleManagerProvider.class)
             .in(LazySingleton.class);
 
-    // SegmentMetadataCache is used only by the Overlord
-    // Bind to noop implementation here to fulfill dependencies
+    // SegmentMetadataCache is bound for all services but is used only by the Overlord
+    // Similar to some other classes bound here, such as IndexerSQLMetadataStorageCoordinator
     binder.bind(SegmentMetadataCache.class)
           .to(HeapMemorySegmentMetadataCache.class)
           .in(LazySingleton.class);

--- a/server/src/main/java/org/apache/druid/guice/SQLMetadataStorageDruidModule.java
+++ b/server/src/main/java/org/apache/druid/guice/SQLMetadataStorageDruidModule.java
@@ -41,7 +41,7 @@ import org.apache.druid.metadata.SqlSegmentsMetadataManager;
 import org.apache.druid.metadata.SqlSegmentsMetadataManagerProvider;
 import org.apache.druid.metadata.segment.SegmentMetadataTransactionFactory;
 import org.apache.druid.metadata.segment.SqlSegmentMetadataTransactionFactory;
-import org.apache.druid.metadata.segment.cache.NoopSegmentMetadataCache;
+import org.apache.druid.metadata.segment.cache.HeapMemorySegmentMetadataCache;
 import org.apache.druid.metadata.segment.cache.SegmentMetadataCache;
 import org.apache.druid.server.audit.AuditManagerConfig;
 import org.apache.druid.server.audit.AuditSerdeHelper;
@@ -108,7 +108,7 @@ public class SQLMetadataStorageDruidModule implements Module
     // SegmentMetadataCache is used only by the Overlord
     // Bind to noop implementation here to fulfill dependencies
     binder.bind(SegmentMetadataCache.class)
-          .to(NoopSegmentMetadataCache.class)
+          .to(HeapMemorySegmentMetadataCache.class)
           .in(LazySingleton.class);
 
     PolyBind.optionBinder(binder, Key.get(SegmentMetadataTransactionFactory.class))

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCache.java
@@ -35,8 +35,6 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Stopwatch;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutorFactory;
-import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
-import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
@@ -135,7 +133,6 @@ public class HeapMemorySegmentMetadataCache implements SegmentMetadataCache
 
 
   @Override
-  @LifecycleStart
   public void start()
   {
     if (!isCacheEnabled) {
@@ -152,7 +149,6 @@ public class HeapMemorySegmentMetadataCache implements SegmentMetadataCache
   }
 
   @Override
-  @LifecycleStop
   public void stop()
   {
     synchronized (cacheStateLock) {

--- a/services/src/main/java/org/apache/druid/cli/CliOverlord.java
+++ b/services/src/main/java/org/apache/druid/cli/CliOverlord.java
@@ -111,8 +111,6 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.metadata.SegmentsMetadataManager;
 import org.apache.druid.metadata.SegmentsMetadataManagerProvider;
 import org.apache.druid.metadata.input.InputSourceModule;
-import org.apache.druid.metadata.segment.cache.HeapMemorySegmentMetadataCache;
-import org.apache.druid.metadata.segment.cache.SegmentMetadataCache;
 import org.apache.druid.query.lookup.LookupSerdeModule;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
@@ -230,11 +228,6 @@ public class CliOverlord extends ServerRunnable
             JsonConfigProvider.bind(binder, "druid.indexer.task", TaskConfig.class);
             JsonConfigProvider.bind(binder, "druid.indexer.task.default", DefaultTaskConfig.class);
             binder.bind(RetryPolicyFactory.class).in(LazySingleton.class);
-
-            // Override the default binding of SegmentMetadataCache done in SQLMetadataStorageDruidModule
-            binder.bind(SegmentMetadataCache.class)
-                  .to(HeapMemorySegmentMetadataCache.class)
-                  .in(ManageLifecycle.class);
 
             binder.bind(DruidOverlord.class).in(ManageLifecycle.class);
             binder.bind(TaskMaster.class).in(ManageLifecycle.class);

--- a/services/src/test/java/org/apache/druid/cli/CliOverlordTest.java
+++ b/services/src/test/java/org/apache/druid/cli/CliOverlordTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.cli;
+
+import com.google.inject.Injector;
+import org.apache.druid.guice.StartupInjectorBuilder;
+import org.apache.druid.metadata.segment.cache.HeapMemorySegmentMetadataCache;
+import org.apache.druid.metadata.segment.cache.SegmentMetadataCache;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CliOverlordTest
+{
+  @Test
+  public void testSegmentMetadataCacheIsBound()
+  {
+    final Injector injector = new StartupInjectorBuilder().forServer().build();
+    final CliOverlord overlord = new CliOverlord();
+    injector.injectMembers(overlord);
+
+    final Injector overlordInjector = overlord.makeInjector();
+
+    final SegmentMetadataCache segmentMetadataCache
+        = overlordInjector.getInstance(SegmentMetadataCache.class);
+    Assert.assertTrue(segmentMetadataCache instanceof HeapMemorySegmentMetadataCache);
+  }
+}


### PR DESCRIPTION
#17653 added a `SegmentMetadataCache` on the Overlord.
But that patch uses a binding that worked only for the default metadata store, Derby.
With any other metadata store used via an extension, the binding would not work and
the `Noop` implementation would always be picked instead.

### Changes

- Bind `SegmentMetadataCache` only once to
`HeapMemorySegmentMetadataCache` in `SQLMetadataStorageDruidModule`
- Invoke `start` and `stop` of the cache from `DruidOverlord` rather than on lifecycle start/stop
- Do not override the binding in `CliOverlord`

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
