### PR TITLE
Forbid usage of asEagerSingleton in Guice bindings

### DIFF
--- a/codestyle/druid-forbidden-apis.txt
+++ b/codestyle/druid-forbidden-apis.txt
@@ -26,6 +26,7 @@ com.google.common.collect.Sets#newTreeSet() @ Create java.util.TreeSet directly
 com.google.common.collect.Sets#newTreeSet(java.util.Comparator) @ Create java.util.TreeSet directly
 com.google.common.io.Files#createTempDir() @ Use org.apache.druid.java.util.common.FileUtils.createTempDir()
 com.google.common.io.Files#write(java.lang.CharSequence, java.io.File, java.nio.charset.Charset) @ Use com.google.common.io.Files.asCharSink(to, charset).write(from) instead.
+com.google.inject.binder.ScopedBindingBuilder#asEagerSingleton() @ Never use eager singletons with Guice. Use LifecycleModule.register() if a dependency needs to be registered to the lifecycle.
 java.io.File#mkdirs() @ Use org.apache.druid.java.util.common.FileUtils.mkdirp instead
 java.io.File#toURL() @ Use java.io.File#toURI() and java.net.URI#toURL() instead
 java.lang.String#matches(java.lang.String) @ Use startsWith(), endsWith(), contains(), or compile and cache a Pattern explicitly

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -24,15 +24,14 @@ import com.google.common.collect.Iterables;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.Key;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import com.google.inject.name.Names;
 import io.timeandspace.cronscheduler.CronScheduler;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.DruidBinders;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.java.util.common.IAE;
@@ -95,10 +94,7 @@ public class MetricsModule implements Module
 
     binder.bind(ExecutorServiceMonitor.class).in(LazySingleton.class);
 
-    // Instantiate eagerly so that we get everything registered and put into the Lifecycle
-    binder.bind(Key.get(MonitorScheduler.class, Names.named("ForTheEagerness")))
-          .to(MonitorScheduler.class)
-          .asEagerSingleton();
+    LifecycleModule.register(binder, MonitorScheduler.class);
   }
 
   @Provides


### PR DESCRIPTION
### Description

Using `asEagerSingleton` is not advisable as it can cause several problems like:
- forces early instantiation even if the instance does not end up getting used
- no guaranteed creation order which can lead circular dependency or partial initialization bugs
- can lead to poor lifecycle management

We already have a `LifecycleModule.register` that should be used instead.

### Sample run before fixing the existing usages of the forbidden API

```java
[INFO] Scanning classes for violations...
[ERROR] Forbidden method invocation: com.google.inject.binder.ScopedBindingBuilder#asEagerSingleton() [Never use eager singletons with Guice. Use LifecycleModule.register() if a dependency needs to be registered to the lifecycle.]
[ERROR]   in org.apache.druid.initialization.Log4jShutterDownerModule (Log4jShutterDownerModule.java:79)
[ERROR] Forbidden method invocation: com.google.inject.binder.ScopedBindingBuilder#asEagerSingleton() [Never use eager singletons with Guice. Use LifecycleModule.register() if a dependency needs to be registered to the lifecycle.]
[ERROR]   in org.apache.druid.server.metrics.MetricsModule (MetricsModule.java:101)
[ERROR] Scanned 1296 class file(s) for forbidden API invocations (in 0.44s), 2 error(s).
```

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
