### PR TITLE
Fix BlobClient issues because of breaking change wrt URL encoding

### DIFF
--- a/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
+++ b/extensions-core/azure-extensions/src/main/java/org/apache/druid/storage/azure/AzureStorage.java
@@ -32,7 +32,6 @@ import com.azure.storage.blob.models.ParallelTransferOptions;
 import com.azure.storage.blob.options.BlobInputStreamOptions;
 import com.azure.storage.blob.options.BlockBlobOutputStreamOptions;
 import com.azure.storage.blob.specialized.BlockBlobClient;
-import com.azure.storage.common.Utility;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import org.apache.druid.java.util.common.RE;
@@ -158,7 +157,7 @@ public class AzureStorage
     final BlockBlobClient blockBlobClient = azureClientFactory
         .getBlobServiceClient(maxAttempts, defaultStorageAccount)
         .createBlobContainerIfNotExists(containerName)
-        .getBlobClient(Utility.urlEncode(blobName))
+        .getBlobClient(blobName)
         .getBlockBlobClient();
 
     // TODO based on the usage here, it might be better to overwrite the existing blob instead; that's what StorageConnector#write documents it does
@@ -187,7 +186,7 @@ public class AzureStorage
     return azureClientFactory
         .getBlobServiceClient(null, defaultStorageAccount)
         .getBlobContainerClient(containerName)
-        .getBlobClient(Utility.urlEncode(blobName))
+        .getBlobClient(blobName)
         .getBlockBlobClient()
         .getProperties()
         .getBlobSize();
@@ -243,7 +242,7 @@ public class AzureStorage
     return azureClientFactory
         .getBlobServiceClient(maxAttempts, defaultStorageAccount)
         .getBlobContainerClient(containerName)
-        .getBlobClient(Utility.urlEncode(blobName))
+        .getBlobClient(blobName)
         .openInputStream(new BlobInputStreamOptions().setRange(new BlobRange(offset, length)));
   }
 
@@ -335,7 +334,7 @@ public class AzureStorage
     return azureClientFactory
         .getBlobServiceClient(maxAttempts, defaultStorageAccount)
         .getBlobContainerClient(container)
-        .getBlobClient(Utility.urlEncode(blobName))
+        .getBlobClient(blobName)
         .exists();
   }
 
@@ -442,7 +441,7 @@ public class AzureStorage
       blobContainerClient
           // Creates a blob by default, no need to use a specific blob client.
           // We also need to urlEncode the path to handle special characters.
-          .getBlobClient(Utility.urlEncode(blobName))
+          .getBlobClient(blobName)
 
           // Set overwrite to true to keep behavior more similar to s3Client.putObject.
           .upload(stream, file.length(), true);


### PR DESCRIPTION
### Description

In https://github.com/apache/druid/pull/17576, we updated the Azure BOM from version `1.2.23` to `1.2.30`. This updated the `azure-storage-blob` package from `12.25.4` to `12.29.0`.

But, version `12.26.0-beta.1` included a breaking change, as can be seen here: https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/storage/azure-storage-blob/CHANGELOG.md#12260-beta1-2024-04-15

Quoting here for quick reference:
> When creating a BlobClient via BlobContainerClient.getBlobClient(String blobName) or BlobServiceClient.getBlobClient(String blobName), the blob name will be stored exactly as passed in and will not be URL-encoded. For example, if blob name is "test%25test" and is created by calling BlobContainerClient.getBlobClient("test%25test") or BlobClient.getBlobName("test%25test"), BlobClient.getBlobName() will return "test%25test" and the blob's url will result in “[https://account.blob.core.windows.net/container/test%25%25test”](https://account.blob.core.windows.net/container/test%25%25test%E2%80%9D).

I also verified this by trying it against an actual Azure setup.

For the test, I had a blob container named `akshat-testing`, in which I had 2 files with the following hierarchy and names:
1. `akshat-testing/outer folder/inner folder/file1`
2. `akshat-testing/outer%20folder/inner%20folder/file2`

I then tried using the library method to fetch info about the blob:
```java
    long blobSize = clientBuilder
        .buildClient()
        .getBlobContainerClient("akshat-testing")
        .getBlobClient(blobPath)
        .getBlockBlobClient()
        .getProperties()
        .getBlobSize();
```

The conclusions with usage of the above method confirmed the reported breaking change as well as the fix being done in this PR.

For version `12.29.0`:
1. `"outer folder/inner folder/file1"` - Passing this `blobPath` directly works, but URL encoded doesn't work
2. `"outer%20folder/inner%20folder/file2"` - Passing this `blobPath` directly works, but URL encoded doesn't work

Comparing this with the older version `12.25.4`:
1. `"outer folder/inner folder/file1"` - Passing this `blobPath` directly works, and URL encoded also works
2. `"outer%20folder/inner%20folder/file2"` - Passing this `blobPath` directly doesn't work, but URL encoded works

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
