### PR TITLE
Feat: Intialize ScheduledThreadPoolExecutor with default worker threads

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -155,7 +155,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
   private static final long TEST_CHAT_RETRIES = 9L;
   private static final Period TEST_HTTP_TIMEOUT = new Period("PT10S");
   private static final Period TEST_SHUTDOWN_TIMEOUT = new Period("PT80S");
-  private static final int DEFAULT_WORKER_THREADS = 2;
 
   private static TestingCluster zkServer;
   private static TestBroker kafkaServer;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -71,10 +71,12 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTuningCon
 import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.supervisor.IdleConfig;
+import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorSpec;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorStateManager;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorTuningConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.TaskReportData;
+import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.LagBasedAutoScalerConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
@@ -155,6 +157,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   private static final long TEST_CHAT_RETRIES = 9L;
   private static final Period TEST_HTTP_TIMEOUT = new Period("PT10S");
   private static final Period TEST_SHUTDOWN_TIMEOUT = new Period("PT80S");
+  private static final int DEFAULT_WORKER_THREADS = 2;
 
   private static TestingCluster zkServer;
   private static TestBroker kafkaServer;
@@ -5153,6 +5156,77 @@ public class KafkaSupervisorTest extends EasyMockSupport
     EasyMock.replay(differentTaskType);
   }
 
+  @Test
+  public void test_calculateWorkerThreads_shouldHonourWorkerConfig()
+  {
+    final int totalThreads = 5;
+    KafkaSupervisorTuningConfig tuningConfig = getTuningConfig(totalThreads);
+    KafkaSupervisorIOConfig ioConfig = getIOConfig();
+    Assert.assertEquals(totalThreads, SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig));
+  }
+
+  @Test
+  public void test_calculateWorkerThreads_shouldUseDefaultWorkerThreads()
+  {
+    KafkaSupervisorTuningConfig tuningConfig = getTuningConfig();
+    KafkaSupervisorIOConfig ioConfig = getIOConfig();
+    Assert.assertEquals(
+        DEFAULT_WORKER_THREADS,
+        SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
+    );
+  }
+
+  @Test
+  public void test_calculateWorkerThreads_shouldUseMinimumWorkerThreadstWithTasks()
+  {
+    KafkaSupervisorTuningConfig tuningConfig = getTuningConfig();
+    KafkaSupervisorIOConfig ioConfig = getIOConfig(7);
+    Assert.assertEquals(
+        DEFAULT_WORKER_THREADS,
+        SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
+    );
+  }
+
+  @Test
+  public void test_calculateWorkerThreads_shouldUseFactorOfTaskCount()
+  {
+    KafkaSupervisorTuningConfig tuningConfig = getTuningConfig();
+    KafkaSupervisorIOConfig ioConfig = getIOConfig(18);
+    Assert.assertEquals(
+        4,
+        SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
+    );
+  }
+
+  @Test
+  public void test_calculateWorkerThreads_shouldUseAutoScalerConfig()
+  {
+    KafkaSupervisorTuningConfig tuningConfig = getTuningConfig();
+    AutoScalerConfig autoScalerConfig = new LagBasedAutoScalerConfig(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        21,
+        null,
+        5,
+        null,
+        null,
+        true,
+        null,
+        null
+    );
+    KafkaSupervisorIOConfig ioConfig = getIOConfig(autoScalerConfig);
+    Assert.assertEquals(
+        5,
+        SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
+    );
+  }
+
   private void addSomeEvents(int numEventsPerPartition) throws Exception
   {
     // create topic manually
@@ -5209,6 +5283,97 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
+  private KafkaSupervisorTuningConfig getTuningConfig()
+  {
+    return getTuningConfig(null);
+  }
+
+  /**
+   * Use this method to create a {@link KafkaSupervisorTuningConfig} with custom thread count.
+   *
+   * @param threadCount the number of threads to use, or null to imitate default settings.
+   */
+  private KafkaSupervisorTuningConfig getTuningConfig(@Nullable Integer threadCount)
+  {
+    return new KafkaSupervisorTuningConfig(
+        null,
+        1000,
+        null,
+        null,
+        50000,
+        null,
+        new Period("P1Y"),
+        null,
+        null,
+        null,
+        false,
+        null,
+        false,
+        null,
+        threadCount,
+        TEST_CHAT_RETRIES,
+        TEST_HTTP_TIMEOUT,
+        TEST_SHUTDOWN_TIMEOUT,
+        null,
+        null,
+        null,
+        null,
+        10,
+        null,
+        null
+    );
+  }
+
+  private KafkaSupervisorIOConfig getIOConfig()
+  {
+    return getIOConfig(1, null);
+  }
+
+  private KafkaSupervisorIOConfig getIOConfig(int taskCount)
+  {
+    return getIOConfig(taskCount, null);
+  }
+
+  private KafkaSupervisorIOConfig getIOConfig(AutoScalerConfig autoScalerConfig)
+  {
+    return getIOConfig(1, autoScalerConfig);
+  }
+
+  /**
+   * Use this method to create a {@link KafkaSupervisorIOConfig} with custom properties.
+   */
+  private KafkaSupervisorIOConfig getIOConfig(
+      int taskCount,
+      AutoScalerConfig autoScalerConfig
+  )
+  {
+    final Map<String, Object> consumerProperties = KafkaConsumerConfigs.getConsumerProperties();
+    consumerProperties.put("myCustomKey", "myCustomValue");
+    consumerProperties.put("bootstrap.servers", kafkaHost);
+    return new KafkaSupervisorIOConfig(
+        topic,
+        null,
+        INPUT_FORMAT,
+        1,
+        taskCount,
+        new Period("PT1H"),
+        consumerProperties,
+        autoScalerConfig,
+        null,
+        KafkaSupervisorIOConfig.DEFAULT_POLL_TIMEOUT_MILLIS,
+        new Period("P1D"),
+        new Period("PT30S"),
+        false,
+        new Period("PT30M"),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        false
+    );
+  }
 
   private TestableKafkaSupervisor getTestableSupervisor(
       int replicas,

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -943,7 +943,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
         spec.isSuspended()
     );
 
-    final int workerThreads = calculateWorkerThreads(tuningConfig, ioConfig, autoScalerConfig);
+    final int workerThreads = calculateWorkerThreads(tuningConfig, ioConfig);
     if (autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler()) {
       log.info("Running Task autoscaler for supervisor[%s] for datasource[%s]", supervisorId, dataSource);
     }
@@ -1010,13 +1010,13 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
   public static int calculateWorkerThreads(
       SeekableStreamSupervisorTuningConfig tuningConfig,
-      SeekableStreamSupervisorIOConfig ioConfig,
-      @Nullable AutoScalerConfig autoScalerConfig
+      SeekableStreamSupervisorIOConfig ioConfig
   )
   {
     if (tuningConfig.getWorkerThreads() != null) {
       return tuningConfig.getWorkerThreads();
     }
+    final AutoScalerConfig autoScalerConfig = ioConfig.getAutoScalerConfig();
     if (autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler()) {
       return Math.max(MIN_WORKER_CORE_THREADS, autoScalerConfig.getTaskCountMax() / DEFAULT_TASKS_PER_WORKER_THREAD);
     } else {

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -973,7 +973,7 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
 
     this.workerExec = MoreExecutors.listeningDecorator(executor);
     log.info(
-        "Created worker pool with [%d] threads for supervisor[%s] for dataSource[%s]",
+        "Created worker pool with [%d] threads for supervisor[%s], dataSource[%s]",
         workerThreads, this.supervisorId, this.dataSource
     );
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -2772,11 +2772,6 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     return createSupervisorTuningConfigWithWorkerThreads(null);
   }
 
-  /**
-   * Creates a {@link SeekableStreamSupervisorTuningConfig} with the given number of worker threads.
-   *
-   * @param workerThreads the number of threads to use, or null to imitate default settings.
-   */
   private static SeekableStreamSupervisorTuningConfig createSupervisorTuningConfigWithWorkerThreads(@Nullable Integer workerThreads)
   {
     return new SeekableStreamSupervisorTuningConfig()

--- a/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
@@ -185,18 +185,22 @@ public class ScheduledExecutors
     return Executors.newScheduledThreadPool(corePoolSize, Execs.makeThreadFactory(nameFormat));
   }
 
+  /**
+   * Creates a new {@link ScheduledExecutorService} with a minimum number of threads along with a
+   * keep-alive time for idle non-core threads.
+   * <p>
+   */
   public static ScheduledThreadPoolExecutor fixedWithKeepAliveTime(
       int corePoolSize,
       String nameFormat,
-      long keepAliveTime,
-      TimeUnit timeUnit
+      long keepAliveTimeInMillis
   )
   {
     ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(
         corePoolSize,
         Execs.makeThreadFactory(nameFormat)
     );
-    scheduledExecutor.setKeepAliveTime(keepAliveTime, timeUnit);
+    scheduledExecutor.setKeepAliveTime(keepAliveTimeInMillis, TimeUnit.MILLISECONDS);
     return scheduledExecutor;
   }
 }

--- a/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
@@ -172,6 +172,13 @@ public class ScheduledExecutors
     return (corePoolSize, nameFormat) -> ExecutorServices.manageLifecycle(lifecycle, fixed(corePoolSize, nameFormat));
   }
 
+  /**
+   * Creates a new {@link ScheduledExecutorService} with a minimum number of threads.
+   *
+   * @param corePoolSize the minimum number of threads in the pool
+   * @param nameFormat   the naming format for threads created by the pool
+   * @return a new {@link ScheduledExecutorService} with the specified configuration
+   */
   public static ScheduledExecutorService fixed(int corePoolSize, String nameFormat)
   {
     return Executors.newScheduledThreadPool(corePoolSize, Execs.makeThreadFactory(nameFormat));

--- a/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/concurrent/ScheduledExecutors.java
@@ -26,6 +26,7 @@ import org.joda.time.Duration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ScheduledExecutors
@@ -182,5 +183,20 @@ public class ScheduledExecutors
   public static ScheduledExecutorService fixed(int corePoolSize, String nameFormat)
   {
     return Executors.newScheduledThreadPool(corePoolSize, Execs.makeThreadFactory(nameFormat));
+  }
+
+  public static ScheduledThreadPoolExecutor fixedWithKeepAliveTime(
+      int corePoolSize,
+      String nameFormat,
+      long keepAliveTime,
+      TimeUnit timeUnit
+  )
+  {
+    ScheduledThreadPoolExecutor scheduledExecutor = new ScheduledThreadPoolExecutor(
+        corePoolSize,
+        Execs.makeThreadFactory(nameFormat)
+    );
+    scheduledExecutor.setKeepAliveTime(keepAliveTime, timeUnit);
+    return scheduledExecutor;
   }
 }


### PR DESCRIPTION
### Description

Updates `workerThread` calculation for `ScheduledThreadPoolExecutor`. It now follows the following logic:
- honor `tuningConfig.workerThreads()` if set.
- if auto scaler config / io config has max task counts specified, set worker threads to `maxTaskCount/4`.
- ensure at least 2 worker threads are spawned if the determined value (`maxTaskCount/4`) is too low.


##### Key changed/added classes in this PR
 * `SeekableStreamSupervisor`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
