### PR TITLE
remove useMaxMemoryEstimates in favor of always using the false behavior which uses the newer more accurate estimates

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerBenchmark.java
@@ -55,7 +55,7 @@ public class StringDimensionIndexerBenchmark
   @Setup
   public void setup()
   {
-    indexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false, true);
+    indexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false);
 
     for (int i = 0; i < cardinality; i++) {
       indexer.processRowValsToUnsortedEncodedKeyComponent("abcd-" + i, true);

--- a/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerProcessBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/indexing/StringDimensionIndexerProcessBenchmark.java
@@ -69,7 +69,7 @@ public class StringDimensionIndexerProcessBenchmark
       inputData[i] = (next < nullNumbers) ? null : ("abcd-" + next + "-efgh");
     }
 
-    fullIndexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false, false);
+    fullIndexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false);
     for (String data : inputData) {
       fullIndexer.processRowValsToUnsortedEncodedKeyComponent(data, true);
     }
@@ -83,7 +83,7 @@ public class StringDimensionIndexerProcessBenchmark
   @Setup(Level.Iteration)
   public void setupEmptyIndexer()
   {
-    emptyIndexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false, false);
+    emptyIndexer = new StringDimensionIndexer(DimensionSchema.MultiValueHandling.ofDefault(), true, false);
   }
 
   @Setup(Level.Iteration)

--- a/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
+++ b/extensions-contrib/materialized-view-maintenance/src/main/java/org/apache/druid/indexing/materializedview/MaterializedViewSupervisorSpec.java
@@ -183,7 +183,6 @@ public class MaterializedViewSupervisorSpec implements SupervisorSpec
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         tuningConfig.getMaxBytesInMemory(),
-        tuningConfig.isUseMaxMemoryEstimates(),
         tuningConfig.isLeaveIntermediate(),
         tuningConfig.isCleanupOnFailure(),
         tuningConfig.isOverwriteFiles(),

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/processor/SegmentGeneratorFrameProcessorFactory.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/processor/SegmentGeneratorFrameProcessorFactory.java
@@ -194,7 +194,6 @@ public class SegmentGeneratorFrameProcessorFactory
                   frameContext.indexMerger(),
                   meters,
                   parseExceptionHandler,
-                  false,
                   // MSQ doesn't support CentralizedDatasourceSchema feature as of now.
                   CentralizedDatasourceSchemaConfig.create(false)
               );

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/HadoopTuningConfig.java
@@ -63,7 +63,6 @@ public class HadoopTuningConfig implements TuningConfig
         DEFAULT_MAX_ROWS_IN_MEMORY_BATCH,
         0L,
         false,
-        false,
         true,
         false,
         false,
@@ -92,7 +91,6 @@ public class HadoopTuningConfig implements TuningConfig
   private final AppendableIndexSpec appendableIndexSpec;
   private final int maxRowsInMemory;
   private final long maxBytesInMemory;
-  private final boolean useMaxMemoryEstimates;
   private final boolean leaveIntermediate;
   private final boolean cleanupOnFailure;
   private final boolean overwriteFiles;
@@ -129,7 +127,6 @@ public class HadoopTuningConfig implements TuningConfig
       final @JsonProperty("appendableIndexSpec") @Nullable AppendableIndexSpec appendableIndexSpec,
       final @JsonProperty("maxRowsInMemory") @Nullable Integer maxRowsInMemory,
       final @JsonProperty("maxBytesInMemory") @Nullable Long maxBytesInMemory,
-      final @JsonProperty("useMaxMemoryEstimates") @Nullable Boolean useMaxMemoryEstimates,
       final @JsonProperty("leaveIntermediate") boolean leaveIntermediate,
       final @JsonProperty("cleanupOnFailure") @Nullable Boolean cleanupOnFailure,
       final @JsonProperty("overwriteFiles") boolean overwriteFiles,
@@ -163,7 +160,6 @@ public class HadoopTuningConfig implements TuningConfig
         maxRowsInMemory,
         Configs.valueOrDefault(maxRowsInMemoryCOMPAT, DEFAULT_MAX_ROWS_IN_MEMORY_BATCH)
     );
-    this.useMaxMemoryEstimates = Configs.valueOrDefault(useMaxMemoryEstimates, false);
     this.appendableIndexSpec = Configs.valueOrDefault(appendableIndexSpec, DEFAULT_APPENDABLE_INDEX);
     // initializing this to 0, it will be lazily initialized to a value
     // @see #getMaxBytesInMemoryOrDefault()
@@ -264,12 +260,6 @@ public class HadoopTuningConfig implements TuningConfig
   public long getMaxBytesInMemory()
   {
     return maxBytesInMemory;
-  }
-
-  @JsonProperty
-  public boolean isUseMaxMemoryEstimates()
-  {
-    return useMaxMemoryEstimates;
   }
 
   @JsonProperty
@@ -381,7 +371,6 @@ public class HadoopTuningConfig implements TuningConfig
         appendableIndexSpec,
         maxRowsInMemory,
         maxBytesInMemory,
-        useMaxMemoryEstimates,
         leaveIntermediate,
         cleanupOnFailure,
         overwriteFiles,
@@ -414,7 +403,6 @@ public class HadoopTuningConfig implements TuningConfig
         appendableIndexSpec,
         maxRowsInMemory,
         maxBytesInMemory,
-        useMaxMemoryEstimates,
         leaveIntermediate,
         cleanupOnFailure,
         overwriteFiles,
@@ -447,7 +435,6 @@ public class HadoopTuningConfig implements TuningConfig
         appendableIndexSpec,
         maxRowsInMemory,
         maxBytesInMemory,
-        useMaxMemoryEstimates,
         leaveIntermediate,
         cleanupOnFailure,
         overwriteFiles,

--- a/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
+++ b/indexing-hadoop/src/main/java/org/apache/druid/indexer/IndexGeneratorJob.java
@@ -311,7 +311,6 @@ public class IndexGeneratorJob implements Jobby
                                             .setIndexSchema(indexSchema)
                                             .setMaxRowCount(tuningConfig.getMaxRowsInMemory())
                                             .setMaxBytesInMemory(tuningConfig.getMaxBytesInMemoryOrDefault())
-                                            .setUseMaxMemoryEstimates(tuningConfig.isUseMaxMemoryEstimates())
                                             .build();
 
     if (oldDimOrder != null && !indexSchema.getDimensionsSpec().hasFixedDimensions()) {

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/BatchDeltaIngestionTest.java
@@ -479,7 +479,6 @@ public class BatchDeltaIngestionTest
                 false,
                 false,
                 false,
-                false,
                 null,
                 false,
                 false,

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineHashedPartitionsJobTest.java
@@ -218,7 +218,6 @@ public class DetermineHashedPartitionsJobTest
             false,
             false,
             false,
-            false,
             null,
             false,
             false,
@@ -247,7 +246,7 @@ public class DetermineHashedPartitionsJobTest
     Map<Long, List<HadoopyShardSpec>> shardSpecs = indexerConfig.getSchema().getTuningConfig().getShardSpecs();
     Assert.assertEquals(
         expectedNumTimeBuckets,
-        shardSpecs.entrySet().size()
+        shardSpecs.size()
     );
     int i = 0;
     for (Map.Entry<Long, List<HadoopyShardSpec>> entry : shardSpecs.entrySet()) {

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DeterminePartitionsJobTest.java
@@ -333,7 +333,6 @@ public class DeterminePartitionsJobTest
                 false,
                 false,
                 false,
-                false,
                 null,
                 false,
                 false,

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineRangePartitionsJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/DetermineRangePartitionsJobTest.java
@@ -382,7 +382,7 @@ public class DetermineRangePartitionsJobTest
                 null,
                 null,
                 null,
-                false, false,
+                false,
                 false,
                 false,
                 false,

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopDruidIndexerConfigTest.java
@@ -268,7 +268,6 @@ public class HadoopDruidIndexerConfigTest
           false,
           false,
           false,
-          false,
           null,
           false,
           false,

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/HadoopTuningConfigTest.java
@@ -48,7 +48,6 @@ public class HadoopTuningConfigTest
         null,
         100,
         null,
-        false,
         true,
         true,
         true,

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/IndexGeneratorJobTest.java
@@ -534,7 +534,6 @@ public class IndexGeneratorJobTest
                 null,
                 maxRowsInMemory,
                 maxBytesInMemory,
-                false,
                 true,
                 false,
                 false,

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/JobHelperTest.java
@@ -177,7 +177,6 @@ public class JobHelperTest
                 false,
                 false,
                 false,
-                false,
                 //Map of job properties
                 ImmutableMap.of(
                     "fs.s3.impl",

--- a/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
+++ b/indexing-hadoop/src/test/java/org/apache/druid/indexer/path/GranularityPathSpecTest.java
@@ -67,7 +67,6 @@ public class GranularityPathSpecTest
       false,
       false,
       false,
-      false,
       null,
       false,
       false,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -385,17 +385,6 @@ public abstract class AbstractTask implements Task
     return context;
   }
 
-  /**
-   * Whether maximum memory usage should be considered in estimation for indexing tasks.
-   */
-  protected boolean isUseMaxMemoryEstimates()
-  {
-    return getContextValue(
-        Tasks.USE_MAX_MEMORY_ESTIMATES,
-        Tasks.DEFAULT_USE_MAX_MEMORY_ESTIMATES
-    );
-  }
-
   protected ServiceMetricEvent.Builder getMetricBuilder()
   {
     return metricBuilder;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/BatchAppenderators.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/BatchAppenderators.java
@@ -42,8 +42,7 @@ public final class BatchAppenderators
       DataSchema dataSchema,
       AppenderatorConfig appenderatorConfig,
       RowIngestionMeters rowIngestionMeters,
-      ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates
+      ParseExceptionHandler parseExceptionHandler
   )
   {
     return newAppenderator(
@@ -55,8 +54,7 @@ public final class BatchAppenderators
         appenderatorConfig,
         toolbox.getSegmentPusher(),
         rowIngestionMeters,
-        parseExceptionHandler,
-        useMaxMemoryEstimates
+        parseExceptionHandler
     );
   }
 
@@ -69,8 +67,7 @@ public final class BatchAppenderators
       AppenderatorConfig appenderatorConfig,
       DataSegmentPusher segmentPusher,
       RowIngestionMeters rowIngestionMeters,
-      ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates
+      ParseExceptionHandler parseExceptionHandler
   )
   {
     return appenderatorsManager.createBatchAppenderatorForTask(
@@ -84,7 +81,6 @@ public final class BatchAppenderators
         toolbox.getIndexMergerV9(),
         rowIngestionMeters,
         parseExceptionHandler,
-        useMaxMemoryEstimates,
         toolbox.getCentralizedTableSchemaConfig()
     );
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -876,8 +876,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler, Pe
         dataSchema,
         tuningConfig,
         buildSegmentsMeters,
-        buildSegmentsParseExceptionHandler,
-        isUseMaxMemoryEstimates()
+        buildSegmentsParseExceptionHandler
     );
     boolean exceptionOccurred = false;
     try (final BatchAppenderatorDriver driver = BatchAppenderators.newDriver(appenderator, toolbox, segmentAllocator)) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Tasks.java
@@ -53,17 +53,6 @@ public class Tasks
   public static final String USE_CONCURRENT_LOCKS = "useConcurrentLocks";
 
   /**
-   * Context flag denoting if maximum possible values should be used to estimate
-   * on-heap memory usage while indexing. Refer to OnHeapIncrementalIndex for
-   * more details.
-   * <p>
-   * @deprecated This flag will be removed in future Druid releases, and the new
-   * method of memory estimation will be used in all cases.
-   */
-  @Deprecated
-  public static final String USE_MAX_MEMORY_ESTIMATES = "useMaxMemoryEstimates";
-
-  /**
    * Context flag to denote if segments published to metadata by a task should
    * have the {@code lastCompactionState} field set.
    */

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentGenerateTask.java
@@ -33,7 +33,6 @@ import org.apache.druid.indexing.common.task.InputSourceProcessor;
 import org.apache.druid.indexing.common.task.SegmentAllocatorForBatch;
 import org.apache.druid.indexing.common.task.SequenceNameFunction;
 import org.apache.druid.indexing.common.task.TaskResource;
-import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.common.task.batch.parallel.iterator.IndexTaskInputRowIteratorBuilder;
 import org.apache.druid.indexing.input.DruidInputSource;
 import org.apache.druid.indexing.input.WindowedSegmentId;
@@ -186,10 +185,6 @@ abstract class PartialSegmentGenerateTask<T extends GeneratedPartitionsReport> e
         tuningConfig.getMaxParseExceptions(),
         tuningConfig.getMaxSavedParseExceptions()
     );
-    final boolean useMaxMemoryEstimates = getContextValue(
-        Tasks.USE_MAX_MEMORY_ESTIMATES,
-        Tasks.DEFAULT_USE_MAX_MEMORY_ESTIMATES
-    );
     final Appenderator appenderator = BatchAppenderators.newAppenderator(
         getId(),
         toolbox.getAppenderatorsManager(),
@@ -199,8 +194,7 @@ abstract class PartialSegmentGenerateTask<T extends GeneratedPartitionsReport> e
         tuningConfig,
         new ShuffleDataSegmentPusher(supervisorTaskId, getId(), toolbox.getIntermediaryDataManager()),
         buildSegmentsMeters,
-        parseExceptionHandler,
-        useMaxMemoryEstimates
+        parseExceptionHandler
     );
     boolean exceptionOccurred = false;
     try (final BatchAppenderatorDriver driver = BatchAppenderators.newDriver(appenderator, toolbox, segmentAllocator)) {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -391,10 +391,6 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
         useLineageBasedSegmentAllocation
     );
 
-    final boolean useMaxMemoryEstimates = getContextValue(
-        Tasks.USE_MAX_MEMORY_ESTIMATES,
-        Tasks.DEFAULT_USE_MAX_MEMORY_ESTIMATES
-    );
     final Appenderator appenderator = BatchAppenderators.newAppenderator(
         getId(),
         toolbox.getAppenderatorsManager(),
@@ -403,8 +399,7 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
         dataSchema,
         tuningConfig,
         rowIngestionMeters,
-        parseExceptionHandler,
-        useMaxMemoryEstimates
+        parseExceptionHandler
     );
     boolean exceptionOccurred = false;
     try (

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -212,7 +212,6 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
         toolbox.getCachePopulatorStats(),
         rowIngestionMeters,
         parseExceptionHandler,
-        isUseMaxMemoryEstimates(),
         toolbox.getCentralizedTableSchemaConfig()
     );
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TestAppenderatorsManager.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TestAppenderatorsManager.java
@@ -71,7 +71,6 @@ public class TestAppenderatorsManager implements AppenderatorsManager
       CachePopulatorStats cachePopulatorStats,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -94,7 +93,6 @@ public class TestAppenderatorsManager implements AppenderatorsManager
         cachePopulatorStats,
         rowIngestionMeters,
         parseExceptionHandler,
-        useMaxMemoryEstimates,
         centralizedDatasourceSchemaConfig
     );
     return realtimeAppenderator;
@@ -112,7 +110,6 @@ public class TestAppenderatorsManager implements AppenderatorsManager
       IndexMerger indexMerger,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -127,7 +124,6 @@ public class TestAppenderatorsManager implements AppenderatorsManager
         indexMerger,
         rowIngestionMeters,
         parseExceptionHandler,
-        useMaxMemoryEstimates,
         centralizedDatasourceSchemaConfig
     );
   }

--- a/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionDictionary.java
@@ -143,10 +143,6 @@ public abstract class DimensionDictionary<T extends Comparable<T>>
    */
   public long sizeInBytes()
   {
-    if (!computeOnHeapSize()) {
-      throw new IllegalStateException("On-heap size computation is disabled");
-    }
-
     return sizeInBytes.get();
   }
 
@@ -169,11 +165,8 @@ public abstract class DimensionDictionary<T extends Comparable<T>>
       }
     }
 
-    long extraSize = 0;
-    if (computeOnHeapSize()) {
-      // Add size of new dim value and 2 references (valueToId and idToValue)
-      extraSize = estimateSizeOfValue(originalValue) + 2L * Long.BYTES;
-    }
+    // Add size of new dim value and 2 references (valueToId and idToValue)
+    final long extraSize = estimateSizeOfValue(originalValue) + 2L * Long.BYTES;
 
     stamp = lock.writeLock();
     try {
@@ -271,15 +264,6 @@ public abstract class DimensionDictionary<T extends Comparable<T>>
 
   /**
    * Estimates the size of the dimension value in bytes.
-   * <p>
-   * This method is called when adding a new dimension value to the lookup only
-   * if {@link #computeOnHeapSize()} returns true.
    */
   public abstract long estimateSizeOfValue(T value);
-
-  /**
-   * Whether on-heap size of this dictionary should be computed.
-   */
-  public abstract boolean computeOnHeapSize();
-
 }

--- a/processing/src/main/java/org/apache/druid/segment/DimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/DimensionHandler.java
@@ -96,11 +96,9 @@ public interface DimensionHandler
    * Creates a new DimensionIndexer, a per-dimension object responsible for processing ingested rows in-memory, used
    * by the IncrementalIndex. See {@link DimensionIndexer} interface for more information.
    *
-   * @param useMaxMemoryEstimates true if the created DimensionIndexer should use
-   *                              maximum values to estimate on-heap memory
    * @return A new DimensionIndexer object.
    */
-  DimensionIndexer<EncodedType, EncodedKeyComponentType, ActualType> makeIndexer(boolean useMaxMemoryEstimates);
+  DimensionIndexer<EncodedType, EncodedKeyComponentType, ActualType> makeIndexer();
 
   /**
    * @deprecated use {@link #makeMerger(String, IndexSpec, SegmentWriteOutMedium, ColumnCapabilities, ProgressIndicator, File, Closer)}

--- a/processing/src/main/java/org/apache/druid/segment/DoubleDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/DoubleDimensionHandler.java
@@ -71,7 +71,7 @@ public class DoubleDimensionHandler implements DimensionHandler<Double, Double, 
   }
 
   @Override
-  public DimensionIndexer<Double, Double, Double> makeIndexer(boolean useMaxMemoryEstimates)
+  public DimensionIndexer<Double, Double, Double> makeIndexer()
   {
     return new DoubleDimensionIndexer(dimensionName);
   }

--- a/processing/src/main/java/org/apache/druid/segment/FloatDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/FloatDimensionHandler.java
@@ -71,7 +71,7 @@ public class FloatDimensionHandler implements DimensionHandler<Float, Float, Flo
   }
 
   @Override
-  public DimensionIndexer<Float, Float, Float> makeIndexer(boolean useMaxMemoryEstimates)
+  public DimensionIndexer<Float, Float, Float> makeIndexer()
   {
     return new FloatDimensionIndexer(dimensionName);
   }

--- a/processing/src/main/java/org/apache/druid/segment/LongDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/LongDimensionHandler.java
@@ -71,7 +71,7 @@ public class LongDimensionHandler implements DimensionHandler<Long, Long, Long>
   }
 
   @Override
-  public DimensionIndexer<Long, Long, Long> makeIndexer(boolean useMaxMemoryEstimates)
+  public DimensionIndexer<Long, Long, Long> makeIndexer()
   {
     return new LongDimensionIndexer(dimensionName);
   }

--- a/processing/src/main/java/org/apache/druid/segment/NestedCommonFormatColumnHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/NestedCommonFormatColumnHandler.java
@@ -71,7 +71,7 @@ public class NestedCommonFormatColumnHandler implements DimensionHandler<Structu
   }
 
   @Override
-  public DimensionIndexer<StructuredData, StructuredData, StructuredData> makeIndexer(boolean useMaxMemoryEstimates)
+  public DimensionIndexer<StructuredData, StructuredData, StructuredData> makeIndexer()
   {
     return new AutoTypeColumnIndexer(name, castTo);
   }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionDictionary.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionDictionary.java
@@ -24,18 +24,12 @@ package org.apache.druid.segment;
  */
 public class StringDimensionDictionary extends DimensionDictionary<String>
 {
-  private final boolean computeOnHeapSize;
-
   /**
    * Creates a StringDimensionDictionary.
-   *
-   * @param computeOnHeapSize true if on-heap memory estimation of the dictionary
-   *                          size should be enabled, false otherwise
    */
-  public StringDimensionDictionary(boolean computeOnHeapSize)
+  public StringDimensionDictionary()
   {
     super(String.class);
-    this.computeOnHeapSize = computeOnHeapSize;
   }
 
   @Override
@@ -44,11 +38,5 @@ public class StringDimensionDictionary extends DimensionDictionary<String>
     // According to https://www.ibm.com/developerworks/java/library/j-codetoheap/index.html
     // Total string size = 28B (string metadata) + 16B (char array metadata) + 2B * num letters
     return 28 + 16 + (2L * value.length());
-  }
-
-  @Override
-  public boolean computeOnHeapSize()
-  {
-    return computeOnHeapSize;
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionHandler.java
@@ -158,9 +158,9 @@ public class StringDimensionHandler implements DimensionHandler<Integer, int[], 
   }
 
   @Override
-  public DimensionIndexer<Integer, int[], String> makeIndexer(boolean useMaxMemoryEstimates)
+  public DimensionIndexer<Integer, int[], String> makeIndexer()
   {
-    return new StringDimensionIndexer(multiValueHandling, hasBitmapIndexes, hasSpatialIndexes, useMaxMemoryEstimates);
+    return new StringDimensionIndexer(multiValueHandling, hasBitmapIndexes, hasSpatialIndexes);
   }
 
   @Override

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -133,10 +133,9 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
       sortedLookup = null;
     }
 
-    long effectiveSizeBytes;
     // size of encoded array + dictionary size change
-    effectiveSizeBytes = 16L + (long) encodedDimensionValues.length * Integer.BYTES
-                         + (dimLookup.sizeInBytes() - oldDictSizeInBytes);
+    final long effectiveSizeBytes = 16L + ((long)encodedDimensionValues.length * Integer.BYTES)
+                                    + (dimLookup.sizeInBytes() - oldDictSizeInBytes);
     return new EncodedKeyComponent<>(encodedDimensionValues, effectiveSizeBytes);
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -134,7 +134,7 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
     }
 
     // size of encoded array + dictionary size change
-    final long effectiveSizeBytes = 16L + ((long)encodedDimensionValues.length * Integer.BYTES)
+    final long effectiveSizeBytes = 16L + ((long) encodedDimensionValues.length * Integer.BYTES)
                                     + (dimLookup.sizeInBytes() - oldDictSizeInBytes);
     return new EncodedKeyComponent<>(encodedDimensionValues, effectiveSizeBytes);
   }

--- a/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
+++ b/processing/src/main/java/org/apache/druid/segment/StringDimensionIndexer.java
@@ -57,21 +57,18 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
   private final MultiValueHandling multiValueHandling;
   private final boolean hasBitmapIndexes;
   private final boolean hasSpatialIndexes;
-  private final boolean useMaxMemoryEstimates;
   private volatile boolean hasMultipleValues = false;
 
   public StringDimensionIndexer(
       @Nullable MultiValueHandling multiValueHandling,
       boolean hasBitmapIndexes,
-      boolean hasSpatialIndexes,
-      boolean useMaxMemoryEstimates
+      boolean hasSpatialIndexes
   )
   {
-    super(new StringDimensionDictionary(!useMaxMemoryEstimates));
+    super(new StringDimensionDictionary());
     this.multiValueHandling = multiValueHandling == null ? MultiValueHandling.ofDefault() : multiValueHandling;
     this.hasBitmapIndexes = hasBitmapIndexes;
     this.hasSpatialIndexes = hasSpatialIndexes;
-    this.useMaxMemoryEstimates = useMaxMemoryEstimates;
   }
 
   @Override
@@ -79,7 +76,7 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
   {
     final int[] encodedDimensionValues;
     final int oldDictSize = dimLookup.size();
-    final long oldDictSizeInBytes = useMaxMemoryEstimates ? 0 : dimLookup.sizeInBytes();
+    final long oldDictSizeInBytes = dimLookup.sizeInBytes();
 
     // expressions which operate on multi-value string inputs as arrays might spit out arrays, coerce to list
     if (dimValues instanceof Object[]) {
@@ -137,13 +134,9 @@ public class StringDimensionIndexer extends DictionaryEncodedColumnIndexer<int[]
     }
 
     long effectiveSizeBytes;
-    if (useMaxMemoryEstimates) {
-      effectiveSizeBytes = estimateEncodedKeyComponentSize(encodedDimensionValues);
-    } else {
-      // size of encoded array + dictionary size change
-      effectiveSizeBytes = 16L + (long) encodedDimensionValues.length * Integer.BYTES
-                           + (dimLookup.sizeInBytes() - oldDictSizeInBytes);
-    }
+    // size of encoded array + dictionary size change
+    effectiveSizeBytes = 16L + (long) encodedDimensionValues.length * Integer.BYTES
+                         + (dimLookup.sizeInBytes() - oldDictSizeInBytes);
     return new EncodedKeyComponent<>(encodedDimensionValues, effectiveSizeBytes);
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/incremental/AppendableIndexBuilder.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/AppendableIndexBuilder.java
@@ -37,7 +37,6 @@ public abstract class AppendableIndexBuilder
   // DruidInputSource since that is the only case where we can have existing metrics.
   // This is currently only use by auto compaction and should not be use for anything else.
   protected boolean preserveExistingMetrics = false;
-  protected boolean useMaxMemoryEstimates = false;
 
   protected final Logger log = new Logger(this.getClass());
 
@@ -100,12 +99,6 @@ public abstract class AppendableIndexBuilder
   public AppendableIndexBuilder setPreserveExistingMetrics(final boolean preserveExistingMetrics)
   {
     this.preserveExistingMetrics = preserveExistingMetrics;
-    return this;
-  }
-
-  public AppendableIndexBuilder setUseMaxMemoryEstimates(final boolean useMaxMemoryEstimates)
-  {
-    this.useMaxMemoryEstimates = useMaxMemoryEstimates;
     return this;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/IncrementalIndex.java
@@ -253,7 +253,6 @@ public abstract class IncrementalIndex implements IncrementalIndexRowSelector, C
   private final Map<String, ColumnFormat> timeAndMetricsColumnFormats;
   private final AtomicInteger numEntries = new AtomicInteger();
   private final AtomicLong bytesInMemory = new AtomicLong();
-  private final boolean useMaxMemoryEstimates;
 
   private final boolean useSchemaDiscovery;
 
@@ -271,12 +270,10 @@ public abstract class IncrementalIndex implements IncrementalIndexRowSelector, C
    *                                  This should only be set for DruidInputSource since that is the only case where we
    *                                  can have existing metrics. This is currently only use by auto compaction and
    *                                  should not be use for anything else.
-   * @param useMaxMemoryEstimates     true if max values should be used to estimate memory
    */
   protected IncrementalIndex(
       final IncrementalIndexSchema incrementalIndexSchema,
-      final boolean preserveExistingMetrics,
-      final boolean useMaxMemoryEstimates
+      final boolean preserveExistingMetrics
   )
   {
     this.minTimestamp = incrementalIndexSchema.getMinTimestamp();
@@ -286,7 +283,6 @@ public abstract class IncrementalIndex implements IncrementalIndexRowSelector, C
     this.metrics = incrementalIndexSchema.getMetrics();
     this.rowTransformers = new CopyOnWriteArrayList<>();
     this.preserveExistingMetrics = preserveExistingMetrics;
-    this.useMaxMemoryEstimates = useMaxMemoryEstimates;
     this.useSchemaDiscovery = incrementalIndexSchema.getDimensionsSpec()
                                                     .useSchemaDiscovery();
 
@@ -898,7 +894,7 @@ public abstract class IncrementalIndex implements IncrementalIndexRowSelector, C
 
   private DimensionDesc initDimension(int dimensionIndex, String dimensionName, DimensionHandler dimensionHandler)
   {
-    return new DimensionDesc(dimensionIndex, dimensionName, dimensionHandler, useMaxMemoryEstimates);
+    return new DimensionDesc(dimensionIndex, dimensionName, dimensionHandler);
   }
 
   @Override
@@ -990,12 +986,12 @@ public abstract class IncrementalIndex implements IncrementalIndexRowSelector, C
     private final DimensionHandler<?, ?, ?> handler;
     private final DimensionIndexer<?, ?, ?> indexer;
 
-    public DimensionDesc(int index, String name, DimensionHandler<?, ?, ?> handler, boolean useMaxMemoryEstimates)
+    public DimensionDesc(int index, String name, DimensionHandler<?, ?, ?> handler)
     {
       this.index = index;
       this.name = name;
       this.handler = handler;
-      this.indexer = handler.makeIndexer(useMaxMemoryEstimates);
+      this.indexer = handler.makeIndexer();
     }
 
     public DimensionDesc(int index, String name, DimensionHandler<?, ?, ?> handler, DimensionIndexer<?, ?, ?> indexer)

--- a/processing/src/test/java/org/apache/druid/segment/StringDimensionIndexerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/StringDimensionIndexerTest.java
@@ -38,7 +38,6 @@ public class StringDimensionIndexerTest extends InitializedNullHandlingTest
     final StringDimensionIndexer indexer = new StringDimensionIndexer(
         DimensionSchema.MultiValueHandling.SORTED_ARRAY,
         true,
-        false,
         false
     );
 
@@ -87,87 +86,18 @@ public class StringDimensionIndexerTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testProcessRowValsToEncodedKeyComponent_usingMaxEstimates()
-  {
-    final StringDimensionIndexer indexer = new StringDimensionIndexer(
-        DimensionSchema.MultiValueHandling.SORTED_ARRAY,
-        true,
-        false,
-        true
-    );
-
-    long totalEstimatedSize = 0L;
-
-    // Verify size for a non-empty dimension value
-    totalEstimatedSize += verifyEncodedValues(
-        indexer,
-        "abc",
-        new int[]{0},
-        54L
-    );
-
-    // Verify size for null dimension value
-    totalEstimatedSize += verifyEncodedValues(
-        indexer,
-        null,
-        new int[]{1},
-        4L
-    );
-
-    // Verify size delta with repeated dimension value
-    totalEstimatedSize += verifyEncodedValues(
-        indexer,
-        "abc",
-        new int[]{0},
-        54L
-    );
-    // Verify size delta with newly added dimension value
-    totalEstimatedSize += verifyEncodedValues(
-        indexer,
-        "def",
-        new int[]{2},
-        54L
-    );
-
-    // Verify size delta for multi-values
-    totalEstimatedSize += verifyEncodedValues(
-        indexer,
-        Arrays.asList("abc", "def", "ghi"),
-        new int[]{0, 2, 3},
-        162L
-    );
-
-    Assert.assertEquals(328L, totalEstimatedSize);
-  }
-
-  @Test
   public void testProcessRowValsToEncodedKeyComponent_comparison()
   {
-    // Create indexers with useMaxMemoryEstimates = true/false
     final StringDimensionIndexer indexerForAvgEstimates = new StringDimensionIndexer(
         DimensionSchema.MultiValueHandling.SORTED_ARRAY,
         true,
-        false,
         false
-    );
-    StringDimensionIndexer indexerForMaxEstimates = new StringDimensionIndexer(
-        DimensionSchema.MultiValueHandling.SORTED_ARRAY,
-        true,
-        false,
-        true
     );
 
     // Verify sizes with newly added dimension values
-    long totalSizeWithMaxEstimates = 0L;
     long totalSizeWithAvgEstimates = 0L;
     for (int i = 0; i < 10; ++i) {
       final String dimValue = "value-" + i;
-      totalSizeWithMaxEstimates += verifyEncodedValues(
-          indexerForMaxEstimates,
-          dimValue,
-          new int[]{i},
-          62L
-      );
       totalSizeWithAvgEstimates += verifyEncodedValues(
           indexerForAvgEstimates,
           dimValue,
@@ -177,20 +107,12 @@ public class StringDimensionIndexerTest extends InitializedNullHandlingTest
     }
 
     // If all dimension values are unique (or cardinality is high),
-    // estimates with useMaxMemoryEstimates = false tend to be higher
-    Assert.assertEquals(620L, totalSizeWithMaxEstimates);
     Assert.assertEquals(940L, totalSizeWithAvgEstimates);
 
     // Verify sizes with repeated dimension values
     for (int i = 0; i < 100; ++i) {
       final int index = i % 10;
       final String dimValue = "value-" + index;
-      totalSizeWithMaxEstimates += verifyEncodedValues(
-          indexerForMaxEstimates,
-          dimValue,
-          new int[]{index},
-          62L
-      );
       totalSizeWithAvgEstimates += verifyEncodedValues(
           indexerForAvgEstimates,
           dimValue,
@@ -199,9 +121,6 @@ public class StringDimensionIndexerTest extends InitializedNullHandlingTest
       );
     }
 
-    // If dimension values are frequently repeated (cardinality is low),
-    // estimates with useMaxMemoryEstimates = false tend to be much lower
-    Assert.assertEquals(6820L, totalSizeWithMaxEstimates);
     Assert.assertEquals(2940L, totalSizeWithAvgEstimates);
   }
 
@@ -211,7 +130,6 @@ public class StringDimensionIndexerTest extends InitializedNullHandlingTest
     final StringDimensionIndexer indexer = new StringDimensionIndexer(
         DimensionSchema.MultiValueHandling.SORTED_ARRAY,
         true,
-        false,
         false
     );
     final byte[] byteVal = new byte[]{0x01, 0x02, 0x03, 0x04};

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowSizeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowSizeTest.java
@@ -76,8 +76,7 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
         "B"  // 50 Bytes
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    // 32 (timestamp + dims array + dimensionDescList) + 50 ("A") + 50 ("B")
-    Assert.assertEquals(132, td1.estimateBytesInMemory());
+    Assert.assertEquals(196, td1.estimateBytesInMemory());
   }
 
   @Test
@@ -93,8 +92,7 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
         Arrays.asList("A", "B") // 100 Bytes
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    // 32 (timestamp + dims array + dimensionDescList) + 50 ("A") + 100 ("A", "B")
-    Assert.assertEquals(182, td1.estimateBytesInMemory());
+    Assert.assertEquals(262, td1.estimateBytesInMemory());
   }
 
   @Test
@@ -110,8 +108,7 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
         Arrays.asList("123", "abcdef") // 54 + 60 Bytes
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    // 32 (timestamp + dims array + dimensionDescList) + 60 ("nelson") + 114 ("123", "abcdef")
-    Assert.assertEquals(206, td1.estimateBytesInMemory());
+    Assert.assertEquals(286, td1.estimateBytesInMemory());
   }
 
   @Test
@@ -122,11 +119,10 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
     IncrementalIndex.IncrementalIndexRowResult tndResult = index.toIncrementalIndexRow(toMapRow(
         time + 1,
         "billy",
-        "" // NullHandling.sqlCompatible() ? 48 Bytes : 4 Bytes
+        ""
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    // 28 (timestamp + dims array + dimensionDescList) + 4 OR 48 depending on NullHandling.sqlCompatible()
-    Assert.assertEquals(76, td1.estimateBytesInMemory());
+    Assert.assertEquals(108, td1.estimateBytesInMemory());
   }
 
   private MapBasedInputRow toMapRow(long time, Object... dimAndVal)

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowSizeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowSizeTest.java
@@ -53,7 +53,6 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
             .setSimpleTestingIndexSchema(new CountAggregatorFactory("cnt"))
             .setMaxRowCount(10_000)
             .setMaxBytesInMemory(1_000)
-            .setUseMaxMemoryEstimates(true)
             .build())
     );
   }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderators.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/Appenderators.java
@@ -60,7 +60,6 @@ public class Appenderators
       CachePopulatorStats cachePopulatorStats,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -91,7 +90,6 @@ public class Appenderators
         cache,
         rowIngestionMeters,
         parseExceptionHandler,
-        useMaxMemoryEstimates,
         centralizedDatasourceSchemaConfig
     );
   }
@@ -107,7 +105,6 @@ public class Appenderators
       IndexMerger indexMerger,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -125,7 +122,6 @@ public class Appenderators
         indexMerger,
         rowIngestionMeters,
         parseExceptionHandler,
-        useMaxMemoryEstimates,
         centralizedDatasourceSchemaConfig
     );
   }

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/AppenderatorsManager.java
@@ -86,7 +86,6 @@ public interface AppenderatorsManager
       CachePopulatorStats cachePopulatorStats,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   );
 
@@ -106,7 +105,6 @@ public interface AppenderatorsManager
       IndexMerger indexMerger,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   );
 

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderator.java
@@ -120,7 +120,6 @@ public class BatchAppenderator implements Appenderator
   private final IndexMerger indexMerger;
   private final long maxBytesTuningConfig;
   private final boolean skipBytesInMemoryOverheadCheck;
-  private final boolean useMaxMemoryEstimates;
 
   private volatile ListeningExecutorService persistExecutor = null;
   private volatile ListeningExecutorService pushExecutor = null;
@@ -171,7 +170,6 @@ public class BatchAppenderator implements Appenderator
       IndexMerger indexMerger,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -189,7 +187,6 @@ public class BatchAppenderator implements Appenderator
     maxBytesTuningConfig = tuningConfig.getMaxBytesInMemoryOrDefault();
     skipBytesInMemoryOverheadCheck = tuningConfig.isSkipBytesInMemoryOverheadCheck();
     maxPendingPersists = tuningConfig.getMaxPendingPersists();
-    this.useMaxMemoryEstimates = useMaxMemoryEstimates;
     this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
     this.fingerprintGenerator = new FingerprintGenerator(objectMapper);
   }
@@ -480,8 +477,7 @@ public class BatchAppenderator implements Appenderator
           identifier.getVersion(),
           tuningConfig.getAppendableIndexSpec(),
           tuningConfig.getMaxRowsInMemory(),
-          maxBytesTuningConfig,
-          useMaxMemoryEstimates
+          maxBytesTuningConfig
       );
       bytesCurrentlyInMemory += calculateSinkMemoryInUsed();
       sinks.put(identifier, retVal);
@@ -1073,7 +1069,6 @@ public class BatchAppenderator implements Appenderator
         tuningConfig.getAppendableIndexSpec(),
         tuningConfig.getMaxRowsInMemory(),
         maxBytesTuningConfig,
-        useMaxMemoryEstimates,
         hydrants
     );
     retVal.finishWriting(); // this sink is not writable

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/DummyForInjectionAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/DummyForInjectionAppenderatorsManager.java
@@ -76,7 +76,6 @@ public class DummyForInjectionAppenderatorsManager implements AppenderatorsManag
       CachePopulatorStats cachePopulatorStats,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -95,7 +94,6 @@ public class DummyForInjectionAppenderatorsManager implements AppenderatorsManag
       IndexMerger indexMerger,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/PeonAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/PeonAppenderatorsManager.java
@@ -82,7 +82,6 @@ public class PeonAppenderatorsManager implements AppenderatorsManager
       CachePopulatorStats cachePopulatorStats,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -110,7 +109,6 @@ public class PeonAppenderatorsManager implements AppenderatorsManager
           cachePopulatorStats,
           rowIngestionMeters,
           parseExceptionHandler,
-          useMaxMemoryEstimates,
           centralizedDatasourceSchemaConfig
       );
     }
@@ -129,7 +127,6 @@ public class PeonAppenderatorsManager implements AppenderatorsManager
       IndexMerger indexMerger,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -148,7 +145,6 @@ public class PeonAppenderatorsManager implements AppenderatorsManager
           indexMerger,
           rowIngestionMeters,
           parseExceptionHandler,
-          useMaxMemoryEstimates,
           centralizedDatasourceSchemaConfig
       );
       return batchAppenderator;

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderator.java
@@ -152,7 +152,6 @@ public class StreamAppenderator implements Appenderator
   private final Set<SegmentIdWithShardSpec> droppingSinks = Sets.newConcurrentHashSet();
   private final long maxBytesTuningConfig;
   private final boolean skipBytesInMemoryOverheadCheck;
-  private final boolean useMaxMemoryEstimates;
 
   private final QuerySegmentWalker texasRanger;
   // This variable updated in add(), persist(), and drop()
@@ -230,7 +229,6 @@ public class StreamAppenderator implements Appenderator
       Cache cache,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -251,7 +249,6 @@ public class StreamAppenderator implements Appenderator
 
     maxBytesTuningConfig = tuningConfig.getMaxBytesInMemoryOrDefault();
     skipBytesInMemoryOverheadCheck = tuningConfig.isSkipBytesInMemoryOverheadCheck();
-    this.useMaxMemoryEstimates = useMaxMemoryEstimates;
     this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
     this.sinkSchemaAnnouncer = new SinkSchemaAnnouncer();
 
@@ -523,8 +520,7 @@ public class StreamAppenderator implements Appenderator
           identifier.getVersion(),
           tuningConfig.getAppendableIndexSpec(),
           tuningConfig.getMaxRowsInMemory(),
-          maxBytesTuningConfig,
-          useMaxMemoryEstimates
+          maxBytesTuningConfig
       );
       bytesCurrentlyInMemory.addAndGet(calculateSinkMemoryInUsed(retVal));
 
@@ -1411,7 +1407,6 @@ public class StreamAppenderator implements Appenderator
             tuningConfig.getAppendableIndexSpec(),
             tuningConfig.getMaxRowsInMemory(),
             maxBytesTuningConfig,
-            useMaxMemoryEstimates,
             hydrants
         );
         rowsSoFar += currSink.getNumRows();

--- a/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManager.java
@@ -168,7 +168,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
       CachePopulatorStats cachePopulatorStats,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -193,7 +192,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
           cache,
           rowIngestionMeters,
           parseExceptionHandler,
-          useMaxMemoryEstimates,
           centralizedDatasourceSchemaConfig
       );
 
@@ -214,7 +212,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
       IndexMerger indexMerger,
       RowIngestionMeters rowIngestionMeters,
       ParseExceptionHandler parseExceptionHandler,
-      boolean useMaxMemoryEstimates,
       CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
   )
   {
@@ -235,7 +232,6 @@ public class UnifiedIndexerAppenderatorsManager implements AppenderatorsManager
           wrapIndexMerger(indexMerger),
           rowIngestionMeters,
           parseExceptionHandler,
-          useMaxMemoryEstimates,
           centralizedDatasourceSchemaConfig
       );
       datasourceBundle.addAppenderator(taskId, appenderator);

--- a/server/src/main/java/org/apache/druid/segment/realtime/sink/Sink.java
+++ b/server/src/main/java/org/apache/druid/segment/realtime/sink/Sink.java
@@ -66,7 +66,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 
 public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
@@ -85,7 +84,6 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
   private final AppendableIndexSpec appendableIndexSpec;
   private final int maxRowsInMemory;
   private final long maxBytesInMemory;
-  private final boolean useMaxMemoryEstimates;
   private final CopyOnWriteArrayList<FireHydrant> hydrants = new CopyOnWriteArrayList<>();
 
   private final LinkedHashSet<String> dimOrder = new LinkedHashSet<>();
@@ -109,8 +107,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
       String version,
       AppendableIndexSpec appendableIndexSpec,
       int maxRowsInMemory,
-      long maxBytesInMemory,
-      boolean useMaxMemoryEstimates
+      long maxBytesInMemory
   )
   {
     this(
@@ -121,7 +118,6 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
         appendableIndexSpec,
         maxRowsInMemory,
         maxBytesInMemory,
-        useMaxMemoryEstimates,
         Collections.emptyList()
     );
   }
@@ -134,7 +130,6 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
       AppendableIndexSpec appendableIndexSpec,
       int maxRowsInMemory,
       long maxBytesInMemory,
-      boolean useMaxMemoryEstimates,
       List<FireHydrant> hydrants
   )
   {
@@ -145,7 +140,6 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
     this.appendableIndexSpec = appendableIndexSpec;
     this.maxRowsInMemory = maxRowsInMemory;
     this.maxBytesInMemory = maxBytesInMemory;
-    this.useMaxMemoryEstimates = useMaxMemoryEstimates;
 
     int maxCount = -1;
     for (int i = 0; i < hydrants.size(); ++i) {
@@ -306,7 +300,7 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
    * Acquire references to all {@link FireHydrant} that represent this sink. Returns null if they cannot all be
    * acquired, possibly because they were closed (swapped to null) concurrently with this method being called.
    *
-   * @param segmentMapFn           from {@link org.apache.druid.query.DataSource#createSegmentMapFunction(Query, AtomicLong)}
+   * @param segmentMapFn           from {@link org.apache.druid.query.DataSource#createSegmentMapFunction(Query)}
    * @param skipIncrementalSegment whether in-memory {@link IncrementalIndex} segments should be skipped
    */
   @Nullable
@@ -336,7 +330,6 @@ public class Sink implements Iterable<FireHydrant>, Overshadowable<Sink>
         .setIndexSchema(indexSchema)
         .setMaxRowCount(maxRowsInMemory)
         .setMaxBytesInMemory(maxBytesInMemory)
-        .setUseMaxMemoryEstimates(useMaxMemoryEstimates)
         .build();
 
     final FireHydrant old;

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorTest.java
@@ -298,12 +298,12 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       // 182 + 1 byte when null handling is enabled
       int nullHandlingOverhead = 1;
       Assert.assertEquals(
-          182 + nullHandlingOverhead,
+          190 + nullHandlingOverhead,
           ((BatchAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
       );
       appenderator.add(IDENTIFIERS.get(1), createInputRow("2000", "bar", 1), null);
       Assert.assertEquals(
-          182 + nullHandlingOverhead,
+          190 + nullHandlingOverhead,
           ((BatchAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(1))
       );
       appenderator.close();
@@ -330,10 +330,10 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       appenderator.add(IDENTIFIERS.get(0), createInputRow("2000", "foo", 1), null);
       //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 182
       int nullHandlingOverhead = 1;
-      Assert.assertEquals(182 + nullHandlingOverhead, ((BatchAppenderator) appenderator).getBytesCurrentlyInMemory());
+      Assert.assertEquals(190 + nullHandlingOverhead, ((BatchAppenderator) appenderator).getBytesCurrentlyInMemory());
       appenderator.add(IDENTIFIERS.get(1), createInputRow("2000", "bar", 1), null);
       Assert.assertEquals(
-          364 + 2 * nullHandlingOverhead,
+          380 + 2 * nullHandlingOverhead,
           ((BatchAppenderator) appenderator).getBytesCurrentlyInMemory()
       );
       Assert.assertEquals(2, appenderator.getSegments().size());
@@ -353,7 +353,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       // Still under maxSizeInBytes after the add. Hence, we do not persist yet
       //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 182 + 1 byte when null handling is enabled
       int nullHandlingOverhead = 1;
-      int currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      int currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       int sinkSizeOverhead = BatchAppenderator.ROUGH_OVERHEAD_PER_SINK;
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
       Assert.assertEquals(
@@ -366,7 +366,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the same sink to cause persist.
-      for (int i = 0; i < 53; i++) {
+      for (int i = 0; i < 50; i++) {
         appenderator.add(IDENTIFIERS.get(0), createInputRow("2000", "bar_" + i, 1), null);
       }
 
@@ -387,7 +387,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       // Add a single row after persisted
       appenderator.add(IDENTIFIERS.get(0), createInputRow("2000", "bob", 1), null);
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
-      currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       Assert.assertEquals(
           currentInMemoryIndexSize,
           ((BatchAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
@@ -398,7 +398,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the same sink to cause persist.
-      for (int i = 0; i < 53; i++) {
+      for (int i = 0; i < 50; i++) {
         appenderator.add(IDENTIFIERS.get(0), createInputRow("2000", "bar_" + i, 1), null);
       }
 
@@ -476,7 +476,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
 
       // Still under maxSizeInBytes after the add. Hence, we do not persist yet
       int nullHandlingOverhead = 1;
-      int currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      int currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       int sinkSizeOverhead = BatchAppenderator.ROUGH_OVERHEAD_PER_SINK;
       Assert.assertEquals(
           currentInMemoryIndexSize + sinkSizeOverhead,
@@ -506,7 +506,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       // Still under maxSizeInBytes after the add. Hence, we do not persist yet
       //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 182 + 1 byte when null handling is enabled
       int nullHandlingOverhead = 1;
-      int currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      int currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       int sinkSizeOverhead = 2 * BatchAppenderator.ROUGH_OVERHEAD_PER_SINK;
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
       Assert.assertEquals(
@@ -523,7 +523,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the same sink to cause persist.
-      for (int i = 0; i < 49; i++) {
+      for (int i = 0; i < 47; i++) {
         // these records are 186 bytes
         appenderator.add(IDENTIFIERS.get(0), createInputRow("2000", "bar_" + i, 1), null);
         appenderator.add(IDENTIFIERS.get(1), createInputRow("2000", "bar_" + i, 1), null);
@@ -549,7 +549,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       // Add a single row after persisted to sink 0
       appenderator.add(IDENTIFIERS.get(0), createInputRow("2000", "bob", 1), null);
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
-      currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       Assert.assertEquals(
           currentInMemoryIndexSize,
           ((BatchAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
@@ -581,7 +581,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the both sink to cause persist.
-      for (int i = 0; i < 49; i++) {
+      for (int i = 0; i < 47; i++) {
         // 186 bytes
         appenderator.add(IDENTIFIERS.get(0), createInputRow("2000", "bar_" + i, 1), null);
         appenderator.add(IDENTIFIERS.get(1), createInputRow("2000", "bar_" + i, 1), null);
@@ -626,7 +626,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       //we still calculate the size even when ignoring it to make persist decision
       int nullHandlingOverhead = 1;
       Assert.assertEquals(
-          182 + nullHandlingOverhead,
+          190 + nullHandlingOverhead,
           ((BatchAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
       );
       Assert.assertEquals(1, ((BatchAppenderator) appenderator).getRowsInMemory());
@@ -636,7 +636,7 @@ public class BatchAppenderatorTest extends InitializedNullHandlingTest
       // persisted:
       int sinkSizeOverhead = 2 * BatchAppenderator.ROUGH_OVERHEAD_PER_SINK;
       Assert.assertEquals(
-          (364 + 2 * nullHandlingOverhead) + sinkSizeOverhead,
+          (380 + 2 * nullHandlingOverhead) + sinkSizeOverhead,
           ((BatchAppenderator) appenderator).getBytesCurrentlyInMemory()
       );
       Assert.assertEquals(2, ((BatchAppenderator) appenderator).getRowsInMemory());

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/BatchAppenderatorTester.java
@@ -239,7 +239,6 @@ public class BatchAppenderatorTester implements AutoCloseable
         indexMerger,
         rowIngestionMeters,
         new ParseExceptionHandler(rowIngestionMeters, false, Integer.MAX_VALUE, 0),
-        true,
         CentralizedDatasourceSchemaConfig.create()
     );
   }

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTest.java
@@ -298,15 +298,14 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
 
       appenderator.startJob();
       appenderator.add(IDENTIFIERS.get(0), ir("2000", "foo", 1), committerSupplier);
-      //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 182 + 1 byte when null handling is enabled
       int nullHandlingOverhead = 1;
       Assert.assertEquals(
-          182 + nullHandlingOverhead,
+          190 + nullHandlingOverhead,
           ((StreamAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
       );
       appenderator.add(IDENTIFIERS.get(1), ir("2000", "bar", 1), committerSupplier);
       Assert.assertEquals(
-          182 + nullHandlingOverhead,
+          190 + nullHandlingOverhead,
           ((StreamAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(1))
       );
       appenderator.close();
@@ -347,12 +346,12 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
 
       appenderator.startJob();
       appenderator.add(IDENTIFIERS.get(0), ir("2000", "foo", 1), committerSupplier);
-      //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 182
+      //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 190
       int nullHandlingOverhead = 1;
-      Assert.assertEquals(182 + nullHandlingOverhead, ((StreamAppenderator) appenderator).getBytesCurrentlyInMemory());
+      Assert.assertEquals(190 + nullHandlingOverhead, ((StreamAppenderator) appenderator).getBytesCurrentlyInMemory());
       appenderator.add(IDENTIFIERS.get(1), ir("2000", "bar", 1), committerSupplier);
       Assert.assertEquals(
-          364 + 2 * nullHandlingOverhead,
+          380 + 2 * nullHandlingOverhead,
           ((StreamAppenderator) appenderator).getBytesCurrentlyInMemory()
       );
       appenderator.close();
@@ -393,9 +392,9 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       appenderator.startJob();
       appenderator.add(IDENTIFIERS.get(0), ir("2000", "foo", 1), committerSupplier);
       // Still under maxSizeInBytes after the add. Hence, we do not persist yet
-      //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 182 + 1 byte when null handling is enabled
+      //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 190 + 1 byte when null handling is enabled
       int nullHandlingOverhead = 1;
-      int currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      int currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       int sinkSizeOverhead = 1 * StreamAppenderator.ROUGH_OVERHEAD_PER_SINK;
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
       Assert.assertEquals(
@@ -408,7 +407,7 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the same sink to cause persist.
-      for (int i = 0; i < 53; i++) {
+      for (int i = 0; i < 50; i++) {
         appenderator.add(IDENTIFIERS.get(0), ir("2000", "bar_" + i, 1), committerSupplier);
       }
       sinkSizeOverhead = 1 * StreamAppenderator.ROUGH_OVERHEAD_PER_SINK;
@@ -433,7 +432,7 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       // Add a single row after persisted
       appenderator.add(IDENTIFIERS.get(0), ir("2000", "bob", 1), committerSupplier);
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
-      currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       Assert.assertEquals(
           currentInMemoryIndexSize,
           ((StreamAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
@@ -444,7 +443,7 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the same sink to cause persist.
-      for (int i = 0; i < 31; i++) {
+      for (int i = 0; i < 30; i++) {
         appenderator.add(IDENTIFIERS.get(0), ir("2000", "bar_" + i, 1), committerSupplier);
       }
       // currHydrant size is 0 since we just persist all indexes to disk.
@@ -591,7 +590,7 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
 
       // Still under maxSizeInBytes after the add. Hence, we do not persist yet
       int nullHandlingOverhead = 1;
-      int currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      int currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       int sinkSizeOverhead = 1 * StreamAppenderator.ROUGH_OVERHEAD_PER_SINK;
       Assert.assertEquals(
           currentInMemoryIndexSize + sinkSizeOverhead,
@@ -641,9 +640,9 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       appenderator.add(IDENTIFIERS.get(1), ir("2000", "bar", 1), committerSupplier);
 
       // Still under maxSizeInBytes after the add. Hence, we do not persist yet
-      //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 182 + 1 byte when null handling is enabled
+      //expectedSizeInBytes = 44(map overhead) + 28 (TimeAndDims overhead) + 56 (aggregator metrics) + 54 (dimsKeySize) = 190 + 1 byte when null handling is enabled
       int nullHandlingOverhead = 1;
-      int currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      int currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       int sinkSizeOverhead = 2 * StreamAppenderator.ROUGH_OVERHEAD_PER_SINK;
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
       Assert.assertEquals(
@@ -690,7 +689,7 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       // Add a single row after persisted to sink 0
       appenderator.add(IDENTIFIERS.get(0), ir("2000", "bob", 1), committerSupplier);
       // currHydrant in the sink still has > 0 bytesInMemory since we do not persist yet
-      currentInMemoryIndexSize = 182 + nullHandlingOverhead;
+      currentInMemoryIndexSize = 190 + nullHandlingOverhead;
       Assert.assertEquals(
           currentInMemoryIndexSize,
           ((StreamAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
@@ -719,9 +718,12 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       );
 
       // We do multiple more adds to the both sink to cause persist.
-      for (int i = 0; i < 34; i++) {
+      for (int i = 0; i < 33; i++) {
         appenderator.add(IDENTIFIERS.get(0), ir("2000", "bar_" + i, 1), committerSupplier);
-        appenderator.add(IDENTIFIERS.get(1), ir("2000", "bar_" + i, 1), committerSupplier);
+        if (i < 32) {
+          // adding the last one puts us over the limit,
+          appenderator.add(IDENTIFIERS.get(1), ir("2000", "bar_" + i, 1), committerSupplier);
+        }
       }
       // currHydrant size is 0 since we just persist all indexes to disk.
       currentInMemoryIndexSize = 0;
@@ -788,14 +790,14 @@ public class StreamAppenderatorTest extends InitializedNullHandlingTest
       //we still calculate the size even when ignoring it to make persist decision
       int nullHandlingOverhead = 1;
       Assert.assertEquals(
-          182 + nullHandlingOverhead,
+          190 + nullHandlingOverhead,
           ((StreamAppenderator) appenderator).getBytesInMemory(IDENTIFIERS.get(0))
       );
       Assert.assertEquals(1, ((StreamAppenderator) appenderator).getRowsInMemory());
       appenderator.add(IDENTIFIERS.get(1), ir("2000", "bar", 1), committerSupplier);
       int sinkSizeOverhead = 2 * StreamAppenderator.ROUGH_OVERHEAD_PER_SINK;
       Assert.assertEquals(
-          (364 + 2 * nullHandlingOverhead) + sinkSizeOverhead,
+          (380 + 2 * nullHandlingOverhead) + sinkSizeOverhead,
           ((StreamAppenderator) appenderator).getBytesCurrentlyInMemory()
       );
       Assert.assertEquals(2, ((StreamAppenderator) appenderator).getRowsInMemory());

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTester.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/StreamAppenderatorTester.java
@@ -246,7 +246,6 @@ public class StreamAppenderatorTester implements AutoCloseable
           new CachePopulatorStats(),
           rowIngestionMeters,
           new ParseExceptionHandler(rowIngestionMeters, false, Integer.MAX_VALUE, 0),
-          true,
           centralizedDatasourceSchemaConfig
       );
     } else {
@@ -288,7 +287,6 @@ public class StreamAppenderatorTester implements AutoCloseable
           new CachePopulatorStats(),
           rowIngestionMeters,
           new ParseExceptionHandler(rowIngestionMeters, false, Integer.MAX_VALUE, 0),
-          true,
           centralizedDatasourceSchemaConfig
       );
     }

--- a/server/src/test/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManagerTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/appenderator/UnifiedIndexerAppenderatorsManagerTest.java
@@ -111,7 +111,6 @@ public class UnifiedIndexerAppenderatorsManagerTest extends InitializedNullHandl
         TestHelper.getTestIndexMergerV9(OnHeapMemorySegmentWriteOutMediumFactory.instance()),
         new NoopRowIngestionMeters(),
         new ParseExceptionHandler(new NoopRowIngestionMeters(), false, 0, 0),
-        true,
         CentralizedDatasourceSchemaConfig.create()
     );
   }

--- a/server/src/test/java/org/apache/druid/segment/realtime/sink/SinkTest.java
+++ b/server/src/test/java/org/apache/druid/segment/realtime/sink/SinkTest.java
@@ -93,8 +93,7 @@ public class SinkTest extends InitializedNullHandlingTest
         version,
         TuningConfig.DEFAULT_APPENDABLE_INDEX,
         MAX_ROWS_IN_MEMORY,
-        TuningConfig.DEFAULT_APPENDABLE_INDEX.getDefaultMaxBytesInMemory(),
-        true
+        TuningConfig.DEFAULT_APPENDABLE_INDEX.getDefaultMaxBytesInMemory()
     );
 
     sink.add(
@@ -276,8 +275,7 @@ public class SinkTest extends InitializedNullHandlingTest
         version,
         TuningConfig.DEFAULT_APPENDABLE_INDEX,
         MAX_ROWS_IN_MEMORY,
-        TuningConfig.DEFAULT_APPENDABLE_INDEX.getDefaultMaxBytesInMemory(),
-        true
+        TuningConfig.DEFAULT_APPENDABLE_INDEX.getDefaultMaxBytesInMemory()
     );
 
     sink.add(new MapBasedInputRow(


### PR DESCRIPTION
Removes `useMaxMemoryEstimates`  config from ingestion and the behavior for the `true` value in favor of always using the `false` behavior which uses the more accurate estimates introduced originally in #12073. The `false` setting has been the default in most modes for native batch and streaming since 25, Hadoop batch since 31, and internally for MSQ as of 33 (an oversight it wasn't being used earlier), so I think it is safe to remove `true` mode.