### PR TITLE
Include empty servers in BrokerServerView.

### DIFF
--- a/benchmarks/src/test/java/org/apache/druid/benchmark/query/CachingClusteredClientBenchmark.java
+++ b/benchmarks/src/test/java/org/apache/druid/benchmark/query/CachingClusteredClientBenchmark.java
@@ -556,7 +556,7 @@ public class CachingClusteredClientBenchmark
     }
 
     @Override
-    public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+    public void registerServerCallback(Executor exec, ServerCallback callback)
     {
       // do nothing
     }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
@@ -352,7 +352,7 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
           }
 
           @Override
-          public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+          public void registerServerCallback(Executor exec, ServerCallback callback)
           {
 
           }

--- a/server/src/main/java/org/apache/druid/client/BrokerServerView.java
+++ b/server/src/main/java/org/apache/druid/client/BrokerServerView.java
@@ -157,11 +157,24 @@ public class BrokerServerView implements TimelineServerView
         segmentFilter
     );
 
-    baseView.registerServerRemovedCallback(
+    baseView.registerServerCallback(
         exec,
-        server -> {
-          removeServer(server);
-          return CallbackAction.CONTINUE;
+        new ServerCallback() {
+          @Override
+          public CallbackAction serverAdded(DruidServer server)
+          {
+            if (!server.getType().equals(ServerType.BROKER)) {
+              addServer(server);
+            }
+            return CallbackAction.CONTINUE;
+          }
+
+          @Override
+          public CallbackAction serverRemoved(DruidServer server)
+          {
+            removeServer(server);
+            return CallbackAction.CONTINUE;
+          }
         }
     );
   }
@@ -378,9 +391,9 @@ public class BrokerServerView implements TimelineServerView
   }
 
   @Override
-  public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+  public void registerServerCallback(Executor exec, ServerCallback callback)
   {
-    baseView.registerServerRemovedCallback(exec, callback);
+    baseView.registerServerCallback(exec, callback);
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/client/CoordinatorServerView.java
+++ b/server/src/main/java/org/apache/druid/client/CoordinatorServerView.java
@@ -125,10 +125,16 @@ public class CoordinatorServerView implements InventoryView
         }
     );
 
-    baseView.registerServerRemovedCallback(
+    baseView.registerServerCallback(
         exec,
-        new ServerView.ServerRemovedCallback()
+        new ServerView.ServerCallback()
         {
+          @Override
+          public ServerView.CallbackAction serverAdded(DruidServer server)
+          {
+            return ServerView.CallbackAction.CONTINUE;
+          }
+
           @Override
           public ServerView.CallbackAction serverRemoved(DruidServer server)
           {

--- a/server/src/main/java/org/apache/druid/client/FilteredServerInventoryView.java
+++ b/server/src/main/java/org/apache/druid/client/FilteredServerInventoryView.java
@@ -34,5 +34,5 @@ public interface FilteredServerInventoryView extends InventoryView
       Predicate<Pair<DruidServerMetadata, DataSegment>> filter
   );
 
-  void registerServerRemovedCallback(Executor exec, ServerView.ServerRemovedCallback callback);
+  void registerServerCallback(Executor exec, ServerView.ServerCallback callback);
 }

--- a/server/src/main/java/org/apache/druid/client/ServerView.java
+++ b/server/src/main/java/org/apache/druid/client/ServerView.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Executor;
  */
 public interface ServerView
 {
-  void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback);
+  void registerServerCallback(Executor exec, ServerCallback callback);
   void registerSegmentCallback(Executor exec, SegmentCallback callback);
 
   enum CallbackAction
@@ -38,8 +38,24 @@ public interface ServerView
     UNREGISTER,
   }
 
-  interface ServerRemovedCallback
+  interface ServerCallback
   {
+    /**
+     * Called when a server is added.
+     *
+     * The return value indicates if this callback has completed its work.  Note that even if this callback
+     * indicates that it should be unregistered, it is not possible to guarantee that this callback will not
+     * get called again.  There is a race condition between when this callback runs and other events that can cause
+     * the callback to be queued for running.  Thus, callbacks shouldn't assume that they will not get called
+     * again after they are done.  The contract is that the callback will eventually be unregistered, enforcing
+     * a happens-before relationship is not part of the contract.
+     *
+     * @param server The server that was removed.
+     * @return UNREGISTER if the callback has completed its work and should be unregistered.  CONTINUE if the callback
+     * should remain registered.
+     */
+    CallbackAction serverAdded(DruidServer server);
+
     /**
      * Called when a server is removed.
      *

--- a/server/src/main/java/org/apache/druid/curator/inventory/CuratorInventoryManager.java
+++ b/server/src/main/java/org/apache/druid/curator/inventory/CuratorInventoryManager.java
@@ -259,8 +259,8 @@ public class CuratorInventoryManager<ContainerClass, InventoryClass>
               containers.put(containerKey, new ContainerHolder(container, inventoryCache));
 
               log.debug("Starting inventory cache for %s, inventoryPath %s", containerKey, inventoryPath);
-              inventoryCache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
               strategy.newContainer(container);
+              inventoryCache.start(PathChildrenCache.StartMode.POST_INITIALIZED_EVENT);
             }
           }
           break;

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -265,7 +265,7 @@ public class CachingClusteredClientFunctionalityTest
           }
 
           @Override
-          public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+          public void registerServerCallback(Executor exec, ServerCallback callback)
           {
 
           }

--- a/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/CachingClusteredClientTest.java
@@ -2643,7 +2643,7 @@ public class CachingClusteredClientTest
           }
 
           @Override
-          public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+          public void registerServerCallback(Executor exec, ServerCallback callback)
           {
 
           }

--- a/server/src/test/java/org/apache/druid/client/SimpleServerView.java
+++ b/server/src/test/java/org/apache/druid/client/SimpleServerView.java
@@ -149,7 +149,7 @@ public class SimpleServerView implements TimelineServerView
   }
 
   @Override
-  public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+  public void registerServerCallback(Executor exec, ServerCallback callback)
   {
     // do nothing
   }

--- a/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/segment/metadata/CoordinatorSegmentDataCacheConcurrencyTest.java
@@ -535,7 +535,7 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
     private final Map<String, DruidServer> serverMap = new HashMap<>();
     private final Map<String, Set<DataSegment>> segmentsMap = new HashMap<>();
     private final List<NonnullPair<SegmentCallback, Executor>> segmentCallbacks = new ArrayList<>();
-    private final List<NonnullPair<ServerRemovedCallback, Executor>> serverRemovedCallbacks = new ArrayList<>();
+    private final List<NonnullPair<ServerCallback, Executor>> serverRemovedCallbacks = new ArrayList<>();
 
     private void init()
     {
@@ -573,7 +573,7 @@ public class CoordinatorSegmentDataCacheConcurrencyTest extends SegmentMetadataC
     }
 
     @Override
-    public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+    public void registerServerCallback(Executor exec, ServerCallback callback)
     {
       serverRemovedCallbacks.add(new NonnullPair<>(callback, exec));
     }

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestServerInventoryView.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/TestServerInventoryView.java
@@ -130,7 +130,7 @@ public class TestServerInventoryView implements ServerInventoryView
   }
 
   @Override
-  public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+  public void registerServerCallback(Executor exec, ServerCallback callback)
   {
     serverChangeHandlers.add(new ServerChangeHandler(callback, exec));
   }
@@ -196,9 +196,9 @@ public class TestServerInventoryView implements ServerInventoryView
   private static class ServerChangeHandler
   {
     private final Executor executor;
-    private final ServerRemovedCallback callback;
+    private final ServerCallback callback;
 
-    private ServerChangeHandler(ServerRemovedCallback callback, Executor executor)
+    private ServerChangeHandler(ServerCallback callback, Executor executor)
     {
       this.callback = callback;
       this.executor = executor;

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheConcurrencyTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/BrokerSegmentMetadataCacheConcurrencyTest.java
@@ -454,7 +454,7 @@ public class BrokerSegmentMetadataCacheConcurrencyTest extends BrokerSegmentMeta
     private final Map<String, DruidServer> serverMap = new HashMap<>();
     private final Map<String, Set<DataSegment>> segmentsMap = new HashMap<>();
     private final List<NonnullPair<ServerView.SegmentCallback, Executor>> segmentCallbacks = new ArrayList<>();
-    private final List<NonnullPair<ServerView.ServerRemovedCallback, Executor>> serverRemovedCallbacks = new ArrayList<>();
+    private final List<NonnullPair<ServerView.ServerCallback, Executor>> serverRemovedCallbacks = new ArrayList<>();
 
     private void init()
     {
@@ -493,7 +493,7 @@ public class BrokerSegmentMetadataCacheConcurrencyTest extends BrokerSegmentMeta
     }
 
     @Override
-    public void registerServerRemovedCallback(Executor exec, ServerView.ServerRemovedCallback callback)
+    public void registerServerCallback(Executor exec, ServerView.ServerCallback callback)
     {
       serverRemovedCallbacks.add(new NonnullPair<>(callback, exec));
     }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/CalciteTests.java
@@ -639,9 +639,9 @@ public class CalciteTests
     }
 
     @Override
-    public void registerServerRemovedCallback(
+    public void registerServerCallback(
         Executor exec,
-        ServerView.ServerRemovedCallback callback
+        ServerView.ServerCallback callback
     )
     {
       throw new UnsupportedOperationException();

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/TestTimelineServerView.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/TestTimelineServerView.java
@@ -176,7 +176,7 @@ public class TestTimelineServerView implements TimelineServerView
   }
 
   @Override
-  public void registerServerRemovedCallback(Executor exec, ServerRemovedCallback callback)
+  public void registerServerCallback(Executor exec, ServerCallback callback)
   {
     // Do nothing
   }


### PR DESCRIPTION
Fixes #18199, because this makes empty Historicals visible through getDruidServerMetadatas. It also makes them visible through getDruidServers, causes them to show up in the sys.servers table.