### PR TITLE
Handle when used_status_last_updated is empty String in HeapMemorySegmentMetadataCache

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/SegmentRecord.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/SegmentRecord.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.metadata.segment.cache;
 
+import com.google.common.base.Strings;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.timeline.SegmentId;
@@ -74,7 +75,7 @@ class SegmentRecord
       serializedId = r.getString("id");
       dataSource = r.getString("dataSource");
 
-      final DateTime lastUpdatedTime = nullSafeDate(r.getString(
+      final DateTime lastUpdatedTime = nullAndEmptySafeDate(r.getString(
           "used_status_last_updated"));
 
       final SegmentId segmentId = SegmentId.tryParse(dataSource, serializedId);
@@ -96,8 +97,8 @@ class SegmentRecord
   }
 
   @Nullable
-  private static DateTime nullSafeDate(String date)
+  private static DateTime nullAndEmptySafeDate(String date)
   {
-    return date == null ? null : DateTimes.of(date);
+    return Strings.isNullOrEmpty(date) ? null : DateTimes.of(date);
   }
 }


### PR DESCRIPTION
Handle when used_status_last_updated is empty String in HeapMemorySegmentMetadataCache

### Description

As the `creates used_status_last_updated VARCHAR(255) NOT NULL` via https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/metadata/SQLMetadataConnector.java#L345 means that the used_status_last_updated can be an empty string, we should handle this case in HeapMemorySegmentMetadataCache. Note that this case will only happen if we downgrade to a version that inserts segments without used_status_last_updated on ingestion or upgrade from such version and the background jobs has not complete backfilling the used_status_last_updated on all the segments. I see that https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/metadata/segment/cache/SegmentRecord.java#L99 means that the cache can work if used_status_last_updated is null and we set null in SegmentRecord. Hence, we should just handle empty string in additional to null so that the HeapMemorySegmentMetadataCache works during these edge cases

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
