### PR TITLE
Make `EXPLAIN PLAN` queries honor the query context set via `SET` statements

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -297,9 +297,8 @@ public class DruidPlanner implements Closeable
    * If an {@link SqlNode} is a {@link SqlNodeList}, it must consist of 0 or more {@link SqlSetOption} followed by a
    * single {@link SqlNode} which is NOT a {@link SqlSetOption}. All {@link SqlSetOption} will be converted into a
    * context parameters {@link Map} and added to the {@link PlannerContext} with
-   * {@link PlannerContext#addAllToQueryContext(Map)} and {@link PlannerContext#addAllToPlannerConfig(Map)}.
-   * The final {@link SqlNode} of the {@link SqlNodeList} is returned by this method as the {@link SqlNode} which
-   * should actually be validated and executed, and will have access to the
+   * {@link PlannerContext#addAllToQueryContext(Map)}. The final {@link SqlNode} of the {@link SqlNodeList} is returned
+   * by this method as the {@link SqlNode} which should actually be validated and executed, and will have access to the
    * modified query context through the {@link PlannerContext}. {@link SqlSetOption} override any existing query
    * context parameter values.
    */
@@ -350,7 +349,6 @@ public class DruidPlanner implements Closeable
         throw InvalidSqlInput.exception("Statement list is missing a non-SET statement to execute");
       }
       plannerContext.addAllToQueryContext(contextMap);
-      plannerContext.addAllToPlannerConfig(contextMap);
     }
     return root;
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -297,8 +297,9 @@ public class DruidPlanner implements Closeable
    * If an {@link SqlNode} is a {@link SqlNodeList}, it must consist of 0 or more {@link SqlSetOption} followed by a
    * single {@link SqlNode} which is NOT a {@link SqlSetOption}. All {@link SqlSetOption} will be converted into a
    * context parameters {@link Map} and added to the {@link PlannerContext} with
-   * {@link PlannerContext#addAllToQueryContext(Map)}. The final {@link SqlNode} of the {@link SqlNodeList} is returned
-   * by this method as the {@link SqlNode} which should actually be validated and executed, and will have access to the
+   * {@link PlannerContext#addAllToQueryContext(Map)} and {@link PlannerContext#addAllToPlannerConfig(Map)}.
+   * The final {@link SqlNode} of the {@link SqlNodeList} is returned by this method as the {@link SqlNode} which
+   * should actually be validated and executed, and will have access to the
    * modified query context through the {@link PlannerContext}. {@link SqlSetOption} override any existing query
    * context parameter values.
    */
@@ -349,6 +350,7 @@ public class DruidPlanner implements Closeable
         throw InvalidSqlInput.exception("Statement list is missing a non-SET statement to execute");
       }
       plannerContext.addAllToQueryContext(contextMap);
+      plannerContext.addAllToPlannerConfig(contextMap);
     }
     return root;
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -174,7 +174,7 @@ public class PlannerContext
     this.engine = engine;
     this.queryContext = new LinkedHashMap<>(queryContext);
     this.hook = hook == null ? NoOpPlannerHook.INSTANCE : hook;
-    initializeContextFields();
+    initializeContextFieldsAndPlannerConfig();
   }
 
   public static PlannerContext create(
@@ -553,15 +553,7 @@ public class PlannerContext
   public void addAllToQueryContext(Map<String, Object> toAdd)
   {
     this.queryContext.putAll(toAdd);
-    initializeContextFields();
-  }
-
-  /**
-   * Add additional query context parameters to planner config, overriding any existing values.
-   */
-  public void addAllToPlannerConfig(Map<String, Object> toAdd)
-  {
-    this.plannerConfig = this.plannerConfig.withOverrides(toAdd);
+    initializeContextFieldsAndPlannerConfig();
   }
 
   public SqlEngine getEngine()
@@ -640,7 +632,7 @@ public class PlannerContext
 
 
 
-  private void initializeContextFields()
+  private void initializeContextFieldsAndPlannerConfig()
   {
     final Object tsParam = queryContext.get(CTX_SQL_CURRENT_TIMESTAMP);
     final DateTime utcNow;

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -163,7 +163,6 @@ public class PlannerContext
   private PlannerContext(
       final PlannerToolbox plannerToolbox,
       final String sql,
-      final PlannerConfig plannerConfig,
       final SqlEngine engine,
       final Map<String, Object> queryContext,
       final PlannerHook hook
@@ -172,7 +171,6 @@ public class PlannerContext
     this.plannerToolbox = plannerToolbox;
     this.expressionParser = new ExpressionParserImpl(plannerToolbox.exprMacroTable());
     this.sql = sql;
-    this.plannerConfig = Preconditions.checkNotNull(plannerConfig, "plannerConfig");
     this.engine = engine;
     this.queryContext = new LinkedHashMap<>(queryContext);
     this.hook = hook == null ? NoOpPlannerHook.INSTANCE : hook;
@@ -190,7 +188,6 @@ public class PlannerContext
     return new PlannerContext(
         plannerToolbox,
         sql,
-        plannerToolbox.plannerConfig().withOverrides(queryContext),
         engine,
         queryContext,
         hook
@@ -702,6 +699,12 @@ public class PlannerContext
     if (Strings.isNullOrEmpty(sqlQueryId)) {
       sqlQueryId = UUID.randomUUID().toString();
       this.queryContext.put(QueryContexts.CTX_SQL_QUERY_ID, UUID.randomUUID().toString());
+    }
+
+    if (plannerConfig != null) {
+      plannerConfig = plannerConfig.withOverrides(queryContext);
+    } else {
+      plannerConfig = getPlannerToolbox().plannerConfig.withOverrides(queryContext);
     }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -128,13 +128,13 @@ public class PlannerContext
   private final PlannerToolbox plannerToolbox;
   private final ExpressionParser expressionParser;
   private final String sql;
-  private final PlannerConfig plannerConfig;
   private final SqlEngine engine;
   private final Map<String, Object> queryContext;
   private final CopyOnWriteArrayList<String> nativeQueryIds = new CopyOnWriteArrayList<>();
   private final PlannerHook hook;
   private final Set<String> lookupsToLoad = new HashSet<>();
 
+  private PlannerConfig plannerConfig;
   private String sqlQueryId;
   private boolean stringifyArrays;
   private boolean useBoundsAndSelectors;
@@ -557,6 +557,14 @@ public class PlannerContext
   {
     this.queryContext.putAll(toAdd);
     initializeContextFields();
+  }
+
+  /**
+   * Add additional query context parameters to planner config, overriding any existing values.
+   */
+  public void addAllToPlannerConfig(Map<String, Object> toAdd)
+  {
+    this.plannerConfig = this.plannerConfig.withOverrides(toAdd);
   }
 
   public SqlEngine getEngine()


### PR DESCRIPTION
This is a follow-up patch to https://github.com/apache/druid/pull/17894 that adds support for honoring the query context for `EXPLAIN PLAN` queries via `SET` statements.


#### Description:
- `EXPLAIN PLAN` queries were ignoring the query context parameters from `SET` statements.
- This was because the planner config was eagerly built _before_ the `SET` statements from the SQL query were processed and the query context extracted in `processStatementList`.
- With this patch, `processStatementList` overrides the planner config in the end. In order to do this override, the field is made non-final (similar to other non-final mutable members in `PlannerContext`).
- Adds a couple of tests for explain plan on select and insert queries.

This PR has:

- [x] been self-reviewed.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
