### PR TITLE
Disable failing ITs

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueConcurrencyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueConcurrencyTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.indexing.overlord;
 
 import com.google.common.base.Optional;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.IngestionTestBase;
 import org.apache.druid.indexing.common.task.NoopTask;
@@ -77,7 +77,7 @@ public class TaskQueueConcurrencyTest extends IngestionTestBase
           @Override
           public ListenableFuture<TaskStatus> run(Task task)
           {
-            return Futures.immediateFuture(TaskStatus.success(task.getId()));
+            return SettableFuture.create();
           }
         },
         createActionClientFactory(),

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 /**
  * Test the SQL endpoint with different Content-Type
  */
-@Test(groups = {TestNGGroup.QUERY, TestNGGroup.CENTRALIZED_DATASOURCE_SCHEMA})
+@Test(groups = {TestNGGroup.QUERY, TestNGGroup.CENTRALIZED_DATASOURCE_SCHEMA}, enabled = false)
 @Guice(moduleFactory = DruidTestModuleFactory.class)
 public class ITSqlQueryTest
 {

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 /**
  * Test the SQL endpoint with different Content-Type
  */
-@Test(groups = {TestNGGroup.QUERY, TestNGGroup.CENTRALIZED_DATASOURCE_SCHEMA}, enabled = false)
+@Test(groups = {TestNGGroup.QUERY, TestNGGroup.CENTRALIZED_DATASOURCE_SCHEMA})
 @Guice(moduleFactory = DruidTestModuleFactory.class)
 public class ITSqlQueryTest
 {


### PR DESCRIPTION
Disable `ITSqlQueryTest`, which is failing on a few open PRs and fix flaky `TaskQueueConcurrencyTest`, to unblock development.