### PR TITLE
Add metric and simulation test for turbo loading mode

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/BatchDataSegmentAnnouncer.java
@@ -348,27 +348,12 @@ public class BatchDataSegmentAnnouncer implements DataSegmentAnnouncer
       synchronized (lock) {
         Iterable<DataSegmentChangeRequest> segments = Iterables.transform(
             segmentLookup.keySet(),
-            new Function<>()
-            {
-              @Nullable
-              @Override
-              public SegmentChangeRequestLoad apply(DataSegment input)
-              {
-                return new SegmentChangeRequestLoad(input);
-              }
-            }
+            SegmentChangeRequestLoad::new
         );
 
         Iterable<DataSegmentChangeRequest> sinkSchema = Iterables.transform(
             taskSinkSchema.values(),
-            new Function<>()
-            {
-              @Override
-              public SegmentSchemasChangeRequest apply(SegmentSchemas input)
-              {
-                return new SegmentSchemasChangeRequest(input);
-              }
-            }
+            SegmentSchemasChangeRequest::new
         );
         Iterable<DataSegmentChangeRequest> changeRequestIterables = Iterables.concat(segments, sinkSchema);
         SettableFuture<ChangeRequestsSnapshot<DataSegmentChangeRequest>> future = SettableFuture.create();

--- a/server/src/main/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfig.java
@@ -22,7 +22,7 @@ package org.apache.druid.server.coordinator.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.druid.common.config.Configs;
-import org.apache.druid.java.util.common.RE;
+import org.apache.druid.error.InvalidInput;
 import org.joda.time.Duration;
 
 import javax.annotation.Nullable;
@@ -50,12 +50,13 @@ public class HttpLoadQueuePeonConfig
   {
     this.hostTimeout = Configs.valueOrDefault(hostTimeout, Duration.standardMinutes(5));
     this.repeatDelay = Configs.valueOrDefault(repeatDelay, Duration.standardMinutes(1));
-
-    if (batchSize != null && batchSize < 1) {
-      throw new RE("Batch size must be greater than 0.");
-    }
-
     this.batchSize = batchSize;
+
+    InvalidInput.conditionalException(
+        batchSize == null || batchSize >= 1,
+        "'druid.coordinator.loadqueuepeon.http.batchSize'[%s] must be greater than 0",
+        batchSize
+    );
   }
 
   @Nullable

--- a/server/src/main/java/org/apache/druid/server/http/SegmentListerResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/SegmentListerResource.java
@@ -62,7 +62,7 @@ import java.util.List;
 /**
  * Endpoints exposed here are to be used only for druid internal management of segments by Coordinators, Brokers etc.
  */
-@Path("/druid-internal/v1/segments/")
+@Path("/druid-internal/v1/segments")
 @ResourceFilters(StateResourceFilter.class)
 public class SegmentListerResource
 {

--- a/server/src/main/java/org/apache/druid/server/http/SegmentLoadingCapabilities.java
+++ b/server/src/main/java/org/apache/druid/server/http/SegmentLoadingCapabilities.java
@@ -41,13 +41,13 @@ public class SegmentLoadingCapabilities
     this.numTurboLoadingThreads = numTurboLoadingThreads;
   }
 
-  @JsonProperty("numLoadingThreads")
+  @JsonProperty
   public int getNumLoadingThreads()
   {
     return numLoadingThreads;
   }
 
-  @JsonProperty("numTurboLoadingThreads")
+  @JsonProperty
   public int getNumTurboLoadingThreads()
   {
     return numTurboLoadingThreads;

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperCacheTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperCacheTest.java
@@ -219,12 +219,12 @@ public class SegmentBootstrapperCacheTest
 
     // Make sure adding segments beyond allowed size fails
     DataSegment newSegment = TestSegmentUtils.makeSegment("test", "new-segment", SEGMENT_SIZE);
-    loadDropHandler.addSegment(newSegment, null);
+    loadDropHandler.addSegment(newSegment, null, null);
     Assert.assertFalse(segmentAnnouncer.getObservedSegments().contains(newSegment));
 
     // Clearing some segment should allow for new segments
     loadDropHandler.removeSegment(expectedSegments.get(0), null, false);
-    loadDropHandler.addSegment(newSegment, null);
+    loadDropHandler.addSegment(newSegment, null, null);
     Assert.assertTrue(segmentAnnouncer.getObservedSegments().contains(newSegment));
 
     bootstrapper.stop();

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentLoadDropHandlerTest.java
@@ -144,7 +144,7 @@ public class SegmentLoadDropHandlerTest
 
     Assert.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment));
 
-    handler.addSegment(segment, DataSegmentChangeCallback.NOOP);
+    handler.addSegment(segment, DataSegmentChangeCallback.NOOP, null);
 
     // Make sure the scheduled runnable that "deletes" segment files has been executed.
     // Because another addSegment() call is executed, which removes the segment from segmentsToDelete field in
@@ -186,7 +186,7 @@ public class SegmentLoadDropHandlerTest
 
     final DataSegment segment = makeSegment("test", "1", Intervals.of("P1d/2011-04-01"));
 
-    handler.addSegment(segment, DataSegmentChangeCallback.NOOP);
+    handler.addSegment(segment, DataSegmentChangeCallback.NOOP, null);
 
     Assert.assertTrue(segmentAnnouncer.getObservedSegments().contains(segment));
 
@@ -194,7 +194,7 @@ public class SegmentLoadDropHandlerTest
 
     Assert.assertFalse(segmentAnnouncer.getObservedSegments().contains(segment));
 
-    handler.addSegment(segment, DataSegmentChangeCallback.NOOP);
+    handler.addSegment(segment, DataSegmentChangeCallback.NOOP, null);
 
     // Make sure the scheduled runnable that "deletes" segment files has been executed.
     // Because another addSegment() call is executed, which removes the segment from segmentsToDelete field in
@@ -232,11 +232,11 @@ public class SegmentLoadDropHandlerTest
         new SegmentChangeRequestDrop(segment2)
     );
 
-    ListenableFuture<List<DataSegmentChangeResponse>> future = handler.processBatch(batch, SegmentLoadingMode.NORMAL);
+    ListenableFuture<List<DataSegmentChangeResponse>> future = handler.processBatch(batch, SegmentLoadingMode.TURBO);
 
     Map<DataSegmentChangeRequest, SegmentChangeStatus> expectedStatusMap = new HashMap<>();
-    expectedStatusMap.put(batch.get(0), SegmentChangeStatus.PENDING);
-    expectedStatusMap.put(batch.get(1), SegmentChangeStatus.SUCCESS);
+    expectedStatusMap.put(batch.get(0), SegmentChangeStatus.pending(SegmentLoadingMode.TURBO));
+    expectedStatusMap.put(batch.get(1), SegmentChangeStatus.success());
     List<DataSegmentChangeResponse> result = future.get();
     for (DataSegmentChangeResponse requestAndStatus : result) {
       Assert.assertEquals(expectedStatusMap.get(requestAndStatus.getRequest()), requestAndStatus.getStatus());
@@ -247,7 +247,7 @@ public class SegmentLoadDropHandlerTest
     }
 
     result = handler.processBatch(ImmutableList.of(new SegmentChangeRequestLoad(segment1)), SegmentLoadingMode.TURBO).get();
-    Assert.assertEquals(SegmentChangeStatus.SUCCESS, result.get(0).getStatus());
+    Assert.assertEquals(SegmentChangeStatus.success(SegmentLoadingMode.TURBO), result.get(0).getStatus());
 
     Assert.assertEquals(ImmutableList.of(segment1), segmentAnnouncer.getObservedSegments());
 
@@ -287,7 +287,7 @@ public class SegmentLoadDropHandlerTest
       runnable.run();
     }
     result = future.get();
-    Assert.assertEquals(State.SUCCESS, result.get(0).getStatus().getState());
+    Assert.assertEquals(SegmentChangeStatus.success(SegmentLoadingMode.NORMAL), result.get(0).getStatus());
     Assert.assertEquals(ImmutableList.of(segment1, segment1), segmentAnnouncer.getObservedSegments());
 
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
@@ -19,10 +19,10 @@
 
 package org.apache.druid.server.coordinator.config;
 
-import com.amazonaws.util.Throwables;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import com.google.common.base.Throwables;
 import org.apache.druid.error.DruidExceptionMatcher;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;

--- a/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/config/HttpLoadQueuePeonConfigTest.java
@@ -19,31 +19,30 @@
 
 package org.apache.druid.server.coordinator.config;
 
+import com.amazonaws.util.Throwables;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
-import org.hamcrest.CoreMatchers;
+import org.apache.druid.error.DruidExceptionMatcher;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
 
 public class HttpLoadQueuePeonConfigTest
 {
   @Test
   public void testValidateBatchSize() throws JsonProcessingException
   {
-    ObjectMapper jsonMapper = new ObjectMapper();
+    final ObjectMapper jsonMapper = new ObjectMapper();
 
     MatcherAssert.assertThat(
-        Assert.assertThrows(ValueInstantiationException.class, () ->
-            jsonMapper.readValue("{\"batchSize\":0}", HttpLoadQueuePeonConfig.class)
-        ),
-        CoreMatchers.allOf(
-            CoreMatchers.instanceOf(ValueInstantiationException.class),
-            ThrowableMessageMatcher.hasMessage(
-                CoreMatchers.containsString("Batch size must be greater than 0.")
+        Throwables.getRootCause(
+            Assert.assertThrows(ValueInstantiationException.class, () ->
+                jsonMapper.readValue("{\"batchSize\":0}", HttpLoadQueuePeonConfig.class)
             )
+        ),
+        DruidExceptionMatcher.invalidInput().expectMessageIs(
+            "'druid.coordinator.loadqueuepeon.http.batchSize'[0] must be greater than 0"
         )
     );
 
@@ -57,6 +56,6 @@ public class HttpLoadQueuePeonConfigTest
         "{\"batchSize\":2}",
         HttpLoadQueuePeonConfig.class
     );
-    Assert.assertEquals(2, config.getBatchSize().intValue());
+    Assert.assertEquals(Integer.valueOf(2), config.getBatchSize());
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
@@ -398,7 +398,7 @@ public class HttpLoadQueuePeonTest
         for (DataSegmentChangeRequest cr : changeRequests) {
           cr.go(this, null);
           statuses.add(
-              new DataSegmentChangeResponse(cr, SegmentChangeStatus.SUCCESS)
+              new DataSegmentChangeResponse(cr, SegmentChangeStatus.success())
           );
         }
         return (ListenableFuture<Final>) Futures.immediateFuture(

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
@@ -217,6 +217,7 @@ public abstract class CoordinatorSimulationBaseTest implements
     static final String DELETED_COUNT = "segment/deleted/count";
     static final String LOAD_QUEUE_COUNT = "segment/loadQueue/count";
     static final String DROP_QUEUE_COUNT = "segment/dropQueue/count";
+    static final String SUCCESS_ACTIONS = "segment/loadQueue/success";
     static final String CANCELLED_ACTIONS = "segment/loadQueue/cancelled";
 
     static final String OVERSHADOWED_COUNT = "segment/overshadowed/count";

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentLoadingTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Coordinator simulation test to verify behaviour of segment loading.
@@ -540,6 +542,45 @@ public class SegmentLoadingTest extends CoordinatorSimulationBaseTest
 
     loadQueuedSegments();
     Assert.assertEquals(historicalT11.getCurrSize(), historicalT12.getCurrSize());
+  }
+
+  @Test
+  public void testSegmentLoadingModes()
+  {
+    CoordinatorDynamicConfig config =
+        CoordinatorDynamicConfig.builder()
+                                .withTurboLoadingNodes(Set.of(historicalT11.getName()))
+                                .build();
+
+    final CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withServers(historicalT11, historicalT12)
+                             .withDynamicConfig(config)
+                             .withRules(datasource, Load.on(Tier.T1, 1).forever())
+                             .withSegments(Segments.WIKI_10X1D)
+                             .build();
+
+    startSimulation(sim);
+
+    // Run 1: Assign and load all segments
+    runCoordinatorCycle();
+    loadQueuedSegments();
+    verifyValue(Metric.ASSIGNED_COUNT, 10L);
+    Assert.assertEquals(5, historicalT11.getTotalSegments());
+    Assert.assertEquals(5, historicalT12.getTotalSegments());
+
+    // Run 2: Emit success metrics
+    runCoordinatorCycle();
+    verifyValue(
+        Metric.SUCCESS_ACTIONS,
+        Map.of("server", historicalT11.getName(), "description", "LOAD: TURBO"),
+        5L
+    );
+    verifyValue(
+        Metric.SUCCESS_ACTIONS,
+        Map.of("server", historicalT12.getName(), "description", "LOAD: NORMAL"),
+        5L
+    );
   }
 
   private int getNumLoadedSegments(DruidServer... servers)


### PR DESCRIPTION
### Changes

- Add field `loadingMode` to `SegmentChangeStatus`
- Including loading mode in `DataSegmentChangeResponse`
- Include loading mode in the `description` of metrics emitted from `HttpLoadQueuePeon`
- Add simulation test to verify loading mode metrics

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
