### PR TITLE
Downgrade Druid version in Docker Compose

### DIFF
--- a/distribution/docker/docker-compose.yml
+++ b/distribution/docker/docker-compose.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-version: "2.2"
+# version: "2.2"
 
 volumes:
   metadata_data: {}
@@ -51,7 +51,7 @@ services:
       - ZOO_MY_ID=1
 
   coordinator:
-    image: apache/druid:34.0.0
+    image: apache/druid:33.0.0-rc3
     container_name: coordinator
     volumes:
       - druid_shared:/opt/shared
@@ -67,7 +67,7 @@ services:
       - environment
 
   broker:
-    image: apache/druid:34.0.0
+    image: apache/druid:33.0.0-rc3
     container_name: broker
     volumes:
       - broker_var:/opt/druid/var
@@ -83,12 +83,12 @@ services:
       - environment
 
   historical:
-    image: apache/druid:34.0.0
+    image: apache/druid:33.0.0-rc3
     container_name: historical
     volumes:
       - druid_shared:/opt/shared
       - historical_var:/opt/druid/var
-    depends_on: 
+    depends_on:
       - zookeeper
       - postgres
       - coordinator
@@ -100,12 +100,12 @@ services:
       - environment
 
   middlemanager:
-    image: apache/druid:34.0.0
+    image: apache/druid:33.0.0-rc3
     container_name: middlemanager
     volumes:
       - druid_shared:/opt/shared
       - middle_var:/opt/druid/var
-    depends_on: 
+    depends_on:
       - zookeeper
       - postgres
       - coordinator
@@ -118,7 +118,7 @@ services:
       - environment
 
   router:
-    image: apache/druid:34.0.0
+    image: apache/druid:33.0.0-rc3
     container_name: router
     volumes:
       - router_var:/opt/druid/var
@@ -132,3 +132,4 @@ services:
       - router
     env_file:
       - environment
+


### PR DESCRIPTION
Updated the Docker Compose configuration to downgrade the Druid image version from 34.0.0 to 33.0.0-rc3 for all services (coordinator, broker, historical, middlemanager, and router). This change ensures compatibility with existing deployments and addresses issues encountered with the newer version.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

### Description

This PR downgrades the Druid image from `34.0.0` to `33.0.0-rc3` across all core services in the `docker-compose.yml` file.

There are two main reasons for this change:

1. **Incompatibility with version 34.0.0**  
   The `34.0.0` image caused runtime issues in our environment, which were not present in the previous release candidate (`33.0.0-rc3`). Downgrading ensures the stability and operational continuity of existing deployments.

2. **Best practices in Docker Compose versioning**  
   Explicitly pinning to an unstable or incompatible version in `docker-compose.yml` can be problematic. It is generally discouraged to hardcode the latest versions unless thoroughly tested in all environments. By reverting to a known-working version, we align better with reproducible deployment practices.

### Release note

Downgraded the Docker image version used in Docker Compose from `34.0.0` to `33.0.0-rc3` to fix runtime compatibility issues.

<hr>

##### Key changed/added classes in this PR
* `docker-compose.yml`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [ ] been tested in a test Druid cluster.
