### PR TITLE
fix bug in NestedComplexColumn.getFieldLogicalType when handling array element paths

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/nested/CompressedNestedDataComplexColumn.java
@@ -878,6 +878,7 @@ public abstract class CompressedNestedDataComplexColumn<TStringDictionary extend
     final String field = getField(path);
     final Set<ColumnType> fieldTypes;
     int index = fields.indexOf(field);
+    ColumnType leastRestrictiveType = null;
     if (index < 0) {
       if (!path.isEmpty() && path.get(path.size() - 1) instanceof NestedPathArrayElement) {
         final String arrayField = getField(path.subList(0, path.size() - 1));
@@ -887,12 +888,21 @@ public abstract class CompressedNestedDataComplexColumn<TStringDictionary extend
         return null;
       }
       fieldTypes = FieldTypeInfo.convertToSet(fieldInfo.getTypes(index).getByteValue());
+      for (ColumnType type : fieldTypes) {
+        if (type.isArray()) {
+          leastRestrictiveType = ColumnType.leastRestrictiveType(
+              leastRestrictiveType,
+              (ColumnType) type.getElementType()
+          );
+        } else {
+          leastRestrictiveType = ColumnType.leastRestrictiveType(leastRestrictiveType, type);
+        }
+      }
     } else {
       fieldTypes = FieldTypeInfo.convertToSet(fieldInfo.getTypes(index).getByteValue());
-    }
-    ColumnType leastRestrictiveType = null;
-    for (ColumnType type : fieldTypes) {
-      leastRestrictiveType = ColumnType.leastRestrictiveType(leastRestrictiveType, type);
+      for (ColumnType type : fieldTypes) {
+        leastRestrictiveType = ColumnType.leastRestrictiveType(leastRestrictiveType, type);
+      }
     }
     return leastRestrictiveType;
   }

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -84,6 +84,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -455,6 +456,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     NullValueIndex sNulls = sIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> sElementPath = NestedPathFinder.parseJsonPath("$.s[1]");
+    Assert.assertEquals(Set.of(ColumnType.STRING), column.getFieldTypes(sElementPath));
+    Assert.assertEquals(ColumnType.STRING, column.getFieldLogicalType(sElementPath));
     ColumnValueSelector<?> sElementSelector = column.makeColumnValueSelector(sElementPath, offset);
     VectorObjectSelector sElementVectorSelector = column.makeVectorObjectSelector(sElementPath, vectorOffset);
     VectorObjectSelector sElementFilteredVectorSelector = column.makeVectorObjectSelector(
@@ -480,6 +483,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     NullValueIndex lNulls = lIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> lElementPath = NestedPathFinder.parseJsonPath("$.l[1]");
+    Assert.assertEquals(Set.of(ColumnType.LONG), column.getFieldTypes(lElementPath));
+    Assert.assertEquals(ColumnType.LONG, column.getFieldLogicalType(lElementPath));
     ColumnValueSelector<?> lElementSelector = column.makeColumnValueSelector(lElementPath, offset);
     VectorValueSelector lElementVectorSelector = column.makeVectorValueSelector(lElementPath, vectorOffset);
     VectorObjectSelector lElementVectorObjectSelector = column.makeVectorObjectSelector(lElementPath, vectorOffset);
@@ -506,6 +511,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     NullValueIndex dNulls = dIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> dElementPath = NestedPathFinder.parseJsonPath("$.d[1]");
+    Assert.assertEquals(Set.of(ColumnType.DOUBLE), column.getFieldTypes(dElementPath));
+    Assert.assertEquals(ColumnType.DOUBLE, column.getFieldLogicalType(dElementPath));
     ColumnValueSelector<?> dElementSelector = column.makeColumnValueSelector(dElementPath, offset);
     VectorValueSelector dElementVectorSelector = column.makeVectorValueSelector(dElementPath, vectorOffset);
     VectorObjectSelector dElementVectorObjectSelector = column.makeVectorObjectSelector(dElementPath, vectorOffset);


### PR DESCRIPTION
### Description
Fixes a regression in the `getFieldLogicalType` method introduced in #18053, which forgot to add the array element adjustment that is present in `getFieldTypes`, so it was incorrectly returning the array type instead of the array element type when dealing with a path like `$.foo[1]` (where `$.foo` is `ARRAY<STRING>` or whatever).