### PR TITLE
[Backport] Allow users to differentiate task pods from different namespaces in multi-namespace settings #17749

### DIFF
--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -748,6 +748,17 @@ If you are running multiple Druid clusters and would like to have a dedicated na
 
 Druid will tag Kubernetes jobs with a `druid.overlord.namespace` label. This label helps Druid filter out Kubernetes jobs belonging to other namespaces.
 
+##### Differentiating Task Pods Created From Multiple Namespaces
+
+When we have task pods started by Overlord servers of different Druid clusters, running in different K8S namespaces, it will be difficult to tell which task pods are being started by which overlord or Druid cluster. You can specify a task name prefix, `druid.indexer.runner.k8sTaskPodNamePrefix`, to apply your specified prefix to all task pods created by your cluster.
+
+After configuration, you can witness the change from `coordinatorissuedcompactdataso-0e74d5132781cc950eecf04--1-vbx6t` to `yourtaskprefix-0e74d5132781cc950eecf04--1-vbx6t` by either doing `kubectl get pods` or by viewing the "Location" column under the web console.
+
+When configuring the `druid.indexer.runner.k8sTaskPodNamePrefix`, you should note that:
+- The prefix will cut off at 30 characters, as the task pod names must respect a character limit of 63 in Kubernetes.
+- Special characters `: - . _` will be ignored.
+- The prefix will be converted to lowercase.
+
 ##### Dealing with ZooKeeper Problems
 
 Ensure that when you are running task pods in another namespace, your task pods are able to communicate with ZooKeeper which might be deployed in the same namespace with overlord. If you are using custom pod templates as described below, you can configure `druid.zk.service.host` to your tasks.
@@ -761,6 +772,7 @@ Should you require the needed permissions for interacting across Kubernetes name
 | --- | --- | --- | --- | --- |
 | `druid.indexer.runner.namespace` | `String` | If Overlord and task pods are running in different namespaces, specify the Overlord namespace. | - | Yes |
 | `druid.indexer.runner.overlordNamespace` | `String` | Only applicable when using Custom Template Pod Adapter. If Overlord and task pods are running in different namespaces, specify the Overlord namespace. | `druid.indexer.runner.namespace` | No |
+| `druid.indexer.runner.k8sTaskPodNamePrefix` | `String` |  Use this if you want to change your task name to contain a more human-readable prefix. Maximum 30 characters. Special characters `: - . _` will be ignored. | `""` | No |
 | `druid.indexer.runner.debugJobs` | `boolean` | Clean up K8s jobs after tasks complete. | False | No |
 | `druid.indexer.runner.sidecarSupport` | `boolean` | Deprecated, specify adapter type as runtime property `druid.indexer.runner.k8s.adapter.type: overlordMultiContainer` instead. If your overlord pod has sidecars, this will attempt to start the task with the same sidecars as the overlord pod. | False | No |
 | `druid.indexer.runner.primaryContainerName` | `String` | If running with sidecars, the `primaryContainerName` should be that of your druid container like `druid-overlord`. | First container in `podSpec` list | No |

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycle.java
@@ -100,14 +100,15 @@ public class KubernetesPeonLifecycle
 
   protected KubernetesPeonLifecycle(
       Task task,
+      K8sTaskId taskId,
       KubernetesPeonClient kubernetesClient,
       TaskLogs taskLogs,
       ObjectMapper mapper,
       TaskStateListener stateListener
   )
   {
-    this.taskId = new K8sTaskId(task);
     this.task = task;
+    this.taskId = taskId;
     this.kubernetesClient = kubernetesClient;
     this.taskLogs = taskLogs;
     this.mapper = mapper;

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
@@ -21,6 +21,7 @@ package org.apache.druid.k8s.overlord;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.tasklogs.TaskLogs;
 
@@ -42,10 +43,11 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
   }
 
   @Override
-  public KubernetesPeonLifecycle build(Task task, KubernetesPeonLifecycle.TaskStateListener stateListener)
+  public KubernetesPeonLifecycle build(Task task, K8sTaskId k8sTaskId, KubernetesPeonLifecycle.TaskStateListener stateListener)
   {
     return new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         client,
         taskLogs,
         mapper,

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -52,6 +52,7 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.InputStreamResponseHandler;
+import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
 import org.apache.druid.tasklogs.TaskLogStreamer;
@@ -154,6 +155,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
           exec.submit(() -> runTask(task)),
           peonLifecycleFactory.build(
               task,
+              new K8sTaskId(config.getK8sTaskPodNamePrefix(), task),
               this::emitTaskStateMetrics
           )
       )).getResult();
@@ -168,6 +170,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
           exec.submit(() -> joinTask(task)),
           peonLifecycleFactory.build(
               task,
+              new K8sTaskId(config.getK8sTaskPodNamePrefix(), task),
               this::emitTaskStateMetrics
           )
       ));

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
@@ -39,6 +39,9 @@ public class KubernetesTaskRunnerConfig
   @NotNull
   private String namespace;
 
+  @JsonProperty
+  private String k8sTaskPodNamePrefix = "";
+
   // This property is the namespace that the Overlord is running in.
   // For cases where we want task pods to run on different namespace from the overlord, we need to specify the namespace of the overlord here.
   // Else, we can simply leave this field alone.
@@ -140,6 +143,7 @@ public class KubernetesTaskRunnerConfig
   private KubernetesTaskRunnerConfig(
       @Nonnull String namespace,
       String overlordNamespace,
+      String k8sTaskPodNamePrefix,
       boolean debugJobs,
       boolean sidecarSupport,
       String primaryContainerName,
@@ -164,6 +168,7 @@ public class KubernetesTaskRunnerConfig
         overlordNamespace,
         this.overlordNamespace
     );
+    this.k8sTaskPodNamePrefix = k8sTaskPodNamePrefix;
     this.debugJobs = ObjectUtils.defaultIfNull(
         debugJobs,
         this.debugJobs
@@ -239,6 +244,11 @@ public class KubernetesTaskRunnerConfig
   public String getOverlordNamespace()
   {
     return overlordNamespace == null ? namespace : overlordNamespace;
+  }
+
+  public String getK8sTaskPodNamePrefix()
+  {
+    return k8sTaskPodNamePrefix;
   }
 
   public boolean isDebugJobs()
@@ -337,6 +347,7 @@ public class KubernetesTaskRunnerConfig
   {
     private String namespace;
     private String overlordNamespace;
+    private String k8sTaskPodNamePrefix;
     private boolean debugJob;
     private boolean sidecarSupport;
     private String primaryContainerName;
@@ -368,6 +379,12 @@ public class KubernetesTaskRunnerConfig
     public Builder withOverlordNamespace(String overlordNamespace)
     {
       this.overlordNamespace = overlordNamespace;
+      return this;
+    }
+
+    public Builder withK8sTaskPodNamePrefix(String k8sTaskPodNamePrefix)
+    {
+      this.k8sTaskPodNamePrefix = k8sTaskPodNamePrefix;
       return this;
     }
 
@@ -479,6 +496,7 @@ public class KubernetesTaskRunnerConfig
       return new KubernetesTaskRunnerConfig(
           this.namespace,
           this.overlordNamespace,
+          this.k8sTaskPodNamePrefix,
           this.debugJob,
           this.sidecarSupport,
           this.primaryContainerName,

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/PeonLifecycleFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/PeonLifecycleFactory.java
@@ -20,8 +20,9 @@
 package org.apache.druid.k8s.overlord;
 
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.k8s.overlord.common.K8sTaskId;
 
 public interface PeonLifecycleFactory
 {
-  KubernetesPeonLifecycle build(Task task, KubernetesPeonLifecycle.TaskStateListener stateListener);
+  KubernetesPeonLifecycle build(Task task, K8sTaskId taskId, KubernetesPeonLifecycle.TaskStateListener stateListener);
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskId.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/K8sTaskId.java
@@ -29,15 +29,15 @@ public class K8sTaskId
   private final String k8sJobName;
   private final String originalTaskId;
 
-  public K8sTaskId(Task task)
+  public K8sTaskId(String k8sTaskPodNamePrefix, Task task)
   {
-    this(task.getId());
+    this(k8sTaskPodNamePrefix, task.getId());
   }
 
-  public K8sTaskId(String taskId)
+  public K8sTaskId(String k8sTaskPodNamePrefix, String taskId)
   {
     this.originalTaskId = taskId;
-    this.k8sJobName = KubernetesOverlordUtils.convertTaskIdToJobName(taskId);
+    this.k8sJobName = KubernetesOverlordUtils.convertTaskIdToJobName(k8sTaskPodNamePrefix, taskId);
   }
 
   public String getK8sJobName()

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesOverlordUtils.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesOverlordUtils.java
@@ -46,9 +46,22 @@ public class KubernetesOverlordUtils
         .toLowerCase(Locale.ENGLISH), 63);
   }
 
+  public static String convertTaskIdToJobName(String k8sTaskPodNamePrefix, String taskId)
+  {
+    return (k8sTaskPodNamePrefix == null || k8sTaskPodNamePrefix.isEmpty())
+      ? convertTaskIdToJobName(taskId)
+      : StringUtils.left(RegExUtils.replaceAll(k8sTaskPodNamePrefix, K8S_TASK_ID_PATTERN, "")
+               .toLowerCase(Locale.ENGLISH), 30) + "-" + hashString(taskId);
+  }
+
   public static String convertTaskIdToJobName(String taskId)
   {
     return taskId == null ? "" : StringUtils.left(RegExUtils.replaceAll(taskId, K8S_TASK_ID_PATTERN, "")
-        .toLowerCase(Locale.ENGLISH), 30) + "-" + Hashing.murmur3_128().hashString(taskId, StandardCharsets.UTF_8);
+        .toLowerCase(Locale.ENGLISH), 30) + "-" + hashString(taskId);
+  }
+
+  private static String hashString(String rawString)
+  {
+    return Hashing.murmur3_128().hashString(rawString, StandardCharsets.UTF_8).toString();
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapter.java
@@ -173,7 +173,7 @@ public abstract class K8sTaskAdapter implements TaskAdapter
     if (taskId == null) {
       throw DruidException.defensive().build("No task_id annotation found on pod spec for job [%s]", from.getMetadata().getName());
     }
-    return new K8sTaskId(taskId);
+    return new K8sTaskId(taskRunnerConfig.getK8sTaskPodNamePrefix(), taskId);
   }
 
   @VisibleForTesting

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/MultiContainerTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/MultiContainerTaskAdapter.java
@@ -76,7 +76,7 @@ public class MultiContainerTaskAdapter extends K8sTaskAdapter
   @Override
   Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException
   {
-    K8sTaskId k8sTaskId = new K8sTaskId(task.getId());
+    K8sTaskId k8sTaskId = new K8sTaskId(taskRunnerConfig.getK8sTaskPodNamePrefix(), task.getId());
 
     // get the container size from java_opts array
     long containerSize = getContainerMemory(context);

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -130,7 +130,7 @@ public class PodTemplateTaskAdapter implements TaskAdapter
 
     return new JobBuilder()
         .withNewMetadata()
-        .withName(new K8sTaskId(task).getK8sJobName())
+        .withName(new K8sTaskId(taskRunnerConfig.getK8sTaskPodNamePrefix(), task).getK8sJobName())
         .addToLabels(getJobLabels(taskRunnerConfig, task))
         .addToAnnotations(getJobAnnotations(taskRunnerConfig, task))
         .addToAnnotations(DruidK8sConstants.TASK_JOB_TEMPLATE, podTemplateWithName.getName())
@@ -209,7 +209,7 @@ public class PodTemplateTaskAdapter implements TaskAdapter
     if (taskId == null) {
       throw DruidException.defensive().build("No task_id annotation found on pod spec for job [%s]", from.getMetadata().getName());
     }
-    return new K8sTaskId(taskId);
+    return new K8sTaskId(taskRunnerConfig.getK8sTaskPodNamePrefix(), taskId);
   }
 
   private Collection<EnvVar> getEnv(Task task) throws IOException

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/SingleContainerTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/SingleContainerTaskAdapter.java
@@ -64,7 +64,7 @@ public class SingleContainerTaskAdapter extends K8sTaskAdapter
   @Override
   Job createJobFromPodSpec(PodSpec podSpec, Task task, PeonCommandContext context) throws IOException
   {
-    K8sTaskId k8sTaskId = new K8sTaskId(task.getId());
+    K8sTaskId k8sTaskId = new K8sTaskId(taskRunnerConfig.getK8sTaskPodNamePrefix(), task.getId());
 
     // get the container size from java_opts array
     long containerSize = getContainerMemory(context);

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -75,7 +75,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     mapper = new TestUtils().getTestObjectMapper();
     task = K8sTestUtils.createTask(ID, 0);
-    k8sTaskId = new K8sTaskId(task);
+    k8sTaskId = new K8sTaskId(null, task);
     EasyMock.expect(logWatch.getOutput()).andReturn(IOUtils.toInputStream("", StandardCharsets.UTF_8)).anyTimes();
   }
 
@@ -84,6 +84,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -129,6 +130,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -173,6 +175,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -222,6 +225,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -266,6 +270,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -313,6 +318,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -351,6 +357,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -404,6 +411,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -464,6 +472,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -512,6 +521,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -562,6 +572,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -612,6 +623,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -651,6 +663,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -664,6 +677,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -685,6 +699,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -706,6 +721,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -721,6 +737,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -736,6 +753,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -751,6 +769,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -774,6 +793,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -790,6 +810,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -806,6 +827,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -822,6 +844,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -844,6 +867,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -872,6 +896,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -908,6 +933,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -944,6 +970,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,
@@ -981,6 +1008,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        k8sTaskId,
         kubernetesClient,
         taskLogs,
         mapper,

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
@@ -23,6 +23,7 @@ import org.apache.druid.indexer.RunnerTaskState;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
@@ -37,6 +38,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
 {
   private KubernetesWorkItem workItem;
   private Task task;
+  private K8sTaskId taskId;
 
   @Mock
   KubernetesPeonLifecycle kubernetesPeonLifecycle;
@@ -45,6 +47,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   public void setup()
   {
     task = NoopTask.create();
+    taskId = new K8sTaskId(null, task);
   }
 
   @Test
@@ -123,6 +126,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        taskId,
         null,
         null,
         null,
@@ -138,6 +142,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        taskId,
         null,
         null,
         null,
@@ -160,6 +165,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        taskId,
         null,
         null,
         null,
@@ -182,6 +188,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        taskId,
         null,
         null,
         null,
@@ -204,6 +211,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        taskId,
         null,
         null,
         null,
@@ -218,6 +226,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   {
     KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
         task,
+        taskId,
         null,
         null,
         null,

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/TestPeonLifecycleFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/TestPeonLifecycleFactory.java
@@ -20,6 +20,7 @@
 package org.apache.druid.k8s.overlord;
 
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.k8s.overlord.common.K8sTaskId;
 
 public class TestPeonLifecycleFactory implements PeonLifecycleFactory
 {
@@ -31,7 +32,7 @@ public class TestPeonLifecycleFactory implements PeonLifecycleFactory
   }
 
   @Override
-  public KubernetesPeonLifecycle build(Task task, KubernetesPeonLifecycle.TaskStateListener stateListener)
+  public KubernetesPeonLifecycle build(Task task, K8sTaskId taskId, KubernetesPeonLifecycle.TaskStateListener stateListener)
   {
     return kubernetesPeonLifecycle;
   }

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskIdTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/K8sTaskIdTest.java
@@ -30,8 +30,24 @@ public class K8sTaskIdTest
   public void testModifyingTaskIDToBeK8sCompliant()
   {
     String original = "coordinator-issued_compact_k8smetrics_aeifmefd_2022-08-18T15:33:26.094Z";
-    String result = new K8sTaskId(original).getK8sJobName();
+    String result = new K8sTaskId(null, original).getK8sJobName();
     assertEquals("coordinatorissuedcompactk8smet-2e2c1862cb7ad1d01f4794b27a4438b0", result);
+  }
+
+  @Test
+  public void testModifyingTaskIDWithEmptyK8sTaskPrefixToBeK8sCompliant()
+  {
+    String original = "coordinator-issued_compact_k8smetrics_aeifmefd_2022-08-18T15:33:26.094Z";
+    String result = new K8sTaskId("", original).getK8sJobName();
+    assertEquals("coordinatorissuedcompactk8smet-2e2c1862cb7ad1d01f4794b27a4438b0", result);
+  }
+
+  @Test
+  public void testModifyingTaskIDWithLongK8sTaskPrefixToBeK8sCompliant()
+  {
+    String original = "coordinator-issued_compact_k8smetrics_aeifmefd_2022-08-18T15:33:26.094Z";
+    String result = new K8sTaskId("this-is_a:VERY-very-long-task-name-prefix", original).getK8sJobName();
+    assertEquals("thisisaveryverylongtasknamepre-2e2c1862cb7ad1d01f4794b27a4438b0", result);
   }
 
   @Test

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 public class KubernetesPeonClientTest
 {
   private static final String ID = "id";
+  private static final String TASK_NAME_PREFIX = "";
   private static final String JOB_NAME = ID;
   private static final String KUBERNETES_JOB_NAME = KubernetesOverlordUtils.convertTaskIdToJobName(JOB_NAME);
   private static final String POD_NAME = "name";
@@ -164,7 +165,7 @@ public class KubernetesPeonClientTest
     client.batch().v1().jobs().inNamespace(NAMESPACE).resource(job).create();
 
     JobResponse jobResponse = instance.waitForPeonJobCompletion(
-        new K8sTaskId(ID),
+        new K8sTaskId(TASK_NAME_PREFIX, ID),
         1,
         TimeUnit.SECONDS
     );
@@ -189,7 +190,7 @@ public class KubernetesPeonClientTest
     client.batch().v1().jobs().inNamespace(NAMESPACE).resource(job).create();
 
     JobResponse jobResponse = instance.waitForPeonJobCompletion(
-        new K8sTaskId(ID),
+        new K8sTaskId(TASK_NAME_PREFIX, ID),
         1,
         TimeUnit.SECONDS
     );
@@ -202,7 +203,7 @@ public class KubernetesPeonClientTest
   void test_waitforPeonJobCompletion_withoutRunningJob_returnsJobResponseWithEmptyJobAndFailedPeonPhase()
   {
     JobResponse jobResponse = instance.waitForPeonJobCompletion(
-        new K8sTaskId(ID),
+        new K8sTaskId(TASK_NAME_PREFIX, ID),
         1,
         TimeUnit.SECONDS
     );
@@ -222,13 +223,13 @@ public class KubernetesPeonClientTest
 
     client.batch().v1().jobs().inNamespace(NAMESPACE).resource(job).create();
 
-    Assertions.assertTrue(instance.deletePeonJob(new K8sTaskId(ID)));
+    Assertions.assertTrue(instance.deletePeonJob(new K8sTaskId(TASK_NAME_PREFIX, ID)));
   }
 
   @Test
   void test_deletePeonJob_withoutJob_returnsFalse()
   {
-    Assertions.assertFalse(instance.deletePeonJob(new K8sTaskId(ID)));
+    Assertions.assertFalse(instance.deletePeonJob(new K8sTaskId(TASK_NAME_PREFIX, ID)));
   }
 
   @Test
@@ -249,7 +250,7 @@ public class KubernetesPeonClientTest
 
     client.batch().v1().jobs().inNamespace(NAMESPACE).resource(job).create();
 
-    Assertions.assertTrue(instance.deletePeonJob(new K8sTaskId(ID)));
+    Assertions.assertTrue(instance.deletePeonJob(new K8sTaskId(TASK_NAME_PREFIX, ID)));
 
     Assertions.assertNotNull(
         client.batch().v1().jobs().inNamespace(NAMESPACE).withName(KUBERNETES_JOB_NAME).get()
@@ -266,7 +267,7 @@ public class KubernetesPeonClientTest
         serviceEmitter
     );
 
-    Assertions.assertTrue(instance.deletePeonJob(new K8sTaskId(ID)));
+    Assertions.assertTrue(instance.deletePeonJob(new K8sTaskId(TASK_NAME_PREFIX, ID)));
   }
 
   @Test
@@ -316,7 +317,7 @@ public class KubernetesPeonClientTest
         .andReturn(HttpURLConnection.HTTP_OK, "data")
         .once();
 
-    Optional<InputStream> maybeInputStream = instance.getPeonLogs(new K8sTaskId(ID));
+    Optional<InputStream> maybeInputStream = instance.getPeonLogs(new K8sTaskId(TASK_NAME_PREFIX, ID));
     Assertions.assertTrue(maybeInputStream.isPresent());
   }
 
@@ -331,14 +332,14 @@ public class KubernetesPeonClientTest
 
     client.batch().v1().jobs().inNamespace(NAMESPACE).resource(job).create();
 
-    Optional<InputStream> maybeInputStream = instance.getPeonLogs(new K8sTaskId(ID));
+    Optional<InputStream> maybeInputStream = instance.getPeonLogs(new K8sTaskId(TASK_NAME_PREFIX, ID));
     Assertions.assertFalse(maybeInputStream.isPresent());
   }
 
   @Test
   void test_getPeonLogs_withoutJob_returnsEmptyOptional()
   {
-    Optional<InputStream> stream = instance.getPeonLogs(new K8sTaskId(ID));
+    Optional<InputStream> stream = instance.getPeonLogs(new K8sTaskId(TASK_NAME_PREFIX, ID));
     Assertions.assertFalse(stream.isPresent());
   }
 
@@ -524,7 +525,7 @@ public class KubernetesPeonClientTest
             .build()
         ).once();
 
-    Pod pod = instance.getPeonPodWithRetries(new K8sTaskId(ID).getK8sJobName());
+    Pod pod = instance.getPeonPodWithRetries(new K8sTaskId(TASK_NAME_PREFIX, ID).getK8sJobName());
 
     Assertions.assertNotNull(pod);
   }
@@ -534,7 +535,7 @@ public class KubernetesPeonClientTest
   {
     Assertions.assertThrows(
         DruidException.class,
-        () -> instance.getPeonPodWithRetries(clientApi.getClient(), new K8sTaskId(ID).getK8sJobName(), 1, 1),
+        () -> instance.getPeonPodWithRetries(clientApi.getClient(), new K8sTaskId(TASK_NAME_PREFIX, ID).getK8sJobName(), 1, 1),
         StringUtils.format("K8s pod with label: job-name=%s not found", ID)
     );
   }
@@ -586,7 +587,7 @@ public class KubernetesPeonClientTest
         .andReturn(HttpURLConnection.HTTP_OK, "data")
         .once();
 
-    Optional<LogWatch> maybeLogWatch = instance.getPeonLogWatcher(new K8sTaskId(ID));
+    Optional<LogWatch> maybeLogWatch = instance.getPeonLogWatcher(new K8sTaskId(TASK_NAME_PREFIX, ID));
     Assertions.assertTrue(maybeLogWatch.isPresent());
   }
 
@@ -594,7 +595,7 @@ public class KubernetesPeonClientTest
   @Test
   void test_getPeonLogsWatcher_withoutJob_returnsEmptyOptional()
   {
-    Optional<LogWatch> maybeLogWatch = instance.getPeonLogWatcher(new K8sTaskId(ID));
+    Optional<LogWatch> maybeLogWatch = instance.getPeonLogWatcher(new K8sTaskId(TASK_NAME_PREFIX, ID));
     Assertions.assertFalse(maybeLogWatch.isPresent());
   }
 
@@ -609,7 +610,7 @@ public class KubernetesPeonClientTest
 
     client.batch().v1().jobs().inNamespace(NAMESPACE).resource(job).create();
 
-    Optional<LogWatch> maybeLogWatch = instance.getPeonLogWatcher(new K8sTaskId(ID));
+    Optional<LogWatch> maybeLogWatch = instance.getPeonLogWatcher(new K8sTaskId(TASK_NAME_PREFIX, ID));
     Assertions.assertFalse(maybeLogWatch.isPresent());
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
@@ -136,7 +136,7 @@ public class DruidPeonClientIntegrationTest
     List<Job> jobs = peonClient.getPeonJobs();
     assertEquals(1, jobs.size());
 
-    K8sTaskId taskId = new K8sTaskId(task.getId());
+    K8sTaskId taskId = new K8sTaskId(null, task.getId());
     InputStream peonLogs = peonClient.getPeonLogs(taskId).get();
     List<Integer> expectedLogs = IntStream.range(1, 1001).boxed().collect(Collectors.toList());
     List<Integer> actualLogs = new ArrayList<>();

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapterTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/K8sTaskAdapterTest.java
@@ -324,7 +324,7 @@ class K8sTaskAdapterTest
         .addToAnnotations(DruidK8sConstants.TASK_ID, "ID")
         .endMetadata().endTemplate().endSpec().build();
 
-    assertEquals(new K8sTaskId("ID"), adapter.getTaskId(job));
+    assertEquals(new K8sTaskId(null, "ID"), adapter.getTaskId(job));
   }
 
   @Test

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapterTest.java
@@ -182,7 +182,29 @@ public class PodTemplateTaskAdapterTest
         .addToAnnotations(DruidK8sConstants.TASK_ID, "ID")
         .endMetadata().endTemplate().endSpec().build();
 
-    assertEquals(new K8sTaskId("ID"), adapter.getTaskId(job));
+    assertEquals(new K8sTaskId(null, "ID"), adapter.getTaskId(job));
+  }
+
+  @Test
+  public void test_getTaskIdWithK8sTaskPodNamePrefix()
+  {
+    TestPodTemplateSelector podTemplateSelector = new TestPodTemplateSelector(podTemplateSpec);
+    taskRunnerConfig = KubernetesTaskRunnerConfig.builder().withK8sTaskPodNamePrefix("k8sTaskPodNamePrefix").build();
+
+    PodTemplateTaskAdapter adapter = new PodTemplateTaskAdapter(
+        taskRunnerConfig,
+        taskConfig,
+        node,
+        mapper,
+        taskLogs,
+        podTemplateSelector
+    );
+    Job job = new JobBuilder()
+        .editSpec().editTemplate().editMetadata()
+        .addToAnnotations(DruidK8sConstants.TASK_ID, "ID")
+        .endMetadata().endTemplate().endSpec().build();
+
+    assertEquals(new K8sTaskId("k8sTaskPodNamePrefix", "ID"), adapter.getTaskId(job));
   }
 
   @Test


### PR DESCRIPTION
Backport #11749 to the Druid 33 branch