### PR TITLE
Disabling parallel builds.

### DIFF
--- a/it.sh
+++ b/it.sh
@@ -229,7 +229,7 @@ case $CMD in
     usage
     ;;
   "ci" )
-    mvn -q clean install -P dist $MAVEN_IGNORE -T1C
+    mvn -q clean install -P dist $MAVEN_IGNORE
     ;;
   "build" )
     mvn -B clean install -P dist $MAVEN_IGNORE -T1.0C $*


### PR DESCRIPTION
Disabling parallel builds so that we donot run into : https://github.com/apache/druid/actions/runs/16289799387/job/45996888923

My hunch is that the parallel build is causing some locks to trip. 
