### PR TITLE
Fix supervisor to tasks view naviagation in the console

### DIFF
--- a/web-console/src/console-application.tsx
+++ b/web-console/src/console-application.tsx
@@ -408,7 +408,7 @@ export class ConsoleApplication extends React.PureComponent<
         goToDatasource={this.goToDatasources}
         goToQuery={this.goToQuery}
         goToStreamingDataLoader={this.goToStreamingDataLoader}
-        goToTasks={this.goToTasksWithDatasource}
+        goToTasks={this.goToTasksWithTaskGroupId}
         capabilities={capabilities}
       />,
     );

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -782,7 +782,10 @@ export class SupervisorsView extends React.PureComponent<
     switch (supervisor.type) {
       case 'kafka':
       case 'kinesis':
-        goToTasks(`index_${supervisor.type}_${supervisor.supervisor_id}`, `index_${supervisor.type}`);
+        goToTasks(
+          `index_${supervisor.type}_${supervisor.supervisor_id}`,
+          `index_${supervisor.type}`,
+        );
         return;
 
       case 'autocompact':

--- a/web-console/src/views/supervisors-view/supervisors-view.tsx
+++ b/web-console/src/views/supervisors-view/supervisors-view.tsx
@@ -782,7 +782,7 @@ export class SupervisorsView extends React.PureComponent<
     switch (supervisor.type) {
       case 'kafka':
       case 'kinesis':
-        goToTasks(supervisor.supervisor_id, `index_${supervisor.type}`);
+        goToTasks(`index_${supervisor.type}_${supervisor.supervisor_id}`, `index_${supervisor.type}`);
         return;
 
       case 'autocompact':


### PR DESCRIPTION
With [apache/druid#18082](https://github.com/apache/druid/pull/18082), the supervisor ID is no longer the same as the datasource name, which breaks the navigation from the supervisors page to the corresponding tasks view.

<img width="3140" height="570" alt="CleanShot 2025-07-21 at 08 48 38@2x" src="https://github.com/user-attachments/assets/dbd38035-1062-4dc5-bae1-f833cafa36c9" />
asks view breaks because currently.

Fix:

Use the `groupId` filter instead of datasource name when navigating from the supervisors to tasks view. This filter is used by other task types too. I think another alternative and cleaner approach would be to add the supervisor ID to the `sys.tasks` table and filter by it explicitly, but that would be a larger server-side change.

<img width="3290" height="606" alt="CleanShot 2025-07-21 at 08 49 18@2x" src="https://github.com/user-attachments/assets/4d21252f-2374-4172-abc5-8701789f16d1" />


This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
