### PR TITLE
update pac4j library to resolve vulnerability in transitive nimbus-jose-jwt

### DIFF
--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -34,12 +34,11 @@
   </parent>
 
   <properties>
-    <pac4j.version>4.5.7</pac4j.version>
+    <pac4j.version>6.1.2</pac4j.version>
 
     <!-- Following must be updated along with any updates to pac4j version. One can find the compatible version of nimbus libraries in org.pac4j:pac4j-oidc dependencies-->
-    <nimbus.lang.tag.version>1.7</nimbus.lang.tag.version>
-    <nimbus.jose.jwt.version>8.22.1</nimbus.jose.jwt.version>
-    <oauth2.oidc.sdk.version>8.22</oauth2.oidc.sdk.version>
+    <nimbus.jose.jwt.version>10.0.2</nimbus.jose.jwt.version>
+    <oauth2.oidc.sdk.version>11.23.1</oauth2.oidc.sdk.version>
   </properties>
 
   <dependencies>
@@ -72,23 +71,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>lang-tag</artifactId>
-      <version>${nimbus.lang.tag.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>nimbus-jose-jwt</artifactId>
-      <version>${nimbus.jose.jwt.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>oauth2-oidc-sdk</artifactId>
-      <version>${oauth2.oidc.sdk.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -774,7 +774,7 @@ name: pac4j-oidc java security library
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 4.5.7
+version: 6.1.2
 libraries:
   - org.pac4j: pac4j-oidc
 
@@ -784,7 +784,7 @@ name: pac4j-core java security library
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 4.5.7
+version: 6.1.2
 libraries:
   - org.pac4j: pac4j-core
 
@@ -805,7 +805,7 @@ name: com.nimbusds nimbus-jose-jwt
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 8.22.1
+version: 10.0.2
 libraries:
   - com.nimbusds: nimbus-jose-jwt
 
@@ -815,7 +815,7 @@ name: com.nimbusds content-type
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 2.1
+version: 2.3
 libraries:
   - com.nimbusds: content-type
 
@@ -825,9 +825,19 @@ name: com.nimbusds oauth2-oidc-sdk
 license_category: binary
 module: extensions/druid-pac4j
 license_name: Apache License version 2.0
-version: 8.22
+version: 11.23.1
 libraries:
   - com.nimbusds: oauth2-oidc-sdk
+
+---
+
+name: org.springframework spring-core
+license_category: binary
+module: extensions/druid-pac4j
+license_name: Apache License version 2.0
+version: 6.2.5
+libraries:
+  - org.springframework: spring-core
 
 ---
 


### PR DESCRIPTION
### Description

Update pac4j from 4.5.7 to 6.1.2 to uplift transitive nimbus libraries to address CVE-2023-52428

#### Release note

Update pac4j from 4.5.7 to 6.1.2 to uplift transitive nimbus libraries to address CVE-2023-52428



This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
