### PR TITLE
Web console: allow freeform tier editing in retention rules

### DIFF
--- a/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
+++ b/web-console/src/components/rule-editor/__snapshots__/rule-editor.spec.tsx.snap
@@ -169,7 +169,7 @@ exports[`RuleEditor matches snapshot no tier in rule 1`] = `
             class="bp5-form-content"
           >
             <div
-              class="bp5-control-group"
+              class="bp5-control-group tiered-replicant"
               role="group"
             >
               <button
@@ -184,46 +184,51 @@ exports[`RuleEditor matches snapshot no tier in rule 1`] = `
                 </span>
               </button>
               <div
-                class="bp5-html-select bp5-fill"
+                class="formatted-input suggestible-input"
               >
-                <select>
-                  <option
-                    value="test1"
-                  >
-                    test1
-                  </option>
-                  <option
-                    value="test2"
-                  >
-                    test2
-                  </option>
-                  <option
-                    value="test3"
-                  >
-                    test3
-                  </option>
-                </select>
-                <span
-                  class="bp5-icon bp5-icon-double-caret-vertical"
+                <div
+                  class="bp5-input-group bp5-fill"
                 >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
+                  <input
+                    aria-disabled="false"
+                    class="bp5-input"
+                    style="padding-right: 0px;"
+                    type="text"
+                    value="test1"
+                  />
+                  <span
+                    class="bp5-input-action"
                   >
-                    <title>
-                      Open dropdown
-                    </title>
-                    <path
-                      d="M100 180H220C231 180 240 189 240 200C240 205.6 237.8 210.6 234.2 214.2L174.2 274.2C170.6 277.8 165.6 280 160 280S149.4 277.8 145.8 274.2L85.8 214.2C82.2 210.6 80 205.6 80 200C80 189 89 180 100 180zM220 140H100C89 140 80 131 80 120C80 114.4 82.2 109.4 85.8 105.8L145.8 45.8C149.4 42.2 154.4 40 160 40S170.6 42.2 174.2 45.8L234.2 105.8C237.8 109.4 240 114.4 240 120C240 131 231 140 220 140z"
-                      fill-rule="evenodd"
-                      style="transform-origin: center;"
-                      transform="scale(0.05, -0.05) translate(-160, -160)"
-                    />
-                  </svg>
-                </span>
+                    <span
+                      class="bp5-popover-target"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="menu"
+                        class="bp5-button bp5-minimal"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="bp5-icon bp5-icon-caret-down"
+                        >
+                          <svg
+                            data-icon="caret-down"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
               </div>
               <button
                 class="bp5-button bp5-minimal"
@@ -738,7 +743,7 @@ exports[`RuleEditor matches snapshot with existing tier and non existing tier in
             class="bp5-form-content"
           >
             <div
-              class="bp5-control-group"
+              class="bp5-control-group tiered-replicant"
               role="group"
             >
               <button
@@ -753,46 +758,51 @@ exports[`RuleEditor matches snapshot with existing tier and non existing tier in
                 </span>
               </button>
               <div
-                class="bp5-html-select bp5-fill"
+                class="formatted-input suggestible-input"
               >
-                <select>
-                  <option
-                    value="test1"
-                  >
-                    test1
-                  </option>
-                  <option
-                    value="test2"
-                  >
-                    test2
-                  </option>
-                  <option
-                    value="test3"
-                  >
-                    test3
-                  </option>
-                </select>
-                <span
-                  class="bp5-icon bp5-icon-double-caret-vertical"
+                <div
+                  class="bp5-input-group bp5-fill"
                 >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
+                  <input
+                    aria-disabled="false"
+                    class="bp5-input"
+                    style="padding-right: 0px;"
+                    type="text"
+                    value="test1"
+                  />
+                  <span
+                    class="bp5-input-action"
                   >
-                    <title>
-                      Open dropdown
-                    </title>
-                    <path
-                      d="M100 180H220C231 180 240 189 240 200C240 205.6 237.8 210.6 234.2 214.2L174.2 274.2C170.6 277.8 165.6 280 160 280S149.4 277.8 145.8 274.2L85.8 214.2C82.2 210.6 80 205.6 80 200C80 189 89 180 100 180zM220 140H100C89 140 80 131 80 120C80 114.4 82.2 109.4 85.8 105.8L145.8 45.8C149.4 42.2 154.4 40 160 40S170.6 42.2 174.2 45.8L234.2 105.8C237.8 109.4 240 114.4 240 120C240 131 231 140 220 140z"
-                      fill-rule="evenodd"
-                      style="transform-origin: center;"
-                      transform="scale(0.05, -0.05) translate(-160, -160)"
-                    />
-                  </svg>
-                </span>
+                    <span
+                      class="bp5-popover-target"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="menu"
+                        class="bp5-button bp5-minimal"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="bp5-icon bp5-icon-caret-down"
+                        >
+                          <svg
+                            data-icon="caret-down"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
               </div>
               <button
                 class="bp5-button bp5-minimal"
@@ -908,7 +918,7 @@ exports[`RuleEditor matches snapshot with existing tier and non existing tier in
               </button>
             </div>
             <div
-              class="bp5-control-group"
+              class="bp5-control-group tiered-replicant"
               role="group"
             >
               <button
@@ -923,46 +933,51 @@ exports[`RuleEditor matches snapshot with existing tier and non existing tier in
                 </span>
               </button>
               <div
-                class="bp5-html-select bp5-fill"
+                class="formatted-input suggestible-input"
               >
-                <select>
-                  <option
-                    value="nonexist"
-                  >
-                    nonexist
-                  </option>
-                  <option
-                    value="test2"
-                  >
-                    test2
-                  </option>
-                  <option
-                    value="test3"
-                  >
-                    test3
-                  </option>
-                </select>
-                <span
-                  class="bp5-icon bp5-icon-double-caret-vertical"
+                <div
+                  class="bp5-input-group bp5-fill"
                 >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
+                  <input
+                    aria-disabled="false"
+                    class="bp5-input"
+                    style="padding-right: 0px;"
+                    type="text"
+                    value="nonexist"
+                  />
+                  <span
+                    class="bp5-input-action"
                   >
-                    <title>
-                      Open dropdown
-                    </title>
-                    <path
-                      d="M100 180H220C231 180 240 189 240 200C240 205.6 237.8 210.6 234.2 214.2L174.2 274.2C170.6 277.8 165.6 280 160 280S149.4 277.8 145.8 274.2L85.8 214.2C82.2 210.6 80 205.6 80 200C80 189 89 180 100 180zM220 140H100C89 140 80 131 80 120C80 114.4 82.2 109.4 85.8 105.8L145.8 45.8C149.4 42.2 154.4 40 160 40S170.6 42.2 174.2 45.8L234.2 105.8C237.8 109.4 240 114.4 240 120C240 131 231 140 220 140z"
-                      fill-rule="evenodd"
-                      style="transform-origin: center;"
-                      transform="scale(0.05, -0.05) translate(-160, -160)"
-                    />
-                  </svg>
-                </span>
+                    <span
+                      class="bp5-popover-target"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="menu"
+                        class="bp5-button bp5-minimal"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="bp5-icon bp5-icon-caret-down"
+                        >
+                          <svg
+                            data-icon="caret-down"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
               </div>
               <button
                 class="bp5-button bp5-minimal"
@@ -1299,7 +1314,7 @@ exports[`RuleEditor matches snapshot with existing tier in rule 1`] = `
             class="bp5-form-content"
           >
             <div
-              class="bp5-control-group"
+              class="bp5-control-group tiered-replicant"
               role="group"
             >
               <button
@@ -1314,46 +1329,51 @@ exports[`RuleEditor matches snapshot with existing tier in rule 1`] = `
                 </span>
               </button>
               <div
-                class="bp5-html-select bp5-fill"
+                class="formatted-input suggestible-input"
               >
-                <select>
-                  <option
-                    value="test1"
-                  >
-                    test1
-                  </option>
-                  <option
-                    value="test2"
-                  >
-                    test2
-                  </option>
-                  <option
-                    value="test3"
-                  >
-                    test3
-                  </option>
-                </select>
-                <span
-                  class="bp5-icon bp5-icon-double-caret-vertical"
+                <div
+                  class="bp5-input-group bp5-fill"
                 >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
+                  <input
+                    aria-disabled="false"
+                    class="bp5-input"
+                    style="padding-right: 0px;"
+                    type="text"
+                    value="test1"
+                  />
+                  <span
+                    class="bp5-input-action"
                   >
-                    <title>
-                      Open dropdown
-                    </title>
-                    <path
-                      d="M100 180H220C231 180 240 189 240 200C240 205.6 237.8 210.6 234.2 214.2L174.2 274.2C170.6 277.8 165.6 280 160 280S149.4 277.8 145.8 274.2L85.8 214.2C82.2 210.6 80 205.6 80 200C80 189 89 180 100 180zM220 140H100C89 140 80 131 80 120C80 114.4 82.2 109.4 85.8 105.8L145.8 45.8C149.4 42.2 154.4 40 160 40S170.6 42.2 174.2 45.8L234.2 105.8C237.8 109.4 240 114.4 240 120C240 131 231 140 220 140z"
-                      fill-rule="evenodd"
-                      style="transform-origin: center;"
-                      transform="scale(0.05, -0.05) translate(-160, -160)"
-                    />
-                  </svg>
-                </span>
+                    <span
+                      class="bp5-popover-target"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="menu"
+                        class="bp5-button bp5-minimal"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="bp5-icon bp5-icon-caret-down"
+                        >
+                          <svg
+                            data-icon="caret-down"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
               </div>
               <button
                 class="bp5-button bp5-minimal"
@@ -1690,7 +1710,7 @@ exports[`RuleEditor matches snapshot with non existing tier in rule 1`] = `
             class="bp5-form-content"
           >
             <div
-              class="bp5-control-group"
+              class="bp5-control-group tiered-replicant"
               role="group"
             >
               <button
@@ -1705,51 +1725,51 @@ exports[`RuleEditor matches snapshot with non existing tier in rule 1`] = `
                 </span>
               </button>
               <div
-                class="bp5-html-select bp5-fill"
+                class="formatted-input suggestible-input"
               >
-                <select>
-                  <option
-                    value="nonexist"
-                  >
-                    nonexist
-                  </option>
-                  <option
-                    value="test1"
-                  >
-                    test1
-                  </option>
-                  <option
-                    value="test2"
-                  >
-                    test2
-                  </option>
-                  <option
-                    value="test3"
-                  >
-                    test3
-                  </option>
-                </select>
-                <span
-                  class="bp5-icon bp5-icon-double-caret-vertical"
+                <div
+                  class="bp5-input-group bp5-fill"
                 >
-                  <svg
-                    data-icon="double-caret-vertical"
-                    height="16"
-                    role="img"
-                    viewBox="0 0 16 16"
-                    width="16"
+                  <input
+                    aria-disabled="false"
+                    class="bp5-input"
+                    style="padding-right: 0px;"
+                    type="text"
+                    value="nonexist"
+                  />
+                  <span
+                    class="bp5-input-action"
                   >
-                    <title>
-                      Open dropdown
-                    </title>
-                    <path
-                      d="M100 180H220C231 180 240 189 240 200C240 205.6 237.8 210.6 234.2 214.2L174.2 274.2C170.6 277.8 165.6 280 160 280S149.4 277.8 145.8 274.2L85.8 214.2C82.2 210.6 80 205.6 80 200C80 189 89 180 100 180zM220 140H100C89 140 80 131 80 120C80 114.4 82.2 109.4 85.8 105.8L145.8 45.8C149.4 42.2 154.4 40 160 40S170.6 42.2 174.2 45.8L234.2 105.8C237.8 109.4 240 114.4 240 120C240 131 231 140 220 140z"
-                      fill-rule="evenodd"
-                      style="transform-origin: center;"
-                      transform="scale(0.05, -0.05) translate(-160, -160)"
-                    />
-                  </svg>
-                </span>
+                    <span
+                      class="bp5-popover-target"
+                    >
+                      <button
+                        aria-expanded="false"
+                        aria-haspopup="menu"
+                        class="bp5-button bp5-minimal"
+                        type="button"
+                      >
+                        <span
+                          aria-hidden="true"
+                          class="bp5-icon bp5-icon-caret-down"
+                        >
+                          <svg
+                            data-icon="caret-down"
+                            height="16"
+                            role="img"
+                            viewBox="0 0 16 16"
+                            width="16"
+                          >
+                            <path
+                              d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                              fill-rule="evenodd"
+                            />
+                          </svg>
+                        </span>
+                      </button>
+                    </span>
+                  </span>
+                </div>
               </div>
               <button
                 class="bp5-button bp5-minimal"

--- a/web-console/src/components/rule-editor/__snapshots__/tiered-replicant.spec.tsx.snap
+++ b/web-console/src/components/rule-editor/__snapshots__/tiered-replicant.spec.tsx.snap
@@ -1,0 +1,879 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TieredReplicant matches snapshot when disabled 1`] = `
+<div
+  class="bp5-control-group tiered-replicant"
+  role="group"
+>
+  <button
+    class="bp5-button bp5-disabled bp5-minimal"
+    disabled=""
+    style="pointer-events: none;"
+    tabindex="-1"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Tier:
+    </span>
+  </button>
+  <div
+    class="formatted-input suggestible-input"
+  >
+    <div
+      class="bp5-input-group bp5-disabled bp5-fill"
+    >
+      <input
+        aria-disabled="true"
+        class="bp5-input"
+        disabled=""
+        style="padding-right: 0px;"
+        type="text"
+        value="test1"
+      />
+      <span
+        class="bp5-input-action"
+      >
+        <span
+          class="bp5-popover-target"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            class="bp5-button bp5-minimal"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="bp5-icon bp5-icon-caret-down"
+            >
+              <svg
+                data-icon="caret-down"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </span>
+    </div>
+  </div>
+  <button
+    class="bp5-button bp5-disabled bp5-minimal"
+    disabled=""
+    style="pointer-events: none;"
+    tabindex="-1"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Replicants:
+    </span>
+  </button>
+  <div
+    class="bp5-control-group bp5-numeric-input"
+    role="group"
+  >
+    <div
+      class="bp5-input-group bp5-disabled"
+    >
+      <input
+        aria-disabled="true"
+        aria-valuemax="256"
+        aria-valuemin="0"
+        aria-valuenow="3"
+        autocomplete="off"
+        class="bp5-input"
+        disabled=""
+        id="numericInput-2"
+        max="256"
+        min="0"
+        role="spinbutton"
+        type="text"
+        value="3"
+      />
+    </div>
+    <div
+      class="bp5-button-group bp5-vertical bp5-fixed"
+    >
+      <button
+        aria-controls="numericInput-2"
+        aria-label="increment"
+        class="bp5-button bp5-disabled"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-up"
+        >
+          <svg
+            data-icon="chevron-up"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M254.2 134.2L174.2 214.2C170.6 217.8 165.6 220 160 220S149.4 217.8 145.8 214.2L65.8 134.2C62.2 130.6 60 125.6 60 120C60 109 69 100 80 100C85.6 100 90.6 102.2 94.2 105.8L160 171.8L225.8 106C229.4 102.2 234.4 100 240 100C251 100 260 109 260 120C260 125.6 257.8 130.6 254.2 134.2z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        aria-controls="numericInput-2"
+        aria-label="decrement"
+        class="bp5-button bp5-disabled"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-down"
+        >
+          <svg
+            data-icon="chevron-down"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M240 220C234.4 220 229.4 217.8 225.8 214.2L160 148.2L94.2 214.2C90.6 217.8 85.6 220 80 220C69 220 60 211 60 200C60 194.4 62.2 189.4 65.8 185.8L145.8 105.8C149.4 102.2 154.4 100 160 100S170.6 102.2 174.2 105.8L254.2 185.8C257.8 189.4 260 194.4 260 200C260 211 251 220 240 220z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <button
+    class="bp5-button"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="bp5-icon bp5-icon-trash"
+    >
+      <svg
+        data-icon="trash"
+        height="16"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`TieredReplicant matches snapshot with existing tier 1`] = `
+<div
+  class="bp5-control-group tiered-replicant"
+  role="group"
+>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Tier:
+    </span>
+  </button>
+  <div
+    class="formatted-input suggestible-input"
+  >
+    <div
+      class="bp5-input-group bp5-fill"
+    >
+      <input
+        aria-disabled="false"
+        class="bp5-input"
+        style="padding-right: 0px;"
+        type="text"
+        value="test1"
+      />
+      <span
+        class="bp5-input-action"
+      >
+        <span
+          class="bp5-popover-target"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            class="bp5-button bp5-minimal"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="bp5-icon bp5-icon-caret-down"
+            >
+              <svg
+                data-icon="caret-down"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </span>
+    </div>
+  </div>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Replicants:
+    </span>
+  </button>
+  <div
+    class="bp5-control-group bp5-numeric-input"
+    role="group"
+  >
+    <div
+      class="bp5-input-group"
+    >
+      <input
+        aria-disabled="false"
+        aria-valuemax="256"
+        aria-valuemin="0"
+        aria-valuenow="2"
+        autocomplete="off"
+        class="bp5-input"
+        id="numericInput-0"
+        max="256"
+        min="0"
+        role="spinbutton"
+        type="text"
+        value="2"
+      />
+    </div>
+    <div
+      class="bp5-button-group bp5-vertical bp5-fixed"
+    >
+      <button
+        aria-controls="numericInput-0"
+        aria-label="increment"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-up"
+        >
+          <svg
+            data-icon="chevron-up"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M254.2 134.2L174.2 214.2C170.6 217.8 165.6 220 160 220S149.4 217.8 145.8 214.2L65.8 134.2C62.2 130.6 60 125.6 60 120C60 109 69 100 80 100C85.6 100 90.6 102.2 94.2 105.8L160 171.8L225.8 106C229.4 102.2 234.4 100 240 100C251 100 260 109 260 120C260 125.6 257.8 130.6 254.2 134.2z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        aria-controls="numericInput-0"
+        aria-label="decrement"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-down"
+        >
+          <svg
+            data-icon="chevron-down"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M240 220C234.4 220 229.4 217.8 225.8 214.2L160 148.2L94.2 214.2C90.6 217.8 85.6 220 80 220C69 220 60 211 60 200C60 194.4 62.2 189.4 65.8 185.8L145.8 105.8C149.4 102.2 154.4 100 160 100S170.6 102.2 174.2 105.8L254.2 185.8C257.8 189.4 260 194.4 260 200C260 211 251 220 240 220z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <button
+    class="bp5-button"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="bp5-icon bp5-icon-trash"
+    >
+      <svg
+        data-icon="trash"
+        height="16"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`TieredReplicant matches snapshot with multiple used tiers 1`] = `
+<div
+  class="bp5-control-group tiered-replicant"
+  role="group"
+>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Tier:
+    </span>
+  </button>
+  <div
+    class="formatted-input suggestible-input"
+  >
+    <div
+      class="bp5-input-group bp5-fill"
+    >
+      <input
+        aria-disabled="false"
+        class="bp5-input"
+        style="padding-right: 0px;"
+        type="text"
+        value="test3"
+      />
+      <span
+        class="bp5-input-action"
+      >
+        <span
+          class="bp5-popover-target"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            class="bp5-button bp5-minimal"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="bp5-icon bp5-icon-caret-down"
+            >
+              <svg
+                data-icon="caret-down"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </span>
+    </div>
+  </div>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Replicants:
+    </span>
+  </button>
+  <div
+    class="bp5-control-group bp5-numeric-input"
+    role="group"
+  >
+    <div
+      class="bp5-input-group"
+    >
+      <input
+        aria-disabled="false"
+        aria-valuemax="256"
+        aria-valuemin="0"
+        aria-valuenow="5"
+        autocomplete="off"
+        class="bp5-input"
+        id="numericInput-4"
+        max="256"
+        min="0"
+        role="spinbutton"
+        type="text"
+        value="5"
+      />
+    </div>
+    <div
+      class="bp5-button-group bp5-vertical bp5-fixed"
+    >
+      <button
+        aria-controls="numericInput-4"
+        aria-label="increment"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-up"
+        >
+          <svg
+            data-icon="chevron-up"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M254.2 134.2L174.2 214.2C170.6 217.8 165.6 220 160 220S149.4 217.8 145.8 214.2L65.8 134.2C62.2 130.6 60 125.6 60 120C60 109 69 100 80 100C85.6 100 90.6 102.2 94.2 105.8L160 171.8L225.8 106C229.4 102.2 234.4 100 240 100C251 100 260 109 260 120C260 125.6 257.8 130.6 254.2 134.2z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        aria-controls="numericInput-4"
+        aria-label="decrement"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-down"
+        >
+          <svg
+            data-icon="chevron-down"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M240 220C234.4 220 229.4 217.8 225.8 214.2L160 148.2L94.2 214.2C90.6 217.8 85.6 220 80 220C69 220 60 211 60 200C60 194.4 62.2 189.4 65.8 185.8L145.8 105.8C149.4 102.2 154.4 100 160 100S170.6 102.2 174.2 105.8L254.2 185.8C257.8 189.4 260 194.4 260 200C260 211 251 220 240 220z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <button
+    class="bp5-button"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="bp5-icon bp5-icon-trash"
+    >
+      <svg
+        data-icon="trash"
+        height="16"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`TieredReplicant matches snapshot with non-existing tier 1`] = `
+<div
+  class="bp5-control-group tiered-replicant"
+  role="group"
+>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Tier:
+    </span>
+  </button>
+  <div
+    class="formatted-input suggestible-input"
+  >
+    <div
+      class="bp5-input-group bp5-fill"
+    >
+      <input
+        aria-disabled="false"
+        class="bp5-input"
+        style="padding-right: 0px;"
+        type="text"
+        value="nonexist"
+      />
+      <span
+        class="bp5-input-action"
+      >
+        <span
+          class="bp5-popover-target"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            class="bp5-button bp5-minimal"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="bp5-icon bp5-icon-caret-down"
+            >
+              <svg
+                data-icon="caret-down"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </span>
+    </div>
+  </div>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Replicants:
+    </span>
+  </button>
+  <div
+    class="bp5-control-group bp5-numeric-input"
+    role="group"
+  >
+    <div
+      class="bp5-input-group"
+    >
+      <input
+        aria-disabled="false"
+        aria-valuemax="256"
+        aria-valuemin="0"
+        aria-valuenow="1"
+        autocomplete="off"
+        class="bp5-input"
+        id="numericInput-1"
+        max="256"
+        min="0"
+        role="spinbutton"
+        type="text"
+        value="1"
+      />
+    </div>
+    <div
+      class="bp5-button-group bp5-vertical bp5-fixed"
+    >
+      <button
+        aria-controls="numericInput-1"
+        aria-label="increment"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-up"
+        >
+          <svg
+            data-icon="chevron-up"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M254.2 134.2L174.2 214.2C170.6 217.8 165.6 220 160 220S149.4 217.8 145.8 214.2L65.8 134.2C62.2 130.6 60 125.6 60 120C60 109 69 100 80 100C85.6 100 90.6 102.2 94.2 105.8L160 171.8L225.8 106C229.4 102.2 234.4 100 240 100C251 100 260 109 260 120C260 125.6 257.8 130.6 254.2 134.2z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        aria-controls="numericInput-1"
+        aria-label="decrement"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-down"
+        >
+          <svg
+            data-icon="chevron-down"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M240 220C234.4 220 229.4 217.8 225.8 214.2L160 148.2L94.2 214.2C90.6 217.8 85.6 220 80 220C69 220 60 211 60 200C60 194.4 62.2 189.4 65.8 185.8L145.8 105.8C149.4 102.2 154.4 100 160 100S170.6 102.2 174.2 105.8L254.2 185.8C257.8 189.4 260 194.4 260 200C260 211 251 220 240 220z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+  <button
+    class="bp5-button"
+    type="button"
+  >
+    <span
+      aria-hidden="true"
+      class="bp5-icon bp5-icon-trash"
+    >
+      <svg
+        data-icon="trash"
+        height="16"
+        role="img"
+        viewBox="0 0 16 16"
+        width="16"
+      >
+        <path
+          d="M14.49 3.99h-13c-.28 0-.5.22-.5.5s.22.5.5.5h.5v10c0 .55.45 1 1 1h10c.55 0 1-.45 1-1v-10h.5c.28 0 .5-.22.5-.5s-.22-.5-.5-.5zm-8.5 9c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm3 0c0 .55-.45 1-1 1s-1-.45-1-1v-6c0-.55.45-1 1-1s1 .45 1 1v6zm2-12h-4c0-.55-.45-1-1-1h-2c-.55 0-1 .45-1 1h-4c-.55 0-1 .45-1 1v1h14v-1c0-.55-.45-1-1-1z"
+          fill-rule="evenodd"
+        />
+      </svg>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`TieredReplicant matches snapshot without remove button 1`] = `
+<div
+  class="bp5-control-group tiered-replicant"
+  role="group"
+>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Tier:
+    </span>
+  </button>
+  <div
+    class="formatted-input suggestible-input"
+  >
+    <div
+      class="bp5-input-group bp5-fill"
+    >
+      <input
+        aria-disabled="false"
+        class="bp5-input"
+        style="padding-right: 0px;"
+        type="text"
+        value="test2"
+      />
+      <span
+        class="bp5-input-action"
+      >
+        <span
+          class="bp5-popover-target"
+        >
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            class="bp5-button bp5-minimal"
+            type="button"
+          >
+            <span
+              aria-hidden="true"
+              class="bp5-icon bp5-icon-caret-down"
+            >
+              <svg
+                data-icon="caret-down"
+                height="16"
+                role="img"
+                viewBox="0 0 16 16"
+                width="16"
+              >
+                <path
+                  d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+          </button>
+        </span>
+      </span>
+    </div>
+  </div>
+  <button
+    class="bp5-button bp5-minimal"
+    style="pointer-events: none;"
+    type="button"
+  >
+    <span
+      class="bp5-button-text"
+    >
+      Replicants:
+    </span>
+  </button>
+  <div
+    class="bp5-control-group bp5-numeric-input"
+    role="group"
+  >
+    <div
+      class="bp5-input-group"
+    >
+      <input
+        aria-disabled="false"
+        aria-valuemax="256"
+        aria-valuemin="0"
+        aria-valuenow="1"
+        autocomplete="off"
+        class="bp5-input"
+        id="numericInput-3"
+        max="256"
+        min="0"
+        role="spinbutton"
+        type="text"
+        value="1"
+      />
+    </div>
+    <div
+      class="bp5-button-group bp5-vertical bp5-fixed"
+    >
+      <button
+        aria-controls="numericInput-3"
+        aria-label="increment"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-up"
+        >
+          <svg
+            data-icon="chevron-up"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M254.2 134.2L174.2 214.2C170.6 217.8 165.6 220 160 220S149.4 217.8 145.8 214.2L65.8 134.2C62.2 130.6 60 125.6 60 120C60 109 69 100 80 100C85.6 100 90.6 102.2 94.2 105.8L160 171.8L225.8 106C229.4 102.2 234.4 100 240 100C251 100 260 109 260 120C260 125.6 257.8 130.6 254.2 134.2z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+      <button
+        aria-controls="numericInput-3"
+        aria-label="decrement"
+        class="bp5-button"
+        type="button"
+      >
+        <span
+          aria-hidden="true"
+          class="bp5-icon bp5-icon-chevron-down"
+        >
+          <svg
+            data-icon="chevron-down"
+            height="16"
+            role="img"
+            viewBox="0 0 16 16"
+            width="16"
+          >
+            <path
+              d="M240 220C234.4 220 229.4 217.8 225.8 214.2L160 148.2L94.2 214.2C90.6 217.8 85.6 220 80 220C69 220 60 211 60 200C60 194.4 62.2 189.4 65.8 185.8L145.8 105.8C149.4 102.2 154.4 100 160 100S170.6 102.2 174.2 105.8L254.2 185.8C257.8 189.4 260 194.4 260 200C260 211 251 220 240 220z"
+              fill-rule="evenodd"
+              style="transform-origin: center;"
+              transform="scale(0.05, -0.05) translate(-160, -160)"
+            />
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -24,7 +24,6 @@ import {
   FormGroup,
   HTMLSelect,
   InputGroup,
-  NumericInput,
   Switch,
 } from '@blueprintjs/core';
 import { IconNames } from '@blueprintjs/icons';
@@ -34,6 +33,8 @@ import type { Rule } from '../../druid-models';
 import { RuleUtil } from '../../druid-models';
 import { durationSanitizer } from '../../utils';
 import { SuggestibleInput } from '../suggestible-input/suggestible-input';
+
+import { TieredReplicant } from './tiered-replicant';
 
 import './rule-editor.scss';
 
@@ -103,45 +104,22 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
 
     return (
       <FormGroup>
-        {tieredReplicantsList.map(([tier, replication]) => (
-          <ControlGroup key={tier}>
-            <Button minimal disabled={disabled} style={{ pointerEvents: 'none' }}>
-              Tier:
-            </Button>
-            <HTMLSelect
-              fill
-              value={tier}
-              disabled={disabled}
-              onChange={(e: any) =>
-                onChange?.(RuleUtil.renameTieredReplicants(rule, tier, e.target.value))
-              }
-            >
-              <option key={tier} value={tier}>
-                {tier}
-              </option>
-              {tiers
-                .filter(t => t !== tier && !tieredReplicants[t])
-                .map(t => (
-                  <option key={t} value={t}>
-                    {t}
-                  </option>
-                ))}
-            </HTMLSelect>
-            <Button minimal disabled={disabled} style={{ pointerEvents: 'none' }}>
-              Replicants:
-            </Button>
-            <NumericInput
-              value={replication}
-              disabled={disabled}
-              onValueChange={(v: number) => {
-                if (isNaN(v)) return;
-                onChange?.(RuleUtil.addTieredReplicant(rule, tier, v));
-              }}
-              min={0}
-              max={256}
-            />
-            {onChange && <Button onClick={() => removeTier(tier)} icon={IconNames.TRASH} />}
-          </ControlGroup>
+        {tieredReplicantsList.map(([tier, replication], i) => (
+          <TieredReplicant
+            key={i}
+            tier={tier}
+            replication={replication}
+            tiers={tiers}
+            usedTiers={Object.keys(tieredReplicants)}
+            disabled={disabled}
+            onChangeTier={newTier =>
+              onChange?.(RuleUtil.renameTieredReplicant(rule, tier, newTier))
+            }
+            onChangeReplication={value =>
+              onChange?.(RuleUtil.addTieredReplicant(rule, tier, value))
+            }
+            onRemove={onChange ? () => removeTier(tier) : undefined}
+          />
         ))}
       </FormGroup>
     );

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -67,7 +67,7 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
 
     let newTierName: string | undefined;
 
-    // Pick an exiting tier that is not assigned
+    // Pick an existing tier that is not assigned
     for (const tier of tiers) {
       if (rule.tieredReplicants[tier] === undefined) {
         newTierName = tier;

--- a/web-console/src/components/rule-editor/rule-editor.tsx
+++ b/web-console/src/components/rule-editor/rule-editor.tsx
@@ -62,10 +62,22 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
   }
 
   function addTier() {
-    let newTierName = tiers[0];
+    if (!rule.tieredReplicants) return;
 
-    if (rule.tieredReplicants) {
-      for (const tier of tiers) {
+    let newTierName: string | undefined;
+
+    // Pick an exiting tier that is not assigned
+    for (const tier of tiers) {
+      if (rule.tieredReplicants[tier] === undefined) {
+        newTierName = tier;
+        break;
+      }
+    }
+
+    // If no such tier exists, pick a new tier name
+    if (!newTierName) {
+      for (let i = 1; i < 100; i++) {
+        const tier = `tier${i}`;
         if (rule.tieredReplicants[tier] === undefined) {
           newTierName = tier;
           break;
@@ -73,7 +85,9 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
       }
     }
 
-    onChange?.(RuleUtil.addTieredReplicant(rule, newTierName, 1));
+    if (newTierName) {
+      onChange?.(RuleUtil.addTieredReplicant(rule, newTierName, 1));
+    }
   }
 
   function renderTiers() {
@@ -135,17 +149,10 @@ export const RuleEditor = React.memo(function RuleEditor(props: RuleEditorProps)
 
   function renderTierAdder() {
     if (!onChange) return;
-    const disabled = Object.keys(rule.tieredReplicants || {}).length >= Object.keys(tiers).length;
 
     return (
       <FormGroup>
-        <Button
-          onClick={addTier}
-          minimal
-          icon={IconNames.PLUS}
-          disabled={disabled}
-          data-tooltip={disabled ? 'There are no tiers left to assign' : undefined}
-        >
+        <Button onClick={addTier} minimal icon={IconNames.PLUS} disabled={disabled}>
           Add historical tier replication
         </Button>
       </FormGroup>

--- a/web-console/src/components/rule-editor/tiered-replicant.spec.tsx
+++ b/web-console/src/components/rule-editor/tiered-replicant.spec.tsx
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render } from '@testing-library/react';
+
+import { TieredReplicant } from './tiered-replicant';
+
+describe('TieredReplicant', () => {
+  it('matches snapshot with existing tier', () => {
+    const tieredReplicant = (
+      <TieredReplicant
+        tier="test1"
+        replication={2}
+        tiers={['test1', 'test2', 'test3']}
+        usedTiers={['test1']}
+        disabled={false}
+        onChangeTier={() => {}}
+        onChangeReplication={() => {}}
+        onRemove={() => {}}
+      />
+    );
+    const { container } = render(tieredReplicant);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot with non-existing tier', () => {
+    const tieredReplicant = (
+      <TieredReplicant
+        tier="nonexist"
+        replication={1}
+        tiers={['test1', 'test2', 'test3']}
+        usedTiers={['nonexist']}
+        disabled={false}
+        onChangeTier={() => {}}
+        onChangeReplication={() => {}}
+        onRemove={() => {}}
+      />
+    );
+    const { container } = render(tieredReplicant);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot when disabled', () => {
+    const tieredReplicant = (
+      <TieredReplicant
+        tier="test1"
+        replication={3}
+        tiers={['test1', 'test2', 'test3']}
+        usedTiers={['test1']}
+        disabled
+        onChangeTier={() => {}}
+        onChangeReplication={() => {}}
+        onRemove={() => {}}
+      />
+    );
+    const { container } = render(tieredReplicant);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot without remove button', () => {
+    const tieredReplicant = (
+      <TieredReplicant
+        tier="test2"
+        replication={1}
+        tiers={['test1', 'test2', 'test3']}
+        usedTiers={['test2']}
+        disabled={false}
+        onChangeTier={() => {}}
+        onChangeReplication={() => {}}
+        onRemove={undefined}
+      />
+    );
+    const { container } = render(tieredReplicant);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot with multiple used tiers', () => {
+    const tieredReplicant = (
+      <TieredReplicant
+        tier="test3"
+        replication={5}
+        tiers={['test1', 'test2', 'test3']}
+        usedTiers={['test1', 'test2']}
+        disabled={false}
+        onChangeTier={() => {}}
+        onChangeReplication={() => {}}
+        onRemove={() => {}}
+      />
+    );
+    const { container } = render(tieredReplicant);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/web-console/src/components/rule-editor/tiered-replicant.tsx
+++ b/web-console/src/components/rule-editor/tiered-replicant.tsx
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Button, ControlGroup, NumericInput } from '@blueprintjs/core';
+import { IconNames } from '@blueprintjs/icons';
+import React from 'react';
+
+import { SuggestibleInput } from '../suggestible-input/suggestible-input';
+
+export interface TieredReplicantProps {
+  tier: string;
+  replication: number;
+  onChangeTier: (newTier: string) => void;
+  onChangeReplication: (value: number) => void;
+  tiers: string[];
+  usedTiers: string[];
+  disabled: boolean;
+  onRemove?: () => void;
+}
+
+export const TieredReplicant = React.memo(function TieredReplicant(props: TieredReplicantProps) {
+  const {
+    tier,
+    replication,
+    tiers,
+    usedTiers,
+    disabled,
+    onChangeReplication,
+    onChangeTier,
+    onRemove,
+  } = props;
+
+  return (
+    <ControlGroup className="tiered-replicant">
+      <Button minimal disabled={disabled} style={{ pointerEvents: 'none' }}>
+        Tier:
+      </Button>
+      <SuggestibleInput
+        fill
+        value={tier}
+        disabled={disabled}
+        onValueChange={value => onChangeTier(value || '')}
+        suggestions={tiers.filter(t => t === tier || !usedTiers.includes(t))}
+      />
+      <Button minimal disabled={disabled} style={{ pointerEvents: 'none' }}>
+        Replicants:
+      </Button>
+      <NumericInput
+        value={replication}
+        disabled={disabled}
+        onValueChange={(v: number) => {
+          if (isNaN(v)) return;
+          onChangeReplication(v);
+        }}
+        min={0}
+        max={256}
+      />
+      {onRemove && <Button onClick={onRemove} icon={IconNames.TRASH} />}
+    </ControlGroup>
+  );
+});

--- a/web-console/src/components/suggestion-menu/__snapshots__/suggestion-menu.spec.tsx.snap
+++ b/web-console/src/components/suggestion-menu/__snapshots__/suggestion-menu.spec.tsx.snap
@@ -1,6 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SuggestionMenu matches snapshot 1`] = `
+exports[`SuggestionMenu matches snapshot when empty 1`] = `
+<ul
+  class="suggestion-menu bp5-menu"
+  role="menu"
+>
+  <li
+    class=""
+    role="none"
+  >
+    <a
+      aria-disabled="true"
+      class="bp5-menu-item bp5-disabled"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="bp5-text-overflow-ellipsis bp5-fill"
+      >
+        (empty)
+      </div>
+    </a>
+  </li>
+</ul>
+`;
+
+exports[`SuggestionMenu matches snapshot with something 1`] = `
 <ul
   class="suggestion-menu bp5-menu"
   role="menu"

--- a/web-console/src/components/suggestion-menu/suggestion-menu.spec.tsx
+++ b/web-console/src/components/suggestion-menu/suggestion-menu.spec.tsx
@@ -21,7 +21,14 @@ import { render } from '@testing-library/react';
 import { SuggestionMenu } from './suggestion-menu';
 
 describe('SuggestionMenu', () => {
-  it('matches snapshot', () => {
+  it('matches snapshot when empty', () => {
+    const arrayInput = <SuggestionMenu suggestions={[]} onSuggest={() => {}} />;
+
+    const { container } = render(arrayInput);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('matches snapshot with something', () => {
     const arrayInput = (
       <SuggestionMenu
         suggestions={[

--- a/web-console/src/components/suggestion-menu/suggestion-menu.tsx
+++ b/web-console/src/components/suggestion-menu/suggestion-menu.tsx
@@ -64,6 +64,7 @@ export const SuggestionMenu = React.memo(function SuggestionMenu(props: Suggesti
           );
         }
       })}
+      {suggestions.length === 0 && <MenuItem text="(empty)" disabled />}
     </Menu>
   );
 });

--- a/web-console/src/dialogs/history-dialog/__snapshots__/history-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/history-dialog/__snapshots__/history-dialog.spec.tsx.snap
@@ -85,11 +85,12 @@ exports[`HistoryDialog matches snapshot 1`] = `
                 aria-selected="true"
                 class="bp5-tab"
                 data-tab-id="0"
+                data-tooltip="2025-04-03 02:01:00"
                 id="bp5-tab-title_undefined_0"
                 role="tab"
                 tabindex="0"
               >
-                test @ 
+                test @ 2025-04-03 02:01:00
               </div>
               <div
                 aria-controls="bp5-tab-panel_undefined_1"
@@ -98,11 +99,12 @@ exports[`HistoryDialog matches snapshot 1`] = `
                 aria-selected="false"
                 class="bp5-tab"
                 data-tab-id="1"
+                data-tooltip="2025-04-03 01:01:00"
                 id="bp5-tab-title_undefined_1"
                 role="tab"
                 tabindex="-1"
               >
-                test @ 
+                test @ 2025-04-03 01:01:00
               </div>
               <div
                 class="bp5-flex-expander"

--- a/web-console/src/dialogs/history-dialog/history-dialog.spec.tsx
+++ b/web-console/src/dialogs/history-dialog/history-dialog.spec.tsx
@@ -28,12 +28,12 @@ describe('HistoryDialog', () => {
         title="History"
         historyRecords={[
           {
-            auditTime: 'test',
+            auditTime: '2025-04-03T02:01:00.000Z',
             auditInfo: { comment: 'test' },
             payload: JSONBig.stringify({ name: 'test' }),
           },
           {
-            auditTime: 'test',
+            auditTime: '2025-04-03T01:01:00.000Z',
             auditInfo: { comment: 'test' },
             payload: JSONBig.stringify({ name: 'test' }),
           },

--- a/web-console/src/dialogs/history-dialog/history-dialog.tsx
+++ b/web-console/src/dialogs/history-dialog/history-dialog.tsx
@@ -65,7 +65,7 @@ export const HistoryDialog = React.memo(function HistoryDialog(props: HistoryDia
     content = (
       <Tabs animate renderActiveTabPanelOnly vertical defaultSelectedTabId={0}>
         {historyRecords.map(({ auditInfo, auditTime, payload }, i) => {
-          const formattedTime = auditTime.replace('T', ' ').substring(0, auditTime.length - 5);
+          const formattedTime = auditTime.replace('T', ' ').substring(0, 19);
           return (
             <Tab
               id={i}

--- a/web-console/src/dialogs/history-dialog/history-dialog.tsx
+++ b/web-console/src/dialogs/history-dialog/history-dialog.tsx
@@ -71,6 +71,7 @@ export const HistoryDialog = React.memo(function HistoryDialog(props: HistoryDia
               id={i}
               key={i}
               title={`${auditInfo.comment || 'Change'} @ ${formattedTime}`}
+              data-tooltip={formattedTime}
               panel={
                 <ShowValue
                   jsonValue={normalizePayload(payload)}
@@ -91,7 +92,7 @@ export const HistoryDialog = React.memo(function HistoryDialog(props: HistoryDia
   if (diffIndex !== -1) {
     return (
       <DiffDialog
-        title="Supervisor spec diff"
+        title={`${title} diff`}
         versions={historyRecords.map(({ auditInfo, auditTime, payload }) => ({
           label: auditInfo.comment || auditTime,
           value: normalizePayload(payload),

--- a/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
+++ b/web-console/src/dialogs/retention-dialog/__snapshots__/retention-dialog.spec.tsx.snap
@@ -347,7 +347,7 @@ exports[`RetentionDialog matches snapshot 1`] = `
                               class="bp5-form-content"
                             >
                               <div
-                                class="bp5-control-group"
+                                class="bp5-control-group tiered-replicant"
                                 role="group"
                               >
                                 <button
@@ -362,36 +362,51 @@ exports[`RetentionDialog matches snapshot 1`] = `
                                   </span>
                                 </button>
                                 <div
-                                  class="bp5-html-select bp5-fill"
+                                  class="formatted-input suggestible-input"
                                 >
-                                  <select>
-                                    <option
-                                      value="_default_tier"
-                                    >
-                                      _default_tier
-                                    </option>
-                                  </select>
-                                  <span
-                                    class="bp5-icon bp5-icon-double-caret-vertical"
+                                  <div
+                                    class="bp5-input-group bp5-fill"
                                   >
-                                    <svg
-                                      data-icon="double-caret-vertical"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
+                                    <input
+                                      aria-disabled="false"
+                                      class="bp5-input"
+                                      style="padding-right: 0px;"
+                                      type="text"
+                                      value="_default_tier"
+                                    />
+                                    <span
+                                      class="bp5-input-action"
                                     >
-                                      <title>
-                                        Open dropdown
-                                      </title>
-                                      <path
-                                        d="M100 180H220C231 180 240 189 240 200C240 205.6 237.8 210.6 234.2 214.2L174.2 274.2C170.6 277.8 165.6 280 160 280S149.4 277.8 145.8 274.2L85.8 214.2C82.2 210.6 80 205.6 80 200C80 189 89 180 100 180zM220 140H100C89 140 80 131 80 120C80 114.4 82.2 109.4 85.8 105.8L145.8 45.8C149.4 42.2 154.4 40 160 40S170.6 42.2 174.2 45.8L234.2 105.8C237.8 109.4 240 114.4 240 120C240 131 231 140 220 140z"
-                                        fill-rule="evenodd"
-                                        style="transform-origin: center;"
-                                        transform="scale(0.05, -0.05) translate(-160, -160)"
-                                      />
-                                    </svg>
-                                  </span>
+                                      <span
+                                        class="bp5-popover-target"
+                                      >
+                                        <button
+                                          aria-expanded="false"
+                                          aria-haspopup="menu"
+                                          class="bp5-button bp5-minimal"
+                                          type="button"
+                                        >
+                                          <span
+                                            aria-hidden="true"
+                                            class="bp5-icon bp5-icon-caret-down"
+                                          >
+                                            <svg
+                                              data-icon="caret-down"
+                                              height="16"
+                                              role="img"
+                                              viewBox="0 0 16 16"
+                                              width="16"
+                                            >
+                                              <path
+                                                d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                                                fill-rule="evenodd"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </button>
+                                      </span>
+                                    </span>
+                                  </div>
                                 </div>
                                 <button
                                   class="bp5-button bp5-minimal"
@@ -515,10 +530,7 @@ exports[`RetentionDialog matches snapshot 1`] = `
                               class="bp5-form-content"
                             >
                               <button
-                                class="bp5-button bp5-disabled bp5-minimal"
-                                data-tooltip="There are no tiers left to assign"
-                                disabled=""
-                                tabindex="-1"
+                                class="bp5-button bp5-minimal"
                                 type="button"
                               >
                                 <span
@@ -754,7 +766,7 @@ exports[`RetentionDialog matches snapshot 1`] = `
                               class="bp5-form-content"
                             >
                               <div
-                                class="bp5-control-group"
+                                class="bp5-control-group tiered-replicant"
                                 role="group"
                               >
                                 <button
@@ -771,38 +783,52 @@ exports[`RetentionDialog matches snapshot 1`] = `
                                   </span>
                                 </button>
                                 <div
-                                  class="bp5-html-select bp5-disabled bp5-fill"
+                                  class="formatted-input suggestible-input"
                                 >
-                                  <select
-                                    disabled=""
+                                  <div
+                                    class="bp5-input-group bp5-disabled bp5-fill"
                                   >
-                                    <option
+                                    <input
+                                      aria-disabled="true"
+                                      class="bp5-input"
+                                      disabled=""
+                                      style="padding-right: 0px;"
+                                      type="text"
                                       value="_default_tier"
+                                    />
+                                    <span
+                                      class="bp5-input-action"
                                     >
-                                      _default_tier
-                                    </option>
-                                  </select>
-                                  <span
-                                    class="bp5-icon bp5-icon-double-caret-vertical"
-                                  >
-                                    <svg
-                                      data-icon="double-caret-vertical"
-                                      height="16"
-                                      role="img"
-                                      viewBox="0 0 16 16"
-                                      width="16"
-                                    >
-                                      <title>
-                                        Open dropdown
-                                      </title>
-                                      <path
-                                        d="M100 180H220C231 180 240 189 240 200C240 205.6 237.8 210.6 234.2 214.2L174.2 274.2C170.6 277.8 165.6 280 160 280S149.4 277.8 145.8 274.2L85.8 214.2C82.2 210.6 80 205.6 80 200C80 189 89 180 100 180zM220 140H100C89 140 80 131 80 120C80 114.4 82.2 109.4 85.8 105.8L145.8 45.8C149.4 42.2 154.4 40 160 40S170.6 42.2 174.2 45.8L234.2 105.8C237.8 109.4 240 114.4 240 120C240 131 231 140 220 140z"
-                                        fill-rule="evenodd"
-                                        style="transform-origin: center;"
-                                        transform="scale(0.05, -0.05) translate(-160, -160)"
-                                      />
-                                    </svg>
-                                  </span>
+                                      <span
+                                        class="bp5-popover-target"
+                                      >
+                                        <button
+                                          aria-expanded="false"
+                                          aria-haspopup="menu"
+                                          class="bp5-button bp5-minimal"
+                                          type="button"
+                                        >
+                                          <span
+                                            aria-hidden="true"
+                                            class="bp5-icon bp5-icon-caret-down"
+                                          >
+                                            <svg
+                                              data-icon="caret-down"
+                                              height="16"
+                                              role="img"
+                                              viewBox="0 0 16 16"
+                                              width="16"
+                                            >
+                                              <path
+                                                d="M12 6.5c0-.28-.22-.5-.5-.5h-7a.495.495 0 00-.37.83l3.5 4c.09.1.22.17.37.17s.28-.07.37-.17l3.5-4c.08-.09.13-.2.13-.33z"
+                                                fill-rule="evenodd"
+                                              />
+                                            </svg>
+                                          </span>
+                                        </button>
+                                      </span>
+                                    </span>
+                                  </div>
                                 </div>
                                 <button
                                   class="bp5-button bp5-disabled bp5-minimal"

--- a/web-console/src/druid-models/load-rule/load-rule.spec.ts
+++ b/web-console/src/druid-models/load-rule/load-rule.spec.ts
@@ -1,0 +1,502 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Rule } from './load-rule';
+import { RuleUtil } from './load-rule';
+
+describe('RuleUtil', () => {
+  describe('ruleToString', () => {
+    it('converts loadForever rule', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 2, cold: 1 },
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('loadForever(3x)');
+    });
+
+    it('converts loadByInterval rule', () => {
+      const rule: Rule = {
+        type: 'loadByInterval',
+        interval: '2010-01-01/2020-01-01',
+        tieredReplicants: { tier1: 1 },
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('loadByInterval(2010-01-01/2020-01-01, 1x)');
+    });
+
+    it('converts loadByPeriod rule', () => {
+      const rule: Rule = {
+        type: 'loadByPeriod',
+        period: 'P1M',
+        tieredReplicants: { hot: 3 },
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('loadByPeriod(P1M+future, 3x)');
+    });
+
+    it('converts loadByPeriod rule with includeFuture false', () => {
+      const rule: Rule = {
+        type: 'loadByPeriod',
+        period: 'P1D',
+        includeFuture: false,
+        tieredReplicants: { hot: 1 },
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('loadByPeriod(P1D, 1x)');
+    });
+
+    it('converts dropForever rule', () => {
+      const rule: Rule = { type: 'dropForever' };
+      expect(RuleUtil.ruleToString(rule)).toBe('dropForever()');
+    });
+
+    it('converts dropByInterval rule', () => {
+      const rule: Rule = {
+        type: 'dropByInterval',
+        interval: '2000-01-01/2010-01-01',
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('dropByInterval(2000-01-01/2010-01-01)');
+    });
+
+    it('converts dropByPeriod rule', () => {
+      const rule: Rule = {
+        type: 'dropByPeriod',
+        period: 'P1Y',
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('dropByPeriod(P1Y+future)');
+    });
+
+    it('converts dropBeforeByPeriod rule', () => {
+      const rule: Rule = {
+        type: 'dropBeforeByPeriod',
+        period: 'P6M',
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('dropBeforeByPeriod(P6M+future)');
+    });
+
+    it('converts broadcastForever rule', () => {
+      const rule: Rule = { type: 'broadcastForever' };
+      expect(RuleUtil.ruleToString(rule)).toBe('broadcastForever()');
+    });
+
+    it('converts broadcastByInterval rule', () => {
+      const rule: Rule = {
+        type: 'broadcastByInterval',
+        interval: '2020-01-01/2021-01-01',
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('broadcastByInterval(2020-01-01/2021-01-01)');
+    });
+
+    it('converts broadcastByPeriod rule', () => {
+      const rule: Rule = {
+        type: 'broadcastByPeriod',
+        period: 'P3M',
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('broadcastByPeriod(P3M+future)');
+    });
+
+    it('handles load rule with no tiered replicants', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: {},
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('loadForever(0x)');
+    });
+
+    it('handles load rule with multiple tiers', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { cold: 1, hot: 2, archive: 3 },
+      };
+      expect(RuleUtil.ruleToString(rule)).toBe('loadForever(6x)');
+    });
+  });
+
+  describe('changeRuleType', () => {
+    it('changes from loadForever to loadByInterval', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.changeRuleType(rule, 'loadByInterval');
+      expect(newRule).toEqual({
+        type: 'loadByInterval',
+        interval: '2010-01-01/2020-01-01',
+        tieredReplicants: { hot: 1 },
+      });
+    });
+
+    it('changes from loadByInterval to loadByPeriod', () => {
+      const rule: Rule = {
+        type: 'loadByInterval',
+        interval: '2010-01-01/2020-01-01',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.changeRuleType(rule, 'loadByPeriod');
+      expect(newRule).toEqual({
+        type: 'loadByPeriod',
+        period: 'P1M',
+        includeFuture: true,
+        tieredReplicants: { hot: 1 },
+      });
+    });
+
+    it('changes from loadForever to dropForever', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.changeRuleType(rule, 'dropForever');
+      expect(newRule).toEqual({
+        type: 'dropForever',
+      });
+    });
+
+    it('preserves period when changing between period types', () => {
+      const rule: Rule = {
+        type: 'loadByPeriod',
+        period: 'P3M',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.changeRuleType(rule, 'dropByPeriod');
+      expect(newRule).toEqual({
+        type: 'dropByPeriod',
+        period: 'P3M',
+        includeFuture: true,
+      });
+    });
+
+    it('preserves interval when changing between interval types', () => {
+      const rule: Rule = {
+        type: 'loadByInterval',
+        interval: '2015-01-01/2016-01-01',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.changeRuleType(rule, 'broadcastByInterval');
+      expect(newRule).toEqual({
+        type: 'broadcastByInterval',
+        interval: '2015-01-01/2016-01-01',
+      });
+    });
+  });
+
+  describe('hasPeriod', () => {
+    it('returns true for period rules', () => {
+      expect(RuleUtil.hasPeriod({ type: 'loadByPeriod' })).toBe(true);
+      expect(RuleUtil.hasPeriod({ type: 'dropByPeriod' })).toBe(true);
+      expect(RuleUtil.hasPeriod({ type: 'dropBeforeByPeriod' })).toBe(true);
+      expect(RuleUtil.hasPeriod({ type: 'broadcastByPeriod' })).toBe(true);
+    });
+
+    it('returns false for non-period rules', () => {
+      expect(RuleUtil.hasPeriod({ type: 'loadForever' })).toBe(false);
+      expect(RuleUtil.hasPeriod({ type: 'loadByInterval' })).toBe(false);
+      expect(RuleUtil.hasPeriod({ type: 'dropForever' })).toBe(false);
+    });
+  });
+
+  describe('changePeriod', () => {
+    it('updates period on a rule', () => {
+      const rule: Rule = {
+        type: 'loadByPeriod',
+        period: 'P1M',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.changePeriod(rule, 'P3M');
+      expect(newRule).toEqual({
+        type: 'loadByPeriod',
+        period: 'P3M',
+        tieredReplicants: { hot: 1 },
+      });
+    });
+  });
+
+  describe('hasIncludeFuture', () => {
+    it('returns true for load and broadcast period rules', () => {
+      expect(RuleUtil.hasIncludeFuture({ type: 'loadByPeriod' })).toBe(true);
+      expect(RuleUtil.hasIncludeFuture({ type: 'broadcastByPeriod' })).toBe(true);
+    });
+
+    it('returns true for drop period rules except dropBeforeByPeriod', () => {
+      expect(RuleUtil.hasIncludeFuture({ type: 'dropByPeriod' })).toBe(true);
+      expect(RuleUtil.hasIncludeFuture({ type: 'dropBeforeByPeriod' })).toBe(false);
+    });
+
+    it('returns false for non-period rules', () => {
+      expect(RuleUtil.hasIncludeFuture({ type: 'loadForever' })).toBe(false);
+      expect(RuleUtil.hasIncludeFuture({ type: 'loadByInterval' })).toBe(false);
+    });
+  });
+
+  describe('getIncludeFuture', () => {
+    it('returns includeFuture value when present', () => {
+      const rule: Rule = {
+        type: 'loadByPeriod',
+        period: 'P1M',
+        includeFuture: false,
+      };
+      expect(RuleUtil.getIncludeFuture(rule)).toBe(false);
+    });
+
+    it('returns true by default', () => {
+      const rule: Rule = {
+        type: 'loadByPeriod',
+        period: 'P1M',
+      };
+      expect(RuleUtil.getIncludeFuture(rule)).toBe(true);
+    });
+  });
+
+  describe('changeIncludeFuture', () => {
+    it('updates includeFuture value', () => {
+      const rule: Rule = {
+        type: 'loadByPeriod',
+        period: 'P1M',
+        includeFuture: true,
+      };
+      const newRule = RuleUtil.changeIncludeFuture(rule, false);
+      expect(newRule).toEqual({
+        type: 'loadByPeriod',
+        period: 'P1M',
+        includeFuture: false,
+      });
+    });
+  });
+
+  describe('hasInterval', () => {
+    it('returns true for interval rules', () => {
+      expect(RuleUtil.hasInterval({ type: 'loadByInterval' })).toBe(true);
+      expect(RuleUtil.hasInterval({ type: 'dropByInterval' })).toBe(true);
+      expect(RuleUtil.hasInterval({ type: 'broadcastByInterval' })).toBe(true);
+    });
+
+    it('returns false for non-interval rules', () => {
+      expect(RuleUtil.hasInterval({ type: 'loadForever' })).toBe(false);
+      expect(RuleUtil.hasInterval({ type: 'loadByPeriod' })).toBe(false);
+      expect(RuleUtil.hasInterval({ type: 'dropForever' })).toBe(false);
+    });
+  });
+
+  describe('changeInterval', () => {
+    it('updates interval on a rule', () => {
+      const rule: Rule = {
+        type: 'loadByInterval',
+        interval: '2010-01-01/2020-01-01',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.changeInterval(rule, '2015-01-01/2025-01-01');
+      expect(newRule).toEqual({
+        type: 'loadByInterval',
+        interval: '2015-01-01/2025-01-01',
+        tieredReplicants: { hot: 1 },
+      });
+    });
+  });
+
+  describe('canHaveTieredReplicants', () => {
+    it('returns true for load rules', () => {
+      expect(RuleUtil.canHaveTieredReplicants({ type: 'loadForever' })).toBe(true);
+      expect(RuleUtil.canHaveTieredReplicants({ type: 'loadByInterval' })).toBe(true);
+      expect(RuleUtil.canHaveTieredReplicants({ type: 'loadByPeriod' })).toBe(true);
+    });
+
+    it('returns false for drop and broadcast rules', () => {
+      expect(RuleUtil.canHaveTieredReplicants({ type: 'dropForever' })).toBe(false);
+      expect(RuleUtil.canHaveTieredReplicants({ type: 'dropByInterval' })).toBe(false);
+      expect(RuleUtil.canHaveTieredReplicants({ type: 'broadcastForever' })).toBe(false);
+    });
+  });
+
+  describe('renameTieredReplicant', () => {
+    it('renames a tier', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 2, cold: 1 },
+      };
+      const newRule = RuleUtil.renameTieredReplicant(rule, 'hot', 'warm');
+      expect(newRule).toEqual({
+        type: 'loadForever',
+        tieredReplicants: { warm: 2, cold: 1 },
+      });
+    });
+
+    it('avoids conflict when renaming to existing tier', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 2, cold: 1 },
+      };
+      const newRule = RuleUtil.renameTieredReplicant(rule, 'hot', 'cold');
+      expect(newRule).toEqual({
+        type: 'loadForever',
+        tieredReplicants: { 'cold': 1, 'cold+': 2 },
+      });
+    });
+
+    it('does nothing when old tier does not exist', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 2 },
+      };
+      const newRule = RuleUtil.renameTieredReplicant(rule, 'nonexistent', 'warm');
+      expect(newRule).toEqual(rule);
+    });
+
+    it('handles undefined tieredReplicants', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+      };
+      const newRule = RuleUtil.renameTieredReplicant(rule, 'hot', 'warm');
+      expect(newRule).toEqual(rule);
+    });
+  });
+
+  describe('addTieredReplicant', () => {
+    it('adds a new tier', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.addTieredReplicant(rule, 'cold', 2);
+      expect(newRule).toEqual({
+        type: 'loadForever',
+        tieredReplicants: { hot: 1, cold: 2 },
+      });
+    });
+
+    it('updates existing tier', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 1 },
+      };
+      const newRule = RuleUtil.addTieredReplicant(rule, 'hot', 3);
+      expect(newRule).toEqual({
+        type: 'loadForever',
+        tieredReplicants: { hot: 3 },
+      });
+    });
+
+    it('sets tier to 0 when replication is 0', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 1, cold: 2 },
+      };
+      const newRule = RuleUtil.addTieredReplicant(rule, 'hot', 0);
+      expect(newRule).toEqual({
+        type: 'loadForever',
+        tieredReplicants: { hot: 0, cold: 2 },
+      });
+    });
+
+    it('creates tieredReplicants when undefined', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+      };
+      const newRule = RuleUtil.addTieredReplicant(rule, 'hot', 1);
+      expect(newRule).toEqual({
+        type: 'loadForever',
+        tieredReplicants: { hot: 1 },
+      });
+    });
+  });
+
+  describe('totalReplicas', () => {
+    it('calculates total replicas', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 2, cold: 3, archive: 1 },
+      };
+      expect(RuleUtil.totalReplicas(rule)).toBe(6);
+    });
+
+    it('returns 0 for empty tieredReplicants', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: {},
+      };
+      expect(RuleUtil.totalReplicas(rule)).toBe(0);
+    });
+
+    it('returns 0 for undefined tieredReplicants', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+      };
+      expect(RuleUtil.totalReplicas(rule)).toBe(0);
+    });
+
+    it('returns 0 for non-load rules', () => {
+      const rule: Rule = {
+        type: 'dropForever',
+      };
+      expect(RuleUtil.totalReplicas(rule)).toBe(0);
+    });
+  });
+
+  describe('isZeroReplicaRule', () => {
+    it('returns true for load rule with zero replicas', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: {},
+      };
+      expect(RuleUtil.isZeroReplicaRule(rule)).toBe(true);
+    });
+
+    it('returns false for load rule with replicas', () => {
+      const rule: Rule = {
+        type: 'loadForever',
+        tieredReplicants: { hot: 1 },
+      };
+      expect(RuleUtil.isZeroReplicaRule(rule)).toBe(false);
+    });
+
+    it('returns false for non-load rules', () => {
+      const rule: Rule = {
+        type: 'dropForever',
+      };
+      expect(RuleUtil.isZeroReplicaRule(rule)).toBe(false);
+    });
+  });
+
+  describe('hasZeroReplicaRule', () => {
+    it('returns true when rules contain zero replica rule', () => {
+      const rules: Rule[] = [
+        { type: 'loadForever', tieredReplicants: { hot: 1 } },
+        { type: 'loadByPeriod', period: 'P1M', tieredReplicants: {} },
+      ];
+      expect(RuleUtil.hasZeroReplicaRule(rules, undefined)).toBe(true);
+    });
+
+    it('returns true when defaultRules contain zero replica rule', () => {
+      const defaultRules: Rule[] = [{ type: 'loadForever', tieredReplicants: {} }];
+      expect(RuleUtil.hasZeroReplicaRule(undefined, defaultRules)).toBe(true);
+    });
+
+    it('returns false when no zero replica rules', () => {
+      const rules: Rule[] = [
+        { type: 'loadForever', tieredReplicants: { hot: 1 } },
+        { type: 'dropByPeriod', period: 'P1Y' },
+      ];
+      const defaultRules: Rule[] = [{ type: 'loadForever', tieredReplicants: { cold: 1 } }];
+      expect(RuleUtil.hasZeroReplicaRule(rules, defaultRules)).toBe(false);
+    });
+
+    it('returns false for undefined arrays', () => {
+      expect(RuleUtil.hasZeroReplicaRule(undefined, undefined)).toBe(false);
+    });
+
+    it('returns false for empty arrays', () => {
+      expect(RuleUtil.hasZeroReplicaRule([], [])).toBe(false);
+    });
+  });
+});

--- a/web-console/src/druid-models/load-rule/load-rule.ts
+++ b/web-console/src/druid-models/load-rule/load-rule.ts
@@ -126,6 +126,7 @@ export class RuleUtil {
   }
 
   static renameTieredReplicant(rule: Rule, oldTier: string, newTier: string): Rule {
+    if (typeof deepGet(rule, `tieredReplicants.${oldTier}`) !== 'number') return rule;
     // Ensure we are never stomping over an existing tier
     while (deepGet(rule, `tieredReplicants.${newTier}`)) newTier += '+';
     return deepMove(rule, `tieredReplicants.${oldTier}`, `tieredReplicants.${newTier}`);

--- a/web-console/src/druid-models/load-rule/load-rule.ts
+++ b/web-console/src/druid-models/load-rule/load-rule.ts
@@ -18,7 +18,7 @@
 
 import { sum } from 'd3-array';
 
-import { deepMove, deepSet } from '../../utils';
+import { deepGet, deepMove, deepSet } from '../../utils';
 
 export type RuleType =
   | 'loadForever'
@@ -125,7 +125,9 @@ export class RuleUtil {
     return rule.type.startsWith('load');
   }
 
-  static renameTieredReplicants(rule: Rule, oldTier: string, newTier: string): Rule {
+  static renameTieredReplicant(rule: Rule, oldTier: string, newTier: string): Rule {
+    // Ensure we are never stomping over an existing tier
+    while (deepGet(rule, `tieredReplicants.${newTier}`)) newTier += '+';
     return deepMove(rule, `tieredReplicants.${oldTier}`, `tieredReplicants.${newTier}`);
   }
 


### PR DESCRIPTION
Makes it possible to assign tiered replication to tiers that are not online at the time the dialog is opened. Also fixed little typos and usability issues.

<img width="728" alt="image" src="https://github.com/user-attachments/assets/ac840a3f-66da-4eac-a143-e9be7d087272" />
