### PR TITLE
update parquet-avro to resolve CVE-2025-30065

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -201,7 +201,7 @@
         </dependency>
       </dependencies>
       <properties>
-        <parquet.version>1.13.0</parquet.version>
+        <parquet.version>1.15.1</parquet.version>
       </properties>
     </profile>
   </profiles>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3278,6 +3278,17 @@ notices:
 
 ---
 
+name: aircompressor
+license_category: binary
+module: extensions/druid-parquet-extensions
+license_name: Apache License version 2.0
+version: "2.0.2"
+libraries:
+  - io.airlift: aircompressor
+
+
+---
+
 name: Protocol Buffers Dynamic Schema
 license_category: binary
 module: extensions/protobuf-extensions

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3231,7 +3231,7 @@ name: Apache Parquet
 license_category: binary
 module: extensions/druid-parquet-extensions
 license_name: Apache License version 2.0
-version: 1.13.0
+version: 1.15.1
 libraries:
   - org.apache.parquet: parquet-avro
   - org.apache.parquet: parquet-column


### PR DESCRIPTION
### Description

Update third-party dependency: parquet-avro to address [CVE-2025-30065](https://nvd.nist.gov/vuln/detail/CVE-2025-30065)

#### Release note

Update: parquet-avro from 1.13.0 to 1.15.1 to resolve CVE-2025-30065

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
