### PR TITLE
Update log level for better problem solving

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
@@ -442,7 +442,7 @@ public class Lifecycle
           }
         }
         if (doStart) {
-          log.debug("Invoking start method[%s] on object[%s].", method, o);
+          log.info("Starting lifecycle [%s#%s]", o.getClass().getSimpleName(), method.getName());
           method.invoke(o);
         }
       }
@@ -460,7 +460,7 @@ public class Lifecycle
           }
         }
         if (doStop) {
-          log.debug("Invoking stop method[%s] on object[%s].", method, o);
+          log.debug("Stopping lifecyle [%s#%s].", o.getClass().getSimpleName(), method.getName());
           try {
             method.invoke(o);
           }

--- a/server/src/main/java/org/apache/druid/discovery/BaseNodeRoleWatcher.java
+++ b/server/src/main/java/org/apache/druid/discovery/BaseNodeRoleWatcher.java
@@ -187,7 +187,7 @@ public class BaseNodeRoleWatcher
         return;
       }
 
-      LOGGER.info("Node [%s] of role [%s] went offline.", druidNode.getDruidNode().getUriToUse(), nodeRole.getJsonName());
+      LOGGER.warn("Node [%s] of role [%s] went offline.", druidNode.getDruidNode().getUriToUse(), nodeRole.getJsonName());
 
       removeNode(druidNode);
     }


### PR DESCRIPTION
### Description

- Updated the log level from DEBUG to INFO for starting phase of Lifecycle. 

We had a cluster which has tasks occasionally failed. They were killed by overlord because of slow start of some lifecycle phase. It turned out to be the Hdfs availability check after long investigation. So turning the logging level to INFO helps.
The STOP phase is still kept as DEBUG.

Now it will show sth like: 
```
2025-04-07T06:51:27,285 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle - Starting lifecycle [module] stage [NORMAL]
2025-04-07T06:51:27,301 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [DerbyConnector#start]
2025-04-07T06:51:27,750 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [ConfigManager#start]
2025-04-07T06:51:27,752 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [ServiceEmitter#start]
2025-04-07T06:51:27,766 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [BasicMonitorScheduler#start]
2025-04-07T06:51:27,766 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [HdfsStorageAuthentication#authenticate]
2025-04-07T06:51:27,767 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [HdfsStorageAvailabilityChecker#checkHdfsAvailability]
2025-04-07T06:51:27,768 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [NettyHttpClient#start]
2025-04-07T06:51:27,768 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [CuratorDruidNodeDiscoveryProvider#start]
2025-04-07T06:51:27,768 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [HttpServerInventoryView#start]
2025-04-07T06:51:27,773 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [CoordinatorServerView#start]
2025-04-07T06:51:32,810 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [SqlSegmentsMetadataManager#start]
2025-04-07T06:51:32,829 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [SQLMetadataRuleManager#start]
2025-04-07T06:51:32,832 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [NettyHttpClient#start]
2025-04-07T06:51:32,833 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [DruidLeaderClient#start]
2025-04-07T06:51:32,833 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [SQLMetadataSupervisorManager#start]
2025-04-07T06:51:32,843 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [IndexerSQLMetadataStorageCoordinator#start]
2025-04-07T06:51:32,855 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [DruidCoordinator#start]
2025-04-07T06:51:32,856 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [MetadataTaskStorage#start]
2025-04-07T06:51:32,934 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [SegmentAllocationQueue#start]
2025-04-07T06:51:32,935 INFO [main] org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler - Starting lifecycle [TaskMaster#start]

```


- Updated the node offline from INFO to WARN. This is very useful for tasks especially coordinator/overlord go offline.
Previously, it's hard to tell such logging at first glance from other lots of INFO logging around for example:

```
2025-04-06T15:02:44,114 INFO [NodeRoleWatcher[COORDINATOR]] org.apache.druid.discovery.BaseNodeRoleWatcher - Node [http://10.242.44.224:8081] of role [coordinator] detected.
2025-04-06T15:02:44,115 INFO [NodeRoleWatcher[COORDINATOR]] org.apache.druid.discovery.BaseNodeRoleWatcher - Node [http://10.242.20.102:8081] of role [coordinator] detected.
2025-04-06T15:02:44,115 INFO [NodeRoleWatcher[COORDINATOR]] org.apache.druid.discovery.BaseNodeRoleWatcher - Node watcher of role [coordinator] is now initialized with 2 nodes.
2025-04-06T15:02:49,660 INFO [NodeRoleWatcher[COORDINATOR]] org.apache.druid.discovery.BaseNodeRoleWatcher - Node [http://10.242.44.224:8081] of role [coordinator] went offline.
```


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
