### PR TITLE
WIP: Add sys.query_setting system table

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQCompactionRunner.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQCompactionRunner.java
@@ -665,7 +665,7 @@ public class MSQCompactionRunner implements CompactionRunner
     // Used for writing the data schema during segment generation phase.
     context.putIfAbsent(MultiStageQueryContext.CTX_FINALIZE_AGGREGATIONS, false);
     // Add appropriate finalization to native query context i.e. for the GroupBy query
-    context.putIfAbsent(QueryContexts.FINALIZE_KEY, false);
+    context.putIfAbsent(QueryContexts.FINALIZE_KEY.name(), false);
     // Only scalar or array-type dimensions are allowed as grouping keys.
     context.putIfAbsent(GroupByQueryConfig.CTX_KEY_ENABLE_MULTI_VALUE_UNNESTING, false);
     // Always override CTX_ARRAY_INGEST_MODE since it can otherwise lead to mixed ARRAY and MVD types for a column.

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
@@ -261,7 +261,7 @@ public class MSQTaskQueryMaker implements QueryMaker
 
     // Add appropriate finalization to native query context.
     final boolean finalizeAggregations = MultiStageQueryContext.isFinalizeAggregations(sqlQueryContext);
-    nativeQueryContextOverrides.put(QueryContexts.FINALIZE_KEY, finalizeAggregations);
+    nativeQueryContextOverrides.put(QueryContexts.FINALIZE_KEY.name(), finalizeAggregations);
 
     // This flag is to ensure backward compatibility, as brokers are upgraded after indexers/middlemanagers.
     nativeQueryContextOverrides.put(MultiStageQueryContext.WINDOW_FUNCTION_OPERATOR_TRANSFORMATION, true);

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -271,7 +271,7 @@ public class MSQTestBase extends BaseCalciteQueryTest
   public static final Map<String, Object> DEFAULT_MSQ_CONTEXT =
       ImmutableMap.<String, Object>builder()
                   .put(QueryContexts.CTX_SQL_QUERY_ID, "test-query")
-                  .put(QueryContexts.FINALIZE_KEY, true)
+                  .put(QueryContexts.FINALIZE_KEY.name(), true)
                   .put(QueryContexts.CTX_SQL_STRINGIFY_ARRAYS, false)
                   .put(MultiStageQueryContext.CTX_MAX_NUM_TASKS, 2)
                   .put(MSQWarnings.CTX_MAX_PARSE_EXCEPTIONS_ALLOWED, 0)

--- a/processing/src/main/java/org/apache/druid/query/FinalizeResultsQueryRunner.java
+++ b/processing/src/main/java/org/apache/druid/query/FinalizeResultsQueryRunner.java
@@ -67,7 +67,7 @@ public class FinalizeResultsQueryRunner<T> implements QueryRunner<T>
     final MetricManipulationFn metricManipulationFn;
 
     if (shouldFinalize) {
-      queryToRun = query.withOverriddenContext(ImmutableMap.of(QueryContexts.FINALIZE_KEY, false));
+      queryToRun = query.withOverriddenContext(ImmutableMap.of(QueryContexts.FINALIZE_KEY.name(), false));
       metricManipulationFn = MetricManipulatorFns.finalizing();
     } else {
       queryToRun = query;

--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -309,7 +309,7 @@ public class QueryContext
   public boolean isFinalize(boolean defaultValue)
 
   {
-    return getBoolean(QueryContexts.FINALIZE_KEY, defaultValue);
+    return getBoolean(QueryContexts.FINALIZE_KEY.name(), defaultValue);
   }
 
   public boolean isSerializeDateTimeAsLong(boolean defaultValue)

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupingEngine.java
@@ -222,7 +222,7 @@ public class GroupingEngine
   {
     // Set up downstream context.
     final ImmutableMap.Builder<String, Object> context = ImmutableMap.builder();
-    context.put(QueryContexts.FINALIZE_KEY, false);
+    context.put(QueryContexts.FINALIZE_KEY.name(), false);
     context.put(CTX_KEY_OUTERMOST, false);
 
     Granularity granularity = query.getGranularity();

--- a/processing/src/main/java/org/apache/druid/setting/BooleanSettingEntry.java
+++ b/processing/src/main/java/org/apache/druid/setting/BooleanSettingEntry.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.druid.setting;
+
+
+import org.apache.druid.query.QueryContext;
+import org.apache.druid.query.QueryContexts;
+
+import java.sql.Types;
+
+public class BooleanSettingEntry extends SettingEntry<Boolean>
+{
+  private BooleanSettingEntry(Builder builder)
+  {
+    super(builder);
+  }
+
+  @Override
+  public Boolean from(QueryContext context)
+  {
+    return QueryContexts.getAsBoolean(name, context.get(name), defaultValue);
+  }
+
+  @Override
+  public Boolean from(QueryContext context, Boolean defaultValue)
+  {
+    return QueryContexts.getAsBoolean(name, context.get(name), defaultValue);
+  }
+
+  @Override
+  public Boolean parse(Object value)
+  {
+    return QueryContexts.getAsBoolean(name, value);
+  }
+
+  public static class Builder extends AbstractBuilder<Boolean>
+  {
+    public Builder()
+    {
+      super(Boolean.class);
+      this.defaultValue = false;
+    }
+
+    @Override
+    public BooleanSettingEntry build()
+    {
+      return new BooleanSettingEntry(this);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/setting/IntegerSettingEntry.java
+++ b/processing/src/main/java/org/apache/druid/setting/IntegerSettingEntry.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.setting;
+
+
+import org.apache.druid.query.QueryContext;
+import org.apache.druid.query.QueryContexts;
+
+public class IntegerSettingEntry extends SettingEntry<Integer>
+{
+  private IntegerSettingEntry(Builder builder)
+  {
+    super(builder);
+  }
+
+  @Override
+  public Integer from(QueryContext context)
+  {
+    return QueryContexts.getAsInt(name, context.get(name), defaultValue);
+  }
+
+  @Override
+  public Integer from(QueryContext context, Integer defaultValue)
+  {
+    return QueryContexts.getAsInt(name, context.get(name), defaultValue);
+  }
+
+  @Override
+  public Integer parse(Object value)
+  {
+    return QueryContexts.getAsInt(name, value);
+  }
+
+  public static class Builder extends AbstractBuilder<Integer>
+  {
+    public Builder()
+    {
+      super(Integer.class);
+      this.defaultValue = 0;
+    }
+
+    @Override
+    public IntegerSettingEntry build()
+    {
+      return new IntegerSettingEntry(this);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/setting/QuerySettingRegistry.java
+++ b/processing/src/main/java/org/apache/druid/setting/QuerySettingRegistry.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.setting;
+
+
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.InvalidInput;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Registry for query settings that can be used to configure query behavior via {@link org.apache.druid.query.QueryContext}.
+ */
+public class QuerySettingRegistry
+{
+  private final Map<String, SettingEntry<?>> settings = new TreeMap<>();
+
+  private QuerySettingRegistry()
+  {
+    // Prevent instantiation
+  }
+
+  public Collection<SettingEntry<?>> getSettings()
+  {
+    return settings.values();
+  }
+
+  private static final QuerySettingRegistry INSTANCE = new QuerySettingRegistry();
+
+  public static <T> SettingEntry<T> register(SettingEntry<T> setting)
+  {
+    if (INSTANCE.settings.put(setting.name(), setting) != null) {
+      throw new IllegalArgumentException("Setting with name [" + setting.name() + "] already exists.");
+    }
+    return setting;
+  }
+
+  public static QuerySettingRegistry getInstance()
+  {
+    return INSTANCE;
+  }
+
+  /**
+   * Validates if the setting name is acceptable and parses the value according to the setting's type.
+   * <p>
+   * If the setting does not exist, {@link DruidException} is thrown.
+   * If the value is not compatible with the setting's type or the value format is illegal, {@link org.apache.druid.query.BadQueryContextException} is thrown.
+   *
+   * @return the parsed value of the setting
+   */
+  public Object validateAndParse(String name, Object val)
+  {
+    SettingEntry<?> entry = this.settings.get(name);
+    if (entry == null ) {
+      throw InvalidInput.exception("Setting with name [%s] does not exist.", name);
+    }
+    return entry.parse(val);
+  }
+}

--- a/processing/src/main/java/org/apache/druid/setting/SettingEntry.java
+++ b/processing/src/main/java/org/apache/druid/setting/SettingEntry.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.druid.setting;
+
+
+import org.apache.druid.query.QueryContext;
+
+import java.util.Locale;
+
+public abstract class SettingEntry<T>
+{
+  protected String name;
+  protected String type;
+  protected T defaultValue;
+  protected boolean deprecated;
+  protected String description;
+
+  protected SettingEntry(AbstractBuilder<T> builder)
+  {
+    this.name = builder.name;
+    this.type = builder.type;
+    this.defaultValue = builder.defaultValue;
+    this.deprecated = builder.deprecated;
+    this.description = builder.description;
+  }
+
+  public String name()
+  {
+    return name;
+  }
+
+  public String type()
+  {
+    return type;
+  }
+
+  public T defaultValue()
+  {
+    return defaultValue;
+  }
+
+  public boolean deprecated()
+  {
+    return deprecated;
+  }
+
+  public String description()
+  {
+    return description;
+  }
+
+  public abstract T from(QueryContext context);
+
+  public abstract T from(QueryContext context, T defaultValue);
+
+  /**
+   * Validate if the given value is valid for this setting.
+   */
+  public abstract T parse(Object value);
+
+  public static abstract class AbstractBuilder<T>
+  {
+    protected final String type;
+    protected String name;
+    protected T defaultValue;
+    protected boolean deprecated;
+    protected String description;
+
+    protected AbstractBuilder(Class<T> clazz)
+    {
+      this.type = clazz.getSimpleName().toLowerCase(Locale.ENGLISH);
+    }
+
+    public AbstractBuilder<T> name(String name)
+    {
+      this.name = name;
+      return this;
+    }
+
+    public AbstractBuilder<T> defaultValue(T defaultValue)
+    {
+      this.defaultValue = defaultValue;
+      return this;
+    }
+
+    public AbstractBuilder<T> deprecated(boolean deprecated)
+    {
+      this.deprecated = deprecated;
+      return this;
+    }
+
+    public AbstractBuilder<T> description(String description)
+    {
+      this.description = description;
+      return this;
+    }
+
+    public abstract SettingEntry<T> build();
+  }
+
+  public static IntegerSettingEntry.Builder newIntegerBuilder()
+  {
+    return new IntegerSettingEntry.Builder();
+  }
+
+  public static BooleanSettingEntry.Builder newBooleanBuilder()
+  {
+    return new BooleanSettingEntry.Builder();
+  }
+
+  public static FloatSettingEntry.Builder newFloatBuilder()
+  {
+    return new FloatSettingEntry.Builder();
+  }
+
+  public static LongSettingEntry.Builder newLongBuilder()
+  {
+    return new LongSettingEntry.Builder();
+  }
+
+  public static StringSettingEntry.Builder newStringBuilder()
+  {
+    return new StringSettingEntry.Builder();
+  }
+
+  public static ReadableNumberSetting.Builder newReadableNumberBuilder()
+  {
+    return new ReadableNumberSetting.Builder();
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/datasourcemetadata/DataSourceMetadataQueryTest.java
@@ -89,7 +89,7 @@ public class DataSourceMetadataQueryTest
                                                         true,
                                                         QueryContexts.POPULATE_CACHE_KEY,
                                                         "true",
-                                                        QueryContexts.FINALIZE_KEY,
+                                                        QueryContexts.FINALIZE_KEY.name(),
                                                         true
                                                     )
                                                 ).build();
@@ -110,10 +110,10 @@ public class DataSourceMetadataQueryTest
     Assert.assertEquals(1, (int) queryContext.getInt(QueryContexts.PRIORITY_KEY));
     Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.USE_CACHE_KEY));
     Assert.assertEquals("true", queryContext.getString(QueryContexts.POPULATE_CACHE_KEY));
-    Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.FINALIZE_KEY));
+    Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.FINALIZE_KEY.name()));
     Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.USE_CACHE_KEY, false));
     Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.POPULATE_CACHE_KEY, false));
-    Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.FINALIZE_KEY, false));
+    Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.FINALIZE_KEY.name(), false));
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/groupby/GroupByQueryRunnerTest.java
@@ -7595,7 +7595,7 @@ public class GroupByQueryRunnerTest extends InitializedNullHandlingTest
             new LongLastAggregatorFactory("innerlast", "index", null)
         )
         .setGranularity(QueryRunnerTestHelper.DAY_GRAN)
-        .overrideContext(ImmutableMap.of(QueryContexts.FINALIZE_KEY, true))
+        .overrideContext(ImmutableMap.of(QueryContexts.FINALIZE_KEY.name(), true))
         .build();
 
     GroupByQuery query = makeQueryBuilder()

--- a/processing/src/test/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryTest.java
@@ -62,7 +62,7 @@ public class TimeBoundaryQueryTest
                                                   true,
                                                   QueryContexts.POPULATE_CACHE_KEY,
                                                   true,
-                                                  QueryContexts.FINALIZE_KEY,
+                                                  QueryContexts.FINALIZE_KEY.name(),
                                                   true
                                               )
                                           ).build();
@@ -83,7 +83,7 @@ public class TimeBoundaryQueryTest
     Assert.assertEquals(1, (int) queryContext.getInt(QueryContexts.PRIORITY_KEY));
     Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.USE_CACHE_KEY));
     Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.POPULATE_CACHE_KEY));
-    Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.FINALIZE_KEY));
+    Assert.assertEquals(true, queryContext.getBoolean(QueryContexts.FINALIZE_KEY.name()));
   }
 
   @Test
@@ -100,7 +100,7 @@ public class TimeBoundaryQueryTest
                                                   "true",
                                                   QueryContexts.POPULATE_CACHE_KEY,
                                                   "true",
-                                                  QueryContexts.FINALIZE_KEY,
+                                                  QueryContexts.FINALIZE_KEY.name(),
                                                   "true"
                                               )
                                           ).build();
@@ -122,6 +122,6 @@ public class TimeBoundaryQueryTest
     Assert.assertEquals("1", queryContext.get(QueryContexts.PRIORITY_KEY));
     Assert.assertEquals("true", queryContext.get(QueryContexts.USE_CACHE_KEY));
     Assert.assertEquals("true", queryContext.get(QueryContexts.POPULATE_CACHE_KEY));
-    Assert.assertEquals("true", queryContext.get(QueryContexts.FINALIZE_KEY));
+    Assert.assertEquals("true", queryContext.get(QueryContexts.FINALIZE_KEY.name()));
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerTest.java
+++ b/processing/src/test/java/org/apache/druid/query/topn/TopNQueryRunnerTest.java
@@ -3665,7 +3665,7 @@ public class TopNQueryRunnerTest extends InitializedNullHandlingTest
             QueryRunnerTestHelper.ADD_ROWS_INDEX_CONSTANT,
             QueryRunnerTestHelper.DEPENDENT_POST_AGG
         )
-        .context(ImmutableMap.of(QueryContexts.FINALIZE_KEY, true, QueryContexts.BY_SEGMENT_KEY, true))
+        .context(ImmutableMap.of(QueryContexts.FINALIZE_KEY.name(), true, QueryContexts.BY_SEGMENT_KEY, true))
         .build();
     TopNResultValue topNResult = TopNResultValue.create(
         Arrays.<Map<String, Object>>asList(

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -170,7 +170,7 @@ import java.util.stream.IntStream;
 public class CachingClusteredClientTest
 {
   private static final ImmutableMap<String, Object> CONTEXT = ImmutableMap.of(
-      QueryContexts.FINALIZE_KEY, false
+      QueryContexts.FINALIZE_KEY.name(), false
   );
   private static final MultipleIntervalSegmentSpec SEG_SPEC = new MultipleIntervalSegmentSpec(ImmutableList.of());
   private static final String DATA_SOURCE = "test";

--- a/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
+++ b/server/src/test/java/org/apache/druid/server/ClientQuerySegmentWalkerTest.java
@@ -1769,7 +1769,7 @@ public class ClientQuerySegmentWalkerTest
       ImmutableMap.Builder<String, Object> contextBuilder = ImmutableMap.builder();
       contextBuilder.put(DirectDruidClient.QUERY_FAIL_TIME, 0L)
                     .put(QueryContexts.DEFAULT_TIMEOUT_KEY, 0L)
-                    .put(QueryContexts.FINALIZE_KEY, true)
+                    .put(QueryContexts.FINALIZE_KEY.name(), true)
                     .put(QueryContexts.MAX_SCATTER_GATHER_BYTES_KEY, 0L)
                     .put(GroupByQuery.CTX_KEY_SORT_BY_DIMS_FIRST, false)
                     .put(GroupByQueryConfig.CTX_KEY_ARRAY_RESULT_ROWS, true)

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/QuerySettingTable.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/QuerySettingTable.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.schema;
+
+
+import org.apache.calcite.DataContext;
+import org.apache.calcite.linq4j.DefaultEnumerable;
+import org.apache.calcite.linq4j.Enumerable;
+import org.apache.calcite.linq4j.Enumerator;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.ScannableTable;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.druid.setting.SettingEntry;
+import org.apache.druid.setting.QuerySettingRegistry;
+import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.segment.column.RowSignature;
+import org.apache.druid.sql.calcite.table.RowSignatures;
+
+import java.util.Iterator;
+
+public class QuerySettingTable extends AbstractTable implements ScannableTable
+{
+  static final String TABLE_NAME = "query_settings";
+
+  static final RowSignature ROW_SIGNATURE = RowSignature
+      .builder()
+      .add("name", ColumnType.STRING)
+      .add("type", ColumnType.STRING)
+      .add("default_value", ColumnType.STRING)
+      .add("deprecated", ColumnType.LONG)
+      .add("description", ColumnType.STRING)
+      .build();
+
+  @Override
+  public RelDataType getRowType(RelDataTypeFactory typeFactory)
+  {
+    return RowSignatures.toRelDataType(ROW_SIGNATURE, typeFactory);
+  }
+
+  @Override
+  public Enumerable<Object[]> scan(DataContext root)
+  {
+    return new DataEnumerable(QuerySettingRegistry.getInstance()
+                                                  .getSettings()
+                                                  .iterator());
+  }
+
+  static class DataEnumerable extends DefaultEnumerable<Object[]>
+  {
+    private final Iterator<SettingEntry<?>> it;
+
+    DataEnumerable(Iterator<SettingEntry<?>> settingIterator)
+    {
+      this.it = settingIterator;
+    }
+
+    @Override
+    public Iterator<Object[]> iterator()
+    {
+      throw new UnsupportedOperationException("Do not use iterator(), it cannot be closed.");
+    }
+
+    @Override
+    public Enumerator<Object[]> enumerator()
+    {
+      return new Enumerator<Object[]>()
+      {
+        @Override
+        public Object[] current()
+        {
+          final SettingEntry<?> task = it.next();
+          return new Object[]{
+              task.name(),
+              task.type(),
+              task.defaultValue() == null ? null : task.defaultValue().toString(),
+              task.deprecated() ? 1L : 0L,
+              task.description()
+          };
+        }
+
+        @Override
+        public boolean moveNext()
+        {
+          return it.hasNext();
+        }
+
+        @Override
+        public void reset()
+        {
+        }
+
+        @Override
+        public void close()
+        {
+        }
+      };
+    }
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -243,24 +243,20 @@ public class SystemSchema extends AbstractSchema
   )
   {
     Preconditions.checkNotNull(serverView, "serverView");
-    this.tableMap = ImmutableMap.of(
-        SEGMENTS_TABLE,
-        new SegmentsTable(druidSchema, metadataView, jsonMapper, authorizerMapper),
-        SERVERS_TABLE,
-        new ServersTable(
-            druidNodeDiscoveryProvider,
-            serverInventoryView,
-            authorizerMapper,
-            overlordClient,
-            coordinatorDruidLeaderClient
-        ),
-        SERVER_SEGMENTS_TABLE,
-        new ServerSegmentsTable(serverView, authorizerMapper),
-        TASKS_TABLE,
-        new TasksTable(overlordClient, authorizerMapper),
-        SUPERVISOR_TABLE,
-        new SupervisorsTable(overlordClient, authorizerMapper)
-    );
+    this.tableMap = ImmutableMap.<String, Table>builder()
+                                .put(SEGMENTS_TABLE, new SegmentsTable(druidSchema, metadataView, jsonMapper, authorizerMapper))
+                                .put(SERVERS_TABLE, new ServersTable(
+                                    druidNodeDiscoveryProvider,
+                                    serverInventoryView,
+                                    authorizerMapper,
+                                    overlordClient,
+                                    coordinatorDruidLeaderClient
+                                ))
+                                .put(SERVER_SEGMENTS_TABLE, new ServerSegmentsTable(serverView, authorizerMapper))
+                                .put(TASKS_TABLE, new TasksTable(overlordClient, authorizerMapper))
+                                .put(SUPERVISOR_TABLE, new SupervisorsTable(overlordClient, authorizerMapper))
+                                .put(QuerySettingTable.TABLE_NAME, new QuerySettingTable())
+                                .build();
   }
 
   @Override


### PR DESCRIPTION
A part of work mentioned in #17769

### Description

- Adds a `sys.query_setting` system table which holds all settings allowed to use in query context. By adding this table, the web console can get all name/default value/description for better code suggestion/completion for the newly added `SET` statement
- Add validation to planner for the `SET` statement to check if the given parameter and value are valid


##### Key changed/added classes in this PR
- a centralized query setting registry is provided and all query context items are changed from String to strong typed `SettingEntry`


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
