### PR TITLE
Fix GitHub Actions workflow for `ITNestedQueryPushDownTest` integration test

### DIFF
--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -173,6 +173,8 @@ jobs:
         run: |
           echo "Running mvn -B -ff install -pl '!web-console' -Pdist,bundle-contrib-exts -Pskip-static-checks,skip-tests -Dmaven.javadoc.skip=true -T1C"
           mvn -B -ff install -pl '!web-console' -Pdist,bundle-contrib-exts -Pskip-static-checks,skip-tests -Dmaven.javadoc.skip=true -T1C
+          # Note: The above command relies on the correct version of the JARs being installed in the local m2 repository.
+          # For any changes, please rebuild it using the command from the previous step (./it.sh ci).
 
           echo "MAVEN_OPTS='-Xmx2048m' ${MVN} verify -pl integration-tests -P int-tests-config-file ${IT_TEST} ${MAVEN_SKIP} -Dpod.name=${POD_NAME} -Dpod.namespace=${POD_NAMESPACE} -Dbuild.druid.cluster=${BUILD_DRUID_CLUSTER}"
           MAVEN_OPTS='-Xmx2048m' ${MVN} verify -pl integration-tests -P int-tests-config-file ${IT_TEST} ${MAVEN_SKIP} -Dpod.name=${POD_NAME} -Dpod.namespace=${POD_NAMESPACE} -Dbuild.druid.cluster=${BUILD_DRUID_CLUSTER}

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -171,7 +171,9 @@ jobs:
       - name: Run IT
         id: test
         run: |
-          # Debug echo
+          echo "Running mvn -B -ff install -pl '!web-console' -Pdist,bundle-contrib-exts -Pskip-static-checks,skip-tests -Dmaven.javadoc.skip=true -T1C"
+          mvn -B -ff install -pl '!web-console' -Pdist,bundle-contrib-exts -Pskip-static-checks,skip-tests -Dmaven.javadoc.skip=true -T1C
+
           echo "MAVEN_OPTS='-Xmx2048m' ${MVN} verify -pl integration-tests -P int-tests-config-file ${IT_TEST} ${MAVEN_SKIP} -Dpod.name=${POD_NAME} -Dpod.namespace=${POD_NAMESPACE} -Dbuild.druid.cluster=${BUILD_DRUID_CLUSTER}"
           MAVEN_OPTS='-Xmx2048m' ${MVN} verify -pl integration-tests -P int-tests-config-file ${IT_TEST} ${MAVEN_SKIP} -Dpod.name=${POD_NAME} -Dpod.namespace=${POD_NAMESPACE} -Dbuild.druid.cluster=${BUILD_DRUID_CLUSTER}
 

--- a/integration-tests/script/build_run_k8s_cluster.sh
+++ b/integration-tests/script/build_run_k8s_cluster.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set -e
+set -x
 
 if ($BUILD_DRUID_CLSUTER); then
 

--- a/integration-tests/script/setup_druid_on_k8s.sh
+++ b/integration-tests/script/setup_druid_on_k8s.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set -e
+set -x
 
 export KUBECTL="/usr/local/bin/kubectl"
 
@@ -24,13 +25,6 @@ cd integration-tests
 rm -rf docker/client_tls
 cp -r client_tls docker/client_tls
 cd ..
-
-# Build Docker images for pods
-mvn -B -ff -q \
-      install \
-      -Pdist,bundle-contrib-exts \
-      -Pskip-static-checks,skip-tests \
-      -Dmaven.javadoc.skip=true -T1C
 
 DOCKER_BUILDKIT=1 docker build --build-arg BUILD_FROM_SOURCE=0 -t druid/base:v1 -f distribution/docker/Dockerfile .
 DOCKER_BUILDKIT=1 docker build --build-arg BASE_IMAGE=druid/base:v1 -t druid/cluster:v1 -f distribution/docker/DockerfileBuildTarAdvanced .

--- a/integration-tests/script/setup_druid_operator_on_k8s.sh
+++ b/integration-tests/script/setup_druid_operator_on_k8s.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set -e
+set -x
 
 export DRUID_OPERATOR_VERSION=v1.0.0
 export KUBECTL="/usr/local/bin/kubectl"

--- a/integration-tests/script/setup_k8s_cluster.sh
+++ b/integration-tests/script/setup_k8s_cluster.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 set -e
+set -x
 
 export INSTALL_K3S_VERSION=v1.21.14+k3s1
 export KUBECONFIG=$HOME/.kube/config


### PR DESCRIPTION
### Description

Lately, there have been quite a few occurrences of `standard-its / (Compile=openjdk17, Run=openjdk17, Cluster Build On K8s` standard integration test (that triggers `ITNestedQueryPushDownTest`) being stuck, and failing after 6 hours of being stuck. Sample run: https://github.com/apache/druid/actions/runs/14400145606/job/40386733833

TLDR: This PR updates the Maven command for this particular GitHub Actions Job to exclude `web-console` module. It's fine to do so as it doesn't have anything to do with the test anyway.

Adding detailed investigation notes below:

On investigating, all such failed runs seem to be stuck at the following line in `setup_druid_on_k8s.sh`:
```
mvn -B -ff -q \
      install \
      -Pdist,bundle-contrib-exts \
      -Pskip-static-checks,skip-tests \
      -Dmaven.javadoc.skip=true -T1C
```

On removing `-q` (quiet mode) from the above command, I found that the above command was hung immediately after having successfully finished with `benchmarks` module.

I tried adding some debug steps in the workflow to get some monitoring data for a failed run vs a successful run.

Failed run had a `npm ci` process (which is most likely the stuck process), whereas the successful one didn't. Also, the reactor build order that gets used has `web-console` module immediately after `benchmarks` module, hence this observation aligns with the previous observation that the command seemed stuck immediately after having successfully finished with `benchmarks` module.

This PR mainly excludes `web-console` module from the Maven command by adding `-pl '!web-console'`. Apart from this, a couple other things have been done:
1. The Maven command has been moved from `setup_druid_on_k8s.sh` to `standard-its.yml`. Previously, `standard-its.yml` was calling `MAVEN_OPTS='-Xmx2048m' ${MVN} verify -pl integration-tests -P int-tests-config-file ${IT_TEST} ${MAVEN_SKIP} -Dpod.name=${POD_NAME} -Dpod.namespace=${POD_NAMESPACE} -Dbuild.druid.cluster=${BUILD_DRUID_CLUSTER}`, which ended up calling a chain of bash scripts, which called the other Maven command, which then ended up stuck. Essentially, a Maven command was triggering another Maven command via a chain of bash scripts. This nested Maven commands could potentially run into other issues, like competing for lock on the local Maven repo etc, which are very difficult to debug. Hence, I brought that "inner" Maven command to the same level as the "outer" Maven command, and now they are running sequentially. It's easier to reason about the flow as well this way.
2. I have also added `set -x` to enable debugging for the bash scripts involved in running this IT. I think it's better to have them, it's not a lot of noise, and those scripts are only used for this IT. So I think it'd be good to improve the ability to debug for future. On a similar note, I have removed the `-q` (quiet mode) argument from the Maven command.

I tried a bunch of runs for this test with this PR's change, all of them passed:
1. 8/8 successful runs [here](https://github.com/Akshat-Jain/druid/actions/runs/14429675741/job/40464412441?pr=7)
2. 5/5 successful runs [here](https://github.com/Akshat-Jain/druid/actions/runs/14429950271/job/40464375268?pr=9)
3. 2/2 successful runs [here](https://github.com/Akshat-Jain/druid/actions/runs/14430480632/job/40464926328?pr=8)

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
