### PR TITLE
Optionally include Content-Disposition header in statement results API response

### DIFF
--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -1286,6 +1286,9 @@ Getting the query results for an ingestion query returns an empty response.
 * `resultFormat` (optional)
     * Type: String
     * Defines the format in which the results are presented. The following options are supported `arrayLines`,`objectLines`,`array`,`object`, and `csv`. The default is `object`.
+* `filename` (optional)
+    * Type: String  
+    * If set, attaches a `Content-Disposition` header to the response with the value of `attachment; filename={filename}`.
 
 #### Responses
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -311,7 +311,7 @@ public class SqlStatementResource
       );
       throwIfQueryIsNotSuccessful(queryId, statusPlus);
 
-      final String contentDispositionHeaderValue = filename != null ? String.format("attachment; filename=%s", filename) : null;
+      final String contentDispositionHeaderValue = filename != null ? StringUtils.format("attachment; filename=%s", filename) : null;
 
       Optional<List<ColumnNameAndTypes>> signature = SqlStatementResourceHelper.getSignature(msqControllerTask);
       if (!signature.isPresent() || MSQControllerTask.isIngestion(msqControllerTask.getQuerySpec())) {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -393,6 +393,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
             sqlStatementResult.getQueryId(),
             null,
             ResultFormat.OBJECTLINES.name(),
+            null,
             SqlStatementResourceTest.makeOkRequest()
         ),
         objectMapper
@@ -406,6 +407,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
             sqlStatementResult.getQueryId(),
             0L,
             ResultFormat.OBJECTLINES.name(),
+            null,
             SqlStatementResourceTest.makeOkRequest()
         ),
         objectMapper
@@ -419,6 +421,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
             sqlStatementResult.getQueryId(),
             2L,
             ResultFormat.OBJECTLINES.name(),
+            null,
             SqlStatementResourceTest.makeOkRequest()
         ),
         objectMapper
@@ -485,6 +488,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         null,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -492,6 +496,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         0L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -499,6 +504,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         1L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -506,6 +512,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         2L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -513,6 +520,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         3L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -520,6 +528,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         4L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
   }
@@ -565,6 +574,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                   sqlStatementResult.getQueryId(),
                   null,
                   resultFormat.name(),
+                  null,
                   SqlStatementResourceTest.makeOkRequest()
               ), objectMapper
           )
@@ -577,6 +587,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                   sqlStatementResult.getQueryId(),
                   0L,
                   resultFormat.name(),
+                  null,
                   SqlStatementResourceTest.makeOkRequest()
               ), objectMapper
           )
@@ -616,6 +627,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         null,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -623,6 +635,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         0L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
   }
@@ -695,6 +708,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         actual.getQueryId(),
         0L,
         null,
+        null,
         SqlStatementResourceTest.makeOkRequest()
     );
     Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
@@ -737,6 +751,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     Response resultsResponse = resource.doGetResults(
         actual.getQueryId(),
         0L,
+        null,
         null,
         SqlStatementResourceTest.makeOkRequest()
     );


### PR DESCRIPTION
### Description

Adds support for an optional `filename` query parameter to the `/druid/v2/sql/statements/{queryId}/results` API. When provided, the response will include a header `Content-Disposition: attachment; filename={filename}`, which will instruct a web browser to save the response as a file rather than displaying it inline.

This save-as-attachment behavior could be achieved by adding a ["download" attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) to the results link, but this only works for same-origin URLs (as in the Web Console). If the UI origin is different from the Druid API origin, browsers will ignore the attribute and serve the results inline, which is poor UX for files that are potentially very large.

For the sake of consistency, all _successful_ responses in `SqlStatementResource.doGetResults` may include this header, even if there are no results.

#### Release note

Improved: The "Get query results" statements API supports an optional `filename` query parameter. When provided, the response will instruct web browsers to save the results as a file instead of showing them inline (via the `Content-Disposition` header).

<hr>

##### Key changed/added classes in this PR
 * `SqlStatementResource`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
