### PR TITLE
fix projection grouping column validation

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapAggregateProjection.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapAggregateProjection.java
@@ -379,6 +379,14 @@ public class OnHeapAggregateProjection implements IncrementalIndexRowSelector
       }
       final IncrementalIndex.DimensionDesc parent = getBaseTableDimensionDesc.apply(dimension.getName());
       if (parent == null) {
+        // ensure that this dimension refers to a virtual column, otherwise it is invalid
+        if (!projectionSpec.getVirtualColumns().exists(dimension.getName())) {
+          throw InvalidInput.exception(
+              "projection[%s] contains dimension[%s] that is not present on the base table or a virtual column",
+              projectionSpec.getName(),
+              dimension.getName()
+          );
+        }
         // this dimension only exists in the child, it needs its own handler
         final IncrementalIndex.DimensionDesc childOnly = new IncrementalIndex.DimensionDesc(
             i++,


### PR DESCRIPTION
### Description

Fixes an issue with projection schema validation to ensure that all defined grouping columns either refer to a column present in the base table, or refers to a virtual column. This prevents projections from creating grouping columns that are not present in the base table