### PR TITLE
Web console: fix go to task selecting correct task type

### DIFF
--- a/web-console/src/views/supervisors-view/__snapshots__/supervisors-view.spec.tsx.snap
+++ b/web-console/src/views/supervisors-view/__snapshots__/supervisors-view.spec.tsx.snap
@@ -172,7 +172,7 @@ exports[`SupervisorsView matches snapshot 1`] = `
           "Header": "Type",
           "accessor": "type",
           "show": true,
-          "width": 80,
+          "width": 120,
         },
         {
           "Cell": [Function],
@@ -188,7 +188,7 @@ exports[`SupervisorsView matches snapshot 1`] = `
           "accessor": "detailed_state",
           "id": "detailed_state",
           "show": true,
-          "width": 150,
+          "width": 170,
         },
         {
           "Cell": [Function],

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -830,10 +830,15 @@ export class SupervisorsView extends React.PureComponent<
                 <TableClickableCell
                   tooltip="Go to tasks"
                   onClick={() => {
-                    const taskType = oneOf(original.type, 'kafka', 'kinesis')
-                      ? `index_${original.type}`
-                      : undefined;
-                    goToTasks(original.supervisor_id, taskType);
+                    let datasource: string = original.supervisor_id;
+                    let taskType: string | undefined;
+                    if (oneOf(original.type, 'kafka', 'kinesis')) {
+                      taskType = `index_${original.type}`;
+                    } else if (original.type === 'autocompact') {
+                      datasource = original.supervisor_id.replace('autocompact__', '');
+                      taskType = 'compact';
+                    }
+                    goToTasks(datasource, taskType);
                   }}
                   hoverIcon={IconNames.ARROW_TOP_RIGHT}
                 >

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -175,6 +175,7 @@ function detailedStateToColor(detailedState: string): string {
     case 'UNHEALTHY_TASKS':
     case 'UNABLE_TO_CONNECT_TO_STREAM':
     case 'LOST_CONTACT_WITH_STREAM':
+    case 'INVALID_SPEC':
       return '#d5100a';
 
     case 'PENDING':
@@ -773,6 +774,7 @@ export class SupervisorsView extends React.PureComponent<
               'CREATING_TASKS',
               'DISCOVERING_INITIAL_TASKS',
               'IDLE',
+              'INVALID_SPEC',
               'LOST_CONTACT_WITH_STREAM',
               'PENDING',
               'RUNNING',

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -138,7 +138,7 @@ export interface SupervisorsViewProps {
   goToDatasource(datasource: string): void;
   goToQuery(queryWithContext: QueryWithContext): void;
   goToStreamingDataLoader(supervisorId: string): void;
-  goToTasks(supervisorId: string, type: string): void;
+  goToTasks(supervisorId: string, type: string | undefined): void;
   capabilities: Capabilities;
 }
 
@@ -825,10 +825,16 @@ export class SupervisorsView extends React.PureComponent<
               } else {
                 label = '';
               }
+
               return (
                 <TableClickableCell
                   tooltip="Go to tasks"
-                  onClick={() => goToTasks(original.supervisor_id, `index_${original.type}`)}
+                  onClick={() => {
+                    const taskType = oneOf(original.type, 'kafka', 'kinesis')
+                      ? `index_${original.type}`
+                      : undefined;
+                    goToTasks(original.supervisor_id, taskType);
+                  }}
                   hoverIcon={IconNames.ARROW_TOP_RIGHT}
                 >
                   {label}


### PR DESCRIPTION
Fix the link taking you to the wrong task type for supervisors that do not follow the conventions of kafka and kinesis.