### PR TITLE
Fix references to javaOpts

### DIFF
--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -74,7 +74,7 @@ Intellij IDEA debugger can attach to a local or remote Java process (Druid proce
 Follow these steps to debug a Druid process using the IntelliJ IDEA debugger.
 1. Enable debugging in the Druid process
     1. For Druid services (such as Overlord, Coordinator, etc), include the following as JVM config `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<PORT>` where `<PORT>` is any available port. Note that different port values should be chosen for each Druid service.
-    2. For the peons (workers on Middlemanager), include the following `agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0` in runtime properties `druid.indexer.runner.javaOptsArray` of the Middle Manager. Note that `address=0` will tell the debugger to assign ephemeral port.
+    2. For the peons (workers on Middlemanager), add the string `"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0"` to the runtime property `druid.indexer.runner.javaOptsArray` of the Middle Manager. Note that `address=0` will tell the debugger to assign an ephemeral port.
 2. Find the port assigned to the Druid process.
     1. For Druid services, the port value is what you chose in the JVM argument of step 1i above. The port value can also be found in the first line of each Druid service log.
     2. For the peons (workers on Middlemanager), you can find the assigned ephemeral port by checking the first line of the task log.

--- a/dev/intellij-setup.md
+++ b/dev/intellij-setup.md
@@ -74,7 +74,7 @@ Intellij IDEA debugger can attach to a local or remote Java process (Druid proce
 Follow these steps to debug a Druid process using the IntelliJ IDEA debugger.
 1. Enable debugging in the Druid process
     1. For Druid services (such as Overlord, Coordinator, etc), include the following as JVM config `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<PORT>` where `<PORT>` is any available port. Note that different port values should be chosen for each Druid service.
-    2. For the peons (workers on Middlemanager), include the following `agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0` in runtime properties `druid.indexer.runner.javaOpts` of the Middle Manager. Note that `address=0` will tell the debugger to assign ephemeral port.
+    2. For the peons (workers on Middlemanager), include the following `agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0` in runtime properties `druid.indexer.runner.javaOptsArray` of the Middle Manager. Note that `address=0` will tell the debugger to assign ephemeral port.
 2. Find the port assigned to the Druid process.
     1. For Druid services, the port value is what you chose in the JVM argument of step 1i above. The port value can also be found in the first line of each Druid service log.
     2. For the peons (workers on Middlemanager), you can find the assigned ephemeral port by checking the first line of the task log.

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -117,7 +117,7 @@ The AWS SDK requires that a target region be specified.  You can set these by us
 For example, to set the region to 'us-east-1' through system properties:
 
 * Add `-Daws.region=us-east-1` to the `jvm.config` file for all Druid services.
-* Add `-Daws.region=us-east-1` to `druid.indexer.runner.javaOptsArray` in [Middle Manager configuration](../../configuration/index.md#middle-manager-configuration) so that the property will be passed to Peon (worker) processes.
+* Add `"-Daws.region=us-east-1"` to `druid.indexer.runner.javaOptsArray` in [Middle Manager configuration](../../configuration/index.md#middle-manager-configuration) so that the property will be passed to Peon (worker) processes.
 
 ### Connecting to S3 configuration
 

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -117,7 +117,7 @@ The AWS SDK requires that a target region be specified.  You can set these by us
 For example, to set the region to 'us-east-1' through system properties:
 
 * Add `-Daws.region=us-east-1` to the `jvm.config` file for all Druid services.
-* Add `-Daws.region=us-east-1` to `druid.indexer.runner.javaOpts` in [Middle Manager configuration](../../configuration/index.md#middle-manager-configuration) so that the property will be passed to Peon (worker) processes.
+* Add `-Daws.region=us-east-1` to `druid.indexer.runner.javaOptsArray` in [Middle Manager configuration](../../configuration/index.md#middle-manager-configuration) so that the property will be passed to Peon (worker) processes.
 
 ### Connecting to S3 configuration
 


### PR DESCRIPTION
### Description

As it says on the tin: This is a docs only fix to change the usage of `javaOpts` in two places to `javaOptsArray`