### PR TITLE
SQL: Defer context-based decisions to rule runtime.

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/AggregateExpandDistinctDispatchRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/AggregateExpandDistinctDispatchRule.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.run.EngineFeature;
+
+import javax.annotation.Nullable;
+
+/**
+ * Rule that dispatches at runtime to either {@link CoreRules#AGGREGATE_EXPAND_DISTINCT_AGGREGATES}
+ * or {@link CoreRules#AGGREGATE_EXPAND_DISTINCT_AGGREGATES_TO_JOIN}.
+ *
+ * It is necessary to defer decisions based on query context until rule runtime, since context from SET statements
+ * is not available at rule construction time.
+ */
+public class AggregateExpandDistinctDispatchRule extends RelOptRule
+{
+  private final PlannerContext plannerContext;
+
+  @Nullable
+  private RelOptRule rule;
+
+  public AggregateExpandDistinctDispatchRule(final PlannerContext plannerContext)
+  {
+    super(
+        CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES.getOperand(),
+        CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES.relBuilderFactory,
+        CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES.toString()
+    );
+
+    this.plannerContext = plannerContext;
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call)
+  {
+    return computeRule().matches(call);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call)
+  {
+    computeRule().onMatch(call);
+  }
+
+  private RelOptRule computeRule()
+  {
+    if (rule == null) {
+      if (plannerContext.getPlannerConfig().isUseGroupingSetForExactDistinct()
+          && plannerContext.featureAvailable(EngineFeature.GROUPING_SETS)) {
+        rule = CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES;
+      } else {
+        rule = CoreRules.AGGREGATE_EXPAND_DISTINCT_AGGREGATES_TO_JOIN;
+      }
+    }
+
+    return rule;
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/ContextuallyConditionalRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/ContextuallyConditionalRule.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTrait;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+
+import javax.annotation.Nullable;
+import java.util.function.Predicate;
+
+/**
+ * A wrapper rule that conditionally executes a delegate rule based on runtime evaluation of {@link PlannerContext}.
+ *
+ * It is necessary to defer decisions based on query context until rule runtime, since context from SET statements
+ * is not available at rule construction time.
+ */
+public class ContextuallyConditionalRule extends RelOptRule
+{
+  private final RelOptRule delegateRule;
+  private final PlannerContext plannerContext;
+  private final Predicate<PlannerContext> condition;
+
+  @Nullable
+  private Boolean doRun;
+
+  /**
+   * Creates a conditional rule that wraps the given delegate rule with a runtime condition.
+   */
+  public ContextuallyConditionalRule(
+      final RelOptRule delegateRule,
+      final PlannerContext plannerContext,
+      final Predicate<PlannerContext> condition
+  )
+  {
+    super(delegateRule.getOperand(), delegateRule.relBuilderFactory, delegateRule.toString());
+    this.delegateRule = delegateRule;
+    this.plannerContext = plannerContext;
+    this.condition = condition;
+  }
+
+  @Override
+  public boolean matches(final RelOptRuleCall call)
+  {
+    if (computeDoRun()) {
+      return delegateRule.matches(call);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public void onMatch(final RelOptRuleCall call)
+  {
+    // No need to check doRun, since "matches" controls conditional enabling.
+    delegateRule.onMatch(call);
+  }
+
+  @Override
+  public Convention getOutConvention()
+  {
+    return delegateRule.getOutConvention();
+  }
+
+  @Override
+  public RelTrait getOutTrait()
+  {
+    return delegateRule.getOutTrait();
+  }
+
+  private boolean computeDoRun()
+  {
+    if (doRun == null) {
+      doRun = condition.test(plannerContext);
+    }
+
+    return doRun;
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DeferredProjectMergeRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DeferredProjectMergeRule.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.rules.ProjectMergeRule;
+import org.apache.druid.sql.calcite.planner.CalciteRulesManager;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+
+/**
+ * Defers creation of {@link ProjectMergeRule} to runtime.
+ *
+ * It is necessary to defer decisions based on query context until rule runtime, since context from SET statements
+ * is not available at rule construction time. In this case, the decision is around
+ * {@link CalciteRulesManager#BLOAT_PROPERTY}.
+ */
+public class DeferredProjectMergeRule extends RelOptRule
+{
+  private final PlannerContext plannerContext;
+  private ProjectMergeRule delegateRule;
+
+  public DeferredProjectMergeRule(PlannerContext plannerContext)
+  {
+    super(operand(Project.class, operand(Project.class, any())));
+    this.plannerContext = plannerContext;
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call)
+  {
+    return getDelegateRule().matches(call);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call)
+  {
+    getDelegateRule().onMatch(call);
+  }
+
+  public ProjectMergeRule getDelegateRule()
+  {
+    if (delegateRule == null) {
+      final int bloat = getBloatProperty();
+      delegateRule = ProjectMergeRule.Config.DEFAULT.withBloat(bloat).toRule();
+    }
+    return delegateRule;
+  }
+
+  private int getBloatProperty()
+  {
+    final Integer bloat = plannerContext.queryContext().getInt(CalciteRulesManager.BLOAT_PROPERTY);
+    return (bloat != null) ? bloat : CalciteRulesManager.DEFAULT_BLOAT;
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidJoinRule.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rule/DruidJoinRule.java
@@ -67,8 +67,8 @@ import java.util.stream.Collectors;
 public class DruidJoinRule extends RelOptRule
 {
 
-  private final boolean enableLeftScanDirect;
   private final PlannerContext plannerContext;
+  private Boolean enableLeftScanDirect;
 
   private DruidJoinRule(final PlannerContext plannerContext)
   {
@@ -79,7 +79,6 @@ public class DruidJoinRule extends RelOptRule
             operand(DruidRel.class, any())
         )
     );
-    this.enableLeftScanDirect = plannerContext.queryContext().getEnableJoinLeftScanDirect();
     this.plannerContext = plannerContext;
   }
 
@@ -129,7 +128,7 @@ public class DruidJoinRule extends RelOptRule
         rexBuilder
     );
     plannerContext.setPlanningError(conditionAnalysis.errorStr);
-    final boolean isLeftDirectAccessPossible = enableLeftScanDirect && (left instanceof DruidQueryRel);
+    final boolean isLeftDirectAccessPossible = isEnableLeftScanDirect() && (left instanceof DruidQueryRel);
 
     final JoinAlgorithm joinAlgorithm = QueryUtils.getJoinAlgorithm(join, plannerContext);
     if (!joinAlgorithm.requiresSubquery()
@@ -279,6 +278,14 @@ public class DruidJoinRule extends RelOptRule
     }
 
     return true;
+  }
+
+  private boolean isEnableLeftScanDirect()
+  {
+    if (enableLeftScanDirect == null) {
+      enableLeftScanDirect = plannerContext.queryContext().getEnableJoinLeftScanDirect();
+    }
+    return enableLeftScanDirect;
   }
 
   public static class ConditionAnalysis

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -15976,4 +15976,52 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         "Only SET statements can appear before the final statement in a statement list, but found non-SET statement[SELECT 1]"
     );
   }
+
+  @Test
+  public void testSetUseApproximateCountDistinctFalse()
+  {
+    testBuilder().sql(
+        "SET useApproximateCountDistinct = FALSE;\n"
+        + "SELECT COUNT(DISTINCT dim2) FROM druid.foo"
+    ).expectedQueries(
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            new QueryDataSource(
+                                GroupByQuery.builder()
+                                            .setDataSource(CalciteTests.DATASOURCE1)
+                                            .setInterval(querySegmentSpec(Filtration.eternity()))
+                                            .setGranularity(Granularities.ALL)
+                                            .setDimensions(dimensions(new DefaultDimensionSpec("dim2", "d0")))
+                                            .setContext(
+                                                ImmutableMap.<String, Object>builder()
+                                                            .putAll(QUERY_CONTEXT_DEFAULT)
+                                                            .put("useApproximateCountDistinct", false)
+                                                            .build()
+                                            )
+                                            .build()
+                            )
+                        )
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setAggregatorSpecs(aggregators(
+                            new FilteredAggregatorFactory(
+                                new CountAggregatorFactory("a0"),
+                                notNull("d0")
+                            )
+                        ))
+                        .setContext(
+                            ImmutableMap.<String, Object>builder()
+                                        .putAll(QUERY_CONTEXT_DEFAULT)
+                                        .put("useApproximateCountDistinct", false)
+                                        .build()
+                        )
+                        .build()
+        )
+    ).expectedResults(
+        ImmutableList.of(
+            new Object[]{3L}
+        )
+    ).run();
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/rule/DeferredProjectMergeRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/rule/DeferredProjectMergeRuleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.rule;
+
+import org.apache.calcite.rel.rules.ProjectMergeRule;
+import org.apache.druid.query.QueryContext;
+import org.apache.druid.sql.calcite.planner.CalciteRulesManager;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+import org.apache.druid.sql.calcite.util.CalciteTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class DeferredProjectMergeRuleTest extends CalciteTestBase
+{
+  private static final int CUSTOM_BLOAT = 1200;
+
+  @Test
+  public void testCustomBloat()
+  {
+    PlannerContext mockContext = Mockito.mock(PlannerContext.class);
+    QueryContext mockQueryContext = Mockito.mock(QueryContext.class);
+
+    Mockito.when(mockContext.queryContext()).thenReturn(mockQueryContext);
+    Mockito.when(mockQueryContext.getInt(CalciteRulesManager.BLOAT_PROPERTY)).thenReturn(CUSTOM_BLOAT);
+
+    final DeferredProjectMergeRule deferredRule = new DeferredProjectMergeRule(mockContext);
+    final ProjectMergeRule delegateRule = deferredRule.getDelegateRule();
+
+    Assertions.assertEquals(CUSTOM_BLOAT, delegateRule.config.bloat());
+  }
+}


### PR DESCRIPTION
SET statements (#17894) provide a new way to set query context. However, they are not available at the time that the planner is constructed, which means they are not available when rules are built. Certain rules are built based on the context, which means SET was unable to affect them.

This patch fixes the problem by deferring context-based decisions from rule creation time to rule runtime.