### PR TITLE
add missing compaction status evaluator for projections

### DIFF
--- a/server/src/main/java/org/apache/druid/server/compaction/CompactionStatus.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/CompactionStatus.java
@@ -73,7 +73,8 @@ public class CompactionStatus
       Evaluator::rollupIsUpToDate,
       Evaluator::dimensionsSpecIsUpToDate,
       Evaluator::metricsSpecIsUpToDate,
-      Evaluator::transformSpecFilterIsUpToDate
+      Evaluator::transformSpecFilterIsUpToDate,
+      Evaluator::projectionsAreUpToDate
   );
 
   private final State state;
@@ -336,6 +337,16 @@ public class CompactionStatus
           "indexSpec",
           Configs.valueOrDefault(tuningConfig.getIndexSpec(), IndexSpec.DEFAULT),
           objectMapper.convertValue(lastCompactionState.getIndexSpec(), IndexSpec.class),
+          String::valueOf
+      );
+    }
+
+    private CompactionStatus projectionsAreUpToDate()
+    {
+      return CompactionStatus.completeIfEqual(
+          "projections",
+          compactionConfig.getProjections(),
+          lastCompactionState.getProjections(),
           String::valueOf
       );
     }


### PR DESCRIPTION
Fixes an oversight in #17803 which missed adding a 'projections' evaluator to `CompactionStatus` checker, causing mismatches between projections in the compaction config and the last compaction state to not trigger compaction.