### PR TITLE
Enable Dart ResultIterator to consider queryTimeout and enhance CI with stack traces

### DIFF
--- a/.github/scripts/collect_jstacks
+++ b/.github/scripts/collect_jstacks
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#--------------------------------------------------------------------
+
+echo "@ capturing threaddumps every minute for all java processes" >&2
+
+while :;do
+	sleep 60
+	t=`date +%s`
+	echo "@ capturing threaddumps $t" >&2
+	pgrep java | while read pid;do
+		jstack $pid > target/jstack.$pid.$t
+	done
+done

--- a/.github/scripts/run_unit-tests
+++ b/.github/scripts/run_unit-tests
@@ -22,4 +22,4 @@ OPTS+="-pl !integration-tests,!:druid-it-tools,!:druid-it-image,!:druid-it-cases
 OPTS+=" -Dsurefire.failIfNoSpecifiedTests=false -P skip-static-checks -Dweb.console.skip=true"
 OPTS+=" -Djacoco.destFile=target/jacoco-${HASH}.exec"
 
-mvn -B $OPTS test "$@"
+mvn -B $OPTS test "-DjfrProfilerArgLine=$JFR_PROFILER_ARG_LINE" "$@"

--- a/.github/scripts/setup_test_profiling_env.sh
+++ b/.github/scripts/setup_test_profiling_env.sh
@@ -21,8 +21,9 @@ JAR_INPUT_FILE="jfr-profiler-1.0.0.jar"
 JAR_OUTPUT_FILE="jfr-profiler.jar"
 ENV_VAR="JFR_PROFILER_ARG_LINE"
 
-if [ "$#" -ne 5 ]; then
-    echo "usage: $0 <jdk_version> <run_id> <run_number> <run_attempt> <module>"
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <jdk_version> [<tag>=<value> ...]"
+    exit 1
 fi
 
 if [[ "$1" -ge "17" ]];
@@ -35,18 +36,16 @@ then
   # Extract the version number using grep and awk
   jvm_version=$(echo "$output" | grep "version" | awk -F '"' '{print $2}')
 
+  shift
+  tags="${@/#/-Djfr.profiler.tags.}"
 
   echo $ENV_VAR=-javaagent:"$PWD"/$JAR_OUTPUT_FILE \
   -Djfr.profiler.http.username=druid-ci \
   -Djfr.profiler.http.password=w3Fb6PW8LIo849mViEkbgA== \
   -Djfr.profiler.tags.project=druid \
-  -Djfr.profiler.tags.run_id=$2 \
-  -Djfr.profiler.tags.run_number=$3 \
-  -Djfr.profiler.tags.run_attempt=$4 \
-  -Djfr.profiler.tags.module=$5 \
-  -Djfr.profiler.tags.jvm_version=$jvm_version
+  -Djfr.profiler.tags.jvm_version=$jvm_version \
+  "${tags[@]}"
 else
   echo $ENV_VAR=\"\"
 fi
-
 

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -78,6 +78,7 @@ jobs:
           set -x
           ./.github/scripts/setup_test_profiling_env.sh ${{ inputs.jdk }} run_id=$GITHUB_RUN_ID run_number=$GITHUB_RUN_NUMBER run_attempt=$GITHUB_RUN_ATTEMPT key=${{ inputs.key }} event_ref=$GITHUB_EVENT_REF run_url=$GITHUB_RUN_URL >> $GITHUB_ENV
           echo "HASH=$(echo -n "${{ inputs.key }}" | sha256sum | cut -c-8)" >> $GITHUB_ENV
+          ./.github/scripts/collect_jstacks &
 
       - name: 'Execute: ${{ inputs.script }}'
         run: ${{ inputs.script }}
@@ -95,3 +96,4 @@ jobs:
             **/core.[0-9]*
             **/TEST-*.xml
             **/target/jacoco*.exec
+            **/target/jstack*

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -47,6 +47,8 @@ env:
   GITHUB_RUN_NUMBER: ${{ github.run_number }}
   GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
   GITHUB_EVENT_REF: ${{ github.event_name }}-${{ github.event.number || github.ref_name }}
+  GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
 
 jobs:
   execute:
@@ -74,7 +76,7 @@ jobs:
       - name: Prepare GITHUB_ENV
         run: |
           set -x
-          ./.github/scripts/setup_test_profiling_env.sh ${{ inputs.jdk }} run_id=$GITHUB_RUN_ID run_number=$GITHUB_RUN_NUMBER run_attempt=$GITHUB_RUN_ATTEMPT module=${{ inputs.key }} event_ref=$GITHUB_EVENT_REF >> $GITHUB_ENV
+          ./.github/scripts/setup_test_profiling_env.sh ${{ inputs.jdk }} run_id=$GITHUB_RUN_ID run_number=$GITHUB_RUN_NUMBER run_attempt=$GITHUB_RUN_ATTEMPT key=${{ inputs.key }} event_ref=$GITHUB_EVENT_REF run_url=$GITHUB_RUN_URL >> $GITHUB_ENV
           echo "HASH=$(echo -n "${{ inputs.key }}" | sha256sum | cut -c-8)" >> $GITHUB_ENV
 
       - name: 'Execute: ${{ inputs.script }}'

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -41,6 +41,12 @@ on:
 
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+  INPUTS_JDK: ${{ inputs.jdk }}
+  INPUTS_KEY: ${{ inputs.key }}
+  GITHUB_RUN_ID: ${{ github.run_id }}
+  GITHUB_RUN_NUMBER: ${{ github.run_number }}
+  GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+  GITHUB_EVENT_REF: ${{ github.event_name }}-${{ github.event.number || github.ref_name }}
 
 jobs:
   execute:
@@ -65,8 +71,11 @@ jobs:
           pattern: ${{ inputs.artifacts_to_download }}
           merge-multiple: true
 
-      - name: Calculate hash for artifact name
-        run: echo "HASH=$(echo -n "${{ inputs.key }}" | sha256sum | cut -c-8)" >> $GITHUB_ENV
+      - name: Prepare GITHUB_ENV
+        run: |
+          set -x
+          ./.github/scripts/setup_test_profiling_env.sh ${{ inputs.jdk }} run_id=$GITHUB_RUN_ID run_number=$GITHUB_RUN_NUMBER run_attempt=$GITHUB_RUN_ATTEMPT module=${{ inputs.key }} event_ref=$GITHUB_EVENT_REF >> $GITHUB_ENV
+          echo "HASH=$(echo -n "${{ inputs.key }}" | sha256sum | cut -c-8)" >> $GITHUB_ENV
 
       - name: 'Execute: ${{ inputs.script }}'
         run: ${{ inputs.script }}

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartQueryMaker.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartQueryMaker.java
@@ -22,6 +22,7 @@ package org.apache.druid.msq.dart.controller.sql;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterators;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.io.LimitedOutputStream;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Either;
@@ -67,6 +68,7 @@ import org.apache.druid.sql.calcite.run.SqlResults;
 
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -79,6 +81,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -362,12 +365,13 @@ public class DartQueryMaker implements QueryMaker
   class ResultIteratorMaker implements BaseSequence.IteratorMaker<Object[], ResultIterator>
   {
     private final ControllerHolder controllerHolder;
-    private final ResultIterator resultIterator = new ResultIterator();
+    private final ResultIterator resultIterator;
     private boolean made;
 
     public ResultIteratorMaker(ControllerHolder holder)
     {
       this.controllerHolder = holder;
+      this.resultIterator = new ResultIterator(controllerHolder.getController().getQueryContext().getTimeoutDuration());
       submitController();
     }
 
@@ -464,6 +468,14 @@ public class DartQueryMaker implements QueryMaker
 
     private volatile boolean complete;
 
+    @Nullable
+    private final Duration timeout;
+
+    public ResultIterator(@Nullable Duration timeout)
+    {
+      this.timeout = timeout;
+    }
+
     @Override
     public boolean hasNext()
     {
@@ -482,7 +494,14 @@ public class DartQueryMaker implements QueryMaker
     {
       if (current == null) {
         try {
-          current = rowBuffer.take();
+          if (timeout != null) {
+            current = rowBuffer.poll(timeout.toMillis(), TimeUnit.MILLISECONDS);
+            if (current == null) {
+              throw DruidException.defensive("Result reader timed out [%s]", timeout);
+            }
+          } else {
+            current = rowBuffer.take();
+          }
         }
         catch (InterruptedException e) {
           Thread.currentThread().interrupt();

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/Controller.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/Controller.java
@@ -28,6 +28,7 @@ import org.apache.druid.msq.indexing.error.CancellationReason;
 import org.apache.druid.msq.indexing.error.MSQErrorReport;
 import org.apache.druid.msq.kernel.StageId;
 import org.apache.druid.msq.statistics.PartialKeyStatisticsInformation;
+import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.sql.calcite.run.SqlEngine;
 
@@ -135,4 +136,6 @@ public interface Controller
   TaskReport.ReportMap liveReports();
 
   ControllerContext getControllerContext();
+
+  QueryContext getQueryContext();
 }

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -2942,4 +2942,10 @@ public class ControllerImpl implements Controller
   {
     return context;
   }
+
+  @Override
+  public QueryContext getQueryContext()
+  {
+    return querySpec.getContext();
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryContext.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryContext.java
@@ -34,6 +34,7 @@ import org.apache.druid.query.filter.TypedInFilter;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -503,6 +504,15 @@ public class QueryContext
             timeout
         )
     );
+  }
+
+  @Nullable
+  public Duration getTimeoutDuration()
+  {
+    if (hasTimeout()) {
+      return Duration.ofMillis(getTimeout());
+    }
+    return null;
   }
 
   public long getDefaultTimeout()


### PR DESCRIPTION
* adds back jfr related things which were disabled earlier 
* add a few additional tags for jfr
* starts a background thread in every job which is run by `worker.yml` and collect stacktraces every minute for all java processes
   * I guess this will increase with around a ~`100k` the artifact data for every job
   * this will probably help analyze post-morten the standing-still `ResultIterator` I have seen 
* configures Dart's ResultIterator to timeout reads after querytimeout
   * this could help mitigate the stuck threads being hanging around after the failure I'm still trying to reproduce