### PR TITLE
Fix usage of compaction supervisor when enableInputSourceSecurity is true

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTask.java
@@ -33,13 +33,10 @@ import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +44,14 @@ import java.util.Set;
 public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition, Long, KafkaRecordEntity>
 {
   private static final String TYPE = "index_kafka";
+
+  /**
+   * Resources that a {@link KafkaIndexTask} is authorized to use. Includes
+   * performing a read action on external resource of type
+   */
+  public static final Set<ResourceAction> INPUT_SOURCE_RESOURCES = Set.of(
+      AuthorizationUtils.createExternalResourceReadAction(KafkaIndexTaskModule.SCHEME)
+  );
 
   private final ObjectMapper configMapper;
 
@@ -154,10 +159,7 @@ public class KafkaIndexTask extends SeekableStreamIndexTask<KafkaTopicPartition,
   @Override
   public Set<ResourceAction> getInputSourceResources()
   {
-    return Collections.singleton(new ResourceAction(
-        new Resource(KafkaIndexTaskModule.SCHEME, ResourceType.EXTERNAL),
-        Action.READ
-    ));
+    return INPUT_SOURCE_RESOURCES;
   }
 
   @Override

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaSamplerSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaSamplerSpec.java
@@ -30,14 +30,10 @@ import org.apache.druid.indexing.overlord.sampler.InputSourceSampler;
 import org.apache.druid.indexing.overlord.sampler.SamplerConfig;
 import org.apache.druid.indexing.seekablestream.SeekableStreamSamplerSpec;
 import org.apache.druid.java.util.common.UOE;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -93,9 +89,6 @@ public class KafkaSamplerSpec extends SeekableStreamSamplerSpec
   @Nonnull
   public Set<ResourceAction> getInputSourceResources() throws UOE
   {
-    return Collections.singleton(new ResourceAction(
-        new Resource(KafkaIndexTaskModule.SCHEME, ResourceType.EXTERNAL),
-        Action.READ
-    ));
+    return KafkaIndexTask.INPUT_SOURCE_RESOURCES;
   }
 }

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpec.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.indexing.kafka.KafkaIndexTask;
 import org.apache.druid.indexing.kafka.KafkaIndexTaskClientFactory;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.indexing.overlord.TaskMaster;
@@ -40,14 +41,10 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -109,10 +106,7 @@ public class KafkaSupervisorSpec extends SeekableStreamSupervisorSpec
   @Override
   public Set<ResourceAction> getInputSourceResources()
   {
-    return Collections.singleton(new ResourceAction(
-        new Resource(TASK_TYPE, ResourceType.EXTERNAL),
-        Action.READ
-    ));
+    return KafkaIndexTask.INPUT_SOURCE_RESOURCES;
   }
 
   @Override

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisIndexTask.java
@@ -35,20 +35,21 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTask;
 import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskRunner;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.utils.RuntimeInfo;
 
 import javax.annotation.Nonnull;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, KinesisRecordEntity>
 {
   private static final String TYPE = "index_kinesis";
+
+  public static final Set<ResourceAction> INPUT_SOURCE_RESOURCES = Set.of(
+      AuthorizationUtils.createExternalResourceReadAction(KinesisIndexingServiceModule.SCHEME)
+  );
 
   // GetRecords returns maximum 10MB per call
   // (https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html)
@@ -173,10 +174,7 @@ public class KinesisIndexTask extends SeekableStreamIndexTask<String, String, Ki
   @Override
   public Set<ResourceAction> getInputSourceResources()
   {
-    return Collections.singleton(new ResourceAction(
-        new Resource(KinesisIndexingServiceModule.SCHEME, ResourceType.EXTERNAL),
-        Action.READ
-    ));
+    return INPUT_SOURCE_RESOURCES;
   }
 
   @Override

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpec.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpec.java
@@ -31,14 +31,10 @@ import org.apache.druid.indexing.overlord.sampler.InputSourceSampler;
 import org.apache.druid.indexing.overlord.sampler.SamplerConfig;
 import org.apache.druid.indexing.seekablestream.SeekableStreamSamplerSpec;
 import org.apache.druid.java.util.common.UOE;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.Set;
 
 public class KinesisSamplerSpec extends SeekableStreamSamplerSpec
@@ -94,9 +90,6 @@ public class KinesisSamplerSpec extends SeekableStreamSamplerSpec
   @Override
   public Set<ResourceAction> getInputSourceResources() throws UOE
   {
-    return Collections.singleton(new ResourceAction(
-        new Resource(KinesisIndexingServiceModule.SCHEME, ResourceType.EXTERNAL),
-        Action.READ
-    ));
+    return KinesisIndexTask.INPUT_SOURCE_RESOURCES;
   }
 }

--- a/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorSpec.java
+++ b/extensions-core/kinesis-indexing-service/src/main/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorSpec.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.name.Named;
 import org.apache.druid.common.aws.AWSCredentialsConfig;
 import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.indexing.kinesis.KinesisIndexTask;
 import org.apache.druid.indexing.kinesis.KinesisIndexTaskClientFactory;
 import org.apache.druid.indexing.kinesis.KinesisIndexingServiceModule;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
@@ -39,14 +40,10 @@ import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.metrics.DruidMonitorSchedulerConfig;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -127,10 +124,7 @@ public class KinesisSupervisorSpec extends SeekableStreamSupervisorSpec
   @Override
   public Set<ResourceAction> getInputSourceResources()
   {
-    return Collections.singleton(new ResourceAction(
-        new Resource(SUPERVISOR_TYPE, ResourceType.EXTERNAL),
-        Action.READ
-    ));
+    return KinesisIndexTask.INPUT_SOURCE_RESOURCES;
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/HadoopIndexTask.java
@@ -62,12 +62,9 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.realtime.ChatHandler;
 import org.apache.druid.segment.realtime.ChatHandlerProvider;
-import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.util.ToolRunner;
@@ -87,7 +84,6 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -202,7 +198,7 @@ public class HadoopIndexTask extends HadoopTask implements ChatHandler
   @Override
   public Set<ResourceAction> getInputSourceResources()
   {
-    return Collections.singleton(new ResourceAction(new Resource(INPUT_SOURCE_TYPE, ResourceType.EXTERNAL), Action.READ));
+    return Set.of(AuthorizationUtils.createExternalResourceReadAction(INPUT_SOURCE_TYPE));
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/IndexTask.java
@@ -93,12 +93,9 @@ import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.segment.realtime.appenderator.SegmentsAndCommitMetadata;
 import org.apache.druid.segment.realtime.appenderator.TransactionalSegmentPublisher;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
-import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
@@ -311,7 +308,7 @@ public class IndexTask extends AbstractBatchIndexTask implements ChatHandler, Pe
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                .stream()
-               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+               .map(AuthorizationUtils::createExternalResourceReadAction)
                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -82,9 +82,7 @@ import org.apache.druid.segment.realtime.appenderator.TransactionalSegmentPublis
 import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.BuildingShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
@@ -294,7 +292,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+                               .map(AuthorizationUtils::createExternalResourceReadAction)
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTask.java
@@ -45,10 +45,8 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.partition.HashPartitioner;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -142,7 +140,7 @@ public class PartialDimensionCardinalityTask extends PerfectRollupWorkerTask
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+                               .map(AuthorizationUtils::createExternalResourceReadAction)
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTask.java
@@ -51,10 +51,8 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.joda.time.Interval;
 
 import javax.annotation.Nonnull;
@@ -183,7 +181,7 @@ public class PartialDimensionDistributionTask extends PerfectRollupWorkerTask
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+                               .map(AuthorizationUtils::createExternalResourceReadAction)
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTask.java
@@ -35,10 +35,8 @@ import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.common.task.batch.parallel.iterator.DefaultIndexTaskInputRowIteratorBuilder;
 import org.apache.druid.indexing.common.task.batch.partition.HashPartitionAnalysis;
 import org.apache.druid.indexing.worker.shuffle.ShuffleDataSegmentPusher;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.PartialShardSpec;
 import org.joda.time.Interval;
@@ -138,7 +136,7 @@ public class PartialHashSegmentGenerateTask extends PartialSegmentGenerateTask<G
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+                               .map(AuthorizationUtils::createExternalResourceReadAction)
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTask.java
@@ -37,10 +37,8 @@ import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.indexing.common.task.batch.parallel.iterator.RangePartitionIndexTaskInputRowIteratorBuilder;
 import org.apache.druid.indexing.common.task.batch.partition.RangePartitionAnalysis;
 import org.apache.druid.indexing.worker.shuffle.ShuffleDataSegmentPusher;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
 import org.joda.time.Interval;
@@ -156,7 +154,7 @@ public class PartialRangeSegmentGenerateTask extends PartialSegmentGenerateTask<
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+                               .map(AuthorizationUtils::createExternalResourceReadAction)
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTask.java
@@ -65,12 +65,9 @@ import org.apache.druid.segment.realtime.appenderator.AppenderatorDriverAddResul
 import org.apache.druid.segment.realtime.appenderator.BaseAppenderatorDriver;
 import org.apache.druid.segment.realtime.appenderator.BatchAppenderatorDriver;
 import org.apache.druid.segment.realtime.appenderator.SegmentsAndCommitMetadata;
-import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
-import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.TimelineObjectHolder;
@@ -201,7 +198,7 @@ public class SinglePhaseSubTask extends AbstractBatchSubtask implements ChatHand
     return getIngestionSchema().getIOConfig().getInputSource() != null ?
            getIngestionSchema().getIOConfig().getInputSource().getTypes()
                                .stream()
-                               .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+                               .map(AuthorizationUtils::createExternalResourceReadAction)
                                .collect(Collectors.toSet()) :
            ImmutableSet.of();
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionSupervisorSpec.java
@@ -26,11 +26,14 @@ import org.apache.druid.common.config.Configs;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.server.coordinator.CompactionConfigValidationResult;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
+import org.apache.druid.server.security.ResourceAction;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 public class CompactionSupervisorSpec implements SupervisorSpec
 {
@@ -118,6 +121,13 @@ public class CompactionSupervisorSpec implements SupervisorSpec
   public String getSource()
   {
     return "";
+  }
+
+  @NotNull
+  @Override
+  public Set<ResourceAction> getInputSourceResources() throws UnsupportedOperationException
+  {
+    return Set.of();
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/compact/CompactionSupervisorSpec.java
@@ -27,8 +27,8 @@ import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.server.coordinator.CompactionConfigValidationResult;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.server.security.ResourceAction;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -123,10 +123,12 @@ public class CompactionSupervisorSpec implements SupervisorSpec
     return "";
   }
 
-  @NotNull
+  @Nonnull
   @Override
   public Set<ResourceAction> getInputSourceResources() throws UnsupportedOperationException
   {
+    // No external resource is read. The datasource being written to is authorized
+    // separately in SupervisorResource itself
     return Set.of();
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/IndexTaskSamplerSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/sampler/IndexTaskSamplerSpec.java
@@ -31,10 +31,8 @@ import org.apache.druid.data.input.InputSource;
 import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -103,7 +101,7 @@ public class IndexTaskSamplerSpec implements SamplerSpec
   {
     return inputSource.getTypes()
                       .stream()
-                      .map(i -> new ResourceAction(new Resource(i, ResourceType.EXTERNAL), Action.READ))
+                      .map(AuthorizationUtils::createExternalResourceReadAction)
                       .collect(Collectors.toSet());
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpec.java
@@ -33,10 +33,13 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.explain.ExplainAttributes;
 import org.apache.druid.query.explain.ExplainPlan;
 import org.apache.druid.query.http.ClientSqlQuery;
+import org.apache.druid.server.security.ResourceAction;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class ScheduledBatchSupervisorSpec implements SupervisorSpec
@@ -187,6 +190,15 @@ public class ScheduledBatchSupervisorSpec implements SupervisorSpec
   public String getSource()
   {
     return "";
+  }
+
+  @NotNull
+  @Override
+  public Set<ResourceAction> getInputSourceResources() throws UnsupportedOperationException
+  {
+    // Scheduled supervisor currently launches MSQ tasks for which
+    // the input sources are determined in the SQL layer.
+    return Set.of();
   }
 
   public CronSchedulerConfig getSchedulerConfig()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpec.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpec.java
@@ -34,8 +34,8 @@ import org.apache.druid.query.explain.ExplainAttributes;
 import org.apache.druid.query.explain.ExplainPlan;
 import org.apache.druid.query.http.ClientSqlQuery;
 import org.apache.druid.server.security.ResourceAction;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -192,7 +192,7 @@ public class ScheduledBatchSupervisorSpec implements SupervisorSpec
     return "";
   }
 
-  @NotNull
+  @Nonnull
   @Override
   public Set<ResourceAction> getInputSourceResources() throws UnsupportedOperationException
   {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/CompactionSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/CompactionSupervisorSpecTest.java
@@ -216,6 +216,17 @@ public class CompactionSupervisorSpecTest
     Assert.assertEquals(activeSpec.getDataSources(), suspendedSpec.getDataSources());
   }
 
+  @Test
+  public void test_getInputSourceResources_returnsEmpty()
+  {
+    final CompactionSupervisorSpec supervisorSpec = new CompactionSupervisorSpec(
+        InlineSchemaDataSourceCompactionConfig.builder().forDataSource(TestDataSource.WIKI).build(),
+        true,
+        scheduler
+    );
+    Assert.assertTrue(supervisorSpec.getInputSourceResources().isEmpty());
+  }
+
   private void testSerde(CompactionSupervisorSpec spec)
   {
     try {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpecTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.query.explain.ExplainAttributes;
 import org.apache.druid.query.explain.ExplainPlan;
 import org.apache.druid.query.http.ClientSqlQuery;
 import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -223,6 +224,22 @@ public class ScheduledBatchSupervisorSpecTest
             "SELECT queries are not supported by the [scheduled_batch] supervisor. Only INSERT or REPLACE ingest queries are allowed."
         )
     );
+  }
+
+  @Test
+  public void test_getInputSourceResources_returnsEmpty()
+  {
+    final ScheduledBatchSupervisorSpec supervisorSpec = new ScheduledBatchSupervisorSpec(
+        query,
+        new UnixCronSchedulerConfig("* * * * *"),
+        true,
+        null,
+        null,
+        OBJECT_MAPPER,
+        scheduler,
+        brokerClient
+    );
+    Assert.assertTrue(supervisorSpec.getInputSourceResources().isEmpty());
   }
 
   private void testSerde(final ScheduledBatchSupervisorSpec spec)

--- a/processing/src/test/java/org/apache/druid/error/DruidExceptionMatcher.java
+++ b/processing/src/test/java/org/apache/druid/error/DruidExceptionMatcher.java
@@ -40,12 +40,12 @@ public class DruidExceptionMatcher extends DiagnosingMatcher<Throwable>
     );
   }
 
-  public static DruidExceptionMatcher notFound()
+  public static DruidExceptionMatcher unsupported()
   {
     return new DruidExceptionMatcher(
-        DruidException.Persona.USER,
-        DruidException.Category.NOT_FOUND,
-        "notFound"
+        DruidException.Persona.OPERATOR,
+        DruidException.Category.UNSUPPORTED,
+        "general"
     );
   }
 

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -88,7 +88,7 @@ public interface SupervisorSpec
   {
     throw DruidException.forPersona(DruidException.Persona.OPERATOR)
                         .ofCategory(DruidException.Category.UNSUPPORTED)
-                        .build("Supervisor type[%s], does not support input source based security", getType());
+                        .build("Supervisor type[%s] does not support input source based security", getType());
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
+++ b/server/src/main/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpec.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAutoScaler;
-import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.server.security.ResourceAction;
 
 import javax.annotation.Nonnull;
@@ -88,10 +86,9 @@ public interface SupervisorSpec
   @Nonnull
   default Set<ResourceAction> getInputSourceResources() throws UnsupportedOperationException
   {
-    throw new UOE(StringUtils.format(
-        "SuperviserSpec type [%s], does not support input source based security",
-        getType()
-    ));
+    throw DruidException.forPersona(DruidException.Persona.OPERATOR)
+                        .ofCategory(DruidException.Category.UNSUPPORTED)
+                        .build("Supervisor type[%s], does not support input source based security", getType());
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/security/AuthorizationUtils.java
+++ b/server/src/main/java/org/apache/druid/server/security/AuthorizationUtils.java
@@ -488,6 +488,18 @@ public class AuthorizationUtils
   }
 
   /**
+   * Creates a {@link ResourceAction} to {@link Action#READ read} an
+   * {@link ResourceType#EXTERNAL external} resource.
+   */
+  public static ResourceAction createExternalResourceReadAction(String resourceName)
+  {
+    return new ResourceAction(
+        new Resource(resourceName, ResourceType.EXTERNAL),
+        Action.READ
+    );
+  }
+
+  /**
    * This method constructs a 'superuser' set of permissions composed of {@link Action#READ} and {@link Action#WRITE}
    * permissions for all known {@link ResourceType#knownTypes()} for any {@link Authorizer} implementation which is
    * built on pattern matching with a regex.

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorSpecTest.java
@@ -19,7 +19,9 @@
 
 package org.apache.druid.indexing.overlord.supervisor;
 
-import org.apache.druid.java.util.common.UOE;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.DruidExceptionMatcher;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,7 +52,7 @@ public class SupervisorSpecTest
     @Override
     public String getType()
     {
-      return null;
+      return "abc";
     }
 
     @Override
@@ -63,6 +65,11 @@ public class SupervisorSpecTest
   @Test
   public void test()
   {
-    Assert.assertThrows(UOE.class, () -> SUPERVISOR_SPEC.getInputSourceResources());
+    MatcherAssert.assertThat(
+        Assert.assertThrows(DruidException.class, SUPERVISOR_SPEC::getInputSourceResources),
+        DruidExceptionMatcher.unsupported().expectMessageIs(
+            "Supervisor type[abc] does not support input source based security"
+        )
+    );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidExternTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/DruidExternTableMacro.java
@@ -25,10 +25,8 @@ import org.apache.calcite.sql.SqlCharStringLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.util.NlsString;
 import org.apache.druid.data.input.InputSource;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.sql.calcite.table.DruidTable;
 
 import javax.validation.constraints.NotNull;
@@ -58,7 +56,7 @@ public class DruidExternTableMacro extends DruidUserDefinedTableMacro
     try {
       InputSource inputSource = ((DruidTableMacro) macro).getJsonMapper().readValue(inputSourceStr, InputSource.class);
       return inputSource.getTypes().stream()
-          .map(inputSourceType -> new ResourceAction(new Resource(inputSourceType, ResourceType.EXTERNAL), Action.READ))
+          .map(AuthorizationUtils::createExternalResourceReadAction)
           .collect(Collectors.toSet());
     }
     catch (JsonProcessingException e) {
@@ -71,7 +69,7 @@ public class DruidExternTableMacro extends DruidUserDefinedTableMacro
   private String getInputSourceArgument(final SqlCall call)
   {
     // this covers case where parameters are used positionally
-    if (call.getOperandList().size() > 0) {
+    if (!call.getOperandList().isEmpty()) {
       if (call.getOperandList().get(0) instanceof SqlCharStringLiteral) {
         return ((SqlCharStringLiteral) call.getOperandList().get(0)).toValue();
       }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/external/SchemaAwareUserDefinedTableMacro.java
@@ -37,10 +37,8 @@ import org.apache.calcite.sql.type.SqlOperandMetadata;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.druid.java.util.common.UOE;
-import org.apache.druid.server.security.Action;
-import org.apache.druid.server.security.Resource;
+import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
-import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.sql.calcite.expression.AuthorizableOperator;
 import org.apache.druid.sql.calcite.table.ExternalTable;
 
@@ -169,8 +167,7 @@ public abstract class SchemaAwareUserDefinedTableMacro
       if (table instanceof ExternalTable && inputSourceTypeSecurityEnabled) {
         resourceActions.addAll(((ExternalTable) table)
                                    .getInputSourceTypeSupplier().get().stream()
-                                   .map(inputSourceType ->
-                                 new ResourceAction(new Resource(inputSourceType, ResourceType.EXTERNAL), Action.READ))
+                                   .map(AuthorizationUtils::createExternalResourceReadAction)
                                    .collect(Collectors.toSet()));
       } else {
         resourceActions.addAll(base.computeResources(call, inputSourceTypeSecurityEnabled));


### PR DESCRIPTION
### Description

Currently, if `druid.auth.enableInputSourceSecurity` is true, posting an autocompaction supervisor spec gives the following error:

```json
{"error":"SuperviserSpec type [autocompact], does not support input source based security"}
```

### Changes

- Update `CompactionSupervisorSpec.getInputSourceResources()` to return empty since it doesn't read from any external source (the datasource to which it writes is authorized separately in `SupervisorResource`)
- Update `ScheduledBatchSupervisorSpec.getInputSourceResources()` to return since it launches MSQ tasks whose input sources are authorized in the SQL layer
- Add utility method `AuthorizationUtils.createExternalResourceReadAction`
- Refactor to use the above utility method where applicable

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
