### PR TITLE
Improve offset auto reset

### DIFF
--- a/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskRunner.java
+++ b/extensions-core/kafka-indexing-service/src/main/java/org/apache/druid/indexing/kafka/KafkaIndexTaskRunner.java
@@ -35,24 +35,18 @@ import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecor
 import org.apache.druid.indexing.seekablestream.common.OrderedSequenceNumber;
 import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.emitter.EmittingLogger;
-import org.apache.druid.utils.CollectionUtils;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
-import org.apache.kafka.common.TopicPartition;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Kafka indexing task runner that supports incremental segment publishing.
@@ -93,14 +87,8 @@ public class KafkaIndexTaskRunner extends SeekableStreamIndexTaskRunner<KafkaTop
       return recordSupplier.poll(task.getIOConfig().getPollTimeout());
     }
     catch (OffsetOutOfRangeException e) {
-      //
-      // Handles OffsetOutOfRangeException, which is thrown if the seeked-to
-      // offset is not present in the topic-partition. This can happen if we're asking a task to read from data
-      // that has not been written yet (which is totally legitimate). So let's wait for it to show up
-      //
       log.warn("OffsetOutOfRangeException with message [%s]", e.getMessage());
-      possiblyResetOffsetsOrWait(e.offsetOutOfRangePartitions(), recordSupplier, toolbox);
-      return Collections.emptyList();
+      throw e;
     }
   }
 
@@ -116,64 +104,6 @@ public class KafkaIndexTaskRunner extends SeekableStreamIndexTaskRunner<KafkaTop
         KafkaTopicPartition.class,
         Long.class
     ));
-  }
-
-  private void possiblyResetOffsetsOrWait(
-      Map<TopicPartition, Long> outOfRangePartitions,
-      RecordSupplier<KafkaTopicPartition, Long, KafkaRecordEntity> recordSupplier,
-      TaskToolbox taskToolbox
-  ) throws InterruptedException, IOException
-  {
-    final String stream = task.getIOConfig().getStartSequenceNumbers().getStream();
-    final boolean isMultiTopic = task.getIOConfig().isMultiTopic();
-    final Map<TopicPartition, Long> resetPartitions = new HashMap<>();
-    boolean doReset = false;
-    if (task.getTuningConfig().isResetOffsetAutomatically()) {
-      for (Map.Entry<TopicPartition, Long> outOfRangePartition : outOfRangePartitions.entrySet()) {
-        final TopicPartition topicPartition = outOfRangePartition.getKey();
-        final long nextOffset = outOfRangePartition.getValue();
-        // seek to the beginning to get the least available offset
-        StreamPartition<KafkaTopicPartition> streamPartition = StreamPartition.of(
-            stream,
-            new KafkaTopicPartition(isMultiTopic, topicPartition.topic(), topicPartition.partition())
-        );
-        final Long leastAvailableOffset = recordSupplier.getEarliestSequenceNumber(streamPartition);
-        if (leastAvailableOffset == null) {
-          throw new ISE(
-              "got null sequence number for partition[%s] when fetching from kafka!",
-              topicPartition.partition()
-          );
-        }
-        // reset the seek
-        recordSupplier.seek(streamPartition, nextOffset);
-        // Reset consumer offset if resetOffsetAutomatically is set to true
-        // and the current message offset in the kafka partition is more than the
-        // next message offset that we are trying to fetch
-        if (leastAvailableOffset > nextOffset) {
-          doReset = true;
-          resetPartitions.put(topicPartition, nextOffset);
-        }
-      }
-    }
-
-    if (doReset) {
-      sendResetRequestAndWait(CollectionUtils.mapKeys(resetPartitions, topicPartition -> StreamPartition.of(
-          stream,
-          new KafkaTopicPartition(isMultiTopic, topicPartition.topic(), topicPartition.partition())
-      )), taskToolbox);
-    } else {
-      log.warn("Retrying in %dms", task.getPollRetryMs());
-      pollRetryLock.lockInterruptibly();
-      try {
-        long nanos = TimeUnit.MILLISECONDS.toNanos(task.getPollRetryMs());
-        while (nanos > 0L && !pauseRequested && !stopRequested.get()) {
-          nanos = isAwaitingRetry.awaitNanos(nanos);
-        }
-      }
-      finally {
-        pollRetryLock.unlock();
-      }
-    }
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisor.java
@@ -4031,8 +4031,8 @@ public abstract class SeekableStreamSupervisor<PartitionIdType, SequenceOffsetTy
                     "Previous sequenceNumber [%s] is no longer available for partition [%s] which now has the least sequence number [%s]. You can clear the previous"
                     + " sequenceNumber and start reading from a valid message by using the supervisor's reset API.",
                     sequence.toString(),
-                    earliestSequenceNumber == null ? "null" : earliestSequenceNumber.toString(),
-                    partition
+                    partition,
+                    earliestSequenceNumber == null ? "null" : earliestSequenceNumber.toString()
                 )
             );
           }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -822,6 +822,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     EasyMock.expect(recordSupplier.isOffsetAvailable(EasyMock.anyObject(), EasyMock.anyObject()))
             .andReturn(true)
             .anyTimes();
+    EasyMock.expect(recordSupplier.getEarliestSequenceNumber(EasyMock.anyObject()))
+            .andReturn("0")
+            .anyTimes();
     EasyMock.expect(taskQueue.getActiveTasksForDatasource(DATASOURCE)).andReturn(Map.of()).anyTimes();
     EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).anyTimes();
     replayAll();
@@ -1910,7 +1913,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     EasyMock.expect(indexerMetadataStorageCoordinator.deleteDataSourceMetadata(SUPERVISOR_ID)).andReturn(
         true
     );
-    taskQueue.shutdown("task1", "DataSourceMetadata is not found while reset");
+    taskQueue.shutdown("task1", "Offset of all partitions has been reset %s", "manually");
     EasyMock.expectLastCall();
     replayAll();
 
@@ -1969,7 +1972,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         true
     );
 
-    taskQueue.shutdown("task1", "DataSourceMetadata is updated while reset offsets is called");
+    taskQueue.shutdown("task1", "Offset of partition [%s] has been reset to [%s] by the user", "0", "1000");
     EasyMock.expectLastCall();
 
     replayAll();
@@ -2105,10 +2108,10 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             expectedOffsets
         )
     ))).andReturn(true);
-    taskQueue.shutdown("task1", "DataSourceMetadata is updated while reset offsets is called");
+    taskQueue.shutdown("task1", "Offset of partition [%s] has been reset to [%s] by the user", "0", "10");
     EasyMock.expectLastCall();
 
-    taskQueue.shutdown("task2", "DataSourceMetadata is updated while reset offsets is called");
+    taskQueue.shutdown("task2", "Offset of partition [%s] has been reset to [%s] by the user", "1", "8");
     EasyMock.expectLastCall();
 
     replayAll();
@@ -2176,10 +2179,10 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             expectedOffsets
         )
     ))).andReturn(true);
-    taskQueue.shutdown("task1", "DataSourceMetadata is updated while reset offsets is called");
+    taskQueue.shutdown("task1", "Offset of partition [%s] has been reset to [%s] by the user", "0", "10");
     EasyMock.expectLastCall();
 
-    taskQueue.shutdown("task2", "DataSourceMetadata is updated while reset offsets is called");
+    taskQueue.shutdown("task2", "Offset of partition [%s] has been reset to [%s] by the user", "1", "8");
     EasyMock.expectLastCall();
 
     replayAll();
@@ -2321,7 +2324,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             expectedOffsets
         )
     ))).andReturn(true);
-    taskQueue.shutdown("task1", "DataSourceMetadata is updated while reset offsets is called");
+    taskQueue.shutdown("task1", "Offset of partition [%s] has been reset to [%s] by the user", "2", "20");
     EasyMock.expectLastCall();
 
     replayAll();


### PR DESCRIPTION
Fixes #18282


### Description

Improve the auto reset logic as proposed in the above issue:

1. only supervisor is responsible for auto reset. task never triggers the auto reset flow
2. task always throws `OffsetOutOfRangeException` if this exception is raised, but will publish ingested message under such case
3. supervisor resets offset to earliest position if it detects offset of a particular partition is unavailable
4. supervisor starts task more quickly if it needs to reset offsets
5. update the obscure error message like `DataSourceMetadata is not found while reset` in task report to make it intuitive when supervisor kills a task because of offset reset

### NOTE
this relies on #18226, which publishes segments when OffsetOutOfRangeException is raised.



This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [X] been tested in a test Druid cluster.
