### PR TITLE
Align decoupled `PlannerResult`'s rowType with prepared `RelDataType`

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/QueryHandler.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/QueryHandler.java
@@ -540,6 +540,8 @@ public abstract class QueryHandler extends SqlStatementHandler.BaseStatementHand
     QueryValidations.validateLogicalQueryForDruid(handlerContext.plannerContext(), parameterized);
     CalcitePlanner planner = handlerContext.planner();
 
+    final RelDataType rowType = prepareResult.getReturnedRowType();
+
     if (plannerContext.getPlannerConfig()
                       .getNativeQuerySqlPlanningMode()
                       .equals(QueryContexts.NATIVE_QUERY_SQL_PLANNING_MODE_DECOUPLED)
@@ -574,7 +576,7 @@ public abstract class QueryHandler extends SqlStatementHandler.BaseStatementHand
         return planExplanation(possiblyLimitedRoot, newRoot, true);
       }
 
-      return new PlannerResult(resultsSupplier, finalBaseQuery.getOutputRowType());
+      return new PlannerResult(resultsSupplier, rowType);
     } else {
       final DruidRel<?> druidRel = (DruidRel<?>) planner.transform(
           CalciteRulesManager.DRUID_CONVENTION_RULES,
@@ -591,9 +593,6 @@ public abstract class QueryHandler extends SqlStatementHandler.BaseStatementHand
       if (explain != null) {
         return planExplanation(possiblyLimitedRoot, druidRel, true);
       } else {
-        // Compute row type.
-        final RelDataType rowType = prepareResult.getReturnedRowType();
-
         // sanity check
         final Set<ResourceAction> readResourceActions =
             plannerContext.getResourceActions()


### PR DESCRIPTION
Please see https://github.com/apache/druid/issues/17994#issuecomment-2873510947 for screenshot & for some additional details.


This PR fixes an issue in the decoupled planner where column names produced by the `PIVOT` clause include a `_null` suffix in some cases — for example, `Women_null` and `Men_null` as we can see in the screenshot from the linked issue. This behavior is particularly visible in SQL direct statements, as the `PlannerResult` is used to construct the response. The SQL row transformer relies on the `PlannerResult`'s output type, so this patch ensures that the output aligns with the planned schema, similar to the default coupled planner.

Added unit tests for a SQL query reproduced from the linked issue, verifying that the resulting column names and types are identical under both the coupled and decoupled planners.

Another alternative I considered was somehow fixing the plan from Calcite itself to avoid producing column names with the `_null` suffix. However, I'm unsure of the broader implications of that change or how trivial it would be to implement.

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
