### PR TITLE
tidy up server manager reference holder type

### DIFF
--- a/integration-tests-ex/tools/src/main/java/org/apache/druid/testing/tools/ServerManagerForQueryErrorTest.java
+++ b/integration-tests-ex/tools/src/main/java/org/apache/druid/testing/tools/ServerManagerForQueryErrorTest.java
@@ -133,7 +133,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
         .create(acquireAllSegments(timeline, specs, segmentMapFn, closer))
         .transform(
             ref ->
-                ref.getSegmentReference()
+                ref.getReference()
                    .map(segment -> {
                           final QueryContext queryContext = query.context();
                           if (queryContext.getBoolean(QUERY_RETRY_TEST_CONTEXT_KEY, false)) {
@@ -145,7 +145,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
                                     ignoredSegments = new HashSet<>();
                                   }
                                   if (ignoredSegments.size() < MAX_NUM_FALSE_MISSING_SEGMENTS_REPORTS) {
-                                    ignoredSegments.add(ref.getSegmentDescriptor());
+                                    ignoredSegments.add(ref.getDescriptor());
                                     isIgnoreSegment.setTrue();
                                   }
                                   return ignoredSegments;
@@ -153,8 +153,8 @@ public class ServerManagerForQueryErrorTest extends ServerManager
                             );
 
                             if (isIgnoreSegment.isTrue()) {
-                              LOG.info("Pretending I don't have segment [%s]", ref.getSegmentReference());
-                              return new ReportTimelineMissingSegmentQueryRunner<T>(ref.getSegmentDescriptor());
+                              LOG.info("Pretending I don't have segment [%s]", ref.getReference());
+                              return new ReportTimelineMissingSegmentQueryRunner<T>(ref.getDescriptor());
                             }
                           } else if (queryContext.getBoolean(QUERY_TIMEOUT_TEST_CONTEXT_KEY, false)) {
                             return (QueryRunner<T>) (queryPlus, responseContext) -> new Sequence<>()
@@ -250,7 +250,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
                             };
                           }
                           return buildQueryRunnerForSegment(
-                              ref.getSegmentDescriptor(),
+                              ref.getDescriptor(),
                               segment,
                               factory,
                               toolChest,
@@ -259,7 +259,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
                           );
                         }
                    ).orElse(
-                       new ReportTimelineMissingSegmentQueryRunner<>(ref.getSegmentDescriptor())
+                       new ReportTimelineMissingSegmentQueryRunner<>(ref.getDescriptor())
                    )
         );
   }

--- a/integration-tests/src/main/java/org/apache/druid/server/coordination/ServerManagerForQueryErrorTest.java
+++ b/integration-tests/src/main/java/org/apache/druid/server/coordination/ServerManagerForQueryErrorTest.java
@@ -131,7 +131,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
         .create(acquireAllSegments(timeline, specs, segmentMapFn, closer))
         .transform(
             ref ->
-                ref.getSegmentReference()
+                ref.getReference()
                    .map(segment -> {
                           final QueryContext queryContext = query.context();
                           if (queryContext.getBoolean(QUERY_RETRY_TEST_CONTEXT_KEY, false)) {
@@ -153,9 +153,9 @@ public class ServerManagerForQueryErrorTest extends ServerManager
                             if (isIgnoreSegment.isTrue()) {
                               LOG.info(
                                   "Pretending I don't have segment[%s]",
-                                  ref.getSegmentDescriptor()
+                                  ref.getDescriptor()
                               );
-                              return new ReportTimelineMissingSegmentQueryRunner<T>(ref.getSegmentDescriptor());
+                              return new ReportTimelineMissingSegmentQueryRunner<T>(ref.getDescriptor());
                             }
                           } else if (queryContext.getBoolean(QUERY_TIMEOUT_TEST_CONTEXT_KEY, false)) {
                             return (QueryRunner<T>) (queryPlus, responseContext) -> new Sequence<>()
@@ -269,7 +269,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
                           }
 
                           return buildQueryRunnerForSegment(
-                              ref.getSegmentDescriptor(),
+                              ref.getDescriptor(),
                               segment,
                               factory,
                               toolChest,
@@ -278,7 +278,7 @@ public class ServerManagerForQueryErrorTest extends ServerManager
                           );
                         }
                    ).orElse(
-                       new ReportTimelineMissingSegmentQueryRunner<>(ref.getSegmentDescriptor())
+                       new ReportTimelineMissingSegmentQueryRunner<>(ref.getDescriptor())
                    )
         );
   }

--- a/processing/src/main/java/org/apache/druid/query/SegmentReferenceAndDescriptor.java
+++ b/processing/src/main/java/org/apache/druid/query/SegmentReferenceAndDescriptor.java
@@ -35,7 +35,7 @@ import java.util.Optional;
  * If the {@link #segmentReference} is empty, it means that either the {@link ReferenceCountedSegmentProvider} was not
  * present in the timeline (e.g. the segment was dropped prior to fetching providers from the timeline) or that a
  * reference could not be acquired from
- * {@link #acquireReference(SegmentDescriptor, ReferenceCountedSegmentProvider, SegmentMapFunction, Closer)}, or if
+ * {@link #acquireReference(SegmentDescriptor, ReferenceCountedObjectProvider, SegmentMapFunction, Closer)}, or if
  * built externally, then from {@link SegmentMapFunction} or {@link ReferenceCountedSegmentProvider#acquireReference()}.
  */
 public class SegmentReferenceAndDescriptor

--- a/processing/src/main/java/org/apache/druid/query/SegmentReferenceAndDescriptor.java
+++ b/processing/src/main/java/org/apache/druid/query/SegmentReferenceAndDescriptor.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.ReferenceCountedSegmentProvider;
+import org.apache.druid.segment.Segment;
+import org.apache.druid.segment.SegmentMapFunction;
+
+import java.util.Optional;
+
+/**
+ * Wrapper for a {@link SegmentDescriptor} and a possible {@link Segment} reference acquired by applying a
+ * {@link org.apache.druid.segment.SegmentMapFunction} (or directly) to the {@link ReferenceCountedSegmentProvider}
+ * retrieved from a {@link org.apache.druid.timeline.VersionedIntervalTimeline} with the descriptor.
+ *
+ * If the {@link #segmentReference} is empty, it means that either the {@link ReferenceCountedSegmentProvider} was not
+ * present in the timeline (e.g. the segment was dropped prior to fetching providers from the timeline) or that a
+ * reference could not be acquired from
+ * {@link #acquireReference(SegmentDescriptor, ReferenceCountedSegmentProvider, SegmentMapFunction, Closer)}, or if
+ * built externally, then from {@link SegmentMapFunction} or {@link ReferenceCountedSegmentProvider#acquireReference()}.
+ */
+public class SegmentReferenceAndDescriptor
+{
+  /**
+   * Creates an 'empty' {@link SegmentReferenceAndDescriptor} which contains no {@link Segment}
+   */
+  public static SegmentReferenceAndDescriptor empty(SegmentDescriptor descriptor)
+  {
+    return new SegmentReferenceAndDescriptor(descriptor, Optional.empty());
+  }
+
+  /**
+   * Builds a {@link SegmentReferenceAndDescriptor} by applying a {@link SegmentMapFunction} to a
+   * {@link ReferenceCountedSegmentProvider}, registering the resulting segment, if present, with the {@link Closer}.
+   */
+  public static SegmentReferenceAndDescriptor acquireReference(
+      SegmentDescriptor descriptor,
+      ReferenceCountedSegmentProvider provider,
+      SegmentMapFunction mapFunction,
+      Closer closer
+  )
+  {
+    return new SegmentReferenceAndDescriptor(descriptor, mapFunction.apply(provider).map(closer::register));
+  }
+
+  private final SegmentDescriptor descriptor;
+  private final Optional<Segment> segmentReference;
+
+  public SegmentReferenceAndDescriptor(
+      SegmentDescriptor descriptor,
+      Optional<Segment> segmentReference
+  )
+  {
+    this.segmentReference = segmentReference;
+    this.descriptor = descriptor;
+  }
+
+  public SegmentDescriptor getDescriptor()
+  {
+    return descriptor;
+  }
+
+  public Optional<Segment> getReference()
+  {
+    return segmentReference;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/SegmentReferenceAndDescriptor.java
+++ b/processing/src/main/java/org/apache/druid/query/SegmentReferenceAndDescriptor.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query;
 
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.ReferenceCountedObjectProvider;
 import org.apache.druid.segment.ReferenceCountedSegmentProvider;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentMapFunction;
@@ -53,7 +54,7 @@ public class SegmentReferenceAndDescriptor
    */
   public static SegmentReferenceAndDescriptor acquireReference(
       SegmentDescriptor descriptor,
-      ReferenceCountedSegmentProvider provider,
+      ReferenceCountedObjectProvider<Segment> provider,
       SegmentMapFunction mapFunction,
       Closer closer
   )

--- a/processing/src/test/java/org/apache/druid/query/SegmentReferenceAndDescriptorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/SegmentReferenceAndDescriptorTest.java
@@ -21,7 +21,9 @@ package org.apache.druid.query;
 
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.ReferenceCountedObjectProvider;
 import org.apache.druid.segment.ReferenceCountedSegmentProvider;
+import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentMapFunction;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
@@ -40,22 +42,21 @@ class SegmentReferenceAndDescriptorTest extends InitializedNullHandlingTest
         TestIndex.getMMappedTestIndex(), SegmentId.dummy("test")
     );
 
-    try (ReferenceCountedSegmentProvider ref = ReferenceCountedSegmentProvider.wrapRootGenerationSegment(segment)) {
-      final SegmentDescriptor descriptor = new SegmentDescriptor(
-          segment.getDataInterval(),
-          segment.getId().getVersion(),
-          segment.getId().getPartitionNum()
-      );
-      Closer closer = Closer.create();
-      final SegmentReferenceAndDescriptor refAndDescriptor = SegmentReferenceAndDescriptor.acquireReference(
-          descriptor,
-          ref,
-          SegmentMapFunction.IDENTITY,
-          closer
-      );
-      Assertions.assertEquals(descriptor, refAndDescriptor.getDescriptor());
-      Assertions.assertNotNull(refAndDescriptor.getReference());
-      closer.close();
-    }
+    final ReferenceCountedSegmentProvider ref = ReferenceCountedSegmentProvider.wrapRootGenerationSegment(segment);
+    final SegmentDescriptor descriptor = new SegmentDescriptor(
+        segment.getDataInterval(),
+        segment.getId().getVersion(),
+        segment.getId().getPartitionNum()
+    );
+    Closer closer = Closer.create();
+    final SegmentReferenceAndDescriptor refAndDescriptor = SegmentReferenceAndDescriptor.acquireReference(
+        descriptor,
+        ref,
+        SegmentMapFunction.IDENTITY,
+        closer
+    );
+    Assertions.assertEquals(descriptor, refAndDescriptor.getDescriptor());
+    Assertions.assertNotNull(refAndDescriptor.getReference());
+    closer.close();
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/SegmentReferenceAndDescriptorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/SegmentReferenceAndDescriptorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query;
+
+import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.segment.QueryableIndexSegment;
+import org.apache.druid.segment.ReferenceCountedSegmentProvider;
+import org.apache.druid.segment.SegmentMapFunction;
+import org.apache.druid.segment.TestIndex;
+import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.timeline.SegmentId;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+class SegmentReferenceAndDescriptorTest extends InitializedNullHandlingTest
+{
+  @Test
+  public void testAcquireReference() throws IOException
+  {
+    final QueryableIndexSegment segment = new QueryableIndexSegment(
+        TestIndex.getMMappedTestIndex(), SegmentId.dummy("test")
+    );
+
+    try (ReferenceCountedSegmentProvider ref = ReferenceCountedSegmentProvider.wrapRootGenerationSegment(segment)) {
+      final SegmentDescriptor descriptor = new SegmentDescriptor(
+          segment.getDataInterval(),
+          segment.getId().getVersion(),
+          segment.getId().getPartitionNum()
+      );
+      Closer closer = Closer.create();
+      final SegmentReferenceAndDescriptor refAndDescriptor = SegmentReferenceAndDescriptor.acquireReference(
+          descriptor,
+          ref,
+          SegmentMapFunction.IDENTITY,
+          closer
+      );
+      Assertions.assertEquals(descriptor, refAndDescriptor.getDescriptor());
+      Assertions.assertNotNull(refAndDescriptor.getReference());
+      closer.close();
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/SegmentReferenceAndDescriptorTest.java
+++ b/processing/src/test/java/org/apache/druid/query/SegmentReferenceAndDescriptorTest.java
@@ -21,9 +21,7 @@ package org.apache.druid.query;
 
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.segment.QueryableIndexSegment;
-import org.apache.druid.segment.ReferenceCountedObjectProvider;
 import org.apache.druid.segment.ReferenceCountedSegmentProvider;
-import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.SegmentMapFunction;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;


### PR DESCRIPTION
### Description
Splits out and renames internal class `ServerManager.SegmentReference` into `SegmentReferenceAndDescriptor` and moves it into druid-processing.
