### PR TITLE
Add timeout to some of the GitHub Actions jobs

### DIFF
--- a/.github/workflows/reusable-revised-its.yml
+++ b/.github/workflows/reusable-revised-its.yml
@@ -176,6 +176,7 @@ jobs:
 
       - name: Run IT
         id: run-it
+        timeout-minutes: 60
         env:
           BACKWARD_COMPATIBILITY_IT_ENABLED: ${{ inputs.BACKWARD_COMPATIBILITY_IT_ENABLED }}
           DRUID_PREVIOUS_VERSION: ${{ inputs.DRUID_PREVIOUS_VERSION }}

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -82,6 +82,7 @@ jobs:
 
       - name: Run IT
         id: run-it
+        timeout-minutes: 60
         env:
           MYSQL_DRIVER_CLASSNAME: ${{ inputs.mysql_driver }}
         run: |

--- a/.github/workflows/reusable-standard-its.yml
+++ b/.github/workflows/reusable-standard-its.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run IT
         id: run-it
-        timeout-minutes: 60
+        timeout-minutes: 90
         env:
           MYSQL_DRIVER_CLASSNAME: ${{ inputs.mysql_driver }}
         run: |

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Run IT
         id: test
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           set -x
           mvn -B -ff install -pl '!web-console' -Pdist,bundle-contrib-exts -Pskip-static-checks,skip-tests -Dmaven.javadoc.skip=true -T1C

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -170,6 +170,7 @@ jobs:
 
       - name: Run IT
         id: test
+        timeout-minutes: 60
         run: |
           set -x
           mvn -B -ff install -pl '!web-console' -Pdist,bundle-contrib-exts -Pskip-static-checks,skip-tests -Dmaven.javadoc.skip=true -T1C

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: 'Execute: ${{ inputs.script }}'
         run: ${{ inputs.script }}
+        timeout-minutes: 60
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Description

This PR adds a timeout of 60 minutes for unit tests and revised ITs, and a timeout of 90 minutes for standard ITs.

This is an improvement which helps us detect if something has started taking longer than it should've. It also helps us avoid a job taking 6 hours to timeout like https://github.com/apache/druid/actions/runs/16216131292/job/45785886888.

A sample run with these changes can be seen here: https://github.com/Akshat-Jain/druid/actions/runs/16222470976/job/45806198764?pr=10. It can be seen that `QTest-2/4` job was timed out after 60 minutes, which otherwise would've timed out after 6 hours.

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
