### PR TITLE
Move context related things from DartSqlResource to DartSqlEngine

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartSqlResource.java
@@ -31,10 +31,7 @@ import org.apache.druid.msq.dart.Dart;
 import org.apache.druid.msq.dart.controller.ControllerHolder;
 import org.apache.druid.msq.dart.controller.DartControllerRegistry;
 import org.apache.druid.msq.dart.controller.sql.DartSqlClients;
-import org.apache.druid.msq.exec.Controller;
 import org.apache.druid.msq.indexing.error.CancellationReason;
-import org.apache.druid.query.BaseQuery;
-import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.ResponseContextConfig;
@@ -71,7 +68,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -89,8 +85,8 @@ public class DartSqlResource extends SqlResource
   private final SqlLifecycleManager sqlLifecycleManager;
   private final DartSqlClients sqlClients;
   private final AuthorizerMapper authorizerMapper;
-  private final DefaultQueryConfig dartQueryConfig;
 
+  // make dartqueryId a prefix the {{queeryid}}-{{startupTime}}-{{queryIndex}
   @Inject
   public DartSqlResource(
       final ObjectMapper jsonMapper,
@@ -101,8 +97,7 @@ public class DartSqlResource extends SqlResource
       final DartSqlClients sqlClients,
       final ServerConfig serverConfig,
       final ResponseContextConfig responseContextConfig,
-      @Self final DruidNode selfNode,
-      @Dart final DefaultQueryConfig dartQueryConfig
+      @Self final DruidNode selfNode
   )
   {
     super(
@@ -118,7 +113,6 @@ public class DartSqlResource extends SqlResource
     this.sqlLifecycleManager = sqlLifecycleManager;
     this.sqlClients = sqlClients;
     this.authorizerMapper = authorizerMapper;
-    this.dartQueryConfig = dartQueryConfig;
   }
 
   /**
@@ -214,24 +208,6 @@ public class DartSqlResource extends SqlResource
   )
   {
     final Map<String, Object> context = new HashMap<>(sqlQuery.getContext());
-
-    // Default context keys from dartQueryConfig.
-    for (Map.Entry<String, Object> entry : dartQueryConfig.getContext().entrySet()) {
-      context.putIfAbsent(entry.getKey(), entry.getValue());
-    }
-
-    /**
-     * Dart queryId must be globally unique, so we cannot use the user-provided {@link QueryContexts#CTX_SQL_QUERY_ID}
-     * or {@link BaseQuery#QUERY_ID}. Instead we generate a UUID in {@link DartSqlResource#doPost}, overriding whatever
-     * the user may have provided. This becomes the {@link Controller#queryId()}.
-     *
-     * The user-provided {@link QueryContexts#CTX_SQL_QUERY_ID} is still registered with the {@link SqlLifecycleManager}
-     * for purposes of query cancellation.
-     *
-     * The user-provided {@link BaseQuery#QUERY_ID} is ignored.
-     */
-    final String dartQueryId = UUID.randomUUID().toString();
-    context.put(QueryContexts.CTX_DART_QUERY_ID, dartQueryId);
 
     return super.doPost(sqlQuery.withOverridenContext(context), req);
   }

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -206,7 +206,8 @@ public class DartSqlResourceTest extends MSQTestBase
             StringUtils.encodeForFormat(getClass().getSimpleName() + "-controller-exec")
         ),
         new DartQueryKitSpecFactory(new TestTimelineServerView(Collections.emptyList())),
-        new ServerConfig()
+        new ServerConfig(),
+        new DefaultQueryConfig(ImmutableMap.of("foo", "bar"))
     );
 
     final DruidSchemaCatalog rootSchema = QueryFrameworkUtils.createMockRootSchema(
@@ -256,8 +257,7 @@ public class DartSqlResourceTest extends MSQTestBase
         dartSqlClients,
         new ServerConfig() /* currently only used for error transform strategy */,
         ResponseContextConfig.newConfig(false),
-        SELF_NODE,
-        new DefaultQueryConfig(ImmutableMap.of("foo", "bar"))
+        SELF_NODE
     );
 
     // Setup mocks

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/CalciteDartTest.java
@@ -30,8 +30,6 @@ import org.apache.druid.sql.calcite.SqlTestFrameworkConfig;
 import org.apache.druid.sql.calcite.util.CalciteTests;
 import org.junit.jupiter.api.Test;
 
-import java.util.UUID;
-
 @SqlTestFrameworkConfig.ComponentSupplier(DartComponentSupplier.class)
 public class CalciteDartTest extends BaseCalciteQueryTest
 {
@@ -41,7 +39,6 @@ public class CalciteDartTest extends BaseCalciteQueryTest
     return new QueryTestBuilder(new CalciteTestConfig(true))
         .queryContext(
             ImmutableMap.<String, Object>builder()
-                .put(QueryContexts.CTX_DART_QUERY_ID, UUID.randomUUID().toString())
                 .put(QueryContexts.ENABLE_DEBUG, true)
                 .build()
         )

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/DartComponentSupplier.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/DartComponentSupplier.java
@@ -124,7 +124,6 @@ public class DartComponentSupplier extends AbstractMSQComponentSupplierDelegate
 
   static class DartTestOverrideModule implements DruidModule
   {
-
     @Provides
     @LazySingleton
     public DruidMeta createMeta(DartDruidMeta druidMeta)

--- a/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
@@ -83,7 +83,7 @@ public abstract class AbstractStatement implements Closeable
     this.reporter = new SqlExecutionReporter(this, remoteAddress);
     this.queryPlus = queryPlus;
     this.queryContext = new HashMap<>(queryPlus.context());
-
+    sqlToolbox.engine.initContextMap(queryContext);
     // "bySegment" results are never valid to use with SQL because the result format is incompatible
     // so, overwrite any user specified context to avoid exceptions down the line
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/run/SqlEngine.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/run/SqlEngine.java
@@ -109,4 +109,11 @@ public interface SqlEngine
       RelRoot relRoot,
       PlannerContext plannerContext
   ) throws ValidationException;
+
+  /**
+   * Enables the engine to make changes to the Context.
+   */
+  default void initContextMap(Map<String, Object> contextMap)
+  {
+  }
 }


### PR DESCRIPTION
* provides a way for the `SqlEngine` to initialize the context
* moves the initialization of `DART_QUERY_ID` and other `DruidQueryConfig` things to be set by `DartSqlEngine`
* adds support for processing multiple patterns in `quidem.filter` 

This enables all methods of `SqlStatementFactory` to function for `Dart` without the need to set `dartQueryId`

