### PR TITLE
Cap default balancerComputeThreads at 100.

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/CoordinatorDynamicConfig.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.druid.common.config.Configs;
 import org.apache.druid.common.config.JacksonConfigManager;
 import org.apache.druid.error.InvalidInput;
+import org.apache.druid.server.coordinator.balancer.SegmentToMoveCalculator;
 import org.apache.druid.server.coordinator.duty.KillUnusedSegments;
 import org.apache.druid.server.coordinator.stats.Dimension;
 import org.apache.druid.server.http.SegmentLoadingMode;
@@ -422,7 +423,10 @@ public class CoordinatorDynamicConfig
    */
   public static int getDefaultBalancerComputeThreads()
   {
-    return Math.max(1, JvmUtils.getRuntimeInfo().getAvailableProcessors() / 2);
+    return Math.min(
+        Math.max(1, JvmUtils.getRuntimeInfo().getAvailableProcessors() / 2),
+        SegmentToMoveCalculator.MAX_BALANCER_THREADS
+    );
   }
 
   private static class Defaults

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculator.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/SegmentToMoveCalculator.java
@@ -41,6 +41,11 @@ import java.util.stream.Collectors;
 public class SegmentToMoveCalculator
 {
   /**
+   * Maximum number of balancer threads that can be passed to {@link #computeMaxSegmentsToMovePerTier}.
+   */
+  public static final int MAX_BALANCER_THREADS = 100;
+
+  /**
    * At least this number of segments must be picked for moving in every cycle
    * to keep the cluster well-balanced.
    */
@@ -132,7 +137,7 @@ public class SegmentToMoveCalculator
   )
   {
     Preconditions.checkArgument(
-        numBalancerThreads > 0 && numBalancerThreads <= 100,
+        numBalancerThreads > 0 && numBalancerThreads <= MAX_BALANCER_THREADS,
         "Number of balancer threads must be in range (0, 100]."
     );
     if (totalSegments <= 0) {


### PR DESCRIPTION
This is the limit required by SegmentToMoveCalculator, so using a number of threads higher than 100 cannot work.

Fixes #17801.