### PR TITLE
Add EmbeddedJdbcLookupTest

### DIFF
--- a/embedded-tests/pom.xml
+++ b/embedded-tests/pom.xml
@@ -111,6 +111,12 @@
       <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.druid.extensions</groupId>
+      <artifactId>druid-lookups-cached-global</artifactId>
+      <version>${project.parent.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Some embedded tests use the router and the web-console for debugging -->
     <dependency>
       <groupId>org.apache.druid</groupId>

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/lookup/EmbeddedJdbcLookupTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/lookup/EmbeddedJdbcLookupTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testing.embedded.lookup;
+
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.metadata.SQLMetadataConnector;
+import org.apache.druid.metadata.TestDerbyConnector;
+import org.apache.druid.server.lookup.namespace.NamespaceExtractionModule;
+import org.apache.druid.testing.embedded.EmbeddedBroker;
+import org.apache.druid.testing.embedded.EmbeddedClusterApis;
+import org.apache.druid.testing.embedded.EmbeddedCoordinator;
+import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
+import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+/**
+ * Embedded test to verify JDBC lookups.
+ */
+public class EmbeddedJdbcLookupTest extends EmbeddedClusterTestBase
+{
+  private static final String JDBC_LOOKUP_TABLE = "embedded_lookups";
+  private static final String BULK_UPDATE_LOOKUP_PAYLOAD
+      = "{"
+        + "  \"__default\": {"
+        + "    \"%s\": {"
+        + "      \"version\": \"v1\","
+        + "      \"lookupExtractorFactory\": {"
+        + "        \"type\": \"cachedNamespace\","
+        + "        \"extractionNamespace\": {"
+        + "          \"type\": \"jdbc\","
+        + "          \"pollPeriod\": \"PT1H\","
+        + "          \"connectorConfig\": {"
+        + "            \"connectURI\": \"%s\""
+        + "          },"
+        + "          \"table\": \"%s\","
+        + "          \"keyColumn\": \"country_code\","
+        + "          \"valueColumn\": \"country_name\","
+        + "          \"tsColumn\": \"created_date\""
+        + "        },"
+        + "        \"injective\": true,"
+        + "        \"firstCacheTimeout\": 120000"
+        + "      }"
+        + "    }"
+        + "  }"
+        + "}";
+
+  private final EmbeddedBroker broker = new EmbeddedBroker();
+  private final EmbeddedCoordinator coordinator = new EmbeddedCoordinator();
+
+  @Override
+  protected EmbeddedDruidCluster createCluster()
+  {
+    return EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper()
+                               .addExtension(NamespaceExtractionModule.class)
+                               .addServer(coordinator);
+  }
+
+  @Test
+  public void test_derbyJdbcLookup() throws Exception
+  {
+    // Create a table in the metadata store to hold the lookup values
+    final SQLMetadataConnector connector = coordinator.bindings().sqlMetadataConnector();
+    connector.retryWithHandle(
+        handle -> handle.update(
+            "CREATE TABLE embedded_lookups("
+            + "  created_date TIMESTAMP NOT NULL,\n"
+            + "  country_code VARCHAR(10) NOT NULL,\n"
+            + "  country_name VARCHAR(255) NOT NULL,\n"
+            + "  PRIMARY KEY (country_code)"
+            + ")"
+        )
+    );
+    connector.retryWithHandle(
+        handle -> handle.insert(
+            "INSERT INTO embedded_lookups"
+            + " (created_date, country_code, country_name) VALUES"
+            + " ('2025-06-01 00:00:00', 'AU', 'Australia'),"
+            + " ('2025-06-02 00:00:00', 'PR', 'Puerto Rico')"
+        )
+    );
+
+    // Initialize lookups
+    cluster.callApi().onLeaderCoordinator(
+        c -> c.updateAllLookups(Map.of())
+    );
+
+    // Create the lookup
+    final String lookupName = dataSource;
+    final String lookupPayload = StringUtils.format(
+        BULK_UPDATE_LOOKUP_PAYLOAD,
+        lookupName,
+        ((TestDerbyConnector) connector).getJdbcUri(),
+        JDBC_LOOKUP_TABLE
+    );
+    cluster.callApi().onLeaderCoordinator(
+        c -> c.updateAllLookups(EmbeddedClusterApis.deserializeJsonToMap(lookupPayload))
+    );
+
+    // Add the broker to the cluster and start it
+    cluster.addServer(broker);
+    broker.start();
+
+    // Query the lookups
+    Assertions.assertEquals(
+        "Puerto Rico,Australia",
+        cluster.runSql("SELECT LOOKUP('PR', '%1$s'), LOOKUP('AU', '%1$s')", dataSource)
+    );
+  }
+}

--- a/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClient.java
+++ b/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClient.java
@@ -101,4 +101,11 @@ public interface CoordinatorClient
    * API: {@code POST /druid/coordinator/v1/config}
    */
   ListenableFuture<Void> updateCoordinatorDynamicConfig(CoordinatorDynamicConfig dynamicConfig);
+
+  /**
+   * Updates lookups for all tiers.
+   * <p>
+   * API: {@code POST /druid/coordinator/v1/lookups/config}
+   */
+  ListenableFuture<Void> updateAllLookups(Object lookups);
 }

--- a/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClientImpl.java
+++ b/server/src/main/java/org/apache/druid/client/coordinator/CoordinatorClientImpl.java
@@ -250,4 +250,15 @@ public class CoordinatorClientImpl implements CoordinatorClient
         IgnoreHttpResponseHandler.INSTANCE
     );
   }
+
+  @Override
+  public ListenableFuture<Void> updateAllLookups(Object lookups)
+  {
+    final String path = "/druid/coordinator/v1/lookups/config";
+    return client.asyncRequest(
+        new RequestBuilder(HttpMethod.POST, path)
+            .jsonContent(jsonMapper, lookups),
+        IgnoreHttpResponseHandler.INSTANCE
+    );
+  }
 }

--- a/server/src/main/java/org/apache/druid/client/coordinator/NoopCoordinatorClient.java
+++ b/server/src/main/java/org/apache/druid/client/coordinator/NoopCoordinatorClient.java
@@ -102,4 +102,11 @@ public class NoopCoordinatorClient implements CoordinatorClient
   {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public ListenableFuture<Void> updateAllLookups(Object lookups)
+  {
+    throw new UnsupportedOperationException();
+  }
+
 }

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
@@ -165,17 +165,26 @@ public class EmbeddedClusterApis
    */
   public static Object createTaskFromPayload(String taskId, String payload)
   {
+    final Map<String, Object> task = deserializeJsonToMap(payload);
+    task.put("id", taskId);
+    return task;
+  }
+
+  /**
+   * Deserializes the given JSON string into a generic map that can be used to
+   * post JSON payloads to a Druid API. Using a generic map allows the client
+   * to make requests even if required types are not loaded.
+   */
+  public static Map<String, Object> deserializeJsonToMap(String payload)
+  {
     try {
-      final Map<String, Object> task = TestHelper.JSON_MAPPER.readValue(
+      return TestHelper.JSON_MAPPER.readValue(
           payload,
           new TypeReference<>() {}
       );
-      task.put("id", taskId);
-
-      return task;
     }
     catch (Exception e) {
-      throw new ISE(e, "Could not deserialize task payload[%s]", payload);
+      throw new ISE(e, "Could not deserialize payload[%s]", payload);
     }
   }
 

--- a/services/src/test/java/org/apache/druid/testing/embedded/ServerReferenceHolder.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/ServerReferenceHolder.java
@@ -30,6 +30,7 @@ import org.apache.druid.guice.annotations.EscalatedGlobal;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.metadata.SQLMetadataConnector;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.metrics.LatchableEmitter;
@@ -65,6 +66,9 @@ public final class ServerReferenceHolder implements ServerReferencesProvider
 
   @Inject(optional = true)
   private IndexerMetadataStorageCoordinator segmentsMetadataStorage;
+
+  @Inject(optional = true)
+  private SQLMetadataConnector sqlMetadataConnector;
 
   @Inject
   private DruidNodeDiscoveryProvider nodeDiscoveryProvider;
@@ -123,6 +127,12 @@ public final class ServerReferenceHolder implements ServerReferencesProvider
   public IndexerMetadataStorageCoordinator segmentsMetadataStorage()
   {
     return Objects.requireNonNull(segmentsMetadataStorage, "Segment metadata storage is not bound");
+  }
+
+  @Override
+  public SQLMetadataConnector sqlMetadataConnector()
+  {
+    return Objects.requireNonNull(sqlMetadataConnector, "SQLMetadataConnector is not bound");
   }
 
   @Override

--- a/services/src/test/java/org/apache/druid/testing/embedded/ServerReferencesProvider.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/ServerReferencesProvider.java
@@ -25,6 +25,7 @@ import org.apache.druid.discovery.DruidLeaderSelector;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
 import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.metadata.SQLMetadataConnector;
 import org.apache.druid.rpc.indexing.OverlordClient;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.metrics.LatchableEmitter;
@@ -76,6 +77,11 @@ public interface ServerReferencesProvider
    * in the metadata store.
    */
   IndexerMetadataStorageCoordinator segmentsMetadataStorage();
+
+  /**
+   * Connector to the SQL-based metadata store.
+   */
+  SQLMetadataConnector sqlMetadataConnector();
 
   /**
    * Provider for {@code DruidNodeDiscovery} for any node type.


### PR DESCRIPTION
### Description

This patch accompanies #18192 and helps verify the change in that PR.

### Changes

- Add `EmbeddedJdbcLookupTest`
- Access the `SQLMetadataConnector` injected into an `EmbeddedDruidServer` in tests

---

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
