### PR TITLE
Web console: add Error column to the tasks view

### DIFF
--- a/web-console/src/views/tasks-view/__snapshots__/tasks-view.spec.tsx.snap
+++ b/web-console/src/views/tasks-view/__snapshots__/tasks-view.spec.tsx.snap
@@ -76,13 +76,18 @@ exports[`TasksView matches snapshot 1`] = `
           "Type",
           "Datasource",
           "Status",
+          "Error",
           "Created time",
           "Duration",
           "Location",
         ]
       }
       onChange={[Function]}
-      tableColumnsHidden={[]}
+      tableColumnsHidden={
+        [
+          "Error",
+        ]
+      }
     />
   </Memo(ViewControlBar)>
   <ReactTable
@@ -181,6 +186,15 @@ exports[`TasksView matches snapshot 1`] = `
           "show": true,
           "sortMethod": [Function],
           "width": 110,
+        },
+        {
+          "Aggregated": [Function],
+          "Cell": [Function],
+          "Header": "Error",
+          "accessor": [Function],
+          "id": "error",
+          "show": false,
+          "width": 300,
         },
         {
           "Aggregated": [Function],

--- a/web-console/src/views/tasks-view/tasks-view.tsx
+++ b/web-console/src/views/tasks-view/tasks-view.tsx
@@ -68,6 +68,7 @@ const taskTableColumns: string[] = [
   'Type',
   'Datasource',
   'Status',
+  'Error',
   'Created time',
   'Duration',
   'Location',
@@ -167,6 +168,7 @@ ORDER BY
 
       visibleColumns: new LocalStorageBackedVisibility(
         LocalStorageKeys.TASK_TABLE_COLUMN_SELECTION,
+        ['Error'],
       ),
     };
 
@@ -475,6 +477,15 @@ ORDER BY
               }
             },
             show: visibleColumns.shown('Status'),
+          },
+          {
+            Header: 'Error',
+            id: 'error',
+            accessor: row => row.error_msg || '',
+            width: 300,
+            Cell: this.renderTaskFilterableCell('error'),
+            Aggregated: () => '',
+            show: visibleColumns.shown('Error'),
           },
           {
             Header: 'Created time',


### PR DESCRIPTION
Added an Error columns to the Tasks view that makes it possible to filter on error.

![image](https://github.com/user-attachments/assets/770f8ef1-963c-414b-b02c-f6eec9655d7d)
