### PR TITLE
fix flaky test in HttpEmitterTest

### DIFF
--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/HttpEmitterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/HttpEmitterTest.java
@@ -26,10 +26,11 @@ import org.asynchttpclient.Request;
 import org.asynchttpclient.Response;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -65,35 +66,43 @@ public class HttpEmitterTest
   }
 
   @Test
-  public void timeoutEmptyQueue() throws IOException, InterruptedException
+  public void timeoutEmptyQueue() throws Exception
   {
-    float timeoutAllowanceFactor = 2.0f;
+    // In HttpPostEmitter, when batch is empty, the timeout is lastBatchFillTimeMillis * config.httpTimeoutAllowanceFactor, and lastBatchFillTimeMillis is at least 1.
+    double timeoutAllowanceFactor = 2.0d;
     final HttpEmitterConfig config = new HttpEmitterConfig.Builder("http://foo.bar")
         .setBatchingStrategy(BatchingStrategy.ONLY_EVENTS)
-        .setHttpTimeoutAllowanceFactor(timeoutAllowanceFactor)
+        .setHttpTimeoutAllowanceFactor((float) timeoutAllowanceFactor)
         .setFlushTimeout(BaseHttpEmittingConfig.TEST_FLUSH_TIMEOUT_MILLIS)
         .build();
-    try (final HttpPostEmitter emitter = new HttpPostEmitter(config, httpClient, OBJECT_MAPPER)) {
-      long startMs = System.currentTimeMillis();
-      emitter.start();
-      emitter.emitAndReturnBatch(new IntEvent());
-      emitter.flush();
-      long fillTimeMs = System.currentTimeMillis() - startMs;
-      MatcherAssert.assertThat(
-          (double) timeoutUsed.get(),
-          Matchers.lessThan(fillTimeMs * (timeoutAllowanceFactor + 0.5))
-      );
+    Field lastBatchFillTimeMillis = HttpPostEmitter.class.getDeclaredField("lastBatchFillTimeMillis");
+    lastBatchFillTimeMillis.setAccessible(true);
+    final HttpPostEmitter emitter = new HttpPostEmitter(config, httpClient, OBJECT_MAPPER);
 
-      startMs = System.currentTimeMillis();
-      final Batch batch = emitter.emitAndReturnBatch(new IntEvent());
-      Thread.sleep(1000);
-      batch.seal();
-      emitter.flush();
-      fillTimeMs = System.currentTimeMillis() - startMs;
-      MatcherAssert.assertThat(
-          (double) timeoutUsed.get(),
-          Matchers.lessThan(fillTimeMs * (timeoutAllowanceFactor + 0.5))
-      );
-    }
+    long startMs = System.currentTimeMillis();
+    emitter.start();
+    emitter.emitAndReturnBatch(new IntEvent());
+    emitter.flush();
+
+    // sometimes System.currentTimeMillis() - startMs might be 0, so we need to use Math.max(1, System.currentTimeMillis() - startMs)
+    long fillTimeMs = Math.max(1, System.currentTimeMillis() - startMs);
+    Assume.assumeTrue(fillTimeMs >= (Long) lastBatchFillTimeMillis.get(emitter));
+    MatcherAssert.assertThat(
+        (double) timeoutUsed.get(),
+        Matchers.lessThanOrEqualTo(fillTimeMs * timeoutAllowanceFactor)
+    );
+
+    startMs = System.currentTimeMillis();
+    final Batch batch = emitter.emitAndReturnBatch(new IntEvent());
+    Thread.sleep(1000);
+    batch.seal();
+    emitter.flush();
+    // sometimes System.currentTimeMillis() - startMs might be 0, so we need to use Math.max(1, System.currentTimeMillis() - startMs)
+    fillTimeMs = Math.max(1, System.currentTimeMillis() - startMs);
+    Assume.assumeTrue(fillTimeMs >= (Long) lastBatchFillTimeMillis.get(emitter));
+    MatcherAssert.assertThat(
+        (double) timeoutUsed.get(),
+        Matchers.lessThanOrEqualTo(fillTimeMs * timeoutAllowanceFactor)
+    );
   }
 }


### PR DESCRIPTION
 
### Description
This test can fail when the emitting process (emit/flush) took 0ms (could be the clock issue), the fix is to make sure `fillTimeMs` is at least 1 .

Tested this on my local with running until failure setting, it didn't fail until OOMed.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
