### PR TITLE
Refactor SegmentId to more clearly distinguish between table and non-table segments: table segments must have a non-empty dataSource, while non-table segments must have an empty dataSource.

### DIFF
--- a/extensions-contrib/distinctcount/src/test/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
+++ b/extensions-contrib/distinctcount/src/test/java/org/apache/druid/query/aggregation/distinctcount/DistinctCountTopNQueryTest.java
@@ -133,7 +133,7 @@ public class DistinctCountTopNQueryTest extends InitializedNullHandlingTest
     final Iterable<Result<TopNResultValue>> results =
         engine.query(
             query,
-            new IncrementalIndexSegment(index, SegmentId.dummy(QueryRunnerTestHelper.DATA_SOURCE)),
+            new IncrementalIndexSegment(index, SegmentId.simpleTable(QueryRunnerTestHelper.DATA_SOURCE)),
             null
         ).toList();
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
@@ -24,8 +24,6 @@ import org.apache.druid.msq.input.external.ExternalSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.timeline.SegmentId;
 
-import java.util.Locale;
-
 
 /**
  * Utility class containing methods that help in generating the {@link org.apache.druid.sql.calcite.parser.ParseException}
@@ -50,7 +48,7 @@ public class ParseExceptionUtils
     SegmentId segmentId = segment.getId();
     return StringUtils.format(
         "%s input source: %s",
-        segmentId.getDataSourceType().toString().toLowerCase(Locale.ENGLISH),
+        StringUtils.toLowerCase(segmentId.getDataSourceType().name()),
         segmentId
     );
   }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
@@ -24,6 +24,8 @@ import org.apache.druid.msq.input.external.ExternalSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.timeline.SegmentId;
 
+import java.util.Locale;
+
 
 /**
  * Utility class containing methods that help in generating the {@link org.apache.druid.sql.calcite.parser.ParseException}
@@ -48,7 +50,7 @@ public class ParseExceptionUtils
     SegmentId segmentId = segment.getId();
     return StringUtils.format(
         "%s input source: %s",
-        segmentId.getDataSourceType().toString().toLowerCase(),
+        segmentId.getDataSourceType().toString().toLowerCase(Locale.ENGLISH),
         segmentId
     );
   }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/ParseExceptionUtils.java
@@ -21,12 +21,9 @@ package org.apache.druid.msq.input;
 
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.msq.input.external.ExternalSegment;
-import org.apache.druid.msq.input.inline.InlineInputSliceReader;
-import org.apache.druid.query.lookup.LookupSegment;
-import org.apache.druid.segment.QueryableIndexSegment;
 import org.apache.druid.segment.Segment;
+import org.apache.druid.timeline.SegmentId;
 
-import javax.annotation.Nullable;
 
 /**
  * Utility class containing methods that help in generating the {@link org.apache.druid.sql.calcite.parser.ParseException}
@@ -39,7 +36,6 @@ public class ParseExceptionUtils
    * Given a segment, this returns the human-readable description of the segment which can allow user to figure out the
    * source of the parse exception
    */
-  @Nullable
   public static String generateReadableInputSourceNameFromMappedSegment(Segment segment)
   {
     if (segment instanceof ExternalSegment) {
@@ -47,14 +43,13 @@ public class ParseExceptionUtils
           "external input source: %s",
           ((ExternalSegment) segment).externalInputSource().toString()
       );
-    } else if (segment instanceof LookupSegment) {
-      return StringUtils.format("lookup input source: %s", segment.getId().getDataSource());
-    } else if (segment instanceof QueryableIndexSegment) {
-      return StringUtils.format("table input source: %s", segment.getId().getDataSource());
-    } else if (InlineInputSliceReader.SEGMENT_ID.equals(segment.getId().getDataSource())) {
-      return "inline input source";
     }
 
-    return null;
+    SegmentId segmentId = segment.getId();
+    return StringUtils.format(
+        "%s input source: %s",
+        segmentId.getDataSourceType().toString().toLowerCase(),
+        segmentId
+    );
   }
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSliceReader.java
@@ -51,7 +51,6 @@ import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.SimpleRowIngestionMeters;
-import org.apache.druid.timeline.SegmentId;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,7 +64,6 @@ import java.util.stream.Collectors;
  */
 public class ExternalInputSliceReader implements InputSliceReader
 {
-  public static final String SEGMENT_ID = "__external";
   private final File temporaryDirectory;
 
   public ExternalInputSliceReader(final File temporaryDirectory)
@@ -153,7 +151,6 @@ public class ExternalInputSliceReader implements InputSliceReader
             reader = inputSource.reader(schema, inputFormat, temporaryDirectory);
           }
 
-          final SegmentId segmentId = SegmentId.dummy(SEGMENT_ID);
           final Segment segment = new ExternalSegment(
               inputSource,
               reader,
@@ -165,7 +162,7 @@ public class ExternalInputSliceReader implements InputSliceReader
           );
           return new SegmentWithDescriptor(
               () -> ResourceHolder.fromCloseable(new CompleteSegment(null, segment)),
-              new RichSegmentDescriptor(segmentId.toDescriptor(), null)
+              new RichSegmentDescriptor(ExternalSegment.SEGMENT_ID.toDescriptor(), null)
           );
         }
     );

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalSegment.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalSegment.java
@@ -42,10 +42,9 @@ import java.util.function.Consumer;
  */
 public class ExternalSegment extends RowBasedSegment<InputRow>
 {
-
+  public static final SegmentId SEGMENT_ID = SegmentId.simple(SegmentId.DataSourceType.EXTERNAL);
   private final InputSource inputSource;
   private final RowSignature signature;
-  public static final String SEGMENT_ID = "__external";
 
   /**
    * @param inputSource       {@link InputSource} that the segment is a representation of
@@ -67,7 +66,7 @@ public class ExternalSegment extends RowBasedSegment<InputRow>
   )
   {
     super(
-        SegmentId.dummy(SEGMENT_ID),
+        SEGMENT_ID,
         new BaseSequence<>(
             new BaseSequence.IteratorMaker<InputRow, CloseableIterator<InputRow>>()
             {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/inline/InlineInputSliceReader.java
@@ -33,7 +33,6 @@ import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.segment.CompleteSegment;
 import org.apache.druid.segment.InlineSegmentWrangler;
 import org.apache.druid.segment.SegmentWrangler;
-import org.apache.druid.timeline.SegmentId;
 
 import java.util.function.Consumer;
 
@@ -43,10 +42,6 @@ import java.util.function.Consumer;
  */
 public class InlineInputSliceReader implements InputSliceReader
 {
-  public static final String SEGMENT_ID = "__inline";
-  private static final RichSegmentDescriptor DUMMY_SEGMENT_DESCRIPTOR
-      = new RichSegmentDescriptor(SegmentId.dummy(SEGMENT_ID).toDescriptor(), null);
-
   private final SegmentWrangler segmentWrangler;
 
   public InlineInputSliceReader(SegmentWrangler segmentWrangler)
@@ -76,7 +71,7 @@ public class InlineInputSliceReader implements InputSliceReader
             segment -> ReadableInput.segment(
                 new SegmentWithDescriptor(
                     () -> ResourceHolder.fromCloseable(new CompleteSegment(null, segment)),
-                    DUMMY_SEGMENT_DESCRIPTOR
+                    new RichSegmentDescriptor(InlineSegmentWrangler.SEGMENT_ID.toDescriptor(), null)
                 )
             )
         )

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
@@ -32,10 +32,10 @@ import org.apache.druid.msq.input.ReadableInputs;
 import org.apache.druid.msq.input.table.RichSegmentDescriptor;
 import org.apache.druid.msq.input.table.SegmentWithDescriptor;
 import org.apache.druid.query.LookupDataSource;
+import org.apache.druid.query.lookup.LookupSegment;
 import org.apache.druid.segment.CompleteSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentWrangler;
-import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CloseableUtils;
 
 import java.util.Iterator;
@@ -101,7 +101,7 @@ public class LookupInputSliceReader implements InputSliceReader
 
                       return ResourceHolder.fromCloseable(new CompleteSegment(null, segment));
                     },
-                    new RichSegmentDescriptor(SegmentId.dummy(lookupName).toDescriptor(), null)
+                    new RichSegmentDescriptor(LookupSegment.SEGMENT_ID.toDescriptor(), null)
                 )
             )
         )

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/input/lookup/LookupInputSliceReader.java
@@ -36,6 +36,7 @@ import org.apache.druid.query.lookup.LookupSegment;
 import org.apache.druid.segment.CompleteSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentWrangler;
+import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CloseableUtils;
 
 import java.util.Iterator;
@@ -71,6 +72,7 @@ public class LookupInputSliceReader implements InputSliceReader
   )
   {
     final String lookupName = ((LookupInputSlice) slice).getLookupName();
+    final SegmentId lookupSegmentId = LookupSegment.buildSegmentId(lookupName);
 
     return ReadableInputs.segments(
         () -> Iterators.singletonIterator(
@@ -101,7 +103,7 @@ public class LookupInputSliceReader implements InputSliceReader
 
                       return ResourceHolder.fromCloseable(new CompleteSegment(null, segment));
                     },
-                    new RichSegmentDescriptor(LookupSegment.SEGMENT_ID.toDescriptor(), null)
+                    new RichSegmentDescriptor(lookupSegmentId.toDescriptor(), null)
                 )
             )
         )

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPreShuffleFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPreShuffleFrameProcessor.java
@@ -58,7 +58,6 @@ import org.apache.druid.segment.CompleteSegment;
 import org.apache.druid.segment.SegmentReference;
 import org.apache.druid.segment.TimeBoundaryInspector;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.timeline.SegmentId;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -187,7 +186,7 @@ public class GroupByPreShuffleFrameProcessor extends BaseLeafFrameProcessor
 
       if (inputChannel.canRead()) {
         final Frame frame = inputChannel.read();
-        final FrameSegment frameSegment = new FrameSegment(frame, inputFrameReader, SegmentId.dummy("x"));
+        final FrameSegment frameSegment = new FrameSegment(frame, inputFrameReader, "x");
         final SegmentReference mappedSegment = mapSegment(frameSegment);
 
         final Sequence<ResultRow> rowSequence =

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/ExportResultsFrameProcessor.java
@@ -46,7 +46,6 @@ import org.apache.druid.sql.calcite.planner.ColumnMappings;
 import org.apache.druid.sql.calcite.run.SqlResults;
 import org.apache.druid.sql.http.ResultFormat;
 import org.apache.druid.storage.StorageConnector;
-import org.apache.druid.timeline.SegmentId;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -151,7 +150,7 @@ public class ExportResultsFrameProcessor implements FrameProcessor<Object>
 
   private void exportFrame(final Frame frame)
   {
-    final Segment segment = new FrameSegment(frame, frameReader, SegmentId.dummy("test"));
+    final Segment segment = new FrameSegment(frame, frameReader, "test");
     try (final CursorHolder cursorHolder = segment.asCursorFactory().makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {
       final Cursor cursor = cursorHolder.asCursor();
       if (cursor == null) {

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/scan/ScanQueryFrameProcessor.java
@@ -78,7 +78,6 @@ import org.apache.druid.segment.SimpleSettableOffset;
 import org.apache.druid.segment.VirtualColumn;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.RowSignature;
-import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CloseableUtils;
 
 import javax.annotation.Nullable;
@@ -313,7 +312,7 @@ public class ScanQueryFrameProcessor extends BaseLeafFrameProcessor
     if (cursor == null || cursor.isDone()) {
       if (inputChannel.canRead()) {
         final Frame frame = inputChannel.read();
-        final FrameSegment frameSegment = new FrameSegment(frame, inputFrameReader, SegmentId.dummy("scan"));
+        final FrameSegment frameSegment = new FrameSegment(frame, inputFrameReader, "scan");
 
         final Segment mappedSegment = mapSegment(frameSegment);
         final CursorFactory cursorFactory = mappedSegment.asCursorFactory();

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/MSQTaskQueryMakerTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/MSQTaskQueryMakerTest.java
@@ -57,7 +57,10 @@ import org.apache.druid.msq.test.MSQTestOverlordServiceClient;
 import org.apache.druid.msq.test.MSQTestTaskActionClient;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.ForwardingQueryProcessingPool;
+import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.JoinDataSource;
+import org.apache.druid.query.LookupDataSource;
+import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryDataSource;
@@ -386,6 +389,75 @@ public class MSQTaskQueryMakerTest
         expectedResults,
         payload.getResults().getResults()
     );
+  }
+
+  @Test
+  public void testInlineDataSourcePassedPolicyValidation() throws Exception
+  {
+    // Arrange
+    policyEnforcer = new RestrictAllTablesPolicyEnforcer(null);
+    RowSignature resultSignature = RowSignature.builder()
+                                               .add("EXPR$0", ColumnType.LONG)
+                                               .build();
+    fieldMapping = buildFieldMapping(resultSignature);
+    InlineDataSource inlineDataSource = InlineDataSource.fromIterable(
+        ImmutableList.of(new Object[]{2L}),
+        resultSignature
+    );
+    Query query = new Druids.ScanQueryBuilder().resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                               .dataSource(inlineDataSource)
+                                               .eternityInterval()
+                                               .columns(resultSignature.getColumnNames())
+                                               .columnTypes(resultSignature.getColumnTypes())
+                                               .build();
+    DruidQuery druidQueryMock = buildDruidQueryMock(query, resultSignature);
+    // Act
+    msqTaskQueryMaker = getMSQTaskQueryMaker();
+    QueryResponse<Object[]> response = msqTaskQueryMaker.runQuery(druidQueryMock);
+    // Assert
+    String taskId = (String) Iterables.getOnlyElement(response.getResults().toList())[0];
+    MSQTaskReportPayload payload = (MSQTaskReportPayload) fakeOverlordClient.taskReportAsMap(taskId)
+                                                                            .get()
+                                                                            .get(MSQTaskReport.REPORT_KEY)
+                                                                            .getPayload();
+    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    ImmutableList<Object[]> expectedResults = ImmutableList.of(new Object[]{2L});
+    assertResultsEquals("select 1 + 1", expectedResults, payload.getResults().getResults());
+  }
+
+  @Test
+  public void testLookupDataSourcePassedPolicyValidation() throws Exception
+  {
+    // Arrange
+    policyEnforcer = new RestrictAllTablesPolicyEnforcer(null);
+    final RowSignature resultSignature = RowSignature.builder().add("v", ColumnType.STRING).build();
+    fieldMapping = buildFieldMapping(resultSignature);
+    Query query = new Druids.ScanQueryBuilder().resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                               .eternityInterval()
+                                               .dataSource(new LookupDataSource("lookyloo"))
+                                               .columns(resultSignature.getColumnNames())
+                                               .columnTypes(resultSignature.getColumnTypes())
+                                               .orderBy(ImmutableList.of(OrderBy.ascending("v")))
+                                               .build();
+    DruidQuery druidQueryMock = buildDruidQueryMock(query, resultSignature);
+    // Act
+    msqTaskQueryMaker = getMSQTaskQueryMaker();
+    QueryResponse<Object[]> response = msqTaskQueryMaker.runQuery(druidQueryMock);
+    // Assert
+    String taskId = (String) Iterables.getOnlyElement(response.getResults().toList())[0];
+    MSQTaskReportPayload payload = (MSQTaskReportPayload) fakeOverlordClient.taskReportAsMap(taskId)
+                                                                            .get()
+                                                                            .get(MSQTaskReport.REPORT_KEY)
+                                                                            .getPayload();
+    // Assert
+    Assert.assertTrue(payload.getStatus().getStatus().isSuccess());
+    ImmutableList<Object[]> expectedResults = ImmutableList.of(
+        new Object[]{"mysteryvalue"},
+        new Object[]{"x6"},
+        new Object[]{"xa"},
+        new Object[]{"xabc"}
+    );
+    assertResultsEquals("select v from lookyloo", expectedResults, payload.getResults().getResults());
   }
 
   @Test

--- a/processing/src/main/java/org/apache/druid/frame/segment/FrameSegment.java
+++ b/processing/src/main/java/org/apache/druid/frame/segment/FrameSegment.java
@@ -43,9 +43,11 @@ public class FrameSegment implements Segment
   private final FrameReader frameReader;
   private final SegmentId segmentId;
 
-  public FrameSegment(Frame frame, FrameReader frameReader, String unused)
+  public FrameSegment(Frame frame, FrameReader frameReader, String version)
   {
-    this(frame, frameReader, SegmentId.simple(SegmentId.DataSourceType.FRAME));
+    this.frame = frame;
+    this.frameReader = frameReader;
+    this.segmentId = SegmentId.simple(SegmentId.DataSourceType.FRAME).withVersion(version);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/frame/segment/FrameSegment.java
+++ b/processing/src/main/java/org/apache/druid/frame/segment/FrameSegment.java
@@ -43,6 +43,15 @@ public class FrameSegment implements Segment
   private final FrameReader frameReader;
   private final SegmentId segmentId;
 
+  public FrameSegment(Frame frame, FrameReader frameReader, String unused)
+  {
+    this(frame, frameReader, SegmentId.simple(SegmentId.DataSourceType.FRAME));
+  }
+
+  /**
+   * @deprecated use {@link #FrameSegment(Frame, FrameReader, String)} instead
+   */
+  @Deprecated
   public FrameSegment(Frame frame, FrameReader frameReader, SegmentId segmentId)
   {
     this.frame = frame;

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupSegment.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupSegment.java
@@ -38,17 +38,24 @@ import java.util.function.ToLongFunction;
  */
 public class LookupSegment extends RowBasedSegment<Map.Entry<String, String>>
 {
-  public static final SegmentId SEGMENT_ID = SegmentId.simple(SegmentId.DataSourceType.LOOKUP);
   private static final RowSignature ROW_SIGNATURE =
       RowSignature.builder()
                   .add(LookupColumnSelectorFactory.KEY_COLUMN, ColumnType.STRING)
                   .add(LookupColumnSelectorFactory.VALUE_COLUMN, ColumnType.STRING)
                   .build();
 
-  public LookupSegment(final String unused, final LookupExtractorFactory lookupExtractorFactory)
+  /**
+   * Builds a {@link SegmentId} for a lookup segment.
+   */
+  public static SegmentId buildSegmentId(String version)
+  {
+    return SegmentId.simple(SegmentId.DataSourceType.LOOKUP).withVersion(version);
+  }
+
+  public LookupSegment(final String lookupName, final LookupExtractorFactory lookupExtractorFactory)
   {
     super(
-        SEGMENT_ID,
+        buildSegmentId(lookupName),
         Sequences.simple(() -> {
           final LookupExtractor extractor = lookupExtractorFactory.get();
 

--- a/processing/src/main/java/org/apache/druid/query/lookup/LookupSegment.java
+++ b/processing/src/main/java/org/apache/druid/query/lookup/LookupSegment.java
@@ -38,16 +38,17 @@ import java.util.function.ToLongFunction;
  */
 public class LookupSegment extends RowBasedSegment<Map.Entry<String, String>>
 {
+  public static final SegmentId SEGMENT_ID = SegmentId.simple(SegmentId.DataSourceType.LOOKUP);
   private static final RowSignature ROW_SIGNATURE =
       RowSignature.builder()
                   .add(LookupColumnSelectorFactory.KEY_COLUMN, ColumnType.STRING)
                   .add(LookupColumnSelectorFactory.VALUE_COLUMN, ColumnType.STRING)
                   .build();
 
-  public LookupSegment(final String lookupName, final LookupExtractorFactory lookupExtractorFactory)
+  public LookupSegment(final String unused, final LookupExtractorFactory lookupExtractorFactory)
   {
     super(
-        SegmentId.dummy(lookupName),
+        SEGMENT_ID,
         Sequences.simple(() -> {
           final LookupExtractor extractor = lookupExtractorFactory.get();
 

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -296,12 +296,12 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
       if (id1 != null && id2 != null) {
         if (id2.getIntervalEnd().isAfter(id1.getIntervalEnd()) ||
             (id2.getIntervalEnd().isEqual(id1.getIntervalEnd()) && id2.getPartitionNum() > id1.getPartitionNum())) {
-          mergedSegmentId = SegmentId.merged(dataSource, id2.getInterval(), id2.getPartitionNum());
+          mergedSegmentId = id2.withVersion(SegmentId.MERGED_VERSION);
           final SegmentAnalysis tmp = arg1;
           arg1 = arg2;
           arg2 = tmp;
         } else {
-          mergedSegmentId = SegmentId.merged(dataSource, id1.getInterval(), id1.getPartitionNum());
+          mergedSegmentId = id1.withVersion(SegmentId.MERGED_VERSION);
         }
         break;
       }
@@ -426,7 +426,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
     if (arg1.getId() != null && arg2.getId() != null && arg1.getId().equals(arg2.getId())) {
       mergedId = arg1.getId();
     } else {
-      mergedId = mergedSegmentId == null ? "merged" : mergedSegmentId.toString();
+      mergedId = mergedSegmentId == null ? SegmentId.MERGED_VERSION : mergedSegmentId.toString();
     }
 
     final Boolean rollup;

--- a/processing/src/main/java/org/apache/druid/query/policy/PolicyEnforcer.java
+++ b/processing/src/main/java/org/apache/druid/query/policy/PolicyEnforcer.java
@@ -27,6 +27,7 @@ import org.apache.druid.query.DataSource;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.SegmentReference;
+import org.apache.druid.timeline.SegmentId;
 
 
 /**
@@ -78,11 +79,12 @@ public interface PolicyEnforcer
    */
   default void validateOrElseThrow(ReferenceCountingSegment segment, Policy policy) throws DruidException
   {
+    SegmentId segmentId = segment.getId();
     // This can happen if the segment is already closed
-    if (segment.getId() == null) {
+    if (segmentId == null) {
       return;
     }
-    switch (segment.getId().getDataSourceType()) {
+    switch (segmentId.getDataSourceType()) {
       case TABLE:
         // Table segment needs to be validated
         break;
@@ -101,7 +103,7 @@ public interface PolicyEnforcer
     }
     throw DruidException.forPersona(DruidException.Persona.OPERATOR)
                         .ofCategory(DruidException.Category.FORBIDDEN)
-                        .build("Failed security validation with segment [%s]", segment.getId());
+                        .build("Failed security validation with segment [%s]", segmentId);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/query/policy/PolicyEnforcer.java
+++ b/processing/src/main/java/org/apache/druid/query/policy/PolicyEnforcer.java
@@ -28,7 +28,6 @@ import org.apache.druid.query.TableDataSource;
 import org.apache.druid.segment.ReferenceCountingSegment;
 import org.apache.druid.segment.SegmentReference;
 
-import java.util.Objects;
 
 /**
  * Interface for enforcing policies on data sources and segments in Druid queries.
@@ -79,7 +78,11 @@ public interface PolicyEnforcer
    */
   default void validateOrElseThrow(ReferenceCountingSegment segment, Policy policy) throws DruidException
   {
-    switch (Objects.requireNonNull(segment.getId()).getDataSourceType()) {
+    // This can happen if the segment is already closed
+    if (segment.getId() == null) {
+      return;
+    }
+    switch (segment.getId().getDataSourceType()) {
       case TABLE:
         // Table segment needs to be validated
         break;

--- a/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
+++ b/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
@@ -134,7 +134,7 @@ public final class SegmentId implements Comparable<SegmentId>
 
   /**
    * Returns a (potentially empty) lazy iteration of all possible valid parsings of the given segment id string into
-   * {@code SegmentId} objects.
+   * {@code SegmentId} objects. Only {@link DataSourceType#TABLE} segment id string is supported.
    * <p>
    * Warning: most of the parsing work is repeated each time {@link Iterable#iterator()} of this iterable is consumed,
    * so it should be consumed only once if possible.
@@ -473,6 +473,7 @@ public final class SegmentId implements Comparable<SegmentId>
   {
     StringBuilder sb = new StringBuilder(safeUpperLimitOfStringSize());
 
+    // We're ignoring dataSourceType here.
     sb.append(dataSource).append(DELIMITER)
       .append(getIntervalStart()).append(DELIMITER)
       .append(getIntervalEnd()).append(DELIMITER)

--- a/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
+++ b/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
@@ -32,6 +32,7 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.guice.annotations.PublicApi;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.SegmentDescriptor;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.DateTime;
@@ -41,7 +42,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.stream.IntStream;
@@ -240,17 +240,18 @@ public final class SegmentId implements Comparable<SegmentId>
   }
 
   /**
-   * Creates a dummy SegmentId with the given data source. This method is useful in benchmark and test code.
+   * @deprecated use {@link #simple(DataSourceType)}} or {@link #simpleTable(String)}} instead.
    */
+  @Deprecated
   public static SegmentId dummy(String dataSource)
   {
     return of(dataSource, Intervals.ETERNITY, "dummy_version", 0);
   }
 
   /**
-   * Creates a dummy SegmentId with the given data source and partition number.
-   * This method is useful in benchmark and test code.
+   * @deprecated use {@link #simple(DataSourceType)}} or {@link #simpleTable(String)}} instead.
    */
+  @Deprecated
   public static SegmentId dummy(String dataSource, int partitionNum)
   {
     return of(dataSource, Intervals.ETERNITY, "dummy_version", partitionNum);
@@ -263,7 +264,15 @@ public final class SegmentId implements Comparable<SegmentId>
    */
   public static SegmentId simple(DataSourceType dataSourceType)
   {
-    return new SegmentId(dataSourceType, "", Intervals.ETERNITY, dataSourceType.name().toLowerCase(Locale.ENGLISH), 0);
+    return new SegmentId(dataSourceType, "", Intervals.ETERNITY, StringUtils.toLowerCase(dataSourceType.name()), 0);
+  }
+
+  /**
+   * Creates a {@link SegmentId} with the given data source.
+   */
+  public static SegmentId simpleTable(String dataSource)
+  {
+    return new SegmentId(DataSourceType.TABLE, dataSource, Intervals.ETERNITY, "", 0);
   }
 
   public enum DataSourceType
@@ -386,7 +395,7 @@ public final class SegmentId implements Comparable<SegmentId>
    */
   public SegmentId withInterval(Interval newInterval)
   {
-    return of(dataSource, newInterval, version, partitionNum);
+    return new SegmentId(dataSourceType, dataSource, newInterval, version, partitionNum);
   }
 
   /**
@@ -394,7 +403,7 @@ public final class SegmentId implements Comparable<SegmentId>
    */
   public SegmentId withVersion(String newVersion)
   {
-    return of(dataSource, interval, newVersion, partitionNum);
+    return new SegmentId(dataSourceType, dataSource, interval, newVersion, partitionNum);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
+++ b/processing/src/main/java/org/apache/druid/timeline/SegmentId.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.stream.IntStream;
@@ -262,7 +263,7 @@ public final class SegmentId implements Comparable<SegmentId>
    */
   public static SegmentId simple(DataSourceType dataSourceType)
   {
-    return new SegmentId(dataSourceType, "", Intervals.ETERNITY, dataSourceType.name().toLowerCase(), 0);
+    return new SegmentId(dataSourceType, "", Intervals.ETERNITY, dataSourceType.name().toLowerCase(Locale.ENGLISH), 0);
   }
 
   public enum DataSourceType
@@ -333,7 +334,7 @@ public final class SegmentId implements Comparable<SegmentId>
     int hashCode = partitionNum;
     // 1000003 is a constant used in Google AutoValue, provides a little better distribution than 31
     hashCode = hashCode * 1000003 + version.hashCode();
-    hashCode = hashCode * 1000003 + dataSourceType.hashCode();
+    hashCode = hashCode * 1000003 + dataSourceType.ordinal();
     hashCode = hashCode * 1000003 + dataSource.hashCode();
     hashCode = hashCode * 1000003 + interval.hashCode();
     return hashCode;

--- a/processing/src/test/java/org/apache/druid/frame/testutil/FrameTestUtil.java
+++ b/processing/src/test/java/org/apache/druid/frame/testutil/FrameTestUtil.java
@@ -31,7 +31,6 @@ import org.apache.druid.frame.file.FrameFileWriter;
 import org.apache.druid.frame.read.FrameReader;
 import org.apache.druid.frame.segment.FrameSegment;
 import org.apache.druid.frame.util.SettableLongVirtualColumn;
-import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.query.OrderBy;
@@ -199,7 +198,7 @@ public class FrameTestUtil
     return new FrameSegment(
         cursorFactoryToFrame(adapter, frameType),
         FrameReader.create(adapter.getRowSignature()),
-        SegmentId.of("TestFrame", Intervals.ETERNITY, "0", 0)
+        "TestFrame"
     );
   }
 
@@ -244,7 +243,7 @@ public class FrameTestUtil
 
   /**
    * Reads a sequence of rows from a {@link CursorFactory}.
-   *
+   * <p>
    * If {@param populateRowNumberIfPresent} is set, and the provided signature contains {@link #ROW_NUMBER_COLUMN},
    * then that column will be populated with a row number from the cursor.
    *
@@ -280,7 +279,7 @@ public class FrameTestUtil
 
   /**
    * Creates a {@link CursorHolder} from a {@link CursorFactory}.
-   *
+   * <p>
    * If {@param populateRowNumber} is set, the row number will be populated into {@link #ROW_NUMBER_COLUMN}.
    *
    * @param cursorFactory     the cursor factory

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
@@ -518,7 +518,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
           Collections.emptyList()
       ).lhs;
 
-      inputSegment = new FrameSegment(inputFrame, FrameReader.create(signature), SegmentId.dummy("xxx"));
+      inputSegment = new FrameSegment(inputFrame, FrameReader.create(signature), "xxx");
     }
 
     try (final CursorHolder cursorHolder = inputSegment.asCursorFactory().makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -657,7 +657,7 @@ public class AggregationTestHelper implements Closeable
     }
     indexMerger.persist(index, outDir, IndexSpec.DEFAULT, null);
 
-    return new QueryableIndexSegment(indexIO.loadIndex(outDir), SegmentId.dummy("some-data-source"));
+    return new QueryableIndexSegment(indexIO.loadIndex(outDir), SegmentId.simpleTable("some-data-source"));
   }
 
   //Simulates running group-by query on individual segments as historicals would do, json serialize the results
@@ -677,7 +677,7 @@ public class AggregationTestHelper implements Closeable
           public Segment apply(File segmentDir)
           {
             try {
-              return new QueryableIndexSegment(indexIO.loadIndex(segmentDir), SegmentId.dummy("some-data-source"));
+              return new QueryableIndexSegment(indexIO.loadIndex(segmentDir), SegmentId.simpleTable("some-data-source"));
             }
             catch (IOException ex) {
               throw new RuntimeException(ex);

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -657,7 +657,7 @@ public class AggregationTestHelper implements Closeable
     }
     indexMerger.persist(index, outDir, IndexSpec.DEFAULT, null);
 
-    return new QueryableIndexSegment(indexIO.loadIndex(outDir), SegmentId.dummy(""));
+    return new QueryableIndexSegment(indexIO.loadIndex(outDir), SegmentId.dummy("some-data-source"));
   }
 
   //Simulates running group-by query on individual segments as historicals would do, json serialize the results
@@ -677,7 +677,7 @@ public class AggregationTestHelper implements Closeable
           public Segment apply(File segmentDir)
           {
             try {
-              return new QueryableIndexSegment(indexIO.loadIndex(segmentDir), SegmentId.dummy(""));
+              return new QueryableIndexSegment(indexIO.loadIndex(segmentDir), SegmentId.dummy("some-data-source"));
             }
             catch (IOException ex) {
               throw new RuntimeException(ex);

--- a/processing/src/test/java/org/apache/druid/query/lookup/LookupSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/query/lookup/LookupSegmentTest.java
@@ -106,7 +106,7 @@ public class LookupSegmentTest
   @Test
   public void test_getId()
   {
-    Assert.assertEquals(SegmentId.dummy(LOOKUP_NAME), LOOKUP_SEGMENT.getId());
+    Assert.assertEquals(SegmentId.simple(SegmentId.DataSourceType.LOOKUP), LOOKUP_SEGMENT.getId());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/lookup/LookupSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/query/lookup/LookupSegmentTest.java
@@ -106,7 +106,10 @@ public class LookupSegmentTest
   @Test
   public void test_getId()
   {
-    Assert.assertEquals(SegmentId.simple(SegmentId.DataSourceType.LOOKUP), LOOKUP_SEGMENT.getId());
+    Assert.assertEquals(
+        SegmentId.simple(SegmentId.DataSourceType.LOOKUP).withVersion(LOOKUP_NAME),
+        LOOKUP_SEGMENT.getId()
+    );
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/policy/RestrictAllTablesPolicyEnforcerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/policy/RestrictAllTablesPolicyEnforcerTest.java
@@ -23,13 +23,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.RestrictedDataSource;
 import org.apache.druid.query.TableDataSource;
 import org.apache.druid.query.filter.NullFilter;
 import org.apache.druid.segment.ReferenceCountingSegment;
+import org.apache.druid.segment.RowBasedSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestSegmentUtils.SegmentForTesting;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.timeline.SegmentId;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -95,6 +100,24 @@ public class RestrictAllTablesPolicyEnforcerTest
         e2.getMessage()
     );
     policyEnforcer.validateOrElseThrow(segment, policy);
+  }
+
+  @Test
+  public void test_validate_allowNonTableSegments() throws Exception
+  {
+    final RestrictAllTablesPolicyEnforcer policyEnforcer = new RestrictAllTablesPolicyEnforcer(null);
+
+    // Test validate segment, success for inline segment
+    final InlineDataSource inlineDataSource = InlineDataSource.fromIterable(ImmutableList.of(), RowSignature.empty());
+    final Segment inlineSegment = new RowBasedSegment<>(
+        SegmentId.simple(SegmentId.DataSourceType.INLINE),
+        Sequences.simple(inlineDataSource.getRows()),
+        inlineDataSource.rowAdapter(),
+        inlineDataSource.getRowSignature()
+    );
+    ReferenceCountingSegment segment = ReferenceCountingSegment.wrapRootGenerationSegment(inlineSegment);
+
+    policyEnforcer.validateOrElseThrow(segment, null);
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/query/policy/RestrictAllTablesPolicyEnforcerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/policy/RestrictAllTablesPolicyEnforcerTest.java
@@ -121,6 +121,17 @@ public class RestrictAllTablesPolicyEnforcerTest
   }
 
   @Test
+  public void test_validate_closedSegment() throws Exception
+  {
+    final RestrictAllTablesPolicyEnforcer policyEnforcer = new RestrictAllTablesPolicyEnforcer(null);
+    Segment baseSegment = new SegmentForTesting("table", Intervals.ETERNITY, "1");
+    ReferenceCountingSegment segment = ReferenceCountingSegment.wrapRootGenerationSegment(baseSegment);
+    segment.close();
+
+    policyEnforcer.validateOrElseThrow(segment, null);
+  }
+
+  @Test
   public void test_validate_withAllowedPolicies() throws Exception
   {
     RestrictAllTablesPolicyEnforcer policyEnforcer = new RestrictAllTablesPolicyEnforcer(ImmutableList.of(

--- a/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
@@ -832,7 +832,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
         cursor.advance();
         count++;
       }
-      Assert.assertEquals(count, 618);
+      Assert.assertEquals(count, 604);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.timeline;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.joda.time.DateTime;
@@ -53,6 +54,29 @@ public class SegmentIdTest
     desc = desc.withInterval(Intervals.of("2014-10-20T00:00:00Z/P1D"));
     Assert.assertEquals("datasource_2014-10-20T00:00:00.000Z_2014-10-21T00:00:00.000Z_ver", desc.toString());
     Assert.assertEquals(desc, SegmentId.tryParse(datasource, desc.toString()));
+  }
+
+  @Test
+  public void testBasicEmptyDataSource()
+  {
+    SegmentId desc = SegmentId.simple(SegmentId.DataSourceType.LOOKUP);
+    Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_lookup", desc.toString());
+    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+
+    desc = SegmentId.simple(SegmentId.DataSourceType.INLINE);
+    Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_inline", desc.toString());
+    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+
+    desc = SegmentId.simple(SegmentId.DataSourceType.EXTERNAL);
+    Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_external", desc.toString());
+    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+
+    desc = SegmentId.simple(SegmentId.DataSourceType.FRAME);
+    Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_frame", desc.toString());
+    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+
+    DruidException e = Assert.assertThrows(DruidException.class, () -> SegmentId.of("", Intervals.ETERNITY, "ver", 0));
+    Assert.assertEquals("Datasource is not specified", e.getMessage());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
@@ -260,4 +260,12 @@ public class SegmentIdTest
     Assert.assertEquals(2, possibleParsings.size());
     Assert.assertEquals(expected, ImmutableSet.copyOf(possibleParsings));
   }
+
+  @Test
+  public void testIterateAllPossibleParsings_emptyDataSource()
+  {
+    String segmentId = "_2015-01-02T00:00:00.000Z_2015-01-03T00:00:00.000Z_ver";
+    Iterable<SegmentId> possibleParsings = SegmentId.iterateAllPossibleParsings(segmentId);
+    Assert.assertTrue(Iterables.isEmpty(possibleParsings));
+  }
 }

--- a/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
@@ -77,6 +77,9 @@ public class SegmentIdTest
 
     DruidException e = Assert.assertThrows(DruidException.class, () -> SegmentId.of("", Intervals.ETERNITY, "ver", 0));
     Assert.assertEquals("Datasource is not specified", e.getMessage());
+
+    DruidException e2 = Assert.assertThrows(DruidException.class, () -> SegmentId.simpleTable(""));
+    Assert.assertEquals("Datasource is not specified", e2.getMessage());
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
+++ b/processing/src/test/java/org/apache/druid/timeline/SegmentIdTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.timeline;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -61,19 +62,23 @@ public class SegmentIdTest
   {
     SegmentId desc = SegmentId.simple(SegmentId.DataSourceType.LOOKUP);
     Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_lookup", desc.toString());
-    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertNull(SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertTrue(Iterables.isEmpty(SegmentId.iterateAllPossibleParsings(desc.toString())));
 
     desc = SegmentId.simple(SegmentId.DataSourceType.INLINE);
     Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_inline", desc.toString());
-    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertNull(SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertTrue(Iterables.isEmpty(SegmentId.iterateAllPossibleParsings(desc.toString())));
 
     desc = SegmentId.simple(SegmentId.DataSourceType.EXTERNAL);
     Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_external", desc.toString());
-    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertNull(SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertTrue(Iterables.isEmpty(SegmentId.iterateAllPossibleParsings(desc.toString())));
 
     desc = SegmentId.simple(SegmentId.DataSourceType.FRAME);
     Assert.assertEquals("_-146136543-09-08T08:23:32.096Z_146140482-04-24T15:36:27.903Z_frame", desc.toString());
-    Assert.assertEquals(null, SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertNull(SegmentId.tryExtractMostProbableDataSource(desc.toString()));
+    Assert.assertTrue(Iterables.isEmpty(SegmentId.iterateAllPossibleParsings(desc.toString())));
 
     DruidException e = Assert.assertThrows(DruidException.class, () -> SegmentId.of("", Intervals.ETERNITY, "ver", 0));
     Assert.assertEquals("Datasource is not specified", e.getMessage());

--- a/server/src/main/java/org/apache/druid/segment/FrameBasedInlineSegmentWrangler.java
+++ b/server/src/main/java/org/apache/druid/segment/FrameBasedInlineSegmentWrangler.java
@@ -46,7 +46,7 @@ public class FrameBasedInlineSegmentWrangler implements SegmentWrangler
             frameSignaturePair -> new FrameSegment(
                 frameSignaturePair.getFrame(),
                 FrameReader.create(frameSignaturePair.getRowSignature()),
-                SegmentId.dummy(SEGMENT_ID)
+                SegmentId.simple(SegmentId.DataSourceType.INLINE)
             )
         )
         .iterator();

--- a/server/src/main/java/org/apache/druid/segment/InlineSegmentWrangler.java
+++ b/server/src/main/java/org/apache/druid/segment/InlineSegmentWrangler.java
@@ -30,12 +30,12 @@ import java.util.Collections;
 
 /**
  * A {@link SegmentWrangler} for {@link InlineDataSource}.
- *
+ * <p>
  * It is not valid to pass any other DataSource type to the "getSegmentsForIntervals" method.
  */
 public class InlineSegmentWrangler implements SegmentWrangler
 {
-  private static final String SEGMENT_ID = "inline";
+  public static final SegmentId SEGMENT_ID = SegmentId.simple(SegmentId.DataSourceType.INLINE);
 
   @Override
   @SuppressWarnings("unchecked")
@@ -46,7 +46,7 @@ public class InlineSegmentWrangler implements SegmentWrangler
     if (inlineDataSource.rowsAreArrayList()) {
       return Collections.singletonList(
           new ArrayListSegment<>(
-              SegmentId.dummy(SEGMENT_ID),
+              SEGMENT_ID,
               (ArrayList<Object[]>) inlineDataSource.getRowsAsList(),
               inlineDataSource.rowAdapter(),
               inlineDataSource.getRowSignature()
@@ -56,7 +56,7 @@ public class InlineSegmentWrangler implements SegmentWrangler
 
     return Collections.singletonList(
         new RowBasedSegment<>(
-            SegmentId.dummy(SEGMENT_ID),
+            SEGMENT_ID,
             Sequences.simple(inlineDataSource.getRows()),
             inlineDataSource.rowAdapter(),
             inlineDataSource.getRowSignature()

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -2768,7 +2768,7 @@ public class CachingClusteredClientTest
       private MyDataSegment()
       {
         super(
-            "",
+            "myDataSource",
             Intervals.utc(0, 1),
             "",
             null,

--- a/services/src/main/java/org/apache/druid/cli/DumpSegment.java
+++ b/services/src/main/java/org/apache/druid/cli/DumpSegment.java
@@ -746,7 +746,7 @@ public class DumpSegment extends GuiceRunnable
   {
     final QueryRunnerFactoryConglomerate conglomerate = injector.getInstance(QueryRunnerFactoryConglomerate.class);
     final QueryRunnerFactory<T, Query<T>> factory = conglomerate.findFactory(query);
-    final QueryRunner<T> runner = factory.createRunner(new QueryableIndexSegment(index, SegmentId.dummy("segment")));
+    final QueryRunner<T> runner = factory.createRunner(new QueryableIndexSegment(index, SegmentId.simpleTable("segment")));
     return factory
         .getToolchest()
         .mergeResults(factory.mergeRunners(DirectQueryProcessingPool.INSTANCE, ImmutableList.of(runner)), true)


### PR DESCRIPTION
This PR proposes to add a new field `dataSourceType` in `SegmentId`, which is an enum of `TABLE, LOOKUP, INLINE, EXTERNAL, FRAME`. Only `TABLE` segment can have non-empty `dataSource` field, others must have empty `dataSource`. This would be used in `PolicyEnforcer` to enforce `Policy` for table segment. 

Besides that:
- Non-table segments can use `version` to store some info. E.x. for lookup segment, the version is the lookup name.
- Deprecated the usage of `dummy` factory method in `SegmentId`, and replace it with `simple` and `simpleTable`.
- Only table segment works with the serde of `toString` and `iterateAllPossibleParsings`.
- `dataSourceType` is ignored in `toString`. 
- When parsing a `SegmentId` string, the `dataSource` field can't be empty. This was not enforced before this PR. E.x. before this PR, `_2015-01-02T00:00:00.000Z_2015-01-03T00:00:00.000Z_ver` can be parsed into a `SegmentId` with empty `dataSource`, after this PR, it cannot.

This PR is a follow-up to https://github.com/apache/druid/pull/17774#pullrequestreview-2794975153. 

##### Key changed/added classes in this PR
 * `SegmentId`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
