### PR TITLE
Dart/MSQ IT changes

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartQueryMaker.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartQueryMaker.java
@@ -51,6 +51,7 @@ import org.apache.druid.msq.indexing.report.MSQStatusReport;
 import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
 import org.apache.druid.msq.sql.DartQueryKitSpecFactory;
 import org.apache.druid.msq.sql.MSQTaskQueryMaker;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.server.QueryResponse;
 import org.apache.druid.sql.calcite.planner.PlannerContext;
@@ -131,7 +132,7 @@ public class DartQueryMaker implements QueryMaker
     final List<Pair<SqlTypeName, ColumnType>> types =
         MSQTaskQueryMaker.getTypes(druidQuery, fieldMapping, plannerContext);
 
-    final String dartQueryId = druidQuery.getQuery().context().getString(DartSqlEngine.CTX_DART_QUERY_ID);
+    final String dartQueryId = druidQuery.getQuery().context().getString(QueryContexts.CTX_DART_QUERY_ID);
     final ControllerContext controllerContext = controllerContextFactory.newContext(dartQueryId);
     final ResultsContext resultsContext = new ResultsContext(
         types.stream().map(p -> p.lhs).collect(Collectors.toList()),
@@ -163,10 +164,7 @@ public class DartQueryMaker implements QueryMaker
         DateTimes.nowUtc()
     );
 
-    final boolean fullReport = druidQuery.getQuery().context().getBoolean(
-        DartSqlEngine.CTX_FULL_REPORT,
-        DartSqlEngine.CTX_FULL_REPORT_DEFAULT
-    );
+    final boolean fullReport = druidQuery.getQuery().context().getFullReport();
 
     // Register controller before submitting anything to controllerExeuctor, so it shows up in
     // "active controllers" lists.
@@ -215,7 +213,7 @@ public class DartQueryMaker implements QueryMaker
                     "maxQueryReportSize[%,d] exceeded. "
                     + "Try limiting the result set for your query, or run it with %s[false]",
                     limit,
-                    DartSqlEngine.CTX_FULL_REPORT
+                    QueryContexts.CTX_FULL_REPORT
                 )
             ),
             plannerContext.getJsonMapper(),
@@ -288,7 +286,7 @@ public class DartQueryMaker implements QueryMaker
         "%s-sqlQueryId[%s]-queryId[%s]",
         Thread.currentThread().getName(),
         plannerContext.getSqlQueryId(),
-        plannerContext.queryContext().get(DartSqlEngine.CTX_DART_QUERY_ID)
+        plannerContext.queryContext().get(QueryContexts.CTX_DART_QUERY_ID)
     );
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerClientImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerClientImpl.java
@@ -27,7 +27,6 @@ import it.unimi.dsi.fastutil.Pair;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
-import org.apache.druid.msq.dart.controller.sql.DartSqlEngine;
 import org.apache.druid.msq.dart.worker.http.DartWorkerResource;
 import org.apache.druid.msq.exec.WorkerClient;
 import org.apache.druid.msq.rpc.BaseWorkerClientImpl;
@@ -68,7 +67,7 @@ public class DartWorkerClientImpl extends BaseWorkerClientImpl implements DartWo
   /**
    * Create a worker client.
    *
-   * @param queryId        dart query ID. see {@link DartSqlEngine#CTX_DART_QUERY_ID}
+   * @param queryId        dart query ID. see {@link org.apache.druid.query.QueryContexts#CTX_DART_QUERY_ID}
    * @param clientFactory  service client factor
    * @param smileMapper    Smile object mapper
    * @param controllerHost Controller host (see {@link DartWorkerResource#HEADER_CONTROLLER_HOST}) if this is a

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/Controller.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/Controller.java
@@ -23,12 +23,12 @@ import org.apache.druid.indexer.report.TaskReport;
 import org.apache.druid.msq.counters.CounterSnapshots;
 import org.apache.druid.msq.counters.CounterSnapshotsTree;
 import org.apache.druid.msq.dart.controller.http.DartSqlResource;
-import org.apache.druid.msq.dart.controller.sql.DartSqlEngine;
 import org.apache.druid.msq.indexing.MSQControllerTask;
 import org.apache.druid.msq.indexing.client.ControllerChatHandler;
 import org.apache.druid.msq.indexing.error.MSQErrorReport;
 import org.apache.druid.msq.kernel.StageId;
 import org.apache.druid.msq.statistics.PartialKeyStatisticsInformation;
+import org.apache.druid.query.QueryContexts;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -44,7 +44,7 @@ public interface Controller
    * Unique task/query ID for the batch query run by this controller.
    *
    * Controller IDs must be globally unique. For tasks, this is the task ID from {@link MSQControllerTask#getId()}.
-   * For Dart, this is {@link DartSqlEngine#CTX_DART_QUERY_ID}, set by {@link DartSqlResource}.
+   * For Dart, this is {@link QueryContexts#CTX_DART_QUERY_ID}, set by {@link DartSqlResource}.
    */
   String queryId();
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -275,7 +275,7 @@ public class MultiStageQueryContext
   {
     return queryContext.getBoolean(
         CTX_IS_REINDEX,
-        true
+        false
     );
   }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -574,7 +574,7 @@ public class DartSqlResourceTest extends MSQTestBase
         false,
         false,
         false,
-        ImmutableMap.of(DartSqlEngine.CTX_FULL_REPORT, true),
+        ImmutableMap.of(QueryContexts.CTX_FULL_REPORT, true),
         Collections.emptyList()
     );
 
@@ -615,7 +615,7 @@ public class DartSqlResourceTest extends MSQTestBase
         false,
         false,
         false,
-        ImmutableMap.of(DartSqlEngine.CTX_FULL_REPORT, true),
+        ImmutableMap.of(QueryContexts.CTX_FULL_REPORT, true),
         Collections.emptyList()
     );
 
@@ -687,7 +687,7 @@ public class DartSqlResourceTest extends MSQTestBase
         false,
         false,
         false,
-        ImmutableMap.of(QueryContexts.CTX_SQL_QUERY_ID, sqlQueryId, DartSqlEngine.CTX_FULL_REPORT, fullReport),
+        ImmutableMap.of(QueryContexts.CTX_SQL_QUERY_ID, sqlQueryId, QueryContexts.CTX_FULL_REPORT, fullReport),
         Collections.emptyList()
     );
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.msq.test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.msq.dart.controller.sql.DartSqlEngine;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.sql.calcite.BaseCalciteQueryTest;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
@@ -40,7 +39,7 @@ public class CalciteDartTest extends BaseCalciteQueryTest
     return new QueryTestBuilder(new CalciteTestConfig(true))
         .queryContext(
             ImmutableMap.<String, Object>builder()
-                .put(DartSqlEngine.CTX_DART_QUERY_ID, UUID.randomUUID().toString())
+                .put(QueryContexts.CTX_DART_QUERY_ID, UUID.randomUUID().toString())
                 .put(QueryContexts.ENABLE_DEBUG, true)
                 .build()
         )

--- a/integration-tests/docker/environment-configs/broker
+++ b/integration-tests/docker/environment-configs/broker
@@ -21,7 +21,7 @@ DRUID_SERVICE=broker
 DRUID_LOG_PATH=/shared/logs/broker.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xms192m -Xmx256m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
+SERVICE_DRUID_JAVA_OPTS=-server -Xms192m -Xmx256m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
 
 # Druid configs
 druid_host=druid-broker

--- a/integration-tests/docker/environment-configs/common
+++ b/integration-tests/docker/environment-configs/common
@@ -82,3 +82,6 @@ druid_audit_manager_type=log
 # Testing the legacy config from https://github.com/apache/druid/pull/10267
 # Can remove this when the flag is no longer needed
 druid_indexer_task_ignoreTimestampSpecForDruidInputSource=true
+
+# Dart
+druid_msq_dart_enabled = true

--- a/integration-tests/docker/environment-configs/common-ldap
+++ b/integration-tests/docker/environment-configs/common-ldap
@@ -86,3 +86,6 @@ druid_request_logging_type=slf4j
 # Setting s3 credentials and region to use pre-populated data for testing.
 druid_s3_accessKey=AKIAT2GGLKKJQCMG64V4
 druid_s3_secretKey=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
+
+# Dart
+druid_msq_dart_enabled = true

--- a/integration-tests/docker/environment-configs/common-ldap
+++ b/integration-tests/docker/environment-configs/common-ldap
@@ -29,7 +29,7 @@ DRUID_DEP_LIB_DIR=/shared/hadoop_xml:/shared/docker/lib/*:/usr/local/druid/lib/m
 
 # Druid configs
 # If you are making a change in load list below, make the necessary changes in github actions too
-druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches"]
+druid_extensions_loadList=["mysql-metadata-storage","druid-s3-extensions","druid-basic-security","simple-client-sslcontext","druid-testing-tools","druid-lookups-cached-global","druid-histogram","druid-datasketches","druid-multi-stage-query"]
 druid_extensions_directory=/shared/docker/extensions
 druid_auth_authenticator_ldap_authorizerName=ldapauth
 druid_auth_authenticator_ldap_initialAdminPassword=priest

--- a/integration-tests/docker/environment-configs/coordinator
+++ b/integration-tests/docker/environment-configs/coordinator
@@ -21,7 +21,7 @@ DRUID_SERVICE=coordinator
 DRUID_LOG_PATH=/shared/logs/coordinator.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5006
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5006
 
 # Druid configs
 druid_host=druid-coordinator

--- a/integration-tests/docker/environment-configs/historical
+++ b/integration-tests/docker/environment-configs/historical
@@ -23,7 +23,7 @@ DRUID_LOG_PATH=/shared/logs/historical.log
 # JAVA OPTS
 # Query IT often fails with historical server running out of memory (OOM).
 # Until the issue is resolved, heap size for historical server is increased from 512m to 700m.
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx700m -Xms700m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5007
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx700m -Xms700m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5007
 
 # Druid configs
 druid_host=druid-historical

--- a/integration-tests/docker/environment-configs/historical-for-query-error-test
+++ b/integration-tests/docker/environment-configs/historical-for-query-error-test
@@ -21,7 +21,7 @@ DRUID_SERVICE=historical-for-query-error-test
 DRUID_LOG_PATH=/shared/logs/historical-for-query-error-test.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx512m -Xms512m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5010
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx512m -Xms512m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5010
 
 # Druid configs
 druid_processing_buffer_sizeBytes=25000000

--- a/integration-tests/docker/environment-configs/indexer
+++ b/integration-tests/docker/environment-configs/indexer
@@ -21,7 +21,7 @@ DRUID_SERVICE=indexer
 DRUID_LOG_PATH=/shared/logs/indexer.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx1g -Xms512m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5008
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx1g -Xms512m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008
 
 # Druid configs
 druid_host=druid-indexer

--- a/integration-tests/docker/environment-configs/middlemanager
+++ b/integration-tests/docker/environment-configs/middlemanager
@@ -21,7 +21,7 @@ DRUID_SERVICE=middleManager
 DRUID_LOG_PATH=/shared/logs/middlemanager.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5008
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5008
 
 # Druid configs
 druid_host=druid-middlemanager

--- a/integration-tests/docker/environment-configs/overlord
+++ b/integration-tests/docker/environment-configs/overlord
@@ -21,7 +21,7 @@ DRUID_SERVICE=overlord
 DRUID_LOG_PATH=/shared/logs/overlord.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5009
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5009
 
 # Druid configs
 druid_host=druid-overlord

--- a/integration-tests/docker/environment-configs/router
+++ b/integration-tests/docker/environment-configs/router
@@ -21,7 +21,7 @@ DRUID_SERVICE=router
 DRUID_LOG_PATH=/shared/logs/router.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5004
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms64m -XX:+UseG1GC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5004
 
 # Druid configs
 druid_host=druid-router

--- a/integration-tests/docker/environment-configs/router-custom-check-tls
+++ b/integration-tests/docker/environment-configs/router-custom-check-tls
@@ -21,7 +21,7 @@ DRUID_SERVICE=router
 DRUID_LOG_PATH=/shared/logs/router-custom-check-tls.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms128m -XX:+UseG1GC -XX:+PrintGCDetails -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5003
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms128m -XX:+UseG1GC -XX:+PrintGCDetails -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5003
 
 # Druid configs
 druid_plaintextPort=8891

--- a/integration-tests/docker/environment-configs/router-no-client-auth-tls
+++ b/integration-tests/docker/environment-configs/router-no-client-auth-tls
@@ -21,7 +21,7 @@ DRUID_SERVICE=router
 DRUID_LOG_PATH=/shared/logs/router-no-client-auth-tls.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms128m -XX:+UseG1GC -XX:+PrintGCDetails -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5002
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms128m -XX:+UseG1GC -XX:+PrintGCDetails -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5002
 
 # Druid configs
 druid_plaintextPort=8890

--- a/integration-tests/docker/environment-configs/router-permissive-tls
+++ b/integration-tests/docker/environment-configs/router-permissive-tls
@@ -21,7 +21,7 @@ DRUID_SERVICE=router
 DRUID_LOG_PATH=/shared/logs/router-permissive-tls.log
 
 # JAVA OPTS
-SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms128m -XX:+UseG1GC -XX:+PrintGCDetails -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5001
+SERVICE_DRUID_JAVA_OPTS=-server -Xmx128m -Xms128m -XX:+UseG1GC -XX:+PrintGCDetails -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5001
 
 # Druid configs
 druid_plaintextPort=8889

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/HttpUtil.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/HttpUtil.java
@@ -38,7 +38,7 @@ public class HttpUtil
   private static final Logger LOG = new Logger(HttpUtil.class);
   private static final StatusResponseHandler RESPONSE_HANDLER = StatusResponseHandler.getInstance();
 
-  static final int NUM_RETRIES = 30;
+  static final int NUM_RETRIES = 0;
   static final long DELAY_FOR_RETRIES_MS = 10000;
 
   public static StatusResponseHolder makeRequest(HttpClient httpClient, HttpMethod method, String url, byte[] content)

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/MsqTestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/MsqTestQueryHelper.java
@@ -209,9 +209,9 @@ public class MsqTestQueryHelper extends AbstractTestQueryHelper<MsqQueryWithResu
   }
 
   /**
-   * Compares the results for a given taskId. It is required that the task has produced some results that can be verified
+   * Fetches the results for a given taskId.
    */
-  private void compareResults(String taskId, MsqQueryWithResults expectedQueryWithResults)
+  public List<Map<String, Object>> getTaskResult(String taskId)
   {
     Map<String, TaskReport> statusReport = fetchStatusReports(taskId);
     MSQTaskReport taskReport = (MSQTaskReport) statusReport.get(MSQTaskReport.REPORT_KEY);
@@ -226,11 +226,8 @@ public class MsqTestQueryHelper extends AbstractTestQueryHelper<MsqQueryWithResu
         taskReportPayload.getResults(),
         "Results report for the task id is empty"
     );
-
     List<Map<String, Object>> actualResults = new ArrayList<>();
-
     List<MSQResultsReport.ColumnAndType> rowSignature = resultsReport.getSignature();
-
     for (final Object[] row : resultsReport.getResults()) {
       Map<String, Object> rowWithFieldNames = new LinkedHashMap<>();
       for (int i = 0; i < row.length; ++i) {
@@ -238,6 +235,15 @@ public class MsqTestQueryHelper extends AbstractTestQueryHelper<MsqQueryWithResu
       }
       actualResults.add(rowWithFieldNames);
     }
+    return actualResults;
+  }
+
+  /**
+   * Compares the results for a given taskId. It is required that the task has produced some results that can be verified
+   */
+  private void compareResults(String taskId, MsqQueryWithResults expectedQueryWithResults)
+  {
+    List<Map<String, Object>> actualResults = getTaskResult(taskId);
 
     QueryResultVerifier.ResultVerificationObject resultsComparison = QueryResultVerifier.compareResults(
         actualResults,

--- a/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.java.util.http.client.CredentialedHttpClient;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.auth.BasicCredentials;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
+import org.apache.druid.query.http.SqlTaskStatus;
 import org.apache.druid.server.security.Access;
 import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.Resource;
@@ -45,6 +46,7 @@ import org.apache.druid.sql.avatica.DruidAvaticaJsonHandler;
 import org.apache.druid.testing.IntegrationTestingConfig;
 import org.apache.druid.testing.clients.CoordinatorResourceTestClient;
 import org.apache.druid.testing.utils.HttpUtil;
+import org.apache.druid.testing.utils.MsqTestQueryHelper;
 import org.apache.druid.testing.utils.TestQueryHelper;
 import org.apache.druid.tests.indexer.AbstractIndexerTest;
 import org.jboss.netty.handler.codec.http.HttpMethod;
@@ -220,6 +222,9 @@ public abstract class AbstractAuthConfigurationTest
 
   @Inject
   protected ObjectMapper jsonMapper;
+
+  @Inject
+  protected MsqTestQueryHelper msqHelper;
 
   @Inject
   @Client
@@ -543,6 +548,57 @@ public abstract class AbstractAuthConfigurationTest
   }
 
   @Test
+  public void test_msqQueryWithContext_datasourceOnlyUser_fail() throws Exception
+  {
+    final String query = "select count(*) from auth_test";
+    makeMSQQueryRequest(
+        getHttpClient(User.DATASOURCE_ONLY_USER),
+        query,
+        ImmutableMap.of("auth_test_ctx", "should-be-denied"),
+        HttpResponseStatus.FORBIDDEN
+    );
+  }
+
+  @Test
+  public void test_msqQueryWithContext_datasourceAndContextParamsUser_succeed() throws Exception
+  {
+    final String query = "select count(*) from auth_test";
+    // Testing basic-auth admin, can read all rows
+    StatusResponseHolder responseHolder = makeMSQQueryRequest(
+        getHttpClient(User.DATASOURCE_AND_CONTEXT_PARAMS_USER),
+        query,
+        ImmutableMap.of("auth_test_ctx", "should-be-allowed"),
+        HttpResponseStatus.ACCEPTED
+    );
+    String taskId = jsonMapper.readValue(responseHolder.getContent(), SqlTaskStatus.class).getTaskId();
+    msqHelper.pollTaskIdForSuccess(taskId);
+  }
+
+  @Test
+  public void test_dartQueryWithContext_datasourceOnlyUser_fail() throws Exception
+  {
+    final String query = "select count(*) from auth_test";
+    makeDartQueryRequest(
+        getHttpClient(User.DATASOURCE_ONLY_USER),
+        query,
+        ImmutableMap.of("auth_test_ctx", "should-be-denied"),
+        HttpResponseStatus.FORBIDDEN
+    );
+  }
+
+  @Test
+  public void test_dartQueryWithContext_datasourceAndContextParamsUser_succeed() throws Exception
+  {
+    final String query = "select count(*) from auth_test";
+    makeDartQueryRequest(
+        getHttpClient(User.DATASOURCE_AND_CONTEXT_PARAMS_USER),
+        query,
+        ImmutableMap.of("auth_test_ctx", "should-be-allowed"),
+        HttpResponseStatus.OK
+    );
+  }
+
+  @Test
   public void test_sqlQueryWithContext_datasourceOnlyUser_fail() throws Exception
   {
     final String query = "select count(*) from auth_test";
@@ -730,12 +786,43 @@ public abstract class AbstractAuthConfigurationTest
       HttpResponseStatus expectedStatus
   ) throws Exception
   {
-    return makeSQLQueryRequest(httpClient, query, ImmutableMap.of(), expectedStatus);
+    return makeSQLQueryRequest(httpClient, query, "/druid/v2/sql", ImmutableMap.of(), expectedStatus);
   }
 
   protected StatusResponseHolder makeSQLQueryRequest(
       HttpClient httpClient,
       String query,
+      Map<String, Object> context,
+      HttpResponseStatus expectedStatus
+  ) throws Exception
+  {
+    return makeSQLQueryRequest(httpClient, query, "/druid/v2/sql", context, expectedStatus);
+  }
+
+  protected StatusResponseHolder makeMSQQueryRequest(
+      HttpClient httpClient,
+      String query,
+      Map<String, Object> context,
+      HttpResponseStatus expectedStatus
+  ) throws Exception
+  {
+    return makeSQLQueryRequest(httpClient, query, "/druid/v2/sql/task", context, expectedStatus);
+  }
+
+  protected StatusResponseHolder makeDartQueryRequest(
+      HttpClient httpClient,
+      String query,
+      Map<String, Object> context,
+      HttpResponseStatus expectedStatus
+  ) throws Exception
+  {
+    return makeSQLQueryRequest(httpClient, query, "/druid/v2/sql/dart", context, expectedStatus);
+  }
+
+  protected StatusResponseHolder makeSQLQueryRequest(
+      HttpClient httpClient,
+      String query,
+      String path,
       Map<String, Object> context,
       HttpResponseStatus expectedStatus
   ) throws Exception
@@ -747,7 +834,7 @@ public abstract class AbstractAuthConfigurationTest
     return HttpUtil.makeRequestWithExpectedStatus(
         httpClient,
         HttpMethod.POST,
-        config.getBrokerUrl() + "/druid/v2/sql",
+        config.getBrokerUrl() + path,
         jsonMapper.writeValueAsBytes(queryMap),
         expectedStatus
     );

--- a/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
@@ -563,7 +563,6 @@ public abstract class AbstractAuthConfigurationTest
   public void test_msqQueryWithContext_datasourceAndContextParamsUser_succeed() throws Exception
   {
     final String query = "select count(*) from auth_test";
-    // Testing basic-auth admin, can read all rows
     StatusResponseHolder responseHolder = makeMSQQueryRequest(
         getHttpClient(User.DATASOURCE_AND_CONTEXT_PARAMS_USER),
         query,

--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -651,7 +651,7 @@ public class QueryContext
   }
 
   /**
-   * Returns true if {@link QueryContexts#CTX_FULL_REPORT} is set to true, false if it is set to false or not set at all.
+   * Returns true if {@link QueryContexts#CTX_FULL_REPORT} is set to true, false if it is set to false or not set.
    */
   public boolean getFullReport()
   {

--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -650,6 +650,17 @@ public class QueryContext
     );
   }
 
+  /**
+   * Returns true if {@link QueryContexts#CTX_FULL_REPORT} is set to true, false if it is set to false or not set at all.
+   */
+  public boolean getFullReport()
+  {
+    return getBoolean(
+        QueryContexts.CTX_FULL_REPORT,
+        QueryContexts.DEFAULT_CTX_FULL_REPORT
+    );
+  }
+
 
   public QueryResourceId getQueryResourceId()
   {

--- a/processing/src/main/java/org/apache/druid/query/QueryContexts.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContexts.java
@@ -126,6 +126,10 @@ public class QueryContexts
   public static final String CTX_SQL_QUERY_ID = BaseQuery.SQL_QUERY_ID;
   public static final String CTX_SQL_STRINGIFY_ARRAYS = "sqlStringifyArrays";
 
+  // Dart
+  public static final String CTX_DART_QUERY_ID = "dartQueryId";
+  public static final String CTX_FULL_REPORT = "fullReport";
+
   // SQL statement resource specific keys
   public static final String CTX_EXECUTION_MODE = "executionMode";
 
@@ -164,6 +168,7 @@ public class QueryContexts
   public static final boolean DEFAULT_CATALOG_VALIDATION_ENABLED = true;
   public static final boolean DEFAULT_USE_NESTED_FOR_UNKNOWN_TYPE_IN_SUBQUERY = false;
   public static final boolean DEFAULT_EXTENDED_FILTERED_SUM_REWRITE_ENABLED = true;
+  public static final boolean DEFAULT_CTX_FULL_REPORT = false;
 
 
   @SuppressWarnings("unused") // Used by Jackson serialization

--- a/server/src/main/java/org/apache/druid/server/security/AuthConfig.java
+++ b/server/src/main/java/org/apache/druid/server/security/AuthConfig.java
@@ -57,6 +57,8 @@ public class AuthConfig
   public static final Set<String> ALLOWED_CONTEXT_KEYS = ImmutableSet.of(
       // Set in the Avatica server path
       QueryContexts.CTX_SQL_STRINGIFY_ARRAYS,
+      // Set in DartSqlResource
+      QueryContexts.CTX_DART_QUERY_ID,
       // Set by the Router
       QueryContexts.CTX_SQL_QUERY_ID
   );


### PR DESCRIPTION
Changes:
- add CTX_DART_QUERY_ID to ALLOWED_CONTEXT_KEYS
- expose docker ports for java17
- add dart/msq tests for security tests.
- set `isReindex` default to false.

##### Key changed/added classes in this PR
 * `AbstractAuthConfigurationTest`
 * `AuthConfig`
 * `QueryContexts`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
