### PR TITLE
Fix segment unavailability race in coordinator duty

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
@@ -125,8 +125,8 @@ public class SegmentLoadQueueManager
                 && !peonA.getSegmentsToDrop().contains(segment)
                 && (taskMaster.isHttpLoading()
                     || serverInventoryView.isSegmentLoadedByServer(serverNameB, segment))) {
+              peonA.dropSegment(segment, moveFinishCallback);
               peonA.unmarkSegmentToDrop(segment);
-              dropSegment(segment, serverA);
             } else {
               moveFinishCallback.execute(success);
             }

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
@@ -126,7 +126,7 @@ public class SegmentLoadQueueManager
                 && (taskMaster.isHttpLoading()
                     || serverInventoryView.isSegmentLoadedByServer(serverNameB, segment))) {
               peonA.unmarkSegmentToDrop(segment);
-              peonA.dropSegment(segment, moveFinishCallback);
+              dropSegment(segment, serverA);
             } else {
               moveFinishCallback.execute(success);
             }

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCount.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCount.java
@@ -66,6 +66,7 @@ public class SegmentReplicaCount
         ++moving;
         break;
       case DROP:
+      case MOVE_FROM:
         ++dropping;
         break;
       default:

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
@@ -266,4 +266,5 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.MOVED_COUNT, 500L);
     verifyNotEmitted(Metric.MOVE_SKIPPED);
   }
+
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
@@ -266,5 +266,4 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
     verifyValue(Metric.MOVED_COUNT, 500L);
     verifyNotEmitted(Metric.MOVE_SKIPPED);
   }
-
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

There is a race that cause segment unavailability between coordinatory dutygroup runs when a segment is re-balancing.

The race is as follows:

```
Given segment S, and historicals A, B.
Using Epoch=X to indicate run # of historical management duty group.
```

1. [T=1]: Segment S is loaded onto A with 1x replication on that tier.
2. [T=2, Epoch=0]: Epoch 0 starts
3. [T=3, Epoch=0]: Segment S move from A to B is initiated.
4. [T=4, Epoch=1]: Epoch 1 starts
5. [T=5, Epoch=1]: `PrepareBalancerAndLoadQueues` duty starts
6. [T=6, Epoch=1]: `PrepareBalancerAndLoadQueues` initializes its list of `ServerHolder` [here](https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/server/coordinator/duty/PrepareBalancerAndLoadQueues.java#L91). This reads in the in-progress `MOVE_FROM` actions [here](https://github.com/apache/druid/blob/-/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java#L171) . This does NOT account for the currently-in-flight `DROP` which is about to be fired..
8. [T=7, Epoch=1]: Load to B completes, callback from Epoch=0 load to B fires. This triggers a `DROP` on A, but this is not reflected on the `SegmentLoadQueueManager` accounting, since the drop is issued [here](https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java#L129) directly to the peon, instead of going through [here](https://github.com/apache/druid/blob/-/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java#L70).
9. [T=8, Epoch=1]: `PrepareBalancerAndLoadQueues` ends 
10. [T=9, Epoch=1]: `RunRules` starts
11. [T=10, Epoch=1]: `LoadRules` starts
12. [T=11, Epoch=1]: Seeing the stale value of `SegmentReplicaCount.dropping` from before, it infers that segment S has 2x replication, causing it to issue a randomized drop to either A or B. In the worst case we drop on B, causing segment unavailability until the next Epoch.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

- I've added logic to treat increment the `dropping` counter to include `MOVE_FROM` cases, protecting against the race.
- I've switched to using `SegmentLoadQueueManager::dropSegment` instead of doing on the HttpLoadQueuePeon directly, so that we can get some extra accounting (might not be needed) about what's actually in the queue, since the `HttpLoadQueuePeon`'s queuedSegments is a local copy initialized at construction.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fixes a race that causes segment unavailability between coordinatory dutygroup runs when a segment is re-balancing.

<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
