### PR TITLE
Add 'multipart' to spelling dictionary.

### DIFF
--- a/website/.spelling
+++ b/website/.spelling
@@ -425,6 +425,7 @@ microbatches
 misconfiguration
 misconfigured
 mostAvailableSize
+multipart
 multitenancy
 multitenant
 MVDs


### PR DESCRIPTION
Follow-up to #17674.

Not sure what happened with this. I thought the checks passed on that one, but maybe they passed long enough ago that they no longer pass today?