### PR TITLE
Remove maven.twttr repo from pom

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -127,7 +127,7 @@ jobs:
           cache: maven
 
       - name: maven build # needed to rebuild incase of maven snapshot resolution fails
-        run: mvn clean install dependency:go-offline -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
+        run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
 
       - name: security vulnerabilities check
         run: |

--- a/integration-tests/script/setup_druid_on_k8s.sh
+++ b/integration-tests/script/setup_druid_on_k8s.sh
@@ -26,7 +26,7 @@ cp -r client_tls docker/client_tls
 cd ..
 
 # Build Docker images for pods
-mvn -B -ff -q dependency:go-offline \
+mvn -B -ff -q \
       install \
       -Pdist,bundle-contrib-exts \
       -Pskip-static-checks,skip-tests \

--- a/it.sh
+++ b/it.sh
@@ -229,7 +229,7 @@ case $CMD in
     usage
     ;;
   "ci" )
-    mvn -q clean install dependency:go-offline -P dist $MAVEN_IGNORE -T1C
+    mvn -q clean install -P dist $MAVEN_IGNORE -T1C
     ;;
   "build" )
     mvn -B clean install -P dist $MAVEN_IGNORE -T1.0C $*

--- a/pom.xml
+++ b/pom.xml
@@ -293,16 +293,6 @@
                <enabled>false</enabled>
             </snapshots>
         </repository>
-
-        <!--
-        maven-dependency-plugin:3.1.2 seems to have updated HTTP repository access behavior.
-        We get the following error "Blocked mirror for repositories: [twitter (http://maven.twttr.com, default, releases+snapshots)]"
-        The suggested action step is to add the mirror: https://maven.apache.org/docs/3.8.1/release-notes.html#how-to-fix-when-i-get-a-http-repository-blocked
-        -->
-        <repository>
-            <id>twitter</id>
-            <url>https://maven.twttr.com</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
CI on all PRs is failing due to this repo being down / slow.
It was added here https://github.com/apache/druid/pull/17466/files#r1843515944

This repo is needed only for LZO support in the thrift extension.
According to [Druid docs](https://druid.apache.org/docs/latest/development/extensions-contrib/thrift/#lzo-support), that dependency needs to be downloaded separately anyway.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
