### PR TITLE
Run CompactionTaskRunTest with concurrent locks

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunTest.java
@@ -130,6 +130,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -168,13 +169,13 @@ public class CompactionTaskRunTest extends IngestionTestBase
       "2014-01-01T02:00:30Z,c|d|e,3\n"
   );
 
-  @Parameterized.Parameters(name = "lockGranularity={0}, useSegmentMetadataCache={1}")
+  @Parameterized.Parameters(name = "lockGranularity={0}, useSegmentMetadataCache={1}, useConcurrentLocks={2}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
-        new Object[]{LockGranularity.TIME_CHUNK, true},
-        new Object[]{LockGranularity.TIME_CHUNK, false},
-        new Object[]{LockGranularity.SEGMENT, true}
+        new Object[]{LockGranularity.TIME_CHUNK, true, true},
+        new Object[]{LockGranularity.TIME_CHUNK, false, false},
+        new Object[]{LockGranularity.SEGMENT, true, false}
     );
   }
 
@@ -183,12 +184,17 @@ public class CompactionTaskRunTest extends IngestionTestBase
   private final CoordinatorClient coordinatorClient;
   private final SegmentCacheManagerFactory segmentCacheManagerFactory;
   private final LockGranularity lockGranularity;
+  private final boolean useConcurrentLocks;
   private final TestUtils testUtils;
 
   private ExecutorService exec;
   private File localDeepStorage;
 
-  public CompactionTaskRunTest(LockGranularity lockGranularity, boolean useSegmentMetadataCache)
+  public CompactionTaskRunTest(
+      LockGranularity lockGranularity,
+      boolean useSegmentMetadataCache,
+      boolean useConcurrentLocks
+  )
   {
     super(useSegmentMetadataCache);
     testUtils = new TestUtils();
@@ -210,6 +216,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     };
     segmentCacheManagerFactory = new SegmentCacheManagerFactory(TestIndex.INDEX_IO, getObjectMapper());
     this.lockGranularity = lockGranularity;
+    this.useConcurrentLocks = useConcurrentLocks;
   }
 
   public static CompactionState getDefaultCompactionState(
@@ -278,12 +285,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .build();
 
@@ -346,12 +348,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .tuningConfig(
             TuningConfigBuilder.forParallelIndexTask()
@@ -413,12 +410,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .build();
 
@@ -457,7 +449,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
       }
     }
 
-    final CompactionTask compactionTask2 = builder
+    final CompactionTask compactionTask2 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .build();
 
@@ -509,12 +501,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01T00:00:00/2014-01-02T03:00:00"))
         .build();
 
@@ -621,13 +608,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // day segmentGranularity
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .segmentGranularity(Granularities.DAY)
         .build();
@@ -653,7 +635,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     );
 
     // hour segmentGranularity
-    final CompactionTask compactionTask2 = builder
+    final CompactionTask compactionTask2 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .segmentGranularity(Granularities.HOUR)
         .build();
@@ -690,12 +672,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .ioConfig(
             new CompactionIOConfig(
                 new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null),
@@ -724,13 +701,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // day segmentGranularity
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .ioConfig(
             new CompactionIOConfig(
                 new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null),
@@ -768,13 +740,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // day segmentGranularity
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.DAY, null, null))
         .transformSpec(new CompactionTransformSpec(new SelectorDimFilter("dim", "a", null)))
@@ -824,13 +791,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // day segmentGranularity
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.DAY, null, null))
         .metricsSpec(new AggregatorFactory[]{
@@ -884,13 +846,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // day segmentGranularity
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.DAY, null, null))
         .build();
@@ -916,7 +873,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     );
 
     // hour segmentGranularity
-    final CompactionTask compactionTask2 = builder
+    final CompactionTask compactionTask2 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.HOUR, null, null))
         .build();
@@ -952,13 +909,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // day queryGranularity
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .granularitySpec(new ClientCompactionTaskGranularitySpec(null, Granularities.SECOND, null))
         .build();
@@ -1006,13 +958,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // day segmentGranularity and day queryGranularity
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.DAY, Granularities.DAY, null))
         .build();
@@ -1044,12 +991,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask1 = builder
+    final CompactionTask compactionTask1 = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .granularitySpec(new ClientCompactionTaskGranularitySpec(null, null, null))
         .build();
@@ -1097,12 +1039,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .build();
 
@@ -1158,11 +1095,6 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> result = runIndexTask();
     Assert.assertEquals(6, result.rhs.getSegments().size());
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // Setup partial compaction:
     // Change the granularity from HOUR to MINUTE through compaction for hour 01, there are three rows in the compaction interval,
     // all three in the same timestamp (see TEST_ROWS), this should generate one segments (task will now use
@@ -1172,7 +1104,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
 
     // **** PARTIAL COMPACTION: hour -> minute ****
     final Interval compactionPartialInterval = Intervals.of("2014-01-01T01:00:00/2014-01-01T02:00:00");
-    final CompactionTask partialCompactionTask = builder
+    final CompactionTask partialCompactionTask = compactionTaskBuilder()
         .segmentGranularity(Granularities.MINUTE)
         // Set dropExisting to true
         .inputSpec(new CompactionIntervalSpec(compactionPartialInterval, null), true)
@@ -1234,7 +1166,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     // for hour 00 one real HOUR segment will be generated;
     // for hour 01, one real minute segment plus 59 minute tombstones;
     // and hour 02 one real HOUR segment for a total of 1 + (1+59) + 1 = 62 total segments
-    final CompactionTask fullCompactionTask = builder
+    final CompactionTask fullCompactionTask = compactionTaskBuilder()
         .segmentGranularity(null)
         // Set dropExisting to true
         .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null), true)
@@ -1313,11 +1245,6 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> result = runIndexTask();
     Assert.assertEquals(6, result.rhs.getSegments().size());
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     // Setup partial interval compaction:
     // Change the granularity from HOUR to MINUTE through compaction for hour 01, there are three rows in the compaction
     // interval,
@@ -1329,7 +1256,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
 
     // **** PARTIAL COMPACTION: hour -> minute ****
     final Interval compactionPartialInterval = Intervals.of("2014-01-01T01:00:00/2014-01-01T02:00:00");
-    final CompactionTask partialCompactionTask = builder
+    final CompactionTask partialCompactionTask = compactionTaskBuilder()
         .segmentGranularity(Granularities.MINUTE)
         // Set dropExisting to true
         .inputSpec(new CompactionIntervalSpec(compactionPartialInterval, null), true)
@@ -1382,7 +1309,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Assert.assertEquals(64, segmentsAfterPartialCompaction.size());
 
     // Now setup compaction over an interval with only tombstones, keeping same, minute granularity
-    final CompactionTask compactionTaskOverOnlyTombstones = builder
+    final CompactionTask compactionTaskOverOnlyTombstones = compactionTaskBuilder()
         .segmentGranularity(null)
         // Set dropExisting to true
         // last 59 minutes of our 01, should be all tombstones
@@ -1420,13 +1347,8 @@ public class CompactionTaskRunTest extends IngestionTestBase
         )
     );
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
     final Interval partialInterval = Intervals.of("2014-01-01T01:00:00/2014-01-01T02:00:00");
-    final CompactionTask partialCompactionTask = builder
+    final CompactionTask partialCompactionTask = compactionTaskBuilder()
         .segmentGranularity(Granularities.MINUTE)
         // Set dropExisting to false
         .inputSpec(new CompactionIntervalSpec(partialInterval, null), false)
@@ -1448,7 +1370,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
 
     Assert.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
 
-    final CompactionTask fullCompactionTask = builder
+    final CompactionTask fullCompactionTask = compactionTaskBuilder()
         .segmentGranularity(null)
         // Set dropExisting to false
         .inputSpec(new CompactionIntervalSpec(Intervals.of("2014-01-01/2014-01-02"), null), false)
@@ -1491,12 +1413,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
         () -> runIndexTask(compactionTaskReadyLatch, indexTaskStartLatch, false)
     );
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01T00:00:00/2014-01-02T03:00:00"))
         .build();
 
@@ -1545,12 +1462,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask();
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01T00:00:00/2014-01-02T03:00:00"))
         .build();
 
@@ -1641,12 +1553,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     );
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .build();
 
@@ -1763,12 +1670,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask(null, null, spec, rows, false);
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .build();
 
@@ -1893,12 +1795,7 @@ public class CompactionTaskRunTest extends IngestionTestBase
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runIndexTask(null, null, spec, rows, false);
     verifySchema(indexTaskResult.rhs);
 
-    final Builder builder = new Builder(
-        DATA_SOURCE,
-        segmentCacheManagerFactory
-    );
-
-    final CompactionTask compactionTask = builder
+    final CompactionTask compactionTask = compactionTaskBuilder()
         .interval(Intervals.of("2014-01-01/2014-01-02"))
         .build();
 
@@ -2142,6 +2039,14 @@ public class CompactionTaskRunTest extends IngestionTestBase
     } else {
       throw new ISE("task[%s] is not ready", task.getId());
     }
+  }
+
+  private Builder compactionTaskBuilder()
+  {
+    return new Builder(
+        DATA_SOURCE,
+        segmentCacheManagerFactory
+    ).context(Map.of(Tasks.USE_CONCURRENT_LOCKS, useConcurrentLocks));
   }
 
   private TaskToolbox createTaskToolbox(ObjectMapper objectMapper, Task task) throws IOException

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -43,6 +43,7 @@ import org.apache.druid.indexing.common.SegmentCacheManagerFactory;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.SegmentTransactionalInsertAction;
+import org.apache.druid.indexing.common.actions.SegmentTransactionalReplaceAction;
 import org.apache.druid.indexing.common.actions.TaskAction;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
@@ -424,6 +425,10 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
         SegmentTransactionalInsertAction insertAction = (SegmentTransactionalInsertAction) taskAction;
         publishedSegments.addAll(insertAction.getSegments());
         segmentSchemaMapping.merge(insertAction.getSegmentSchemaMapping());
+      } else if (taskAction instanceof SegmentTransactionalReplaceAction) {
+        SegmentTransactionalReplaceAction replaceAction = (SegmentTransactionalReplaceAction) taskAction;
+        publishedSegments.addAll(replaceAction.getSegments());
+        segmentSchemaMapping.merge(replaceAction.getSegmentSchemaMapping());
       }
       return result;
     }


### PR DESCRIPTION
### Changes

- Enable unit test `CompactionTaskRunTest` to run with `useConcurrentLocks: true`