### PR TITLE
Wrap populateResults() method to prevent query from failing

### DIFF
--- a/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java
@@ -144,21 +144,32 @@ public class ResultLevelCachingQueryRunner<T> implements QueryRunner<T>
                     resultLevelCachePopulator,
                     "ResultLevelCachePopulator cannot be null during cache population"
                 );
-                if (thrown != null) {
-                  log.error(
-                      thrown,
-                      "Error while preparing for result level caching for query %s with error %s ",
-                      query.getId(),
-                      thrown.getMessage()
-                  );
-                } else if (resultLevelCachePopulator.isShouldPopulate()) {
-                  // The resultset identifier and its length is cached along with the resultset
-                  resultLevelCachePopulator.populateResults();
-                  log.debug("Cache population complete for query %s", query.getId());
-                } else { // thrown == null && !resultLevelCachePopulator.isShouldPopulate()
-                  log.error("Failed (gracefully) to populate result level cache for query %s", query.getId());
+                try {
+                  if (thrown != null) {
+                    log.error(
+                        thrown,
+                        "Error while preparing for result level caching for query %s with error %s ",
+                        query.getId(),
+                        thrown.getMessage()
+                    );
+                  } else if (resultLevelCachePopulator.isShouldPopulate()) {
+                    // The resultset identifier and its length is cached along with the resultset
+                    resultLevelCachePopulator.populateResults();
+                    log.debug("Cache population complete for query %s", query.getId());
+                  } else { // thrown == null && !resultLevelCachePopulator.isShouldPopulate()
+                    log.error("Failed (gracefully) to prepare result level cache entry for query %s", query.getId());
+                  }
                 }
-                resultLevelCachePopulator.stopPopulating();
+                catch (Exception e) {
+                  log.error(
+                      "Failed to populate result level cache for query %s with error %s",
+                      query.getId(),
+                      e.getMessage()
+                  );
+                }
+                finally {
+                  resultLevelCachePopulator.stopPopulating();
+                }
               }
             }
         );


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes the case where the ObjectStream construction is possible, but cache insertion fails. An example of cache insertion failure might be an LZ4 max compression size breach. In this case LZ4 limits the size of compressable objects to `2_113_929_216` bytes per https://dev.mysql.com/doc/refman/8.4/en/group-replication-message-compression.html. This value is < `Integer.MAX_VALUE`, so default guardrails don't catch this entry. This means that attempts to compress objects whose byte sizes fall in the range:
```
2_113_929_216 < size ≤ Integer.MAX_VALUE
```
result in failure to populate the cache, which then fails the query.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

- Wraps entire after hook in a try/catch to swallow any benign errors. 
- Adds a regression test which catches this scenario


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fixes the case where the ObjectStream construction is possible, but result level cache insertion fails.

<hr>

##### Key changed/added classes in this PR
* `server/src/main/java/org/apache/druid/query/ResultLevelCachingQueryRunner.java`
* `server/src/test/java/org/apache/druid/query/ResultLevelCachingQueryRunnerTest.java`


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
