### PR TITLE
feat: add groupby metrics to prometheus emitter

### DIFF
--- a/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
+++ b/extensions-contrib/prometheus-emitter/src/main/resources/defaultMetrics.json
@@ -44,6 +44,13 @@
   "jetty/threadPool/max" : { "dimensions" : [], "type" : "gauge", "help": "Number of maximum threads allocatable."},
   "jetty/threadPool/queueSize" : { "dimensions" : [], "type" : "gauge", "help": "Size of the worker queue."},
 
+  "mergeBuffer/used": { "dimensions":  [], "type":  "gauge", "help":  "Number of merge buffers used"},
+  "mergeBuffer/acquisitionTimeNs": { "dimensions":  [], "type":  "timer", "help":  "Total time in nanoseconds to acquire merge buffer for groupBy queries."},
+  "mergeBuffer/queries": { "dimensions":  [], "type":  "gauge", "help":  "Number of groupBy queries that acquired a batch of buffers from the merge buffer pool."},
+  "groupBy/spilledQueries": { "dimensions":  [], "type":  "gauge", "help":  "Number of groupBy queries that have spilled onto the disk."},
+  "groupBy/spilledBytes": { "dimensions":  [], "type":  "gauge", "help":  "Number of bytes spilled on the disk by the groupBy queries."},
+  "groupBy/mergeDictionarySize": { "dimensions":  [], "type":  "gauge", "help":  "Size of on-heap merge dictionary in bytes."},
+
   "query/cache/delta/numEntries" : { "dimensions" : [], "type" : "gauge", "help": "Number of entries in cache"},
   "query/cache/delta/sizeBytes" : { "dimensions" : [], "type" : "gauge", "help": "Size of cache in bytes."},
   "query/cache/delta/hits" : { "dimensions" : [], "type" : "gauge", "help": "Number of cache hits."},
@@ -176,7 +183,7 @@
   "metadata/kill/rule/count" : { "dimensions" : [], "type" : "count", "help": "Total number of rules that were automatically deleted from metadata store per each Coordinator kill rule duty run."},
   "metadata/kill/datasource/count" : { "dimensions" : [], "type" : "count", "help": "Total number of datasource metadata that were automatically deleted from metadata store per each Coordinator kill datasource duty run."},
 
-  "service/heartbeat" : { "dimensions" : ["dataSource", "type"], "type" : "gauge", "help":  "Metric indicating the service is up. This metric is only available if the ServiceStatusMonitor module is included."},
+  "service/heartbeat" : { "dimensions" : ["dataSource", "type", "leader"], "type" : "gauge", "help":  "Metric indicating the service is up. This metric is only available if the ServiceStatusMonitor module is included."},
 
   "segment/max" : { "dimensions" : [], "type" : "gauge", "help": "Maximum byte limit available for segments."},
   "segment/used" : { "dimensions" : ["dataSource", "tier", "priority"], "type" : "gauge", "help": "Bytes used for served segments."},


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #17908.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
Add Groupby metrics to Prometheus emitter


#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

Add Groupby metrics to Prometheus emitter

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
