### PR TITLE
Optionally include Content-Disposition header in statement results API response

### DIFF
--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -1286,6 +1286,9 @@ Getting the query results for an ingestion query returns an empty response.
 * `resultFormat` (optional)
     * Type: String
     * Defines the format in which the results are presented. The following options are supported `arrayLines`,`objectLines`,`array`,`object`, and `csv`. The default is `object`.
+* `filename` (optional)
+    * Type: String  
+    * If set, attaches a `Content-Disposition` header to the response with the value of `attachment; filename={filename}`.
 
 #### Responses
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -1288,7 +1288,7 @@ Getting the query results for an ingestion query returns an empty response.
     * Defines the format in which the results are presented. The following options are supported `arrayLines`,`objectLines`,`array`,`object`, and `csv`. The default is `object`.
 * `filename` (optional)
     * Type: String  
-    * If set, attaches a `Content-Disposition` header to the response with the value of `attachment; filename={filename}`.
+    * If set, attaches a `Content-Disposition` header to the response with the value of `attachment; filename={filename}`. The filename must be not longer than 255 characters and must not contain the characters `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`, `\0`, `\n`, or `\r`.
 
 #### Responses
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -1288,7 +1288,7 @@ Getting the query results for an ingestion query returns an empty response.
     * Defines the format in which the results are presented. The following options are supported `arrayLines`,`objectLines`,`array`,`object`, and `csv`. The default is `object`.
 * `filename` (optional)
     * Type: String  
-    * If set, attaches a `Content-Disposition` header to the response with the value of `attachment; filename={filename}`. The filename must be not longer than 255 characters and must not contain the characters `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`, `\0`, `\n`, or `\r`.
+    * If set, attaches a `Content-Disposition` header to the response with the value of `attachment; filename={filename}`. The filename must not be longer than 255 characters and must not contain the characters `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`, `\0`, `\n`, or `\r`.
 
 #### Responses
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -311,7 +311,7 @@ public class SqlStatementResource
       );
       throwIfQueryIsNotSuccessful(queryId, statusPlus);
 
-      final String contentDispositionHeaderValue = filename != null ? String.format("attachment; filename=%s", filename) : null;
+      final String contentDispositionHeaderValue = filename != null ? StringUtils.format("attachment; filename=%s", filename) : null;
 
       Optional<List<ColumnNameAndTypes>> signature = SqlStatementResourceHelper.getSignature(msqControllerTask);
       if (!signature.isPresent() || MSQControllerTask.isIngestion(msqControllerTask.getQuerySpec())) {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -95,6 +95,7 @@ import org.apache.druid.storage.StorageConnectorProvider;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -114,6 +115,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 
@@ -123,6 +125,7 @@ public class SqlStatementResource
 
   public static final String RESULT_FORMAT = "__resultFormat";
   public static final String CONTENT_DISPOSITION_RESPONSE_HEADER = "Content-Disposition";
+  private static final Pattern FILENAME_PATTERN = Pattern.compile("^[^/:*?><\\\\\"|\0\n\r]*$");
   private static final Logger log = new Logger(SqlStatementResource.class);
   private final SqlStatementFactory msqSqlStatementFactory;
   private final ObjectMapper jsonMapper;
@@ -311,18 +314,12 @@ public class SqlStatementResource
       );
       throwIfQueryIsNotSuccessful(queryId, statusPlus);
 
-      final String contentDispositionHeaderValue = filename != null ? StringUtils.format("attachment; filename=%s", filename) : null;
+      final String contentDispositionHeaderValue = filename != null ? StringUtils.format("attachment; filename=\"%s\"", validateFilename(filename)) : null;
 
       Optional<List<ColumnNameAndTypes>> signature = SqlStatementResourceHelper.getSignature(msqControllerTask);
       if (!signature.isPresent() || MSQControllerTask.isIngestion(msqControllerTask.getQuerySpec())) {
         // Since it's not a select query, nothing to return.
-        final Response.ResponseBuilder responseBuilder = Response.ok();
-
-        if (contentDispositionHeaderValue != null) {
-          responseBuilder.header(CONTENT_DISPOSITION_RESPONSE_HEADER, contentDispositionHeaderValue);
-        }
-
-        return responseBuilder.build();
+        return addContentDisposition(Response.ok(), contentDispositionHeaderValue).build();
       }
 
       // returning results
@@ -331,13 +328,7 @@ public class SqlStatementResource
       results = getResultYielder(queryId, page, msqControllerTask, closer);
       if (!results.isPresent()) {
         // no results, return empty
-        final Response.ResponseBuilder responseBuilder = Response.ok();
-
-        if (contentDispositionHeaderValue != null) {
-          responseBuilder.header(CONTENT_DISPOSITION_RESPONSE_HEADER, contentDispositionHeaderValue);
-        }
-
-        return responseBuilder.build();
+        return addContentDisposition(Response.ok(), contentDispositionHeaderValue).build();
       }
 
       ResultFormat preferredFormat = getPreferredResultFormat(resultFormat, msqControllerTask.getQuerySpec());
@@ -350,11 +341,7 @@ public class SqlStatementResource
           preferredFormat
       ));
 
-      if (contentDispositionHeaderValue != null) {
-        responseBuilder.header(CONTENT_DISPOSITION_RESPONSE_HEADER, contentDispositionHeaderValue);
-      }
-
-      return responseBuilder.build();
+      return addContentDisposition(responseBuilder, contentDispositionHeaderValue).build();
     }
 
 
@@ -996,6 +983,42 @@ public class SqlStatementResource
                               )
                           );
     }
+  }
+
+  private static Response.ResponseBuilder addContentDisposition(
+      Response.ResponseBuilder responseBuilder,
+      String contentDisposition
+  )
+  {
+    if (contentDisposition != null) {
+      responseBuilder.header(CONTENT_DISPOSITION_RESPONSE_HEADER, contentDisposition);
+    }
+    return responseBuilder;
+  }
+
+  /**
+   * Validates that a filename in valid. File names are considered to be valid if it is:
+   * <ul>
+   *   <li>Not empty.</li>
+   *   <li>Not longer than 255 characters.</li>
+   *   <li>Does not contain the characters `/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`, `\0`, `\n`, or `\r`.</li>
+   * </ul>
+   */
+  @VisibleForTesting
+  static String validateFilename(@NotNull String filename)
+  {
+    if (filename.isEmpty()) {
+      throw InvalidInput.exception("Filename cannot be empty.");
+    }
+
+    if (filename.length() > 255) {
+      throw InvalidInput.exception("Filename cannot be longer than 255 characters.");
+    }
+
+    if (!FILENAME_PATTERN.matcher(filename).matches()) {
+      throw InvalidInput.exception("Filename contains invalid characters.");
+    }
+    return filename;
   }
 
   private <T> T contactOverlord(final ListenableFuture<T> future, String queryId)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -997,7 +997,7 @@ public class SqlStatementResource
   }
 
   /**
-   * Validates that a filename in valid. File names are considered to be valid if it is:
+   * Validates that a filename is valid. Filenames are considered to be valid if it is:
    * <ul>
    *   <li>Not empty.</li>
    *   <li>Not longer than 255 characters.</li>
@@ -1016,7 +1016,7 @@ public class SqlStatementResource
     }
 
     if (!FILENAME_PATTERN.matcher(filename).matches()) {
-      throw InvalidInput.exception("Filename contains invalid characters.");
+      throw InvalidInput.exception("Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
     }
     return filename;
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -393,6 +393,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
             sqlStatementResult.getQueryId(),
             null,
             ResultFormat.OBJECTLINES.name(),
+            null,
             SqlStatementResourceTest.makeOkRequest()
         ),
         objectMapper
@@ -406,6 +407,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
             sqlStatementResult.getQueryId(),
             0L,
             ResultFormat.OBJECTLINES.name(),
+            null,
             SqlStatementResourceTest.makeOkRequest()
         ),
         objectMapper
@@ -419,6 +421,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
             sqlStatementResult.getQueryId(),
             2L,
             ResultFormat.OBJECTLINES.name(),
+            null,
             SqlStatementResourceTest.makeOkRequest()
         ),
         objectMapper
@@ -485,6 +488,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         null,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -492,6 +496,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         0L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -499,6 +504,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         1L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -506,6 +512,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         2L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -513,6 +520,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         3L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -520,6 +528,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         4L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
   }
@@ -565,6 +574,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                   sqlStatementResult.getQueryId(),
                   null,
                   resultFormat.name(),
+                  null,
                   SqlStatementResourceTest.makeOkRequest()
               ), objectMapper
           )
@@ -577,6 +587,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
                   sqlStatementResult.getQueryId(),
                   0L,
                   resultFormat.name(),
+                  null,
                   SqlStatementResourceTest.makeOkRequest()
               ), objectMapper
           )
@@ -616,6 +627,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         null,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
 
@@ -623,6 +635,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         sqlStatementResult.getQueryId(),
         0L,
         ResultFormat.ARRAY.name(),
+        null,
         SqlStatementResourceTest.makeOkRequest()
     )));
   }
@@ -695,6 +708,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         actual.getQueryId(),
         0L,
         null,
+        null,
         SqlStatementResourceTest.makeOkRequest()
     );
     Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse.getStatus());
@@ -737,6 +751,7 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
     Response resultsResponse = resource.doGetResults(
         actual.getQueryId(),
         0L,
+        null,
         null,
         SqlStatementResourceTest.makeOkRequest()
     );

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -1283,18 +1283,18 @@ public class SqlStatementResourceTest extends MSQTestBase
     assertInvalidFileName(StringUtils.repeat("A", 300), "Filename cannot be longer than 255 characters.");
 
     // Special characters
-    assertInvalidFileName("He\\llo", "Filename contains invalid characters.");
-    assertInvalidFileName("Hello/Name", "Filename contains invalid characters.");
-    assertInvalidFileName("C:/Users/Name", "Filename contains invalid characters.");
-    assertInvalidFileName("username:password", "Filename contains invalid characters.");
-    assertInvalidFileName("A>B", "Filename contains invalid characters.");
-    assertInvalidFileName("A<B", "Filename contains invalid characters.");
-    assertInvalidFileName("A\0a11", "Filename contains invalid characters.");
-    assertInvalidFileName("\rrB", "Filename contains invalid characters.");
-    assertInvalidFileName("\nAnB", "Filename contains invalid characters.");
-    assertInvalidFileName("A|B", "Filename contains invalid characters.");
-    assertInvalidFileName("A<\"B", "Filename contains invalid characters.");
-    assertInvalidFileName("A<?B", "Filename contains invalid characters.");
+    assertInvalidFileName("He\\llo", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("Hello/Name", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("C:/Users/Name", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("username:password", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("A>ValueB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("A<ValueB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("A\0a11", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("\rrB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("\nAnB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("A|B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("A\"B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("A?B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
   }
 
   private void assertInvalidFileName(String filename, String errorMessage)

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -85,7 +85,6 @@ import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.apache.druid.sql.http.ResultFormat;
 import org.apache.druid.sql.http.SqlResourceTest;
-import org.hamcrest.MatcherAssert;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
@@ -107,6 +106,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.function.Supplier;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class SqlStatementResourceTest extends MSQTestBase
 {
@@ -1293,7 +1294,7 @@ public class SqlStatementResourceTest extends MSQTestBase
 
   private void assertInvalidFileName(String filename, String errorMessage)
   {
-    MatcherAssert.assertThat(
+    assertThat(
         Throwables.getRootCause(
             Assert.assertThrows(DruidException.class, () -> SqlStatementResource.validateFilename(filename))
         ),

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -1283,18 +1283,18 @@ public class SqlStatementResourceTest extends MSQTestBase
     assertInvalidFileName(StringUtils.repeat("A", 300), "Filename cannot be longer than 255 characters.");
 
     // Special characters
-    assertInvalidFileName("He\\llo", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("Hello/Name", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("C:/Users/Name", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("username:password", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("A>ValueB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("A<ValueB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("A\0a11", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("\rrB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("\nAnB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("A|B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("A\"B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
-    assertInvalidFileName("A?B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \\0, \\n, or \\r)");
+    assertInvalidFileName("He\\llo", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("Hello/Name", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("C:/Users/Name", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("username:password", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("A>ValueB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("A<ValueB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("A\0a11", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("\rrB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("\nAnB", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("A|B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("A\"B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
+    assertInvalidFileName("A?B", "Filename contains invalid characters. (/, \\, :, *, ?, \", <, >, |, \0, \n, or \r)");
   }
 
   private void assertInvalidFileName(String filename, String errorMessage)

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.msq.sql.resources;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -892,12 +891,18 @@ public class SqlStatementResourceTest extends MSQTestBase
 
     Response resultsResponse1 = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), "results.txt", makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse1.getStatus());
-    Assert.assertEquals("attachment; filename=\"results.txt\"", resultsResponse1.getMetadata().get("Content-Disposition").get(0));
+    Assert.assertEquals(
+        "attachment; filename=\"results.txt\"",
+        getHeader(resultsResponse1, "Content-Disposition")
+    );
     assertExpectedResults(expectedResult, resultsResponse1);
 
     Response resultsResponse2 = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), "final results.txt", makeOkRequest());
     Assert.assertEquals(Response.Status.OK.getStatusCode(), resultsResponse2.getStatus());
-    Assert.assertEquals("attachment; filename=\"final results.txt\"", resultsResponse2.getMetadata().get("Content-Disposition").get(0));
+    Assert.assertEquals(
+        "attachment; filename=\"final results.txt\"",
+        getHeader(resultsResponse2, "Content-Disposition")
+    );
     assertExpectedResults(expectedResult, resultsResponse2);
 
     Response resultsResponse3 = resource.doGetResults(FINISHED_SELECT_MSQ_QUERY, 0L, ResultFormat.OBJECTLINES.name(), "/Users/Name/final.txt", makeOkRequest());
@@ -1261,7 +1266,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   }
 
   @Test
-  void testValidFilename()
+  public void testValidFilename()
   {
     // Valid cases
     SqlStatementResource.validateFilename("testname");
@@ -1295,9 +1300,7 @@ public class SqlStatementResourceTest extends MSQTestBase
   private void assertInvalidFileName(String filename, String errorMessage)
   {
     assertThat(
-        Throwables.getRootCause(
-            Assert.assertThrows(DruidException.class, () -> SqlStatementResource.validateFilename(filename))
-        ),
+        Assert.assertThrows(DruidException.class, () -> SqlStatementResource.validateFilename(filename)),
         DruidExceptionMatcher.invalidInput().expectMessageIs(errorMessage)
     );
   }


### PR DESCRIPTION
### Description

Cloned from https://github.com/apache/druid/pull/17827 after addressing comments. Doesn't include support for `filename*` yet.

Adds support for an optional `filename` query parameter to the `/druid/v2/sql/statements/{queryId}/results` API. When provided, the response will include a header `Content-Disposition: attachment; filename="{filename}"`, which will instruct a web browser to save the response as a file rather than displaying it inline.

This save-as-attachment behavior could be achieved by adding a ["download" attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#download) to the results link, but this only works for same-origin URLs (as in the Web Console). If the UI origin is different from the Druid API origin, browsers will ignore the attribute and serve the results inline, which is poor UX for files that are potentially very large.

For the sake of consistency, all _successful_ responses in `SqlStatementResource.doGetResults` may include this header, even if there are no results.

#### Release note

Improved: The "Get query results" statements API supports an optional `filename` query parameter. When provided, the response will instruct web browsers to save the results as a file instead of showing them inline (via the `Content-Disposition` header).

<hr>

##### Key changed/added classes in this PR
 * `SqlStatementResource`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
