### PR TITLE
Use openjdk:17-slim as base image for ITs

### DIFF
--- a/integration-tests-ex/image/docker/Dockerfile
+++ b/integration-tests-ex/image/docker/Dockerfile
@@ -28,7 +28,7 @@
 # This Dockerfile prefers to use the COPY command over ADD.
 # See: https://phoenixnap.com/kb/docker-add-vs-copy
 
-ARG JDK_VERSION=17-slim-bookworm
+ARG JDK_VERSION=17-slim
 
 # The FROM image provides Java on top of Debian, and
 # thus provides bash, apt-get, etc.

--- a/integration-tests-ex/image/docker/Dockerfile
+++ b/integration-tests-ex/image/docker/Dockerfile
@@ -28,7 +28,7 @@
 # This Dockerfile prefers to use the COPY command over ADD.
 # See: https://phoenixnap.com/kb/docker-add-vs-copy
 
-ARG JDK_VERSION=17-slim-buster
+ARG JDK_VERSION=17-slim-bookworm
 
 # The FROM image provides Java on top of Debian, and
 # thus provides bash, apt-get, etc.

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -41,9 +41,9 @@ RUN echo "[mysqld]\ncharacter-set-server=utf8\ncollation-server=utf8_bin\n" >> /
 
 # Setup metadata store
 # touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.
-RUN find /var/lib/mysql -type f -exec touch {} \; && /etc/init.d/mysql start \
+RUN find /var/lib/mysql -type f -exec touch {} \; && /etc/init.d/mariadb start \
       && echo "CREATE USER 'druid'@'%' IDENTIFIED BY 'diurd'; GRANT ALL ON druid.* TO 'druid'@'%'; CREATE database druid DEFAULT CHARACTER SET utf8mb4;" | mysql -u root \
-      && /etc/init.d/mysql stop
+      && /etc/init.d/mariadb stop
 
 # Add Druid scripts and jars
 ADD bin/* /usr/local/druid/bin/
@@ -69,7 +69,7 @@ RUN wget -q "https://packages.confluent.io/maven/io/confluent/kafka-protobuf-pro
 # touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.
 RUN find /var/lib/mysql -type f -exec touch {} \; && service mysql start \
       && /usr/local/druid/bin/run-java -cp "/usr/local/druid/lib/*" -Ddruid.extensions.directory=/usr/local/druid/extensions -Ddruid.extensions.loadList='["mysql-metadata-storage"]' -Ddruid.metadata.storage.type=mysql -Ddruid.metadata.mysql.driver.driverClassName=$MYSQL_DRIVER_CLASSNAME org.apache.druid.cli.Main tools metadata-init --connectURI="jdbc:mysql://localhost:3306/druid" --user=druid --password=diurd \
-      && /etc/init.d/mysql stop
+      && /etc/init.d/mariadb stop
 ADD test-data /test-data
 
 # Setup supervisord

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG JDK_VERSION=17-slim-buster
+ARG JDK_VERSION=17-slim-bookworm
 FROM openjdk:$JDK_VERSION as druidbase
 
 # Bundle everything into one script so cleanup can reduce image size.

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG JDK_VERSION=17-slim-bookworm
+ARG JDK_VERSION=17-slim
 FROM openjdk:$JDK_VERSION as druidbase
 
 # Bundle everything into one script so cleanup can reduce image size.

--- a/integration-tests/docker/druid.sh
+++ b/integration-tests/docker/druid.sh
@@ -89,7 +89,7 @@ setupData()
     # touch is needed because OverlayFS's copy-up operation breaks POSIX standards. See https://github.com/docker/for-linux/issues/72.
     find /var/lib/mysql -type f -exec touch {} \; && service mysql start \
       && cat /test-data/${DRUID_INTEGRATION_TEST_GROUP}-sample-data.sql | mysql -u root druid \
-      && /etc/init.d/mysql stop
+      && /etc/init.d/mariadb stop
   fi
 
   if [ "$MYSQL_DRIVER_CLASSNAME" != "com.mysql.jdbc.Driver" ] ; then
@@ -102,6 +102,6 @@ setupData()
     find /var/lib/mysql -type f -exec touch {} \; && service mysql start \
         && echo "GRANT ALL ON sqlinputsource.* TO 'druid'@'%'; CREATE database sqlinputsource DEFAULT CHARACTER SET utf8mb4;" | mysql -u root druid \
         && cat /test-data/sql-input-source-sample-data.sql | mysql -u root druid \
-        && /etc/init.d/mysql stop
+        && /etc/init.d/mariadb stop
   fi
 }

--- a/integration-tests/script/docker_build_containers.sh
+++ b/integration-tests/script/docker_build_containers.sh
@@ -29,7 +29,7 @@ else
   11 | 17 | 21)
     echo "Build druid-cluster with Java $DRUID_INTEGRATION_TEST_JVM_RUNTIME"
     docker build -t druid/cluster \
-      --build-arg JDK_VERSION=$DRUID_INTEGRATION_TEST_JVM_RUNTIME-slim-buster \
+      --build-arg JDK_VERSION=$DRUID_INTEGRATION_TEST_JVM_RUNTIME-slim \
       --build-arg ZK_VERSION \
       --build-arg KAFKA_VERSION \
       --build-arg CONFLUENT_VERSION \


### PR DESCRIPTION
Debian Buster has reached EOL causing ITs to fail.
Trying out a newer stable image here.