### PR TITLE
In default cluster config unset druid.host

### DIFF
--- a/examples/conf/druid/cluster/_common/common.runtime.properties
+++ b/examples/conf/druid/cluster/_common/common.runtime.properties
@@ -34,7 +34,7 @@ druid.extensions.loadList=["druid-hdfs-storage", "druid-kafka-indexing-service",
 #
 # Hostname
 #
-druid.host=localhost
+#druid.host=localhost
 
 #
 # Logging


### PR DESCRIPTION
Setting to `druid.host` to anything in a cluster configuration might be necessary; but a setting of `localhost` may only lead to problems.
Leaving it unset and letting the [default logic](https://github.com/apache/druid/blob/3766e3a14fb49ca98ab3b02495bf1336c7eee75c/server/src/main/java/org/apache/druid/server/DruidNode.java#L168) work should be preferred.