### PR TITLE
supress 2 new CVEs that popped in the druid34 release process

### DIFF
--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -142,6 +142,7 @@
     <cve>CVE-2024-47561</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to hadoop-client 3.4 which required aws sdk v2 dependency work to finish -->
     <cve>CVE-2024-29131</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to hadoop-client 3.4 which required aws sdk v2 dependency work to finish -->
     <cve>CVE-2024-22201</cve> <!--  This seems to be a legitimate vulnerability. We would need to go to a hadoop-client which was not yet released  -->
+    <cve>CVE-2025-52999</cve> <!--  This is vulneraability in all versions of hadoop-client-runtime and has not been fixed by hadoop yet -->
   </suppress>
 
   <!-- those are false positives, no other tools report any of those CVEs in the hadoop package -->
@@ -192,6 +193,7 @@
     <cve>CVE-2022-34917</cve>
     <cve>CVE-2023-25194</cve>
     <cve>CVE-2024-31141</cve>
+    <cve>CVE-2025-27818</cve> <!-- not fixed in any version of ranger dependency. I don't think it is exploitable in Druid within this extension -->
   </suppress>
 
   <suppress>


### PR DESCRIPTION

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

The mvn cve check turned up two new CVEs for our dependencies. Both of them are unfortunately associated with dependencies that have historically not addressed CVEs and already have suppressions

##### druid-ranger-security 

[CVE-2025-27818](https://nvd.nist.gov/vuln/detail/CVE-2025-27818)
* This dependency is depending on kafka-clients 2.8.x and has resulted in previous supressions by us.
* even the latest version of the ranger dep is still on this old kafka-clients dep.
* I think that it is not exploitable in our env though, unless an audit producer is setup druid side and not just on the ranger servers that this extension relies on for auth? I'm not very familiar with the extension.

##### hadoop-client-runtime

[CVE-2025-52999](https://nvd.nist.gov/vuln/detail/CVE-2025-52999)
* Related to jackson dependency that is shaded into hadoop-client-runtime. We have other supressions related to jackson already. 
* Even upgrading to latest hadoop 3.4.1 (which we can't do yet due to aws clients), wouldn't fix this.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * owasp-dependency-check-supressions.xml

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
