### PR TITLE
[Docs] add set command examplee to sql api

### DIFF
--- a/docs/api-reference/sql-api.md
+++ b/docs/api-reference/sql-api.md
@@ -154,7 +154,12 @@ If you detect a truncated response, treat it as an error.
 
 #### Sample request
 
-The following example retrieves all rows in the `wikipedia` datasource where the `user` is `BlueMoon2662`. The query is assigned the ID `request01` using the `sqlQueryId` context parameter. The optional properties `header`, `typesHeader`, and `sqlTypesHeader` are set to `true` to include type information to the response.
+This sample request demonstrates the following actions:
+- This example retrieves all rows from the `wikipedia` datasource.
+- It filters the results to include only rows where the `user` column is equal to `BlueMoon2662`.
+- The query is assigned the ID `request01` using the `sqlQueryId` context parameter.
+- The response includes optional properties like the `header`, `typesHeader`, and `sqlTypesHeader` properties, which all are set as `true`.
+
 
 <Tabs>
 
@@ -194,6 +199,22 @@ Content-Length: 192
 
 </TabItem>
 </Tabs>
+
+You can also specify query-level context parameters directly within the SQL query string using the `SET` command, which provides an inline alternative to the top-level `"context"` JSON object while passing data. For more details on `SET` statements, refer to the see [SET statements](../querying/sql.md#set-statements).
+
+Here's a JSON object that's functionally equivalent to the examples above, using `SET` command for `sqlQueryId` directly in the query string instead of using the context parameter:
+
+```shell
+
+{
+  "query": "SET sqlQueryId='request01'; SELECT * FROM wikipedia WHERE user='BlueMoon2662'",
+  "header": true,
+  "typesHeader": true,
+  "sqlTypesHeader": true
+}
+
+```
+
 
 #### Sample response
 


### PR DESCRIPTION
Add the Set Command example to sql api doc page

This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
