### PR TITLE
Raw SQL Support on HTTP endpoints

### DIFF
--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -49,7 +49,8 @@ Each query has an associated SQL query ID. You can set this ID manually using th
 
 #### JSON Format Request body
 
-To send queries in JSON format, the 'Content-Type' in the HTTP request MUST be `application/json`.
+To send queries in JSON format, the `Content-Type` in the HTTP request MUST be `application/json`.
+If there're multiple `Content-Type` headers, the **first** one is used.
 
 The request body takes the following properties:
 
@@ -105,10 +106,13 @@ The request body takes the following properties:
 ##### Text Format Request body
 
 Druid also allows you to submit SQL queries in text format which is simpler than above JSON format. 
-To do this, just leave the `Content-Type` rquest header blank or set it to anything other than `application/json`.
-The whole request body is treated as a single SQL query string.
+To do this, just leave the `Content-Type` rquest header blank or set it to anything other than `application/json`. 
+If there're multiple `Content-Type` headers, the **first** one is used.
 
-In this request format, the `resultFormat` of response is always `object` with the HTTP response header Content-Type: application/json.
+In this format, the whole request body is treated as a single SQL query string.
+
+For response, the `resultFormat` is always `object` with the HTTP response header `Content-Type: application/json`.
+
 If you want more control over the query context or response format, use the above JSON format request body instead.
 
 ```commandline

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -113,12 +113,23 @@ If there are multiple `Content-Type` headers, the **first** one is used.
 For response, the `resultFormat` is always `object` with the HTTP response header `Content-Type: application/json`.
 If you want more control over the query context or response format, use the above JSON format request body instead.
 
-For example:
+The following example demonstrates how to submit a SQL query in text format:
 
 ```commandline
-echo 'SELECT 1' | curl http://ROUTER_IP:ROUTER_PORT/druid/v2/sql --data @-
 echo 'SELECT 1' | curl -H 'Content-Type: text/plain' http://ROUTER_IP:ROUTER_PORT/druid/v2/sql --data @- 
 ```
+
+We can also use `application/x-www-form-urlencoded` to submit URL-encoded SQL queries as shown by the following examples:
+
+```commandline
+echo 'SELECT%20%31' | curl http://ROUTER_IP:ROUTER_PORT/druid/v2/sql --data @-
+echo 'SELECT 1' | curl http://ROUTER_IP:ROUTER_PORT/druid/v2/sql --data-urlencode @-
+```
+
+The `curl` tool uses `application/x-www-form-urlencoded` as Content-Type header if the header is not given.
+
+The first example pass the URL-encoded query `SELECT%20%31`, which is `SELECT 1`, to the `curl` and `curl` will directly sends it to the server.
+While the second example passes the raw query `SELECT 1` to `curl` and the `curl` encodes the query to `SELECT%20%31` because of `--data-urlencode` option and sends the encoded text to the server.
 
 #### Responses
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -108,6 +108,8 @@ The request body takes the following properties:
 Druid also allows you to submit SQL queries in text format which is simpler than above JSON format. 
 To do this, just set the `Content-Type` request header to `text/plain` or `application/x-www-form-urlencoded`, and pass SQL via the HTTP Body. 
 
+If `application/x-www-form-urlencoded` is used, make sure the SQL query is URL-encoded.
+
 If there are multiple `Content-Type` headers, the **first** one is used.
 
 For response, the `resultFormat` is always `object` with the HTTP response header `Content-Type: application/json`.

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -38,7 +38,8 @@ In this topic, `http://ROUTER_IP:ROUTER_PORT` is a placeholder for your Router s
 
 ### Submit a query
 
-Submits a SQL-based query in the JSON request body. Returns a JSON object with the query results and optional metadata for the results. You can also use this endpoint to query [metadata tables](../querying/sql-metadata-tables.md).
+Submits a SQL-based query in the JSON or text format request body. 
+Returns a JSON object with the query results and optional metadata for the results. You can also use this endpoint to query [metadata tables](../querying/sql-metadata-tables.md).
 
 Each query has an associated SQL query ID. You can set this ID manually using the SQL context parameter `sqlQueryId`. If not set, Druid automatically generates `sqlQueryId` and returns it in the response header for `X-Druid-SQL-Query-Id`. Note that you need the `sqlQueryId` to [cancel a query](#cancel-a-query).
 
@@ -46,7 +47,9 @@ Each query has an associated SQL query ID. You can set this ID manually using th
 
 `POST` `/druid/v2/sql`
 
-#### Request body
+#### JSON Format Request body
+
+To send queries in JSON format, the 'Content-Type' in the HTTP request MUST be `application/json`.
 
 The request body takes the following properties:
 
@@ -98,6 +101,19 @@ The request body takes the following properties:
             ]
     }
     ```
+
+##### Text Format Request body
+
+Druid also allows you to submit SQL queries in text format which is simpler than above JSON format. 
+To do this, just leave the `Content-Type` rquest header blank or set it to anything other than `application/json`.
+The whole request body is treated as a single SQL query string.
+
+In this request format, the `resultFormat` of response is always `object` with the HTTP response header Content-Type: application/json.
+If you want more control over the query context or response format, use the above JSON format request body instead.
+
+```commandline
+echo 'SELECT 1' | curl -X POST "http://ROUTER_IP:ROUTER_PORT/druid/v2/sql" --data @- 
+```
 
 #### Responses
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -50,7 +50,7 @@ Each query has an associated SQL query ID. You can set this ID manually using th
 #### JSON Format Request body
 
 To send queries in JSON format, the `Content-Type` in the HTTP request MUST be `application/json`.
-If there're multiple `Content-Type` headers, the **first** one is used.
+If there are multiple `Content-Type` headers, the **first** one is used.
 
 The request body takes the following properties:
 
@@ -106,8 +106,8 @@ The request body takes the following properties:
 ##### Text Format Request body
 
 Druid also allows you to submit SQL queries in text format which is simpler than above JSON format. 
-To do this, just leave the `Content-Type` rquest header blank or set it to anything other than `application/json`. 
-If there're multiple `Content-Type` headers, the **first** one is used.
+To do this, just leave the `Content-Type` request header blank or set it to anything other than `application/json`. 
+If there are multiple `Content-Type` headers, the **first** one is used.
 
 In this format, the whole request body is treated as a single SQL query string.
 

--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -106,17 +106,18 @@ The request body takes the following properties:
 ##### Text Format Request body
 
 Druid also allows you to submit SQL queries in text format which is simpler than above JSON format. 
-To do this, just leave the `Content-Type` request header blank or set it to anything other than `application/json`. 
+To do this, just set the `Content-Type` request header to `text/plain` or `application/x-www-form-urlencoded`, and pass SQL via the HTTP Body. 
+
 If there are multiple `Content-Type` headers, the **first** one is used.
 
-In this format, the whole request body is treated as a single SQL query string.
-
 For response, the `resultFormat` is always `object` with the HTTP response header `Content-Type: application/json`.
-
 If you want more control over the query context or response format, use the above JSON format request body instead.
 
+For example:
+
 ```commandline
-echo 'SELECT 1' | curl -X POST "http://ROUTER_IP:ROUTER_PORT/druid/v2/sql" --data @- 
+echo 'SELECT 1' | curl http://ROUTER_IP:ROUTER_PORT/druid/v2/sql --data @-
+echo 'SELECT 1' | curl -H 'Content-Type: text/plain' http://ROUTER_IP:ROUTER_PORT/druid/v2/sql --data @- 
 ```
 
 #### Responses

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
@@ -208,7 +208,7 @@ public class DartSqlResource extends SqlResource
       @Context final HttpContext httpContext
   )
   {
-    SqlQuery sqlQuery = parseQuery(httpContext);
+    SqlQuery sqlQuery = SqlQuery.from(httpContext);
 
     final Map<String, Object> context = new HashMap<>(sqlQuery.getContext());
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.Futures;
 import com.google.inject.Inject;
+import com.sun.jersey.api.core.HttpContext;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -50,7 +51,6 @@ import org.apache.druid.sql.http.SqlQuery;
 import org.apache.druid.sql.http.SqlResource;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -202,13 +202,14 @@ public class DartSqlResource extends SqlResource
    */
   @POST
   @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.APPLICATION_JSON)
   @Override
   public Response doPost(
-      final SqlQuery sqlQuery,
-      @Context final HttpServletRequest req
+      @Context final HttpServletRequest req,
+      @Context final HttpContext httpContext
   )
   {
+    SqlQuery sqlQuery = parseQuery(httpContext);
+
     final Map<String, Object> context = new HashMap<>(sqlQuery.getContext());
 
     // Default context keys from dartQueryConfig.

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
@@ -208,8 +208,15 @@ public class DartSqlResource extends SqlResource
       @Context final HttpContext httpContext
   )
   {
-    SqlQuery sqlQuery = SqlQuery.from(httpContext);
+    return this.doPost(SqlQuery.from(httpContext), req);
+  }
 
+  @Override
+  public Response doPost(
+      final SqlQuery sqlQuery,
+      final HttpServletRequest req
+  )
+  {
     final Map<String, Object> context = new HashMap<>(sqlQuery.getContext());
 
     // Default context keys from dartQueryConfig.

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
+import com.sun.jersey.api.core.HttpContext;
 import org.apache.druid.client.indexing.TaskPayloadResponse;
 import org.apache.druid.client.indexing.TaskStatusResponse;
 import org.apache.druid.common.guava.FutureUtils;
@@ -96,7 +97,6 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -167,8 +167,14 @@ public class SqlStatementResource
 
   @POST
   @Produces(MediaType.APPLICATION_JSON)
-  @Consumes(MediaType.APPLICATION_JSON)
-  public Response doPost(final SqlQuery sqlQuery, @Context final HttpServletRequest req)
+  public Response doPost(@Context final HttpServletRequest req,
+                         @Context final HttpContext httpContext)
+  {
+    return doPost(SqlQuery.from(httpContext), req);
+  }
+
+  public Response doPost(SqlQuery sqlQuery,
+                         @Context final HttpServletRequest req)
   {
     SqlQuery modifiedQuery = createModifiedSqlQuery(sqlQuery);
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -173,8 +173,9 @@ public class SqlStatementResource
     return doPost(SqlQuery.from(httpContext), req);
   }
 
-  public Response doPost(SqlQuery sqlQuery,
-                         @Context final HttpServletRequest req)
+  @VisibleForTesting
+  Response doPost(final SqlQuery sqlQuery,
+                  final HttpServletRequest req)
   {
     SqlQuery modifiedQuery = createModifiedSqlQuery(sqlQuery);
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -421,12 +421,10 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.11</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
         </dependency>
 
         <!-- Tests -->

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -418,6 +418,16 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.11</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.guice.DruidTestModuleFactory;
 import org.apache.druid.tests.TestNGGroup;
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -87,22 +88,18 @@ public class ITSqlQueryTest
   }
 
   @Test
-  public void testEmptyContentType()
+  public void testUnsupportedMediaType()
   {
     executeWithRetry(
         "<EMPTY>",
         (endpoint) -> {
           try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
             HttpPost request = new HttpPost(endpoint);
+            request.addHeader("Content-Type", "application/xml");
             request.setEntity(new StringEntity("select 1"));
 
             try (CloseableHttpResponse response = client.execute(request)) {
-              assertEquals(200, response.getStatusLine().getStatusCode());
-
-              HttpEntity entity = response.getEntity();
-              assertNotNull(entity);
-              String responseBody = EntityUtils.toString(entity).trim();
-              assertEquals("[{\"EXPR$0\":1}]", responseBody);
+              assertEquals(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, response.getStatusLine().getStatusCode());
             }
           }
         }

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -100,7 +100,8 @@ public class ITSqlQueryTest
               Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertNotNull(entity);
+              String responseBody = EntityUtils.toString(entity).trim();
               Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
@@ -123,7 +124,8 @@ public class ITSqlQueryTest
               Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertNotNull(entity);
+              String responseBody = EntityUtils.toString(entity).trim();
               Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
@@ -146,7 +148,8 @@ public class ITSqlQueryTest
               Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertNotNull(entity);
+              String responseBody = EntityUtils.toString(entity).trim();
               Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
@@ -169,7 +172,8 @@ public class ITSqlQueryTest
               Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertNotNull(entity);
+              String responseBody = EntityUtils.toString(entity).trim();
               Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -195,7 +195,8 @@ public class ITSqlQueryTest
               Assert.assertEquals(400, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertNotNull(entity);
+              String responseBody = EntityUtils.toString(entity).trim();
               Assert.assertTrue(responseBody.contains("invalidInput"));
             }
           }
@@ -222,7 +223,8 @@ public class ITSqlQueryTest
               Assert.assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertNotNull(entity);
+              String responseBody = EntityUtils.toString(entity).trim();
               Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -52,14 +52,19 @@ public class ITSqlQueryTest
   @Inject
   IntegrationTestingConfig config;
 
-  interface IExecutable {
+  interface IExecutable
+  {
     void execute(String endpoint) throws IOException;
   }
 
   private void executeWithRetry(String contentType, IExecutable executable)
   {
-    String endpoint = StringUtils.format("%s/druid/v2/sql/", config.getBrokerUrl());
+    executeWithRetry(StringUtils.format("%s/druid/v2/sql/", config.getBrokerUrl()), contentType, executable);
+    executeWithRetry(StringUtils.format("%s/druid/v2/sql/", config.getRouterUrl()), contentType, executable);
+  }
 
+  private void executeWithRetry(String endpoint, String contentType, IExecutable executable)
+  {
     Throwable lastException = null;
     for (int i = 1; i <= 5; i++) {
       LOG.info("Query to %s with Content-Type = %s, tries = %s", endpoint, contentType, i);

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -172,7 +172,7 @@ public class ITSqlQueryTest
   }
 
   @Test
-  public void testUnsupportedCotentType()
+  public void testUnsupportedContentType()
   {
     executeQuery(
         "application/xml",

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.tests.query;
+
+import com.google.inject.Inject;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.testing.IntegrationTestingConfig;
+import org.apache.druid.testing.guice.DruidTestModuleFactory;
+import org.apache.druid.tests.TestNGGroup;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Test the SQL endpoint with different Content-Type
+ */
+@Test(groups = {TestNGGroup.QUERY, TestNGGroup.CENTRALIZED_DATASOURCE_SCHEMA})
+@Guice(moduleFactory = DruidTestModuleFactory.class)
+public class ITSqlQueryTest
+{
+  private static final Logger LOG = new Logger(ITSqlQueryTest.class);
+
+  @Inject
+  IntegrationTestingConfig config;
+
+  interface IExecutable {
+    void execute(String endpoint) throws IOException;
+  }
+
+  private void executeWithRetry(String contentType, IExecutable executable)
+  {
+    String endpoint = "/druid/v2/sql/";
+
+    Throwable lastException = null;
+    for (int i = 1; i <= 5; i++) {
+      LOG.info("Query to %s with Content-Type = %s, tries = %s", endpoint, contentType, i);
+      try {
+        executable.execute(StringUtils.format("%s%s", config.getBrokerUrl(), endpoint));
+        return;
+      }
+      catch (IOException e) {
+        // Only catch IOException
+        lastException = e;
+      }
+      try {
+        Thread.sleep(200);
+      }
+      catch (InterruptedException ignored) {
+        break;
+      }
+    }
+    Assert.fail(contentType + " failed after 5 tries, last exception: " + lastException);
+  }
+
+  @Test
+  public void testEmptyContentType()
+  {
+    executeWithRetry(
+        "<EMPTY>",
+        (endpoint) -> {
+          try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpPost request = new HttpPost(endpoint);
+            request.setEntity(new StringEntity("select 1"));
+
+            try (CloseableHttpResponse response = client.execute(request)) {
+              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+              HttpEntity entity = response.getEntity();
+              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+            }
+          }
+        }
+    );
+  }
+
+  @Test
+  public void testTextPlain()
+  {
+    executeWithRetry(
+        "text/plain",
+        (endpoint) -> {
+          try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpPost request = new HttpPost(endpoint);
+            request.setHeader("Content-Type", "text/plain");
+            request.setEntity(new StringEntity("select 1"));
+
+            try (CloseableHttpResponse response = client.execute(request)) {
+              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+              HttpEntity entity = response.getEntity();
+              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+            }
+          }
+        }
+    );
+  }
+
+  @Test
+  public void testFormURLEncoded()
+  {
+    executeWithRetry(
+        "application/x-www-form-urlencoded",
+        (endpoint) -> {
+          try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpPost request = new HttpPost(endpoint);
+            request.setHeader("Content-Type", "application/x-www-form-urlencoded");
+            request.setEntity(new StringEntity(URLEncoder.encode("select 1", StandardCharsets.UTF_8)));
+
+            try (CloseableHttpResponse response = client.execute(request)) {
+              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+              HttpEntity entity = response.getEntity();
+              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+            }
+          }
+        }
+    );
+  }
+
+  @Test
+  public void testJSON()
+  {
+    executeWithRetry(
+        "application/json",
+        (endpoint) -> {
+          try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
+            HttpPost request = new HttpPost(endpoint);
+            request.setHeader("Content-Type", "application/json");
+            request.setEntity(new StringEntity(StringUtils.format("{\"query\":\"select 1\"}")));
+
+            try (CloseableHttpResponse response = client.execute(request)) {
+              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+
+              HttpEntity entity = response.getEntity();
+              String responseBody = entity != null ? EntityUtils.toString(entity).trim() : null;
+              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+            }
+          }
+        }
+    );
+  }
+}

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.tests.query;
 
 import com.google.inject.Inject;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.testing.IntegrationTestingConfig;
@@ -32,7 +33,6 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.junit.Assert;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
@@ -83,7 +83,7 @@ public class ITSqlQueryTest
         break;
       }
     }
-    Assert.fail(contentType + " failed after 5 tries, last exception: " + lastException);
+    throw new ISE(contentType + " failed after 5 tries, last exception: " + lastException);
   }
 
   @Test
@@ -97,12 +97,12 @@ public class ITSqlQueryTest
             request.setEntity(new StringEntity("select 1"));
 
             try (CloseableHttpResponse response = client.execute(request)) {
-              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+              assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              Assert.assertNotNull(entity);
+              assertNotNull(entity);
               String responseBody = EntityUtils.toString(entity).trim();
-              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+              assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
         }
@@ -121,12 +121,12 @@ public class ITSqlQueryTest
             request.setEntity(new StringEntity("select 1"));
 
             try (CloseableHttpResponse response = client.execute(request)) {
-              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+              assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              Assert.assertNotNull(entity);
+              assertNotNull(entity);
               String responseBody = EntityUtils.toString(entity).trim();
-              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+              assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
         }
@@ -145,12 +145,12 @@ public class ITSqlQueryTest
             request.setEntity(new StringEntity(URLEncoder.encode("select 1", StandardCharsets.UTF_8)));
 
             try (CloseableHttpResponse response = client.execute(request)) {
-              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+              assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              Assert.assertNotNull(entity);
+              assertNotNull(entity);
               String responseBody = EntityUtils.toString(entity).trim();
-              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+              assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
         }
@@ -169,12 +169,12 @@ public class ITSqlQueryTest
             request.setEntity(new StringEntity(StringUtils.format("{\"query\":\"select 1\"}")));
 
             try (CloseableHttpResponse response = client.execute(request)) {
-              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+              assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              Assert.assertNotNull(entity);
+              assertNotNull(entity);
               String responseBody = EntityUtils.toString(entity).trim();
-              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+              assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
         }
@@ -192,12 +192,12 @@ public class ITSqlQueryTest
             request.addHeader("Content-Type", "text/plain");
 
             try (CloseableHttpResponse response = client.execute(request)) {
-              Assert.assertEquals(400, response.getStatusLine().getStatusCode());
+              assertEquals(400, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              Assert.assertNotNull(entity);
+              assertNotNull(entity);
               String responseBody = EntityUtils.toString(entity).trim();
-              Assert.assertTrue(responseBody.contains("invalidInput"));
+              assertTrue(responseBody.contains("invalidInput"));
             }
           }
         }
@@ -220,15 +220,43 @@ public class ITSqlQueryTest
             request.setEntity(new StringEntity(StringUtils.format("SELECT 1")));
 
             try (CloseableHttpResponse response = client.execute(request)) {
-              Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+              assertEquals(200, response.getStatusLine().getStatusCode());
 
               HttpEntity entity = response.getEntity();
-              Assert.assertNotNull(entity);
+              assertNotNull(entity);
               String responseBody = EntityUtils.toString(entity).trim();
-              Assert.assertEquals("[{\"EXPR$0\":1}]", responseBody);
+              assertEquals("[{\"EXPR$0\":1}]", responseBody);
             }
           }
         }
     );
+  }
+
+  private void assertEquals(String expected, String actual)
+  {
+    if (!expected.equals(actual)) {
+      throw new ISE("Expected [%s] but got [%s]", expected, actual);
+    }
+  }
+
+  private void assertEquals(int expected, int actual)
+  {
+    if (expected != actual) {
+      throw new ISE("Expected [%d] but got [%d]", expected, actual);
+    }
+  }
+
+  private void assertNotNull(Object object)
+  {
+    if (object == null) {
+      throw new ISE("Expected not null");
+    }
+  }
+
+  private void assertTrue(boolean condition)
+  {
+    if (!condition) {
+      throw new ISE("Expected true");
+    }
   }
 }

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpException.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpException.java
@@ -1,17 +1,20 @@
 /*
- *    Copyright 2020 bithon.org
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.druid.server.initialization.jetty;

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpException.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpException.java
@@ -1,0 +1,43 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.druid.server.initialization.jetty;
+
+
+import javax.ws.rs.core.Response;
+
+public class HttpException extends RuntimeException
+{
+  private final Response.Status statusCode;
+  private final String message;
+
+  public HttpException(Response.Status statusCode, String message)
+  {
+    this.statusCode = statusCode;
+    this.message = message;
+  }
+
+  public Response.Status getStatusCode()
+  {
+    return statusCode;
+  }
+
+  @Override
+  public String getMessage()
+  {
+    return message;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpExceptionMapper.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpExceptionMapper.java
@@ -1,19 +1,21 @@
 /*
- *    Copyright 2020 bithon.org
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.druid.server.initialization.jetty;
 
 

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpExceptionMapper.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpExceptionMapper.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.druid.server.initialization.jetty;
 
 

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpExceptionMapper.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/HttpExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ *    Copyright 2020 bithon.org
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.druid.server.initialization.jetty;
+
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class HttpExceptionMapper implements ExceptionMapper<HttpException>
+{
+  @Override
+  public Response toResponse(HttpException exception)
+  {
+    return Response.status(exception.getStatusCode())
+                   .type(MediaType.APPLICATION_JSON)
+                   .entity(ImmutableMap.of(
+                       "error", exception.getMessage()
+                   ))
+                   .build();
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
+++ b/server/src/main/java/org/apache/druid/server/initialization/jetty/JettyServerModule.java
@@ -127,6 +127,7 @@ public class JettyServerModule extends JerseyServletModule
     binder.bind(ForbiddenExceptionMapper.class).in(LazySingleton.class);
     binder.bind(BadRequestExceptionMapper.class).in(LazySingleton.class);
     binder.bind(ServiceUnavailableExceptionMapper.class).in(LazySingleton.class);
+    binder.bind(HttpExceptionMapper.class).in(LazySingleton.class);
 
     serve("/*").with(GuiceContainer.class);
 

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -26,6 +26,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.sun.jersey.server.impl.application.WebApplicationImpl;
+import com.sun.jersey.spi.container.ContainerRequest;
 import org.apache.calcite.avatica.remote.ProtobufTranslation;
 import org.apache.calcite.avatica.remote.ProtobufTranslationImpl;
 import org.apache.calcite.avatica.remote.Service;
@@ -273,7 +275,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       }
     } else if (isSqlQueryEndpoint && HttpMethod.POST.is(method)) {
       try {
-        SqlQuery inputSqlQuery = objectMapper.readValue(request.getInputStream(), SqlQuery.class);
+        SqlQuery inputSqlQuery = SqlQuery.from(request, objectMapper);
         inputSqlQuery = buildSqlQueryWithId(inputSqlQuery);
         request.setAttribute(SQL_QUERY_ATTRIBUTE, inputSqlQuery);
         if (routeSqlByStrategy) {
@@ -470,6 +472,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       byte[] bytes = objectMapper.writeValueAsBytes(content);
       proxyRequest.content(new BytesContentProvider(bytes));
       proxyRequest.getHeaders().put(HttpHeader.CONTENT_LENGTH, String.valueOf(bytes.length));
+      proxyRequest.getHeaders().put(HttpHeader.CONTENT_TYPE, MediaType.APPLICATION_JSON);
     }
     catch (JsonProcessingException e) {
       throw new RuntimeException(e);

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -294,7 +294,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
         handleQueryParseException(request, response, objectMapper, e, false);
         return;
       }
-      catch(HttpException e) {
+      catch (HttpException e) {
         handleException(response, e.getStatusCode().getStatusCode(), objectMapper, e);
         return;
       }

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -26,8 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
-import com.sun.jersey.server.impl.application.WebApplicationImpl;
-import com.sun.jersey.spi.container.ContainerRequest;
 import org.apache.calcite.avatica.remote.ProtobufTranslation;
 import org.apache.calcite.avatica.remote.ProtobufTranslationImpl;
 import org.apache.calcite.avatica.remote.Service;

--- a/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
+++ b/services/src/test/java/org/apache/druid/server/AsyncQueryForwardingServletTest.java
@@ -590,7 +590,7 @@ public class AsyncQueryForwardingServletTest extends BaseJettyTest
       }
     };
     final HttpServletRequest requestMock = EasyMock.createMock(HttpServletRequest.class);
-    EasyMock.expect(requestMock.getContentType()).andReturn("application/json").times(2);
+    EasyMock.expect(requestMock.getContentType()).andReturn("application/json").anyTimes();
     requestMock.setAttribute("org.apache.druid.proxy.objectMapper", jsonMapper);
     EasyMock.expectLastCall();
     EasyMock.expect(requestMock.getRequestURI())

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -166,6 +166,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
       <version>${checkerframework.version}</version>
@@ -262,11 +266,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -190,6 +190,10 @@
       <artifactId>value-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.sun.jersey</groupId>
+      <artifactId>jersey-server</artifactId>
+    </dependency>
 
     <!-- Tests -->
     <dependency>

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -229,7 +229,7 @@ public class SqlQuery
   /**
    * For BROKERs to use.
    * <p>
-   * Brokers use com.sun.jersey upon Jetty for RESTful API, however jersey internally has special handling for x-www-form-urlencoded,
+   * Brokers use com.sun.jersey upon Jetty for RESTful API, however jersey intØernally has special handling for x-www-form-urlencoded,
    * it's not able to get the data from the stream of HttpServletRequest for such content type.
    * So we use HttpContext to get the request entity/string instead of using HttpServletRequest.
    *

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -233,8 +233,7 @@ public class SqlQuery
    * it's not able to get the data from the stream of HttpServletRequest for such content type.
    * So we use HttpContext to get the request entity/string instead of using HttpServletRequest.
    *
-   * @throws HttpException       if the content type is not supported
-   * @throws BadRequestException if the SQL query is malformed or fail to read from the request
+   * @throws HttpException       if the content type is not supported or the SQL query is malformed
    */
   public static SqlQuery from(HttpContext httpContext) throws HttpException
   {
@@ -262,8 +261,7 @@ public class SqlQuery
   /**
    * For Router to use
    *
-   * @throws HttpException if the content type is not supported
-   * @throws IOException   if the SQL query is malformed or fail to read from the request
+   * @throws HttpException if the content type is not supported or the SQL query is malformed
    */
   public static SqlQuery from(HttpServletRequest request, ObjectMapper objectMapper) throws HttpException
   {

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -36,7 +36,6 @@ import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.http.ClientSqlQuery;
-import org.apache.druid.server.initialization.jetty.BadRequestException;
 import org.apache.druid.server.initialization.jetty.HttpException;
 
 import javax.annotation.Nullable;
@@ -233,7 +232,7 @@ public class SqlQuery
    * it's not able to get the data from the stream of HttpServletRequest for such content type.
    * So we use HttpContext to get the request entity/string instead of using HttpServletRequest.
    *
-   * @throws HttpException       if the content type is not supported or the SQL query is malformed
+   * @throws HttpException if the content type is not supported or the SQL query is malformed
    */
   public static SqlQuery from(HttpContext httpContext) throws HttpException
   {

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -29,7 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.sun.jersey.api.core.HttpContext;
 import com.sun.jersey.server.impl.model.HttpHelper;
 import org.apache.calcite.avatica.remote.TypedValue;
-import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.http.ClientSqlQuery;

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -27,7 +27,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.sun.jersey.api.core.HttpContext;
-import com.sun.jersey.server.impl.model.HttpHelper;
 import org.apache.calcite.avatica.remote.TypedValue;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.java.util.common.ISE;

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -218,9 +218,6 @@ public class SqlQuery
       if (MediaType.APPLICATION_FORM_URLENCODED_TYPE.isCompatible(contentType)) {
         sql = URLDecoder.decode(sql, StandardCharsets.UTF_8);
       }
-      if (sql == null || sql.trim().isEmpty()) {
-        throw new IAE("SQL query is empty");
-      }
       return new SqlQuery(sql, null, false, false, false, null, null);
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -30,6 +30,7 @@ import com.sun.jersey.api.core.HttpContext;
 import org.apache.calcite.avatica.remote.TypedValue;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.java.util.common.ISE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.http.ClientSqlQuery;
 import org.apache.druid.server.initialization.jetty.BadRequestException;
@@ -297,7 +298,8 @@ public class SqlQuery
     } else {
       throw new HttpException(
           Response.Status.UNSUPPORTED_MEDIA_TYPE,
-          "Unsupported Content-Type: " + contentType
+          StringUtils.format("Unsupported Content-Type: %s. Only application/json, text/plain or application/x-www-form-urlencoded is supported.",
+                             contentType)
       );
     }
   }

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -220,12 +220,12 @@ public class SqlQuery
   public static SqlQuery from(HttpContext httpContext)
   {
     MediaType contentType = httpContext.getRequest().getMediaType();
-    if (MediaType.APPLICATION_JSON_TYPE.isCompatible(contentType)) {
+    if (MediaType.APPLICATION_JSON_TYPE.equals(contentType)) {
       return httpContext.getRequest().getEntity(SqlQuery.class);
     } else {
       // Treats the whole HTTP body as a SQL
       String sql = httpContext.getRequest().getEntity(String.class);
-      if (MediaType.APPLICATION_FORM_URLENCODED_TYPE.isCompatible(contentType)) {
+      if (MediaType.APPLICATION_FORM_URLENCODED_TYPE.equals(contentType)) {
         sql = URLDecoder.decode(sql, StandardCharsets.UTF_8);
       }
       return new SqlQuery(sql, null, false, false, false, null, null);
@@ -237,13 +237,13 @@ public class SqlQuery
    */
   public static SqlQuery from(HttpServletRequest request, ObjectMapper objectMapper) throws IOException
   {
-    MediaType contentType = HttpHelper.getContentType(request.getHeader("Content-Type"));
-    if (MediaType.APPLICATION_JSON_TYPE.isCompatible(contentType)) {
+    String contentType = request.getContentType();
+    if (MediaType.APPLICATION_JSON.equals(contentType)) {
       return objectMapper.readValue(request.getInputStream(), SqlQuery.class);
     } else {
       // Treats the whole HTTP body as a SQL
       String sql = new String(IOUtils.toByteArray(request.getInputStream()), StandardCharsets.UTF_8);
-      if (MediaType.APPLICATION_FORM_URLENCODED_TYPE.isCompatible(contentType)) {
+      if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
         sql = URLDecoder.decode(sql, StandardCharsets.UTF_8);
       }
       return new SqlQuery(sql, null, false, false, false, null, null);

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResource.java
@@ -59,8 +59,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,22 +110,7 @@ public class SqlResource
       @Context final HttpContext httpContext
   )
   {
-    return doPost(parseQuery(httpContext), req);
-  }
-
-  protected SqlQuery parseQuery(HttpContext httpContext)
-  {
-    MediaType contentType = httpContext.getRequest().getMediaType();
-    if (MediaType.APPLICATION_JSON_TYPE.isCompatible(contentType)) {
-      return httpContext.getRequest().getEntity(SqlQuery.class);
-    } else {
-      // Treats the whole HTTP body as a SQL
-      String sql = httpContext.getRequest().getEntity(String.class);
-      if (MediaType.APPLICATION_FORM_URLENCODED_TYPE.isCompatible(contentType)) {
-        sql = URLDecoder.decode(sql, StandardCharsets.UTF_8);
-      }
-      return new SqlQuery(sql, null, false, false, false, null, null);
-    }
+    return doPost(SqlQuery.from(httpContext), req);
   }
 
   /**


### PR DESCRIPTION
A part of #17769.


### Description

Allow raw sql in the HTTP body on http endpoints. This helps reduce the client side complexity which requires users to do character escaping when the SQL is placed in the JSON document. The following example demonstrates the usage:

```bash
echo 'SELECT 1' | curl -X POST "http://localhost:8082/druid/v2/sql" --data @-
```

#### Release note

Druid now supports raw text format SQL on `/druid/v2/sql` endpoint. The content in the HTTP body of a HTTP request which does not set `Content-Type` to `application/json` will be treated as a raw sql text.


##### Key changed/added classes in this PR
1. Only HTTP requests with `Content-Type: application/json` will be parsed as traditional JSON format SQL
2. All other HTTP requests including those with empty Content-Type will be parsed as raw SQL
3. Router also supports raw text SQL, but when it forwards queries to brokers, it uses the JSON format for simplicity


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
