### PR TITLE
Fix resultFormat of SegmentLoadStatusFetcher.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/SegmentLoadStatusFetcher.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/SegmentLoadStatusFetcher.java
@@ -237,8 +237,12 @@ public class SegmentLoadStatusFetcher implements AutoCloseable
   {
     ClientSqlQuery clientSqlQuery = new ClientSqlQuery(
         StringUtils.format(LOAD_QUERY, datasource, versionsConditionString),
-        ResultFormat.OBJECTLINES.contentType(),
-        false, false, false, null, null
+        ResultFormat.OBJECTLINES.name(),
+        false,
+        false,
+        false,
+        null,
+        null
     );
     final String response = FutureUtils.get(brokerClient.submitSqlQuery(clientSqlQuery), true);
 


### PR DESCRIPTION
In #17846, SegmentLoadStatusFetcher was changed to send a resultFormat of "text/plain" rather than "objectLines". This effectively broke the feature of waiting for load status, since the load status would always be FAILED.

I am not sure why tests didn't catch this. I noticed it while running a local cluster.