### PR TITLE
[Backport] Fix race in SegmentLoadDropHandler. (#18291) 

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordination/SegmentDropLatch.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/SegmentDropLatch.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordination;
+
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+
+/**
+ * Latch held by {@link SegmentLoadDropHandler#segmentDropLatches} when a drop is scheduled or actively happening.
+ */
+public class SegmentDropLatch
+{
+  enum State
+  {
+    PENDING,
+    DROPPING,
+    DONE
+  }
+
+  private final Object lock = new Object();
+
+  @GuardedBy("lock")
+  private State state = State.PENDING;
+
+  /**
+   * Sets this latch to {@link State#DROPPING} state, if it was in {@link State#PENDING}.
+   *
+   * @return whether the original state was {@link State#PENDING}
+   */
+  public boolean startDropping()
+  {
+    synchronized (lock) {
+      if (state == State.PENDING) {
+        state = State.DROPPING;
+        lock.notifyAll();
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+
+  /**
+   * Sets this latch to {@link State#DONE} state, if it was in {@link State#DROPPING}. Otherwise does nothing.
+   */
+  public void doneDropping()
+  {
+    synchronized (lock) {
+      if (state == State.DROPPING) {
+        state = State.DONE;
+        lock.notifyAll();
+      }
+    }
+  }
+
+  /**
+   * Cancels this latch if the drop has not yet begun to execute. Otherwise, waits for the drop to finish.
+   * Once this method returns, the drop is definitely no longer scheduled (it has either been canceled, or has
+   * already happened).
+   */
+  public void cancelOrAwait() throws InterruptedException
+  {
+    synchronized (lock) {
+      if (state == State.PENDING) {
+        state = State.DONE;
+      } else {
+        while (state != State.DONE) {
+          lock.wait();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
SegmentLoadDropHandler has a race that causes dropSegmentDelayMillis to not be respected. It happens in this sequence of events:

- removeSegment is called, which adds the segment to segmentsToDelete and schedules a future drop.
- addSegment is called, which removes the segment from segmentsToDelete and proceeds to load it.
- removeSegment is called again, which adds the segment back to segmentsToDelete, before the originally-scheduled drop executes.
- The originally-scheduled drop executes, sees the segment is in segmentsToDelete, and removes it. This could happen immediately after the second call to removeSegment, defeating dropSegmentDelayMillis.

This can occur in practice when the coordinator period is less than the dropSegmentDelayMillis. By default, it's not (default is 1m Coordinator period and 30s dropSegmentDelayMillis).

This patch addresses it by ensuring that delayed drops only happen if the entry in segmentDropLatches corresponds to the removeSegment call that scheduled the drop.

(cherry picked from commit d5bdb7384af3bce609b98f5e0b70d9e041a250df)

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->
