### PR TITLE
Embedded tests: stricter segment waiting, longer startup timeouts.

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedIndexTaskTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedIndexTaskTest.java
@@ -24,7 +24,6 @@ import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Comparators;
-import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.testing.embedded.EmbeddedBroker;
 import org.apache.druid.testing.embedded.EmbeddedClusterApis;
 import org.apache.druid.testing.embedded.EmbeddedCoordinator;
@@ -103,9 +102,7 @@ public class EmbeddedIndexTaskTest extends EmbeddedClusterTestBase
     }
 
     // Wait for segments to be queryable
-    broker.latchableEmitter().waitForEvent(
-        event -> event.hasDimension(DruidMetrics.DATASOURCE, dataSource)
-    );
+    broker.waitForSegmentAvailability(segments.stream().map(DataSegment::getId).collect(Collectors.toList()));
     Assertions.assertEquals(Resources.CSV_DATA_10_DAYS, cluster.runSql("SELECT * FROM %s", dataSource));
     Assertions.assertEquals("10", cluster.runSql("SELECT COUNT(*) FROM %s", dataSource));
   }

--- a/services/src/test/java/org/apache/druid/testing/embedded/DruidServerResource.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/DruidServerResource.java
@@ -89,7 +89,7 @@ class DruidServerResource implements EmbeddedResource
     executorService.submit(() -> runServer(serverRunnable));
 
     // Wait for lifecycle to be created and started
-    if (lifecycleCreated.await(10, TimeUnit.SECONDS)) {
+    if (lifecycleCreated.await(30, TimeUnit.SECONDS)) {
       awaitLifecycleStart();
     } else {
       throw new ISE("Timed out waiting for lifecycle of server[%s] to be created", server.getName());

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedBroker.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedBroker.java
@@ -36,6 +36,7 @@ import org.apache.druid.timeline.SegmentId;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -99,7 +100,7 @@ public class EmbeddedBroker extends EmbeddedDruidServer
   private static class SegmentAvailabilityTracker implements ServerView.SegmentCallback
   {
     @GuardedBy("itself")
-    private final Set<SegmentId> segments = Sets.newHashSet();
+    private final Set<SegmentId> segments = new HashSet<>();
 
     public void waitForSegmentAvailability(Collection<SegmentId> desiredSegments) throws InterruptedException
     {


### PR DESCRIPTION
Two things that make the embedded tests less flaky:

1) Add a "waitForSegmentAvailability" method to EmbeddedBroker, so tests
   can be sure all desired segments are visible. Prior to this change,
   sometimes I would see failures on EmbeddedIndexTaskTest due to not all
   segments being available when the test query runs.

2) Extend the service startup timeout from 10s to 30s. On my machine,
   when it's busy, sometimes it takes more than 10s to start up a service.