### PR TITLE
Switch to counter for tracking used task slots on ForkingTaskRunner

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -159,8 +159,8 @@ public class TaskStorageDirTracker
   public synchronized void returnStorageSlot(StorageSlot slot)
   {
     if (slot.getParentRef() == this) {
-      --numUsedSlots;
       slot.runningTaskId = null;
+      --numUsedSlots;
     } else {
       throw new IAE("Cannot return storage slot for task [%s] that I don't own.", slot.runningTaskId);
     }
@@ -195,8 +195,8 @@ public class TaskStorageDirTracker
       if (candidateSlot == null) {
         missingIds.add(taskId);
       } else {
-        candidateSlot.runningTaskId = taskId;
         ++numUsedSlots;
+        candidateSlot.runningTaskId = taskId;
         retVal.put(taskId, candidateSlot);
       }
     }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -20,6 +20,7 @@
 package org.apache.druid.indexing.common;
 
 import com.google.common.collect.ImmutableList;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.FileUtils;
@@ -45,6 +46,8 @@ import java.util.stream.Collectors;
 public class TaskStorageDirTracker
 {
   private static final Logger log = new Logger(TaskStorageDirTracker.class);
+
+  @GuardedBy("this")
   private long numUsedSlots = 0;
 
   public static TaskStorageDirTracker fromConfigs(WorkerConfig workerConfig, TaskConfig taskConfig)

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -148,8 +148,8 @@ public class TaskStorageDirTracker
       final int currIncrement = Math.abs(iterationCounter.getAndIncrement() % slots.length);
       final StorageSlot candidateSlot = slots[currIncrement % slots.length];
       if (candidateSlot.runningTaskId == null) {
-        candidateSlot.runningTaskId = taskId;
         ++numUsedSlots;
+        candidateSlot.runningTaskId = taskId;
         return candidateSlot;
       }
     }
@@ -159,8 +159,8 @@ public class TaskStorageDirTracker
   public synchronized void returnStorageSlot(StorageSlot slot)
   {
     if (slot.getParentRef() == this) {
-      slot.runningTaskId = null;
       --numUsedSlots;
+      slot.runningTaskId = null;
     } else {
       throw new IAE("Cannot return storage slot for task [%s] that I don't own.", slot.runningTaskId);
     }
@@ -268,6 +268,10 @@ public class TaskStorageDirTracker
     }
   }
 
+  /**
+   * Retrieves the number of currently used storage slots.
+   * @return the number of storage slots currently in use.
+   */
   public synchronized long getNumUsedSlots()
   {
     return numUsedSlots;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java
@@ -265,7 +265,8 @@ public class TaskStorageDirTracker
     }
   }
 
-  public synchronized long getNumUsedSlots() {
+  public synchronized long getNumUsedSlots()
+  {
     return numUsedSlots;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -713,13 +713,13 @@ public class ForkingTaskRunner
   @Override
   public Map<String, Long> getTotalTaskSlotCount()
   {
-    return ImmutableMap.of(workerConfig.getCategory(), getWorkerTotalTaskSlotCount());
+    return Map.of(workerConfig.getCategory(), getWorkerTotalTaskSlotCount());
   }
 
   @Override
   public Map<String, Long> getIdleTaskSlotCount()
   {
-    return ImmutableMap.of(
+    return Map.of(
         workerConfig.getCategory(),
         Math.max(getWorkerTotalTaskSlotCount() - getWorkerUsedTaskSlotCount(), 0)
     );

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -713,29 +713,22 @@ public class ForkingTaskRunner
   @Override
   public Map<String, Long> getTotalTaskSlotCount()
   {
-    return ImmutableMap.of(workerConfig.getCategory(), getTotalTaskSlotCountLong());
-  }
-
-  public long getTotalTaskSlotCountLong()
-  {
-    return workerConfig.getCapacity();
+    return ImmutableMap.of(workerConfig.getCategory(), getWorkerTotalTaskSlotCount());
   }
 
   @Override
   public Map<String, Long> getIdleTaskSlotCount()
   {
-    return ImmutableMap.of(workerConfig.getCategory(), Math.max(getTotalTaskSlotCountLong() - getUsedTaskSlotCountLong(), 0));
+    return ImmutableMap.of(
+        workerConfig.getCategory(),
+        Math.max(getWorkerTotalTaskSlotCount() - getWorkerUsedTaskSlotCount(), 0)
+    );
   }
 
   @Override
   public Map<String, Long> getUsedTaskSlotCount()
   {
-    return ImmutableMap.of(workerConfig.getCategory(), getUsedTaskSlotCountLong());
-  }
-
-  public long getUsedTaskSlotCountLong()
-  {
-    return getWorkerUsedTaskSlotCount();
+    return Map.of(workerConfig.getCategory(), getWorkerUsedTaskSlotCount());
   }
 
   @Override
@@ -762,7 +755,7 @@ public class ForkingTaskRunner
   @Override
   public Long getWorkerIdleTaskSlotCount()
   {
-    return Math.max(getTotalTaskSlotCountLong() - getUsedTaskSlotCountLong(), 0);
+    return Math.max(getWorkerTotalTaskSlotCount() - getWorkerUsedTaskSlotCount(), 0);
   }
 
   @Override
@@ -774,7 +767,7 @@ public class ForkingTaskRunner
   @Override
   public Long getWorkerTotalTaskSlotCount()
   {
-    return getTotalTaskSlotCountLong();
+    return (long) workerConfig.getCapacity();
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -735,7 +735,7 @@ public class ForkingTaskRunner
 
   public long getUsedTaskSlotCountLong()
   {
-    return getTracker().getNumUsedSlots();
+    return getWorkerUsedTaskSlotCount();
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -730,12 +730,12 @@ public class ForkingTaskRunner
   @Override
   public Map<String, Long> getUsedTaskSlotCount()
   {
-    return ImmutableMap.of(workerConfig.getCategory(), Long.valueOf(portFinder.findUsedPortCount()));
+    return ImmutableMap.of(workerConfig.getCategory(), getUsedTaskSlotCountLong());
   }
 
   public long getUsedTaskSlotCountLong()
   {
-    return portFinder.findUsedPortCount();
+    return getTracker().getNumUsedSlots();
   }
 
   @Override
@@ -768,7 +768,7 @@ public class ForkingTaskRunner
   @Override
   public Long getWorkerUsedTaskSlotCount()
   {
-    return (long) portFinder.findUsedPortCount();
+    return getTracker().getNumUsedSlots();
   }
 
   @Override


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

`ForkingTaskRunner` incorrectly assumes that the # of ports in use == the # of task slots used. I've updated this to use an protected counter instead.

I've made it so the counter is incremented/decremented right before/after the slot id entry is allocated/cleared for that task, since [this](https://github.com/apache/druid/blob/-/indexing-service/src/main/java/org/apache/druid/indexing/common/TaskStorageDirTracker.java#L146) line will prevent allocation of the slot to another task. This ensures the count always is inline with the # of used tasks (where if it was outside the synchronized section you might get an artificially low # if tasks are submitted concurrently).

One consideration worth mentioning is that this isn't as flexible for allowing new dimensions, etc. to be emitted with the count.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

ForkingTaskRunner incorrectly assumes that the # of ports in use == the # of task slots used. I've updated this to use an atomic counter instead. This is an issue when both plaintext port and TLS port on the peon are enabled causing the task slots used to double count each task.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Switch to counter for tracking used task slots on ForkingTaskRunner

<hr>

##### Key changed/added classes in this PR
* `indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
