### PR TITLE
Fix resource leak for GroupBy query merge buffer when query matched result cache

### DIFF
--- a/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
@@ -106,6 +106,7 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
 
       if (useResultCache && newResultSetId != null && newResultSetId.equals(existingResultSetId)) {
         log.debug("Return cached result set as there is no change in identifiers for query %s ", query.getId());
+        // Call accumulate on the sequence to ensure that all Wrapper/Closer/Baggage/etc. get called
         resultFromClient.accumulate(null, (accumulated, in) -> accumulated);
         return deserializeResults(cachedResultSet, strategy, existingResultSetId);
       } else {

--- a/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
@@ -98,16 +98,17 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
       query = query.withOverriddenContext(
           ImmutableMap.of(QueryResource.HEADER_IF_NONE_MATCH, existingResultSetId));
 
-      Sequence<T> resultFromClient = baseRunner.run(
-          QueryPlus.wrap(query),
-          responseContext
-      );
       String newResultSetId = responseContext.getEntityTag();
 
       if (useResultCache && newResultSetId != null && newResultSetId.equals(existingResultSetId)) {
         log.debug("Return cached result set as there is no change in identifiers for query %s ", query.getId());
         return deserializeResults(cachedResultSet, strategy, existingResultSetId);
       } else {
+        Sequence<T> resultFromClient = baseRunner.run(
+            QueryPlus.wrap(query),
+            responseContext
+        );
+
         @Nullable
         ResultLevelCachePopulator resultLevelCachePopulator = createResultLevelCachePopulator(
             cacheKey,

--- a/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
@@ -98,17 +98,17 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
       query = query.withOverriddenContext(
           ImmutableMap.of(QueryResource.HEADER_IF_NONE_MATCH, existingResultSetId));
 
+      Sequence<T> resultFromClient = baseRunner.run(
+          QueryPlus.wrap(query),
+          responseContext
+      );
       String newResultSetId = responseContext.getEntityTag();
 
       if (useResultCache && newResultSetId != null && newResultSetId.equals(existingResultSetId)) {
         log.debug("Return cached result set as there is no change in identifiers for query %s ", query.getId());
+        resultFromClient.accumulate(null, (accumulated, in) -> accumulated);
         return deserializeResults(cachedResultSet, strategy, existingResultSetId);
       } else {
-        Sequence<T> resultFromClient = baseRunner.run(
-            QueryPlus.wrap(query),
-            responseContext
-        );
-
         @Nullable
         ResultLevelCachePopulator resultLevelCachePopulator = createResultLevelCachePopulator(
             cacheKey,

--- a/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
@@ -333,7 +333,7 @@ public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnCluster
         QueryPlus.wrap(query),
         responseContext()
     );
-    final List<Result<TimeseriesResultValue>> results3 = sequence2.toList();
+    final List<Result<TimeseriesResultValue>> results3 = sequence3.toList();
     Assert.assertEquals(results1, results3);
     Assert.assertEquals(2, cache.getStats().getNumHits());
     Assert.assertEquals(1, cache.getStats().getNumEntries());

--- a/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
+++ b/server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.druid.client.SimpleServerView;
 import org.apache.druid.client.cache.Cache;
 import org.apache.druid.client.cache.CacheConfig;
@@ -28,44 +27,24 @@ import org.apache.druid.collections.BlockingPool;
 import org.apache.druid.collections.DefaultBlockingPool;
 import org.apache.druid.collections.ReferenceCountingResourceHolder;
 import org.apache.druid.java.util.common.Intervals;
-import org.apache.druid.java.util.common.concurrent.Execs;
-import org.apache.druid.java.util.common.granularity.PeriodGranularity;
-import org.apache.druid.java.util.common.guava.MergeSequence;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.io.Closer;
-import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
-import org.apache.druid.query.context.ResponseContext;
-import org.apache.druid.query.dimension.DefaultDimensionSpec;
-import org.apache.druid.query.groupby.GroupByQuery;
-import org.apache.druid.query.groupby.GroupByQueryConfig;
-import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
-import org.apache.druid.query.groupby.GroupByQueryRunnerTestHelper;
-import org.apache.druid.query.groupby.ResultRow;
-import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
-import org.apache.druid.segment.IncrementalIndexSegment;
-import org.apache.druid.segment.TestIndex;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.joda.time.Period;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
-import static org.apache.druid.query.QueryRunnerTestHelper.SEGMENT_ID;
 import static org.junit.Assert.fail;
 
 public class ResultLevelCachingQueryRunnerTest extends QueryRunnerBasedOnClusteredClientTestBase


### PR DESCRIPTION
Fix resource leak for GroupBy query merge buffer when query matched result cache

### Description

In processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest#initAndMergeGroupByResults, we acquire the resource via groupByResourcesReservationPool.reserve() and then we add a Closer to the Sequences which runs after execution of the query (after the mergedSequence accumulate/toYielder). However, in ResultLevelCachingQueryRunner, if useResultCache is enabled and we return cached result, then this will cause resource to leak. Resource (mergeBuffer) will be acquired in https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java#L101 but in https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java#L109 the cached result set is returned instead of resultFromClient. The mergedSequence will not be accumulate and the closer will not be run. Hence, mergeBuffer will not be release back to the pool

This fix is to exhaust the sequence before returning the cached result set.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
