### PR TITLE
CI improvement: Leverage cancelled() instead of always() for CI jobs

### DIFF
--- a/.github/workflows/unit-and-integration-tests-unified.yml
+++ b/.github/workflows/unit-and-integration-tests-unified.yml
@@ -209,12 +209,12 @@ jobs:
 
   standard-its:
     needs: [build, unit-tests-unapproved, check-approval]
-    if: ${{ always() && (needs.check-approval.outputs.approved == 'true' || needs.unit-tests-unapproved.result == 'success') }}
+    if: ${{ !cancelled() && (needs.check-approval.outputs.approved == 'true' || needs.unit-tests-unapproved.result == 'success') }}
     uses: ./.github/workflows/standard-its.yml
 
   revised-its:
     needs: [build, unit-tests-unapproved, check-approval]
-    if: ${{ always() && (needs.check-approval.outputs.approved == 'true' || needs.unit-tests-unapproved.result == 'success') }}
+    if: ${{ !cancelled() && (needs.check-approval.outputs.approved == 'true' || needs.unit-tests-unapproved.result == 'success') }}
     uses: ./.github/workflows/revised-its.yml
     with:
       BACKWARD_COMPATIBILITY_IT_ENABLED: ${{ needs.set-env-var.outputs.BACKWARD_COMPATIBILITY_IT_ENABLED }}
@@ -225,6 +225,6 @@ jobs:
   actions-timeline:
     needs: [build, unit-tests-approved, unit-tests-unapproved, revised-its, standard-its]
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ !cancelled() }}
     steps:
       - uses: Kesin11/actions-timeline@427ee2cf860166e404d0d69b4f2b24012bb7af4f


### PR DESCRIPTION
### Description

We have the following concurrency group configured in unit-and-integration-tests-unified.yml:

```
concurrency:
  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}' # group workflows only on pull_requests and not on branch commits
  cancel-in-progress: true
```

`cancel: true` means that it should cancel any ongoing run, if there exists any.

But, currently, canceling standard-ITs and revised-ITs doesn't cancel them, even if we try to cancel them by clicking on the "cancel workflow" button for them from the GitHub UI.

The standard-its and revised-its have an `if: ${{ always() && other things }}` condition.

Quoting from the [docs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/canceling-a-workflow#steps-github-takes-to-cancel-a-workflow-run):
```
To cancel the workflow run, the server re-evaluates if conditions for all currently running jobs. If the condition evaluates to true, the job will not get canceled. For example, the condition if: always() would evaluate to true and the job continues to run. When there is no condition, that is the equivalent of the condition if: success(), which only runs if the previous step finished successfully.
```

There's also [documentation for always()](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always) which says the same thing. It also has a warning, recommending to use `!cancelled()` instead of `always()`.

This PR makes that change.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
