### PR TITLE
SQL: Apply DefaultQueryConfig as early as possible.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlStatementResource.java
@@ -68,6 +68,7 @@ import org.apache.druid.msq.sql.entity.ResultSetInformation;
 import org.apache.druid.msq.sql.entity.SqlStatementResult;
 import org.apache.druid.msq.util.MultiStageQueryContext;
 import org.apache.druid.msq.util.SqlStatementResourceHelper;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.ExecutionMode;
 import org.apache.druid.query.QueryContext;
 import org.apache.druid.query.QueryContexts;
@@ -133,7 +134,7 @@ public class SqlStatementResource
   private final OverlordClient overlordClient;
   private final StorageConnector storageConnector;
   private final AuthorizerMapper authorizerMapper;
-
+  private final DefaultQueryConfig defaultQueryConfig;
 
   @Inject
   public SqlStatementResource(
@@ -141,7 +142,8 @@ public class SqlStatementResource
       final ObjectMapper jsonMapper,
       final OverlordClient overlordClient,
       final @MultiStageQuery StorageConnectorProvider storageConnectorProvider,
-      final AuthorizerMapper authorizerMapper
+      final AuthorizerMapper authorizerMapper,
+      final DefaultQueryConfig defaultQueryConfig
   )
   {
     this.msqSqlStatementFactory = msqSqlStatementFactory;
@@ -149,6 +151,7 @@ public class SqlStatementResource
     this.overlordClient = overlordClient;
     this.storageConnector = storageConnectorProvider.createStorageConnector(null);
     this.authorizerMapper = authorizerMapper;
+    this.defaultQueryConfig = defaultQueryConfig;
   }
 
   /**
@@ -186,9 +189,9 @@ public class SqlStatementResource
 
     try {
       sqlQuery = createModifiedSqlQuery(sqlQuery);
-      sqlQueryPlus = SqlResource.makeSqlQueryPlus(sqlQuery, req);
+      sqlQueryPlus = SqlResource.makeSqlQueryPlus(sqlQuery, req, defaultQueryConfig);
       queryContext = QueryContext.of(sqlQueryPlus.context());
-      stmt = msqSqlStatementFactory.httpStatement(SqlResource.makeSqlQueryPlus(sqlQuery, req), req);
+      stmt = msqSqlStatementFactory.httpStatement(sqlQueryPlus, req);
     }
     catch (Exception e) {
       return SqlResource.handleExceptionBeforeStatementCreated(e, sqlQuery.queryContext());

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlTaskResource.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/sql/resources/SqlTaskResource.java
@@ -33,13 +33,12 @@ import org.apache.druid.java.util.common.guava.Yielders;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.msq.guice.MultiStageQuery;
 import org.apache.druid.msq.sql.MSQTaskSqlEngine;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.QueryException;
 import org.apache.druid.query.http.SqlTaskStatus;
 import org.apache.druid.server.QueryResponse;
-import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.security.Access;
 import org.apache.druid.server.security.AuthorizationUtils;
-import org.apache.druid.server.security.AuthorizerMapper;
 import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.sql.DirectStatement;
 import org.apache.druid.sql.HttpStatement;
@@ -81,21 +80,18 @@ public class SqlTaskResource
   private static final Logger log = new Logger(SqlTaskResource.class);
 
   private final SqlStatementFactory sqlStatementFactory;
-  private final ServerConfig serverConfig;
-  private final AuthorizerMapper authorizerMapper;
+  private final DefaultQueryConfig defaultQueryConfig;
   private final ObjectMapper jsonMapper;
 
   @Inject
   public SqlTaskResource(
       final @MultiStageQuery SqlStatementFactory sqlStatementFactory,
-      final ServerConfig serverConfig,
-      final AuthorizerMapper authorizerMapper,
+      final DefaultQueryConfig defaultQueryConfig,
       final ObjectMapper jsonMapper
   )
   {
     this.sqlStatementFactory = sqlStatementFactory;
-    this.serverConfig = serverConfig;
-    this.authorizerMapper = authorizerMapper;
+    this.defaultQueryConfig = defaultQueryConfig;
     this.jsonMapper = jsonMapper;
   }
 
@@ -131,7 +127,7 @@ public class SqlTaskResource
     final SqlQueryPlus sqlQueryPlus;
     final HttpStatement stmt;
     try {
-      sqlQueryPlus = SqlResource.makeSqlQueryPlus(sqlQuery, req);
+      sqlQueryPlus = SqlResource.makeSqlQueryPlus(sqlQuery, req, defaultQueryConfig);
       stmt = sqlStatementFactory.httpStatement(sqlQueryPlus, req);
     }
     catch (Exception e) {

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -215,7 +215,6 @@ public class DartSqlResourceTest extends MSQTestBase
         NoopServiceEmitter.instance(),
         NoopRequestLogger.instance(),
         QueryStackTests.DEFAULT_NOOP_SCHEDULER,
-        new DefaultQueryConfig(ImmutableMap.of()),
         lifecycleManager
     );
 
@@ -272,6 +271,7 @@ public class DartSqlResourceTest extends MSQTestBase
         lifecycleManager,
         new SqlEngineRegistry(Set.of(engine)),
         ResponseContextConfig.newConfig(false),
+        DefaultQueryConfig.NIL,
         SELF_NODE
     );
 

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlMSQStatementResourcePostTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.msq.sql.entity.SqlStatementResult;
 import org.apache.druid.msq.test.MSQTestBase;
 import org.apache.druid.msq.test.MSQTestOverlordServiceClient;
 import org.apache.druid.msq.util.MultiStageQueryContext;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.ExecutionMode;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.segment.column.ValueType;
@@ -75,7 +76,8 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         objectMapper,
         indexingServiceClient,
         s -> localFileStorageConnector,
-        authorizerMapper
+        authorizerMapper,
+        DefaultQueryConfig.NIL
     );
   }
 
@@ -329,7 +331,8 @@ public class SqlMSQStatementResourcePostTest extends MSQTestBase
         objectMapper,
         indexingServiceClient,
         s -> NilStorageConnector.getInstance(),
-        authorizerMapper
+        authorizerMapper,
+        DefaultQueryConfig.NIL
     );
 
     String errorMessage = "The sql statement api cannot read from the select destination [durableStorage] provided in "

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/sql/resources/SqlStatementResourceTest.java
@@ -62,6 +62,7 @@ import org.apache.druid.msq.sql.entity.PageInformation;
 import org.apache.druid.msq.sql.entity.ResultSetInformation;
 import org.apache.druid.msq.sql.entity.SqlStatementResult;
 import org.apache.druid.msq.test.MSQTestBase;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.scan.ScanQuery;
@@ -711,7 +712,8 @@ public class SqlStatementResourceTest extends MSQTestBase
         objectMapper,
         overlordClient,
         tempDir -> localFileStorageConnector,
-        authorizerMapper
+        authorizerMapper,
+        DefaultQueryConfig.NIL
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/query/DefaultQueryConfig.java
+++ b/processing/src/main/java/org/apache/druid/query/DefaultQueryConfig.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.Nonnull;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -38,6 +39,11 @@ import java.util.Map;
  */
 public class DefaultQueryConfig
 {
+  /**
+   * Config that does nothing.
+   */
+  public static final DefaultQueryConfig NIL = new DefaultQueryConfig(Collections.emptyMap());
+
   /**
    * Note that context values should not be directly retrieved from this field but instead should
    * be read through {@link QueryContexts}. This field contains context configs from runtime property

--- a/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/AbstractStatement.java
@@ -91,9 +91,6 @@ public abstract class AbstractStatement implements Closeable
       log.warn("'bySegment' results are not supported for SQL queries, ignoring query context parameter");
     }
     this.queryContext.putIfAbsent(QueryContexts.CTX_SQL_QUERY_ID, UUID.randomUUID().toString());
-    for (Map.Entry<String, Object> entry : sqlToolbox.defaultQueryConfig.getContext().entrySet()) {
-      this.queryContext.putIfAbsent(entry.getKey(), entry.getValue());
-    }
   }
 
   public String sqlQueryId()

--- a/sql/src/main/java/org/apache/druid/sql/SqlToolbox.java
+++ b/sql/src/main/java/org/apache/druid/sql/SqlToolbox.java
@@ -21,7 +21,6 @@ package org.apache.druid.sql;
 
 import com.google.common.base.Preconditions;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
-import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.server.QueryScheduler;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.sql.calcite.planner.PlannerFactory;
@@ -37,7 +36,6 @@ public class SqlToolbox
   final ServiceEmitter emitter;
   final RequestLogger requestLogger;
   final QueryScheduler queryScheduler;
-  final DefaultQueryConfig defaultQueryConfig;
   final SqlLifecycleManager sqlLifecycleManager;
 
   public SqlToolbox(
@@ -46,7 +44,6 @@ public class SqlToolbox
       final ServiceEmitter emitter,
       final RequestLogger requestLogger,
       final QueryScheduler queryScheduler,
-      final DefaultQueryConfig defaultQueryConfig,
       final SqlLifecycleManager sqlLifecycleManager
   )
   {
@@ -55,7 +52,6 @@ public class SqlToolbox
     this.emitter = emitter;
     this.requestLogger = requestLogger;
     this.queryScheduler = queryScheduler;
-    this.defaultQueryConfig = defaultQueryConfig;
     this.sqlLifecycleManager = Preconditions.checkNotNull(sqlLifecycleManager, "sqlLifecycleManager");
   }
 
@@ -67,7 +63,6 @@ public class SqlToolbox
         emitter,
         requestLogger,
         queryScheduler,
-        defaultQueryConfig,
         sqlLifecycleManager
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/guice/SqlModule.java
+++ b/sql/src/main/java/org/apache/druid/sql/guice/SqlModule.java
@@ -20,7 +20,6 @@
 package org.apache.druid.sql.guice;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
 import com.google.inject.Binder;
 import com.google.inject.Inject;
 import com.google.inject.Key;
@@ -32,7 +31,6 @@ import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.PolyBind;
 import org.apache.druid.guice.annotations.NativeQuery;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
-import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.server.QueryScheduler;
 import org.apache.druid.server.log.RequestLogger;
 import org.apache.druid.sql.SqlLifecycleManager;
@@ -172,7 +170,6 @@ public class SqlModule implements Module
         final ServiceEmitter emitter,
         final RequestLogger requestLogger,
         final QueryScheduler queryScheduler,
-        final Supplier<DefaultQueryConfig> defaultQueryConfig,
         final SqlLifecycleManager sqlLifecycleManager
     )
     {
@@ -182,7 +179,6 @@ public class SqlModule implements Module
           emitter,
           requestLogger,
           queryScheduler,
-          defaultQueryConfig.get(),
           sqlLifecycleManager
       );
     }

--- a/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
@@ -486,7 +486,7 @@ public class SqlStatementTest
   }
 
   @Test
-  public void testPreparePolicyEnforcerThrowsForNoPolicy() throws Exception
+  public void testPreparePolicyEnforcerThrowsForNoPolicy()
   {
     policyEnforcer = new RestrictAllTablesPolicyEnforcer(null);
     sqlStatementFactory = buildSqlStatementFactory();
@@ -531,26 +531,8 @@ public class SqlStatementTest
         .build();
     DirectStatement stmt = sqlStatementFactory.directStatement(sqlReq);
     Map<String, Object> context = stmt.context();
-    Assert.assertEquals(2, context.size());
     // should contain only query id, not bySegment since it is not valid for SQL
-    Assert.assertTrue(context.containsKey(QueryContexts.CTX_SQL_QUERY_ID));
-  }
-
-  @Test
-  public void testDefaultQueryContextIsApplied()
-  {
-    SqlQueryPlus sqlReq = SqlQueryPlus
-        .builder("select 1 + ?")
-        .context(ImmutableMap.of(QueryContexts.BY_SEGMENT_KEY, "true"))
-        .auth(CalciteTests.REGULAR_USER_AUTH_RESULT)
-        .build();
-    DirectStatement stmt = sqlStatementFactory.directStatement(sqlReq);
-    Map<String, Object> context = stmt.context();
-    Assert.assertEquals(2, context.size());
-    // Statement should contain default query context values
-    for (String defaultContextKey : defaultQueryConfig.getContext().keySet()) {
-      Assert.assertTrue(context.containsKey(defaultContextKey));
-    }
+    Assert.assertEquals(Collections.singleton(QueryContexts.CTX_SQL_QUERY_ID), context.keySet());
   }
 
   private SqlStatementFactory buildSqlStatementFactory()

--- a/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/SqlStatementTest.java
@@ -591,7 +591,6 @@ public class SqlStatementTest
             new NoopServiceEmitter(),
             testRequestLogger,
             QueryStackTests.DEFAULT_NOOP_SCHEDULER,
-            defaultQueryConfig,
             new SqlLifecycleManager()
         )
     );

--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/QueryFrameworkUtils.java
@@ -139,7 +139,6 @@ public class QueryFrameworkUtils
         NoopServiceEmitter.instance(),
         NoopRequestLogger.instance(),
         QueryStackTests.DEFAULT_NOOP_SCHEDULER,
-        new DefaultQueryConfig(ImmutableMap.of()),
         new SqlLifecycleManager()
     );
   }

--- a/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/guice/SqlModuleTest.java
@@ -221,6 +221,7 @@ public class SqlModuleTest
               binder.bind(CoordinatorClient.class).to(NoopCoordinatorClient.class);
               binder.bind(CentralizedDatasourceSchemaConfig.class)
                     .toInstance(CentralizedDatasourceSchemaConfig.enabled(false));
+              binder.bind(DefaultQueryConfig.class).toInstance(DefaultQueryConfig.NIL);
             },
             sqlModule,
             new TestViewManagerModule()

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlHttpModuleTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlHttpModuleTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.guice.annotations.JSR311Resource;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.NativeQuery;
 import org.apache.druid.guice.annotations.Self;
+import org.apache.druid.query.DefaultQueryConfig;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.ResponseContextConfig;
 import org.apache.druid.server.security.AuthorizerMapper;
@@ -72,6 +73,7 @@ public class SqlHttpModuleTest
           binder.bind(SqlStatementFactory.class)
                 .annotatedWith(NativeQuery.class)
                 .toInstance(EasyMock.mock(SqlStatementFactory.class));
+          binder.bind(DefaultQueryConfig.class).toInstance(DefaultQueryConfig.NIL);
         },
         target
     );

--- a/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/http/SqlResourceTest.java
@@ -285,7 +285,6 @@ public class SqlResourceTest extends CalciteTestBase
         stubServiceEmitter,
         testRequestLogger,
         scheduler,
-        defaultQueryConfig,
         lifecycleManager
     );
     sqlStatementFactory = new SqlStatementFactory(null)
@@ -331,6 +330,7 @@ public class SqlResourceTest extends CalciteTestBase
         lifecycleManager,
         new SqlEngineRegistry(Set.of(engine)),
         TEST_RESPONSE_CONTEXT_CONFIG,
+        DefaultQueryConfig.NIL,
         DUMMY_DRUID_NODE
     );
   }
@@ -1668,6 +1668,7 @@ public class SqlResourceTest extends CalciteTestBase
         lifecycleManager,
         new SqlEngineRegistry(Set.of(engine)),
         TEST_RESPONSE_CONTEXT_CONFIG,
+        DefaultQueryConfig.NIL,
         DUMMY_DRUID_NODE
     );
 


### PR DESCRIPTION
This patch allows the default query context parameters to work properly with any context field. In particular, it allows `druid.query.default.context.engine` to work properly. Previously, this was ignored.