### PR TITLE
Revert "Run JDK 21 workflows with latest JDK. (#17694)"

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -41,7 +41,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17', '21' ]
+        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
+        java: [ '11', '17', '21.0.4' ]
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch

--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -79,7 +79,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ '11', '17', '21' ]
+        # Use JDK 21.0.4 to work around https://github.com/apache/druid/issues/17429
+        jdk: [ '11', '17', '21.0.4' ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch


### PR DESCRIPTION
This reverts commit 31ede5cb

Found errors like 
```
ror:  org.apache.maven.surefire.booter.SurefireBooterForkException: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
Error:  Command was /bin/sh -c cd '/home/runner/work/druid/druid/indexing-service' && '/opt/hostedtoolcache/Java_Zulu_jdk/21.0.6-7/x64/bin/java' '-javaagent:/home/runner/.m2/repository/org/jacoco/org.jacoco.agent/0.8.12/org.jacoco.agent-0.8.12-runtime.jar=destfile=/home/runner/work/druid/druid/indexing-service/target/jacoco.exec,excludes=org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClientSyncImpl.class' '--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED' '--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED' '--add-opens=java.base/java.nio=ALL-UNNAMED' '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED' '--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED' '--add-opens=java.base/java.io=ALL-UNNAMED' '--add-opens=java.base/java.lang=ALL-UNNAMED' '--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED' '--add-opens=java.base/java.util=ALL-UNNAMED' '-Djava.security.manager=allow' '-Xmx2048m' '-XX:MaxDirectMemorySize=2500m' '-XX:+ExitOnOutOfMemoryError' '-XX:+HeapDumpOnOutOfMemoryError' '-Duser.language=en' '-Duser.GroupByQueryRunnerTest.javacountry=US' '-Dfile.encoding=UTF-8' '-Duser.timezone=UTC' '-Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager' '-Daws.region=us-east-1' '-Ddruid.test.stupidPool.poison=true' '-XX:OnOutOfMemoryError=/home/runner/work/druid/druid/dev/chmod-heap-dumps.sh' '-XX:HeapDumpPath=/home/runner/work/druid/druid/target' '-Ddruid.indexing.doubleStorage=double' '-javaagent:/home/runner/work/druid/druid/jfr-profiler.jar' '-Djfr.profiler.http.username=druid-ci' '-Djfr.profiler.http.***' '-Djfr.profiler.tags.project=druid' '-Djfr.profiler.tags.run_id=13173423115' '-Djfr.profiler.tags.run_number=13934' '-Djfr.profiler.tags.run_attempt=1' '-Djfr.profiler.tags.module=indexing' '-Djfr.profiler.tags.jvm_version=21.0.6' '-jar' '/home/runner/work/druid/druid/indexing-service/target/surefire/surefirebooter-20250206080608137_81.jar' '/home/runner/work/druid/druid/indexing-service/target/surefire' '2025-02-06T08-05-01_553-jvmRun1' 'surefire-20250206080608137_79tmp' 'surefire_1-20250206080608137_80tmp'
Error:  Error occurred in starting fork, check output in log
Error:  Process Exit Code: 134
Error:  Crashed tests:
```