### PR TITLE
Fix flaky unit tests in SegmentBootstrapperTest and KinesisIndexTaskTest

### DIFF
--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -793,7 +793,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
-    waitUntil(task, this::isTaskReadingOrPublishing);
+    waitUntil(task, this::isTaskPublishing);
 
     // Wait for task to exit
     Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
@@ -856,7 +856,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
-    waitUntil(task, this::isTaskReadingOrPublishing);
+    waitUntil(task, this::isTaskPublishing);
 
     // Wait for task to exit
     Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
@@ -915,7 +915,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
 
     final ListenableFuture<TaskStatus> future = runTask(task);
-    waitUntil(task, this::isTaskReadingOrPublishing);
+    waitUntil(task, this::isTaskPublishing);
 
     // Wait for task to exit
     Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
@@ -2462,17 +2462,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   }
 
   /**
-   * Return true if specified task is in READING OR PUBLISHING state
-   * This helper method allows UTs to wait until the task associated with the test has started before continuing on with
-   * the test. Checking for PUBLISHING state in addition to READING prevents a race condition where a task could go
-   * publishing before the wait for READING state had started.
+   * Return true if specified task is in PUBLISHING state
    * @param task {@link KinesisIndexTask} having its state checked
-   * @return true if task is in READING or PUBLISHING state, otherwise false
+   * @return true if task is in PUBLISHING state, otherwise false
    */
-  private boolean isTaskReadingOrPublishing(KinesisIndexTask task)
+  private boolean isTaskPublishing(KinesisIndexTask task)
   {
-    return task.getRunner().getStatus() == SeekableStreamIndexTaskRunner.Status.READING ||
-           task.getRunner().getStatus() == SeekableStreamIndexTaskRunner.Status.PUBLISHING;
+    return task.getRunner().getStatus() == SeekableStreamIndexTaskRunner.Status.PUBLISHING;
   }
 
   private static KinesisRecordEntity kjb(

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -793,7 +793,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
-    waitUntil(task, this::isTaskReading);
+    waitUntil(task, this::isTaskReadingOrPublishing);
 
     // Wait for task to exit
     Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
@@ -856,7 +856,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
-    waitUntil(task, this::isTaskReading);
+    waitUntil(task, this::isTaskReadingOrPublishing);
 
     // Wait for task to exit
     Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
@@ -915,7 +915,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
 
     final ListenableFuture<TaskStatus> future = runTask(task);
-    waitUntil(task, this::isTaskReading);
+    waitUntil(task, this::isTaskReadingOrPublishing);
 
     // Wait for task to exit
     Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
@@ -2459,6 +2459,20 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   private boolean isTaskReading(KinesisIndexTask task)
   {
     return task.getRunner().getStatus() == SeekableStreamIndexTaskRunner.Status.READING;
+  }
+
+  /**
+   * Return true if specified task is in READING OR PUBLISHING state
+   * This helper method allows UTs to wait until the task associated with the test has started before continuing on with
+   * the test. Checking for PUBLISHING state in addition to READING prevents a race condition where a task could go
+   * publishing before the wait for READING state had started.
+   * @param task {@link KinesisIndexTask} having its state checked
+   * @return true if task is in READING or PUBLISHING state, otherwise false
+   */
+  private boolean isTaskReadingOrPublishing(KinesisIndexTask task)
+  {
+    return task.getRunner().getStatus() == SeekableStreamIndexTaskRunner.Status.READING ||
+           task.getRunner().getStatus() == SeekableStreamIndexTaskRunner.Status.PUBLISHING;
   }
 
   private static KinesisRecordEntity kjb(

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
@@ -150,11 +150,18 @@ public class SegmentBootstrapperTest
       Assert.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
     }
 
-    Assert.assertEquals(ImmutableList.copyOf(segments), segmentAnnouncer.getObservedSegments());
-
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
+
+    // The following verbose assert - seen throughout this test class - confirms list item equality irrespective of item order.
+    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
+                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
+                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
+                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
+                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegmentsLoadedIntoPageCache());
 
@@ -211,11 +218,16 @@ public class SegmentBootstrapperTest
       Assert.assertEquals(2L, segmentManager.getDataSourceCounts().get("test_two" + i).longValue());
     }
 
-    Assert.assertEquals(ImmutableList.copyOf(segments), segmentAnnouncer.getObservedSegments());
-
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
+    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
+                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
+                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
+                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
+                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegmentsLoadedIntoPageCache());
 
@@ -270,10 +282,18 @@ public class SegmentBootstrapperTest
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
 
-    Assert.assertEquals(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
+    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
+                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
+                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
 
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
+                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
+
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
+                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
+
     serviceEmitter.verifyValue("segment/bootstrap/count", expectedBootstrapSegments.size());
     serviceEmitter.verifyEmitted("segment/bootstrap/time", 1);
 

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
@@ -447,7 +447,7 @@ public class SegmentBootstrapperTest
    * Given two lists, assert they are equivalent and contain the same set of entries irrespecive of entry ordering
    * @param expected The expected result list
    * @param actual The actual result list
-   * @param <T>
+   * @param <T> Object type stored in the list parameters
    */
   private static <T> void assertUnsortedListsAreEqual(List<T> expected, List<T> actual)
   {

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
@@ -413,10 +413,18 @@ public class SegmentBootstrapperTest
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.of(ds1Segment2, ds1Segment1);
 
-    Assert.assertEquals(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
+    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
+                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
+                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
 
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
-    Assert.assertEquals(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
+                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
+
+    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
+                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
+                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
+
     serviceEmitter.verifyValue("segment/bootstrap/count", expectedBootstrapSegments.size());
     serviceEmitter.verifyEmitted("segment/bootstrap/time", 1);
 

--- a/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/SegmentBootstrapperTest.java
@@ -152,16 +152,10 @@ public class SegmentBootstrapperTest
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
 
-    // The following verbose assert - seen throughout this test class - confirms list item equality irrespective of item order.
-    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
-                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
-                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
-                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
-                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
+
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegmentsLoadedIntoPageCache());
 
@@ -219,15 +213,11 @@ public class SegmentBootstrapperTest
     }
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
-    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
-                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
-                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
-                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
-                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
+
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
+
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegments());
     Assert.assertEquals(ImmutableList.of(), cacheManager.getObservedSegmentsLoadedIntoPageCache());
 
@@ -282,17 +272,9 @@ public class SegmentBootstrapperTest
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.copyOf(segments);
 
-    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
-                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
-                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
-
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
-                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
-
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
-                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
 
     serviceEmitter.verifyValue("segment/bootstrap/count", expectedBootstrapSegments.size());
     serviceEmitter.verifyEmitted("segment/bootstrap/time", 1);
@@ -413,17 +395,9 @@ public class SegmentBootstrapperTest
 
     final ImmutableList<DataSegment> expectedBootstrapSegments = ImmutableList.of(ds1Segment2, ds1Segment1);
 
-    Assert.assertTrue(expectedBootstrapSegments.size() == segmentAnnouncer.getObservedSegments().size() &&
-                      expectedBootstrapSegments.containsAll(segmentAnnouncer.getObservedSegments()) &&
-                      segmentAnnouncer.getObservedSegments().containsAll(expectedBootstrapSegments));
-
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegments().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegments()) &&
-                      cacheManager.getObservedBootstrapSegments().containsAll(expectedBootstrapSegments));
-
-    Assert.assertTrue(expectedBootstrapSegments.size() == cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().size() &&
-                      expectedBootstrapSegments.containsAll(cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache()) &&
-                      cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache().containsAll(expectedBootstrapSegments));
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, segmentAnnouncer.getObservedSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegments());
+    assertUnsortedListsAreEqual(expectedBootstrapSegments, cacheManager.getObservedBootstrapSegmentsLoadedIntoPageCache());
 
     serviceEmitter.verifyValue("segment/bootstrap/count", expectedBootstrapSegments.size());
     serviceEmitter.verifyEmitted("segment/bootstrap/time", 1);
@@ -467,5 +441,17 @@ public class SegmentBootstrapperTest
     serviceEmitter.verifyEmitted("segment/bootstrap/time", 1);
 
     bootstrapper.stop();
+  }
+
+  /**
+   * Given two lists, assert they are equivalent and contain the same set of entries irrespecive of entry ordering
+   * @param expected The expected result list
+   * @param actual The actual result list
+   * @param <T>
+   */
+  private static <T> void assertUnsortedListsAreEqual(List<T> expected, List<T> actual)
+  {
+    Assert.assertEquals(expected.size(), actual.size());
+    Assert.assertEquals(Set.copyOf(expected), Set.copyOf(actual));
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordination/TestSegmentCacheManager.java
+++ b/server/src/test/java/org/apache/druid/server/coordination/TestSegmentCacheManager.java
@@ -30,9 +30,9 @@ import org.apache.druid.server.TestSegmentUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -59,11 +59,15 @@ class TestSegmentCacheManager extends NoopSegmentCacheManager
   TestSegmentCacheManager(final Set<DataSegment> segmentsToCache)
   {
     this.cachedSegments = ImmutableList.copyOf(segmentsToCache);
-    this.observedBootstrapSegments = new ArrayList<>();
-    this.observedBootstrapSegmentsLoadedIntoPageCache = new ArrayList<>();
-    this.observedSegments = new ArrayList<>();
-    this.observedSegmentsLoadedIntoPageCache = new ArrayList<>();
-    this.observedSegmentsRemovedFromCache = new ArrayList<>();
+
+    // While inneficient, these CopyOnWriteArrayList objects greatly simplify meeting the thread
+    // safety mandate from SegmentCacheManager. For testing, this should be ok.
+    this.observedBootstrapSegments = new CopyOnWriteArrayList<>();
+    this.observedBootstrapSegmentsLoadedIntoPageCache = new CopyOnWriteArrayList<>();
+    this.observedSegments = new CopyOnWriteArrayList<>();
+    this.observedSegmentsLoadedIntoPageCache = new CopyOnWriteArrayList<>();
+    this.observedSegmentsRemovedFromCache = new CopyOnWriteArrayList<>();
+
     this.observedShutdownBootstrapCount = new AtomicInteger(0);
   }
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

When getting a new Druid development environment setup, I ran into some stubborn unit tests that kept flaking as I tried to get a clean local build. After some analysis I identified some quick (and perhaps a little bit dirty?) changes to the tests in question to avoid what I perceive to be issues related to concurrency. I am definitely a little bit perplexed on how CI is so much more stable than my local when it come to running these tests. I'm hard pressed to get a single clean run on either of the Test classes until I modified.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fix test flakes in `SegmentBootstrapperTest`

##### Make TestSegmentCacheManager thread safe

`SegmentCacheManager` interface asserts that implementations must be thread safe. Using `ArrayList` with no further protections to ensure thread safety in the `TestSegmentCacheManager` was violating that assertion and leading to concurrency related problems running unit tests who depend on this implementation.

Using the hammer approach of switching to `CopyOnWriteArrayList` allows us to easily meet thread safety requirements and not have to change any implementation details of `TestSegmentCacheManager`. Since this implementation is strictly for unit testing, I think this tradeoff is ok.

##### Modify assertions in `SegmentBootstrapperTest` to ignore ordering of lists

The order of segments added to these unsorted collections is non-deterministic if there are multiple bootstrap threads working behind the scenes during test execution. Modifying the asserts to confirm collection sizes are equal and checking that all items in each are in the other is one way to confirm that the segment set in the test results matches expectations. There are definitely other ways to go about this assertion if we think mine is too ugly. 

#### Fix test flakes in `KinesisIndexTaskTest`

I found that, at least on my local, some test cases constantly run into a situation where the test starts waiting for the task to be in reading state when it is already moved on to publishing by the time the wait begins. The simplest way I could see to fix this was to allow those waits to wait for state to be reading OR publishing. I left the old implementation that only checks for read state because there was an additional use of that method that was not associated with this test startup race condition I was facing.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

N/A

<hr>

##### Key changed/added classes in this PR
 * TestSegmentCacheManager

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
