### PR TITLE
Update all profiles to Parquet 1.15.1.

### DIFF
--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -33,7 +33,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <properties>
-    <parquet.version>1.13.1</parquet.version>
+    <parquet.version>1.15.1</parquet.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
PR https://github.com/apache/druid/pull/17874 missed one of the version tags, which would affect certain build profiles.