### PR TITLE
Web console: download follow up

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -6038,6 +6038,16 @@ license_file_path: licenses/bin/lower-case.MIT
 
 ---
 
+name: "markdown-table-ts"
+license_category: binary
+module: web-console
+license_name: MIT License
+copyright: Jiri Hajek
+version: 1.0.3
+license_file_path: licenses/bin/markdown-table-ts.MIT
+
+---
+
 name: "memoize-one"
 license_category: binary
 module: web-console

--- a/web-console/package-lock.json
+++ b/web-console/package-lock.json
@@ -37,6 +37,7 @@
         "json-bigint-native": "^1.2.0",
         "lodash.debounce": "^4.0.8",
         "lodash.escape": "^4.0.1",
+        "markdown-table-ts": "^1.0.3",
         "memoize-one": "^5.2.1",
         "numeral": "^2.0.6",
         "react": "^18.3.1",
@@ -12747,6 +12748,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/markdown-table-ts": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-table-ts/-/markdown-table-ts-1.0.3.tgz",
+      "integrity": "sha512-lYrp7FXmBqpmGmsEF92WnSukdgYvLm15FPIODZOx9+3nobkxJxjBYcszqZf5VqTjBtISPSNC7zjU9o3zwpL6AQ==",
+      "license": "MIT"
     },
     "node_modules/mathml-tag-names": {
       "version": "2.1.3",
@@ -27437,6 +27444,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "markdown-table-ts": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/markdown-table-ts/-/markdown-table-ts-1.0.3.tgz",
+      "integrity": "sha512-lYrp7FXmBqpmGmsEF92WnSukdgYvLm15FPIODZOx9+3nobkxJxjBYcszqZf5VqTjBtISPSNC7zjU9o3zwpL6AQ=="
     },
     "mathml-tag-names": {
       "version": "2.1.3",

--- a/web-console/package.json
+++ b/web-console/package.json
@@ -78,6 +78,7 @@
     "json-bigint-native": "^1.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.escape": "^4.0.1",
+    "markdown-table-ts": "^1.0.3",
     "memoize-one": "^5.2.1",
     "numeral": "^2.0.6",
     "react": "^18.3.1",

--- a/web-console/src/utils/download.spec.ts
+++ b/web-console/src/utils/download.spec.ts
@@ -40,8 +40,8 @@ describe('download', () => {
         ['LONG', 'STRING', 'LONG'],
         ['TIMESTAMP', 'VARCHAR', 'BIGINT'],
         ['1970-01-01T00:00:00.000Z', 'Chrome', 76261],
-        ['1970-01-01T00:00:00.000Z', 'Chrome Mobile', 252689],
-        ['1970-01-01T00:00:00.000Z', 'Chrome', 1753602],
+        ['1970-01-01T00:00:00.000Z', 'Chrome\nMobile', 252689],
+        ['1970-01-01T00:00:00.000Z', '"Ch|rome"', 1753602],
       ],
       true,
       true,
@@ -54,7 +54,7 @@ describe('download', () => {
         "__time","browser","session_length"
         "1970-01-01T00:00:00.000Z","Chrome","76261"
         "1970-01-01T00:00:00.000Z","Chrome Mobile","252689"
-        "1970-01-01T00:00:00.000Z","Chrome","1753602"
+        "1970-01-01T00:00:00.000Z","""Ch|rome""","1753602"
       `);
     });
 
@@ -63,7 +63,7 @@ describe('download', () => {
         __time	browser	session_length
         1970-01-01T00:00:00.000Z	Chrome	76261
         1970-01-01T00:00:00.000Z	Chrome Mobile	252689
-        1970-01-01T00:00:00.000Z	Chrome	1753602
+        1970-01-01T00:00:00.000Z	"Ch|rome"	1753602
       `);
     });
 
@@ -71,7 +71,7 @@ describe('download', () => {
       expect(queryResultsToString(queryResult, 'json')).toEqual(sane`
         {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome","session_length":76261}
         {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome Mobile","session_length":252689}
-        {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome","session_length":1753602}
+        {"__time":"1970-01-01T00:00:00.000Z","browser":"\"Ch|rome\"","session_length":1753602}
       `);
     });
 

--- a/web-console/src/utils/download.spec.ts
+++ b/web-console/src/utils/download.spec.ts
@@ -16,17 +16,17 @@
  * limitations under the License.
  */
 
-import { formatForFormat } from './download';
+import { formatForFileFormat } from './download';
 
 describe('download', () => {
   it('.formatForFormat', () => {
-    expect(formatForFormat(null, 'csv')).toEqual('');
-    expect(formatForFormat(null, 'tsv')).toEqual('');
-    expect(formatForFormat('', 'csv')).toEqual('""');
-    expect(formatForFormat('null', 'csv')).toEqual('"null"');
-    expect(formatForFormat('hello\nworld', 'csv')).toEqual('"hello world"');
-    expect(formatForFormat(123, 'csv')).toEqual('"123"');
-    expect(formatForFormat(new Date('2021-01-02T03:04:05.678Z'), 'csv')).toEqual(
+    expect(formatForFileFormat(null, 'csv')).toEqual('');
+    expect(formatForFileFormat(null, 'tsv')).toEqual('');
+    expect(formatForFileFormat('', 'csv')).toEqual('""');
+    expect(formatForFileFormat('null', 'csv')).toEqual('"null"');
+    expect(formatForFileFormat('hello\nworld', 'csv')).toEqual('"hello world"');
+    expect(formatForFileFormat(123, 'csv')).toEqual('"123"');
+    expect(formatForFileFormat(new Date('2021-01-02T03:04:05.678Z'), 'csv')).toEqual(
       '"2021-01-02T03:04:05.678Z"',
     );
   });

--- a/web-console/src/utils/download.spec.ts
+++ b/web-console/src/utils/download.spec.ts
@@ -16,10 +16,12 @@
  * limitations under the License.
  */
 
-import { formatForFileFormat } from './download';
+import { QueryResult, sane } from 'druid-query-toolkit';
+
+import { formatForFileFormat, queryResultsToString } from './download';
 
 describe('download', () => {
-  it('.formatForFormat', () => {
+  it('formatForFormat', () => {
     expect(formatForFileFormat(null, 'csv')).toEqual('');
     expect(formatForFileFormat(null, 'tsv')).toEqual('');
     expect(formatForFileFormat('', 'csv')).toEqual('""');
@@ -29,5 +31,73 @@ describe('download', () => {
     expect(formatForFileFormat(new Date('2021-01-02T03:04:05.678Z'), 'csv')).toEqual(
       '"2021-01-02T03:04:05.678Z"',
     );
+  });
+
+  describe('queryResultsToString', () => {
+    const queryResult = QueryResult.fromRawResult(
+      [
+        ['__time', 'browser', 'session_length'],
+        ['LONG', 'STRING', 'LONG'],
+        ['TIMESTAMP', 'VARCHAR', 'BIGINT'],
+        ['1970-01-01T00:00:00.000Z', 'Chrome', 76261],
+        ['1970-01-01T00:00:00.000Z', 'Chrome Mobile', 252689],
+        ['1970-01-01T00:00:00.000Z', 'Chrome', 1753602],
+      ],
+      true,
+      true,
+      true,
+      true,
+    );
+
+    it('works with CSV', () => {
+      expect(queryResultsToString(queryResult, 'csv')).toEqual(sane`
+        "__time","browser","session_length"
+        "1970-01-01T00:00:00.000Z","Chrome","76261"
+        "1970-01-01T00:00:00.000Z","Chrome Mobile","252689"
+        "1970-01-01T00:00:00.000Z","Chrome","1753602"
+      `);
+    });
+
+    it('works with TSV', () => {
+      expect(queryResultsToString(queryResult, 'tsv')).toEqual(sane`
+        __time	browser	session_length
+        1970-01-01T00:00:00.000Z	Chrome	76261
+        1970-01-01T00:00:00.000Z	Chrome Mobile	252689
+        1970-01-01T00:00:00.000Z	Chrome	1753602
+      `);
+    });
+
+    it('works with JSON', () => {
+      expect(queryResultsToString(queryResult, 'json')).toEqual(sane`
+        {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome","session_length":76261}
+        {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome Mobile","session_length":252689}
+        {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome","session_length":1753602}
+      `);
+    });
+
+    it('works with SQL', () => {
+      expect(queryResultsToString(queryResult, 'sql')).toEqual(sane`
+        SELECT
+          CAST("c1" AS TIMESTAMP) AS "__time",
+          CAST("c2" AS VARCHAR) AS "browser",
+          CAST("c3" AS BIGINT) AS "session_length"
+        FROM (
+          VALUES
+          ('1970-01-01T00:00:00.000Z', 'Chrome', 76261),
+          ('1970-01-01T00:00:00.000Z', 'Chrome Mobile', 252689),
+          ('1970-01-01T00:00:00.000Z', 'Chrome', 1753602)
+        ) AS "t" ("c1", "c2", "c3")
+      `);
+    });
+
+    it('works with Markdown', () => {
+      expect(queryResultsToString(queryResult, 'markdown')).toEqual(sane`
+        | __time                   | browser       | session_length |
+        | :----------------------- | :------------ | -------------: |
+        | 1970-01-01T00:00:00.000Z | Chrome        |          76261 |
+        | 1970-01-01T00:00:00.000Z | Chrome Mobile |         252689 |
+        | 1970-01-01T00:00:00.000Z | Chrome        |        1753602 |
+      `);
+    });
   });
 });

--- a/web-console/src/utils/download.spec.ts
+++ b/web-console/src/utils/download.spec.ts
@@ -18,30 +18,59 @@
 
 import { QueryResult, sane } from 'druid-query-toolkit';
 
-import { formatForFileFormat, queryResultsToString } from './download';
+import { queryResultsToString, stringifyCsvValue, stringifyTsvValue } from './download';
 
 describe('download', () => {
-  it('formatForFormat', () => {
-    expect(formatForFileFormat(null, 'csv')).toEqual('');
-    expect(formatForFileFormat(null, 'tsv')).toEqual('');
-    expect(formatForFileFormat('', 'csv')).toEqual('""');
-    expect(formatForFileFormat('null', 'csv')).toEqual('"null"');
-    expect(formatForFileFormat('hello\nworld', 'csv')).toEqual('"hello world"');
-    expect(formatForFileFormat(123, 'csv')).toEqual('"123"');
-    expect(formatForFileFormat(new Date('2021-01-02T03:04:05.678Z'), 'csv')).toEqual(
-      '"2021-01-02T03:04:05.678Z"',
+  it('stringifyCsvValue', () => {
+    expect(stringifyCsvValue(null)).toEqual('');
+    expect(stringifyCsvValue('')).toEqual('');
+    expect(stringifyCsvValue('null')).toEqual('null');
+    expect(stringifyCsvValue('hello\nworld')).toEqual('hello world');
+    expect(stringifyCsvValue('Jane "JD" Smith')).toEqual('"Jane ""JD"" Smith"');
+    expect(stringifyCsvValue(123)).toEqual('123');
+    expect(stringifyCsvValue(new Date('2021-01-02T03:04:05.678Z'))).toEqual(
+      '2021-01-02T03:04:05.678Z',
+    );
+  });
+
+  it('stringifyTsvValue', () => {
+    expect(stringifyTsvValue(null)).toEqual('');
+    expect(stringifyTsvValue('')).toEqual('');
+    expect(stringifyTsvValue('null')).toEqual('null');
+    expect(stringifyTsvValue('hello\nworld')).toEqual('hello world');
+    expect(stringifyTsvValue(123)).toEqual('123');
+    expect(stringifyTsvValue(new Date('2021-01-02T03:04:05.678Z'))).toEqual(
+      '2021-01-02T03:04:05.678Z',
     );
   });
 
   describe('queryResultsToString', () => {
+    /*
+    Data for testing:
+    =================
+    {"name": "John, Doe", "age": 29, "city": "New York", "bio": "Loves coding\nand coffee"}
+    {"name": "Jane \"JD\" Smith", "age": 34, "city": "Los Angeles", "bio": "Enjoys \"live music\" and travel"}
+    {"name": "Michael, O'Connor", "age": 41, "city": "Chicago", "bio": "Expert in AI\\ML"}
+    {"name": "李四 (Li Si)", "age": 27, "city": "北京 (Beijing)", "bio": "喜欢编程和阅读"}
+    {"name": "O'Reilly, Patrick", "age": 45, "city": null, "bio": "\nLoves\ttabs"}
+     */
+
     const queryResult = QueryResult.fromRawResult(
       [
-        ['__time', 'browser', 'session_length'],
-        ['LONG', 'STRING', 'LONG'],
-        ['TIMESTAMP', 'VARCHAR', 'BIGINT'],
-        ['1970-01-01T00:00:00.000Z', 'Chrome', 76261],
-        ['1970-01-01T00:00:00.000Z', 'Chrome\nMobile', 252689],
-        ['1970-01-01T00:00:00.000Z', '"Ch|rome"', 1753602],
+        ['__time', 'name', 'age', 'city', 'bio'],
+        ['LONG', 'STRING', 'LONG', 'STRING', 'STRING'],
+        ['TIMESTAMP', 'VARCHAR', 'BIGINT', 'VARCHAR', 'VARCHAR'],
+        [
+          '1970-01-01T00:00:00.000Z',
+          'Jane "JD" Smith',
+          34,
+          'Los Angeles',
+          'Enjoys "live music" and travel',
+        ],
+        ['1970-01-01T00:00:00.000Z', 'John, Doe', 29, 'New York', 'Loves coding\nand coffee'],
+        ['1970-01-01T00:00:00.000Z', "Michael, O'Connor", 41, 'Chicago', 'Expert in AI\\ML'],
+        ['1970-01-01T00:00:00.000Z', "O'Reilly, Patrick", 45, null, '\nLoves\ttabs'],
+        ['1970-01-01T00:00:00.000Z', '李四 (Li Si)', 27, '北京 (Beijing)', '喜欢编程和阅读'],
       ],
       true,
       true,
@@ -50,28 +79,34 @@ describe('download', () => {
     );
 
     it('works with CSV', () => {
-      expect(queryResultsToString(queryResult, 'csv')).toEqual(sane`
-        "__time","browser","session_length"
-        "1970-01-01T00:00:00.000Z","Chrome","76261"
-        "1970-01-01T00:00:00.000Z","Chrome Mobile","252689"
-        "1970-01-01T00:00:00.000Z","""Ch|rome""","1753602"
+      expect(queryResultsToString(queryResult, 'csv').replaceAll('\t', '\\t')).toEqual(sane`
+        __time,name,age,city,bio
+        1970-01-01T00:00:00.000Z,"Jane ""JD"" Smith",34,Los Angeles,"Enjoys ""live music"" and travel"
+        1970-01-01T00:00:00.000Z,"John, Doe",29,New York,Loves coding and coffee
+        1970-01-01T00:00:00.000Z,"Michael, O'Connor",41,Chicago,Expert in AI\\ML
+        1970-01-01T00:00:00.000Z,"O'Reilly, Patrick",45,," Loves\ttabs"
+        1970-01-01T00:00:00.000Z,李四 (Li Si),27,北京 (Beijing),喜欢编程和阅读
       `);
     });
 
     it('works with TSV', () => {
-      expect(queryResultsToString(queryResult, 'tsv')).toEqual(sane`
-        __time	browser	session_length
-        1970-01-01T00:00:00.000Z	Chrome	76261
-        1970-01-01T00:00:00.000Z	Chrome Mobile	252689
-        1970-01-01T00:00:00.000Z	"Ch|rome"	1753602
+      expect(queryResultsToString(queryResult, 'tsv').replaceAll('\t', '\\t')).toEqual(sane`
+        __time\tname\tage\tcity\tbio
+        1970-01-01T00:00:00.000Z\tJane "JD" Smith\t34\tLos Angeles\tEnjoys "live music" and travel
+        1970-01-01T00:00:00.000Z\tJohn, Doe\t29\tNew York\tLoves coding and coffee
+        1970-01-01T00:00:00.000Z\tMichael, O'Connor\t41\tChicago\tExpert in AI\\ML
+        1970-01-01T00:00:00.000Z\tO'Reilly, Patrick\t45\t\t Loves tabs
+        1970-01-01T00:00:00.000Z\t李四 (Li Si)\t27\t北京 (Beijing)\t喜欢编程和阅读
       `);
     });
 
     it('works with JSON', () => {
       expect(queryResultsToString(queryResult, 'json')).toEqual(sane`
-        {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome","session_length":76261}
-        {"__time":"1970-01-01T00:00:00.000Z","browser":"Chrome Mobile","session_length":252689}
-        {"__time":"1970-01-01T00:00:00.000Z","browser":"\"Ch|rome\"","session_length":1753602}
+        {"__time":"1970-01-01T00:00:00.000Z","name":"Jane \\"JD\\" Smith","age":34,"city":"Los Angeles","bio":"Enjoys \\"live music\\" and travel"}
+        {"__time":"1970-01-01T00:00:00.000Z","name":"John, Doe","age":29,"city":"New York","bio":"Loves coding\\nand coffee"}
+        {"__time":"1970-01-01T00:00:00.000Z","name":"Michael, O'Connor","age":41,"city":"Chicago","bio":"Expert in AI\\\\ML"}
+        {"__time":"1970-01-01T00:00:00.000Z","name":"O'Reilly, Patrick","age":45,"city":null,"bio":"\\nLoves\\ttabs"}
+        {"__time":"1970-01-01T00:00:00.000Z","name":"李四 (Li Si)","age":27,"city":"北京 (Beijing)","bio":"喜欢编程和阅读"}
       `);
     });
 
@@ -79,24 +114,30 @@ describe('download', () => {
       expect(queryResultsToString(queryResult, 'sql')).toEqual(sane`
         SELECT
           CAST("c1" AS TIMESTAMP) AS "__time",
-          CAST("c2" AS VARCHAR) AS "browser",
-          CAST("c3" AS BIGINT) AS "session_length"
+          CAST("c2" AS VARCHAR) AS "name",
+          CAST("c3" AS BIGINT) AS "age",
+          CAST("c4" AS VARCHAR) AS "city",
+          CAST("c5" AS VARCHAR) AS "bio"
         FROM (
           VALUES
-          ('1970-01-01T00:00:00.000Z', 'Chrome', 76261),
-          ('1970-01-01T00:00:00.000Z', 'Chrome Mobile', 252689),
-          ('1970-01-01T00:00:00.000Z', 'Chrome', 1753602)
-        ) AS "t" ("c1", "c2", "c3")
+          ('1970-01-01T00:00:00.000Z', 'Jane "JD" Smith', 34, 'Los Angeles', 'Enjoys "live music" and travel'),
+          ('1970-01-01T00:00:00.000Z', 'John, Doe', 29, 'New York', U&'Loves coding\000aand coffee'),
+          ('1970-01-01T00:00:00.000Z', 'Michael, O''Connor', 41, 'Chicago', 'Expert in AI\ML'),
+          ('1970-01-01T00:00:00.000Z', 'O''Reilly, Patrick', 45, NULL, U&'\000aLoves\0009tabs'),
+          ('1970-01-01T00:00:00.000Z', '李四 (Li Si)', 27, '北京 (Beijing)', '喜欢编程和阅读')
+        ) AS "t" ("c1", "c2", "c3", "c4", "c5")
       `);
     });
 
     it('works with Markdown', () => {
-      expect(queryResultsToString(queryResult, 'markdown')).toEqual(sane`
-        | __time                   | browser       | session_length |
-        | :----------------------- | :------------ | -------------: |
-        | 1970-01-01T00:00:00.000Z | Chrome        |          76261 |
-        | 1970-01-01T00:00:00.000Z | Chrome Mobile |         252689 |
-        | 1970-01-01T00:00:00.000Z | Chrome        |        1753602 |
+      expect(queryResultsToString(queryResult, 'markdown').replaceAll('\t', '\\t')).toEqual(sane`
+        | __time                   | name              | age | city         | bio                            |
+        | :----------------------- | :---------------- | --: | :----------- | :----------------------------- |
+        | 1970-01-01T00:00:00.000Z | Jane "JD" Smith   |  34 | Los Angeles  | Enjoys "live music" and travel |
+        | 1970-01-01T00:00:00.000Z | John, Doe         |  29 | New York     | Loves coding<br>and coffee     |
+        | 1970-01-01T00:00:00.000Z | Michael, O'Connor |  41 | Chicago      | Expert in AI\\ML                |
+        | 1970-01-01T00:00:00.000Z | O'Reilly, Patrick |  45 |              | <br>Loves\ttabs                 |
+        | 1970-01-01T00:00:00.000Z | 李四 (Li Si)        |  27 | 北京 (Beijing) | 喜欢编程和阅读                        |
       `);
     });
   });

--- a/web-console/src/utils/download.ts
+++ b/web-console/src/utils/download.ts
@@ -45,13 +45,23 @@ export const FILE_FORMAT_TO_LABEL: Record<FileFormat, string> = {
 
 export function stringifyCsvValue(s: null | string | number | Date): string {
   if (s == null) return '';
-  const str = stringifyValue(s).replace(/\r?\n/g, ' ');
-  return `"${str.replace(/"/g, '""')}"`;
+  const str = stringifyValue(s).replace(/\r?\n/g, ' ').replace(/"/g, '""');
+
+  if (/["\n\t,]/.test(str)) {
+    return `"${str}"`;
+  }
+
+  return str;
 }
 
 export function stringifyTsvValue(s: null | string | number | Date): string {
   if (s == null) return '';
-  return stringifyValue(s).replace(/\r?\n/g, ' ').replace(/\t/g, ' ');
+  return stringifyValue(s).replace(/\r?\n|\t/g, ' ');
+}
+
+export function stringifyMarkdownValue(s: null | string | number | Date): string {
+  if (s == null) return '';
+  return stringifyValue(s).replace(/\r?\n/g, '<br>');
 }
 
 function queryResultToDsv(
@@ -97,7 +107,7 @@ export function queryResultsToString(queryResult: QueryResult, format: FileForma
       return getMarkdownTable({
         table: {
           head: header.map(column => column.name),
-          body: rows.map(row => row.map(cell => stringifyValue(cell))),
+          body: rows.map(row => row.map(stringifyMarkdownValue)),
         },
         alignment: header.map(column => (column.isNumeric() ? Align.Right : Align.Left)),
       });

--- a/web-console/src/utils/download.ts
+++ b/web-console/src/utils/download.ts
@@ -43,23 +43,6 @@ export const FILE_FORMAT_TO_LABEL: Record<FileFormat, string> = {
   markdown: 'Markdown table',
 };
 
-export function downloadUrl(url: string, filename: string) {
-  // Create a link and set the URL using `createObjectURL`
-  const link = document.createElement('a');
-  link.style.display = 'none';
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-
-  // To make this work on Firefox we need to wait
-  // a little while before removing it.
-  setTimeout(() => {
-    if (!link.parentNode) return;
-    link.parentNode.removeChild(link);
-  }, 0);
-}
-
 export function formatForFileFormat(
   s: null | string | number | Date,
   format: 'csv' | 'tsv',
@@ -67,7 +50,7 @@ export function formatForFileFormat(
   if (s == null) return '';
 
   // stringify and remove line break
-  const str = stringifyValue(s).replace(/(?:\r\n|\r|\n)/g, ' ');
+  const str = stringifyValue(s).replace(/\r\n|\r|\n/g, ' ');
 
   if (format === 'csv') {
     // csv: single quote => double quote, handle ','

--- a/web-console/src/utils/download.ts
+++ b/web-console/src/utils/download.ts
@@ -87,7 +87,7 @@ export function downloadFile(text: string, fileFormat: FileFormat, filename: str
   );
 }
 
-function queryResultsToString(queryResult: QueryResult, format: FileFormat): string {
+export function queryResultsToString(queryResult: QueryResult, format: FileFormat): string {
   const { header, rows } = queryResult;
 
   switch (format) {

--- a/web-console/src/views/workbench-view/destination-pages-pane/destination-pages-pane.tsx
+++ b/web-console/src/views/workbench-view/destination-pages-pane/destination-pages-pane.tsx
@@ -124,15 +124,13 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
             rightIcon={IconNames.CARET_DOWN}
           />
         </Popover>{' '}
-        {pages.length > 1 && (
-          <AnchorButton
-            intent={Intent.PRIMARY}
-            icon={IconNames.DOWNLOAD}
-            text="Download all data (concatenated)"
-            href={getResultUrl(-1)}
-            download
-          />
-        )}
+        <AnchorButton
+          intent={Intent.PRIMARY}
+          icon={IconNames.DOWNLOAD}
+          text="Download all data (concatenated)"
+          href={getResultUrl(-1)}
+          download
+        />
       </p>
       <ReactTable
         data={pages}

--- a/web-console/src/views/workbench-view/destination-pages-pane/destination-pages-pane.tsx
+++ b/web-console/src/views/workbench-view/destination-pages-pane/destination-pages-pane.tsx
@@ -77,6 +77,7 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
   const destination = execution.destination;
   const pages = execution.destinationPages;
   if (!pages) return null;
+  const numPages = pages.length;
   const id = Api.encodePath(execution.id);
 
   const numTotalRows = destination?.numTotalRows;
@@ -85,11 +86,11 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
     return UrlBaser.base(
       `/druid/v2/sql/statements/${id}/results?${
         pageIndex < 0 ? '' : `page=${pageIndex}&`
-      }resultFormat=${desiredResultFormat}`,
+      }resultFormat=${desiredResultFormat}&filename=${getPageFilename(pageIndex)}`,
     );
   }
 
-  function getPageFilename(pageIndex: number, numPages: number) {
+  function getPageFilename(pageIndex: number) {
     const numPagesString = String(numPages);
     const pageNumberString = String(pageIndex + 1).padStart(numPagesString.length, '0');
     return `${id}_page_${pageNumberString}_of_${numPagesString}.${desiredExtension}`;
@@ -101,7 +102,6 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
     await wait(100);
   }
 
-  const numPages = pages.length;
   return (
     <div className="destination-pages-pane">
       <p>
@@ -184,7 +184,6 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
                 text="Download"
                 minimal
                 href={getResultUrl(value)}
-                download={getPageFilename(value, numPages)}
               />
             ),
           },

--- a/web-console/src/views/workbench-view/destination-pages-pane/destination-pages-pane.tsx
+++ b/web-console/src/views/workbench-view/destination-pages-pane/destination-pages-pane.tsx
@@ -24,15 +24,7 @@ import ReactTable from 'react-table';
 import type { Execution } from '../../../druid-models';
 import { SMALL_TABLE_PAGE_SIZE } from '../../../react-table';
 import { Api, UrlBaser } from '../../../singletons';
-import {
-  clamp,
-  downloadUrl,
-  formatBytes,
-  formatInteger,
-  pluralIfNeeded,
-  tickIcon,
-  wait,
-} from '../../../utils';
+import { clamp, formatBytes, formatInteger, pluralIfNeeded, tickIcon } from '../../../utils';
 
 import './destination-pages-pane.scss';
 
@@ -90,16 +82,15 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
     );
   }
 
-  function getPageFilename(pageIndex: number) {
+  function getFilenamePageInfo(pageIndex: number) {
+    if (pageIndex < 0) return 'all_data';
     const numPagesString = String(numPages);
     const pageNumberString = String(pageIndex + 1).padStart(numPagesString.length, '0');
-    return `${id}_page_${pageNumberString}_of_${numPagesString}.${desiredExtension}`;
+    return `page_${pageNumberString}_of_${numPagesString}`;
   }
 
-  async function downloadAllData() {
-    if (!pages) return;
-    downloadUrl(getResultUrl(-1), `${id}_all_data.${desiredExtension}`);
-    await wait(100);
+  function getPageFilename(pageIndex: number) {
+    return `${id}_${getFilenamePageInfo(pageIndex)}.${desiredExtension}`;
   }
 
   return (
@@ -134,11 +125,12 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
           />
         </Popover>{' '}
         {pages.length > 1 && (
-          <Button
+          <AnchorButton
             intent={Intent.PRIMARY}
             icon={IconNames.DOWNLOAD}
             text="Download all data (concatenated)"
-            onClick={() => void downloadAllData()}
+            href={getResultUrl(-1)}
+            download
           />
         )}
       </p>
@@ -184,6 +176,7 @@ export const DestinationPagesPane = React.memo(function DestinationPagesPane(
                 text="Download"
                 minimal
                 href={getResultUrl(value)}
+                download
               />
             ),
           },

--- a/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
+++ b/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
@@ -16,7 +16,15 @@
  * limitations under the License.
  */
 
-import { Button, ButtonGroup, Menu, MenuItem, Popover, Position } from '@blueprintjs/core';
+import {
+  Button,
+  ButtonGroup,
+  Menu,
+  MenuDivider,
+  MenuItem,
+  Popover,
+  Position,
+} from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
 import type { JSX } from 'react';
 import React, { useState } from 'react';
@@ -110,39 +118,36 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
             : `Query ID\n${execution.id}\n(click to copy)`)
         }
       />,
-      execution?.destination?.type === 'durableStorage' && execution.destinationPages ? (
-        <Button
-          key="download"
-          icon={IconNames.DOWNLOAD}
-          data-tooltip="Download data"
-          minimal
-          onClick={() => setShowDestinationPages(true)}
-        />
-      ) : (
-        <Popover
-          key="download"
-          className="download-button"
-          content={
-            <Menu>
-              <MenuItem text="Download results as...">
-                <MenuItem text="CSV" onClick={() => handleDownload('csv')} />
-                <MenuItem text="TSV" onClick={() => handleDownload('tsv')} />
-                <MenuItem text="JSON (new line delimited)" onClick={() => handleDownload('json')} />
-                <MenuItem text="SQL (VALUES)" onClick={() => handleDownload('sql')} />
-              </MenuItem>
-              <MenuItem text="Copy to clipboard as...">
-                <MenuItem text="CSV" onClick={() => handleCopy('csv')} />
-                <MenuItem text="TSV" onClick={() => handleCopy('tsv')} />
-                <MenuItem text="JSON (new line delimited)" onClick={() => handleCopy('json')} />
-                <MenuItem text="SQL (VALUES)" onClick={() => handleCopy('sql')} />
-              </MenuItem>
-            </Menu>
-          }
-          position={Position.BOTTOM_RIGHT}
-        >
-          <Button icon={IconNames.DOWNLOAD} data-tooltip="Download data in view" minimal />
-        </Popover>
-      ),
+      <Popover
+        key="download"
+        className="download-button"
+        position={Position.BOTTOM_RIGHT}
+        content={
+          <Menu>
+            {execution.destinationPages && (
+              <>
+                <MenuDivider title="Download in bulk" />
+                <MenuItem text="Show result pages" onClick={() => setShowDestinationPages(true)} />
+                <MenuDivider title="Download data in view" />
+              </>
+            )}
+            <MenuItem text="Download results as...">
+              <MenuItem text="CSV" onClick={() => handleDownload('csv')} />
+              <MenuItem text="TSV" onClick={() => handleDownload('tsv')} />
+              <MenuItem text="JSON (new line delimited)" onClick={() => handleDownload('json')} />
+              <MenuItem text="SQL (VALUES)" onClick={() => handleDownload('sql')} />
+            </MenuItem>
+            <MenuItem text="Copy to clipboard as...">
+              <MenuItem text="CSV" onClick={() => handleCopy('csv')} />
+              <MenuItem text="TSV" onClick={() => handleCopy('tsv')} />
+              <MenuItem text="JSON (new line delimited)" onClick={() => handleCopy('json')} />
+              <MenuItem text="SQL (VALUES)" onClick={() => handleCopy('sql')} />
+            </MenuItem>
+          </Menu>
+        }
+      >
+        <Button icon={IconNames.DOWNLOAD} data-tooltip="Download" minimal />
+      </Popover>,
     );
   }
 

--- a/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
+++ b/web-console/src/views/workbench-view/execution-summary-panel/execution-summary-panel.tsx
@@ -30,11 +30,13 @@ import type { JSX } from 'react';
 import React, { useState } from 'react';
 
 import type { Execution } from '../../../druid-models';
-import type { Format } from '../../../utils';
+import type { FileFormat } from '../../../utils';
 import {
   copyAndAlert,
   copyQueryResultsToClipboard,
   downloadQueryResults,
+  FILE_FORMAT_TO_LABEL,
+  FILE_FORMATS,
   formatDurationHybrid,
   formatInteger,
   oneOf,
@@ -86,11 +88,11 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
 
     const warningCount = execution?.stages?.getWarningCount();
 
-    const handleDownload = (format: Format) => {
+    const handleDownload = (format: FileFormat) => {
       downloadQueryResults(queryResult, `results-${execution.id}.${format}`, format);
     };
 
-    const handleCopy = (format: Format) => {
+    const handleCopy = (format: FileFormat) => {
       copyQueryResultsToClipboard(queryResult, format);
     };
 
@@ -132,16 +134,22 @@ export const ExecutionSummaryPanel = React.memo(function ExecutionSummaryPanel(
               </>
             )}
             <MenuItem text="Download results as...">
-              <MenuItem text="CSV" onClick={() => handleDownload('csv')} />
-              <MenuItem text="TSV" onClick={() => handleDownload('tsv')} />
-              <MenuItem text="JSON (new line delimited)" onClick={() => handleDownload('json')} />
-              <MenuItem text="SQL (VALUES)" onClick={() => handleDownload('sql')} />
+              {FILE_FORMATS.map(fileFormat => (
+                <MenuItem
+                  key={fileFormat}
+                  text={FILE_FORMAT_TO_LABEL[fileFormat]}
+                  onClick={() => handleDownload(fileFormat)}
+                />
+              ))}
             </MenuItem>
             <MenuItem text="Copy to clipboard as...">
-              <MenuItem text="CSV" onClick={() => handleCopy('csv')} />
-              <MenuItem text="TSV" onClick={() => handleCopy('tsv')} />
-              <MenuItem text="JSON (new line delimited)" onClick={() => handleCopy('json')} />
-              <MenuItem text="SQL (VALUES)" onClick={() => handleCopy('sql')} />
+              {FILE_FORMATS.map(fileFormat => (
+                <MenuItem
+                  key={fileFormat}
+                  text={FILE_FORMAT_TO_LABEL[fileFormat]}
+                  onClick={() => handleCopy(fileFormat)}
+                />
+              ))}
             </MenuItem>
           </Menu>
         }


### PR DESCRIPTION
The web console followup to https://github.com/apache/druid/pull/17840 and normalized how the console exports data with how Druid does it

Also includes the ability to export results (from the web console) as a markdown table... see unit test for example.