### PR TITLE
SQL: Parse queries immediately for non-JDBC endpoints.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlTaskResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlTaskResource.java
@@ -133,7 +133,8 @@ public class SqlTaskResource
     try {
       sqlQueryPlus = SqlResource.makeSqlQueryPlus(sqlQuery, req);
       stmt = sqlStatementFactory.httpStatement(sqlQueryPlus, req);
-    } catch (Exception e) {
+    }
+    catch (Exception e) {
       return SqlResource.handleExceptionBeforeStatementCreated(e, sqlQuery.queryContext());
     }
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ResultsContextSerdeTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/exec/ResultsContextSerdeTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.policy.NoopPolicyEnforcer;
 import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.sql.calcite.parser.DruidSqlParser;
 import org.apache.druid.sql.calcite.planner.CalciteRulesManager;
 import org.apache.druid.sql.calcite.planner.CatalogResolver;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
@@ -86,9 +87,11 @@ public class ResultsContextSerdeTest
         EasyMock.createMock(QueryRunnerFactoryConglomerate.class)
     );
 
+    final String sql = "SELECT 1";
     PlannerContext plannerContext = PlannerContext.create(
         toolbox,
-        "DUMMY",
+        sql,
+        DruidSqlParser.parse(sql, false).getMainStatement(),
         engine,
         Collections.emptyMap(),
         null

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -810,12 +810,12 @@ public class MSQTestBase extends BaseCalciteQueryTest
   )
   {
     final DirectStatement stmt = sqlStatementFactory.directStatement(
-        new SqlQueryPlus(
-            query,
-            context,
-            parameters,
-            authenticationResult
-        )
+        SqlQueryPlus.builder()
+                    .sql(query)
+                    .context(context)
+                    .parameters(parameters)
+                    .auth(authenticationResult)
+                    .build()
     );
 
     final List<Object[]> sequence = stmt.execute().getResults().toList();

--- a/sql/src/main/java/org/apache/druid/sql/DirectStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/DirectStatement.java
@@ -241,9 +241,9 @@ public class DirectStatement extends AbstractStatement implements Cancelable
     return sqlToolbox.plannerFactory.createPlanner(
         sqlToolbox.engine,
         queryPlus.sql(),
+        queryPlus.sqlNode(),
         queryContext,
-        hook,
-        false
+        hook
     );
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/HttpStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/HttpStatement.java
@@ -23,7 +23,6 @@ import org.apache.druid.server.security.AuthorizationResult;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.sql.calcite.planner.DruidPlanner;
-import org.apache.druid.sql.http.SqlQuery;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Set;
@@ -45,15 +44,13 @@ public class HttpStatement extends DirectStatement
 
   public HttpStatement(
       final SqlToolbox lifecycleToolbox,
-      final SqlQuery sqlQuery,
+      final SqlQueryPlus sqlQueryPlus,
       final HttpServletRequest req
   )
   {
     super(
         lifecycleToolbox,
-        SqlQueryPlus.builder(sqlQuery)
-                    .auth(AuthorizationUtils.authenticationResultFromRequest(req))
-                    .build(),
+        sqlQueryPlus,
         req.getRemoteAddr()
     );
     this.req = req;
@@ -65,9 +62,9 @@ public class HttpStatement extends DirectStatement
     return sqlToolbox.plannerFactory.createPlanner(
         sqlToolbox.engine,
         queryPlus.sql(),
+        queryPlus.sqlNode(),
         queryContext,
-        hook,
-        true
+        hook
     );
   }
 

--- a/sql/src/main/java/org/apache/druid/sql/PreparedStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/PreparedStatement.java
@@ -31,7 +31,6 @@ import java.util.List;
 public class PreparedStatement extends AbstractStatement
 {
   private final SqlQueryPlus originalRequest;
-  private PrepareResult prepareResult;
 
   public PreparedStatement(
       final SqlToolbox lifecycleToolbox,
@@ -70,8 +69,7 @@ public class PreparedStatement extends AbstractStatement
       authorize(planner, authorizer());
 
       // Do the prepare step.
-      this.prepareResult = planner.prepare();
-      return prepareResult;
+      return planner.prepare();
     }
     catch (RuntimeException e) {
       reporter.failed(e);
@@ -92,7 +90,7 @@ public class PreparedStatement extends AbstractStatement
   {
     return new DirectStatement(
         sqlToolbox,
-        originalRequest.withParameters(parameters)
+        originalRequest.freshCopy().withParameters(parameters)
     );
   }
 
@@ -101,9 +99,9 @@ public class PreparedStatement extends AbstractStatement
     return sqlToolbox.plannerFactory.createPlanner(
         sqlToolbox.engine,
         queryPlus.sql(),
+        queryPlus.freshCopy().sqlNode(),
         queryContext,
-        hook,
-        false
+        hook
     );
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/SqlQueryPlus.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlQueryPlus.java
@@ -21,24 +21,36 @@ package org.apache.druid.sql;
 
 import com.google.common.base.Preconditions;
 import org.apache.calcite.avatica.remote.TypedValue;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.sql.calcite.parser.DruidSqlParser;
+import org.apache.druid.sql.calcite.parser.StatementAndSetContext;
+import org.apache.druid.sql.calcite.planner.CalcitePlanner;
 import org.apache.druid.sql.http.SqlParameter;
 import org.apache.druid.sql.http.SqlQuery;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Captures the inputs to a SQL execution request: the statement,the context,
- * parameters, and the authorization result. Pass this around rather than the
- * quad of items. The request can evolve: the context and parameters can be
- * filled in later as needed.
+ * Captures the inputs to a SQL execution request: the statement (as a string),
+ * the parsed statement, the context, parameters, and the authorization result.
+ * The request can evolve: the context and parameters can be filled in later
+ * as needed.
  * <p>
  * SQL requests come from a variety of sources in a variety of formats. Use
  * the {@link Builder} class to create an instance from the information
  * available at each point in the code.
+ * <p>
+ * Each instance of SqlQueryPlus can only be used once, because {@link #sqlNode}
+ * is a mutable data structure, modified during {@link CalcitePlanner#validate}.
+ * If you need to use one again, call {@link #freshCopy()} to create a fresh
+ * copy with a new {@link SqlNode}.
  * <p>
  * The query context has a complex lifecycle. The copy here is immutable:
  * it is the set of values which the user requested. Planning will
@@ -50,24 +62,31 @@ import java.util.Map;
 public class SqlQueryPlus
 {
   private final String sql;
+  @Nullable
+  private final SqlNode sqlNode;
+  private boolean allowSetStatements;
   private final Map<String, Object> queryContext;
   private final List<TypedValue> parameters;
   private final AuthenticationResult authResult;
 
-  public SqlQueryPlus(
+  private SqlQueryPlus(
       String sql,
+      SqlNode sqlNode,
+      boolean allowSetStatements,
       Map<String, Object> queryContext,
       List<TypedValue> parameters,
       AuthenticationResult authResult
   )
   {
     this.sql = Preconditions.checkNotNull(sql);
+    this.sqlNode = sqlNode;
+    this.allowSetStatements = allowSetStatements;
     this.queryContext = queryContext == null
-        ? Collections.emptyMap()
-        : Collections.unmodifiableMap(new HashMap<>(queryContext));
+                        ? Collections.emptyMap()
+                        : Collections.unmodifiableMap(new HashMap<>(queryContext));
     this.parameters = parameters == null
-        ? Collections.emptyList()
-        : parameters;
+                      ? Collections.emptyList()
+                      : parameters;
     this.authResult = Preconditions.checkNotNull(authResult);
   }
 
@@ -81,14 +100,18 @@ public class SqlQueryPlus
     return new Builder().sql(sql);
   }
 
-  public static Builder builder(SqlQuery sqlQuery)
-  {
-    return new Builder().query(sqlQuery);
-  }
-
   public String sql()
   {
     return sql;
+  }
+
+  public SqlNode sqlNode()
+  {
+    if (sqlNode == null) {
+      throw DruidException.defensive("sqlNode not set");
+    }
+
+    return sqlNode;
   }
 
   public Map<String, Object> context()
@@ -108,19 +131,40 @@ public class SqlQueryPlus
 
   public SqlQueryPlus withContext(Map<String, Object> context)
   {
-    return new SqlQueryPlus(sql, context, parameters, authResult);
+    return new SqlQueryPlus(sql, sqlNode, allowSetStatements, context, parameters, authResult);
   }
 
   public SqlQueryPlus withParameters(List<TypedValue> parameters)
   {
-    return new SqlQueryPlus(sql, queryContext, parameters, authResult);
+    return new SqlQueryPlus(sql, sqlNode, allowSetStatements, queryContext, parameters, authResult);
+  }
+
+  /**
+   * Returns a copy of this instance where everything is shared, except the {@link #sqlNode}, which is re-parsed from
+   * the SQL statement.
+   */
+  public SqlQueryPlus freshCopy()
+  {
+    return new SqlQueryPlus(
+        sql,
+        DruidSqlParser.parse(sql, allowSetStatements).getMainStatement(),
+        allowSetStatements,
+        queryContext,
+        parameters,
+        authResult
+    );
   }
 
   @Override
   public String toString()
   {
-    return "SqlQueryPlus {queryContext=" + queryContext + ", parameters=" + parameters
-        + ", authResult=" + authResult + ", sql=" + sql + " }";
+    return "SqlQueryPlus{" +
+           "sql='" + sql + '\'' +
+           ", sqlNode=" + sqlNode +
+           ", queryContext=" + queryContext +
+           ", parameters=" + parameters +
+           ", authResult=" + authResult +
+           '}';
   }
 
   public static class Builder
@@ -133,14 +177,6 @@ public class SqlQueryPlus
     public Builder sql(String sql)
     {
       this.sql = sql;
-      return this;
-    }
-
-    public Builder query(SqlQuery sqlQuery)
-    {
-      this.sql = sqlQuery.getQuery();
-      this.queryContext = sqlQuery.getContext();
-      this.parameters = sqlQuery.getParameterList();
       return this;
     }
 
@@ -168,14 +204,38 @@ public class SqlQueryPlus
       return this;
     }
 
+    /**
+     * Parses the provided {@link #sql} and builds a {@link SqlQueryPlus} with SET statements folded into the
+     * context, and with the parsed SQL in {@link #sqlNode}.
+     *
+     * When using this method, the {@link #sqlNode()} must only be run through validation once. (The validator
+     * mutates the {@link SqlNode}).
+     */
     public SqlQueryPlus build()
     {
+      final StatementAndSetContext statementAndSetContext = DruidSqlParser.parse(sql, true);
       return new SqlQueryPlus(
           sql,
-          queryContext,
+          statementAndSetContext.getMainStatement(),
+          true,
+          statementAndSetContext.getSetContext().isEmpty()
+          ? queryContext
+          : QueryContexts.override(queryContext, statementAndSetContext.getSetContext()),
           parameters,
           authResult
       );
+    }
+
+    /**
+     * Builds a {@link SqlQueryPlus} with no {@link SqlNode} and with {@link #allowSetStatements} set to false.
+     * This is done for JDBC becauase it can runs each {@link SqlQueryPlus} multiple times, and it needs to keep
+     * re-parsing and re-validating the query on each run.
+     *
+     * When using this method, you must create a copy with {@link #freshCopy()} prior to calling {@link #sqlNode()}.
+     */
+    public SqlQueryPlus buildJdbc()
+    {
+      return new SqlQueryPlus(sql, null, false, queryContext, parameters, authResult);
     }
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/SqlStatementFactory.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlStatementFactory.java
@@ -19,8 +19,6 @@
 
 package org.apache.druid.sql;
 
-import org.apache.druid.sql.http.SqlQuery;
-
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -44,11 +42,11 @@ public class SqlStatementFactory
   }
 
   public HttpStatement httpStatement(
-      final SqlQuery sqlQuery,
+      final SqlQueryPlus sqlQueryPlus,
       final HttpServletRequest req
   )
   {
-    return new HttpStatement(lifecycleToolbox, sqlQuery, req);
+    return new HttpStatement(lifecycleToolbox, sqlQueryPlus, req);
   }
 
   public DirectStatement directStatement(final SqlQueryPlus sqlRequest)

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcStatement.java
@@ -57,7 +57,7 @@ public class DruidJdbcStatement extends AbstractDruidJdbcStatement
   public synchronized void execute(SqlQueryPlus queryPlus, long maxRowCount)
   {
     closeResultSet();
-    this.sqlQuery = queryPlus.withContext(queryContext);
+    this.sqlQuery = queryPlus.withContext(queryContext).freshCopy();
     DirectStatement stmt = lifecycleFactory.directStatement(this.sqlQuery);
     resultSet = new DruidJdbcResultSet(this, stmt, Long.MAX_VALUE, fetcherFactory);
     try {

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidMeta.java
@@ -271,12 +271,11 @@ public class DruidMeta extends MetaImpl
   {
     try {
       final DruidConnection druidConnection = getDruidConnection(ch.id);
-      final SqlQueryPlus sqlReq = new SqlQueryPlus(
-          sql,
-          druidConnection.sessionContext(),
-          null, // No parameters in this path
-          doAuthenticate(druidConnection)
-      );
+      final SqlQueryPlus sqlReq = SqlQueryPlus.builder()
+          .sql(sql)
+          .context(druidConnection.sessionContext())
+          .auth(doAuthenticate(druidConnection))
+          .buildJdbc();
       final DruidJdbcPreparedStatement stmt = getDruidConnection(ch.id).createPreparedStatement(
           sqlStatementFactory,
           sqlReq,
@@ -351,7 +350,7 @@ public class DruidMeta extends MetaImpl
         final AuthenticationResult authenticationResult = doAuthenticate(druidConnection);
         final SqlQueryPlus sqlRequest = SqlQueryPlus.builder(sql)
             .auth(authenticationResult)
-            .build();
+            .buildJdbc();
         druidStatement.execute(sqlRequest, maxRowCount);
         final ExecuteResult result = doFetch(druidStatement, maxRowsInFirstFrame);
         LOG.debug("Successfully prepared statement [%s] and started execution", druidStatement.getStatementId());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/DruidSqlParser.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.parser;
+
+import com.google.common.base.Joiner;
+import org.apache.calcite.avatica.util.Casing;
+import org.apache.calcite.avatica.util.Quoting;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlSetOption;
+import org.apache.calcite.sql.SqlUtil;
+import org.apache.calcite.sql.dialect.CalciteSqlDialect;
+import org.apache.calcite.sql.parser.SqlParseException;
+import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.NlsString;
+import org.apache.calcite.util.SourceStringReader;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.InvalidSqlInput;
+import org.apache.druid.query.QueryContext;
+import org.apache.druid.sql.calcite.planner.Calcites;
+import org.apache.druid.sql.calcite.planner.DruidConformance;
+import org.apache.druid.sql.calcite.planner.PlannerContext;
+
+import javax.annotation.Nullable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Contains the utility function {@link #parse(String, boolean)}, for parsing Druid SQL statements.
+ */
+public class DruidSqlParser
+{
+  public static final SqlParser.Config PARSER_CONFIG = SqlParser
+      .config()
+      .withCaseSensitive(true)
+      .withUnquotedCasing(Casing.UNCHANGED)
+      .withQuotedCasing(Casing.UNCHANGED)
+      .withQuoting(Quoting.DOUBLE_QUOTE)
+      .withConformance(DruidConformance.instance())
+      .withParserFactory(new DruidSqlParserImplFactory());
+
+  private static final Joiner SPACE_JOINER = Joiner.on(" ");
+  private static final Joiner COMMA_JOINER = Joiner.on(", ");
+
+  private DruidSqlParser()
+  {
+    // No instantiation.
+  }
+
+  public static StatementAndSetContext parse(final String sql, final boolean allowSetStatements)
+  {
+    try {
+      SqlParser parser = SqlParser.create(new SourceStringReader(sql), PARSER_CONFIG);
+      SqlNode sqlNode = parser.parseStmtList();
+      return processStatementList(sqlNode, allowSetStatements);
+    }
+    catch (SqlParseException e) {
+      throw translateParseException(e);
+    }
+  }
+
+  /**
+   * If an {@link SqlNode} is a {@link SqlNodeList}, it must consist of 0 or more {@link SqlSetOption} followed by a
+   * single {@link SqlNode} which is NOT a {@link SqlSetOption}. All {@link SqlSetOption} will be converted into a
+   * context parameters {@link Map} and added to the {@link PlannerContext} with
+   * {@link PlannerContext#addAllToQueryContext(Map)}. The final {@link SqlNode} of the {@link SqlNodeList} is returned
+   * by this method as the {@link SqlNode} which should actually be validated and executed, and will have access to the
+   * modified query context through the {@link PlannerContext}. {@link SqlSetOption} override any existing query
+   * context parameter values.
+   */
+  private static StatementAndSetContext processStatementList(
+      SqlNode root,
+      final boolean allowSetStatements
+  )
+  {
+    if (root instanceof SqlNodeList) {
+      final Map<String, Object> setContext = new LinkedHashMap<>();
+      final SqlNodeList nodeList = (SqlNodeList) root;
+      if (!allowSetStatements && nodeList.size() > 1) {
+        throw InvalidSqlInput.exception("SQL query string must contain only a single statement");
+      }
+      boolean isMissingDruidStatementNode = true;
+      // convert 0 or more SET statements into a Map of stuff to add to the query context
+      for (int i = 0; i < nodeList.size(); i++) {
+        SqlNode sqlNode = nodeList.get(i);
+        if (sqlNode instanceof SqlSetOption) {
+          final SqlSetOption sqlSetOption = (SqlSetOption) sqlNode;
+          if (!(sqlSetOption.getValue() instanceof SqlLiteral)) {
+            throw InvalidSqlInput.exception(
+                "Assigned value must be a literal for SET statement[%s]",
+                sqlSetOption.toSqlString(CalciteSqlDialect.DEFAULT)
+            );
+          }
+          setContext.put(
+              sqlSetOption.getName().getSimple(),
+              sqlLiteralToContextValue((SqlLiteral) sqlSetOption.getValue())
+          );
+        } else if (i < nodeList.size() - 1) {
+          // only SET statements can appear before the last statement
+          throw InvalidSqlInput.exception(
+              "Only SET statements can appear before the final statement in a statement list, but found non-SET statement[%s]",
+              sqlNode.toSqlString(CalciteSqlDialect.DEFAULT)
+          );
+        } else {
+          // last SqlNode
+          root = sqlNode;
+          isMissingDruidStatementNode = false;
+        }
+      }
+      if (isMissingDruidStatementNode) {
+        throw InvalidSqlInput.exception("Statement list is missing a non-SET statement to execute");
+      }
+
+      return new StatementAndSetContext(root, setContext);
+    } else {
+      return new StatementAndSetContext(root, Collections.emptyMap());
+    }
+  }
+
+  /**
+   * Coerces a SQL literal from a SET statement to a form acceptable for {@link QueryContext}.
+   */
+  @Nullable
+  static Object sqlLiteralToContextValue(final SqlLiteral literal)
+  {
+    if (SqlUtil.isNullLiteral(literal, false)) {
+      return null;
+    } else if (SqlTypeName.CHAR_TYPES.contains(literal.getTypeName())) {
+      return ((NlsString) literal.getValue()).getValue();
+    } else if (SqlTypeName.BOOLEAN_TYPES.contains(literal.getTypeName())) {
+      return literal.getValue();
+    } else if (SqlTypeName.NUMERIC_TYPES.contains(literal.getTypeName())) {
+      final Number number = (Number) literal.getValue();
+      if (number instanceof BigDecimal && number.equals(BigDecimal.valueOf(number.longValue()))) {
+        return number.longValue();
+      } else if (number instanceof BigInteger && number.equals(BigInteger.valueOf(number.longValue()))) {
+        return number.longValue();
+      } else if (number instanceof BigDecimal && number.equals(BigDecimal.valueOf(number.doubleValue()))) {
+        return number.doubleValue();
+      } else {
+        return number.toString();
+      }
+    } else if (literal.getTypeName() == SqlTypeName.DATE) {
+      return Calcites.CALCITE_DATE_PARSER.parse(literal.getValue().toString()).toString();
+    } else if (literal.getTypeName() == SqlTypeName.TIMESTAMP) {
+      return Calcites.CALCITE_TIMESTAMP_PARSER.parse(literal.getValue().toString()).toString();
+    } else {
+      throw InvalidSqlInput.exception("Unsupported type for SET[%s]", literal.getTypeName());
+    }
+  }
+
+  /**
+   * Constructs a user-friendly {@link DruidException} from a Calcite {@link SqlParseException}.
+   */
+  private static DruidException translateParseException(SqlParseException e)
+  {
+    final Throwable cause = e.getCause();
+    if (cause instanceof DruidException) {
+      return (DruidException) cause;
+    }
+
+    if (cause instanceof ParseException) {
+      ParseException parseException = (ParseException) cause;
+      final SqlParserPos failurePosition = e.getPos();
+      // When calcite catches a syntax error at the top level
+      // expected token sequences can be null.
+      // In such a case return the syntax error to the user
+      // wrapped in a DruidException with invalid input
+      if (parseException.expectedTokenSequences == null) {
+        return DruidException.forPersona(DruidException.Persona.USER)
+                             .ofCategory(DruidException.Category.INVALID_INPUT)
+                             .withErrorCode("invalidInput")
+                             .build(e, "%s", e.getMessage())
+                             .withContext("sourceType", "sql");
+      } else {
+        final String theUnexpectedToken = getUnexpectedTokenString(parseException);
+
+        final String[] tokenDictionary = e.getTokenImages();
+        final int[][] expectedTokenSequences = e.getExpectedTokenSequences();
+        final ArrayList<String> expectedTokens = new ArrayList<>(expectedTokenSequences.length);
+        for (int[] expectedTokenSequence : expectedTokenSequences) {
+          String[] strings = new String[expectedTokenSequence.length];
+          for (int i = 0; i < expectedTokenSequence.length; ++i) {
+            strings[i] = tokenDictionary[expectedTokenSequence[i]];
+          }
+          expectedTokens.add(SPACE_JOINER.join(strings));
+        }
+
+        return InvalidSqlInput
+            .exception(
+                e,
+                "Received an unexpected token [%s] (line [%s], column [%s]), acceptable options: [%s]",
+                theUnexpectedToken,
+                failurePosition.getLineNum(),
+                failurePosition.getColumnNum(),
+                COMMA_JOINER.join(expectedTokens)
+            )
+            .withContext("line", failurePosition.getLineNum())
+            .withContext("column", failurePosition.getColumnNum())
+            .withContext("endLine", failurePosition.getEndLineNum())
+            .withContext("endColumn", failurePosition.getEndColumnNum())
+            .withContext("token", theUnexpectedToken)
+            .withContext("expected", expectedTokens);
+
+      }
+    }
+
+    return InvalidSqlInput.exception(e.getMessage());
+  }
+
+  /**
+   * Grabs the unexpected token string.  This code is borrowed with minimal adjustments from
+   * {@link ParseException#getMessage()}.  It is possible that if that code changes, we need to also
+   * change this code to match it.
+   *
+   * @param parseException the parse exception to extract from
+   *
+   * @return the String representation of the unexpected token string
+   */
+  private static String getUnexpectedTokenString(ParseException parseException)
+  {
+    int maxSize = 0;
+    for (int[] ints : parseException.expectedTokenSequences) {
+      if (maxSize < ints.length) {
+        maxSize = ints.length;
+      }
+    }
+
+    StringBuilder bob = new StringBuilder();
+    Token tok = parseException.currentToken.next;
+    for (int i = 0; i < maxSize; i++) {
+      if (i != 0) {
+        bob.append(" ");
+      }
+      if (tok.kind == 0) {
+        bob.append("<EOF>");
+        break;
+      }
+      char ch;
+      for (int i1 = 0; i1 < tok.image.length(); i1++) {
+        switch (tok.image.charAt(i1)) {
+          case 0:
+            continue;
+          case '\b':
+            bob.append("\\b");
+            continue;
+          case '\t':
+            bob.append("\\t");
+            continue;
+          case '\n':
+            bob.append("\\n");
+            continue;
+          case '\f':
+            bob.append("\\f");
+            continue;
+          case '\r':
+            bob.append("\\r");
+            continue;
+          case '\"':
+            bob.append("\\\"");
+            continue;
+          case '\'':
+            bob.append("\\\'");
+            continue;
+          case '\\':
+            bob.append("\\\\");
+            continue;
+          default:
+            if ((ch = tok.image.charAt(i1)) < 0x20 || ch > 0x7e) {
+              String s = "0000" + Integer.toString(ch, 16);
+              bob.append("\\u").append(s.substring(s.length() - 4, s.length()));
+            } else {
+              bob.append(ch);
+            }
+        }
+      }
+      tok = tok.next;
+    }
+    return bob.toString();
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/parser/StatementAndSetContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/parser/StatementAndSetContext.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.parser;
+
+import org.apache.calcite.sql.SqlNode;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a parsed "main" (not SET) SQL statement, plus context derived from SET statements.
+ */
+public class StatementAndSetContext
+{
+  private final SqlNode mainStatement;
+  private final Map<String, Object> setContext;
+
+  public StatementAndSetContext(SqlNode mainStatement, Map<String, Object> setContext)
+  {
+    this.mainStatement = mainStatement;
+    this.setContext = setContext;
+  }
+
+  public SqlNode getMainStatement()
+  {
+    return mainStatement;
+  }
+
+  public Map<String, Object> getSetContext()
+  {
+    return setContext;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StatementAndSetContext that = (StatementAndSetContext) o;
+    return Objects.equals(mainStatement, that.mainStatement)
+           && Objects.equals(setContext, that.setContext);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(mainStatement, setContext);
+  }
+
+  @Override
+  public String toString()
+  {
+    return "StatementAndSetContext{" +
+           "mainStatement=" + mainStatement +
+           ", setContext=" + setContext +
+           '}';
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalcitePlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/CalcitePlanner.java
@@ -60,6 +60,7 @@ import org.apache.calcite.tools.Program;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.calcite.util.Pair;
+import org.apache.druid.sql.calcite.parser.DruidSqlParser;
 
 import javax.annotation.Nullable;
 import java.io.Reader;
@@ -230,6 +231,25 @@ public class CalcitePlanner implements Planner, ViewExpander
     SqlNode sqlNode = parser.parseStmtList();
     state = CalcitePlanner.State.STATE_3_PARSED;
     return sqlNode;
+  }
+
+  /**
+   * Skip parsing, moving state along to a {@link State#STATE_3_PARSED}. We have this because we
+   * parse before the planner is even created, using {@link DruidSqlParser}, in order to capture
+   * SET statements as early as possible.
+   */
+  public void skipParse()
+  {
+    switch (state) {
+      case STATE_0_CLOSED:
+      case STATE_1_RESET:
+        ready();
+        break;
+      default:
+        break;
+    }
+    ensure(CalcitePlanner.State.STATE_2_READY);
+    state = CalcitePlanner.State.STATE_3_PARSED;
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/Calcites.java
@@ -77,8 +77,8 @@ import java.util.regex.Pattern;
  */
 public class Calcites
 {
-  private static final DateTimes.UtcFormatter CALCITE_DATE_PARSER = DateTimes.wrapFormatter(ISODateTimeFormat.dateParser());
-  private static final DateTimes.UtcFormatter CALCITE_TIMESTAMP_PARSER = DateTimes.wrapFormatter(
+  public static final DateTimes.UtcFormatter CALCITE_DATE_PARSER = DateTimes.wrapFormatter(ISODateTimeFormat.dateParser());
+  public static final DateTimes.UtcFormatter CALCITE_TIMESTAMP_PARSER = DateTimes.wrapFormatter(
       new DateTimeFormatterBuilder()
           .append(ISODateTimeFormat.dateParser())
           .appendLiteral(' ')

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/DruidPlanner.java
@@ -20,20 +20,13 @@
 package org.apache.druid.sql.calcite.planner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.sql.SqlExplain;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlSetOption;
-import org.apache.calcite.sql.dialect.CalciteSqlDialect;
-import org.apache.calcite.sql.parser.SqlParseException;
-import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.ValidationException;
 import org.apache.druid.error.DruidException;
@@ -44,16 +37,11 @@ import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.sql.calcite.parser.DruidSqlInsert;
 import org.apache.druid.sql.calcite.parser.DruidSqlReplace;
-import org.apache.druid.sql.calcite.parser.ParseException;
-import org.apache.druid.sql.calcite.parser.Token;
 import org.apache.druid.sql.calcite.run.SqlEngine;
-import org.apache.druid.sql.calcite.run.SqlResults;
 import org.joda.time.DateTimeZone;
 
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -70,9 +58,6 @@ import java.util.function.Function;
  */
 public class DruidPlanner implements Closeable
 {
-  public static final Joiner SPACE_JOINER = Joiner.on(" ");
-  public static final Joiner COMMA_JOINER = Joiner.on(", ");
-
   public enum State
   {
     START, VALIDATED, PREPARED, PLANNED
@@ -112,7 +97,6 @@ public class DruidPlanner implements Closeable
   private final PlannerContext plannerContext;
   private final SqlEngine engine;
   private final PlannerHook hook;
-  private final boolean allowSetStatementsToBuildContext;
   private State state = State.START;
   private SqlStatementHandler handler;
   private boolean authorized;
@@ -121,8 +105,7 @@ public class DruidPlanner implements Closeable
       final FrameworkConfig frameworkConfig,
       final PlannerContext plannerContext,
       final SqlEngine engine,
-      final PlannerHook hook,
-      final boolean allowSetStatementsToBuildContext
+      final PlannerHook hook
   )
   {
     this.frameworkConfig = frameworkConfig;
@@ -130,7 +113,6 @@ public class DruidPlanner implements Closeable
     this.plannerContext = plannerContext;
     this.engine = engine;
     this.hook = hook == null ? NoOpPlannerHook.INSTANCE : hook;
-    this.allowSetStatementsToBuildContext = allowSetStatementsToBuildContext;
   }
 
   /**
@@ -145,19 +127,8 @@ public class DruidPlanner implements Closeable
 
     // Validate query context.
     engine.validateContext(plannerContext.queryContextMap());
-
-    // Parse the query string.
-    String sql = plannerContext.getSql();
-    hook.captureSql(sql);
-    SqlNode root;
-    try {
-      root = planner.parse(sql);
-    }
-    catch (SqlParseException e1) {
-      throw translateException(e1);
-    }
-    root = processStatementList(root);
-    root = rewriteParameters(root);
+    planner.skipParse();
+    final SqlNode root = rewriteParameters(plannerContext.getSqlNode());
     hook.captureSqlNode(root);
     handler = createHandler(root);
     handler.validate();
@@ -293,66 +264,6 @@ public class DruidPlanner implements Closeable
     planner.close();
   }
 
-  /**
-   * If an {@link SqlNode} is a {@link SqlNodeList}, it must consist of 0 or more {@link SqlSetOption} followed by a
-   * single {@link SqlNode} which is NOT a {@link SqlSetOption}. All {@link SqlSetOption} will be converted into a
-   * context parameters {@link Map} and added to the {@link PlannerContext} with
-   * {@link PlannerContext#addAllToQueryContext(Map)}. The final {@link SqlNode} of the {@link SqlNodeList} is returned
-   * by this method as the {@link SqlNode} which should actually be validated and executed, and will have access to the
-   * modified query context through the {@link PlannerContext}. {@link SqlSetOption} override any existing query
-   * context parameter values.
-   */
-  private SqlNode processStatementList(SqlNode root)
-  {
-    if (root instanceof SqlNodeList) {
-      final SqlNodeList nodeList = (SqlNodeList) root;
-      if (!allowSetStatementsToBuildContext && nodeList.size() > 1) {
-        throw InvalidSqlInput.exception("SQL query string must contain only a single statement");
-      }
-      final Map<String, Object> contextMap = new LinkedHashMap<>();
-      boolean isMissingDruidStatementNode = true;
-      // convert 0 or more SET statements into a Map of stuff to add to the query context
-      for (int i = 0; i < nodeList.size(); i++) {
-        SqlNode sqlNode = nodeList.get(i);
-        if (sqlNode instanceof SqlSetOption) {
-          final SqlSetOption sqlSetOption = (SqlSetOption) sqlNode;
-          if (!(sqlSetOption.getValue() instanceof SqlLiteral)) {
-            throw InvalidSqlInput.exception(
-                "Assigned value must be a literal for SET statement[%s]",
-                sqlSetOption.toSqlString(CalciteSqlDialect.DEFAULT)
-            );
-          }
-          final SqlLiteral value = (SqlLiteral) sqlSetOption.getValue();
-          contextMap.put(
-              sqlSetOption.getName().getSimple(),
-              SqlResults.coerce(
-                  plannerContext.getJsonMapper(),
-                  SqlResults.Context.fromPlannerContext(plannerContext),
-                  value.getValue(),
-                  value.getTypeName(),
-                  "set"
-              )
-          );
-        } else if (i < nodeList.size() - 1) {
-          // only SET statements can appear before the last statement
-          throw InvalidSqlInput.exception(
-              "Only SET statements can appear before the final statement in a statement list, but found non-SET statement[%s]",
-              sqlNode.toSqlString(CalciteSqlDialect.DEFAULT)
-          );
-        } else {
-          // last SqlNode
-          root = sqlNode;
-          isMissingDruidStatementNode = false;
-        }
-      }
-      if (isMissingDruidStatementNode) {
-        throw InvalidSqlInput.exception("Statement list is missing a non-SET statement to execute");
-      }
-      plannerContext.addAllToQueryContext(contextMap);
-    }
-    return root;
-  }
-
   protected class HandlerContextImpl implements SqlStatementHandler.HandlerContext
   {
     @Override
@@ -421,59 +332,6 @@ public class DruidPlanner implements Closeable
     catch (ValidationException inner) {
       return parseValidationMessage(inner);
     }
-    catch (SqlParseException inner) {
-      final Throwable cause = inner.getCause();
-      if (cause instanceof DruidException) {
-        return (DruidException) cause;
-      }
-
-      if (cause instanceof ParseException) {
-        ParseException parseException = (ParseException) cause;
-        final SqlParserPos failurePosition = inner.getPos();
-        // When calcite catches a syntax error at the top level
-        // expected token sequences can be null.
-        // In such a case return the syntax error to the user
-        // wrapped in a DruidException with invalid input
-        if (parseException.expectedTokenSequences == null) {
-          return DruidException.forPersona(DruidException.Persona.USER)
-                               .ofCategory(DruidException.Category.INVALID_INPUT)
-                               .withErrorCode("invalidInput")
-                               .build(inner, "%s", inner.getMessage()).withContext("sourceType", "sql");
-        } else {
-          final String theUnexpectedToken = getUnexpectedTokenString(parseException);
-
-          final String[] tokenDictionary = inner.getTokenImages();
-          final int[][] expectedTokenSequences = inner.getExpectedTokenSequences();
-          final ArrayList<String> expectedTokens = new ArrayList<>(expectedTokenSequences.length);
-          for (int[] expectedTokenSequence : expectedTokenSequences) {
-            String[] strings = new String[expectedTokenSequence.length];
-            for (int i = 0; i < expectedTokenSequence.length; ++i) {
-              strings[i] = tokenDictionary[expectedTokenSequence[i]];
-            }
-            expectedTokens.add(SPACE_JOINER.join(strings));
-          }
-
-          return InvalidSqlInput
-              .exception(
-                  inner,
-                  "Received an unexpected token [%s] (line [%s], column [%s]), acceptable options: [%s]",
-                  theUnexpectedToken,
-                  failurePosition.getLineNum(),
-                  failurePosition.getColumnNum(),
-                  COMMA_JOINER.join(expectedTokens)
-              )
-              .withContext("line", failurePosition.getLineNum())
-              .withContext("column", failurePosition.getColumnNum())
-              .withContext("endLine", failurePosition.getEndLineNum())
-              .withContext("endColumn", failurePosition.getEndColumnNum())
-              .withContext("token", theUnexpectedToken)
-              .withContext("expected", expectedTokens);
-
-        }
-      }
-
-      return InvalidSqlInput.exception(inner.getMessage());
-    }
     catch (RelOptPlanner.CannotPlanException inner) {
       return DruidException.forPersona(DruidException.Persona.USER)
                            .ofCategory(DruidException.Category.INVALID_INPUT)
@@ -524,76 +382,4 @@ public class DruidPlanner implements Closeable
                            .build(e, "Uncategorized calcite error message: [%s]", e.getMessage());
     }
   }
-
-  /**
-   * Grabs the unexpected token string.  This code is borrowed with minimal adjustments from
-   * {@link ParseException#getMessage()}.  It is possible that if that code changes, we need to also
-   * change this code to match it.
-   *
-   * @param parseException the parse exception to extract from
-   * @return the String representation of the unexpected token string
-   */
-  private static String getUnexpectedTokenString(ParseException parseException)
-  {
-    int maxSize = 0;
-    for (int[] ints : parseException.expectedTokenSequences) {
-      if (maxSize < ints.length) {
-        maxSize = ints.length;
-      }
-    }
-
-    StringBuilder bob = new StringBuilder();
-    Token tok = parseException.currentToken.next;
-    for (int i = 0; i < maxSize; i++) {
-      if (i != 0) {
-        bob.append(" ");
-      }
-      if (tok.kind == 0) {
-        bob.append("<EOF>");
-        break;
-      }
-      char ch;
-      for (int i1 = 0; i1 < tok.image.length(); i1++) {
-        switch (tok.image.charAt(i1)) {
-          case 0:
-            continue;
-          case '\b':
-            bob.append("\\b");
-            continue;
-          case '\t':
-            bob.append("\\t");
-            continue;
-          case '\n':
-            bob.append("\\n");
-            continue;
-          case '\f':
-            bob.append("\\f");
-            continue;
-          case '\r':
-            bob.append("\\r");
-            continue;
-          case '\"':
-            bob.append("\\\"");
-            continue;
-          case '\'':
-            bob.append("\\\'");
-            continue;
-          case '\\':
-            bob.append("\\\\");
-            continue;
-          default:
-            if ((ch = tok.image.charAt(i1)) < 0x20 || ch > 0x7e) {
-              String s = "0000" + Integer.toString(ch, 16);
-              bob.append("\\u").append(s.substring(s.length() - 4, s.length()));
-            } else {
-              bob.append(ch);
-            }
-            continue;
-        }
-      }
-      tok = tok.next;
-    }
-    return bob.toString();
-  }
-
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/planner/PlannerContext.java
@@ -28,6 +28,7 @@ import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.avatica.remote.TypedValue;
 import org.apache.calcite.linq4j.QueryProvider;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlNode;
 import org.apache.druid.error.InvalidSqlInput;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
@@ -128,6 +129,7 @@ public class PlannerContext
   private final PlannerToolbox plannerToolbox;
   private final ExpressionParser expressionParser;
   private final String sql;
+  private final SqlNode sqlNode;
   private final SqlEngine engine;
   private final Map<String, Object> queryContext;
   private final CopyOnWriteArrayList<String> nativeQueryIds = new CopyOnWriteArrayList<>();
@@ -163,6 +165,7 @@ public class PlannerContext
   private PlannerContext(
       final PlannerToolbox plannerToolbox,
       final String sql,
+      final SqlNode sqlNode,
       final SqlEngine engine,
       final Map<String, Object> queryContext,
       final PlannerHook hook
@@ -171,6 +174,7 @@ public class PlannerContext
     this.plannerToolbox = plannerToolbox;
     this.expressionParser = new ExpressionParserImpl(plannerToolbox.exprMacroTable());
     this.sql = sql;
+    this.sqlNode = sqlNode;
     this.engine = engine;
     this.queryContext = new LinkedHashMap<>(queryContext);
     this.hook = hook == null ? NoOpPlannerHook.INSTANCE : hook;
@@ -180,6 +184,7 @@ public class PlannerContext
   public static PlannerContext create(
       final PlannerToolbox plannerToolbox,
       final String sql,
+      final SqlNode sqlNode,
       final SqlEngine engine,
       final Map<String, Object> queryContext,
       final PlannerHook hook
@@ -188,6 +193,7 @@ public class PlannerContext
     return new PlannerContext(
         plannerToolbox,
         sql,
+        sqlNode,
         engine,
         queryContext,
         hook
@@ -391,6 +397,11 @@ public class PlannerContext
   public String getSql()
   {
     return sql;
+  }
+
+  public SqlNode getSqlNode()
+  {
+    return sqlNode;
   }
 
   public PlannerHook getPlannerHook()

--- a/sql/src/main/java/org/apache/druid/sql/calcite/view/DruidViewMacro.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/view/DruidViewMacro.java
@@ -28,6 +28,7 @@ import org.apache.calcite.schema.FunctionParameter;
 import org.apache.calcite.schema.TableMacro;
 import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.schema.impl.ViewTable;
+import org.apache.druid.sql.calcite.parser.DruidSqlParser;
 import org.apache.druid.sql.calcite.planner.DruidPlanner;
 import org.apache.druid.sql.calcite.planner.PlannerFactory;
 import org.apache.druid.sql.calcite.schema.DruidSchemaName;
@@ -61,9 +62,9 @@ public class DruidViewMacro implements TableMacro
              plannerFactory.createPlanner(
                  ViewSqlEngine.INSTANCE,
                  viewSql,
+                 DruidSqlParser.parse(viewSql, false).getMainStatement(), // views cannot embed SET
                  Collections.emptyMap(),
-                 null,
-                 false
+                 null
              )
     ) {
       planner.validate();

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlEngineRegistry.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlEngineRegistry.java
@@ -20,8 +20,8 @@
 package org.apache.druid.sql.http;
 
 import com.google.inject.Inject;
+import org.apache.druid.error.InvalidSqlInput;
 import org.apache.druid.query.QueryContexts;
-import org.apache.druid.server.initialization.jetty.BadRequestException;
 import org.apache.druid.sql.calcite.run.SqlEngine;
 
 import javax.validation.constraints.NotNull;
@@ -46,7 +46,7 @@ public class SqlEngineRegistry
   {
     SqlEngine engine = engines.getOrDefault(engineName == null ? QueryContexts.DEFAULT_ENGINE : engineName, null);
     if (engine == null) {
-      throw new BadRequestException("Unsupported engine");
+      throw InvalidSqlInput.exception("Unsupported engine[%s]", engineName);
     }
     return engine;
   }

--- a/sql/src/test/java/org/apache/druid/sql/SqlQueryPlusTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlQueryPlusTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql;
+
+import org.apache.druid.error.DruidException;
+import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.sql.calcite.util.CalciteTests;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SqlQueryPlusTest
+{
+  @Test
+  public void testSyntaxError()
+  {
+    // SqlQueryPlus throws parse errors on build() if the statement is invalid
+    final DruidException e = Assert.assertThrows(
+        DruidException.class,
+        () -> SqlQueryPlus.builder("SELECT COUNT(*) AS cnt, 'foo' AS")
+                          .auth(CalciteTests.REGULAR_USER_AUTH_RESULT)
+                          .build()
+    );
+
+    MatcherAssert.assertThat(
+        e,
+        DruidExceptionMatcher
+            .invalidSqlInput()
+            .expectMessageContains("Incorrect syntax near the keyword 'AS' at line 1, column 31")
+    );
+  }
+
+  @Test
+  public void testSyntaxErrorJdbc()
+  {
+    // SqlQueryPlus does not throw parse errors on buildJdbc(), because parsing is deferred
+    final SqlQueryPlus sqlQueryPlus =
+        SqlQueryPlus.builder("SELECT COUNT(*) AS cnt, 'foo' AS")
+                    .auth(CalciteTests.REGULAR_USER_AUTH_RESULT)
+                    .buildJdbc();
+
+    // It does throw exceptions on freshCopy(), though.
+    final DruidException e = Assert.assertThrows(
+        DruidException.class,
+        sqlQueryPlus::freshCopy
+    );
+
+    MatcherAssert.assertThat(
+        e,
+        DruidExceptionMatcher
+            .invalidSqlInput()
+            .expectMessageContains("Incorrect syntax near the keyword 'AS' at line 1, column 31")
+    );
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidStatementTest.java
@@ -152,12 +152,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testSubQueryWithOrderByDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SUB_QUERY_WITH_ORDER_BY,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SUB_QUERY_WITH_ORDER_BY)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       // First frame, ask for all rows.
       statement.execute(queryPlus, -1);
@@ -173,12 +172,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testFetchPastEOFDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SUB_QUERY_WITH_ORDER_BY,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SUB_QUERY_WITH_ORDER_BY)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       // First frame, ask for all rows.
       statement.execute(queryPlus, -1);
@@ -221,12 +219,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testFetchAfterResultCloseDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SUB_QUERY_WITH_ORDER_BY,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SUB_QUERY_WITH_ORDER_BY)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       // First frame, ask for all rows.
       statement.execute(queryPlus, -1);
@@ -243,12 +240,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testSubQueryWithOrderByDirectTwice()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SUB_QUERY_WITH_ORDER_BY,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SUB_QUERY_WITH_ORDER_BY)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       statement.execute(queryPlus, -1);
       Meta.Frame frame = statement.nextFrame(AbstractDruidJdbcStatement.START_OFFSET, 6);
@@ -288,12 +284,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testSelectAllInFirstFrameDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SELECT_FROM_FOO,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       // First frame, ask for all rows.
       statement.execute(queryPlus, -1);
@@ -330,12 +325,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testSelectSplitOverTwoFramesDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SELECT_FROM_FOO,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
 
       // First frame, ask for 2 rows.
@@ -367,12 +361,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testTwoFramesAutoCloseDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SELECT_FROM_FOO,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       // First frame, ask for 2 rows.
       statement.execute(queryPlus, -1);
@@ -409,12 +402,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testTwoFramesCloseWithResultSetDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SELECT_FROM_FOO,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       // First frame, ask for 2 rows.
       statement.execute(queryPlus, -1);
@@ -464,12 +456,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testSignatureDirect()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SELECT_STAR_FROM_FOO,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_STAR_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcStatement statement = jdbcStatement()) {
       // Check signature.
       statement.execute(queryPlus, -1);
@@ -533,12 +524,11 @@ public class DruidStatementTest extends CalciteTestBase
   public void testSubQueryWithOrderByPrepared()
   {
     final String sql = "select T20.F13 as F22  from (SELECT DISTINCT dim1 as F13 FROM druid.foo T10) T20 order by T20.F13 ASC";
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        sql,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(sql)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcPreparedStatement statement = jdbcPreparedStatement(queryPlus)) {
       statement.prepare();
       // First frame, ask for all rows.
@@ -556,12 +546,11 @@ public class DruidStatementTest extends CalciteTestBase
   public void testSubQueryWithOrderByPreparedTwice()
   {
     final String sql = "select T20.F13 as F22  from (SELECT DISTINCT dim1 as F13 FROM druid.foo T10) T20 order by T20.F13 ASC";
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        sql,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(sql)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcPreparedStatement statement = jdbcPreparedStatement(queryPlus)) {
       statement.prepare();
       statement.execute(Collections.emptyList());
@@ -586,12 +575,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testSignaturePrepared()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        SELECT_STAR_FROM_FOO,
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_STAR_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     try (final DruidJdbcPreparedStatement statement = jdbcPreparedStatement(queryPlus)) {
       statement.prepare();
       verifySignature(statement.getSignature());
@@ -601,12 +589,11 @@ public class DruidStatementTest extends CalciteTestBase
   @Test
   public void testParameters()
   {
-    SqlQueryPlus queryPlus = new SqlQueryPlus(
-        "SELECT COUNT(*) AS cnt FROM sys.servers WHERE servers.host = ?",
-        null,
-        null,
-        AllowAllAuthenticator.ALLOW_ALL_RESULT
-    );
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql("SELECT COUNT(*) AS cnt FROM sys.servers WHERE servers.host = ?")
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
     Meta.Frame expected = Meta.Frame.create(0, true, Collections.singletonList(new Object[] {1L}));
     List<TypedValue> matchingParams = Collections.singletonList(TypedValue.ofLocal(ColumnMetaData.Rep.STRING, "dummy"));
     try (final DruidJdbcPreparedStatement statement = jdbcPreparedStatement(queryPlus)) {

--- a/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/CalciteQueryTest.java
@@ -15976,4 +15976,52 @@ public class CalciteQueryTest extends BaseCalciteQueryTest
         "Only SET statements can appear before the final statement in a statement list, but found non-SET statement[SELECT 1]"
     );
   }
+
+  @Test
+  public void testSetUseApproximateCountDistinctFalse()
+  {
+    testBuilder().sql(
+        "SET useApproximateCountDistinct = FALSE;\n"
+        + "SELECT COUNT(DISTINCT dim2) FROM druid.foo"
+    ).expectedQueries(
+        ImmutableList.of(
+            GroupByQuery.builder()
+                        .setDataSource(
+                            new QueryDataSource(
+                                GroupByQuery.builder()
+                                            .setDataSource(CalciteTests.DATASOURCE1)
+                                            .setInterval(querySegmentSpec(Filtration.eternity()))
+                                            .setGranularity(Granularities.ALL)
+                                            .setDimensions(dimensions(new DefaultDimensionSpec("dim2", "d0")))
+                                            .setContext(
+                                                ImmutableMap.<String, Object>builder()
+                                                            .putAll(QUERY_CONTEXT_DEFAULT)
+                                                            .put("useApproximateCountDistinct", false)
+                                                            .build()
+                                            )
+                                            .build()
+                            )
+                        )
+                        .setInterval(querySegmentSpec(Filtration.eternity()))
+                        .setGranularity(Granularities.ALL)
+                        .setAggregatorSpecs(aggregators(
+                            new FilteredAggregatorFactory(
+                                new CountAggregatorFactory("a0"),
+                                notNull("d0")
+                            )
+                        ))
+                        .setContext(
+                            ImmutableMap.<String, Object>builder()
+                                        .putAll(QUERY_CONTEXT_DEFAULT)
+                                        .put("useApproximateCountDistinct", false)
+                                        .build()
+                        )
+                        .build()
+        )
+    ).expectedResults(
+        ImmutableList.of(
+            new Object[]{3L}
+        )
+    ).run();
+  }
 }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/QueryTestRunner.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/QueryTestRunner.java
@@ -263,10 +263,6 @@ public class QueryTestRunner
       BaseCalciteQueryTest.log.info("SQL: %s", builder.sql);
 
       final SqlStatementFactory sqlStatementFactory = builder.statementFactory();
-      final SqlQueryPlus sqlQuery = SqlQueryPlus.builder(builder.sql)
-                                                .sqlParameters(builder.parameters)
-                                                .auth(builder.authenticationResult)
-                                                .build();
 
       final List<String> vectorizeValues = new ArrayList<>();
       vectorizeValues.add("false");
@@ -275,7 +271,14 @@ public class QueryTestRunner
       }
 
       for (final String vectorize : vectorizeValues) {
-        final Map<String, Object> theQueryContext = new HashMap<>(builder.queryContext);
+        // Need to create sqlQuery inside the loop, because SqlQueryPlus can only be used once
+        final SqlQueryPlus sqlQuery = SqlQueryPlus.builder(builder.sql)
+                                                  .sqlParameters(builder.parameters)
+                                                  .auth(builder.authenticationResult)
+                                                  .context(builder.queryContext)
+                                                  .build();
+
+        final Map<String, Object> theQueryContext = new HashMap<>(sqlQuery.context());
         theQueryContext.put(QueryContexts.VECTORIZE_KEY, vectorize);
         theQueryContext.put(QueryContexts.VECTORIZE_VIRTUAL_COLUMNS_KEY, vectorize);
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/expression/ExpressionTestHelper.java
@@ -106,6 +106,7 @@ public class ExpressionTestHelper
   public static final PlannerContext PLANNER_CONTEXT = PlannerContext.create(
       PLANNER_TOOLBOX,
       "SELECT 1", // The actual query isn't important for this test
+      null, /* Don't need SQL node */
       null, /* Don't need engine */
       Collections.emptyMap(),
       null

--- a/sql/src/test/java/org/apache/druid/sql/calcite/external/ExternalTableScanRuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/external/ExternalTableScanRuleTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.query.QueryRunnerFactoryConglomerate;
 import org.apache.druid.query.QuerySegmentWalker;
 import org.apache.druid.query.policy.NoopPolicyEnforcer;
 import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.sql.calcite.parser.DruidSqlParser;
 import org.apache.druid.sql.calcite.planner.CalciteRulesManager;
 import org.apache.druid.sql.calcite.planner.CatalogResolver;
 import org.apache.druid.sql.calcite.planner.PlannerConfig;
@@ -79,7 +80,8 @@ public class ExternalTableScanRuleTest
     );
     final PlannerContext plannerContext = PlannerContext.create(
         toolbox,
-        "DUMMY", // The actual query isn't important for this test
+        "SELECT 1", // The actual query isn't important for this test
+        DruidSqlParser.parse("SELECT 1", false).getMainStatement(),
         engine,
         Collections.emptyMap(),
         null

--- a/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/parser/DruidSqlParserTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.calcite.parser;
+
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.DateString;
+import org.apache.calcite.util.TimestampString;
+import org.apache.druid.error.DruidException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DruidSqlParserTest
+{
+  @Test
+  public void test_sqlLiteralToContextValue_null()
+  {
+    final SqlLiteral literal = SqlLiteral.createNull(SqlParserPos.ZERO);
+    Assert.assertNull(DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_string()
+  {
+    final SqlLiteral literal = SqlLiteral.createCharString("abc", SqlParserPos.ZERO);
+    Assert.assertEquals("abc", DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_stringWithSpecialChars()
+  {
+    final SqlLiteral literal = SqlLiteral.createCharString("hello\nworld\t\"test\"", SqlParserPos.ZERO);
+    Assert.assertEquals("hello\nworld\t\"test\"", DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_integer()
+  {
+    // Numbers within Long range are converted to Long.
+    final SqlLiteral literal = SqlLiteral.createExactNumeric("42", SqlParserPos.ZERO);
+    Assert.assertEquals(42L, DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_negativeInteger()
+  {
+    final SqlLiteral literal = SqlLiteral.createExactNumeric("-123", SqlParserPos.ZERO);
+    Assert.assertEquals(-123L, DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_decimal()
+  {
+    // Decimals are converted to Double.
+    final SqlLiteral literal = SqlLiteral.createExactNumeric("3.14159", SqlParserPos.ZERO);
+    Assert.assertEquals(3.14159, DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_largeNumber()
+  {
+    // Integers outside Long range are retained as strings.
+    final SqlLiteral literal = SqlLiteral.createExactNumeric("123456789012345678901234567890", SqlParserPos.ZERO);
+    Assert.assertEquals("123456789012345678901234567890", DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_approximateNumeric()
+  {
+    final SqlLiteral literal = SqlLiteral.createApproxNumeric("1.23E10", SqlParserPos.ZERO);
+    Assert.assertEquals(1.23E10, DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_booleanTrue()
+  {
+    final SqlLiteral literal = SqlLiteral.createBoolean(true, SqlParserPos.ZERO);
+    Assert.assertEquals(true, DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_booleanFalse()
+  {
+    final SqlLiteral literal = SqlLiteral.createBoolean(false, SqlParserPos.ZERO);
+    Assert.assertEquals(false, DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_timestamp()
+  {
+    // Timestamps are returned as strings in ISO8601 format
+    final TimestampString timestampString = new TimestampString("2023-01-15 14:30:00");
+    final SqlLiteral literal =
+        SqlLiteral.createTimestamp(SqlTypeName.TIMESTAMP, timestampString, 0, SqlParserPos.ZERO);
+    Assert.assertEquals("2023-01-15T14:30:00.000Z", DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_timestampWithFractionalSeconds()
+  {
+    final TimestampString timestampString = new TimestampString("2023-01-15 14:30:00.123");
+    final SqlLiteral literal =
+        SqlLiteral.createTimestamp(SqlTypeName.TIMESTAMP, timestampString, 3, SqlParserPos.ZERO);
+    Assert.assertEquals("2023-01-15T14:30:00.123Z", DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_date()
+  {
+    final DateString dateString = new DateString("2023-01-15");
+    final SqlLiteral literal = SqlLiteral.createDate(dateString, SqlParserPos.ZERO);
+    Assert.assertEquals("2023-01-15T00:00:00.000Z", DruidSqlParser.sqlLiteralToContextValue(literal));
+  }
+
+  @Test
+  public void test_sqlLiteralToContextValue_unsupportedType()
+  {
+    final SqlLiteral literal = SqlLiteral.createSymbol(SqlTypeName.BINARY, SqlParserPos.ZERO);
+    final DruidException exception = Assert.assertThrows(
+        DruidException.class,
+        () -> DruidSqlParser.sqlLiteralToContextValue(literal)
+    );
+    Assert.assertTrue(exception.getMessage().contains("Unsupported type for SET"));
+  }
+}

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/CalcitePlannerModuleTest.java
@@ -44,6 +44,7 @@ import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.sql.SqlStatementFactory;
 import org.apache.druid.sql.calcite.aggregation.SqlAggregator;
 import org.apache.druid.sql.calcite.expression.SqlOperatorConversion;
+import org.apache.druid.sql.calcite.parser.DruidSqlParser;
 import org.apache.druid.sql.calcite.rule.ExtensionCalciteRuleProvider;
 import org.apache.druid.sql.calcite.run.NativeSqlEngine;
 import org.apache.druid.sql.calcite.schema.DruidSchemaCatalog;
@@ -184,9 +185,11 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
     ObjectMapper mapper = new DefaultObjectMapper();
     PlannerToolbox toolbox = injector.getInstance(PlannerFactory.class);
 
+    final String sql = "SELECT 1";
     PlannerContext context = PlannerContext.create(
         toolbox,
-        "SELECT 1",
+        sql,
+        DruidSqlParser.parse(sql, false).getMainStatement(),
         new NativeSqlEngine(queryLifecycleFactory, mapper, (SqlStatementFactory) null),
         Collections.emptyMap(),
         null
@@ -204,9 +207,11 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
     ObjectMapper mapper = new DefaultObjectMapper();
     PlannerToolbox toolbox = injector.getInstance(PlannerFactory.class);
 
+    final String sql = "SELECT 1";
     PlannerContext contextWithBloat = PlannerContext.create(
             toolbox,
-            "SELECT 1",
+            sql,
+            DruidSqlParser.parse(sql, false).getMainStatement(),
             new NativeSqlEngine(queryLifecycleFactory, mapper, (SqlStatementFactory) null),
             Collections.singletonMap(BLOAT_PROPERTY, BLOAT),
             null
@@ -214,7 +219,8 @@ public class CalcitePlannerModuleTest extends CalciteTestBase
 
     PlannerContext contextWithoutBloat = PlannerContext.create(
             toolbox,
-            "SELECT 1",
+            sql,
+            DruidSqlParser.parse(sql, false).getMainStatement(),
             new NativeSqlEngine(queryLifecycleFactory, mapper, (SqlStatementFactory) null),
             Collections.emptyMap(),
             null

--- a/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/planner/DruidRexExecutorTest.java
@@ -112,6 +112,7 @@ public class DruidRexExecutorTest extends InitializedNullHandlingTest
   private static final PlannerContext PLANNER_CONTEXT = PlannerContext.create(
       PLANNER_TOOLBOX,
       "SELECT 1", // The actual query isn't important for this test
+      null, /* Don't need a SQL node */
       null, /* Don't need an engine */
       Collections.emptyMap(),
       null

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
@@ -368,9 +368,9 @@ public class QueryFrameworkUtils
           return plannerFactory.createPlanner(
               engine,
               queryPlus.sql(),
+              queryPlus.sqlNode(),
               queryContext,
-              hook,
-              true
+              hook
           );
         }
       };
@@ -387,9 +387,9 @@ public class QueryFrameworkUtils
           return plannerFactory.createPlanner(
               engine,
               queryPlus.sql(),
+              queryPlus.sqlNode(),
               queryContext,
-              hook,
-              true
+              hook
           );
         }
 

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -292,13 +292,13 @@ public class SqlResourceTest extends CalciteTestBase
     {
       @Override
       public HttpStatement httpStatement(
-          final SqlQuery sqlQuery,
+          final SqlQueryPlus sqlQueryPlus,
           final HttpServletRequest req
       )
       {
         TestHttpStatement stmt = new TestHttpStatement(
             sqlToolbox.withEngine(engine),
-            sqlQuery,
+            sqlQueryPlus,
             req,
             validateAndAuthorizeLatchSupplier,
             planLatchSupplier,
@@ -1481,7 +1481,7 @@ public class SqlResourceTest extends CalciteTestBase
         errorResponse,
         "Incorrect syntax near the keyword 'FROM' at line 1, column 1"
     );
-    checkSqlRequestLog(false);
+    Assert.assertEquals(0, testRequestLogger.getSqlQueryLogs().size()); // Invalid queries are not logged
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
   }
 
@@ -1590,15 +1590,10 @@ public class SqlResourceTest extends CalciteTestBase
             ImmutableMap.of(BaseQuery.SQL_QUERY_ID, "id"),
             null
         ),
-        501
+        DruidException.Category.INVALID_INPUT.getExpectedStatus()
     );
 
-    validateLegacyQueryExceptionErrorResponse(
-        exception,
-        QueryException.QUERY_UNSUPPORTED_ERROR_CODE,
-        QueryUnsupportedException.class.getName(),
-        ""
-    );
+    validateInvalidSqlError(exception, "Incorrect syntax near the keyword 'TO'");
     Assert.assertTrue(lifecycleManager.getAll("id").isEmpty());
   }
 
@@ -1623,32 +1618,31 @@ public class SqlResourceTest extends CalciteTestBase
 
     // This is checked in the common method that returns the response, but checking it again just protects
     // from changes there breaking the checks, so doesn't hurt.
-    assertStatusAndCommonHeaders(response, 501);
+    assertStatusAndCommonHeaders(response, DruidException.Category.INVALID_INPUT.getExpectedStatus());
     Assert.assertEquals(queryId, getHeader(response, QueryResource.QUERY_ID_RESPONSE_HEADER));
     Assert.assertEquals(queryId, getHeader(response, SqlResource.SQL_QUERY_ID_RESPONSE_HEADER));
   }
 
   @Test
-  public void testErrorResponseReturnNewQueryIdWhenNotSetInContext()
+  public void testErrorResponseReturnNoQueryIdWhenNotSetInContext()
   {
     String errorMessage = "This will be supported in Druid 9999";
     failOnExecute(errorMessage);
-    final Response response = postForSyncResponse(
-        new SqlQuery(
-            "SELECT ANSWER TO LIFE",
-            ResultFormat.OBJECT,
-            false,
-            false,
-            false,
-            ImmutableMap.of(),
-            null
-        ),
-        req
+    final SqlQuery sqlQuery = new SqlQuery(
+        "SELECT ANSWER TO LIFE",
+        ResultFormat.OBJECT,
+        false,
+        false,
+        false,
+        ImmutableMap.of(),
+        null
     );
 
-    // This is checked in the common method that returns the response, but checking it again just protects
-    // from changes there breaking the checks, so doesn't hurt.
-    assertStatusAndCommonHeaders(response, 501);
+    final Response response = resource.doPost(sqlQuery, req);
+
+    // Query ID won't be set, but we can look for other aspects of the response that we expect.
+    Assert.assertEquals(DruidException.Category.INVALID_INPUT.getExpectedStatus(), response.getStatus());
+    Assert.assertEquals("application/json", getContentType(response));
   }
 
   @Test
@@ -1681,7 +1675,7 @@ public class SqlResourceTest extends CalciteTestBase
     failOnExecute(errorMessage);
     ErrorResponse exception = postSyncForException(
         new SqlQuery(
-            "SELECT ANSWER TO LIFE",
+            "SELECT 1",
             ResultFormat.OBJECT,
             false,
             false,
@@ -2297,7 +2291,7 @@ public class SqlResourceTest extends CalciteTestBase
 
     private TestHttpStatement(
         final SqlToolbox lifecycleContext,
-        final SqlQuery sqlQuery,
+        final SqlQueryPlus sqlQueryPlus,
         final HttpServletRequest req,
         SettableSupplier<NonnullPair<CountDownLatch, Boolean>> validateAndAuthorizeLatchSupplier,
         SettableSupplier<NonnullPair<CountDownLatch, Boolean>> planLatchSupplier,
@@ -2307,7 +2301,7 @@ public class SqlResourceTest extends CalciteTestBase
         final Consumer<DirectStatement> onAuthorize
     )
     {
-      super(lifecycleContext, sqlQuery, req);
+      super(lifecycleContext, sqlQueryPlus, req);
       this.validateAndAuthorizeLatchSupplier = validateAndAuthorizeLatchSupplier;
       this.planLatchSupplier = planLatchSupplier;
       this.executeLatchSupplier = executeLatchSupplier;


### PR DESCRIPTION
SET statements (#17894) provide a new way to set query context. However, they are not available early enough to inform important operations like engine selection and planner rule construction. This patch moves parsing as early as possible: immediately on receiving the query from the user.

Behavior change: as a consequence of moving parsing prior to statement creation, SQL queries that cannot be parsed are no longer logged, nor do they have metrics emitted.