### PR TITLE
Allow task autoscaler to scale to nearest divisor of the partition count

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
@@ -49,6 +49,7 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
   private final boolean enableTaskAutoScaler;
   private final long minTriggerScaleActionFrequencyMillis;
   private final AggregateFunction lagAggregate;
+  private final boolean useNearestFactorScaling;
 
   @JsonCreator
   public LagBasedAutoScalerConfig(
@@ -67,7 +68,8 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
           @Nullable @JsonProperty("scaleOutStep") Integer scaleOutStep,
           @Nullable @JsonProperty("enableTaskAutoScaler") Boolean enableTaskAutoScaler,
           @Nullable @JsonProperty("minTriggerScaleActionFrequencyMillis") Long minTriggerScaleActionFrequencyMillis,
-          @Nullable @JsonProperty("lagAggregate") AggregateFunction lagAggregate
+          @Nullable @JsonProperty("lagAggregate") AggregateFunction lagAggregate,
+          @Nullable @JsonProperty("useNearestFactorScaling") Boolean useNearestFactorScaling
   )
   {
     this.enableTaskAutoScaler = enableTaskAutoScaler != null ? enableTaskAutoScaler : false;
@@ -100,6 +102,7 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
     this.scaleOutStep = scaleOutStep != null ? scaleOutStep : 2;
     this.minTriggerScaleActionFrequencyMillis = minTriggerScaleActionFrequencyMillis
         != null ? minTriggerScaleActionFrequencyMillis : 600000;
+    this.useNearestFactorScaling = useNearestFactorScaling != null ? useNearestFactorScaling : false;
   }
 
   @JsonProperty
@@ -171,6 +174,12 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
   public Integer getTaskCountStart()
   {
     return taskCountStart;
+  }
+
+  @JsonProperty
+  public Boolean getUseNearestFactorScaling()
+  {
+    return useNearestFactorScaling;
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerTest.java
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.seekablestream.supervisor.autoscaler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
+import org.apache.druid.indexing.overlord.supervisor.autoscaler.AggregateFunction;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
+import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+public class LagBasedAutoScalerTest
+{
+  private static final String DATASOURCE = "testDataSource";
+  private static final String STREAM = "testStream";
+
+  private static final int DEFAULT_MIN_TASK_COUNT = 0;
+  private static final int DEFAULT_SCALE_IN = 1;
+  private static final int DEFAULT_SCALE_OUT = 1;
+  private static final long DEFAULT_SCALE_IN_THRESHOLD = 100L;
+  private static final long DEFAULT_SCALE_OUT_THRESHOLD = 1000L;
+  private static final double DEFAULT_SCALE_IN_THRESHOLD_PCT = 0.9;
+  private static final double DEFAULT_SCALE_OUT_THRESHOLD_PCT = 0.2;
+
+  private StubServiceEmitter emitter;
+
+  @Mock
+  private SeekableStreamSupervisor supervisor;
+
+  @Mock
+  private SupervisorSpec spec;
+
+  @Mock
+  private SeekableStreamSupervisorIOConfig ioConfig;
+
+  private LagBasedAutoScalerConfig defaultConfig;
+
+  @Before
+  public void setup()
+  {
+    MockitoAnnotations.openMocks(this);
+    Mockito.when(supervisor.getIoConfig()).thenReturn(ioConfig);
+    Mockito.when(ioConfig.getStream()).thenReturn(STREAM);
+    Mockito.when(spec.isSuspended()).thenReturn(false);
+
+    defaultConfig = createConfig(false, 10);
+    emitter = new StubServiceEmitter();
+  }
+
+  private static LagBasedAutoScalerConfig createConfig(boolean useNearestFactorScaling, int partitionCount)
+  {
+    return createConfig(
+        useNearestFactorScaling,
+        DEFAULT_MIN_TASK_COUNT,
+        partitionCount,
+        DEFAULT_SCALE_IN,
+        DEFAULT_SCALE_OUT,
+        DEFAULT_SCALE_IN_THRESHOLD,
+        DEFAULT_SCALE_OUT_THRESHOLD,
+        DEFAULT_SCALE_IN_THRESHOLD_PCT,
+        DEFAULT_SCALE_OUT_THRESHOLD_PCT
+    );
+  }
+
+  private static LagBasedAutoScalerConfig createConfig(
+      boolean useNearestFactorScaling,
+      int taskCountMin,
+      int taskCountMax,
+      int scaleInStep,
+      int scaleOutStep,
+      long scaleInThreshold,
+      long scaleOutThreshold,
+      double scaleInThresholdPct,
+      double scaleOutThresholdPct
+  )
+  {
+    return new LagBasedAutoScalerConfig(
+        1L,
+        10L,
+        0L,
+        1L,
+        scaleOutThreshold,
+        scaleInThreshold,
+        scaleOutThresholdPct,
+        scaleInThresholdPct,
+        taskCountMax,
+        null,
+        taskCountMin,
+        scaleInStep,
+        scaleOutStep,
+        true,
+        0L,
+        AggregateFunction.SUM,
+        useNearestFactorScaling
+    );
+  }
+
+  private int testStaticAutoScale(
+      List<Long> lagValues,
+      LagBasedAutoScalerConfig config,
+      int currentTaskCount,
+      int partitionCount
+  )
+  {
+    Mockito.when(supervisor.getActiveTaskGroupsCount()).thenReturn(currentTaskCount);
+    Mockito.when(supervisor.getPartitionCount()).thenReturn(partitionCount);
+
+    final LagBasedAutoScaler autoScaler = new LagBasedAutoScaler(supervisor, DATASOURCE, config, spec, emitter);
+
+    return autoScaler.computeDesiredTaskCount(lagValues);
+  }
+
+  @Test
+  public void testScaleOut()
+  {
+    List<Long> lagValues = ImmutableList.of(2000L, 2100L, 1900L, 2200L, 500L);
+    int result = testStaticAutoScale(lagValues, defaultConfig, 2, 10);
+    Assert.assertEquals("Should scale out by 1 task", 3, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testScaleIn()
+  {
+    List<Long> lagValues = ImmutableList.of(500L, 50L, 60L, 70L, 80L, 20L, 10L, 10L, 20L, 20L);
+    int result = testStaticAutoScale(lagValues, defaultConfig, 3, 10);
+    Assert.assertEquals("Should scale in by 1 task", 2, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testScaleOutMax()
+  {
+    List<Long> lagValues = ImmutableList.of(2000L, 2100L, 1900L, 2200L, 2300L);
+    // currentActiveTaskCount == taskCountMax == partitionCount
+    int result = testStaticAutoScale(lagValues, createConfig(false, 10), 10, 10);
+    Assert.assertEquals("Should not scale as already at max", -1, result);
+    emitter.verifyEmitted(
+        SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC,
+        ImmutableMap.of(
+            SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION, "Already at max task count"
+        ),
+        1
+    );
+    emitter.flush();
+
+    // currentActiveTaskCount == taskCountMax < partitionCount
+    LagBasedAutoScalerConfig config = createConfig(
+        false,
+        1,
+        8,
+        DEFAULT_SCALE_IN,
+        DEFAULT_SCALE_OUT,
+        DEFAULT_SCALE_IN_THRESHOLD,
+        DEFAULT_SCALE_OUT_THRESHOLD,
+        DEFAULT_SCALE_IN_THRESHOLD_PCT,
+        DEFAULT_SCALE_OUT_THRESHOLD_PCT
+    );
+    result = testStaticAutoScale(lagValues, config, 8, 10);
+    Assert.assertEquals("Should not scale as already at max", -1, result);
+    emitter.verifyEmitted(
+        SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC,
+        ImmutableMap.of(
+            SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION, "Already at max task count"
+        ),
+        1
+    );
+    emitter.flush();
+
+    // currentActiveTaskCount < taskCountMax < partitionCount
+    result = testStaticAutoScale(lagValues, config, 7, 10);
+    Assert.assertEquals("Should scale to max", 8, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testScaleInMin()
+  {
+    List<Long> lagValues = ImmutableList.of(50L, 60L, 70L, 80L, 90L);
+
+    // min == current task
+    int result = testStaticAutoScale(lagValues, defaultConfig, 0, 10);
+    Assert.assertEquals("Should scale as not at min", -1, result);
+    emitter.verifyEmitted(
+        SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC,
+        ImmutableMap.of(
+            SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION, "Already at min task count"
+        ),
+        1
+    );
+  }
+
+  @Test
+  public void testNoScaleNoOp()
+  {
+    List<Long> lagValues = ImmutableList.of(500L, 600L, 700L, 800L, 900L);
+    int result = testStaticAutoScale(lagValues, defaultConfig, 3, 10);
+    Assert.assertEquals("Should not scale as lag is between thresholds", -1, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testNotEnoughSamples()
+  {
+    List<Long> lagValues = ImmutableList.of(2000L, 500L, 600L, 500L, 600L, 400L, 500L);
+    int result = testStaticAutoScale(lagValues, defaultConfig, 3, 10);
+    Assert.assertEquals("Should not scale as not enough samples above threshold", -1, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testNearestFactorScaleOut()
+  {
+    List<Long> lagValues = ImmutableList.of(2000L, 2100L, 1900L, 2200L, 500L);
+    int result = testStaticAutoScale(lagValues, createConfig(true, 10), 2, 10);
+    Assert.assertEquals("Should scale out to next factor (5)", 5, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testNearestFactorScaleIn()
+  {
+    List<Long> lagValues = ImmutableList.of(500L, 50L, 60L, 70L, 80L, 20L, 10L, 10L, 20L, 20L);
+    int result = testStaticAutoScale(lagValues, createConfig(true, 10), 5, 10);
+    Assert.assertEquals("Scale down -1", 4, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testNearestFactorScaleOutMax()
+  {
+    List<Long> lagValues = ImmutableList.of(2000L, 2100L, 1900L, 2200L, 2300L);
+
+    // currentActiveTaskCount == taskCountMax == partitionCount
+    int result = testStaticAutoScale(lagValues, createConfig(true, 10), 10, 10);
+    Assert.assertEquals("Should not scale as already at max", -1, result);
+    emitter.verifyEmitted(
+        SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC,
+        ImmutableMap.of(
+            SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION, "Already at max task count"
+        ),
+        1
+    );
+    emitter.flush();
+
+    // currentActiveTaskCount == taskCountMax < partitionCount
+    LagBasedAutoScalerConfig config = createConfig(
+        true,
+        1,
+        8,
+        DEFAULT_SCALE_IN,
+        DEFAULT_SCALE_OUT,
+        DEFAULT_SCALE_IN_THRESHOLD,
+        DEFAULT_SCALE_OUT_THRESHOLD,
+        DEFAULT_SCALE_IN_THRESHOLD_PCT,
+        DEFAULT_SCALE_OUT_THRESHOLD_PCT
+    );
+    result = testStaticAutoScale(lagValues, config, 8, 10);
+    Assert.assertEquals("Should not scale as already at max", -1, result);
+    emitter.verifyEmitted(
+        SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC,
+        ImmutableMap.of(
+            SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION, "Already at max task count"
+        ),
+        1
+    );
+    emitter.flush();
+
+    // currentActiveTaskCount < taskCountMax < partitionCount
+    result = testStaticAutoScale(lagValues, config, 6, 10);
+    Assert.assertEquals("Should scale to max", 8, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testNearestFactorScaleInMin()
+  {
+    List<Long> lagValues = ImmutableList.of(50L, 60L, 70L, 80L, 90L);
+    // min == current task
+    int result = testStaticAutoScale(lagValues, createConfig(true, 10), 0, 10);
+    Assert.assertEquals("Should scale as not at min", -1, result);
+    emitter.verifyEmitted(
+        SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC,
+        ImmutableMap.of(
+            SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION, "Already at min task count"
+        ),
+        1
+    );
+  }
+
+  @Test
+  public void testNearestFactorNoScaleNoOp()
+  {
+    List<Long> lagValues = ImmutableList.of(500L, 600L, 700L, 800L, 900L);
+    int result = testStaticAutoScale(lagValues, createConfig(true, 10), 2, 10);
+    Assert.assertEquals("Should not scale as lag is between thresholds", -1, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testNearestFactorWithPrimePartitionCount()
+  {
+    List<Long> lagValues = ImmutableList.of(2000L, 2100L, 1900L, 2200L, 2300L);
+    int result = testStaticAutoScale(lagValues, createConfig(true, 11), 3, 11);
+    Assert.assertEquals("Should scale out to next factor (11)", 11, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testNearestFactorWithCompositePartitionCount()
+  {
+    List<Long> lagValues = ImmutableList.of(2000L, 2100L, 1900L, 2200L, 2300L);
+    int result = testStaticAutoScale(lagValues, createConfig(true, 10), 7, 10);
+    Assert.assertEquals("Should find nearest factor (10)", 10, result);
+    emitter.verifyNotEmitted(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
+  }
+
+  @Test
+  public void testScaleOutDifferentThresholds()
+  {
+    final List<Long> lagValues = ImmutableList.of(1500L, 1600L, 1700L, 1800L, 1900L);
+
+    LagBasedAutoScalerConfig highThresholdConfig = createConfig(
+        false,
+        DEFAULT_MIN_TASK_COUNT,
+        10,
+        DEFAULT_SCALE_IN,
+        DEFAULT_SCALE_OUT,
+        DEFAULT_SCALE_IN_THRESHOLD,
+        2000L,
+        DEFAULT_SCALE_IN_THRESHOLD_PCT,
+        DEFAULT_SCALE_OUT_THRESHOLD_PCT
+    );
+    int result = testStaticAutoScale(lagValues, highThresholdConfig, 3, 10);
+    Assert.assertEquals("Should not scale out with high threshold", -1, result);
+
+    Mockito.reset();
+
+    LagBasedAutoScalerConfig lowThresholdConfig = createConfig(
+        false,
+        DEFAULT_MIN_TASK_COUNT,
+        10,
+        DEFAULT_SCALE_IN,
+        DEFAULT_SCALE_OUT,
+        DEFAULT_SCALE_IN_THRESHOLD,
+        DEFAULT_SCALE_OUT_THRESHOLD,
+        DEFAULT_SCALE_IN_THRESHOLD_PCT,
+        DEFAULT_SCALE_OUT_THRESHOLD_PCT
+    );
+    result = testStaticAutoScale(lagValues, lowThresholdConfig, 3, 10);
+    Assert.assertEquals("Should scale out with low threshold", 4, result);
+  }
+
+  @Test
+  public void testScaleInDifferentThresholds()
+  {
+    final List<Long> lagValues = ImmutableList.of(50L, 60L, 70L, 80L, 90L);
+
+    LagBasedAutoScalerConfig highThresholdConfig = createConfig(
+        false,
+        DEFAULT_MIN_TASK_COUNT,
+        10,
+        DEFAULT_SCALE_IN,
+        DEFAULT_SCALE_OUT,
+        2000L,
+        2500L,
+        DEFAULT_SCALE_IN_THRESHOLD_PCT,
+        DEFAULT_SCALE_OUT_THRESHOLD_PCT
+    );
+    int result = testStaticAutoScale(lagValues, highThresholdConfig, 3, 10);
+    Assert.assertEquals("Should scale in with high threshold", 2, result);
+
+    Mockito.reset();
+
+    LagBasedAutoScalerConfig lowThresholdConfig = createConfig(
+        false,
+        DEFAULT_MIN_TASK_COUNT,
+        10,
+        DEFAULT_SCALE_IN,
+        DEFAULT_SCALE_OUT,
+        20L,
+        DEFAULT_SCALE_OUT_THRESHOLD,
+        DEFAULT_SCALE_IN_THRESHOLD_PCT,
+        DEFAULT_SCALE_OUT_THRESHOLD_PCT
+    );
+    result = testStaticAutoScale(lagValues, lowThresholdConfig, 3, 10);
+    Assert.assertEquals("Should not scale in with low threshold", -1, result);
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerTest.java
@@ -159,7 +159,7 @@ public class LagBasedAutoScalerTest
   {
     List<Long> lagValues = ImmutableList.of(2000L, 2100L, 1900L, 2200L, 2300L);
     // currentActiveTaskCount == taskCountMax == partitionCount
-    int result = testStaticAutoScale(lagValues, createConfig(false, 10), 10, 10);
+    int result = testStaticAutoScale(lagValues, defaultConfig, 10, 10);
     Assert.assertEquals("Should not scale as already at max", -1, result);
     emitter.verifyEmitted(
         SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC,
@@ -360,8 +360,6 @@ public class LagBasedAutoScalerTest
     int result = testStaticAutoScale(lagValues, highThresholdConfig, 3, 10);
     Assert.assertEquals("Should not scale out with high threshold", -1, result);
 
-    Mockito.reset();
-
     LagBasedAutoScalerConfig lowThresholdConfig = createConfig(
         false,
         DEFAULT_MIN_TASK_COUNT,
@@ -395,8 +393,6 @@ public class LagBasedAutoScalerTest
     );
     int result = testStaticAutoScale(lagValues, highThresholdConfig, 3, 10);
     Assert.assertEquals("Should scale in with high threshold", 2, result);
-
-    Mockito.reset();
 
     LagBasedAutoScalerConfig lowThresholdConfig = createConfig(
         false,


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Allows the scaler to scale up to the nearest divisor of the partition count. This helps support even distribution of partitions across tasks, lowering total lag across the supervisor. Computes/caches the factors for the `partitionCount` on supervisor submit, and re-computes them ad-hoc if the topic's partition counts are changed during supervisor execution.

Scale up:
- First, bump by `scaleOutStep`.
- Then, search in partition count factors for the next highest factor ≥ the new `desiredTaskCount`. Set to this value.

Scale down:
- Remains the same. I figured it'd be better to be precise in the scale down (and not cause inadvertent lag by either scaling below the new `desiredTaskCount`, or preventing scale down in the case where no factor exists between `currentTaskCount` and `desiredTaskCount`).

I intend to contribute the proportional scaler spoken about [here](https://github.com/apache/druid/pull/17903) in a separate change.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Allows the scaler to scale up to the nearest divisor of the partition count. This helps support even distribution of partitions across tasks, lowering total lag across the supervisor. I opted to go with static tests in the `LagBasedAutoScalerTest.java` file, since this was more flexible/easier than start/stop + sleeping until the scheduled threads were able to run.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Allows the lag-based auto-scaler to scale up to the nearest divisor of the partition count.

<hr>

##### Key changed/added classes in this PR
* `indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScaler.java`
* `indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java`
* `indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
