### PR TITLE
Embedded tests: Use regular Kafka image.

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -44,7 +44,7 @@ public class KafkaResource extends TestcontainerResource<KafkaContainer>
     super();
   }
 
-  private static final String KAFKA_IMAGE = "apache/kafka-native:4.0.0";
+  private static final String KAFKA_IMAGE = "apache/kafka:4.0.0";
 
   @Override
   protected KafkaContainer createContainer()


### PR DESCRIPTION
This patch switches the image from apache/kafka-native (GraalVM ahead-of-time compiled) to apache/kafka (regular JVM).

Previously the kafka-native image was used, because it boots up more quickly. However, on my machine it segfaults on ~5% of bootups, causing tests to be flaky. Container startup has also been flaky in GitHub Actions, so something similar may be happening there.