### PR TITLE
Log query stack traces for DEVELOPER and OPERATOR personas.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -28,6 +28,7 @@ import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.QueryLifecycle;
 import org.apache.druid.server.QueryResource;
 import org.apache.druid.server.QueryResponse;
 import org.apache.druid.server.QueryResultPusher;
@@ -304,7 +305,7 @@ public class SqlResource
         @Override
         public void recordFailure(Exception e)
         {
-          if (sqlQuery.queryContext().isDebug()) {
+          if (QueryLifecycle.shouldLogStackTrace(e, sqlQuery.queryContext())) {
             log.warn(e, "Exception while processing sqlQueryId[%s]", sqlQueryId);
           } else {
             log.noStackTrace().warn(e, "Exception while processing sqlQueryId[%s]", sqlQueryId);


### PR DESCRIPTION
Currently, query stack traces are logged only when "debug: true" is set in the query context. This patch additionally logs stack traces targeted at the DEVELOPER or OPERATOR personas, because for these personas, stack traces are useful more often than not.

We continue to omit stack traces by default for USER and ADMIN, because these personas are meant to interact with the API, not with code or logs. Skipping stack traces minimizes clutter in the logs.