### PR TITLE
DruidQuidemTestBase: Fix handling of comma-separated filters.

### DIFF
--- a/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
+++ b/sql/src/test/java/org/apache/druid/quidem/DruidQuidemTestBase.java
@@ -126,7 +126,7 @@ public abstract class DruidQuidemTestBase
     for (String filter : filterStr.split(",")) {
 
       if (!filter.endsWith("*") && !filter.endsWith(IQ_SUFFIX)) {
-        filter = filterStr + IQ_SUFFIX;
+        filter = filter + IQ_SUFFIX;
       }
       fileFilters.add(new WildcardFileFilter(filter));
     }


### PR DESCRIPTION
The `IQ_SUFFIX` should be added to "filter", not the unsplit "filterStr".