### PR TITLE
Web console: Change to use overlord APIs vs coordinator APIs

### DIFF
--- a/web-console/src/dialogs/kill-datasource-dialog/kill-datasource-dialog.tsx
+++ b/web-console/src/dialogs/kill-datasource-dialog/kill-datasource-dialog.tsx
@@ -58,9 +58,9 @@ export const KillDatasourceDialog = function KillDatasourceDialog(
       className="kill-datasource-dialog"
       action={async () => {
         const resp = await Api.instance.delete(
-          `/druid/coordinator/v1/datasources/${Api.encodePath(
-            datasource,
-          )}?kill=true&interval=${Api.encodePath(interval)}`,
+          `/druid/indexer/v1/datasources/${Api.encodePath(datasource)}/intervals/${Api.encodePath(
+            interval.replace(/\//g, '_'),
+          )}`,
           {},
         );
         return resp.data;

--- a/web-console/src/views/segments-view/segments-view.tsx
+++ b/web-console/src/views/segments-view/segments-view.tsx
@@ -546,13 +546,19 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
   }
 
   private getSegmentActions(id: string, datasource: string): BasicAction[] {
+    const { capabilities } = this.props;
     const actions: BasicAction[] = [];
-    actions.push({
-      icon: IconNames.IMPORT,
-      title: 'Drop segment (disable)',
-      intent: Intent.DANGER,
-      onAction: () => this.setState({ terminateSegmentId: id, terminateDatasourceId: datasource }),
-    });
+
+    if (capabilities.hasOverlordAccess()) {
+      actions.push({
+        icon: IconNames.IMPORT,
+        title: 'Drop segment (disable)',
+        intent: Intent.DANGER,
+        onAction: () =>
+          this.setState({ terminateSegmentId: id, terminateDatasourceId: datasource }),
+      });
+    }
+
     return actions;
   }
 
@@ -1017,7 +1023,7 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
       <AsyncActionDialog
         action={async () => {
           const resp = await Api.instance.delete(
-            `/druid/coordinator/v1/datasources/${Api.encodePath(
+            `/druid/indexer/v1/datasources/${Api.encodePath(
               terminateDatasourceId,
             )}/segments/${Api.encodePath(terminateSegmentId)}`,
             {},
@@ -1025,7 +1031,7 @@ export class SegmentsView extends React.PureComponent<SegmentsViewProps, Segment
           return resp.data;
         }}
         confirmButtonText="Drop segment"
-        successText="Segment drop request acknowledged, next time the coordinator runs segment will be dropped"
+        successText="Segment drop request acknowledged, next time the overlord runs segment will be dropped"
         failText="Could not drop segment"
         intent={Intent.DANGER}
         onClose={() => {


### PR DESCRIPTION
This is the console follow up to:

- https://github.com/apache/druid/pull/17545 (added new Overlord APIs for data-management)
- https://github.com/apache/druid/pull/17935 (completely removes support for updating segments from the Coordinator)
- https://github.com/apache/druid/pull/17999 (document the API changes)