### PR TITLE
update asynchttpclient to 2.12.4

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2040,7 +2040,7 @@ name: AsyncHttpClient asynchttpclient
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.5.3
+version: 2.12.4
 libraries:
   - org.asynchttpclient: async-http-client
   - org.asynchttpclient: async-http-client-netty-utils

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -479,7 +479,7 @@ name: Netty Reactive Streams
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.0.0
+version: 2.0.4
 libraries:
   - com.typesafe.netty: netty-reactive-streams
 
@@ -3852,7 +3852,7 @@ name: Reactive Streams
 license_category: binary
 module: java-core
 license_name: Creative Commons CC0
-version: 1.0.2
+version: 1.0.3
 license_file_path: licenses/bin/reactive-streams.CC0
 libraries:
   - org.reactivestreams: reactive-streams
@@ -5004,7 +5004,7 @@ name: jakarta.activation
 license_category: binary
 module: extensions/druid-avro-extensions
 license_name: Eclipse Distribution License 1.0
-version: 1.2.1
+version: 1.2.2
 libraries:
   - com.sun.activation: jakarta.activation
 

--- a/pom.xml
+++ b/pom.xml
@@ -997,7 +997,7 @@
                 <groupId>org.asynchttpclient</groupId>
                 <artifactId>async-http-client</artifactId>
                 <!-- Uses Netty 4.1.x -->
-                <version>2.5.3</version>
+                <version>2.12.4</version>
             </dependency>
             <dependency>
                 <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION

### Description
 Update asynchttpclient from 2.5.3 to 2.12.4 to resolve CVE-2024-53990

#### Release note

Update asynchttpclient from 2.5.3 to 2.12.4 to resolve CVE-2024-53990


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
