### PR TITLE
Fix mark used API response serialization

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordDataSourcesResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordDataSourcesResource.java
@@ -88,6 +88,7 @@ public class OverlordDataSourcesResource
   @POST
   @Path("/{dataSourceName}")
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markAllNonOvershadowedSegmentsAsUsed(
       @PathParam("dataSourceName") final String dataSourceName,
@@ -123,6 +124,7 @@ public class OverlordDataSourcesResource
   @POST
   @Path("/{dataSourceName}/markUsed")
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markNonOvershadowedSegmentsAsUsed(
       @PathParam("dataSourceName") final String dataSourceName,
@@ -206,6 +208,7 @@ public class OverlordDataSourcesResource
   @POST
   @Path("/{dataSourceName}/segments/{segmentId}")
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markSegmentAsUsed(
       @PathParam("dataSourceName") String dataSourceName,
@@ -230,6 +233,7 @@ public class OverlordDataSourcesResource
 
   @DELETE
   @Path("/{dataSourceName}/segments/{segmentId}")
+  @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markSegmentAsUnused(
       @PathParam("dataSourceName") String dataSourceName,

--- a/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
+++ b/server/src/main/java/org/apache/druid/server/http/DataSourcesResource.java
@@ -199,6 +199,7 @@ public class DataSourcesResource
   @POST
   @Path("/{dataSourceName}")
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markAsUsedAllNonOvershadowedSegments(@PathParam("dataSourceName") final String dataSourceName)
   {
@@ -658,6 +659,7 @@ public class DataSourcesResource
   @Deprecated
   @DELETE
   @Path("/{dataSourceName}/segments/{segmentId}")
+  @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markSegmentAsUnused(
       @PathParam("dataSourceName") String dataSourceName,
@@ -687,6 +689,7 @@ public class DataSourcesResource
   @POST
   @Path("/{dataSourceName}/segments/{segmentId}")
   @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
   @ResourceFilters(DatasourceResourceFilter.class)
   public Response markSegmentAsUsed(
       @PathParam("dataSourceName") String dataSourceName,


### PR DESCRIPTION
### Bug

For some APIs, `DataSourcesResource` and `OverlordDataSourcesResource` are not able to
serialize out the JSON response.

__Note that the API is handled correctly by the server, it just fails to send back an appropriate response.__

This bug was introduced a while back in #17545 
While most of the APIs already handled sending back a JSON response,
some APIs didn't.

![error_to_update](https://github.com/user-attachments/assets/b454f487-f6c0-445a-867b-7889c7bcb2d9)

```java
2025-06-12T01:40:01,545 ERROR [qtp41470360-100] com.sun.jersey.spi.container.ContainerResponse - 
Mapped exception to response: 500 (Internal Server Error)
javax.ws.rs.WebApplicationException: com.sun.jersey.api.MessageException: 
A message body writer for Java class org.apache.druid.rpc.indexing.SegmentUpdateResponse, 
and Java type class org.apache.druid.rpc.indexing.SegmentUpdateResponse, 
and MIME media type application/octet-stream was not found.
```

### Fix

- Update all APIs in `DataSourcesResource` and `OverlordDataSourcesResource` to handle
sending back a JSON response by annotating with `@Produces(MediaType.APPLICATION_JSON)`

### Release note

Fix a bug with the following mark used / mark unused APIs so that they can send back a JSON response successfully.
Currently, these APIs work correctly but error out while sending back a response.

|Method|Path|Description|
|-------|----|----------|
|POST|/druid/indexer/v1/datasources/{dataSourceName}|Mark all non-overshadowed segments as used|
|POST|/druid/indexer/v1/datasources/{dataSourceName}/markUsed|Mark non-overshadowed segments in an interval as used|
|POST|/druid/indexer/v1/datasources/{dataSourceName}/segments/{segmentId}|Mark a single segment as used|
|DELETE|/druid/indexer/v1/datasources/{dataSourceName}/segments/{segmentId}|Mark a single segment as unused|
|POST|/druid/coordinator/v1/datasources/{dataSourceName}|Mark all non-overshadowed segments as used|
|POST|/druid/coordinator/v1/datasources/{dataSourceName}/markUsed|Mark non-overshadowed segments in an interval as used|
|POST|/druid/coordinator/v1/datasources/{dataSourceName}/segments/{segmentId}|Mark a single segment as used|
|DELETE|/druid/coordinator/v1/datasources/{dataSourceName}/segments/{segmentId}|Mark a single segment as unused|

<hr>

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
