### PR TITLE
Bump kafka client dep to 3.9.1 and mitigate CVE-2025-27817

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
@@ -64,6 +64,17 @@ import java.util.concurrent.atomic.AtomicReference;
 @JsonTypeName("kafka")
 public class KafkaLookupExtractorFactory implements LookupExtractorFactory
 {
+  // by default, we reject all URLs for OAuthBearer authentication
+  // CVE ref: https://www.cve.org/CVERecord?id=CVE-2025-27817
+  // Upgrade kafka dependencies to 4.x to remove the need for this static block
+  static {
+    final String allowedSaslOauthbearerUrlsConfig = "org.apache.kafka.sasl.oauthbearer.allowed.urls";
+    String allowedUrlsProp = System.getProperty(allowedSaslOauthbearerUrlsConfig);
+    if (allowedUrlsProp == null) {
+      System.setProperty(allowedSaslOauthbearerUrlsConfig, "notallowed");
+    }
+  }
+
   private static final Logger LOG = new Logger(KafkaLookupExtractorFactory.class);
   private final ListeningExecutorService executorService;
   private final AtomicLong doubleEventCount = new AtomicLong(0L);

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.query.lookup;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -40,8 +41,11 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.utils.Time;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,6 +62,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  *
@@ -219,6 +225,49 @@ public class TestKafkaExtractionCluster
         throw new ISE("server is not active!");
       }
     }
+  }
+
+  @Test
+  public void test_defaultRejectAllUrlsForSaslOauthBearerUrlConsumerProperty() throws JsonProcessingException
+  {
+    Map<String, String> properties = getConsumerProperties();
+    properties.put("sasl.mechanism", "OAUTHBEARER");
+    properties.put("security.protocol", "SASL_SSL");
+    properties.put("sasl.jaas.config", "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
+    properties.put("sasl.login.callback.handler.class", "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler");
+
+    properties.put("sasl.oauthbearer.token.endpoint.url", "http://localhost:8080/token");
+    KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
+        null,
+        TOPIC_NAME,
+        properties
+    );
+    MatcherAssert.assertThat(
+        assertThrows(KafkaException.class, factory::getConsumer),
+        CoreMatchers.instanceOf(KafkaException.class)
+    );
+
+    properties.remove("sasl.oauthbearer.token.endpoint.url");
+    properties.put("sasl.oauthbearer.jwks.endpoint.url", "http://localhost:8080/jwks");
+    factory = new KafkaLookupExtractorFactory(
+        null,
+        TOPIC_NAME,
+        properties
+    );
+    MatcherAssert.assertThat(
+        assertThrows(KafkaException.class, factory::getConsumer),
+        CoreMatchers.instanceOf(KafkaException.class)
+    );
+
+
+    properties.put("sasl.oauthbearer.jwks.endpoint.url", "http://localhost:8080/jwks");
+    factory = new KafkaLookupExtractorFactory(
+        null,
+        TOPIC_NAME,
+        properties
+    );
+    factory.getConsumer();
+    factory.close();
   }
 
   @Test(timeout = 60_000L)

--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaRecordSupplier.java
@@ -63,6 +63,17 @@ import java.util.stream.Collectors;
 
 public class KafkaRecordSupplier implements RecordSupplier<KafkaTopicPartition, Long, KafkaRecordEntity>
 {
+  // by default, we reject all URLs for OAuthBearer authentication
+  // CVE ref: https://www.cve.org/CVERecord?id=CVE-2025-27817
+  // Upgrade kafka dependencies to 4.x to remove the need for this static block
+  static {
+    final String allowedSaslOauthbearerUrlsConfig = "org.apache.kafka.sasl.oauthbearer.allowed.urls";
+    String allowedUrlsProp = System.getProperty(allowedSaslOauthbearerUrlsConfig);
+    if (allowedUrlsProp == null) {
+      System.setProperty(allowedSaslOauthbearerUrlsConfig, "notallowed");
+    }
+  }
+
   private final KafkaConsumer<byte[], byte[]> consumer;
   private final KafkaConsumerMonitor monitor;
   private boolean closed;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -41,9 +41,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.serialization.Deserializer;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -60,6 +63,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertThrows;
 
 public class KafkaRecordSupplierTest
 {
@@ -238,6 +243,53 @@ public class KafkaRecordSupplierTest
         StreamPartition.of(TOPIC, PARTITION_1)
     );
 
+    KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
+        KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false);
+
+    Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
+
+    recordSupplier.assign(partitions);
+
+    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+    Assert.assertEquals(ImmutableSet.of(PARTITION_0, PARTITION_1),
+                        recordSupplier.getPartitionIds(TOPIC));
+
+    recordSupplier.close();
+  }
+
+  @Test
+  public void test_defaultRejectAllUrlsForSaslOauthBearerUrlConsumerProperty() throws ExecutionException, InterruptedException
+  {
+    // Insert data
+    insertData();
+
+    Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(
+        StreamPartition.of(TOPIC, PARTITION_0),
+        StreamPartition.of(TOPIC, PARTITION_1)
+    );
+
+    Map<String, Object> properties = KAFKA_SERVER.consumerProperties();
+    properties.put("sasl.mechanism", "OAUTHBEARER");
+    properties.put("security.protocol", "SASL_SSL");
+    properties.put("sasl.jaas.config", "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;");
+    properties.put("sasl.login.callback.handler.class", "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler");
+
+    properties.put("sasl.oauthbearer.token.endpoint.url", "http://localhost:8080/token");
+
+    MatcherAssert.assertThat(
+        assertThrows(KafkaException.class, () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false)),
+        CoreMatchers.instanceOf(KafkaException.class)
+    );
+
+    properties.remove("sasl.oauthbearer.token.endpoint.url");
+    properties.put("sasl.oauthbearer.jwks.endpoint.url", "http://localhost:8080/jwks");
+    MatcherAssert.assertThat(
+        assertThrows(KafkaException.class, () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false)),
+        CoreMatchers.instanceOf(KafkaException.class)
+    );
+
+    properties.remove("sasl.oauthbearer.jwks.endpoint.url");
+    properties.put("sasl.oauthbearer.token.endpoint.url", "notallowed");
     KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
         KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false);
 

--- a/integration-tests-ex/image/pom.xml
+++ b/integration-tests-ex/image/pom.xml
@@ -204,7 +204,8 @@ Reference: https://dzone.com/articles/build-docker-image-from-maven
                                         <MARIADB_VERSION>${mariadb.version}</MARIADB_VERSION>
                                         <MYSQL_IMAGE_VERSION>${mysql.image.version}</MYSQL_IMAGE_VERSION>
                                         <CONFLUENT_VERSION>${confluent-version}</CONFLUENT_VERSION>
-                                        <KAFKA_VERSION>${apache.kafka.version}</KAFKA_VERSION>
+                                        <!-- bitnami currently does not offer 3.9.1 image -->
+                                        <KAFKA_VERSION>4.0.0</KAFKA_VERSION>
                                         <ZK_VERSION>${zookeeper.version}</ZK_VERSION>
                                         <HADOOP_VERSION>${hadoop.compile.version}</HADOOP_VERSION>
                                         <DRUID_VERSION>${project.version}</DRUID_VERSION>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3228,7 +3228,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 3.9.0
+version: 3.9.1
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>5.8.0</apache.curator.version>
-        <apache.kafka.version>3.9.0</apache.kafka.version>
+        <apache.kafka.version>3.9.1</apache.kafka.version>
         <!-- when updating apache ranger, verify the usage of aws-bundle-sdk vs aws-logs-sdk
         and update as needed in extensions-core/druid-ranger-security/pm.xml  -->
         <apache.ranger.version>2.4.0</apache.ranger.version>


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Builds on #18139 which is in regards to addressing a [kafka cve](https://www.cve.org/CVERecord?id=CVE-2025-27817)

Ideally we'd jump to kafka 4.x which has a strict deny all default instead of kafka 3.9.1 which defaults to allowAll. Jumping to 4.x would allow us to avoid the static block in our code slipping in the denyAll default. However, we have a lot of test code that relies on being able to run KafkaServer embedded and this is now gone in 4.x. Initially I was looking into making the jump to 4.x anyways. I was going to migrate as much of the tests that rely on KafkaServer to MockConsumer as I could and then disable the rest of the tests in place of relying more on the kafka ITs. However, I then realized that the new Druid Simulations introduced by @kfaraz also rely on kafka 3.x KafkaServer. So jumping to 4 right now would knee-cap that new and really nice test functionality. At this point, I decided to propose the change in this PR. It is an idea suggested by @kgyrtkirk where we can use 3.9.1 and some static blocks on on our side to protect Druid from this CVE. Operators could still follow the Kafka patch nodes to set the system property with a legitimate allow list for the two consumer configs called out under the CVE. This approach buys us time to move to kafka 4 and find long term replacements to using KafkaServer in our tests to run Kafka embedded.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `KafkaLookupExtractorFactory`
 * `KafkaREcordSupplier`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
