### PR TITLE
Upgrade to junit-5.13.3; set default testcase to 10m ; enable threaddump on timeouts

### DIFF
--- a/.github/scripts/run_unit-tests
+++ b/.github/scripts/run_unit-tests
@@ -20,6 +20,8 @@ set -x
 
 OPTS+="-pl !integration-tests,!:druid-it-tools,!:druid-it-image,!:druid-it-cases"
 OPTS+=" -Dsurefire.failIfNoSpecifiedTests=false -P skip-static-checks -Dweb.console.skip=true"
+OPTS+=" -Djunit.jupiter.execution.timeout.test.method.default=10m"
+OPTS+=" -Djunit.jupiter.execution.timeout.threaddump.enabled=true"
 OPTS+=" -Djacoco.destFile=target/jacoco-${HASH}.exec"
 
 mvn -B $OPTS test "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -1094,7 +1094,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.2</version>
+                <version>5.13.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Some recent runs of `QTest` testcases seem to have started hanging. This PR tries to dig into that:

* upgrades to use `junit-5.13.3`
* set default testcase timeout to `10m`
* enables threaddump on timeout [feature](https://docs.junit.org/current/user-guide/#writing-tests-declarative-timeouts-debugging-thread-dump) (available above junit-5.12)

