### PR TITLE
AsyncQueryForwardingServlet: Suppress stack traces for cancellation errors.

### DIFF
--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -334,7 +334,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       // issue async requests
       Response.CompleteListener completeListener = result -> {
         if (result.isFailed()) {
-          LOG.warn(
+          LOG.noStackTrace().warn(
               result.getFailure(),
               "Failed to forward cancellation request to [%s]",
               server.getHost()


### PR DESCRIPTION
There is no real need to log the entire stack trace, and they can clutter up the logs quite a bit.