### PR TITLE
Fix single container config creates failing peon tasks

### DIFF
--- a/distribution/docker/peon.sh
+++ b/distribution/docker/peon.sh
@@ -161,4 +161,8 @@ fi
 # If TASK_JSON is not set, CliPeon will pull the task.json file from deep storage.
 mkdir -p ${TASK_DIR}; [ -n "$TASK_JSON" ] && echo ${TASK_JSON} | base64 -d | gzip -d > ${TASK_DIR}/task.json;
 
-exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main internal peon --taskId ${TASK_ID} $@
+if [ -n "$TASK_ID" ]; then
+    exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main internal peon --taskId "${TASK_ID}" "$@"
+else
+    exec bin/run-java ${JAVA_OPTS} -cp $COMMON_CONF_DIR:$SERVICE_CONF_DIR:lib/*: org.apache.druid.cli.Main internal peon "$@"
+fi

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -24,6 +24,7 @@ import com.github.rvesse.airline.annotations.Arguments;
 import com.github.rvesse.airline.annotations.Command;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.Required;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -234,6 +235,12 @@ public class CliPeon extends GuiceRunnable
           public void configure(Binder binder)
           {
             ServerRunnable.validateCentralizedDatasourceSchemaConfig(getProperties());
+            Preconditions.checkArgument(
+                taskAndStatusFile.size() >= 2,
+                "taskAndStatusFile array[%s]: should contain 2 or more elements.",
+                taskAndStatusFile.toString()
+            );
+
             taskDirPath = taskAndStatusFile.get(0);
             attemptId = taskAndStatusFile.get(1);
 

--- a/services/src/main/java/org/apache/druid/cli/CliPeon.java
+++ b/services/src/main/java/org/apache/druid/cli/CliPeon.java
@@ -237,7 +237,7 @@ public class CliPeon extends GuiceRunnable
             ServerRunnable.validateCentralizedDatasourceSchemaConfig(getProperties());
             Preconditions.checkArgument(
                 taskAndStatusFile.size() >= 2,
-                "taskAndStatusFile array[%s]: should contain 2 or more elements.",
+                "taskAndStatusFile array should contain 2 or more elements. Current array elements: [%s]",
                 taskAndStatusFile.toString()
             );
 


### PR DESCRIPTION
Fixes a bug introduced by #17742 .

### Description

This bug is found when running Overlord with config `druid_indexer_runner_k8s_adapter_type: overlordSingleContainer` after changes to `peon.sh` in #17742.

I received an error message `Caused by: java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1` that ultimately traces to the piece of code below:

```java
    taskDirPath = taskAndStatusFile.get(0);
    attemptId = taskAndStatusFile.get(1);
```

Turns out that in the case `${TASK_ID}` is empty, `--taskId "${TASK_ID}" "$@"` will be resolved to `--taskId "first value of $@" "remaining values of $@"`. In cases where "$@" is "taskDirPath attemptId", this causes `taskAndStatusFile.size() == 1`, hence creating the bug. I am not really sure if there's a more elegant way of writing the fix, please do let me know if there's an alternative.

I have also left a `taskAndStatusFile.size() >= 2` check, ensuring that a more helpful error message is shown instead of `IndexOutOfBoundsException`.

After making the changes, the cluster is able to run ingestion tasks healthily.

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->
Fix a bug where Kubernetes task pods will not run if Overlord is configured as `druid_indexer_runner_k8s_adapter_type: overlordSingleContainer` 

<hr>

##### Key changed/added classes in this PR
 * `peon.sh`
 * `CliPeon`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] been tested in a test Druid cluster.
