### PR TITLE
Fix minor typo in `subtotalsSpec` part of GroupBy docs

### DIFF
--- a/docs/querying/groupbyquery.md
+++ b/docs/querying/groupbyquery.md
@@ -174,13 +174,13 @@ For example, consider a groupBy query like this one:
 ],
 ...
 ...
-"subtotalsSpec":[ ["D1", "D2", D3"], ["D1", "D3"], ["D3"]],
+"subtotalsSpec":[ ["D1", "D2", "D3"], ["D1", "D3"], ["D3"]],
 ..
 
 }
 ```
 
-The result of the subtotalsSpec would be equivalent to concatenating the result of three groupBy queries, with the "dimensions" field being `["D1", "D2", D3"]`, `["D1", "D3"]` and `["D3"]`, given the `DimensionSpec` shown above.
+The result of the subtotalsSpec would be equivalent to concatenating the result of three groupBy queries, with the "dimensions" field being `["D1", "D2", "D3"]`, `["D1", "D3"]` and `["D3"]`, given the `DimensionSpec` shown above.
 The response for the query above would look something like: 
 
 ```json


### PR DESCRIPTION
### Description

There's a minor typo in `subtotalsSpec` part of the GroupBy doc: `["D1", "D2", D3"]`

It can be seen on https://druid.apache.org/docs/latest/querying/groupbyquery/

This PR fixes that by adding the missing quote.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
