### PR TITLE
Fix stalling quidem tests running dart queries

### DIFF
--- a/extensions-core/multi-stage-query/src/main/resources/log4j2.xml
+++ b/extensions-core/multi-stage-query/src/main/resources/log4j2.xml
@@ -31,7 +31,7 @@
     <Logger level="info" name="org.apache.druid.frame" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
-    <Logger level="debug" name="org.apache.druid.msq" additivity="false">
+    <Logger level="info" name="org.apache.druid.msq" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
     <Logger level="info" name="org.apache.calcite" additivity="false">

--- a/extensions-core/multi-stage-query/src/main/resources/log4j2.xml
+++ b/extensions-core/multi-stage-query/src/main/resources/log4j2.xml
@@ -31,7 +31,7 @@
     <Logger level="info" name="org.apache.druid.frame" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
-    <Logger level="info" name="org.apache.druid.msq" additivity="false">
+    <Logger level="debug" name="org.apache.druid.msq" additivity="false">
       <AppenderRef ref="Console"/>
     </Logger>
     <Logger level="info" name="org.apache.calcite" additivity="false">

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
@@ -88,6 +88,19 @@ public class CalciteDartTest extends BaseCalciteQueryTest
         .run();
   }
 
+  @Test
+  public void testCount()
+  {
+    testBuilder()
+        .sql("SELECT count(1) from foo")
+        .expectedResults(
+            ImmutableList.of(
+                new Object[] {2},
+                new Object[] {2}
+            )
+        )
+        .run();
+  }
 
   @Test
   public void testSelectDim1FromFoo11()

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
@@ -25,7 +25,6 @@ import org.apache.druid.msq.dart.controller.sql.DartSqlEngine;
 import org.apache.druid.sql.calcite.BaseCalciteQueryTest;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
 import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
@@ -74,7 +73,6 @@ public class CalciteDartTest extends BaseCalciteQueryTest
   }
 
   @Test
-  @Disabled("this case currently stalls")
   public void testSelectFromFooLimit2()
   {
     testBuilder()
@@ -95,8 +93,7 @@ public class CalciteDartTest extends BaseCalciteQueryTest
         .sql("SELECT count(1) from foo")
         .expectedResults(
             ImmutableList.of(
-                new Object[] {2},
-                new Object[] {2}
+                new Object[] {6L}
             )
         )
         .run();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
@@ -151,7 +151,7 @@ public class MSQTestWorkerContext implements WorkerContext
   @Override
   public int maxConcurrentStages()
   {
-    return 1;
+    return 2;
   }
 
   @Override


### PR DESCRIPTION
Dart queries have stalled due to the fact that only 1 stage was allowed to be run - which have lead to a stall