### PR TITLE
some enhancements to embedded tests for writing query oriented tests

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDurableShuffleStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDurableShuffleStorageTest.java
@@ -125,7 +125,7 @@ public class EmbeddedDurableShuffleStorageTest extends EmbeddedClusterTestBase
   }
 
   @BeforeAll
-  void setupData() throws IOException
+  final void setupData() throws IOException
   {
     msqApis = new EmbeddedMSQApis(cluster, overlord);
     dataSource = EmbeddedClusterApis.createTestDatasourceName();

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
@@ -99,8 +99,6 @@ public class EmbeddedMSQRealtimeQueryTest extends EmbeddedClusterTestBase
   @Override
   public EmbeddedDruidCluster createCluster()
   {
-    final EmbeddedDruidCluster cluster = EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper();
-
     kafka = new KafkaResource();
 
     coordinator.addProperty("druid.manager.segments.useIncrementalCache", "always");
@@ -121,30 +119,32 @@ public class EmbeddedMSQRealtimeQueryTest extends EmbeddedClusterTestBase
            .addProperty("druid.processing.numThreads", "3")
            .addProperty("druid.worker.capacity", "4");
 
-    cluster.addExtension(KafkaIndexTaskModule.class)
-           .addExtension(DartControllerModule.class)
-           .addExtension(DartWorkerModule.class)
-           .addExtension(DartControllerMemoryManagementModule.class)
-           .addExtension(DartControllerModule.class)
-           .addExtension(DartWorkerMemoryManagementModule.class)
-           .addExtension(DartWorkerModule.class)
-           .addExtension(IndexerMemoryManagementModule.class)
-           .addExtension(MSQDurableStorageModule.class)
-           .addExtension(MSQIndexingModule.class)
-           .addExtension(MSQSqlModule.class)
-           .addExtension(SqlTaskModule.class)
-           .addCommonProperty("druid.monitoring.emissionPeriod", "PT0.1s")
-           .addCommonProperty("druid.msq.dart.enabled", "true")
-           .useLatchableEmitter()
-           .addResource(kafka)
-           .addServer(coordinator)
-           .addServer(overlord)
-           .addServer(indexer)
-           .addServer(broker)
-           .addServer(historical)
-           .addServer(router);
-
-    return cluster;
+    return EmbeddedDruidCluster
+        .withEmbeddedDerbyAndZookeeper()
+        .addExtensions(
+            KafkaIndexTaskModule.class,
+            DartControllerModule.class,
+            DartWorkerModule.class,
+            DartControllerMemoryManagementModule.class,
+            DartControllerModule.class,
+            DartWorkerMemoryManagementModule.class,
+            DartWorkerModule.class,
+            IndexerMemoryManagementModule.class,
+            MSQDurableStorageModule.class,
+            MSQIndexingModule.class,
+            MSQSqlModule.class,
+            SqlTaskModule.class
+        )
+        .addCommonProperty("druid.monitoring.emissionPeriod", "PT0.1s")
+        .addCommonProperty("druid.msq.dart.enabled", "true")
+        .useLatchableEmitter()
+        .addResource(kafka)
+        .addServer(coordinator)
+        .addServer(overlord)
+        .addServer(indexer)
+        .addServer(broker)
+        .addServer(historical)
+        .addServer(router);
   }
 
   @BeforeEach

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidCluster.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidCluster.java
@@ -189,6 +189,9 @@ public class EmbeddedDruidCluster implements ClusterReferencesProvider, Embedded
     server.onAddedToCluster(commonProperties);
     servers.add(server);
     resources.add(server);
+    if (startedFirstDruidServer) {
+      server.beforeStart(this);
+    }
     return this;
   }
 

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidCluster.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidCluster.java
@@ -34,7 +34,6 @@ import org.apache.druid.testing.embedded.emitter.LatchableEmitterModule;
 import org.apache.druid.utils.RuntimeInfo;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -158,7 +157,7 @@ public class EmbeddedDruidCluster implements ClusterReferencesProvider, Embedded
 
   /**
    * Adds an extension to this cluster. The list of extensions is populated in
-   * the common property {@code druid.extensions.modulesForSimulation}.
+   * the common property {@code druid.extensions.modulesForEmbeddedTest}.
    */
   public EmbeddedDruidCluster addExtension(Class<? extends DruidModule> moduleClass)
   {
@@ -167,11 +166,16 @@ public class EmbeddedDruidCluster implements ClusterReferencesProvider, Embedded
     return this;
   }
 
+  /**
+   * Adds extensions to this cluster.
+   *
+   * @see #addExtension(Class)
+   */
   @SafeVarargs
   public final EmbeddedDruidCluster addExtensions(Class<? extends DruidModule>... moduleClasses)
   {
     validateNotStarted();
-    extensionModules.addAll(Arrays.asList(moduleClasses));
+    extensionModules.addAll(List.of(moduleClasses));
     return this;
   }
 
@@ -182,7 +186,7 @@ public class EmbeddedDruidCluster implements ClusterReferencesProvider, Embedded
    */
   public EmbeddedDruidCluster addServer(EmbeddedDruidServer server)
   {
-    server.onAddedToCluster(this, commonProperties);
+    server.onAddedToCluster(commonProperties);
     servers.add(server);
     resources.add(server);
     return this;

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidCluster.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidCluster.java
@@ -34,6 +34,7 @@ import org.apache.druid.testing.embedded.emitter.LatchableEmitterModule;
 import org.apache.druid.utils.RuntimeInfo;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -166,6 +167,14 @@ public class EmbeddedDruidCluster implements ClusterReferencesProvider, Embedded
     return this;
   }
 
+  @SafeVarargs
+  public final EmbeddedDruidCluster addExtensions(Class<? extends DruidModule>... moduleClasses)
+  {
+    validateNotStarted();
+    extensionModules.addAll(Arrays.asList(moduleClasses));
+    return this;
+  }
+
   /**
    * Adds a Druid server to this cluster. A server added to the cluster after the
    * cluster has started must be started explicitly by calling
@@ -247,6 +256,7 @@ public class EmbeddedDruidCluster implements ClusterReferencesProvider, Embedded
         }
 
         log.info("Starting resource[%s].", resource);
+        resource.beforeStart(this);
         resource.start();
         resource.onStarted(this);
       }

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidServer.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidServer.java
@@ -150,7 +150,11 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
     return (T) this;
   }
 
-  public final T addBeforeStart(BeforeStart hook)
+  /**
+   * Adds a {@link BeforeStart} to run as part of {@link #beforeStart(EmbeddedDruidCluster)}
+   */
+  @SuppressWarnings("UnusedReturnValue")
+  public final T addBeforeStartHook(BeforeStart hook)
   {
     beforeStartHooks.add(hook);
     return (T) this;
@@ -178,11 +182,9 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
    * Called from {@link EmbeddedDruidCluster#addServer(EmbeddedDruidServer)} to
    * tie the lifecycle of this server to the cluster.
    */
-  final void onAddedToCluster(EmbeddedDruidCluster cluster, Properties commonProperties)
+  final void onAddedToCluster(Properties commonProperties)
   {
-    this.lifecycle.set(
-        new EmbeddedServerLifecycle(this, cluster.getTestFolder(), cluster.getZookeeper(), commonProperties)
-    );
+    this.lifecycle.set(new EmbeddedServerLifecycle(this, commonProperties));
   }
 
   /**
@@ -266,6 +268,12 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
   @FunctionalInterface
   public interface BeforeStart
   {
-    void run(EmbeddedDruidCluster cluster, EmbeddedDruidServer self);
+    /**
+     * Allows a {@link EmbeddedDruidServer} to perform additional initialization before starting
+     *
+     * @param cluster - the {@link EmbeddedDruidCluster} the {@link EmbeddedDruidServer} is part of
+     * @param self    - the {@link EmbeddedDruidServer} to perform initialization on
+     */
+    void run(EmbeddedDruidCluster cluster, EmbeddedDruidServer<?> self);
   }
 }

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidServer.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedDruidServer.java
@@ -22,6 +22,7 @@ package org.apache.druid.testing.embedded;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import org.apache.druid.cli.ServerRunnable;
+import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
@@ -29,7 +30,9 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.server.metrics.LatchableEmitter;
 import org.apache.druid.utils.RuntimeInfo;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -43,7 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> implements EmbeddedResource
 {
   private static final Logger log = new Logger(EmbeddedDruidServer.class);
-  protected static final long MEM_100_MB = 100_000_000;
+  protected static final long MEM_100_MB = HumanReadableBytes.parse("100M");
 
   /**
    * A static incremental ID is used instead of a random number to ensure that
@@ -57,6 +60,7 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
   private long serverMemory = MEM_100_MB;
   private long serverDirectMemory = MEM_100_MB;
   private final Map<String, String> serverProperties = new HashMap<>();
+  private final List<BeforeStart> beforeStartHooks = new ArrayList<>();
   private final ServerReferenceHolder referenceHolder = new ServerReferenceHolder();
 
   EmbeddedDruidServer()
@@ -65,6 +69,34 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
         "%s-%d",
         this.getClass().getSimpleName(),
         SERVER_ID.incrementAndGet()
+    );
+    beforeStartHooks.add(
+        (cluster, self) -> {
+          // Add properties for temporary directories used by the servers
+          final String logsDirectory = cluster.getTestFolder().getOrCreateFolder("indexer-logs").getAbsolutePath();
+          final String taskDirectory = cluster.getTestFolder().newFolder().getAbsolutePath();
+          final String storageDirectory = cluster.getTestFolder().newFolder().getAbsolutePath();
+          log.info(
+              "Server[%s] using directories: task directory[%s], logs directory[%s], storage directory[%s].",
+              self.getName(),
+              taskDirectory,
+              logsDirectory,
+              storageDirectory
+          );
+          self.addProperty("druid.host", "localhost");
+          self.addProperty("druid.indexer.task.baseDir", taskDirectory);
+          self.addProperty("druid.indexer.logs.directory", logsDirectory);
+          self.addProperty("druid.storage.storageDirectory", storageDirectory);
+
+          // Add properties for Zookeeper
+          if (cluster.getZookeeper() != null) {
+            self.addProperty("druid.zk.service.host", cluster.getZookeeper().getConnectString());
+          }
+
+          // Add properties for RuntimeInfoModule
+          self.addProperty(RuntimeInfoModule.SERVER_MEMORY_PROPERTY, String.valueOf(serverMemory));
+          self.addProperty(RuntimeInfoModule.SERVER_DIRECT_MEMORY_PROPERTY, String.valueOf(serverDirectMemory));
+        }
     );
   }
 
@@ -90,6 +122,14 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
     }
   }
 
+  @Override
+  public void beforeStart(EmbeddedDruidCluster cluster)
+  {
+    for (BeforeStart hook : beforeStartHooks) {
+      hook.run(cluster, this);
+    }
+  }
+
   /**
    * @return Name of this server = type + 2-digit ID.
    */
@@ -107,6 +147,12 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
   public final T addProperty(String key, String value)
   {
     serverProperties.put(key, value);
+    return (T) this;
+  }
+
+  public final T addBeforeStart(BeforeStart hook)
+  {
+    beforeStartHooks.add(hook);
     return (T) this;
   }
 
@@ -160,45 +206,9 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
    * this server. This must be called only after all the resources required by
    * the Druid server have been initialized.
    */
-  final Properties getStartupProperties(
-      TestFolder testFolder,
-      EmbeddedZookeeper zookeeper
-  )
+  final Properties getStartupProperties()
   {
     final Properties serverProperties = new Properties();
-
-    // Add properties for temporary directories used by the servers
-    final String logsDirectory = testFolder.getOrCreateFolder("indexer-logs").getAbsolutePath();
-    final String taskDirectory = testFolder.newFolder().getAbsolutePath();
-    final String storageDirectory = testFolder.newFolder().getAbsolutePath();
-    log.info(
-        "Server[%s] using directories: task directory[%s], logs directory[%s], storage directory[%s].",
-        name, taskDirectory, logsDirectory, storageDirectory
-    );
-    serverProperties.setProperty("druid.indexer.task.baseDir", taskDirectory);
-    serverProperties.setProperty("druid.indexer.logs.directory", logsDirectory);
-    serverProperties.setProperty("druid.storage.storageDirectory", storageDirectory);
-
-    // Add properties for Zookeeper
-    if (zookeeper != null) {
-      serverProperties.setProperty("druid.zk.service.host", zookeeper.getConnectString());
-    }
-
-    if (this instanceof EmbeddedHistorical) {
-      serverProperties.setProperty(
-          "druid.segmentCache.locations",
-          StringUtils.format(
-              "[{\"path\":\"%s\",\"maxSize\":\"%s\"}]",
-              testFolder.newFolder().getAbsolutePath(),
-              MEM_100_MB
-          )
-      );
-    }
-
-    // Add properties for RuntimeInfoModule
-    serverProperties.setProperty(RuntimeInfoModule.SERVER_MEMORY_PROPERTY, String.valueOf(serverMemory));
-    serverProperties.setProperty(RuntimeInfoModule.SERVER_DIRECT_MEMORY_PROPERTY, String.valueOf(serverDirectMemory));
-
     serverProperties.putAll(this.serverProperties);
     return serverProperties;
   }
@@ -251,5 +261,11 @@ public abstract class EmbeddedDruidServer<T extends EmbeddedDruidServer<T>> impl
      * from {@link ServerRunnable#initLifecycle(Injector)}.
      */
     void onLifecycleInit(Lifecycle lifecycle);
+  }
+
+  @FunctionalInterface
+  public interface BeforeStart
+  {
+    void run(EmbeddedDruidCluster cluster, EmbeddedDruidServer self);
   }
 }

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedHistorical.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedHistorical.java
@@ -38,8 +38,7 @@ public class EmbeddedHistorical extends EmbeddedDruidServer<EmbeddedHistorical>
 {
   public EmbeddedHistorical()
   {
-    super();
-    addBeforeStart((cluster, self) -> {
+    addBeforeStartHook((cluster, self) -> {
         self.addProperty(
             "druid.segmentCache.locations",
             StringUtils.format(

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedHistorical.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedHistorical.java
@@ -23,6 +23,7 @@ import com.google.inject.Injector;
 import com.google.inject.Module;
 import org.apache.druid.cli.CliHistorical;
 import org.apache.druid.cli.ServerRunnable;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 
 import java.util.ArrayList;
@@ -35,6 +36,20 @@ import java.util.List;
  */
 public class EmbeddedHistorical extends EmbeddedDruidServer<EmbeddedHistorical>
 {
+  public EmbeddedHistorical()
+  {
+    super();
+    addBeforeStart((cluster, self) -> {
+        self.addProperty(
+            "druid.segmentCache.locations",
+            StringUtils.format(
+                "[{\"path\":\"%s\",\"maxSize\":\"%s\"}]",
+                cluster.getTestFolder().newFolder().getAbsolutePath(),
+                MEM_100_MB
+            )
+        );
+    });
+  }
 
   @Override
   ServerRunnable createRunnable(LifecycleInitHandler handler)

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedHistorical.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedHistorical.java
@@ -39,14 +39,14 @@ public class EmbeddedHistorical extends EmbeddedDruidServer<EmbeddedHistorical>
   public EmbeddedHistorical()
   {
     addBeforeStartHook((cluster, self) -> {
-        self.addProperty(
-            "druid.segmentCache.locations",
-            StringUtils.format(
-                "[{\"path\":\"%s\",\"maxSize\":\"%s\"}]",
-                cluster.getTestFolder().newFolder().getAbsolutePath(),
-                MEM_100_MB
-            )
-        );
+      self.addProperty(
+          "druid.segmentCache.locations",
+          StringUtils.format(
+              "[{\"path\":\"%s\",\"maxSize\":\"%s\"}]",
+              cluster.getTestFolder().newFolder().getAbsolutePath(),
+              MEM_100_MB
+          )
+      );
     });
   }
 

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedResource.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedResource.java
@@ -27,6 +27,7 @@ package org.apache.druid.testing.embedded;
  */
 public interface EmbeddedResource
 {
+
   /**
    * Starts this resource. Implementations of this method should clean up any
    * previous state as it may be called multiple times on a single instance of
@@ -38,6 +39,17 @@ public interface EmbeddedResource
    * Cleans up this resource.
    */
   void stop() throws Exception;
+
+
+  /**
+   * Called before {@link #start()} with a pointer to the current cluster. This is primarily useful for any
+   * final initialization of {@link EmbeddedDruidServer} that need to configure themselves based on some
+   * shared resources which have already been started, such as {@link TestFolder}.
+   */
+  default void beforeStart(EmbeddedDruidCluster cluster)
+  {
+    // do nothing by default
+  }
 
   /**
    * Called after {@link #start()} with a pointer to the current cluster. This is intended for use by resources

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedServerLifecycle.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedServerLifecycle.java
@@ -43,23 +43,14 @@ class EmbeddedServerLifecycle
 
   private final EmbeddedDruidServer server;
 
-  private final TestFolder testFolder;
-  private final EmbeddedZookeeper zookeeper;
   private final Properties commonProperties;
 
   private ExecutorService executorService;
   private final AtomicReference<Lifecycle> lifecycle = new AtomicReference<>();
 
-  EmbeddedServerLifecycle(
-      EmbeddedDruidServer server,
-      TestFolder testFolder,
-      EmbeddedZookeeper zookeeper,
-      Properties commonProperties
-  )
+  EmbeddedServerLifecycle(EmbeddedDruidServer server, Properties commonProperties)
   {
     this.server = server;
-    this.zookeeper = zookeeper;
-    this.testFolder = testFolder;
     this.commonProperties = commonProperties;
   }
 

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedServerLifecycle.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedServerLifecycle.java
@@ -151,7 +151,7 @@ class EmbeddedServerLifecycle
     try {
       final Properties serverProperties = new Properties();
       serverProperties.putAll(commonProperties);
-      serverProperties.putAll(server.getStartupProperties(testFolder, zookeeper));
+      serverProperties.putAll(server.getStartupProperties());
 
       final Injector injector = new StartupInjectorBuilder()
           .withProperties(serverProperties)

--- a/services/src/test/java/org/apache/druid/testing/embedded/junit5/EmbeddedClusterTestBase.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/junit5/EmbeddedClusterTestBase.java
@@ -62,7 +62,7 @@ public abstract class EmbeddedClusterTestBase
   protected abstract EmbeddedDruidCluster createCluster();
 
   @BeforeAll
-  protected final void setup() throws Exception
+  protected void setup() throws Exception
   {
     cluster = createCluster();
     cluster.start();

--- a/services/src/test/java/org/apache/druid/testing/embedded/junit5/EmbeddedClusterTestBase.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/junit5/EmbeddedClusterTestBase.java
@@ -62,7 +62,7 @@ public abstract class EmbeddedClusterTestBase
   protected abstract EmbeddedDruidCluster createCluster();
 
   @BeforeAll
-  protected void setup() throws Exception
+  protected final void setup() throws Exception
   {
     cluster = createCluster();
     cluster.start();


### PR DESCRIPTION
Some improvements to the embedded test stuff from my experience writing test for #18176, which is a query oriented test.

The primary change is a new `beforeStart` method on `EmbeddedResource` interface, which allows them to perform additional operations when starting up (with access to the `EmbeddedDruidCluster` at this point, so shared resources are available).

I have added usage of this new functionality to clean up how druid service properties are set, specifically `EmbeddedDruidService` has a new `addBeforeStart` method that takes a function add to a list of things to call during its implementation of the new `beforeStart` method. With this, I've cleaned up the `getStartupProperties` method to just copy all the stuff from the map, and moved all of the previous logic into the `beforeStart` hooks (and the historical specific logic into the `EmbeddedHistorical`).

While i was here, I made the durable shuffle test re-use the same ingested data between runs instead of reingesting per test.