### PR TITLE
Fix move race condition, add simulation test

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCount.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCount.java
@@ -33,7 +33,8 @@ public class SegmentReplicaCount
 
   private int loading;
   private int dropping;
-  private int moving;
+  private int movingTo;
+  private int movingFrom;
 
   /**
    * Increments number of replicas loaded on historical servers.
@@ -63,7 +64,10 @@ public class SegmentReplicaCount
         ++loading;
         break;
       case MOVE_TO:
-        ++moving;
+        ++movingTo;
+        break;
+      case MOVE_FROM:
+        ++movingFrom;
         break;
       case DROP:
         ++dropping;
@@ -110,7 +114,12 @@ public class SegmentReplicaCount
 
   int moving()
   {
-    return moving;
+    return movingTo;
+  }
+
+  int moveCompletedPendingDrop()
+  {
+    return movingFrom - movingTo;
   }
 
   /**
@@ -162,6 +171,6 @@ public class SegmentReplicaCount
 
     this.loading += other.loading;
     this.dropping += other.dropping;
-    this.moving += other.moving;
+    this.movingTo += other.movingTo;
   }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -264,7 +264,8 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
         = replicaCountMap.get(segment.getId(), tier);
 
     final int projectedReplicas = replicaCountOnTier.loadedNotDropping()
-                                  + replicaCountOnTier.loading();
+                                  + replicaCountOnTier.loading()
+                                  - replicaCountOnTier.moveCompletedPendingDrop();
 
     final int movingReplicas = replicaCountOnTier.moving();
     final boolean shouldCancelMoves = requiredReplicas == 0 && movingReplicas > 0;

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulation.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulation.java
@@ -108,6 +108,12 @@ public interface CoordinatorSimulation
     void loadQueuedSegments();
 
     /**
+     * Finishes load of all the segments that were queued in the previous
+     * coordinator run. Does not execute the respective callbacks on the coordinator.
+     */
+    void loadQueuedSegmentsSkipCallbacks();
+
+    /**
      * Removes the specified server from the cluster.
      */
     void removeServer(DruidServer server);

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
@@ -127,6 +127,12 @@ public abstract class CoordinatorSimulationBaseTest implements
   }
 
   @Override
+  public void loadQueuedSegmentsSkipCallbacks()
+  {
+    sim.cluster().loadQueuedSegmentsSkipCallbacks();
+  }
+
+  @Override
   public void removeServer(DruidServer server)
   {
     sim.cluster().removeServer(server);

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBuilder.java
@@ -328,7 +328,18 @@ public class CoordinatorSimulationBuilder
     }
 
     @Override
+    public void loadQueuedSegmentsSkipCallbacks()
+    {
+      loadSegments(false);
+    }
+
+    @Override
     public void loadQueuedSegments()
+    {
+      loadSegments(true);
+    }
+
+    private void loadSegments(boolean executeCallbacks)
     {
       verifySimulationRunning();
       Preconditions.checkState(
@@ -345,7 +356,9 @@ public class CoordinatorSimulationBuilder
         // Load all the queued segments, handle their responses and execute callbacks
         int loadedSegments = env.executorFactory.historicalLoader.finishAllPendingTasks();
         loadQueueExecutor.finishNextPendingTasks(loadedSegments);
-        env.executorFactory.loadCallbackExecutor.finishAllPendingTasks();
+        if (executeCallbacks) {
+          env.executorFactory.loadCallbackExecutor.finishAllPendingTasks();
+        }
       }
     }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
@@ -93,6 +93,42 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
   }
 
   @Test
+  public void testBalancingDoesNotUnderReplicateSegment()
+  {
+    // historicals = 2(T1), replicas = 1(T1)
+    final CoordinatorSimulation sim =
+        CoordinatorSimulation.builder()
+                             .withSegments(segments)
+                             .withServers(historicalT11, historicalT12)
+                             .withRules(datasource, Load.on(Tier.T1, 1).forever())
+                             .build();
+
+    // Put all the segments on histT11
+    segments.forEach(historicalT11::addDataSegment);
+
+    // Run cycle and verify that segments have been chosen for balancing
+    startSimulation(sim);
+    runCoordinatorCycle();
+    verifyValue(Metric.MOVED_COUNT, 5L);
+
+    // Load segments, skip callbacks and verify that some segments are now loaded on histT12
+    loadQueuedSegmentsSkipCallbacks();
+    Assert.assertEquals(10, historicalT11.getTotalSegments());
+    Assert.assertEquals(5, historicalT12.getTotalSegments());
+
+    // Run another coordinator cycle
+    runCoordinatorCycle();
+    loadQueuedSegmentsSkipCallbacks();
+
+    // Verify that segments have not been dropped from either server since
+    // MOVE_FROM operation is still not complete
+    Assert.assertEquals(10, historicalT11.getTotalSegments());
+    Assert.assertEquals(5, historicalT12.getTotalSegments());
+    verifyNotEmitted(Metric.DROPPED_COUNT);
+    verifyNotEmitted(Metric.MOVED_COUNT);
+  }
+
+  @Test
   public void testDropDoesNotHappenWhenLoadFails()
   {
     // historicals = 2(T1), replicas = 1(T1)


### PR DESCRIPTION
### Description

Addresses the race condition identified in #18161 
Kudos to @jtuglu-netflix for identifying it!

### Race condition

- Segment is moving from server A to server B
- If it has just finished its MOVE_TO operation on B but the MOVE_FROM operation on A is still pending,
the segment may be chosen to drop from server B causing under-replication
- If it is chosen to drop from server A, that operation would be ignored since the segment already has an ongoing
operation on server A

### Fix

- Use the delta of MOVE_FROM - MOVE_TO to track pending drop callbacks
- Add a simulation test to verify the change. This test fails before the fix.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
