### PR TITLE
Fix leak in activeTasks map in TaskQueue

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -853,10 +853,10 @@ public class TaskQueue
         final Collection<Task> removedTasks = mapDifference.entriesOnlyOnLeft().values();
 
         // Remove tasks not present in metadata store if their lastUpdatedTime is before syncStartTime
-        int numTaskRemoved = 0;
+        int numTasksRemoved = 0;
         for (Task task : removedTasks) {
           if (removeTaskInternal(task.getId(), syncStartTime)) {
-            ++numTaskRemoved;
+            ++numTasksRemoved;
           }
         }
 
@@ -867,7 +867,7 @@ public class TaskQueue
 
         log.info(
             "Synced [%d] tasks from storage (%d tasks added, %d tasks removable, %d tasks removed).",
-            newTasks.size(), addedTasks.size(), removedTasks.size(), numTaskRemoved
+            newTasks.size(), addedTasks.size(), removedTasks.size(), numTasksRemoved
         );
         requestManagement();
       } else {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -577,15 +577,15 @@ public class TaskQueue
    * might add it back to the queue, thus causing a duplicate run of the task.
    */
   @GuardedBy("startStopLock")
-  private void removeTaskInternal(final String taskId, final DateTime deleteTime)
+  private boolean removeTaskInternal(final String taskId, final DateTime deleteTime)
   {
     final AtomicReference<Task> removedTask = new AtomicReference<>();
 
     addOrUpdateTaskEntry(
         taskId,
         prevEntry -> {
-          // Remove the task only if it doesn't have a more recent update
-          if (prevEntry != null && prevEntry.lastUpdatedTime.isBefore(deleteTime)) {
+          // Remove the task only if is complete OR it doesn't have a more recent update
+          if (prevEntry != null && (prevEntry.isComplete || prevEntry.lastUpdatedTime.isBefore(deleteTime))) {
             removedTask.set(prevEntry.task);
             // Remove this taskId from activeTasks by mapping it to null
             return null;
@@ -597,7 +597,9 @@ public class TaskQueue
 
     if (removedTask.get() != null) {
       removeTaskLock(removedTask.get());
+      return true;
     }
+    return false;
   }
 
   /**
@@ -851,8 +853,11 @@ public class TaskQueue
         final Collection<Task> removedTasks = mapDifference.entriesOnlyOnLeft().values();
 
         // Remove tasks not present in metadata store if their lastUpdatedTime is before syncStartTime
+        int numRemoved = 0;
         for (Task task : removedTasks) {
-          removeTaskInternal(task.getId(), syncStartTime);
+          if (removeTaskInternal(task.getId(), syncStartTime)) {
+            ++numRemoved;
+          }
         }
 
         // Add new tasks present in metadata store if their lastUpdatedTime is before syncStartTime
@@ -861,8 +866,8 @@ public class TaskQueue
         }
 
         log.info(
-            "Synced [%d] tasks from storage (%d tasks added, %d tasks removed).",
-            newTasks.size(), addedTasks.size(), removedTasks.size()
+            "Synced [%d] tasks from storage (%d tasks added, %d tasks removable, %d removed).",
+            newTasks.size(), addedTasks.size(), removedTasks.size(), numRemoved
         );
         requestManagement();
       } else {
@@ -958,6 +963,7 @@ public class TaskQueue
                                                .collect(Collectors.toSet());
 
     return activeTasks.values().stream()
+                      .filter(entry -> !entry.isComplete)
                       .map(entry -> entry.task)
                       .filter(task -> !runnerKnownTaskIds.contains(task.getId()))
                       .collect(Collectors.toMap(Task::getDataSource, task -> 1L, Long::sum));

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -584,7 +584,7 @@ public class TaskQueue
     addOrUpdateTaskEntry(
         taskId,
         prevEntry -> {
-          // Remove the task only if is complete OR it doesn't have a more recent update
+          // Remove the task only if it is complete OR it doesn't have a more recent update
           if (prevEntry != null && (prevEntry.isComplete || prevEntry.lastUpdatedTime.isBefore(deleteTime))) {
             removedTask.set(prevEntry.task);
             // Remove this taskId from activeTasks by mapping it to null
@@ -853,10 +853,10 @@ public class TaskQueue
         final Collection<Task> removedTasks = mapDifference.entriesOnlyOnLeft().values();
 
         // Remove tasks not present in metadata store if their lastUpdatedTime is before syncStartTime
-        int numRemoved = 0;
+        int numTaskRemoved = 0;
         for (Task task : removedTasks) {
           if (removeTaskInternal(task.getId(), syncStartTime)) {
-            ++numRemoved;
+            ++numTaskRemoved;
           }
         }
 
@@ -866,8 +866,8 @@ public class TaskQueue
         }
 
         log.info(
-            "Synced [%d] tasks from storage (%d tasks added, %d tasks removable, %d removed).",
-            newTasks.size(), addedTasks.size(), removedTasks.size(), numRemoved
+            "Synced [%d] tasks from storage (%d tasks added, %d tasks removable, %d tasks removed).",
+            newTasks.size(), addedTasks.size(), removedTasks.size(), numTaskRemoved
         );
         requestManagement();
       } else {


### PR DESCRIPTION
Currently we check only whether the timestamp on the task comes strictly before the current clock value during a `syncFromStorage()`. This can cause races between `startPendingTasksOnRunner()` and `syncFromStorage()` where the latter spuriously updates the clock values for all tasks in activeTasks, preventing `syncFromStorage()` from making any deletion progress. This can cause waiting tasks to continuously increase without GC.

![Screenshot 2025-05-23 at 1 49 20 PM](https://github.com/user-attachments/assets/9cea8d0b-d3a7-45b4-ad08-71ab779b444e)


<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

- I elected to update `removeTaskInternal` instead of `updateTaskEntry` because of [this](https://github.com/apache/druid/blob/master/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L1085) being opaque to the caller. I think the invariant that if the `updateOperation` is called on an entry ===> its `lastUpdated` field should also be updated makes sense here.
- It's my understanding that the definition of "waiting" is a task which is yet to be placed in the taskRunner queue. Therefore, I've adjusted `getWaitingTaskCount` to filter out the completed tasks. This should ensure that the only unknown tasks to the taskRunner are those which have not been placed in its queue (in line with the definition).
- This change also enhances the log to print how many tasks were actually removed from `activeTasks` for better debugging.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fix task leak in activeTasks map in TaskQueue and fix waiting task metric count

<hr>

##### Key changed/added classes in this PR
 * `indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
