### PR TITLE
fix OR filter partial index value matcher on cursor reset

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/ExpressionFilter.java
@@ -154,39 +154,31 @@ public class ExpressionFilter implements Filter
         }
 
         if (eval.type().isArray()) {
+          final Object[] result = eval.asArray();
+          if (result == null) {
+            // if value was null and includeUnknown was true we would have already returned before getting here so
+            // is safe to return false
+            return false;
+          }
           switch (eval.elementType().getType()) {
             case LONG:
-              final Object[] lResult = eval.asArray();
-              if (lResult == null) {
-                return false;
-              }
               if (includeUnknown) {
-                return Arrays.stream(lResult).anyMatch(o -> o == null || Evals.asBoolean((long) o));
+                return Arrays.stream(result).anyMatch(o -> o == null || Evals.asBoolean((long) o));
               }
 
-              return Arrays.stream(lResult).filter(Objects::nonNull).anyMatch(o -> Evals.asBoolean((long) o));
+              return Arrays.stream(result).filter(Objects::nonNull).anyMatch(o -> Evals.asBoolean((long) o));
             case STRING:
-              final Object[] sResult = eval.asArray();
-              if (sResult == null) {
-                return false;
-              }
-
               if (includeUnknown) {
-                return Arrays.stream(sResult).anyMatch(o -> o == null || Evals.asBoolean((String) o));
+                return Arrays.stream(result).anyMatch(o -> o == null || Evals.asBoolean((String) o));
               }
 
-              return Arrays.stream(sResult).anyMatch(o -> Evals.asBoolean((String) o));
+              return Arrays.stream(result).anyMatch(o -> Evals.asBoolean((String) o));
             case DOUBLE:
-              final Object[] dResult = eval.asArray();
-              if (dResult == null) {
-                return false;
-              }
-
               if (includeUnknown) {
-                return Arrays.stream(dResult).anyMatch(o -> o == null || Evals.asBoolean((double) o));
+                return Arrays.stream(result).anyMatch(o -> o == null || Evals.asBoolean((double) o));
               }
 
-              return Arrays.stream(dResult).filter(Objects::nonNull).anyMatch(o -> Evals.asBoolean((double) o));
+              return Arrays.stream(result).filter(Objects::nonNull).anyMatch(o -> Evals.asBoolean((double) o));
           }
         }
         return eval.asBoolean();

--- a/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
@@ -296,21 +296,27 @@ public class OrFilter implements BooleanFilter
 
     if (descending) {
 
-      final IntIterator iter = BitmapOffset.getReverseBitmapOffsetIterator(rowBitmap);
+      final IntIterator initialIterator = BitmapOffset.getReverseBitmapOffsetIterator(rowBitmap);
 
-      if (!iter.hasNext()) {
+      if (!initialIterator.hasNext()) {
         return ValueMatchers.allFalse();
       }
       return new ValueMatcher()
       {
         int iterOffset = Integer.MAX_VALUE;
+        IntIterator iterator = initialIterator;
 
         @Override
         public boolean matches(boolean includeUnknown)
         {
           int currentOffset = offset.getOffset();
-          while (iterOffset > currentOffset && iter.hasNext()) {
-            iterOffset = iter.next();
+          // check if the cursor was reset, and reset iterator if so
+          if (currentOffset > iterOffset) {
+            iterOffset = Integer.MAX_VALUE;
+            iterator = BitmapOffset.getReverseBitmapOffsetIterator(rowBitmap);
+          }
+          while (iterOffset > currentOffset && iterator.hasNext()) {
+            iterOffset = iterator.next();
           }
 
           return iterOffset == currentOffset;
@@ -320,26 +326,32 @@ public class OrFilter implements BooleanFilter
         public void inspectRuntimeShape(RuntimeShapeInspector inspector)
         {
           inspector.visit("offset", offset);
-          inspector.visit("iter", iter);
+          inspector.visit("iter", iterator);
         }
       };
     } else {
-      final PeekableIntIterator peekableIterator = rowBitmap.peekableIterator();
+      final PeekableIntIterator initialIterator = rowBitmap.peekableIterator();
 
-      if (!peekableIterator.hasNext()) {
+      if (!initialIterator.hasNext()) {
         return ValueMatchers.allFalse();
       }
       return new ValueMatcher()
       {
         int iterOffset = -1;
+        PeekableIntIterator iterator = initialIterator;
 
         @Override
         public boolean matches(boolean includeUnknown)
         {
           int currentOffset = offset.getOffset();
-          peekableIterator.advanceIfNeeded(currentOffset);
-          if (peekableIterator.hasNext()) {
-            iterOffset = peekableIterator.peekNext();
+          // check if the cursor was reset, and reset iterator if so
+          if (currentOffset < iterOffset) {
+            iterOffset = -1;
+            iterator = rowBitmap.peekableIterator();
+          }
+          iterator.advanceIfNeeded(currentOffset);
+          if (iterator.hasNext()) {
+            iterOffset = iterator.peekNext();
           }
 
           return iterOffset == currentOffset;
@@ -349,7 +361,7 @@ public class OrFilter implements BooleanFilter
         public void inspectRuntimeShape(RuntimeShapeInspector inspector)
         {
           inspector.visit("offset", offset);
-          inspector.visit("peekableIterator", peekableIterator);
+          inspector.visit("peekableIterator", iterator);
         }
       };
     }
@@ -360,8 +372,8 @@ public class OrFilter implements BooleanFilter
       final ImmutableBitmap bitmap
   )
   {
-    final PeekableIntIterator peekableIntIterator = bitmap.peekableIterator();
-    if (!peekableIntIterator.hasNext()) {
+    final PeekableIntIterator initialIterator = bitmap.peekableIterator();
+    if (!initialIterator.hasNext()) {
       return BooleanVectorValueMatcher.of(vectorOffset, ConstantMatcherType.ALL_FALSE);
     }
 
@@ -369,19 +381,26 @@ public class OrFilter implements BooleanFilter
     {
       final VectorMatch match = VectorMatch.wrap(new int[vectorOffset.getMaxVectorSize()]);
       int iterOffset = -1;
+      PeekableIntIterator iterator = initialIterator;
 
       @Override
       public ReadableVectorMatch match(ReadableVectorMatch mask, boolean includeUnknown)
       {
+        // check if the cursor was reset, and reset iterator if so
+        if (vectorOffset.getStartOffset() < iterOffset) {
+          iterOffset = -1;
+          iterator = bitmap.peekableIterator();
+        }
         final int[] selection = match.getSelection();
+
         if (vectorOffset.isContiguous()) {
           int numRows = 0;
           for (int i = 0; i < mask.getSelectionSize(); i++) {
             final int maskNum = mask.getSelection()[i];
             final int rowNum = vectorOffset.getStartOffset() + maskNum;
-            peekableIntIterator.advanceIfNeeded(rowNum);
-            if (peekableIntIterator.hasNext()) {
-              iterOffset = peekableIntIterator.peekNext();
+            iterator.advanceIfNeeded(rowNum);
+            if (iterator.hasNext()) {
+              iterOffset = iterator.peekNext();
               if (iterOffset == rowNum) {
                 selection[numRows++] = maskNum;
               }
@@ -395,9 +414,9 @@ public class OrFilter implements BooleanFilter
           for (int i = 0; i < mask.getSelectionSize(); i++) {
             final int maskNum = mask.getSelection()[i];
             final int rowNum = currentOffsets[mask.getSelection()[i]];
-            peekableIntIterator.advanceIfNeeded(rowNum);
-            if (peekableIntIterator.hasNext()) {
-              iterOffset = peekableIntIterator.peekNext();
+            iterator.advanceIfNeeded(rowNum);
+            if (iterator.hasNext()) {
+              iterOffset = iterator.peekNext();
               if (iterOffset == rowNum) {
                 selection[numRows++] = maskNum;
               }

--- a/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
@@ -304,7 +304,7 @@ public class OrFilter implements BooleanFilter
       return new ValueMatcher()
       {
         int iterOffset = Integer.MAX_VALUE;
-        int lastOffset = Integer.MAX_VALUE;
+        int previousOffset = Integer.MAX_VALUE;
         IntIterator iterator = initialIterator;
 
         @Override
@@ -312,11 +312,11 @@ public class OrFilter implements BooleanFilter
         {
           int currentOffset = offset.getOffset();
           // check if the cursor was reset, and reset iterator if so
-          if (currentOffset >= lastOffset) {
+          if (currentOffset >= previousOffset) {
             iterOffset = Integer.MAX_VALUE;
             iterator = BitmapOffset.getReverseBitmapOffsetIterator(rowBitmap);
           }
-          lastOffset = currentOffset;
+          previousOffset = currentOffset;
           while (iterOffset > currentOffset && iterator.hasNext()) {
             iterOffset = iterator.next();
           }
@@ -340,7 +340,7 @@ public class OrFilter implements BooleanFilter
       return new ValueMatcher()
       {
         int iterOffset = -1;
-        int lastOffset = -1;
+        int previousOffset = -1;
         PeekableIntIterator iterator = initialIterator;
 
         @Override
@@ -348,11 +348,11 @@ public class OrFilter implements BooleanFilter
         {
           int currentOffset = offset.getOffset();
           // check if the cursor was reset, and reset iterator if so
-          if (currentOffset <= lastOffset) {
+          if (currentOffset <= previousOffset) {
             iterOffset = -1;
             iterator = rowBitmap.peekableIterator();
           }
-          lastOffset = currentOffset;
+          previousOffset = currentOffset;
           iterator.advanceIfNeeded(currentOffset);
           if (iterator.hasNext()) {
             iterOffset = iterator.peekNext();
@@ -385,7 +385,7 @@ public class OrFilter implements BooleanFilter
     {
       final VectorMatch match = VectorMatch.wrap(new int[vectorOffset.getMaxVectorSize()]);
       int iterOffset = -1;
-      int lastStartOffset = -1;
+      int previousStartOffset = -1;
       PeekableIntIterator iterator = initialIterator;
 
       @Override
@@ -396,11 +396,11 @@ public class OrFilter implements BooleanFilter
         if (vectorOffset.isContiguous()) {
           final int startOffset = vectorOffset.getStartOffset();
           // check if the cursor was reset, and reset iterator if so
-          if (startOffset <= lastStartOffset) {
+          if (startOffset <= previousStartOffset) {
             iterOffset = -1;
             iterator = bitmap.peekableIterator();
           }
-          lastStartOffset = startOffset;
+          previousStartOffset = startOffset;
           int numRows = 0;
           for (int i = 0; i < mask.getSelectionSize(); i++) {
             final int maskNum = mask.getSelection()[i];
@@ -417,11 +417,11 @@ public class OrFilter implements BooleanFilter
           return match;
         } else {
           final int[] currentOffsets = vectorOffset.getOffsets();
-          if (getCurrentVectorSize() > 0 && currentOffsets[0] <= lastStartOffset) {
+          if (getCurrentVectorSize() > 0 && currentOffsets[0] <= previousStartOffset) {
             iterOffset = -1;
             iterator = bitmap.peekableIterator();
           }
-          lastStartOffset = currentOffsets[0];
+          previousStartOffset = currentOffsets[0];
           int numRows = 0;
           for (int i = 0; i < mask.getSelectionSize(); i++) {
             final int maskNum = mask.getSelection()[i];

--- a/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
+++ b/processing/src/main/java/org/apache/druid/segment/filter/OrFilter.java
@@ -311,7 +311,7 @@ public class OrFilter implements BooleanFilter
         {
           int currentOffset = offset.getOffset();
           // check if the cursor was reset, and reset iterator if so
-          if (currentOffset > iterOffset) {
+          if (currentOffset >= iterOffset) {
             iterOffset = Integer.MAX_VALUE;
             iterator = BitmapOffset.getReverseBitmapOffsetIterator(rowBitmap);
           }
@@ -345,7 +345,7 @@ public class OrFilter implements BooleanFilter
         {
           int currentOffset = offset.getOffset();
           // check if the cursor was reset, and reset iterator if so
-          if (currentOffset < iterOffset) {
+          if (currentOffset <= iterOffset) {
             iterOffset = -1;
             iterator = rowBitmap.peekableIterator();
           }
@@ -387,7 +387,7 @@ public class OrFilter implements BooleanFilter
       public ReadableVectorMatch match(ReadableVectorMatch mask, boolean includeUnknown)
       {
         // check if the cursor was reset, and reset iterator if so
-        if (vectorOffset.getStartOffset() < iterOffset) {
+        if (vectorOffset.getStartOffset() <= iterOffset) {
           iterOffset = -1;
           iterator = bitmap.peekableIterator();
         }

--- a/processing/src/main/java/org/apache/druid/segment/virtual/RowBasedExpressionColumnValueSelector.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/RowBasedExpressionColumnValueSelector.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.virtual;
 
+import com.google.common.collect.Lists;
 import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import org.apache.druid.math.expr.Expr;
@@ -27,7 +28,6 @@ import org.apache.druid.math.expr.Parser;
 import org.apache.druid.segment.RowIdSupplier;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -67,7 +67,7 @@ public class RowBasedExpressionColumnValueSelector extends BaseExpressionColumnV
   protected ExprEval<?> eval()
   {
     // check to find any arrays for this row
-    List<String> arrayBindings = new ArrayList<>();
+    final List<String> arrayBindings = Lists.newArrayListWithCapacity(unknownColumns.size());
 
     for (String unknownColumn : unknownColumns) {
       if (isBindingArray(unknownColumn)) {
@@ -77,12 +77,12 @@ public class RowBasedExpressionColumnValueSelector extends BaseExpressionColumnV
 
     // if there are arrays, we need to transform the expression to one that applies each value of the array to the
     // base expression, we keep a cache of transformed expressions to minimize extra work
-    if (arrayBindings.size() > 0) {
+    if (!arrayBindings.isEmpty()) {
       final int key = arrayBindings.hashCode();
       if (transformedCache.containsKey(key)) {
         return transformedCache.get(key).eval(bindings);
       }
-      Expr transformed = Parser.applyUnappliedBindings(expression, baseBindingAnalysis, arrayBindings);
+      final Expr transformed = Parser.applyUnappliedBindings(expression, baseBindingAnalysis, arrayBindings);
       transformedCache.put(key, transformed);
       return transformed.eval(bindings);
     }

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -732,6 +732,11 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
     return false;
   }
 
+  protected boolean hasTypeInformation()
+  {
+    return !testName.contains("rowBasedWithoutTypeSignature");
+  }
+
   protected boolean canTestArrayColumns()
   {
     if (testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature")) {

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -808,6 +808,12 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
       while (!cursor.isDone()) {
         IndexedInts row = selector.getRow();
         Preconditions.checkState(row.size() == 1);
+        cursor.advance();
+      }
+      cursor.reset();
+      while (!cursor.isDone()) {
+        IndexedInts row = selector.getRow();
+        Preconditions.checkState(row.size() == 1);
         values.add(selector.lookupName(row.get(0)));
         cursor.advance();
       }
@@ -919,6 +925,12 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
       while (!cursor.isDone()) {
         IndexedInts row = selector.getRow();
         Preconditions.checkState(row.size() == 1);
+        cursor.advance();
+      }
+      cursor.reset();
+      while (!cursor.isDone()) {
+        IndexedInts row = selector.getRow();
+        Preconditions.checkState(row.size() == 1);
         values.add(selector.lookupName(row.get(0)));
         cursor.advance();
       }
@@ -977,6 +989,10 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
       final List<String> values = new ArrayList<>();
 
       while (!cursor.isDone()) {
+        cursor.advance();
+      }
+      cursor.reset();
+      while (!cursor.isDone()) {
         final int[] rowVector = selector.getRowVector();
         for (int i = 0; i < cursor.getCurrentVectorSize(); i++) {
           values.add(selector.lookupName(rowVector[i]));
@@ -1001,6 +1017,10 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
 
       final List<String> values = new ArrayList<>();
 
+      while (!cursor.isDone()) {
+        cursor.advance();
+      }
+      cursor.reset();
       while (!cursor.isDone()) {
         final int[] rowVector = selector.getRowVector();
         for (int i = 0; i < cursor.getCurrentVectorSize(); i++) {

--- a/processing/src/test/java/org/apache/druid/segment/filter/ExpressionFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/ExpressionFilterTest.java
@@ -176,6 +176,23 @@ public class ExpressionFilterTest extends BaseFilterTest
     assertFilterMatchesSkipVectorize(edf("dim4 == ''"), ImmutableList.of("2"));
     // AS per SQL standard null == null returns false.
     assertFilterMatchesSkipVectorize(edf("dim4 == null"), ImmutableList.of());
+    if (hasTypeInformation()) {
+      assertFilterMatchesSkipVectorize(edf("isnull(dim4)"), ImmutableList.of("1", "6", "7", "8"));
+      assertFilterMatchesSkipVectorize(
+          NotDimFilter.of(edf("isnull(dim4)")),
+          ImmutableList.of("0", "2", "3", "4", "5", "9")
+      );
+      assertFilterMatchesSkipVectorize(edf("cast(dim4, 'LONG')"), ImmutableList.of("0", "3", "4", "5", "9"));
+      assertFilterMatchesSkipVectorize(NotDimFilter.of(edf("cast(dim4, 'LONG')")), ImmutableList.of());
+      assertFilterMatchesSkipVectorize(edf("cast(dim4, 'STRING')"), ImmutableList.of());
+      assertFilterMatchesSkipVectorize(
+          NotDimFilter.of(edf("cast(dim4, 'STRING')")),
+          ImmutableList.of("0", "2", "3", "4", "5", "9")
+      );
+      assertFilterMatchesSkipVectorize(edf("cast(dim4, 'DOUBLE')"), ImmutableList.of("0", "3", "4", "5", "9"));
+      assertFilterMatchesSkipVectorize(NotDimFilter.of(edf("cast(dim4, 'DOUBLE')")), ImmutableList.of());
+    }
+
     assertFilterMatchesSkipVectorize(edf("dim4 == '1'"), ImmutableList.of("0"));
     assertFilterMatchesSkipVectorize(edf("dim4 == '3'"), ImmutableList.of("3"));
     assertFilterMatchesSkipVectorize(edf("dim4 == '4'"), ImmutableList.of("4", "5"));

--- a/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.query.filter.AndDimFilter;
+import org.apache.druid.query.filter.FilterTuning;
 import org.apache.druid.query.filter.InDimFilter;
 import org.apache.druid.query.filter.NotDimFilter;
 import org.apache.druid.query.filter.OrDimFilter;
@@ -239,6 +240,31 @@ public class OrFilterTest extends BaseFilterTest
   }
 
   @Test
+  public void testTwoFilterFirstMatchesSomeSecondMatchesNonePartialIndex()
+  {
+    assertFilterMatches(
+        new OrDimFilter(
+            ImmutableList.of(
+                new InDimFilter("dim0", ImmutableSet.of("1", "2", "3"), null),
+                new SelectorDimFilter("dim1", "7", null, new FilterTuning(false, null, null))
+            )
+        ),
+        ImmutableList.of("1", "2", "3")
+    );
+    assertFilterMatches(
+        NotDimFilter.of(
+            new OrDimFilter(
+                ImmutableList.of(
+                    new InDimFilter("dim0", ImmutableSet.of("1", "2", "3"), null),
+                    new SelectorDimFilter("dim1", "7", null, new FilterTuning(false, null, null))
+                )
+            )
+        ),
+        ImmutableList.of("0", "4", "5")
+    );
+  }
+
+  @Test
   public void testTwoFilterFirstMatchesNoneSecondMatchesSome()
   {
     assertFilterMatches(
@@ -249,6 +275,20 @@ public class OrFilterTest extends BaseFilterTest
             )
         ),
         ImmutableList.of("3")
+    );
+  }
+
+  @Test
+  public void testTwoFilterFirstMatchesNoneSecondMatchesSomePartialIndex()
+  {
+    assertFilterMatches(
+        new OrDimFilter(
+            ImmutableList.of(
+                new SelectorDimFilter("dim1", "7", null),
+                new InDimFilter("dim0", ImmutableSet.of("1", "2", "3"), null)
+            )
+        ),
+        ImmutableList.of("1", "2", "3")
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/OrFilterTest.java
@@ -284,7 +284,7 @@ public class OrFilterTest extends BaseFilterTest
     assertFilterMatches(
         new OrDimFilter(
             ImmutableList.of(
-                new SelectorDimFilter("dim1", "7", null),
+                new SelectorDimFilter("dim1", "7", null, new FilterTuning(false, null, null)),
                 new InDimFilter("dim0", ImmutableSet.of("1", "2", "3"), null)
             )
         ),


### PR DESCRIPTION
### Description
Fixes a bug that can happen when a cursor is reset where the offset contains an OR filter bundle that contains 'partial index' value matchers (where the value matcher consists of one or more value matchers that are actually backed by iterators of the index bitmap). These index backed value matchers are stateful and assume that the offset will be advanced in order, and so must be reset if the underlying offset goes 'backwards' (e.g. from cursor reset).

The added tests fail without the changes in this PR, and also modified `BaseFilterTest` to have some cursor resets involved before collecting the values to try to prevent and help catch any other similar lurking issues.

Adding the cursor reset to the filter tests uncovered a flaw in `RowBasedExpressionColumnValueSelector`, where if a column had any numeric values, even if it previously had array values, then it would be no longer eligible to transform the expression into a map expression to handle mvds. Since this selector probably isn't used nearly as much anymore due to improved type information availability, i have just removed the 'ignored' marking functionality, so that we will always examine the input values to determine if they are scalar or not.

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
