### PR TITLE
Web console: fix segment view issuing query that does not work sometimes.

### DIFF
--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -44,7 +44,7 @@ import {
 import { AsyncActionDialog } from '../../dialogs';
 import { SegmentTableActionDialog } from '../../dialogs/segments-table-action-dialog/segment-table-action-dialog';
 import { ShowValueDialog } from '../../dialogs/show-value-dialog/show-value-dialog';
-import type { QueryWithContext, ShardSpec } from '../../druid-models';
+import type { QueryContext, QueryWithContext, ShardSpec } from '../../druid-models';
 import { computeSegmentTimeSpan, getDatasourceColor } from '../../druid-models';
 import type { Capabilities, CapabilitiesMode } from '../../helpers';
 import {
@@ -319,6 +319,7 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
           const orderByClause = sortedToOrderByClause(effectiveSorted);
 
           let queryParts: string[];
+          const sqlQueryContext: QueryContext = {};
           if (groupByInterval) {
             const innerQuery = compact([
               `SELECT "start", "end"`,
@@ -345,6 +346,9 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
               orderByClause,
               `LIMIT ${pageSize * 1000}`,
             ]);
+
+            // This is needed because there might be an IN filter with a lot of intervals, the number of which exceeds the default inFunctionThreshold
+            sqlQueryContext.inFunctionThreshold = 1000;
           } else {
             queryParts = compact([
               base,
@@ -358,7 +362,10 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
           }
           const sqlQuery = queryParts.join('\n');
           setIntermediateQuery(sqlQuery);
-          let result = await queryDruidSql({ query: sqlQuery }, cancelToken);
+          let result = await queryDruidSql(
+            { query: sqlQuery, context: sqlQueryContext },
+            cancelToken,
+          );
 
           if (visibleColumns.shown('Shard type', 'Shard spec')) {
             result = result.map(sr => ({

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -347,8 +347,8 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
               `LIMIT ${pageSize * 1000}`,
             ]);
 
-            // This is needed because there might be an IN filter with a lot of intervals, the number of which exceeds the default inFunctionThreshold
-            sqlQueryContext.inFunctionThreshold = 1000;
+            // This is needed because there might be an IN filter with {pageSize} intervals, the number of which exceeds the default inFunctionThreshold, set it to something greater than the {pageSize}
+            sqlQueryContext.inFunctionThreshold = pageSize + 1;
           } else {
             queryParts = compact([
               base,


### PR DESCRIPTION
Bug: In segments view of a cluster with at least 200 intervals, group by Interval and then change the displayed page size to 200 rows you get an error.

The view generates a query with an `IN` of 200 inervals that then gets rewritten by Druid to a JOIN (?) which does not work. Fix: set the context parameter `inFunctionThreshold` to something bigger than 200 in that case to prevent that behavior. 