### PR TITLE
Fix flakiness in compaction ITs

### DIFF
--- a/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/CoordinatorCompactionConfigsResource.java
@@ -22,10 +22,8 @@ package org.apache.druid.server.http;
 import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
 import org.apache.druid.audit.AuditInfo;
-import org.apache.druid.common.config.Configs;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.CompactionEngine;
-import org.apache.druid.server.coordinator.ClusterCompactionConfig;
 import org.apache.druid.server.coordinator.CoordinatorConfigManager;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.server.http.security.ConfigResourceFilter;
@@ -85,18 +83,9 @@ public class CoordinatorCompactionConfigsResource
       return ServletResourceUtils.buildUpdateResponse(() -> true);
     }
 
-    final ClusterCompactionConfig currentConfig = configManager.getCurrentCompactionConfig().clusterConfig();
-    final ClusterCompactionConfig updatedClusterConfig = new ClusterCompactionConfig(
-        Configs.valueOrDefault(compactionTaskSlotRatio, currentConfig.getCompactionTaskSlotRatio()),
-        Configs.valueOrDefault(maxCompactionTaskSlots, currentConfig.getMaxCompactionTaskSlots()),
-        currentConfig.getCompactionPolicy(),
-        currentConfig.isUseSupervisors(),
-        currentConfig.getEngine()
-    );
-
     final AuditInfo auditInfo = AuthorizationUtils.buildAuditInfo(req);
     return ServletResourceUtils.buildUpdateResponse(
-        () -> configManager.updateClusterCompactionConfig(updatedClusterConfig, auditInfo)
+        () -> configManager.updateCompactionTaskSlots(compactionTaskSlotRatio, maxCompactionTaskSlots, auditInfo)
     );
   }
 


### PR DESCRIPTION
### Description

#17834 has made some ITs flaky due to a race condition in the `/taskslots` Coordinator API.
Since the Overlord now exposes APIs to update compaction configs, the Coordinator may have
a stale version of the config while trying to update the task slots. This config is refreshed from
the metadata store every minute. But if the config has just been updated on the Overlord and
the taskslots API is called, it may end up reverting the change performed by the Overlord API.

This issue does not exist with the other compaction config APIs.

### Changes

- Use latest config in the `/taskslots` API

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
