### PR TITLE
Web console: fix row numbers to be abbreviated

### DIFF
--- a/web-console/src/components/segment-timeline/segment-bar-chart-render.tsx
+++ b/web-console/src/components/segment-timeline/segment-bar-chart-render.tsx
@@ -40,6 +40,7 @@ import {
   filterMap,
   formatBytes,
   formatNumber,
+  formatNumberAbbreviated,
   formatStartDuration,
   groupBy,
   groupByAsMap,
@@ -345,7 +346,7 @@ export const SegmentBarChartRender = function SegmentBarChartRender(
         return formatNumber(n); // + ' seg/day';
 
       case 'rows':
-        return formatNumber(n); // + ' row/day';
+        return formatNumberAbbreviated(n); // + ' row/day';
 
       case 'size':
         return formatBytes(n);

--- a/web-console/src/utils/general.spec.ts
+++ b/web-console/src/utils/general.spec.ts
@@ -25,6 +25,7 @@ import {
   formatMegabytes,
   formatMillions,
   formatNumber,
+  formatNumberAbbreviated,
   formatPercent,
   hashJoaat,
   moveElement,
@@ -103,6 +104,18 @@ describe('general', () => {
       expect(formatNumber(0)).toEqual('0');
       expect(formatNumber(5)).toEqual('5');
       expect(formatNumber(5.1)).toEqual('5.1');
+    });
+  });
+
+  describe('formatNumberAbbreviated', () => {
+    it('works', () => {
+      expect(formatNumberAbbreviated(null as any)).toEqual('0');
+      expect(formatNumberAbbreviated(0)).toEqual('0');
+      expect(formatNumberAbbreviated(5)).toEqual('5');
+      expect(formatNumberAbbreviated(5.1)).toEqual('5.1');
+      expect(formatNumberAbbreviated(10000)).toEqual('10K');
+      expect(formatNumberAbbreviated(4000000000)).toEqual('4B');
+      expect(formatNumberAbbreviated(1234567890)).toEqual('1.23B');
     });
   });
 

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -279,6 +279,14 @@ export function formatNumber(n: NumberLike): string {
   return (n || 0).toLocaleString('en-US', { maximumFractionDigits: 20 });
 }
 
+export function formatNumberAbbreviated(n: NumberLike): string {
+  return (n || 0).toLocaleString('en-US', {
+    notation: 'compact',
+    compactDisplay: 'short',
+    maximumFractionDigits: 2,
+  });
+}
+
 export function formatRate(n: NumberLike) {
   return numeral(n).format('0,0.0') + '/s';
 }


### PR DESCRIPTION
Fixes this:

<img width="272" alt="image" src="https://github.com/user-attachments/assets/46adba0f-c023-46bf-bdec-a451252284e7" />
 
(this is a mild case)

Makes it look like this:

<img width="290" alt="image" src="https://github.com/user-attachments/assets/0c0f8e34-7ab6-4d6b-8a9e-fddfcc342f22" />

(that's my test cluster - less rows but you get the gist)