### PR TITLE
Fix quidem output file path for properly handling nested input files

### DIFF
--- a/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
+++ b/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
@@ -295,6 +295,10 @@ public abstract class DruidQuidemTestBase
         } else {
           fail("Files differ: " + outFile + " " + inFile + "\n" + diff);
         }
+      } else {
+        if (outFile.exists()) {
+          outFile.delete();
+        }
       }
     }
 

--- a/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
+++ b/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
@@ -218,7 +218,7 @@ public abstract class DruidQuidemTestBase
     final String testName = testConfig.getTestName();
 
     File inFile = new File(getTestRoot(), testConfig.fileName);
-    final File outFile = new File(inFile.getParentFile(), testName + ".iq.out");
+    final File outFile = new File(getTestRoot(), testName + ".out");
     try (AutoCloseable closeable = Threads.withThreadName(testName)) {
       druidQuidemRunner.run(inFile, outFile, testConfig.componentSupplierName);
     }


### PR DESCRIPTION
### Description

Currently, if we have a quidem test directory of following hierarchy:
```
├── dir1
│   ├── subdir1
│   │   ├── sampletest-1.iq
│   │   └── sampletest-2.iq
│   └── subdir2
│       ├── sampletest-1.iq
│       └── sampletest-2.iq
├── dir2
│   ├── subdir1
│   │   ├── sampletest-1.iq
│   │   └── sampletest-2.iq
│   └── subdir2
│       ├── sampletest-1.iq
│       └── sampletest-2.iq
```

Quidem test output files end up looking like the following:
```
├── dir1
│   ├── subdir1
│   │   ├── dir1
│   │   │   └── subdir1
│   │   │       ├── sampletest-1.iq.iq.out
│   │   │       └── sampletest-2.iq.iq.out
│   │   ├── sampletest-1.iq
│   │   └── sampletest-2.iq
│   └── subdir2
│       ├── dir1
│       │   └── subdir2
│       │       ├── sampletest-1.iq.iq.out
│       │       └── sampletest-2.iq.iq.out
│       ├── sampletest-1.iq
│       └── sampletest-2.iq
├── dir2
│   ├── subdir1
│   │   ├── dir2
│   │   │   └── subdir1
│   │   │       ├── sampletest-1.iq.iq.out
│   │   │       └── sampletest-2.iq.iq.out
│   │   ├── sampletest-1.iq
│   │   └── sampletest-2.iq
│   └── subdir2
│       ├── dir2
│       │   └── subdir2
│       │       ├── sampletest-1.iq.iq.out
│       │       └── sampletest-2.iq.iq.out
│       ├── sampletest-1.iq
│       └── sampletest-2.iq
```

This PR improves it by fixing the output file path. With this PR's changes, the output file hierarchy for the above example looks like the following:
```
├── dir1
│   ├── subdir1
│   │   ├── sampletest-1.iq
│   │   ├── sampletest-1.iq.out
│   │   ├── sampletest-2.iq
│   │   └── sampletest-2.iq.out
│   └── subdir2
│       ├── sampletest-1.iq
│       ├── sampletest-1.iq.out
│       ├── sampletest-2.iq
│       └── sampletest-2.iq.out
├── dir2
│   ├── subdir1
│   │   ├── sampletest-1.iq
│   │   ├── sampletest-1.iq.out
│   │   ├── sampletest-2.iq
│   │   └── sampletest-2.iq.out
│   └── subdir2
│       ├── sampletest-1.iq
│       ├── sampletest-1.iq.out
│       ├── sampletest-2.iq
│       └── sampletest-2.iq.out
```

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
