### PR TITLE
Associate NotYetSupported reasons with scopes

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledCalciteDartTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/DecoupledCalciteDartTest.java
@@ -22,16 +22,18 @@ package org.apache.druid.msq.test;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.sql.calcite.DecoupledExtension;
+import org.apache.druid.sql.calcite.NotYetSupported;
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.apache.druid.sql.calcite.QueryTestBuilder;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.UUID;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class DecoupledCalciteDartTest extends CalciteDartTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(NotYetSupported.Scope.DECOUPLED);
+
   @RegisterExtension
   DecoupledExtension decoupledExtension = new DecoupledExtension(this);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteSysQueryTest.java
@@ -23,11 +23,13 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.sql.calcite.NotYetSupported.Modes;
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class CalciteSysQueryTest extends BaseCalciteQueryTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(NotYetSupported.Scope.BINDABLE);
+
   @Test
   public void testTasksSum()
   {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledExtension.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledExtension.java
@@ -31,7 +31,6 @@ import org.apache.druid.sql.calcite.planner.PlannerConfig;
 import org.apache.druid.sql.calcite.util.SqlTestFramework;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.io.File;
 import java.util.List;
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteArraysQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteArraysQueryTest.java
@@ -20,12 +20,14 @@
 package org.apache.druid.sql.calcite;
 
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.druid.sql.calcite.NotYetSupported.Scope;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class DecoupledPlanningCalciteArraysQueryTest extends CalciteArraysQueryTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(Scope.DECOUPLED);
+
   @RegisterExtension
   DecoupledExtension decoupledExtension = new DecoupledExtension(this);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteCorrelatedQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteCorrelatedQueryTest.java
@@ -20,12 +20,13 @@
 package org.apache.druid.sql.calcite;
 
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class DecoupledPlanningCalciteCorrelatedQueryTest extends CalciteCorrelatedQueryTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(NotYetSupported.Scope.DECOUPLED);
+
   @RegisterExtension
   DecoupledExtension decoupledExtension = new DecoupledExtension(this);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteJoinQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteJoinQueryTest.java
@@ -20,7 +20,6 @@
 package org.apache.druid.sql.calcite;
 
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -29,9 +28,11 @@ import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class DecoupledPlanningCalciteJoinQueryTest extends CalciteJoinQueryTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(NotYetSupported.Scope.DECOUPLED);
+
   @RegisterExtension
   DecoupledExtension decoupledExtension = new DecoupledExtension(this);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteNestedDataQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteNestedDataQueryTest.java
@@ -20,12 +20,13 @@
 package org.apache.druid.sql.calcite;
 
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class DecoupledPlanningCalciteNestedDataQueryTest extends CalciteNestedDataQueryTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(NotYetSupported.Scope.DECOUPLED);
+
   @RegisterExtension
   DecoupledExtension decoupledExtension = new DecoupledExtension(this);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteQueryTest.java
@@ -21,12 +21,13 @@ package org.apache.druid.sql.calcite;
 
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class DecoupledPlanningCalciteQueryTest extends CalciteQueryTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(NotYetSupported.Scope.DECOUPLED);
+
   @RegisterExtension
   DecoupledExtension decoupledExtension = new DecoupledExtension(this);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteUnionQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DecoupledPlanningCalciteUnionQueryTest.java
@@ -20,12 +20,13 @@
 package org.apache.druid.sql.calcite;
 
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ExtendWith(NotYetSupportedProcessor.class)
 public class DecoupledPlanningCalciteUnionQueryTest extends CalciteUnionQueryTest
 {
+  @RegisterExtension
+  NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(NotYetSupported.Scope.DECOUPLED);
+
   @RegisterExtension
   DecoupledExtension decoupledExtension = new DecoupledExtension(this);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.server.SpecificSegmentsQuerySegmentWalker;
 import org.apache.druid.sql.calcite.DrillWindowQueryTest.DrillComponentSupplier;
 import org.apache.druid.sql.calcite.NotYetSupported.Modes;
 import org.apache.druid.sql.calcite.NotYetSupported.NotYetSupportedProcessor;
+import org.apache.druid.sql.calcite.NotYetSupported.Scope;
 import org.apache.druid.sql.calcite.QueryTestRunner.QueryResults;
 import org.apache.druid.sql.calcite.planner.PlannerCaptureHook;
 import org.apache.druid.sql.calcite.util.SqlTestFramework.StandardComponentSupplier;
@@ -94,7 +95,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class DrillWindowQueryTest extends BaseCalciteQueryTest
 {
   @RegisterExtension
-  public NotYetSupportedProcessor ignoreProcessor = new NotYetSupportedProcessor();
+  public NotYetSupportedProcessor ignoreProcessor = new NotYetSupportedProcessor(Scope.WINDOWING);
 
   @RegisterExtension
   public DrillTestCaseLoaderRule drillTestCaseRule = new DrillTestCaseLoaderRule();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/DrillWindowQueryTest.java
@@ -95,7 +95,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class DrillWindowQueryTest extends BaseCalciteQueryTest
 {
   @RegisterExtension
-  public NotYetSupportedProcessor ignoreProcessor = new NotYetSupportedProcessor(Scope.WINDOWING);
+  public NotYetSupportedProcessor notYetSupportedProcessor = new NotYetSupportedProcessor(Scope.WINDOWING);
 
   @RegisterExtension
   public DrillTestCaseLoaderRule drillTestCaseRule = new DrillTestCaseLoaderRule();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
@@ -75,16 +75,17 @@ public @interface NotYetSupported
 {
   Modes value();
 
-  enum Scope {
+  enum Scope
+  {
+    WINDOWING,
     DECOUPLED,
-    WINDOWING
+    BINDABLE,
   }
 
   enum Modes
   {
     // @formatter:off
     DISTINCT_AGGREGATE_NOT_SUPPORTED(Scope.WINDOWING, DruidException.class, "DISTINCT is not supported"),
-    EXPRESSION_NOT_GROUPED(Scope.WINDOWING, DruidException.class, "Expression '[a-z]+' is not being grouped"),
     NULLS_FIRST_LAST(Scope.WINDOWING, DruidException.class, "NULLS (FIRST|LAST)"),
     BIGINT_TO_DATE(Scope.WINDOWING, DruidException.class, "BIGINT to type (DATE|TIME)"),
     AGGREGATION_NOT_SUPPORT_TYPE(Scope.WINDOWING, DruidException.class, "Aggregation \\[(MIN|MAX)\\] does not support type \\[STRING\\]"),
@@ -94,6 +95,8 @@ public @interface NotYetSupported
     RESULT_MISMATCH(Scope.WINDOWING, AssertionError.class, "(assertResulEquals|AssertionError: column content mismatch)"),
     LONG_CASTING(Scope.WINDOWING, AssertionError.class, "expected: java.lang.Long"),
     UNSUPPORTED_NULL_ORDERING(Scope.WINDOWING, DruidException.class, "(A|DE)SCENDING ordering with NULLS (LAST|FIRST)"),
+
+    EXPRESSION_NOT_GROUPED(Scope.BINDABLE, DruidException.class, "Expression '[a-z]+' is not being grouped"),
 
     NOT_ENOUGH_RULES(Scope.DECOUPLED, DruidException.class, "There are not enough rules to produce a node"),
     SORT_REMOVE_TROUBLE(Scope.DECOUPLED, DruidException.class, "Calcite assertion violated.*Sort\\.<init>"),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/NotYetSupported.java
@@ -42,7 +42,10 @@ import static org.junit.Assert.assertThrows;
  *
  * In case a testcase marked with this annotation fails - it means that the
  * testcase no longer fails with the annotated expectation. This means that a
- * code change affected this test either
+ * code change affected this test either.
+ *
+ * Each reason must belong to a {@link Scope}; for which the
+ * {@link NotYetSupportedProcessor} be enable to be supressed.
  *
  * <ol>
  * <li>it suddenly passes: yay, assuming it makes sense that it suddenly passes,
@@ -52,15 +55,14 @@ import static org.junit.Assert.assertThrows;
  * expected error.</li>
  * </ol>
  *
- * During usage; the annotation process have to be added to registered with the testclass.
- * Ensure that it's loaded as the most outer-rule by using the right ExtendWith order - or by
- * specifying Order:
- * <code>
- *   @Order(0)
+ * During usage; the annotation process have to be added to registered with the
+ * testclass. Ensure that it's loaded as the most outer-rule by using the right
+ * ExtendWith order - or by specifying Order: <code>
+ *   &#64;Order(0)
  *   @RegisterExtension
- *   public TestRule notYetSupportedRule = new NotYetSupportedProcessor();
+ *   public TestRule notYetSupportedRule = new NotYetSupportedProcessor(Scope.DECOUPLED);
  *
- *   @NotYetSupported(NOT_ENOUGH_RULES)
+ *   &#64;NotYetSupported(NOT_ENOUGH_RULES)
  *   &#64;Test
  *   public void testA() {
  *   }


### PR DESCRIPTION
The `@NotYetSupported` annotations might be confusing as they are not explicitly suggests in what conditions these are not supported.

This PR associates all reasons wiht a `scope` in which a specific `@NotYetSupported` should be considered - the processor is also enhanced to only suppress a single `scope` of them.