### PR TITLE
Set useMaxMemoryEstimates=false for MSQ tasks

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/processor/SegmentGeneratorFrameProcessorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/processor/SegmentGeneratorFrameProcessorFactory.java
@@ -194,7 +194,7 @@ public class SegmentGeneratorFrameProcessorFactory
                   frameContext.indexMerger(),
                   meters,
                   parseExceptionHandler,
-                  true,
+                  false,
                   // MSQ doesn't support CentralizedDatasourceSchema feature as of now.
                   CentralizedDatasourceSchemaConfig.create(false)
               );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
@@ -57,9 +57,10 @@ public class Tasks
    * on-heap memory usage while indexing. Refer to OnHeapIncrementalIndex for
    * more details.
    * <p>
-   * The value of this flag is true by default which corresponds to the old method
-   * of estimation.
+   * @deprecated This flag will be removed in future Druid releases, and the new
+   * method of memory estimation will be used in all cases.
    */
+  @Deprecated
   public static final String USE_MAX_MEMORY_ESTIMATES = "useMaxMemoryEstimates";
 
   /**


### PR DESCRIPTION
The default value of this flag is already `false` for native batch and streaming tasks.
Setting `useMaxMemoryEstimates = false` allows for better on-heap memory estimation in `OnHeapIncrementalIndex`

This flag is now deprecated and will be removed in future releases.
It is being retained only to allow testing of MSQ tasks with the new value.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
