### PR TITLE
Refactor union datasource

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/DataSourcePlan.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/DataSourcePlan.java
@@ -552,7 +552,7 @@ public class DataSourcePlan
   )
   {
     // This is done to prevent loss of generality since MSQ can plan any type of DataSource.
-    List<DataSource> children = unionDataSource.getDataSources();
+    List<DataSource> children = unionDataSource.getChildren();
 
     final QueryDefinitionBuilder subqueryDefBuilder = QueryDefinition.builder(queryKitSpec.getQueryId());
     final List<DataSource> newChildren = new ArrayList<>();

--- a/processing/src/main/java/org/apache/druid/query/UnionDataSourceQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/UnionDataSourceQueryRunner.java
@@ -19,7 +19,6 @@
 
 package org.apache.druid.query;
 
-import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
@@ -31,6 +30,7 @@ import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.planning.ExecutionVertex;
 
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -38,9 +38,7 @@ public class UnionDataSourceQueryRunner<T> implements QueryRunner<T>
 {
   private final QueryRunner<T> baseRunner;
 
-  public UnionDataSourceQueryRunner(
-      QueryRunner<T> baseRunner
-  )
+  public UnionDataSourceQueryRunner(QueryRunner<T> baseRunner)
   {
     this.baseRunner = baseRunner;
   }
@@ -55,19 +53,18 @@ public class UnionDataSourceQueryRunner<T> implements QueryRunner<T>
 
     if (ev.isProcessable() && ev.isTableBased() && baseDataSource instanceof UnionDataSource) {
       // Union of tables.
-
       final UnionDataSource unionDataSource = (UnionDataSource) baseDataSource;
 
-      if (unionDataSource.getDataSourcesAsTableDataSources().isEmpty()) {
+      if (unionDataSource.getChildren().isEmpty()) {
         // Shouldn't happen, because UnionDataSource doesn't allow empty unions.
         throw new ISE("Unexpectedly received empty union");
-      } else if (unionDataSource.getDataSourcesAsTableDataSources().size() == 1) {
+      } else if (unionDataSource.getChildren().size() == 1) {
         // Single table. Run as a normal query.
         return baseRunner.run(
             queryPlus.withQuery(
                 Queries.withBaseDataSource(
                     query,
-                    Iterables.getOnlyElement(unionDataSource.getDataSourcesAsTableDataSources())
+                    Iterables.getOnlyElement(unionDataSource.getChildren())
                 )
             ),
             responseContext
@@ -78,26 +75,25 @@ public class UnionDataSourceQueryRunner<T> implements QueryRunner<T>
             query.getResultOrdering(),
             Sequences.simple(
                 Lists.transform(
-                    IntStream.range(0, unionDataSource.getDataSourcesAsTableDataSources().size())
-                             .mapToObj(i -> new Pair<>(unionDataSource.getDataSourcesAsTableDataSources().get(i), i + 1))
+                    IntStream.range(0, unionDataSource.getChildren().size())
+                             .mapToObj(i -> new Pair<>(unionDataSource.getChildren().get(i), i + 1))
                              .collect(Collectors.toList()),
-                    (Function<Pair<TableDataSource, Integer>, Sequence<T>>) singleSourceWithIndex ->
-                        baseRunner.run(
+                    singleSourceWithIndex ->
+                        (Sequence<T>) baseRunner.run(
                             queryPlus.withQuery(
                                 ev.buildQueryWithBaseDataSource(singleSourceWithIndex.lhs)
-                                       // assign the subqueryId. this will be used to validate that every query servers
-                                       // have responded per subquery in RetryQueryRunner
-                                       .withSubQueryId(generateSubqueryId(
-                                           query.getSubQueryId(),
-                                           singleSourceWithIndex.lhs.getName(),
-                                           singleSourceWithIndex.rhs
-                                       ))
+                                  // assign the subqueryId. this will be used to validate that every query servers
+                                  // have responded per subquery in RetryQueryRunner
+                                  .withSubQueryId(generateSubqueryId(
+                                      query.getSubQueryId(),
+                                      singleSourceWithIndex.lhs.getTableNames(),
+                                      singleSourceWithIndex.rhs
+                                  ))
                             ),
                             responseContext
                         )
                 )
             )
-
         );
       }
     } else {
@@ -110,14 +106,14 @@ public class UnionDataSourceQueryRunner<T> implements QueryRunner<T>
    * Appends and returns the name and the position of the individual datasource in the union with the parent query id
    * if preseent
    *
-   * @param parentSubqueryId The subquery Id of the parent query which is generating this subquery
-   * @param dataSourceName   Name of the datasource for which the UnionRunner is running
+   * @param parentSubqueryId The subquery id of the parent query which is generating this subquery
+   * @param tableNames       Table names of the child datasource, must contain exactly one table name.
    * @param dataSourceIndex  Position of the datasource for which the UnionRunner is running
-   * @return Subquery Id which needs to be populated
+   * @return Subquery id which needs to be populated
    */
-  private String generateSubqueryId(String parentSubqueryId, String dataSourceName, int dataSourceIndex)
+  private String generateSubqueryId(String parentSubqueryId, Set<String> tableNames, int dataSourceIndex)
   {
-    String dataSourceNameIndex = dataSourceName + "." + dataSourceIndex;
+    String dataSourceNameIndex = Iterables.getOnlyElement(tableNames) + "." + dataSourceIndex;
     if (StringUtils.isEmpty(parentSubqueryId)) {
       return dataSourceNameIndex;
     }

--- a/processing/src/main/java/org/apache/druid/query/planning/ExecutionVertex.java
+++ b/processing/src/main/java/org/apache/druid/query/planning/ExecutionVertex.java
@@ -137,10 +137,7 @@ public class ExecutionVertex
   public boolean isTableBased()
   {
     return baseDataSource instanceof TableDataSource
-        || (baseDataSource instanceof UnionDataSource &&
-            baseDataSource.getChildren()
-                .stream()
-                .allMatch(ds -> ds instanceof TableDataSource));
+           || (baseDataSource instanceof UnionDataSource && ((UnionDataSource) baseDataSource).isTableBased());
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/query/DataSourceTest.java
+++ b/processing/src/test/java/org/apache/druid/query/DataSourceTest.java
@@ -120,7 +120,7 @@ public class DataSourceTest
     Assert.assertTrue(dataSource instanceof UnionDataSource);
     Assert.assertEquals(
         Lists.newArrayList(new TableDataSource("ds1"), new TableDataSource("ds2")),
-        Lists.newArrayList(((UnionDataSource) dataSource).getDataSourcesAsTableDataSources())
+        Lists.newArrayList(dataSource.getChildren())
     );
     Assert.assertEquals(
         ImmutableSet.of("ds1", "ds2"),

--- a/processing/src/test/java/org/apache/druid/query/UnionDataSourceTest.java
+++ b/processing/src/test/java/org/apache/druid/query/UnionDataSourceTest.java
@@ -54,6 +54,16 @@ public class UnionDataSourceTest
       )
   );
 
+  private final UnionDataSource tableAndInlineUniondataSource = new UnionDataSource(
+      ImmutableList.of(
+          new TableDataSource("foo"),
+          InlineDataSource.fromIterable(
+              Collections.emptyList(),
+              RowSignature.empty()
+          )
+      )
+  );
+
   @Test
   public void test_constructor_empty()
   {
@@ -73,6 +83,15 @@ public class UnionDataSourceTest
     Assert.assertTrue(UnionDataSource.isCompatibleDataSource(tableDataSource));
     Assert.assertTrue(UnionDataSource.isCompatibleDataSource(inlineDataSource));
     Assert.assertFalse(UnionDataSource.isCompatibleDataSource(new NoopDataSource()));
+  }
+
+  @Test
+  public void test_isTableBased()
+  {
+    Assert.assertTrue(unionDataSource.isTableBased());
+    Assert.assertTrue(unionDataSourceWithDuplicates.isTableBased());
+
+    Assert.assertFalse(tableAndInlineUniondataSource.isTableBased());
   }
 
   @Test


### PR DESCRIPTION
### Description

Some refactors on `UnionDataSource`:
- replaced `getDataSources()` usage with `getChildren()`
- added `isTableBased()` which determined whether it can be ran by native engine
- replaced `getDataSourcesAsTableDataSources()` usage with a combination of `isTableBased()` and `getChildren()`
 
This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
