### PR TITLE
Fix races between callback and shutdown routines in TaskQueue

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -742,7 +742,7 @@ public class TaskQueue
     removeTaskLock(task);
     requestManagement();
 
-    log.info("Completed notifyStatus for task[%s] with status[%s]", task.getId(), taskStatus.getStatusCode());
+    log.info("Completed notifyStatus for task[%s] with status[%s]", task.getId(), taskStatus);
   }
 
   /**
@@ -1058,7 +1058,7 @@ public class TaskQueue
 
       log.info(
           "Completed task[%s] with status[%s] in [%d]ms.",
-          task.getId(), status.getStatusCode(), status.getDuration()
+          task.getId(), status, status.getDuration()
       );
     }
   }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Saw [this](https://github.com/apache/druid/actions/runs/15367007273/job/43241891519) CI had flakes for `TaskQueueConcurrencyTest::test_manageQueuedTasks_blocks_shutdown_forSameTaskId`.

This is caused by a race in TaskQueue:
1. Scenario where the task receives successful completion callback before shutdown

- T1: success callback triggered [here](https://github.com/apache/druid/blob/8e55eb5c098080a08e55e62714fa81834e71ff5d/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L767)
- T2: shutdown call triggered [here](https://github.com/apache/druid/blob/8e55eb5c098080a08e55e62714fa81834e71ff5d/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L619)
- T2: shutdown wins the race on key lock and gets to [here](https://github.com/apache/druid/blob/8e55eb5c098080a08e55e62714fa81834e71ff5d/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L716), commits the FAILED
- T1: success callback gets un-parked and hits [this](https://github.com/apache/druid/blob/8e55eb5c098080a08e55e62714fa81834e71ff5d/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L713) branch, later ignoring the shutdown
- T1: then gets [here](https://github.com/apache/druid/blob/8e55eb5c098080a08e55e62714fa81834e71ff5d/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L802) and will report the task as complete even though it was indeed failed.

2. Scenario where the succeeded callback beats race before shutdown call
- This is the occasional case that's materializing as a test failure

It's my understanding that tasks can receive status updates via ≥ 5 paths:
1. Invocation of `shutdown`
2. Invocation of `shutdownWithSuccess`  
3. Failure to fetch task readiness on worker [here](https://github.com/apache/druid/blob/0061e764fd0d1d59e8276c2292b1e1dcb6bd7adf/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L450): `startPendingTaskOnRunner`
4. Either of the 2 success/failure callbacks [here](https://github.com/apache/druid/blob/0061e764fd0d1d59e8276c2292b1e1dcb6bd7adf/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L797).

We currently are not emitting any metrics/logs on #3 and the metric/log can be incorrect with certain interleavings of #1,#2 and #4. Since the `TaskStatus` used in both shutdown routines is not accurate (-1), we need to rely on one of the callbacks returning post-shutdown to emit the true runtime of the task.

This currently doesn't affect correctness since we skip the writeback to DB in the case where it's already completed. The only thing I could see being an issue is [this](https://github.com/apache/druid/blob/8e55eb5c098080a08e55e62714fa81834e71ff5d/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L739), but these calls seem to be idempotent. 

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

- Fix status change callbacks racing with each other by including a check to `isComplete` in `notifyCompletedStatus`.
  - I will note that this removes some built-in cleanup redundancy (in the form of multiple callbacks calling the same code) in case exceptions occur in [these](https://github.com/apache/druid/blob/fae734eef70a8e8f37c81fe403635126dac20c75/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L716-L746) lines.
  - If we crash before the metadata commit, we'll re-run/discover the running task on reboot (and eventually run the same loop again).
  - If we crash after the commit, we won't acquire the resources that are to be freed [here](https://github.com/apache/druid/blob/fae734eef70a8e8f37c81fe403635126dac20c75/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java#L736-L746) so this should be fine.
- Ensure all final state changes are properly emitted/logged.
- Fix up `TaskQueueConcurrencyTest` to actually simulate a task delay, and not just immediately trigger the success callback when via the immediate future.
- Ensure the callbacks use the `readLock`
- Ensure correct metrics are being emitted on the above scenarios
- Style cleanup in `TaskQueue`

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fix races between callback and shutdown routines in TaskQueue

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
