### PR TITLE
Handle when used_status_last_updated is empty String in HeapMemorySegmentMetadataCache

### DIFF
--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -113,6 +113,15 @@ public class SqlSegmentsMetadataQuery
   }
 
   /**
+   * Create a DateTime object from a string. If the string is null or empty, return null.
+   */
+  @Nullable
+  public static DateTime nullAndEmptySafeDate(String date)
+  {
+    return Strings.isNullOrEmpty(date) ? null : DateTimes.of(date);
+  }
+
+  /**
    * Retrieves segments for a given datasource that are marked used (i.e. published) in the metadata store, and that
    * *overlap* any interval in a particular collection of intervals. If the collection of intervals is empty, this
    * method will retrieve all used segments.
@@ -511,11 +520,10 @@ public class SqlSegmentsMetadataQuery
               (index, r, ctx) -> {
                 String schemaFingerprint = (String) r.getObject(3);
                 Long numRows = (Long) r.getObject(4);
-                String usedStatusLastUpdatedDate = r.getString(6);
                 return new DataSegmentPlus(
                     JacksonUtils.readValue(jsonMapper, r.getBytes(1), DataSegment.class),
                     null,
-                    Strings.isNullOrEmpty(usedStatusLastUpdatedDate) ? null : DateTimes.of(usedStatusLastUpdatedDate),
+                    nullAndEmptySafeDate(r.getString(6)),
                     r.getBoolean(2),
                     schemaFingerprint,
                     numRows,
@@ -539,18 +547,15 @@ public class SqlSegmentsMetadataQuery
           .bind("dataSource", datasource)
           .setFetchSize(connector.getStreamingFetchSize())
           .map(
-              (index, r, ctx) -> {
-                String usedStatusLastUpdatedDate = r.getString(4);
-                return new DataSegmentPlus(
-                    JacksonUtils.readValue(jsonMapper, r.getBytes(1), DataSegment.class),
-                    DateTimes.of(r.getString(5)),
-                    Strings.isNullOrEmpty(usedStatusLastUpdatedDate) ? null : DateTimes.of(usedStatusLastUpdatedDate),
-                    r.getBoolean(2),
-                    null,
-                    null,
-                    r.getString(3)
-                );
-              }
+              (index, r, ctx) -> new DataSegmentPlus(
+                  JacksonUtils.readValue(jsonMapper, r.getBytes(1), DataSegment.class),
+                  DateTimes.of(r.getString(5)),
+                  nullAndEmptySafeDate(r.getString(4)),
+                  r.getBoolean(2),
+                  null,
+                  null,
+                  r.getString(3)
+              )
           )
           .iterator();
     }
@@ -1242,11 +1247,10 @@ public class SqlSegmentsMetadataQuery
     return sql.map((index, r, ctx) -> {
       final String segmentId = r.getString(1);
       try {
-        String usedStatusLastUpdatedDate = r.getString(4);
         return new DataSegmentPlus(
             JacksonUtils.readValue(jsonMapper, r.getBytes(2), DataSegment.class),
             DateTimes.of(r.getString(3)),
-            Strings.isNullOrEmpty(usedStatusLastUpdatedDate) ? null : DateTimes.of(usedStatusLastUpdatedDate),
+            nullAndEmptySafeDate(r.getString(4)),
             used,
             null,
             null,

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCache.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/HeapMemorySegmentMetadataCache.java
@@ -834,7 +834,7 @@ public class HeapMemorySegmentMetadataCache implements SegmentMetadataCache
       return new DataSegmentPlus(
           JacksonUtils.readValue(jsonMapper, resultSet.getBytes(2), DataSegment.class),
           DateTimes.of(resultSet.getString(3)),
-          DateTimes.of(resultSet.getString(4)),
+          SqlSegmentsMetadataQuery.nullAndEmptySafeDate(resultSet.getString(4)),
           true,
           null,
           null,

--- a/server/src/main/java/org/apache/druid/metadata/segment/cache/SegmentRecord.java
+++ b/server/src/main/java/org/apache/druid/metadata/segment/cache/SegmentRecord.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.metadata.segment.cache;
 
-import com.google.common.base.Strings;
-import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.metadata.SqlSegmentsMetadataQuery;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;
 
@@ -75,7 +74,7 @@ class SegmentRecord
       serializedId = r.getString("id");
       dataSource = r.getString("dataSource");
 
-      final DateTime lastUpdatedTime = nullAndEmptySafeDate(r.getString(
+      final DateTime lastUpdatedTime = SqlSegmentsMetadataQuery.nullAndEmptySafeDate(r.getString(
           "used_status_last_updated"));
 
       final SegmentId segmentId = SegmentId.tryParse(dataSource, serializedId);
@@ -94,11 +93,5 @@ class SegmentRecord
       );
       return null;
     }
-  }
-
-  @Nullable
-  private static DateTime nullAndEmptySafeDate(String date)
-  {
-    return Strings.isNullOrEmpty(date) ? null : DateTimes.of(date);
   }
 }


### PR DESCRIPTION
Handle when used_status_last_updated is empty String in HeapMemorySegmentMetadataCache

### Description

This is the same as https://github.com/apache/druid/pull/17890 but I missed one place that was not checking null/empty string on used_status_last_updated. This PR adds the check to that one place missed in the earlier PR and also refactor the check into a static utility method in `SqlSegmentsMetadataQuery` so that it can be reused (addressing https://github.com/apache/druid/pull/17890#discussion_r2032279739).

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
