### PR TITLE
Suppress kafka emitter by delta

### DIFF
--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -66,7 +66,6 @@ public class KafkaEmitter implements Emitter
   private final AtomicLong previousSegmentMetadataLost;
   private final AtomicLong previousInvalidLost;
 
-
   private final KafkaEmitterConfig config;
   private final Producer<String, String> producer;
   private final ObjectMapper jsonMapper;
@@ -171,26 +170,24 @@ public class KafkaEmitter implements Emitter
       long deltaInvalidLost = currentInvalidLost - previousInvalidLost.getAndSet(currentInvalidLost);
 
       // Refrain from clogging logs when there are no lost messages.
-      if (deltaMetricLost + deltaAlertLost + deltaRequestLost + deltaSegmentMetadataLost + deltaInvalidLost == 0) {
-        return;
+      if (deltaMetricLost + deltaAlertLost + deltaRequestLost + deltaSegmentMetadataLost + deltaInvalidLost > 0) {
+        log.info("Messages lost for past %d minutes: metricLost=[%d], alertLost=[%d], requestLost=[%d], segmentMetadataLost=[%d], invalidLost=[%d]",
+                 DEFAULT_SEND_LOST_INTERVAL_MINUTES,
+                 deltaMetricLost,
+                 deltaAlertLost,
+                 deltaRequestLost,
+                 deltaSegmentMetadataLost,
+                 deltaInvalidLost
+        );
+
+        log.info("Message lost counter: metricLost=[%d], alertLost=[%d], requestLost=[%d], segmentMetadataLost=[%d], invalidLost=[%d]",
+                 currentMetricLost,
+                 currentAlertLost,
+                 currentRequestLost,
+                 currentSegmentMetadataLost,
+                 currentInvalidLost
+        );
       }
-
-      log.info("Messages lost for past %d minutes: metricLost=[%d], alertLost=[%d], requestLost=[%d], segmentMetadataLost=[%d], invalidLost=[%d]",
-               DEFAULT_SEND_LOST_INTERVAL_MINUTES,
-               deltaMetricLost,
-               deltaAlertLost,
-               deltaRequestLost,
-               deltaSegmentMetadataLost,
-               deltaInvalidLost
-      );
-
-      log.info("Message lost counter: metricLost=[%d], alertLost=[%d], requestLost=[%d], segmentMetadataLost=[%d], invalidLost=[%d]",
-               currentMetricLost,
-               currentAlertLost,
-               currentRequestLost,
-               currentSegmentMetadataLost,
-               currentInvalidLost
-      );
     }, DEFAULT_SEND_LOST_INTERVAL_MINUTES, DEFAULT_SEND_LOST_INTERVAL_MINUTES, TimeUnit.MINUTES);
     log.info("Starting Kafka Emitter.");
   }

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -60,6 +60,12 @@ public class KafkaEmitter implements Emitter
   private final AtomicLong requestLost;
   private final AtomicLong segmentMetadataLost;
   private final AtomicLong invalidLost;
+  private final AtomicLong previousMetricLost;
+  private final AtomicLong previousAlertLost;
+  private final AtomicLong previousRequestLost;
+  private final AtomicLong previousSegmentMetadataLost;
+  private final AtomicLong previousInvalidLost;
+
 
   private final KafkaEmitterConfig config;
   private final Producer<String, String> producer;
@@ -92,6 +98,11 @@ public class KafkaEmitter implements Emitter
     this.requestLost = new AtomicLong(0L);
     this.segmentMetadataLost = new AtomicLong(0L);
     this.invalidLost = new AtomicLong(0L);
+    this.previousMetricLost = new AtomicLong(0);
+    this.previousAlertLost = new AtomicLong(0);
+    this.previousRequestLost = new AtomicLong(0);
+    this.previousSegmentMetadataLost = new AtomicLong(0);
+    this.previousInvalidLost = new AtomicLong(0);
   }
 
   private Callback setProducerCallback(AtomicLong lostCounter)
@@ -142,13 +153,43 @@ public class KafkaEmitter implements Emitter
     if (eventTypes.contains(EventType.SEGMENT_METADATA)) {
       scheduler.schedule(this::sendSegmentMetadataToKafka, sendInterval, TimeUnit.SECONDS);
     }
+
     scheduler.scheduleWithFixedDelay(() -> {
+      // Get current counts
+      long currentMetricLost = metricLost.get();
+      long currentAlertLost = alertLost.get();
+      long currentRequestLost = requestLost.get();
+      long currentSegmentMetadataLost = segmentMetadataLost.get();
+      long currentInvalidLost = invalidLost.get();
+
+      // Calculate delta (newly lost messages since last check)
+      long deltaMetricLost = currentMetricLost - previousMetricLost.getAndSet(currentMetricLost);
+      long deltaAlertLost = currentAlertLost - previousAlertLost.getAndSet(currentAlertLost);
+      long deltaRequestLost = currentRequestLost - previousRequestLost.getAndSet(currentRequestLost);
+      long deltaSegmentMetadataLost =
+          currentSegmentMetadataLost - previousSegmentMetadataLost.getAndSet(currentSegmentMetadataLost);
+      long deltaInvalidLost = currentInvalidLost - previousInvalidLost.getAndSet(currentInvalidLost);
+
+      // Refrain from clogging logs when there are no lost messages.
+      if (deltaMetricLost + deltaAlertLost + deltaRequestLost + deltaSegmentMetadataLost + deltaInvalidLost == 0) {
+        return;
+      }
+
+      log.info("Messages lost for past %d minutes: metricLost=[%d], alertLost=[%d], requestLost=[%d], segmentMetadataLost=[%d], invalidLost=[%d]",
+               DEFAULT_SEND_LOST_INTERVAL_MINUTES,
+               deltaMetricLost,
+               deltaAlertLost,
+               deltaRequestLost,
+               deltaSegmentMetadataLost,
+               deltaInvalidLost
+      );
+
       log.info("Message lost counter: metricLost=[%d], alertLost=[%d], requestLost=[%d], segmentMetadataLost=[%d], invalidLost=[%d]",
-          metricLost.get(),
-          alertLost.get(),
-          requestLost.get(),
-          segmentMetadataLost.get(),
-          invalidLost.get()
+               currentMetricLost,
+               currentAlertLost,
+               currentRequestLost,
+               currentSegmentMetadataLost,
+               currentInvalidLost
       );
     }, DEFAULT_SEND_LOST_INTERVAL_MINUTES, DEFAULT_SEND_LOST_INTERVAL_MINUTES, TimeUnit.MINUTES);
     log.info("Starting Kafka Emitter.");

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -159,7 +159,6 @@ public class KafkaEmitter implements Emitter
     log.info("Starting Kafka Emitter.");
   }
 
-  // package-private method for testing
   @VisibleForTesting
   protected void logLostMessagesStatus()
   {

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -173,6 +173,14 @@ public class KafkaEmitterTest
     Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
     Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
     Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+
+    kafkaEmitter.logLostMessagesStatus();
+
+    Assert.assertEquals(0, kafkaEmitter.getPreviousMetricLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousAlertLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousRequestLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousInvalidLostCount());
   }
 
   /**
@@ -223,7 +231,6 @@ public class KafkaEmitterTest
     Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
     Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
     Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
-
   }
 
   /**
@@ -321,10 +328,27 @@ public class KafkaEmitterTest
     Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
     Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
 
+    Assert.assertEquals(0, kafkaEmitter.getPreviousAlertLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousInvalidLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousMetricLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousSegmentMetadataLostCount());
+    Assert.assertEquals(0, kafkaEmitter.getPreviousRequestLostCount());
+
     // Others would be dropped as we've only subscribed to alert events.
     Assert.assertEquals(SERVICE_METRIC_EVENTS.size(), kafkaEmitter.getMetricLostCount());
+    Assert.assertNotEquals(kafkaEmitter.getMetricLostCount(), kafkaEmitter.getPreviousMetricLostCount());
     Assert.assertEquals(SEGMENT_METADATA_EVENTS.size(), kafkaEmitter.getSegmentMetadataLostCount());
+    Assert.assertNotEquals(kafkaEmitter.getSegmentMetadataLostCount(), kafkaEmitter.getPreviousSegmentMetadataLostCount());
     Assert.assertEquals(REQUEST_LOG_EVENTS.size(), kafkaEmitter.getRequestLostCount());
+    Assert.assertNotEquals(kafkaEmitter.getRequestLostCount(), kafkaEmitter.getPreviousRequestLostCount());
+
+    kafkaEmitter.logLostMessagesStatus();
+
+    Assert.assertEquals(kafkaEmitter.getMetricLostCount(), kafkaEmitter.getPreviousMetricLostCount());
+    Assert.assertEquals(kafkaEmitter.getAlertLostCount(), kafkaEmitter.getPreviousAlertLostCount());
+    Assert.assertEquals(kafkaEmitter.getRequestLostCount(), kafkaEmitter.getPreviousRequestLostCount());
+    Assert.assertEquals(kafkaEmitter.getSegmentMetadataLostCount(), kafkaEmitter.getPreviousSegmentMetadataLostCount());
+    Assert.assertEquals(kafkaEmitter.getInvalidLostCount(), kafkaEmitter.getPreviousInvalidLostCount());
   }
 
   /**


### PR DESCRIPTION
### Description

`
[pool-13-thread-4] org.apache.druid.emitter.kafka.KafkaEmitter - Message lost counter: metricLost=[0], alertLost=[0], requestLost=[0], invalidLost=[0]
`
The above log is scheduled. We found the log to be very repetitive, and would like to change the functionality to only log when there's a problem (e.g. there are messages lost for the past scheduled minutes).


#### Release note
* Reduced Kafka Emitter logging to only report when messages are lost.


<hr>

##### Key changed/added classes in this PR
 * `KafkaEmitter.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
