### PR TITLE
Fix relative dir resolution for test datasets

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/FakeIndexTaskUtil.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/FakeIndexTaskUtil.java
@@ -75,7 +75,7 @@ public class FakeIndexTaskUtil
     if (localInputSource.getBaseDir().isAbsolute()) {
       return inputSource;
     }
-    File newBaseDir = localInputSource.getBaseDir().toPath().resolve(projectRoot.toPath()).toFile();
+    File newBaseDir = projectRoot.toPath().resolve(localInputSource.getBaseDir().toPath()).toFile();
     return new LocalInputSource(
         newBaseDir,
         localInputSource.getFilter(),

--- a/sql/src/test/quidem/sampledataset/rollup-index.json
+++ b/sql/src/test/quidem/sampledataset/rollup-index.json
@@ -30,7 +30,7 @@
       "type" : "index_parallel",
       "inputSource" : {
         "type" : "local",
-        "baseDir" : "quickstart/tutorial",
+        "baseDir" : "examples/quickstart/tutorial",
         "filter" : "rollup-data.json"
       },
       "inputFormat" : {


### PR DESCRIPTION
The path was resolved the opposite way - which made it return the basedir (projectroot) to be returned all the time.
since there was only 1 matching file in the project it was unnoticed.

Thank you @weishiuntsai for spotting this issue!