### PR TITLE
Fix flaky EmbeddedMsqRealtimeQueryTest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
@@ -176,6 +176,9 @@ public class EmbeddedMSQRealtimeQueryTest extends BaseRealtimeQueryTest
                       .hasDimension(DruidMetrics.DATASOURCE, Collections.singletonList(dataSource)),
         agg -> agg.hasSumAtLeast(totalRows)
     );
+    broker.latchableEmitter().waitForEvent(
+        event -> event.hasDimension(DruidMetrics.DATASOURCE, dataSource)
+    );
   }
 
   @Test


### PR DESCRIPTION
### Description

`EmbeddedMsqRealtimeQueryTest` is a little flaky.

```java
Error:  Errors: 
Error:    EmbeddedMSQRealtimeQueryTest.test_selectJoinWithConcatVirtualDimension_dart:475 » Runtime org.apache.druid.rpc.HttpResponseException: Server error [400 Bad Request]; body: {"error":"druidException","errorCode":"invalidInput","persona":"USER","category":"INVALID_INPUT","errorMessage":"Object 'wiki_cgpbpkdo' not found (line [6], column [6])","context":{"sourceType":"sql","line":"6","column":"6","endLine":"6","endColumn":"18"}}
```

This can happen due to a race condition where we fire the query before the broker has discovered the datasource.

### Fix

- Latch on the Broker having discovered the datasource

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
