### PR TITLE
add `isValidComplexInputType` check for theta sketches

### DIFF
--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.PeriodGranularity;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.Druids;
+import org.apache.druid.query.InlineDataSource;
 import org.apache.druid.query.QueryDataSource;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
@@ -55,6 +56,7 @@ import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
@@ -74,6 +76,7 @@ import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -382,6 +385,52 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
     Assert.assertTrue(druidException.getMessage().contains(
         "Cannot apply 'APPROX_COUNT_DISTINCT_DS_THETA' to arguments of type 'APPROX_COUNT_DISTINCT_DS_THETA(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"
     ));
+  }
+
+  @Test
+  public void testApproxCountDistinctFunctionOnSupportedMatieralizedColumn()
+  {
+    cannotVectorize();
+
+    final String sketchValue = "AQMDAAA6zJMa0TALmYwvIg==";
+    final String base64SketchValue = "'" + StringUtils.replace(sketchValue, "=", "\\u003D") + "'";
+
+    Assertions.assertDoesNotThrow(() ->
+                                      testQuery(
+                                          "SELECT APPROX_COUNT_DISTINCT(DECODE_BASE64_COMPLEX('thetaSketch', '"
+                                          + sketchValue
+                                          + "'))",
+                                          ImmutableMap.of("vectorize", false),
+                                          ImmutableList.of(Druids.newTimeseriesQueryBuilder()
+                                                                 .dataSource(InlineDataSource.fromIterable(
+                                                                     Collections.singletonList(new Object[]{0L}),
+                                                                     RowSignature.builder()
+                                                                                 .add("ZERO", ColumnType.LONG)
+                                                                                 .build()
+                                                                 ))
+                                                                 .intervals(new MultipleIntervalSegmentSpec(
+                                                                     ImmutableList.of(Filtration.eternity())))
+                                                                 .granularity(Granularities.ALL)
+                                                                 .virtualColumns(new ExpressionVirtualColumn(
+                                                                     "v0",
+                                                                     StringUtils.format(
+                                                                         "complex_decode_base64('thetaSketch',%s)",
+                                                                         base64SketchValue
+                                                                     ),
+                                                                     ColumnType.ofComplex("thetaSketch"),
+                                                                     queryFramework().macroTable()
+                                                                 ))
+                                                                 .aggregators(ImmutableList.of(new SketchMergeAggregatorFactory(
+                                                                     "a0",
+                                                                     "v0",
+                                                                     null,
+                                                                     null,
+                                                                     null,
+                                                                     null
+                                                                 )))
+                                                                 .build()),
+                                          ImmutableList.of(new Object[]{1L})
+                                      ));
   }
 
   @Test


### PR DESCRIPTION

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Similar to HLLs, this patch adds an additional layer of validation to the Theta Sketch SQL aggregators. This change fixes a bug in the planner that incorrectly prevented queries with data type `COMPLEX<thetaSketch>` from being planned. The patch also adds a test case validating such plans now work as expected.

For more information on this issue, please see [this post from the developers mailing list](https://groups.google.com/g/druid-user/c/Ra_PExA1zmk).


<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note

Fix a bug in the planner that incorrectly prevented queries with data type `COMPLEX<thetaSketch>` from being planned

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `ThetaSketchBaseSqlAggregator`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
(Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
