### PR TITLE
Use concurrent locks for multiple appends

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -630,9 +630,9 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     final ParallelIndexSupervisorTask task = newTask(interval, Granularities.DAY, true, true);
     final ParallelIndexSupervisorTask task2 = newTask(interval, Granularities.DAY, true, true);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, true);
-    task.addToContext(Tasks.USE_SHARED_LOCK, true);
+    task.addToContext(Tasks.USE_CONCURRENT_LOCKS, true);
     task2.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, true);
-    task2.addToContext(Tasks.USE_SHARED_LOCK, true);
+    task2.addToContext(Tasks.USE_CONCURRENT_LOCKS, true);
     getIndexingServiceClient().runTask(task.getId(), task);
     getIndexingServiceClient().runTask(task2.getId(), task2);
 


### PR DESCRIPTION
The unit test `testMultipleAppend` has been quite flaky recently. It's using the shared lock, and sometimes one lock would fail because segment version has been updated. It gives consistent result with append lock.

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
