### PR TITLE
Fix ExprEval of BigDecimal data type

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/ExprEval.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExprEval.java
@@ -33,6 +33,7 @@ import org.apache.druid.segment.column.Types;
 import org.apache.druid.segment.nested.StructuredData;
 
 import javax.annotation.Nullable;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
@@ -388,7 +389,7 @@ public abstract class ExprEval<T>
       return new StringExprEval((String) val);
     }
     if (val instanceof Number) {
-      if (val instanceof Float || val instanceof Double) {
+      if (val instanceof Float || val instanceof Double || val instanceof BigDecimal) {
         return new DoubleExprEval((Number) val);
       }
       return new LongExprEval((Number) val);

--- a/processing/src/test/java/org/apache/druid/math/expr/EvalTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/EvalTest.java
@@ -33,6 +33,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1379,6 +1380,9 @@ public class EvalTest extends InitializedNullHandlingTest
     // longs
     assertBestEffortOf(1L, ExpressionType.LONG, 1L);
     assertBestEffortOf(1, ExpressionType.LONG, 1L);
+
+    // BigDecimal
+    assertBestEffortOf(new BigDecimal("0.034"), ExpressionType.DOUBLE, 0.034);
 
     // by default, booleans are handled as longs
     assertBestEffortOf(true, ExpressionType.LONG, 1L);


### PR DESCRIPTION
Fix ExprEval of BigDecimal data type

### Description
This PR fixes a regression caused by https://github.com/apache/druid/pull/13947 (more specifically at https://github.com/apache/druid/pull/13947/files#diff-199493eb5b59a386d1fcade78da6578074cd94c80c114cfdd875a218106ca302L127 was changed to https://github.com/apache/druid/pull/13947/files#diff-5be9af304a8dda2062ca806bcc5320628757609c441fee5aec6e1ce51f71ded6R120)
Previously, we were just returning the raw but now we are using the method bestEffortOf which incorrectly handle BigDecimal data type. BigDecimal data type is incorrectly converted to Long. This issue was discovered with ingestion of Parquet files which use BigDecimal data type

##### Key changed/added classes in this PR
processing/src/main/java/org/apache/druid/math/expr/ExprEval.java

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
