### PR TITLE
Cleanup segment metadata cache for a datasource if not in use

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/DatasourceSegmentCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/DatasourceSegmentCache.java
@@ -27,26 +27,5 @@ import org.apache.druid.metadata.segment.DatasourceSegmentMetadataWriter;
  */
 public interface DatasourceSegmentCache extends DatasourceSegmentMetadataWriter, DatasourceSegmentMetadataReader
 {
-  /**
-   * Performs a thread-safe read action on the cache.
-   * Read actions can be concurrent with other reads but are mutually exclusive
-   * from other write actions.
-   */
-  <T> T read(Action<T> action) throws Exception;
 
-  /**
-   * Performs a thread-safe write action on the cache.
-   * Write actions are mutually exclusive from other writes or reads.
-   */
-  <T> T write(Action<T> action) throws Exception;
-
-  /**
-   * Represents a thread-safe read or write action performed on the cache within
-   * required locks.
-   */
-  @FunctionalInterface
-  interface Action<T>
-  {
-    T perform() throws Exception;
-  }
 }

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/Metric.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/Metric.java
@@ -109,6 +109,11 @@ public class Metric
   // CACHE UPDATE METRICS
 
   /**
+   * Total number of segments deleted from the cache in the latest sync.
+   */
+  public static final String DELETED_DATASOURCES = METRIC_NAME_PREFIX + "dataSource/deleted";
+
+  /**
    * Number of segments which are now stale in the cache and need to be refreshed.
    */
   public static final String STALE_USED_SEGMENTS = METRIC_NAME_PREFIX + "used/stale";

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/NoopSegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/NoopSegmentMetadataCache.java
@@ -65,7 +65,13 @@ public class NoopSegmentMetadataCache implements SegmentMetadataCache
   }
 
   @Override
-  public DatasourceSegmentCache getDatasource(String dataSource)
+  public <T> T readCacheForDataSource(String dataSource, Action<T> readAction)
+  {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T writeCacheForDataSource(String dataSource, Action<T> writeAction)
   {
     throw new UnsupportedOperationException();
   }

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/ReadWriteCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/ReadWriteCache.java
@@ -80,32 +80,6 @@ public abstract class ReadWriteCache implements DatasourceSegmentCache
     }
   }
 
-  @Override
-  public <T> T read(DatasourceSegmentCache.Action<T> action) throws Exception
-  {
-    stateLock.readLock().lock();
-    try {
-      verifyCacheIsNotStopped();
-      return action.perform();
-    }
-    finally {
-      stateLock.readLock().unlock();
-    }
-  }
-
-  @Override
-  public <T> T write(DatasourceSegmentCache.Action<T> action) throws Exception
-  {
-    stateLock.writeLock().lock();
-    try {
-      verifyCacheIsNotStopped();
-      return action.perform();
-    }
-    finally {
-      stateLock.writeLock().unlock();
-    }
-  }
-
   private void verifyCacheIsNotStopped()
   {
     if (isStopped) {

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/SegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/SegmentMetadataCache.java
@@ -65,9 +65,28 @@ public interface SegmentMetadataCache
   boolean isSyncedForRead();
 
   /**
-   * Returns the cache for the given datasource.
+   * Performs a thread-safe read action on the cache for the given datasource.
+   * Read actions can be concurrent with other reads but are mutually exclusive
+   * from other write actions on the same datasource.
    */
-  DatasourceSegmentCache getDatasource(String dataSource);
+  <T> T readCacheForDataSource(String dataSource, Action<T> readAction);
+
+  /**
+   * Performs a thread-safe write action on the cache for the given datasource.
+   * Write actions are mutually exclusive from other writes or reads on the same
+   * datasource.
+   */
+  <T> T writeCacheForDataSource(String dataSource, Action<T> writeAction);
+
+  /**
+   * Represents a thread-safe read or write action performed on the cache within
+   * required locks.
+   */
+  @FunctionalInterface
+  interface Action<T>
+  {
+    T perform(DatasourceSegmentCache dataSourceCache) throws Exception;
+  }
 
   /**
    * Cache usage modes.

--- a/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCacheTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCacheTest.java
@@ -200,18 +200,18 @@ public class HeapMemorySegmentMetadataCacheTest
   }
 
   @Test
-  public void testGetDataSource_throwsException_ifCacheIsDisabled()
+  public void testReadCacheForDataSource_throwsException_ifCacheIsDisabled()
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.NEVER);
     DruidExceptionMatcher.defensive().expectMessageIs(
         "Segment metadata cache is not enabled."
     ).assertThrowsAndMatches(
-        () -> cache.getDatasource(TestDataSource.WIKI)
+        () -> cache.readCacheForDataSource(TestDataSource.WIKI, d -> 0)
     );
   }
 
   @Test
-  public void testGetDataSource_throwsException_ifCacheIsStoppedOrNotLeader()
+  public void testReadCacheForDataSource_throwsException_ifCacheIsStoppedOrNotLeader()
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.ALWAYS);
     Assert.assertTrue(cache.isEnabled());
@@ -219,19 +219,19 @@ public class HeapMemorySegmentMetadataCacheTest
     DruidExceptionMatcher.internalServerError().expectMessageIs(
         "Segment metadata cache has not been started yet."
     ).assertThrowsAndMatches(
-        () -> cache.getDatasource(TestDataSource.WIKI)
+        () -> cache.readCacheForDataSource(TestDataSource.WIKI, d -> 0)
     );
 
     cache.start();
     DruidExceptionMatcher.internalServerError().expectMessageIs(
         "Not leader yet. Segment metadata cache is not usable."
     ).assertThrowsAndMatches(
-        () -> cache.getDatasource(TestDataSource.WIKI)
+        () -> cache.readCacheForDataSource(TestDataSource.WIKI, d -> 0)
     );
   }
 
   @Test(timeout = 60_000)
-  public void testGetDataSource_waitsForOneSync_afterBecomingLeader() throws InterruptedException
+  public void testReadCacheForDataSource_waitsForOneSync_afterBecomingLeader() throws InterruptedException
   {
     setupTargetWithCaching(SegmentMetadataCache.UsageMode.ALWAYS);
     cache.start();
@@ -241,7 +241,7 @@ public class HeapMemorySegmentMetadataCacheTest
 
     // Invoke getDatasource in Thread 1
     final Thread getDatasourceThread = new Thread(() -> {
-      cache.getDatasource(TestDataSource.WIKI);
+      cache.readCacheForDataSource(TestDataSource.WIKI, d -> 0);
       observedEventOrder.add("getDatasource completed");
     });
     getDatasourceThread.start();
@@ -264,7 +264,7 @@ public class HeapMemorySegmentMetadataCacheTest
 
     // Verify that subsequent calls to getDatasource do not wait
     final Thread getDatasourceThread2 = new Thread(() -> {
-      cache.getDatasource(TestDataSource.WIKI);
+      cache.readCacheForDataSource(TestDataSource.WIKI, d -> 0);
       observedEventOrder.add("getDatasource 2 completed");
     });
     getDatasourceThread2.start();
@@ -281,16 +281,29 @@ public class HeapMemorySegmentMetadataCacheTest
   {
     setupAndSyncCache();
 
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
-
     final DataSegmentPlus segment = CreateDataSegments.ofDatasource(TestDataSource.WIKI)
                                                       .markUsed().asPlus();
     final SegmentId segmentId = segment.getDataSegment().getId();
 
-    Assert.assertNull(wikiCache.findUsedSegment(segmentId));
+    Assert.assertNull(
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(segmentId)
+        )
+    );
 
-    Assert.assertEquals(1, wikiCache.insertSegments(Set.of(segment)));
-    Assert.assertEquals(segment.getDataSegment(), wikiCache.findUsedSegment(segmentId));
+    final int numInsertedSegments = cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.insertSegments(Set.of(segment))
+    );
+    Assert.assertEquals(1, numInsertedSegments);
+    Assert.assertEquals(
+        segment.getDataSegment(),
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(segmentId)
+        )
+    );
   }
 
   @Test
@@ -302,9 +315,11 @@ public class HeapMemorySegmentMetadataCacheTest
         = CreateDataSegments.ofDatasource(TestDataSource.WIKI).updatedNow().markUsed().asPlus();
     insertSegmentsInMetadataStore(Set.of(usedSegmentPlus));
 
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
     Assert.assertTrue(
-        wikiCache.findUsedSegmentsPlusOverlappingAnyOf(List.of()).isEmpty()
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
+        ).isEmpty()
     );
 
     syncCache();
@@ -314,7 +329,10 @@ public class HeapMemorySegmentMetadataCacheTest
 
     Assert.assertEquals(
         usedSegmentPlus.getDataSegment(),
-        wikiCache.findUsedSegment(usedSegmentPlus.getDataSegment().getId())
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(usedSegmentPlus.getDataSegment().getId())
+        )
     );
   }
 
@@ -363,11 +381,18 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.CACHED_USED_SEGMENTS, 1L);
     serviceEmitter.verifyValue(Metric.SKIPPED_SEGMENTS, 1L);
 
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
-    Assert.assertNull(wikiCache.findUsedSegment(invalidSegment.getDataSegment().getId()));
+    Assert.assertNull(
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(invalidSegment.getDataSegment().getId())
+        )
+    );
     Assert.assertEquals(
         validSegment.getDataSegment(),
-        wikiCache.findUsedSegment(validSegment.getDataSegment().getId())
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(validSegment.getDataSegment().getId())
+        )
     );
   }
 
@@ -412,11 +437,18 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.PERSISTED_USED_SEGMENTS, 1L);
     serviceEmitter.verifyValue(Metric.PERSISTED_PENDING_SEGMENTS, 0L);
 
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
-    Assert.assertEquals(segment.getDataSegment(), wikiCache.findUsedSegment(segment.getDataSegment().getId()));
+    Assert.assertEquals(
+        segment.getDataSegment(),
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(segment.getDataSegment().getId())
+        )
+    );
     Assert.assertTrue(
-        wikiCache.findPendingSegmentsOverlapping(Intervals.ETERNITY)
-                 .isEmpty()
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findPendingSegmentsOverlapping(Intervals.ETERNITY)
+        ).isEmpty()
     );
   }
 
@@ -424,7 +456,6 @@ public class HeapMemorySegmentMetadataCacheTest
   public void testSync_updatesUsedSegment_ifCacheHasOlderEntry()
   {
     setupAndSyncCache();
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
 
     // Add a used segment to both metadata store and cache
     final DateTime updateTime = DateTimes.nowUtc();
@@ -432,11 +463,17 @@ public class HeapMemorySegmentMetadataCacheTest
         CreateDataSegments.ofDatasource(TestDataSource.WIKI).markUsed()
                           .lastUpdatedOn(updateTime).asPlus();
     insertSegmentsInMetadataStore(Set.of(usedSegmentPlus));
-    wikiCache.insertSegments(Set.of(usedSegmentPlus));
+    cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.insertSegments(Set.of(usedSegmentPlus))
+    );
 
     Assert.assertEquals(
         Set.of(usedSegmentPlus),
-        wikiCache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
+        )
     );
 
     // Add a newer version of segment to metadata store
@@ -458,7 +495,10 @@ public class HeapMemorySegmentMetadataCacheTest
 
     Assert.assertEquals(
         Set.of(updatedSegment),
-        wikiCache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegmentsPlusOverlappingAnyOf(List.of())
+        )
     );
   }
 
@@ -466,16 +506,21 @@ public class HeapMemorySegmentMetadataCacheTest
   public void testSync_removesUsedSegment_ifNotPresentInMetadataStore()
   {
     setupAndSyncCache();
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
 
     final DataSegmentPlus unpersistedSegmentPlus =
         CreateDataSegments.ofDatasource(TestDataSource.WIKI).markUsed().asPlus();
-    wikiCache.insertSegments(Set.of(unpersistedSegmentPlus));
+    cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.insertSegments(Set.of(unpersistedSegmentPlus))
+    );
 
     final DataSegment unpersistedSegment = unpersistedSegmentPlus.getDataSegment();
     Assert.assertEquals(
         unpersistedSegment,
-        wikiCache.findUsedSegment(unpersistedSegment.getId())
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(unpersistedSegment.getId())
+        )
     );
 
     syncCache();
@@ -483,7 +528,10 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyNotEmitted(Metric.PERSISTED_USED_SEGMENTS);
 
     Assert.assertNull(
-        wikiCache.findUsedSegment(unpersistedSegment.getId())
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findUsedSegment(unpersistedSegment.getId())
+        )
     );
   }
 
@@ -491,13 +539,21 @@ public class HeapMemorySegmentMetadataCacheTest
   public void testSync_removesUnusedSegment_ifCacheHasOlderEntry()
   {
     setupAndSyncCache();
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
 
     final DateTime now = DateTimes.nowUtc();
     final DataSegmentPlus unpersistedSegmentPlus =
         CreateDataSegments.ofDatasource(TestDataSource.WIKI).markUsed().asPlus();
-    wikiCache.insertSegments(Set.of(unpersistedSegmentPlus));
-    wikiCache.markSegmentAsUnused(unpersistedSegmentPlus.getDataSegment().getId(), now.minusMinutes(1));
+    cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.insertSegments(Set.of(unpersistedSegmentPlus))
+    );
+    cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.markSegmentAsUnused(
+            unpersistedSegmentPlus.getDataSegment().getId(),
+            now.minusMinutes(1)
+        )
+    );
 
     syncCache();
     serviceEmitter.verifyValue(Metric.DELETED_SEGMENTS, 1L);
@@ -515,9 +571,14 @@ public class HeapMemorySegmentMetadataCacheTest
         CreateDataSegments.ofDatasource(TestDataSource.WIKI).updatedNow().markUsed().asPlus();
 
     final DateTime now = DateTimes.nowUtc();
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
-    wikiCache.insertSegments(Set.of(usedSegment));
-    wikiCache.markSegmentAsUnused(usedSegment.getDataSegment().getId(), now.plusMinutes(1));
+    cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.insertSegments(Set.of(usedSegment))
+    );
+    cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.markSegmentAsUnused(usedSegment.getDataSegment().getId(), now.plusMinutes(1))
+    );
 
     syncCache();
     serviceEmitter.verifyValue(Metric.CACHED_UNUSED_SEGMENTS, 1L);
@@ -544,11 +605,13 @@ public class HeapMemorySegmentMetadataCacheTest
     );
 
     final SegmentIdWithShardSpec segmentId = pendingSegment.getId();
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
     Assert.assertTrue(
-        wikiCache.findPendingSegmentIdsWithExactInterval(
-            pendingSegment.getSequenceName(),
-            segmentId.getInterval()
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findPendingSegmentIdsWithExactInterval(
+                pendingSegment.getSequenceName(),
+                segmentId.getInterval()
+            )
         ).isEmpty()
     );
 
@@ -558,9 +621,12 @@ public class HeapMemorySegmentMetadataCacheTest
 
     Assert.assertEquals(
         List.of(segmentId),
-        wikiCache.findPendingSegmentIdsWithExactInterval(
-            pendingSegment.getSequenceName(),
-            segmentId.getInterval()
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findPendingSegmentIdsWithExactInterval(
+                pendingSegment.getSequenceName(),
+                segmentId.getInterval()
+            )
         )
     );
   }
@@ -572,15 +638,20 @@ public class HeapMemorySegmentMetadataCacheTest
 
     // Create a pending segment and add it only to the cache
     final PendingSegmentRecord pendingSegment = createPendingSegment(DateTimes.nowUtc().minusHours(1));
-    final DatasourceSegmentCache wikiCache = cache.getDatasource(TestDataSource.WIKI);
-    wikiCache.insertPendingSegment(pendingSegment, false);
+    cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.insertPendingSegment(pendingSegment, false)
+    );
 
     final SegmentIdWithShardSpec segmentId = pendingSegment.getId();
     Assert.assertEquals(
         List.of(segmentId),
-        wikiCache.findPendingSegmentIdsWithExactInterval(
-            pendingSegment.getSequenceName(),
-            segmentId.getInterval()
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findPendingSegmentIdsWithExactInterval(
+                pendingSegment.getSequenceName(),
+                segmentId.getInterval()
+            )
         )
     );
 
@@ -590,11 +661,35 @@ public class HeapMemorySegmentMetadataCacheTest
     serviceEmitter.verifyValue(Metric.DELETED_PENDING_SEGMENTS, 1L);
 
     Assert.assertTrue(
-        wikiCache.findPendingSegmentIdsWithExactInterval(
-            pendingSegment.getSequenceName(),
-            segmentId.getInterval()
+        cache.readCacheForDataSource(
+            TestDataSource.WIKI,
+            wikiCache -> wikiCache.findPendingSegmentIdsWithExactInterval(
+                pendingSegment.getSequenceName(),
+                segmentId.getInterval()
+            )
         ).isEmpty()
     );
+  }
+
+  @Test
+  public void testSync_cleansUpDataSourceCache_ifEmptyAndNotInUse()
+  {
+    setupAndSyncCache();
+
+    final DateTime now = DateTimes.nowUtc();
+    final DataSegmentPlus segment = CreateDataSegments.ofDatasource(TestDataSource.WIKI)
+                                                      .markUsed().lastUpdatedOn(now.minusHours(1))
+                                                      .asPlus();
+    final int numInsertedSegments = cache.writeCacheForDataSource(
+        TestDataSource.WIKI,
+        wikiCache -> wikiCache.insertSegments(Set.of(segment))
+    );
+    Assert.assertEquals(1, numInsertedSegments);
+
+    // Verify that sync removes the extra entry from the cache and also cleans it up
+    syncCache();
+    serviceEmitter.verifyValue(Metric.DELETED_SEGMENTS, 1L);
+    serviceEmitter.verifyValue(Metric.DELETED_DATASOURCES, 1L);
   }
 
   private void insertSegmentsInMetadataStore(Set<DataSegmentPlus> segments)


### PR DESCRIPTION
Follow up to #17824 

This patch adds the implementation suggested in [this comment](https://github.com/apache/druid/pull/17824#discussion_r2017556232)

### Changes

- Simplify the contract of `DatasourceSegmentCache` and `SegmentMetadataCache`
- Hold a reference on a `HeapMemoryDatasourceSegmentCache` while it is being used by a transaction
- Clean up unreferenced instances of `HeapMemoryDatasourceSegmentCache` in the sync thread
- Fix up tests

#### Read-Write Transaction flow

- Start JDBI transaction
- Create instance of `SqlSegmentMetadataTransaction`
- Within `SegmentMetadataCache.writeCacheForDatasource()`:
  - Get or create a cache instance for the datasource
  - Acquire a reference to the cache instance
  - Acquire write lock on the cache instance
  - Perform the write operation
  - Invoke `SqlSegmentMetadataTransaction.close()`
  - Release write lock on the cache instance
  - Release the reference to the cache instance
- Finish JDBI transaction

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
