### PR TITLE
Fix IT failure

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -418,14 +418,6 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.testing.utils.ITRetryUtil;
 import org.apache.druid.tests.TestNGGroup;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.testng.Assert;
 import org.testng.annotations.Guice;
 import org.testng.annotations.Test;
 
@@ -109,8 +110,7 @@ public class ITSqlQueryTest
 
       StatusResponseHolder response = httpClient.go(request, StatusResponseHandler.getInstance())
                                                 .get();
-
-      assertNotNull(response);
+      Assert.assertNotNull(response);
 
       onResponse.on(
           response.getStatus().getCode(),
@@ -121,29 +121,8 @@ public class ITSqlQueryTest
     // Send query to broker to exeucte
     executeWithRetry(StringUtils.format("%s/druid/v2/sql/", config.getBrokerUrl()), contentType, executable);
 
-    // Send a query to router to execute
+    // Send query to router to execute
     executeWithRetry(StringUtils.format("%s/druid/v2/sql/", config.getRouterUrl()), contentType, executable);
-  }
-
-  private void assertEquals(String expected, String actual)
-  {
-    if (!expected.equals(actual)) {
-      throw new ISE("Expected [%s] but got [%s]", expected, actual);
-    }
-  }
-
-  private void assertEquals(int expected, int actual, String message)
-  {
-    if (expected != actual) {
-      throw new ISE("Expected [%d] but got [%d]: %s", expected, actual, message);
-    }
-  }
-
-  private void assertNotNull(Object object)
-  {
-    if (object == null) {
-      throw new ISE("Expected not null");
-    }
   }
 
   private void assertStringCompare(String expected, String actual, Function<String, Boolean> predicate)
@@ -162,7 +141,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE.getCode(), statusCode, responseBody);
+          Assert.assertEquals(statusCode, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE.getCode(), responseBody);
           assertStringCompare("Unsupported Content-Type:", responseBody, responseBody::contains);
         }
     );
@@ -177,7 +156,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE.getCode(), statusCode, responseBody);
+          Assert.assertEquals(statusCode, HttpResponseStatus.UNSUPPORTED_MEDIA_TYPE.getCode(), responseBody);
           assertStringCompare("Unsupported Content-Type:", responseBody, responseBody::contains);
         }
     );
@@ -192,8 +171,8 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(200, statusCode, responseBody);
-          assertEquals("[{\"EXPR$0\":1}]", responseBody);
+          Assert.assertEquals(statusCode, 200, responseBody);
+          Assert.assertEquals(responseBody, "[{\"EXPR$0\":1}]");
         }
     );
   }
@@ -207,8 +186,8 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(200, statusCode, responseBody);
-          assertEquals("[{\"EXPR$0\":\"x % y\"}]", responseBody);
+          Assert.assertEquals(statusCode, 200, responseBody);
+          Assert.assertEquals(responseBody, "[{\"EXPR$0\":\"x % y\"}]");
         }
     );
   }
@@ -222,7 +201,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(400, statusCode, responseBody);
+          Assert.assertEquals(statusCode, 400, responseBody);
           assertStringCompare("Unable to decode", responseBody, responseBody::contains);
         }
     );
@@ -237,8 +216,8 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(200, statusCode, responseBody);
-          assertEquals("[{\"EXPR$0\":567}]", responseBody);
+          Assert.assertEquals(statusCode, 200, responseBody);
+          Assert.assertEquals(responseBody, "[{\"EXPR$0\":567}]");
         }
     );
   }
@@ -252,7 +231,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(400, statusCode, responseBody);
+          Assert.assertEquals(statusCode, 400, responseBody);
           assertStringCompare("Malformed SQL query", responseBody, responseBody::contains);
         }
     );
@@ -267,7 +246,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(400, statusCode, responseBody);
+          Assert.assertEquals(statusCode, 400, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -282,7 +261,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(400, statusCode, responseBody);
+          Assert.assertEquals(statusCode, 400, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -297,7 +276,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(400, statusCode, responseBody);
+          Assert.assertEquals(statusCode, 400, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -312,7 +291,7 @@ public class ITSqlQueryTest
         (request) -> {
         },
         (statusCode, responseBody) -> {
-          assertEquals(400, statusCode, responseBody);
+          Assert.assertEquals(statusCode, 400, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -332,8 +311,8 @@ public class ITSqlQueryTest
           request.addHeader("Content-Type", MediaType.APPLICATION_JSON);
         },
         (statusCode, responseBody) -> {
-          assertEquals(200, statusCode, responseBody);
-          assertEquals("[{\"EXPR$0\":1}]", responseBody);
+          Assert.assertEquals(statusCode, 200, responseBody);
+          Assert.assertEquals(responseBody, "[{\"EXPR$0\":1}]");
         }
     );
   }

--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 /**
  * Test the SQL endpoint with different Content-Type
  */
-@Test(groups = {TestNGGroup.QUERY, TestNGGroup.CENTRALIZED_DATASOURCE_SCHEMA})
+@Test(groups = {TestNGGroup.QUERY})
 @Guice(moduleFactory = DruidTestModuleFactory.class)
 public class ITSqlQueryTest
 {
@@ -133,10 +133,10 @@ public class ITSqlQueryTest
     }
   }
 
-  private void assertEquals(int expected, int actual)
+  private void assertEquals(int expected, int actual, String message)
   {
     if (expected != actual) {
-      throw new ISE("Expected [%d] but got [%d]", expected, actual);
+      throw new ISE("Expected [%d] but got [%d]: %s", expected, actual, message);
     }
   }
 
@@ -159,13 +159,11 @@ public class ITSqlQueryTest
   {
     executeQuery(
         null,
-        (request) -> {
-          request.setEntity(new StringEntity("select 1"));
-        },
+        (request) -> request.setEntity(new StringEntity("select 1")),
         (statusCode, responseEntity) -> {
-          assertEquals(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, statusCode, responseBody);
           assertStringCompare("Unsupported Content-Type:", responseBody, responseBody::contains);
         }
     );
@@ -176,13 +174,11 @@ public class ITSqlQueryTest
   {
     executeQuery(
         "application/xml",
-        (request) -> {
-          request.setEntity(new StringEntity("select 1"));
-        },
+        (request) -> request.setEntity(new StringEntity("select 1")),
         (statusCode, responseEntity) -> {
-          assertEquals(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, statusCode, responseBody);
           assertStringCompare("Unsupported Content-Type:", responseBody, responseBody::contains);
         }
     );
@@ -193,13 +189,11 @@ public class ITSqlQueryTest
   {
     executeQuery(
         MediaType.TEXT_PLAIN,
-        (request) -> {
-          request.setEntity(new StringEntity("select \n1"));
-        },
+        (request) -> request.setEntity(new StringEntity("select \n1")),
         (statusCode, responseEntity) -> {
-          assertEquals(200, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(200, statusCode, responseBody);
           assertEquals("[{\"EXPR$0\":1}]", responseBody);
         }
     );
@@ -210,13 +204,11 @@ public class ITSqlQueryTest
   {
     executeQuery(
         MediaType.APPLICATION_FORM_URLENCODED,
-        (request) -> {
-          request.setEntity(new StringEntity(URLEncoder.encode("select 'x % y'", StandardCharsets.UTF_8)));
-        },
+        (request) -> request.setEntity(new StringEntity(URLEncoder.encode("select 'x % y'", StandardCharsets.UTF_8))),
         (statusCode, responseEntity) -> {
-          assertEquals(200, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(200, statusCode, responseBody);
           assertEquals("[{\"EXPR$0\":\"x % y\"}]", responseBody);
         }
     );
@@ -227,13 +219,11 @@ public class ITSqlQueryTest
   {
     executeQuery(
         MediaType.APPLICATION_FORM_URLENCODED,
-        (request) -> {
-          request.setEntity(new StringEntity("select 'x % y'"));
-        },
+        (request) -> request.setEntity(new StringEntity("select 'x % y'")),
         (statusCode, responseEntity) -> {
-          assertEquals(400, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(400, statusCode, responseBody);
           assertStringCompare("Unable to decoded", responseBody, responseBody::contains);
         }
     );
@@ -244,13 +234,11 @@ public class ITSqlQueryTest
   {
     executeQuery(
         MediaType.APPLICATION_JSON,
-        (request) -> {
-          request.setEntity(new StringEntity(StringUtils.format("{\"query\":\"select 567\"}")));
-        },
+        (request) -> request.setEntity(new StringEntity(StringUtils.format("{\"query\":\"select 567\"}"))),
         (statusCode, responseEntity) -> {
-          assertEquals(200, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(200, statusCode, responseBody);
           assertEquals("[{\"EXPR$0\":567}]", responseBody);
         }
     );
@@ -261,13 +249,11 @@ public class ITSqlQueryTest
   {
     executeQuery(
         MediaType.APPLICATION_JSON,
-        (request) -> {
-          request.setEntity(new StringEntity(StringUtils.format("{\"query\":select 567}")));
-        },
+        (request) -> request.setEntity(new StringEntity(StringUtils.format("{\"query\":select 567}"))),
         (statusCode, responseEntity) -> {
-          assertEquals(400, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(400, statusCode, responseBody);
           assertStringCompare("Malformed SQL query", responseBody, responseBody::contains);
         }
     );
@@ -282,9 +268,9 @@ public class ITSqlQueryTest
           // Empty query, DO NOTHING
         },
         (statusCode, responseEntity) -> {
-          assertEquals(400, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(400, statusCode, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -299,9 +285,9 @@ public class ITSqlQueryTest
           // Empty query, DO NOTHING
         },
         (statusCode, responseEntity) -> {
-          assertEquals(400, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(400, statusCode, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -313,13 +299,13 @@ public class ITSqlQueryTest
     executeQuery(
         MediaType.TEXT_PLAIN,
         (request) -> {
-          // an query with blank characters
+          // a query with blank characters
           request.setEntity(new StringEntity("     "));
         },
         (statusCode, responseEntity) -> {
-          assertEquals(400, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(400, statusCode, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -334,9 +320,9 @@ public class ITSqlQueryTest
           // Empty query, DO NOTHING
         },
         (statusCode, responseEntity) -> {
-          assertEquals(400, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(400, statusCode, responseBody);
           assertStringCompare("Empty query", responseBody, responseBody::contains);
         }
     );
@@ -356,9 +342,9 @@ public class ITSqlQueryTest
           request.setEntity(new StringEntity(StringUtils.format("SELECT 1")));
         },
         (statusCode, responseEntity) -> {
-          assertEquals(200, statusCode);
-
           String responseBody = EntityUtils.toString(responseEntity).trim();
+
+          assertEquals(200, statusCode, responseBody);
           assertEquals("[{\"EXPR$0\":1}]", responseBody);
         }
     );

--- a/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
+++ b/services/src/main/java/org/apache/druid/server/AsyncQueryForwardingServlet.java
@@ -21,6 +21,7 @@ package org.apache.druid.server;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.jaxrs.smile.SmileMediaTypes;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -484,7 +485,7 @@ public class AsyncQueryForwardingServlet extends AsyncProxyServlet implements Qu
       byte[] bytes = objectMapper.writeValueAsBytes(content);
       proxyRequest.content(new BytesContentProvider(bytes));
       proxyRequest.getHeaders().put(HttpHeader.CONTENT_LENGTH, String.valueOf(bytes.length));
-      proxyRequest.getHeaders().put(HttpHeader.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+      proxyRequest.getHeaders().put(HttpHeader.CONTENT_TYPE, objectMapper.getFactory() instanceof SmileFactory ? SmileMediaTypes.APPLICATION_JACKSON_SMILE : MediaType.APPLICATION_JSON);
     }
     catch (JsonProcessingException e) {
       throw new RuntimeException(e);

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -308,7 +308,7 @@ public class SqlQuery
         catch (IllegalArgumentException e) {
           throw new HttpException(
               Response.Status.BAD_REQUEST,
-              "Unable to decoded URL-Encoded SQL query: " + e.getMessage()
+              "Unable to decode URL-Encoded SQL query: " + e.getMessage()
           );
         }
 


### PR DESCRIPTION
Fixes the IT failure caused by #17937

Using the TestHttpClient as a standard way to issue http in IT.

I have ran the test cases by using the command `mvn verify -P integration-tests -pl integration-tests -P int-tests-config-file -Ddocker.build.skip=true -Ddocker.run.skip=true -Dit.test=ITSqlQueryTest` against docker containers under the integration test, so I think the problem should be resolved.
