### PR TITLE
Fix concurrent append to interval with unused segments

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
@@ -1141,8 +1141,10 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     // Allocate and commit another APPEND segment
     final SegmentIdWithShardSpec pendingSegment2
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment2.getVersion());
-    Assert.assertEquals(1, pendingSegment2.getShardSpec().getPartitionNum());
+
+    // Verify that the new segment gets a different version
+    Assert.assertEquals(SEGMENT_V0 + "S", pendingSegment2.getVersion());
+    Assert.assertEquals(0, pendingSegment2.getShardSpec().getPartitionNum());
 
     final DataSegment segmentV02 = asSegment(pendingSegment2);
     appendTask.commitAppendSegments(segmentV02);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
@@ -23,6 +23,8 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.apache.druid.error.DruidExceptionMatcher;
+import org.apache.druid.error.ExceptionMatcher;
 import org.apache.druid.indexing.common.MultipleFileTaskReportFileWriter;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.TaskStorageDirTracker;
@@ -63,6 +65,7 @@ import org.apache.druid.tasklogs.NoopTaskLogs;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
+import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.junit.After;
@@ -1120,7 +1123,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   }
 
   @Test
-  public void test_concurrentAppend_toIntervalWithUnusedSegments()
+  public void test_concurrentAppend_toIntervalWithUnusedAppendSegment_createsFreshVersion()
   {
     // Allocate and commit an APPEND segment
     final SegmentIdWithShardSpec pendingSegment
@@ -1152,6 +1155,54 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     verifyIntervalHasUsedSegments(FIRST_OF_JAN_23, segmentV02);
     verifyIntervalHasVisibleSegments(FIRST_OF_JAN_23, segmentV02);
+  }
+
+  @Test
+  public void test_allocateCommitDelete_createsFreshVersion_uptoMaxAllowedRetries()
+  {
+    final int maxAllowedAppends = 10;
+    final int expectedParitionNum = 0;
+    String expectedVersion = SEGMENT_V0;
+
+    // Allocate, commit, delete, repeat
+    for (int i = 0; i < maxAllowedAppends; ++i, expectedVersion += "S") {
+      // Allocate a segment and verify its version and partition number
+      final SegmentIdWithShardSpec pendingSegment
+          = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
+
+      Assert.assertEquals(expectedVersion, pendingSegment.getVersion());
+      Assert.assertEquals(expectedParitionNum, pendingSegment.getShardSpec().getPartitionNum());
+
+      // Commit the segment and verify its version and partition number
+      final DataSegment segment = asSegment(pendingSegment);
+      appendTask.commitAppendSegments(segment);
+
+      Assert.assertEquals(expectedVersion, segment.getVersion());
+      Assert.assertEquals(expectedParitionNum, segment.getShardSpec().getPartitionNum());
+
+      verifyIntervalHasUsedSegments(FIRST_OF_JAN_23, segment);
+      verifyIntervalHasVisibleSegments(FIRST_OF_JAN_23, segment);
+
+      // Mark the segment as unused
+      getStorageCoordinator().markAllSegmentsAsUnused(appendTask.getDataSource());
+      verifyIntervalHasUsedSegments(FIRST_OF_JAN_23);
+    }
+
+    // Verify that the next attempt fails
+    MatcherAssert.assertThat(
+        Assert.assertThrows(
+            ISE.class,
+            () -> appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY)
+        ),
+        ExceptionMatcher.of(ISE.class).expectRootCause(
+            DruidExceptionMatcher.internalServerError().expectMessageIs(
+                "Could not allocate segment"
+                + "[wiki_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_1970-01-01T00:00:00.000Z]"
+                + " as there are too many clashing unused versions(upto [1970-01-01T00:00:00.000ZSSSSSSSSSS])"
+                + " in the interval. Kill the old unused versions to proceed."
+            )
+        )
+    );
   }
 
   @Nullable

--- a/processing/src/test/java/org/apache/druid/error/ExceptionMatcher.java
+++ b/processing/src/test/java/org/apache/druid/error/ExceptionMatcher.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.error;
 
+import com.google.common.base.Throwables;
 import org.apache.druid.matchers.DruidMatchers;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
@@ -72,6 +73,12 @@ public class ExceptionMatcher extends DiagnosingMatcher<Throwable>
   public ExceptionMatcher expectCause(Matcher<Throwable> causeMatcher)
   {
     matcherList.add(0, DruidMatchers.fn("cause", Throwable::getCause, causeMatcher));
+    return this;
+  }
+
+  public ExceptionMatcher expectRootCause(Matcher<Throwable> causeMatcher)
+  {
+    matcherList.add(0, DruidMatchers.fn("rootCause", Throwables::getRootCause, causeMatcher));
     return this;
   }
 

--- a/server/src/main/java/org/apache/druid/metadata/PendingSegmentRecord.java
+++ b/server/src/main/java/org/apache/druid/metadata/PendingSegmentRecord.java
@@ -52,6 +52,19 @@ import java.sql.ResultSet;
  */
 public class PendingSegmentRecord
 {
+  /**
+   * Default lock version used by concurrent APPEND tasks.
+   */
+  public static final String DEFAULT_VERSION_FOR_CONCURRENT_APPEND = DateTimes.EPOCH.toString();
+
+  /**
+   * Suffix to use to construct fresh segment versions in the event of a clash.
+   * The chosen character {@code S} is just for visual ease so that two versions
+   * are not easily confused for each other.
+   * {@code 1970-01-01T00:00:00.000Z_1} vs {@code 1970-01-01T00:00:00.000ZS_1}.
+   */
+  public static final String CONCURRENT_APPEND_VERSION_SUFFIX = "S";
+
   private final SegmentIdWithShardSpec id;
   private final String sequenceName;
   private final String sequencePrevId;

--- a/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
+++ b/server/src/main/java/org/apache/druid/metadata/SqlSegmentsMetadataQuery.java
@@ -1129,6 +1129,29 @@ public class SqlSegmentsMetadataQuery
   }
 
   /**
+   * Retrieves the versions of unused segments which are perfectly aligned with
+   * the given interval.
+   */
+  public Set<String> retrieveUnusedSegmentVersionsWithInterval(String dataSource, Interval interval)
+  {
+    final String sql = StringUtils.format(
+        "SELECT DISTINCT(version) FROM %1$s"
+        + " WHERE dataSource = :dataSource AND used = false"
+        + " AND %2$send%2$s = :end AND start = :start",
+        dbTables.getSegmentsTable(),
+        connector.getQuoteString()
+    );
+    return Set.copyOf(
+        handle.createQuery(sql)
+              .bind("dataSource", dataSource)
+              .bind("start", interval.getStart().toString())
+              .bind("end", interval.getEnd().toString())
+              .mapTo(String.class)
+              .list()
+    );
+  }
+
+  /**
    * Retrieve the used segment for a given id if it exists in the metadata store and null otherwise
    */
   @Nullable


### PR DESCRIPTION
### Description

This is a better fix for #18216 as suggested by @imply-cheddar  in the [PR comments](https://github.com/apache/druid/pull/18216#issuecomment-3051438524).

#### Note on the original fix

The case of version collision during segment allocation handled in the original PR can happen only if the following conditions are met:
- The task performing the allocation is an append task (`appendToExisting: true`)
   - .Non-append tasks don't use segment allocation anyway and just replace segments that have the same version as their locks.
- The task is using an APPEND lock.
   - Otherwise, the task would have been using an EXCLUSIVE lock which would always have a unique version (due to exclusivity).
- The interval in question has no used segments but it does have some unused segments.
   - If there were no unused segments, there would be no clash.
   - If there were any used segments, we would simply be appending to that version which wouldn't constitute a clash.
- The unused segments in the interval must have been created by a prior task that was also using an APPEND lock.
   - Any other kind of lock would have resulted in a non-1970 version, thus avoiding clash with subsequent APPEND tasks.

__Despite this fact, appending to an already existing version as a side effect is not desirable and can lead to data consistency issues when this version is marked used / unused.__

### Changes

- Use a new segment version rather than allocating new partition numbers for an existing unused version

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
