### PR TITLE
Pass through enableTLS properties from config with druid-redis-cache

### DIFF
--- a/docs/development/extensions-contrib/redis-cache.md
+++ b/docs/development/extensions-contrib/redis-cache.md
@@ -47,18 +47,18 @@ To enable this extension after installation,
 
 ## Configuration
 
-### Cluster mode 
+### Cluster mode
 
 To utilize a redis cluster, following properties must be set.
 
 Note: some redis cloud service providers provide redis cluster service via a redis proxy, for these clusters, please follow the [Standalone mode](#standalone-mode) configuration below.
 
-| Properties |Description|Default|Required|
-|--------------------|-----------|-------|--------|
-|`druid.cache.cluster.nodes`| Redis nodes in a cluster, represented in comma separated string. See example below | None | yes |
-|`druid.cache.cluster.maxRedirection`| Max retry count | 5 | no |
+| Properties                           | Description                                                                        | Default | Required |
+| ------------------------------------ | ---------------------------------------------------------------------------------- | ------- | -------- |
+| `druid.cache.cluster.nodes`          | Redis nodes in a cluster, represented in comma separated string. See example below | None    | yes      |
+| `druid.cache.cluster.maxRedirection` | Max retry count                                                                    | 5       | no       |
 
-#### Example 
+#### Example
 
 ```properties
 # a typical redis cluster with 6 nodes
@@ -69,11 +69,11 @@ druid.cache.cluster.nodes=127.0.0.1:7001,127.0.0.1:7002,127.0.0.1:7003,127.0.0.1
 
 To use a standalone redis, following properties must be set.
 
-| Properties |Description|Default|Required|
-|--------------------|-----------|-------|--------|
-|`druid.cache.host`|Redis server host|None|yes|
-|`druid.cache.port`|Redis server port|None|yes|
-|`druid.cache.database`|Redis database index|0|no|
+| Properties             | Description          | Default | Required |
+| ---------------------- | -------------------- | ------- | -------- |
+| `druid.cache.host`     | Redis server host    | None    | yes      |
+| `druid.cache.port`     | Redis server port    | None    | yes      |
+| `druid.cache.database` | Redis database index | 0       | no       |
 
 Note: if both `druid.cache.cluster.nodes` and `druid.cache.host` are provided, cluster mode is preferred.
 
@@ -81,14 +81,15 @@ Note: if both `druid.cache.cluster.nodes` and `druid.cache.host` are provided, c
 
 Except for the properties above, there are some extra properties which can be customized to meet different needs.
 
-| Properties |Description|Default|Required|
-|--------------------|-----------|-------|--------|
-|`druid.cache.password`| Password to access redis server/cluster | None |no|
-|`druid.cache.expiration`|Expiration for cache entries | P1D |no|
-|`druid.cache.timeout`|Timeout for connecting to Redis and reading entries from Redis|PT2S|no|
-|`druid.cache.maxTotalConnections`|Max total connections to Redis|8|no|
-|`druid.cache.maxIdleConnections`|Max idle connections to Redis|8|no|
-|`druid.cache.minIdleConnections`|Min idle connections to Redis|0|no|
+| Properties                        | Description                                                    | Default | Required |
+| --------------------------------- | -------------------------------------------------------------- | ------- | -------- |
+| `druid.cache.password`            | Password to access redis server/cluster                        | None    | no       |
+| `druid.cache.expiration`          | Expiration for cache entries                                   | P1D     | no       |
+| `druid.cache.timeout`             | Timeout for connecting to Redis and reading entries from Redis | PT2S    | no       |
+| `druid.cache.maxTotalConnections` | Max total connections to Redis                                 | 8       | no       |
+| `druid.cache.maxIdleConnections`  | Max idle connections to Redis                                  | 8       | no       |
+| `druid.cache.minIdleConnections`  | Min idle connections to Redis                                  | 0       | no       |
+| `druid.cache.enableTls`           | Enable TLS based connection for Redis client. Boolean.         | false   |
 
 For `druid.cache.expiration` and `druid.cache.timeout` properties, values can be format of `Period` or a number in milliseconds.
 
@@ -106,6 +107,6 @@ druid.cache.expiration=3600000
 
 In addition to the normal cache metrics, the redis cache implementation also reports the following in both `total` and `delta`
 
-|Metric|Description|Normal value|
-|------|-----------|------------|
-|`query/cache/redis/*/requests`|Count of requests to redis cache|whatever request to redis will increase request count by 1|
+| Metric                         | Description                      | Normal value                                               |
+| ------------------------------ | -------------------------------- | ---------------------------------------------------------- |
+| `query/cache/redis/*/requests` | Count of requests to redis cache | whatever request to redis will increase request count by 1 |

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCacheConfig.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCacheConfig.java
@@ -147,6 +147,9 @@ public class RedisCacheConfig
   @JsonProperty
   private RedisClusterConfig cluster;
 
+  @JsonProperty
+  private boolean enableTls = false;
+
   public String getHost()
   {
     return host;
@@ -195,5 +198,10 @@ public class RedisCacheConfig
   public int getDatabase()
   {
     return database;
+  }
+
+  public boolean getEnableTls()
+  {
+    return enableTls;
   }
 }

--- a/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCacheFactory.java
+++ b/extensions-contrib/redis-cache/src/main/java/org/apache/druid/client/cache/RedisCacheFactory.java
@@ -73,14 +73,16 @@ public class RedisCacheFactory
             config.getTimeout().getMillisecondsAsInt(), //read timeout
             config.getCluster().getMaxRedirection(),
             config.getPassword().getPassword(),
-            poolConfig
+            poolConfig,
+            config.getEnableTls()
         );
       } else {
         cluster = new JedisCluster(
             nodes,
             config.getTimeout().getMillisecondsAsInt(), //connection timeout and read timeout
             config.getCluster().getMaxRedirection(),
-            poolConfig
+            poolConfig,
+            config.getEnableTls()
         );
       }
 
@@ -105,7 +107,8 @@ public class RedisCacheFactory
               config.getTimeout().getMillisecondsAsInt(), //connection timeout and read timeout
               config.getPassword() == null ? null : config.getPassword().getPassword(),
               config.getDatabase(),
-              null
+              null,
+              config.getEnableTls()
           ),
           config
       );


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/1796

### Description

This PR updates the community extension `druid-redis-cache` so that it can also connect to Redis Clusters with TLS enabled. This is awesome because AWS ElastiCache has TLS enabled by default and it's not always possible to disable that setting. 

It adds an `enableTls` property to `RedisCacheConfig` and use its contents for Jedis’ `ssl` parameter.

It also updates the docs to list the new parameter.

While I'm reasonably proficient with other languages, I haven't touched Java for a long while, so I'd be very open to improvement requests. I tried to stay as close to other implementations such as the one for `MemcachedCacheConfig` as possible.

#### Release note
Add TLS support to the `druid-redis-cache` community extension.

<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
