### PR TITLE
Fix incorrect FixedBucketsHistogram counts when merging indexes

### DIFF
--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogram.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogram.java
@@ -433,6 +433,22 @@ public class FixedBucketsHistogram
   }
 
   /**
+   * Resets all the counts to 0 and min/max values +/- infinity.
+   */
+  public void reset()
+  {
+    readWriteLock.writeLock().lock();
+    this.upperOutlierCount = 0;
+    this.lowerOutlierCount = 0;
+    this.missingValueCount = 0;
+    this.count = 0;
+    this.max = Double.NEGATIVE_INFINITY;
+    this.min = Double.POSITIVE_INFINITY;
+    Arrays.fill(histogram, 0);
+    readWriteLock.writeLock().unlock();
+  }
+
+  /**
    * Merge another datapoint into this one. The other datapoint could be
    *  - base64 encoded string of {@code FixedBucketsHistogram}
    *  - {@code FixedBucketsHistogram} object

--- a/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
+++ b/extensions-core/histogram/src/main/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregatorFactory.java
@@ -169,8 +169,8 @@ public class FixedBucketsHistogramAggregatorFactory extends AggregatorFactory
       @Override
       public void reset(ColumnValueSelector selector)
       {
-        FixedBucketsHistogram first = (FixedBucketsHistogram) selector.getObject();
-        combined.combineHistogram(first);
+        combined.reset();
+        fold(selector);
       }
 
       @Override

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
@@ -40,6 +40,7 @@ import org.junit.runners.Parameterized;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -111,7 +112,7 @@ public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlin
                        + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t30\n"
                        + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t40\n"
                        + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t50\n";
-    MapBasedRow row = ingestAndQuery(new ByteArrayInputStream(inputRows.getBytes()));
+    MapBasedRow row = ingestAndQuery(new ByteArrayInputStream(inputRows.getBytes(StandardCharsets.UTF_8)));
     FixedBucketsHistogram histogram = (FixedBucketsHistogram) row.getRaw("index_fbh");
     Assert.assertEquals(10, histogram.getCount());
     Assert.assertEquals(10, row.getMetric("index_min").floatValue(), 0.0001);

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
@@ -37,7 +37,9 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -48,7 +50,7 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlingTest
 {
-  private AggregationTestHelper helper;
+  private final AggregationTestHelper helper;
 
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
@@ -82,13 +84,43 @@ public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlin
   @Test
   public void testIngestWithNullsIgnoredAndQuery() throws Exception
   {
-    MapBasedRow row = ingestAndQuery();
+    MapBasedRow row = ingestAndQuery(this.getClass().getClassLoader().getResourceAsStream("sample.data.tsv"));
+    FixedBucketsHistogram histogram = (FixedBucketsHistogram) row.getRaw("index_fbh");
+    Assert.assertEquals(5, histogram.getCount());
     Assert.assertEquals(92.782760, row.getMetric("index_min").floatValue(), 0.0001);
     Assert.assertEquals(135.109191, row.getMetric("index_max").floatValue(), 0.0001);
     Assert.assertEquals(135.9499969482422, row.getMetric("index_quantile").floatValue(), 0.0001);
   }
 
-  private MapBasedRow ingestAndQuery() throws Exception
+  /**
+   * When {@link org.apache.druid.segment.RowCombiningTimeAndDimsIterator#moveToNext} is merging indexes,
+   * if {@link org.apache.druid.segment.MergingRowIterator#hasTimeAndDimsChangedSinceMark} is false, then
+   * {@link org.apache.druid.query.aggregation.AggregateCombiner#reset} gets called. This is the only path
+   * that calls this method.
+   */
+  @Test
+  public void testAggregateCombinerReset() throws Exception
+  {
+    String inputRows = "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t10\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t20\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t30\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t40\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t50\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t10\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t20\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t30\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t40\n"
+                       + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t50\n";
+    MapBasedRow row = ingestAndQuery(new ByteArrayInputStream(inputRows.getBytes()));
+    FixedBucketsHistogram histogram = (FixedBucketsHistogram) row.getRaw("index_fbh");
+    Assert.assertEquals(10, histogram.getCount());
+    Assert.assertEquals(10, row.getMetric("index_min").floatValue(), 0.0001);
+    Assert.assertEquals(50, row.getMetric("index_max").floatValue(), 0.0001);
+    // Current interpolation logic doesn't consider min/max: it assumes the values seen were evenly-distributed between 50 and 51.
+    Assert.assertEquals(50.95, row.getMetric("index_quantile").floatValue(), 0.0001);
+  }
+
+  private MapBasedRow ingestAndQuery(InputStream inputDataStream) throws Exception
   {
     String ingestionAgg = FixedBucketsHistogramAggregator.TYPE_NAME;
 
@@ -132,7 +164,8 @@ public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlin
                    + "   \"numBuckets\": 200,"
                    + "   \"lowerLimit\": 0,"
                    + "   \"upperLimit\": 200,"
-                   + "   \"outlierHandlingMode\": \"overflow\""
+                   + "   \"outlierHandlingMode\": \"overflow\","
+                   + "   \"finalizeAsBase64Binary\": true"
                    + "  }"
                    + "],"
                    + "\"postAggregations\": ["
@@ -144,12 +177,12 @@ public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlin
                    + "}";
 
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
-        this.getClass().getClassLoader().getResourceAsStream("sample.data.tsv"),
+        inputDataStream,
         parseSpec,
         metricSpec,
         0,
         Granularities.NONE,
-        50000,
+        5, // ensure we get more than one index, to test merging
         query
     );
 


### PR DESCRIPTION
When `RowCombiningTimeAndDimsIterator.moveToNext()` is merging indexes, if `MergingRowIterator.hasTimeAndDimsChangedSinceMark()` is `false`, then `AggregateCombiner.reset()` will be called through the call sequence `moveToNext()` -> `combineToCurrentTimeAndDims()` -> `resetCombinedMetrics()`, if `soleCurrentPointSourceOriginalIteratorIndex >= 0`. When exactly is all that the case? I'm not sure. But the net result was occasional over-counting, often wildly so, since `reset()` wasn't resetting anything, just combining whatever it had with the reset value.

Fixes #17822.

### Description

The `AggregateCombiner.reset()` JavaDoc says:
> Resets this AggregateCombiner's state value to the value of the given selector, e. g. after calling this method
> combiner.get*() should return the same value as selector.get*().

And indeed most implementors are doing this, e.g.:
- `DoubleSumAggregateCombiner` -> `sum = selector.getDouble();`
- `TDigestSketchAggregatorFactory` -> `combined = null; fold(selector);`
- `HllSketchAggregatorFactory` -> `union.reset(); fold(selector);`
- `ApproximateHistogramAggregatorFactory` -> `ApproximateHistogram first = (ApproximateHistogram) selector.getObject(); combined.copy(first);`

However, `FixedBucketsHistogramAggregatorFactory` is not meeting this contract: its `reset()` method is identical to its `fold()` method:
```
FixedBucketsHistogram first = (FixedBucketsHistogram) selector.getObject();
combined.combineHistogram(first);
```

That means when `reset()` is called, it's merging the current state into the desired state, leading to overcounts. The code path that calls `reset()` is very infrequently hit: it's only used when merging multiple indexes and even then only when the grouping values across the indexes are equal. The net result is the overcounts rarely show up, but when they do, they can cause results with wildly-high overcounts.

This PR updates the `reset()` implementation to actually meet the contract. It adds a `reset()` method to `FixedBucketsHistogram`, and calls this before calling `fold()`.

Other approaches considered were adding a `copy()` method, and making the `combined` member variable non-final. In the case of `copy()`, it would need to handle the non-count member variables (which aren't currently `final` but could/should be). In the case of a non-final `combined` member variable, I was nervous about changing the lifetime of any of the objects: if `selector.getObject()` is later mutated or there's someone else storing the reference returned by `AggregateCombiner.getObject()`, then changing what objects are referenced could cause issues. That's very unlikely, but `reset()` seemed simple enough and didn't have these concerns. The main downside is if new member variables are added, we need to remember to update `reset()`. Given the rate of change of this class, that's unlikely to happen.

#### Release note
Fixed: FixedBucketsHistogram no longer occasionally introduces large overcounts in rollup results

<hr>

##### Key changed classes in this PR
 * `FixedBucketsHistogram`
 * `FixedBucketsHistogramAggregatorFactory`

<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.