### PR TITLE
Ignore exceptions when pushing task logs to ensure task success

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -521,9 +521,19 @@ public class ForkingTaskRunner
     finally {
       Thread.currentThread().setName(priorThreadName);
         // Upload task logs
-      taskLogPusher.pushTaskLog(task.getId(), logFile);
+      try {
+        taskLogPusher.pushTaskLog(task.getId(), logFile);
+      }
+      catch (IOException e) {
+        LOGGER.error("Task[%s] failed to push task logs to [%s]", task.getId(), logFile.getName());
+      }
       if (reportsFile.exists()) {
-        taskLogPusher.pushTaskReports(task.getId(), reportsFile);
+        try {
+          taskLogPusher.pushTaskReports(task.getId(), reportsFile);
+        }
+        catch (IOException e) {
+          LOGGER.error("Task[%s] failed to push task reports to [%s]", task.getId(), reportsFile.getName());
+        }
       }
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/ForkingTaskRunner.java
@@ -525,14 +525,16 @@ public class ForkingTaskRunner
         taskLogPusher.pushTaskLog(task.getId(), logFile);
       }
       catch (IOException e) {
-        LOGGER.error("Task[%s] failed to push task logs to [%s]", task.getId(), logFile.getName());
+        LOGGER.error("Task[%s] failed to push task logs to [%s]: Exception[%s]",
+            task.getId(), logFile.getName(), e.getMessage());
       }
       if (reportsFile.exists()) {
         try {
           taskLogPusher.pushTaskReports(task.getId(), reportsFile);
         }
         catch (IOException e) {
-          LOGGER.error("Task[%s] failed to push task reports to [%s]", task.getId(), reportsFile.getName());
+          LOGGER.error("Task[%s] failed to push task reports to [%s]: Exception[%s]",
+              task.getId(), reportsFile.getName(), e.getMessage());
         }
       }
     }


### PR DESCRIPTION
### Description

During task execution, the task is able to finish without disruptions, but is unable to complete successfully. Error logs show that the task is unable to push task logs to HDFS. This PR aims to allow the tasks to succeed even if the task is unable to push its logs to deep storage. 

```
2024-12-26T12:41:40,943 INFO [forking-task-runner-3] org.apache.druid.indexing.overlord.ForkingTaskRunner - Exception caught during executionorg.apache.hadoop.ipc.RemoteException: Router <REDACTED> is in safe mode and cannot handle WRITE requests    
at org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.checkSafeMode(RouterRpcServer.java:563)    
at org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.checkOperation(RouterRpcServer.java:548)    
at org.apache.hadoop.hdfs.server.federation.router.RouterClientProtocol.create(RouterClientProtocol.java:383)    
at org.apache.hadoop.hdfs.server.federation.router.RouterRpcServer.create(RouterRpcServer.java:660)    
at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolServerSideTranslatorPB.create(ClientNamenodeProtocolServerSideTranslatorPB.java:522)    
at org.apache.hadoop.hdfs.protocol.proto.ClientNamenodeProtocolProtos$ClientNamenodeProtocol$2.callBlockingMethod(ClientNamenodeProtocolProtos.java)    
at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:637)    
at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:605)    
at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:589)    
at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1146)    
at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1249)    
at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1147)    
at java.security.AccessController.doPrivileged(Native Method)    
at javax.security.auth.Subject.doAs(Subject.java:422)    
at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:2005)    
at org.apache.hadoop.ipc.DeepHandlerManager$SurfaceHandler.run(DeepHandlerManager.java:269)
```

Replaced unhandled exceptions with WARN loggings. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
Tasks can successfully complete after finishing, even if there are problems pushing logs and report to deep storage.
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `ForkingTaskRunner`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
