### PR TITLE
feat: extensions-contrib/ddsketch allow reading raw b64 encoded string

### DIFF
--- a/extensions-contrib/ddsketch/src/main/java/org/apache/druid/query/aggregation/ddsketch/DDSketchComplexMetricSerde.java
+++ b/extensions-contrib/ddsketch/src/main/java/org/apache/druid/query/aggregation/ddsketch/DDSketchComplexMetricSerde.java
@@ -60,18 +60,23 @@ public class DDSketchComplexMetricSerde extends ComplexMetricSerde
           if (objString.isEmpty()) {
             return null;
           }
-
           try {
-            Double doubleValue = Double.parseDouble(objString);
-            return doubleValue;
+            return DDSketchUtils.deserialize(obj);
           }
-          catch (NumberFormatException e) {
-            throw new IAE("Expected string with a number, received value: " + objString);
+          catch (IAE e) {
+            try {
+              return Double.parseDouble(objString);
+            }
+            catch (NumberFormatException nfe) {
+              throw new IAE("Expected string with a number, received value: " + objString);
+            }
           }
-
         }
-
-        return DDSketchUtils.deserialize(obj);
+        throw new IAE(
+            "Expected a number or an instance of DDSketch(b64), but received [%s] of type [%s]",
+            obj,
+            obj.getClass()
+        );
       }
     };
   }

--- a/extensions-contrib/ddsketch/src/main/java/org/apache/druid/query/aggregation/ddsketch/DDSketchObjectStrategy.java
+++ b/extensions-contrib/ddsketch/src/main/java/org/apache/druid/query/aggregation/ddsketch/DDSketchObjectStrategy.java
@@ -48,9 +48,8 @@ public class DDSketchObjectStrategy implements ObjectStrategy<DDSketch>
     readOnlyBuffer.limit(buffer.position() + numBytes);
     try {
       com.datadoghq.sketch.ddsketch.proto.DDSketch proto = com.datadoghq.sketch.ddsketch.proto.DDSketch.parseFrom(readOnlyBuffer);
-      DDSketch recovered = DDSketchProtoBinding.fromProto(() -> new CollapsingLowestDenseStore(1000), proto);
-      return recovered;
-    } 
+      return DDSketchProtoBinding.fromProto(() -> new CollapsingLowestDenseStore(1000), proto);
+    }
     catch (InvalidProtocolBufferException e) {
       throw new UnsupportedOperationException("Unable to decode from Proto");
     }
@@ -60,6 +59,10 @@ public class DDSketchObjectStrategy implements ObjectStrategy<DDSketch>
   public byte[] toBytes(@Nullable DDSketch val)
   {
     if (val == null) {
+      return EMPTY_BYTES;
+    }
+
+    if (val.isEmpty()) {
       return EMPTY_BYTES;
     }
     return DDSketchProtoBinding.toProto(val).toByteArray();


### PR DESCRIPTION
Fixes Eager Double Parsing/Try to deserialize base64 strings as ddsketch to allow raw ddsketch at ingestion time.

### Description
Fixes Eager Double Parsing/Try to deserialize base64 strings as ddsketch to allow raw ddsketch at ingestion time.

#### Release note
Allow ingesting of base64 serialized ddsketches at ingestion time, store empty sketches as empty_bytes to save space.

<hr>
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
