### PR TITLE
Add support to detect abrupt termination of a node in the k8s based service discovery

### DIFF
--- a/docs/development/extensions-core/kubernetes.md
+++ b/docs/development/extensions-core/kubernetes.md
@@ -51,6 +51,8 @@ Additionally, this extension has following configuration.
 |`druid.discovery.k8s.leaseDuration`|`Duration`|Lease duration used by Leader Election algorithm. Candidates wait for this time before taking over previous Leader.|PT60S|No|
 |`druid.discovery.k8s.renewDeadline`|`Duration`|Lease renewal period used by Leader.|PT17S|No|
 |`druid.discovery.k8s.retryPeriod`|`Duration`|Retry wait used by Leader Election algorithm on failed operations.|PT5S|No|
+|`druid.discovery.k8s.pollDuration`|`Duration`|Interval between periodic pod listings for node discovery.|PT1M|No|
+|`druid.discovery.k8s.ignoreTerminatingStateDuration`|`Duration`|The duration for which a pod will be considered running if its in terminating state. Set this to higher than graceful termination period.|PT30S|No|
 
 ### Gotchas
 

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sApiClient.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sApiClient.java
@@ -20,6 +20,9 @@
 package org.apache.druid.k8s.discovery;
 
 import org.apache.druid.discovery.NodeRole;
+import org.joda.time.Duration;
+
+import javax.annotation.Nullable;
 
 /**
  * Interface to abstract pod read/update with K8S API Server to allow unit tests with mock impl.
@@ -28,7 +31,7 @@ public interface K8sApiClient
 {
   void patchPod(String podName, String namespace, String jsonPatchStr);
 
-  DiscoveryDruidNodeList listPods(String namespace, String labelSelector, NodeRole nodeRole);
+  DiscoveryDruidNodeList listPods(String namespace, String labelSelector, NodeRole nodeRole, @Nullable Duration ignoreTerminatingStateDuration);
 
   /**
    * @return NULL if history not available or else return the {@link WatchResult} object

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfig.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfig.java
@@ -60,6 +60,12 @@ public class K8sDiscoveryConfig
   @JsonProperty
   private final Duration retryPeriod;
 
+  @JsonProperty
+  private final Duration ignoreTerminatingStateDuration;
+
+  @JsonProperty
+  private final Duration pollDuration;
+
   @JsonCreator
   public K8sDiscoveryConfig(
       @JsonProperty("clusterIdentifier") String clusterIdentifier,
@@ -69,7 +75,9 @@ public class K8sDiscoveryConfig
       @JsonProperty("overlordLeaderElectionConfigMapNamespace") String overlordLeaderElectionConfigMapNamespace,
       @JsonProperty("leaseDuration") Duration leaseDuration,
       @JsonProperty("renewDeadline") Duration renewDeadline,
-      @JsonProperty("retryPeriod") Duration retryPeriod
+      @JsonProperty("retryPeriod") Duration retryPeriod,
+      @JsonProperty("ignoreTerminatingStateDuration") Duration ignoreTerminatingStateDuration,
+      @JsonProperty("pollDuration") Duration pollDuration
   )
   {
     Preconditions.checkArgument(clusterIdentifier != null && !clusterIdentifier.isEmpty(), "null/empty clusterIdentifier");
@@ -97,6 +105,8 @@ public class K8sDiscoveryConfig
     this.leaseDuration = leaseDuration == null ? Duration.millis(60000) : leaseDuration;
     this.renewDeadline = renewDeadline == null ? Duration.millis(17000) : renewDeadline;
     this.retryPeriod = retryPeriod == null ? Duration.millis(5000) : retryPeriod;
+    this.ignoreTerminatingStateDuration = ignoreTerminatingStateDuration == null ? Duration.standardSeconds(30) : ignoreTerminatingStateDuration;
+    this.pollDuration = pollDuration == null ? Duration.standardMinutes(1) : pollDuration;
   }
 
   @JsonProperty
@@ -147,6 +157,18 @@ public class K8sDiscoveryConfig
     return retryPeriod;
   }
 
+  @JsonProperty
+  public Duration getIgnoreTerminatingStateDuration()
+  {
+    return ignoreTerminatingStateDuration;
+  }
+
+  @JsonProperty
+  public Duration getPollDuration()
+  {
+    return pollDuration;
+  }
+
   @Override
   public String toString()
   {
@@ -159,6 +181,8 @@ public class K8sDiscoveryConfig
            ", leaseDuration=" + leaseDuration +
            ", renewDeadline=" + renewDeadline +
            ", retryPeriod=" + retryPeriod +
+           ", ignoreTerminatingStateDuration=" + ignoreTerminatingStateDuration +
+           ", pollDuration=" + pollDuration +
            '}';
   }
 
@@ -185,7 +209,9 @@ public class K8sDiscoveryConfig
            ) &&
            Objects.equals(leaseDuration, that.leaseDuration) &&
            Objects.equals(renewDeadline, that.renewDeadline) &&
-           Objects.equals(retryPeriod, that.retryPeriod);
+           Objects.equals(retryPeriod, that.retryPeriod) &&
+           Objects.equals(ignoreTerminatingStateDuration, that.ignoreTerminatingStateDuration) &&
+           Objects.equals(pollDuration, that.pollDuration);
   }
 
   @Override
@@ -199,7 +225,9 @@ public class K8sDiscoveryConfig
         overlordLeaderElectionConfigMapNamespace,
         leaseDuration,
         renewDeadline,
-        retryPeriod
+        retryPeriod,
+        ignoreTerminatingStateDuration,
+        pollDuration
     );
   }
 }

--- a/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
+++ b/extensions-core/kubernetes-extensions/src/main/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProvider.java
@@ -97,7 +97,7 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
     return () -> k8sApiClient.listPods(
         podInfo.getPodNamespace(),
         K8sDruidNodeAnnouncer.getLabelSelectorForNode(discoveryConfig, nodeRole, node),
-        nodeRole
+        nodeRole, discoveryConfig.getIgnoreTerminatingStateDuration()
     ).getDruidNodes().containsKey(node.getHostAndPortToUse());
   }
 
@@ -223,9 +223,35 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
         return;
       }
 
+      // Create a scheduled executor for polling the pod list
+      ScheduledExecutorService periodicListExecutor = Execs.scheduledSingleThreaded(
+          "K8sDruidNodeDiscoveryProvider-PeriodicList-" + nodeRole.getJsonName()
+      );
+
+      periodicListExecutor.scheduleAtFixedRate(() -> {
+        try {
+          LOGGER.info("Performing periodic pod listing for NodeRole [%s]", nodeRole);
+          DiscoveryDruidNodeList list = k8sApiClient.listPods(
+              podInfo.getPodNamespace(),
+              labelSelector,
+              nodeRole,
+              discoveryConfig.getIgnoreTerminatingStateDuration()
+          );
+          baseNodeRoleWatcher.resetNodes(list.getDruidNodes());
+        }
+        catch (Throwable ex) {
+          LOGGER.error(ex, "Error during periodic pod listing for NodeRole [%s]", nodeRole);
+        }
+      }, 120000, discoveryConfig.getPollDuration().getMillis(), TimeUnit.MILLISECONDS);
+
       while (lifecycleLock.awaitStarted(1, TimeUnit.MILLISECONDS)) {
         try {
-          DiscoveryDruidNodeList list = k8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, nodeRole);
+          DiscoveryDruidNodeList list = k8sApiClient.listPods(
+              podInfo.getPodNamespace(),
+              labelSelector,
+              nodeRole,
+              discoveryConfig.getIgnoreTerminatingStateDuration()
+          );
           baseNodeRoleWatcher.resetNodes(list.getDruidNodes());
 
           if (!cacheInitialized) {
@@ -247,6 +273,8 @@ public class K8sDruidNodeDiscoveryProvider extends DruidNodeDiscoveryProvider
       }
 
       LOGGER.info("Exited Watch for role[%s].", nodeRole);
+      // Shutdown the periodic executor when the watch is stopped
+      periodicListExecutor.shutdownNow();
     }
 
     private void keepWatching(String labelSelector, String resourceVersion)

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sAnnouncerAndDiscoveryIntTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sAnnouncerAndDiscoveryIntTest.java
@@ -52,7 +52,7 @@ public class K8sAnnouncerAndDiscoveryIntTest
 
   private final PodInfo podInfo = new PodInfo("busybox", "default");
 
-  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null);
+  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null, null);
 
   @Test(timeout = 30000L)
   public void testAnnouncementAndDiscoveryWorkflow() throws Exception

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfigTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDiscoveryConfigTest.java
@@ -34,7 +34,7 @@ public class K8sDiscoveryConfigTest
   {
     testSerde(
         "{\"clusterIdentifier\": \"test-cluster\"}\n",
-        new K8sDiscoveryConfig("test-cluster", null, null, null, null, null, null, null)
+        new K8sDiscoveryConfig("test-cluster", null, null, null, null, null, null, null, null, null)
     );
   }
 
@@ -50,8 +50,10 @@ public class K8sDiscoveryConfigTest
         + "  \"overlordLeaderElectionConfigMapNamespace\": \"overlordns\",\n"
         + "  \"leaseDuration\": \"PT3S\",\n"
         + "  \"renewDeadline\": \"PT2S\",\n"
-        + "  \"retryPeriod\": \"PT1S\"\n"
-        + "}\n",
+        + "  \"retryPeriod\": \"PT1S\",\n"
+        + "  \"ignoreTerminatingStateDuration\": \"PT30S\",\n"
+        + "  \"pollDuration\": \"PT20S\"\n"
+        + "\n}",
         new K8sDiscoveryConfig(
             "test-cluster",
             "PODNAMETEST",
@@ -60,7 +62,9 @@ public class K8sDiscoveryConfigTest
             "overlordns",
             Duration.millis(3000),
             Duration.millis(2000),
-            Duration.millis(1000)
+            Duration.millis(1000),
+            Duration.millis(30000),
+            Duration.millis(20000)
         )
     );
   }

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderElectionIntTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderElectionIntTest.java
@@ -54,7 +54,7 @@ public class K8sDruidLeaderElectionIntTest
   );
 
   private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, "default", "default",
-                                                                            Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000));
+                                                                            Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000), null, null);
 
   private final ApiClient k8sApiClient;
 

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderSelectorTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidLeaderSelectorTest.java
@@ -38,7 +38,7 @@ public class K8sDruidLeaderSelectorTest
   );
 
   private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null,
-                                                                            "default", "default", Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000));
+                                                                            "default", "default", Duration.millis(10_000), Duration.millis(7_000), Duration.millis(3_000), null, null);
 
   private final String lockResourceName = "druid-leader-election";
 

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeAnnouncerTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeAnnouncerTest.java
@@ -47,7 +47,7 @@ public class K8sDruidNodeAnnouncerTest
 
   private final PodInfo podInfo = new PodInfo("testpod", "testns");
 
-  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null);
+  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null, null);
 
   @Test
   public void testAnnounce() throws Exception

--- a/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
+++ b/extensions-core/kubernetes-extensions/src/test/java/org/apache/druid/k8s/discovery/K8sDruidNodeDiscoveryProviderTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.DruidNode;
 import org.easymock.EasyMock;
+import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -76,14 +77,14 @@ public class K8sDruidNodeDiscoveryProviderTest
 
   private final PodInfo podInfo = new PodInfo("testpod", "testns");
 
-  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null);
+  private final K8sDiscoveryConfig discoveryConfig = new K8sDiscoveryConfig("druid-cluster", null, null, null, null, null, null, null, null, null);
 
   @Test(timeout = 60_000)
   public void testGetForNodeRole() throws Exception
   {
     String labelSelector = "druidDiscoveryAnnouncement-cluster-identifier=druid-cluster,druidDiscoveryAnnouncement-router=true";
     K8sApiClient mockK8sApiClient = EasyMock.createMock(K8sApiClient.class);
-    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER)).andReturn(
+    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER, Duration.millis(30000))).andReturn(
         new DiscoveryDruidNodeList(
             "v1",
             ImmutableMap.of(
@@ -94,7 +95,7 @@ public class K8sDruidNodeDiscoveryProviderTest
     );
     EasyMock.expect(mockK8sApiClient.watchPods(
         podInfo.getPodNamespace(), labelSelector, "v1", NodeRole.ROUTER)).andReturn(null);
-    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER)).andReturn(
+    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER, Duration.millis(30000))).andReturn(
         new DiscoveryDruidNodeList(
             "v2",
             ImmutableMap.of(
@@ -168,7 +169,7 @@ public class K8sDruidNodeDiscoveryProviderTest
   {
     String labelSelector = "druidDiscoveryAnnouncement-cluster-identifier=druid-cluster,druidDiscoveryAnnouncement-router=true";
     K8sApiClient mockK8sApiClient = EasyMock.createMock(K8sApiClient.class);
-    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER)).andReturn(
+    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER, Duration.millis(30000))).andReturn(
         new DiscoveryDruidNodeList(
             "v1",
             ImmutableMap.of(
@@ -187,7 +188,7 @@ public class K8sDruidNodeDiscoveryProviderTest
             false
             )
     );
-    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER)).andReturn(
+    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER, Duration.millis(30000))).andReturn(
         new DiscoveryDruidNodeList(
             "v2",
             ImmutableMap.of(
@@ -231,7 +232,7 @@ public class K8sDruidNodeDiscoveryProviderTest
   {
     String labelSelector = "druidDiscoveryAnnouncement-cluster-identifier=druid-cluster,druidDiscoveryAnnouncement-router=true";
     K8sApiClient mockK8sApiClient = EasyMock.createMock(K8sApiClient.class);
-    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER)).andReturn(
+    EasyMock.expect(mockK8sApiClient.listPods(podInfo.getPodNamespace(), labelSelector, NodeRole.ROUTER, Duration.millis(30000))).andReturn(
         new DiscoveryDruidNodeList(
             "v1",
             ImmutableMap.of(


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes https://github.com/apache/druid/issues/18090

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description
- In the current implementation, the pod list is fetched once, and later, the pods only watch for the announcements being made by the other nodes 
- In this PR, I am proposing a fix to update the pod list every configured duration and exclude the pods that are in a terminating state for a longer period of time (configurable)
- When the pod is in terminating state for a duration longer than the terminationGracePeriod set on the pod, it makes no sense to keep it in the list, as it might be the issue of a faulty node


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note

Improved:
Kubernetes service discovery now properly handles a pod stuck in the terminating state or abrupt terminations

You can now configure how Druid handles pods stuck in the terminating state/ get killed abruptly during service discovery. This prevents issues where Druid might incorrectly consider terminated pods as available nodes.

Key changes:
- Added `druid.discovery.k8s.ignoreTerminatingStateDuration` (default: 30 seconds) to control how long a pod in terminating state should be considered as running
- Added `druid.discovery.k8s.pollDuration` (default: 1 minute) to set the interval between periodic pod listings to refresh the list of pods to detect the nodes/pods stuck in terminating state
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
