### PR TITLE
Web console: adjust to work with the latest dart iteration 

### DIFF
--- a/web-console/src/druid-models/dart/dart-query-entry.mock.ts
+++ b/web-console/src/druid-models/dart/dart-query-entry.mock.ts
@@ -20,6 +20,7 @@ import type { DartQueryEntry } from './dart-query-entry';
 
 export const DART_QUERIES: DartQueryEntry[] = [
   {
+    engine: 'msq-dart',
     sqlQueryId: '77b2344c-0a1f-4aa0-b127-de6fbc0c2b57',
     dartQueryId: '99cdba0d-ed77-433d-9adc-0562d816e105',
     sql: 'SELECT\n  "URL",\n  COUNT(*)\nFROM "c"\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 50\n',
@@ -29,6 +30,7 @@ export const DART_QUERIES: DartQueryEntry[] = [
     state: 'RUNNING',
   },
   {
+    engine: 'msq-dart',
     sqlQueryId: '45441cf5-d8b7-46cb-b6d8-682334f056ef',
     dartQueryId: '25af9bff-004d-494e-b562-2752dc3779c8',
     sql: 'SELECT\n  "URL",\n  COUNT(*)\nFROM "c"\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 50\n',
@@ -38,6 +40,7 @@ export const DART_QUERIES: DartQueryEntry[] = [
     state: 'CANCELED',
   },
   {
+    engine: 'msq-dart',
     sqlQueryId: 'f7257c78-6bbe-439d-99ba-f4998b300770',
     dartQueryId: 'f7c2d644-9c40-4d61-9fdb-7b0e15219886',
     sql: 'SELECT\n  "URL",\n  COUNT(*)\nFROM "c"\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 50\n',

--- a/web-console/src/druid-models/dart/dart-query-entry.ts
+++ b/web-console/src/druid-models/dart/dart-query-entry.ts
@@ -17,6 +17,7 @@
  */
 
 export interface DartQueryEntry {
+  engine: 'msq-dart';
   sqlQueryId: string;
   dartQueryId: string;
   sql: string;

--- a/web-console/src/druid-models/workbench-query/workbench-query.ts
+++ b/web-console/src/druid-models/workbench-query/workbench-query.ts
@@ -566,6 +566,7 @@ export class WorkbenchQuery {
     }
 
     if (engine === 'sql-msq-dart') {
+      apiQuery.context.engine = 'msq-dart';
       apiQuery.context.fullReport ??= true;
     }
 

--- a/web-console/src/helpers/capabilities.ts
+++ b/web-console/src/helpers/capabilities.ts
@@ -143,8 +143,11 @@ export class Capabilities {
 
   static async detectMultiStageQueryDart(): Promise<boolean> {
     try {
-      const resp = await Api.instance.get(`/druid/v2/sql/dart/enabled?capabilities`);
-      return Boolean(resp.data.enabled);
+      const resp = (await Api.instance.get(`/druid/v2/sql/engines?capabilities`)).data;
+      return (
+        Array.isArray(resp.engines) &&
+        resp.engines.some(({ name }: { name: string }) => name === 'msq-dart')
+      );
     } catch {
       return false;
     }

--- a/web-console/src/utils/druid-query.ts
+++ b/web-console/src/utils/druid-query.ts
@@ -348,19 +348,6 @@ export async function queryDruidSql<T = any>(
   return sqlResultResp.data;
 }
 
-export async function queryDruidSqlDart<T = any>(
-  sqlQueryPayload: Record<string, any>,
-  cancelToken?: CancelToken,
-): Promise<T[]> {
-  let sqlResultResp: AxiosResponse;
-  try {
-    sqlResultResp = await Api.instance.post('/druid/v2/sql/dart', sqlQueryPayload, { cancelToken });
-  } catch (e) {
-    throw new Error(getDruidErrorMessage(e));
-  }
-  return sqlResultResp.data;
-}
-
 export async function getApiArray<T = any>(url: string, cancelToken?: CancelToken): Promise<T[]> {
   const result = (await Api.instance.get(url, { cancelToken })).data;
   if (!Array.isArray(result)) throw new Error('unexpected result');

--- a/web-console/src/views/workbench-view/current-dart-panel/current-dart-panel.tsx
+++ b/web-console/src/views/workbench-view/current-dart-panel/current-dart-panel.tsx
@@ -62,7 +62,10 @@ export const CurrentDartPanel = React.memo(function CurrentViberPanel(
   const [dartQueryEntriesState, queryManager] = useQueryManager<number, DartQueryEntry[]>({
     query: useStore(WORK_STATE_STORE, getMsqDartVersion),
     processQuery: async (_, cancelToken) => {
-      return (await Api.instance.get('/druid/v2/sql/dart', { cancelToken })).data.queries;
+      return (
+        (await Api.instance.get('/druid/v2/sql/queries', { cancelToken })).data
+          .queries as DartQueryEntry[]
+      ).filter(q => q.engine === 'msq-dart');
     },
   });
 
@@ -167,7 +170,7 @@ export const CurrentDartPanel = React.memo(function CurrentViberPanel(
           onCancel={async () => {
             if (!confirmCancelId) return;
             try {
-              await Api.instance.delete(`/druid/v2/sql/dart/${Api.encodePath(confirmCancelId)}`);
+              await Api.instance.delete(`/druid/v2/sql/${Api.encodePath(confirmCancelId)}`);
 
               AppToaster.show({
                 message: 'Query canceled',

--- a/web-console/src/views/workbench-view/explain-dialog/explain-dialog.tsx
+++ b/web-console/src/views/workbench-view/explain-dialog/explain-dialog.tsx
@@ -45,7 +45,6 @@ import {
   getDruidErrorMessage,
   nonEmptyArray,
   queryDruidSql,
-  queryDruidSqlDart,
   wrapInExplainIfNeeded,
 } from '../../../utils';
 
@@ -91,6 +90,7 @@ export const ExplainDialog = React.memo(function ExplainDialog(props: ExplainDia
       let result: any[];
       switch (engine) {
         case 'sql-native':
+        case 'sql-msq-dart':
           result = await queryDruidSql(payload, cancelToken);
           break;
 
@@ -100,10 +100,6 @@ export const ExplainDialog = React.memo(function ExplainDialog(props: ExplainDia
           } catch (e) {
             throw new Error(getDruidErrorMessage(e));
           }
-          break;
-
-        case 'sql-msq-dart':
-          result = await queryDruidSqlDart(payload, cancelToken);
           break;
 
         default:

--- a/web-console/src/views/workbench-view/query-tab/query-tab.tsx
+++ b/web-console/src/views/workbench-view/query-tab/query-tab.tsx
@@ -278,7 +278,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
               void cancelToken.promise
                 .then(cancel => {
                   if (cancel.message === QueryManager.TERMINATION_MESSAGE) return;
-                  return Api.instance.delete(`/druid/v2/sql/dart/${Api.encodePath(cancelQueryId)}`);
+                  return Api.instance.delete(`/druid/v2/sql/${Api.encodePath(cancelQueryId)}`);
                 })
                 .catch(() => {});
             }
@@ -286,7 +286,7 @@ export const QueryTab = React.memo(function QueryTab(props: QueryTabProps) {
             onQueryChange(props.query.changeLastExecution(undefined));
 
             const executionPromise = Api.instance
-              .post(`/druid/v2/sql/dart`, query, {
+              .post(`/druid/v2/sql`, query, {
                 cancelToken: new axios.CancelToken(cancelFn => {
                   nativeQueryCancelFnRef.current = cancelFn;
                 }),


### PR DESCRIPTION
This is the web console followup to: https://github.com/apache/druid/pull/18003

Does not change anything, just makes Dart from the console work again.