### PR TITLE
Remove query/node/backpressure from docs, configs.

### DIFF
--- a/docs/design/extensions-contrib/dropwizard.md
+++ b/docs/design/extensions-contrib/dropwizard.md
@@ -116,13 +116,6 @@ Latest default metrics mapping can be found [here] (https://github.com/apache/dr
     "type": "timer",
     "timeUnit": "MILLISECONDS"
   },
-  "query/node/backpressure": {
-    "dimensions": [
-      "server"
-    ],
-    "type": "timer",
-    "timeUnit": "MILLISECONDS"
-  },
   "query/segment/time": {
     "dimensions": [],
     "type": "timer",

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -56,7 +56,6 @@ Most metric values reset each emission period, as specified in `druid.monitoring
 |`query/node/time`|Milliseconds taken to query individual historical/realtime processes.|`id`, `status`, `server`|< 1s|
 |`query/node/bytes`|Number of bytes returned from querying individual historical/realtime processes.|`id`, `status`, `server`| |
 |`query/node/ttfb`|Time to first byte. Milliseconds elapsed until Broker starts receiving the response from individual historical/realtime processes.|`id`, `status`, `server`|< 1s|
-|`query/node/backpressure`|Milliseconds that the channel to this process has spent suspended due to backpressure.|`id`, `status`, `server`.| |
 |`query/count`|Number of total queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/success/count`|Number of queries successfully processed.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |
 |`query/failed/count`|Number of failed queries.|This metric is only available if the `QueryCountStatsMonitor` module is included.| |

--- a/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/dropwizard-emitter/src/main/resources/defaultMetricDimensions.json
@@ -21,13 +21,6 @@
     "type": "timer",
     "timeUnit": "MILLISECONDS"
   },
-  "query/node/backpressure": {
-    "dimensions": [
-      "server"
-    ],
-    "type": "timer",
-    "timeUnit": "MILLISECONDS"
-  },
   "query/segment/time": {
     "dimensions": [],
     "type": "timer",

--- a/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
@@ -4,7 +4,6 @@
   "query/node/time" : { "dimensions" : ["server"], "type" : "timer", "conversionFactor": 1000.0, "help": "Seconds taken to query individual historical/realtime processes."},
   "query/node/bytes" : { "dimensions" : ["server"], "type" : "count", "help": "Number of bytes returned from querying individual historical/realtime processes."},
   "query/node/ttfb" : { "dimensions" : ["server"], "type" : "timer", "conversionFactor": 1000.0, "help":  "Time to first byte. Seconds elapsed until Broker starts receiving the response from individual historical/realtime processes."},
-  "query/node/backpressure": { "dimensions" : ["server"], "type" : "timer", "conversionFactor": 1000.0, "help": "Seconds that the channel to this process has spent suspended due to backpressure."},
   "query/count" : { "dimensions" : [], "type" : "count", "help": "Number of total queries" },
   "query/success/count" : { "dimensions" : [], "type" : "count", "help": "Number of queries successfully processed"},
   "query/failed/count" : { "dimensions" : [], "type" : "count", "help": "Number of failed queries"},

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -4,7 +4,6 @@
   "query/node/time" : { "dimensions" : ["server"], "type" : "timer"},
   "query/node/ttfb" : { "dimensions" : ["server"], "type" : "timer"},
   "query/node/bytes" : { "dimensions" : ["server"], "type" : "count"},
-  "query/node/backpressure": { "dimensions" : ["server"], "type" : "timer"},
 
   "query/segment/time" : { "dimensions" : [], "type" : "timer"},
   "query/wait/time" : { "dimensions" : [], "type" : "timer"},


### PR DESCRIPTION
This metric was never actually released. It was reverted prior to going out, in #6631, pursuant to discussion in #6559. At the time it was controversial to add a new query-specific metric, due to the potential increase in traffic to users' metric systems.

Note that the code to generate the metric does exist, and can be enabled by site-specific `QueryMetrics` extensions. But the name `query/node/backpressure` is not specified and does not appear anywhere in the code. (Site-specific extensions must provide their own name.)