### PR TITLE
Add metric task/autoScaler/scaleActionTime to task autoscaler

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -284,6 +284,7 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
 |`task/autoScaler/requiredCount`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`dataSource`, `stream`, `scalingSkipReason`|Depends on auto scaler config.|
+|`task/autoScaler/scaleActionTime`|Time in ms taken to complete the scale action.|`dataSource`,`stream`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -284,7 +284,7 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
 |`task/autoScaler/requiredCount`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`dataSource`, `stream`, `scalingSkipReason`|Depends on auto scaler config.|
-|`task/autoScaler/scaleActionTime`|Time in ms taken to complete the scale action.|`dataSource`,`stream`|Depends on auto scaler config.|
+|`task/autoScaler/scaleActionTime`|Time in ms taken to complete the scale action.|`dataSource`, `stream`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -284,7 +284,7 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/pause/time`|Milliseconds spent by a task in a paused state without ingesting.|`dataSource`, `taskId`, `tags`| < 10 seconds|
 |`ingest/handoff/time`|Total number of milliseconds taken to handoff a set of segments.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the coordinator cycle time.|
 |`task/autoScaler/requiredCount`|Count of required tasks based on the calculations of `lagBased` auto scaler.|`dataSource`, `stream`, `scalingSkipReason`|Depends on auto scaler config.|
-|`task/autoScaler/scaleActionTime`|Time in ms taken to complete the scale action.|`dataSource`, `stream`|Depends on auto scaler config.|
+|`task/autoScaler/scaleActionTime`|Time taken in milliseconds to complete the scale action.|`dataSource`, `stream`|Depends on auto scaler config.|
 
 If the JVM does not support CPU time measurement for the current thread, `ingest/merge/cpu` and `ingest/persists/cpu` will be 0.
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -788,10 +788,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
             .map(metric -> metric.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION))
             .filter(Objects::nonNull)
             .anyMatch("minTriggerScaleActionFrequencyMillis not elapsed yet"::equals));
-    Assert.assertEquals(
-        1,
-        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
-    );
+    emitter.verifyEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC, 1);
     autoScaler.reset();
     autoScaler.stop();
   }
@@ -850,7 +847,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
             .map(metric -> metric.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION))
             .filter(Objects::nonNull)
             .anyMatch("Already at max task count"::equals));
-    Assert.assertFalse(emitter.getMetricEvents().containsKey(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC));
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -945,10 +942,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
     Assert.assertEquals(2, taskCountAfterScaleOut);
-    Assert.assertEquals(
-        1,
-        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
-    );
+    emitter.verifyEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC, 1);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -997,10 +991,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
     Assert.assertEquals(1, taskCountAfterScaleOut);
-    Assert.assertEquals(
-        1,
-        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
-    );
+    emitter.verifyEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC, 1);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -1054,10 +1045,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Thread.sleep(2000);
     Assert.assertEquals(10, (int) supervisor.getIoConfig().getTaskCount());
 
-    Assert.assertEquals(
-        1,
-        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
-    );
+    emitter.verifyEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC, 1);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -1117,7 +1105,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
             .map(metric -> metric.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION))
             .filter(Objects::nonNull)
             .anyMatch("Already at min task count"::equals));
-    Assert.assertFalse(emitter.getMetricEvents().containsKey(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC));
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC);
 
     autoScaler.reset();
     autoScaler.stop();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -941,8 +941,8 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
     Assert.assertEquals(2, taskCountAfterScaleOut);
     Assert.assertEquals(
-        1, emitter.getMetricEvents()
-                  .get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
+        1,
+        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
     );
 
     autoScaler.reset();
@@ -993,8 +993,8 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
     Assert.assertEquals(1, taskCountAfterScaleOut);
     Assert.assertEquals(
-        1, emitter.getMetricEvents()
-                  .get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
+        1,
+        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
     );
 
     autoScaler.reset();
@@ -1050,8 +1050,8 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Assert.assertEquals(10, (int) supervisor.getIoConfig().getTaskCount());
 
     Assert.assertEquals(
-        1, emitter.getMetricEvents()
-                  .get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
+        1,
+        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
     );
 
     autoScaler.reset();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -788,6 +788,10 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
             .map(metric -> metric.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION))
             .filter(Objects::nonNull)
             .anyMatch("minTriggerScaleActionFrequencyMillis not elapsed yet"::equals));
+    Assert.assertEquals(
+        1,
+        emitter.getMetricEvents().get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
+    );
     autoScaler.reset();
     autoScaler.stop();
   }
@@ -846,6 +850,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
             .map(metric -> metric.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION))
             .filter(Objects::nonNull)
             .anyMatch("Already at max task count"::equals));
+    Assert.assertFalse(emitter.getMetricEvents().containsKey(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC));
 
     autoScaler.reset();
     autoScaler.stop();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java
@@ -90,7 +90,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
   private TaskStorage taskStorage;
   private TaskMaster taskMaster;
   private IndexerMetadataStorageCoordinator indexerMetadataStorageCoordinator;
-  private ServiceEmitter emitter;
+  private StubServiceEmitter emitter;
   private RowIngestionMetersFactory rowIngestionMetersFactory;
   private DataSchema dataSchema;
   private SeekableStreamSupervisorTuningConfig seekableStreamSupervisorTuningConfig;
@@ -116,7 +116,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     taskStorage = EasyMock.mock(TaskStorage.class);
     taskMaster = EasyMock.mock(TaskMaster.class);
     indexerMetadataStorageCoordinator = EasyMock.mock(IndexerMetadataStorageCoordinator.class);
-    emitter = EasyMock.mock(ServiceEmitter.class);
+    emitter = new StubServiceEmitter();
     rowIngestionMetersFactory = EasyMock.mock(RowIngestionMetersFactory.class);
     dataSchema = EasyMock.mock(DataSchema.class);
     seekableStreamSupervisorTuningConfig = EasyMock.mock(SeekableStreamSupervisorTuningConfig.class);
@@ -940,6 +940,10 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
     Assert.assertEquals(2, taskCountAfterScaleOut);
+    Assert.assertEquals(
+        1, emitter.getMetricEvents()
+                  .get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
+    );
 
     autoScaler.reset();
     autoScaler.stop();
@@ -988,6 +992,10 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
     Assert.assertEquals(1, taskCountAfterScaleOut);
+    Assert.assertEquals(
+        1, emitter.getMetricEvents()
+                  .get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
+    );
 
     autoScaler.reset();
     autoScaler.stop();
@@ -1040,6 +1048,11 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
     Assert.assertEquals(2, (int) supervisor.getIoConfig().getTaskCount());
     Thread.sleep(2000);
     Assert.assertEquals(10, (int) supervisor.getIoConfig().getTaskCount());
+
+    Assert.assertEquals(
+        1, emitter.getMetricEvents()
+                  .get(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC).size()
+    );
 
     autoScaler.reset();
     autoScaler.stop();
@@ -1099,6 +1112,7 @@ public class SeekableStreamSupervisorSpecTest extends EasyMockSupport
             .map(metric -> metric.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION))
             .filter(Objects::nonNull)
             .anyMatch("Already at min task count"::equals));
+    Assert.assertFalse(emitter.getMetricEvents().containsKey(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC));
 
     autoScaler.reset();
     autoScaler.stop();


### PR DESCRIPTION
Emits a metric `task/autoScaler/scaleActionTime` which measures in ms how long the scale action took. This is useful for tuning the minimum time between scaling actions.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Emits a metric `task/autoScaler/scaleActionTime` which measures in ms how long the scale action took. This is useful for tuning the minimum time between scaling actions.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Add metric `task/autoScaler/scaleActionTime` to indexing task autoscaler.


<hr>

##### Key changed/added classes in this PR
* `indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java`
* `indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSupervisorSpecTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
