### PR TITLE
Fix concurrent replace single phase tasks 

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -535,7 +535,7 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
   /**
    * Determines the type of lock to use with the given lock granularity.
    */
-  private TaskLockType determineLockType(LockGranularity lockGranularity)
+  public TaskLockType determineLockType(LockGranularity lockGranularity)
   {
     if (lockGranularity == LockGranularity.SEGMENT) {
       return TaskLockType.EXCLUSIVE;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -310,6 +310,13 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
     return ingestionSchema;
   }
 
+  @Nullable
+  @JsonIgnore
+  public String getBaseSubtaskSpecName()
+  {
+    return baseSubtaskSpecName;
+  }
+
   @VisibleForTesting
   @Nullable
   ParallelIndexTaskRunner getCurrentRunner()
@@ -351,12 +358,7 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
   {
     return new SinglePhaseParallelIndexTaskRunner(
         toolbox,
-        getId(),
-        getGroupId(),
-        baseSubtaskSpecName,
-        ingestionSchema,
-        getContext(),
-        toolbox.getCentralizedTableSchemaConfig()
+        this
     );
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexTaskRunner.java
@@ -28,13 +28,11 @@ import org.apache.druid.indexing.common.Counters;
 import org.apache.druid.indexing.common.LockGranularity;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.TaskToolbox;
-import org.apache.druid.indexing.common.actions.TaskLocks;
 import org.apache.druid.indexing.common.task.AbstractBatchIndexTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.TaskMonitor.SubTaskCompleteEvent;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.NonnullPair;
-import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.BuildingNumberedShardSpec;
@@ -101,42 +99,25 @@ public class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner
 
   private final ParallelIndexIngestionSpec ingestionSchema;
   private final SplittableInputSource<?> baseInputSource;
-  private CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig;
-
-  SinglePhaseParallelIndexTaskRunner(
-      TaskToolbox toolbox,
-      String taskId,
-      String groupId,
-      String baseSubtaskSpecName,
-      ParallelIndexIngestionSpec ingestionSchema,
-      Map<String, Object> context,
-      CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
-  )
-  {
-    super(
-        toolbox,
-        taskId,
-        groupId,
-        baseSubtaskSpecName,
-        ingestionSchema.getTuningConfig(),
-        context
-    );
-    this.ingestionSchema = ingestionSchema;
-    this.baseInputSource = (SplittableInputSource) ingestionSchema.getIOConfig().getNonNullInputSource(toolbox);
-    this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
-  }
+  private final ParallelIndexSupervisorTask supervisorTask;
 
   @VisibleForTesting
   SinglePhaseParallelIndexTaskRunner(
       TaskToolbox toolbox,
-      String taskId,
-      String groupId,
-      ParallelIndexIngestionSpec ingestionSchema,
-      Map<String, Object> context,
-      CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig
+      ParallelIndexSupervisorTask supervisorTask
   )
   {
-    this(toolbox, taskId, groupId, taskId, ingestionSchema, context, centralizedDatasourceSchemaConfig);
+    super(
+        toolbox,
+        supervisorTask.getId(),
+        supervisorTask.getGroupId(),
+        supervisorTask.getBaseSubtaskSpecName(),
+        supervisorTask.getIngestionSchema().getTuningConfig(),
+        supervisorTask.getContext()
+    );
+    this.ingestionSchema = supervisorTask.getIngestionSchema();
+    this.baseInputSource = (SplittableInputSource) ingestionSchema.getIOConfig().getNonNullInputSource(toolbox);
+    this.supervisorTask = supervisorTask;
   }
 
   @Override
@@ -207,7 +188,7 @@ public class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner
   @Deprecated
   public SegmentIdWithShardSpec allocateNewSegment(String dataSource, DateTime timestamp) throws IOException
   {
-    NonnullPair<Interval, String> intervalAndVersion = findIntervalAndVersion(timestamp);
+    NonnullPair<Interval, String> intervalAndVersion = findIntervalAndVersion(timestamp, supervisorTask.getTaskLockHelper().getLockGranularityToUse());
 
     final int partitionNum = Counters.getAndIncrementInt(partitionNumCountersPerInterval, intervalAndVersion.lhs);
     return new SegmentIdWithShardSpec(
@@ -237,7 +218,7 @@ public class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner
       @Nullable String prevSegmentId
   ) throws IOException
   {
-    NonnullPair<Interval, String> intervalAndVersion = findIntervalAndVersion(timestamp);
+    NonnullPair<Interval, String> intervalAndVersion = findIntervalAndVersion(timestamp, LockGranularity.TIME_CHUNK);
 
     MutableObject<SegmentIdWithShardSpec> segmentIdHolder = new MutableObject<>();
     sequenceToSegmentIds.compute(sequenceName, (k, v) -> {
@@ -285,9 +266,9 @@ public class SinglePhaseParallelIndexTaskRunner extends ParallelIndexPhaseRunner
     return segmentIdHolder.getValue();
   }
 
-  NonnullPair<Interval, String> findIntervalAndVersion(DateTime timestamp) throws IOException
+  NonnullPair<Interval, String> findIntervalAndVersion(DateTime timestamp, LockGranularity granularity) throws IOException
   {
-    TaskLockType taskLockType = TaskLocks.determineLockTypeForAppend(getContext());
+    TaskLockType taskLockType = supervisorTask.determineLockType(granularity);
     return AbstractBatchIndexTask.findIntervalAndVersion(getToolbox(), ingestionSchema, timestamp, taskLockType);
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -256,11 +256,7 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
     {
       super(
           toolbox,
-          supervisorTask.getId(),
-          supervisorTask.getGroupId(),
-          supervisorTask.getIngestionSchema(),
-          supervisorTask.getContext(),
-          CentralizedDatasourceSchemaConfig.create()
+          supervisorTask
       );
       this.supervisorTask = supervisorTask;
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -495,11 +495,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
     {
       super(
           toolbox,
-          supervisorTask.getId(),
-          supervisorTask.getGroupId(),
-          supervisorTask.getIngestionSchema(),
-          supervisorTask.getContext(),
-          CentralizedDatasourceSchemaConfig.enabled(true)
+          supervisorTask
       );
       this.supervisorTask = supervisorTask;
     }


### PR DESCRIPTION
### Description

#### The Issue
REPLACE tasks (single-phase parallel index) that should delete rows were marked successful but did nothing - the row count stayed the same even though the thrownAway metric was positive.
Logs showed that segments created by these tasks had a version of epoch (0).

After some debugging, the flow appears to be:

* When an existing lock can’t be obtained, the task [acquires a new one](https://github.com/apache/druid/blob/89cf9b263dc16238bd1493414826ea087f50d168/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java#L867).
* TaskLockAcquireAction [builds the lock request without preferredVersion](https://github.com/apache/druid/blob/89cf9b263dc16238bd1493414826ea087f50d168/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TimeChunkLockTryAcquireAction.java#L76).
* The request [returns a version of epoch (0)](https://github.com/apache/druid/blob/89cf9b263dc16238bd1493414826ea087f50d168/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java#L90) for [an APPEND lock](https://github.com/apache/druid/blob/89cf9b263dc16238bd1493414826ea087f50d168/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TimeChunkLockRequest.java#L118).
* With concurrent locks enabled, the lock type is [always APPEND](https://github.com/apache/druid/blob/89cf9b263dc16238bd1493414826ea087f50d168/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java#L158), even for REPLACE tasks.

#### Possible fixes
__1st option__ – Allow a REPLACE lock in [determineLockTypeForAppend](https://github.com/apache/druid/blob/12c1536e441011cd7d55dd05752d3567bd97fb16/indexing-service/src/main/java/org/apache/druid/indexing/common/actions/TaskLocks.java#L150).
_Workaround-ish, since it needs an explicit lock type in the task context._

_was_ 
```
public static TaskLockType determineLockTypeForAppend(Map<String, Object> taskContext) {
  final boolean useConcurrentLocks = (boolean) taskContext.getOrDefault(
      Tasks.USE_CONCURRENT_LOCKS,
      Tasks.DEFAULT_USE_CONCURRENT_LOCKS
  );
  if (useConcurrentLocks) {
    return TaskLockType.APPEND;
  }
  final Object lockType = taskContext.get(Tasks.TASK_LOCK_TYPE);
  if (lockType == null) {
    final boolean useSharedLock = (boolean) taskContext.getOrDefault(Tasks.USE_SHARED_LOCK, false);
    return useSharedLock ? TaskLockType.SHARED : TaskLockType.EXCLUSIVE;
  } else {
    return TaskLockType.valueOf(lockType.toString());
  }
}
```
_became_ 
```
public static TaskLockType determineLockTypeForAppend(Map<String, Object> taskContext) {
  final boolean useConcurrentLocks = (boolean) taskContext.getOrDefault(
      Tasks.USE_CONCURRENT_LOCKS,
      Tasks.DEFAULT_USE_CONCURRENT_LOCKS
  );
  final Object rawLock = taskContext.get(Tasks.TASK_LOCK_TYPE);
  TaskLockType lockType = (rawLock != null) ? TaskLockType.valueOf(rawLock.toString()) : null;

  if (useConcurrentLocks) {
    return (lockType == TaskLockType.REPLACE) ? TaskLockType.REPLACE : TaskLockType.APPEND;
  }
  if (lockType == null) {
    final boolean useSharedLock = (boolean) taskContext.getOrDefault(Tasks.USE_SHARED_LOCK, false);
    return useSharedLock ? TaskLockType.SHARED : TaskLockType.EXCLUSIVE;
  } else {
    return TaskLockType.valueOf(lockType.toString());
  }
}

```
__2nd option – The solution implemented in this PR.__
It follows the TaskLocks comment about deduplicating determineLockTypeForAppend, making the logic cleaner and ensuring REPLACE tasks get the correct lock type and version.

This PR has:

- [X] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
