### PR TITLE
Remove JDK matrix for `query` integration tests

### DIFF
--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -91,15 +91,11 @@ jobs:
 
   integration-query-tests-middleManager-mariaDB:
     needs: changes
-    strategy:
-      fail-fast: false
-      matrix:
-        jdk: [11, 17, 21]
     uses: ./.github/workflows/reusable-standard-its.yml
     if: ${{ needs.changes.outputs.core == 'true' || needs.changes.outputs.common-extensions == 'true' }}
     with:
-      build_jdk: ${{ matrix.jdk }}
-      runtime_jdk: ${{ matrix.jdk }}
+      build_jdk: 17
+      runtime_jdk: 17
       testing_groups: -Dgroups=query
       use_indexer: middleManager
       mysql_driver: org.mariadb.jdbc.Driver

--- a/it.sh
+++ b/it.sh
@@ -23,7 +23,7 @@
 set -e
 
 # Enable for debugging
-set -x
+#set -x
 
 export DRUID_DEV=$(cd $(dirname $0) && pwd)
 

--- a/it.sh
+++ b/it.sh
@@ -23,7 +23,7 @@
 set -e
 
 # Enable for debugging
-#set -x
+set -x
 
 export DRUID_DEV=$(cd $(dirname $0) && pwd)
 


### PR DESCRIPTION
### Description

We run the standard ITs against JDK 17, but we had `Dgroups=query` integration tests running on a matrix of JDKs. It doesn't seem intentional, and seems like we just missed removing the JDK matrix for this test as part of https://github.com/apache/druid/pull/13918/files#diff-d5b9dbcc3da61889996a6d61ffbe52ff2407debfdae053a7c0bce2373b09361a.

Hence, this PR removes the JDK matrix and runs the test against JDK 17, similar to other ITs.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
