### PR TITLE
Disable dependabot on JS assets (website and web-console)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,17 @@ updates:
       # pin Testng dependencies to 7.3.0
       - dependency-name: "org.testng"
         versions: "[7.4.0,)"
+
+  # Don't run dependabot on website
+  - package-ecosystem: "npm"
+    directory: "/website/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]
+
+  # Don't run dependabot on web-console
+  - package-ecosystem: "npm"
+    directory: "/web-console/"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major"]


### PR DESCRIPTION
These PRs are usually not safe to merge without manual testing and it is easier to make one PR bumping a bunch of dependencies and test the changes all together.