### PR TITLE
Add server dimension to segment assignment skip metrics

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -390,9 +390,9 @@ These metrics are emitted by the Druid Coordinator in every run of the correspon
 |`segment/dropped/count`|Number of segments chosen to be dropped from the cluster due to being over-replicated.|`dataSource`, `tier`|Varies|
 |`segment/deleted/count`|Number of segments marked as unused due to drop rules.|`dataSource`|Varies|
 |`segment/unneeded/count`|Number of segments dropped due to being marked as unused.|`dataSource`, `tier`|Varies|
-|`segment/assignSkipped/count`|Number of segments that could not be assigned to any server for loading. This can occur due to replication throttling, no available disk space, or a full load queue.|`dataSource`, `tier`, `description`|Varies|
-|`segment/moveSkipped/count`|Number of segments that were chosen for balancing but could not be moved. This can occur when segments are already optimally placed.|`dataSource`, `tier`, `description`|Varies|
-|`segment/dropSkipped/count`|Number of segments that could not be dropped from any server.|`dataSource`, `tier`, `description`|Varies|
+|`segment/assignSkipped/count`|Number of segments that could not be assigned to any server for loading. This can occur due to replication throttling, no available disk space, or a full load queue.|`dataSource`, `server`, `tier`, `description`|Varies|
+|`segment/moveSkipped/count`|Number of segments that were chosen for balancing but could not be moved. This can occur when segments are already optimally placed.|`dataSource`, `server`, `tier`, `description`|Varies|
+|`segment/dropSkipped/count`|Number of segments that could not be dropped from any server.|`dataSource`, `server`, `tier`, `description`|Varies|
 |`segment/loadQueue/size`|Size in bytes of segments to load.|`server`|Varies|
 |`segment/loadQueue/count`|Number of segments to load.|`server`|Varies|
 |`segment/loading/rateKbps`|Current rate of segment loading on a server in kbps (1000 bits per second). The rate is calculated as a moving average over the last 10 GiB or more of successful segment loads on that server.|`server`|Varies|

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/StrategicSegmentAssigner.java
@@ -146,7 +146,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
                           .collect(Collectors.toList());
 
     if (eligibleDestinationServers.isEmpty()) {
-      incrementSkipStat(Stats.Segments.MOVE_SKIPPED, "No eligible server", segment, tier);
+      incrementSkipStat(Stats.Segments.MOVE_SKIPPED, "No eligible server", segment, sourceServer);
       return false;
     }
 
@@ -160,13 +160,13 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
         strategy.findDestinationServerToMoveSegment(segment, sourceServer, eligibleDestinationServers);
 
     if (destination == null || destination.getServer().equals(sourceServer.getServer())) {
-      incrementSkipStat(Stats.Segments.MOVE_SKIPPED, "Optimally placed", segment, tier);
+      incrementSkipStat(Stats.Segments.MOVE_SKIPPED, "Optimally placed", segment, sourceServer);
       return false;
     } else if (moveSegment(segment, sourceServer, destination)) {
       incrementStat(Stats.Segments.MOVED, segment, tier, 1);
       return true;
     } else {
-      incrementSkipStat(Stats.Segments.MOVE_SKIPPED, "Encountered error", segment, tier);
+      incrementSkipStat(Stats.Segments.MOVE_SKIPPED, "Encountered error", segment, sourceServer);
       return false;
     }
   }
@@ -393,7 +393,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       skipReason = "Unknown error";
     }
 
-    incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, skipReason, segment, server.getServer().getTier());
+    incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, skipReason, segment, server);
     return false;
   }
 
@@ -489,7 +489,7 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
       if (dropped) {
         ++numDropsQueued;
       } else {
-        incrementSkipStat(Stats.Segments.DROP_SKIPPED, "Encountered error", segment, tier);
+        incrementSkipStat(Stats.Segments.DROP_SKIPPED, "Encountered error", segment, holder);
       }
     }
 
@@ -543,11 +543,10 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
 
   private boolean loadSegment(DataSegment segment, ServerHolder server)
   {
-    final String tier = server.getServer().getTier();
     final boolean assigned = loadQueueManager.loadSegment(segment, server, SegmentAction.LOAD);
 
     if (!assigned) {
-      incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Encountered error", segment, tier);
+      incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Encountered error", segment, server);
     }
 
     return assigned;
@@ -557,13 +556,13 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   {
     final String tier = server.getServer().getTier();
     if (replicationThrottler.isReplicationThrottledForTier(tier)) {
-      incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Throttled replication", segment, tier);
+      incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Throttled replication", segment, server);
       return false;
     }
 
     final boolean assigned = loadQueueManager.loadSegment(segment, server, SegmentAction.REPLICATE);
     if (!assigned) {
-      incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Encountered error", segment, tier);
+      incrementSkipStat(Stats.Segments.ASSIGN_SKIPPED, "Encountered error", segment, server);
     } else {
       replicationThrottler.incrementAssignedReplicas(tier);
     }
@@ -613,6 +612,15 @@ public class StrategicSegmentAssigner implements SegmentActionHandler
   {
     final RowKey key = RowKey.with(Dimension.TIER, tier)
                              .with(Dimension.DATASOURCE, segment.getDataSource())
+                             .and(Dimension.DESCRIPTION, reason);
+    stats.add(stat, key, 1);
+  }
+
+  private void incrementSkipStat(CoordinatorStat stat, String reason, DataSegment segment, ServerHolder server)
+  {
+    final RowKey key = RowKey.with(Dimension.TIER, server.getServer().getTier())
+                             .with(Dimension.DATASOURCE, segment.getDataSource())
+                             .with(Dimension.SERVER, server.getServer().getName())
                              .and(Dimension.DESCRIPTION, reason);
     stats.add(stat, key, 1);
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
@@ -207,11 +207,13 @@ public class BroadcastDistributionRuleTest
     Assert.assertEquals(1L, stats.getSegmentStat(Stats.Segments.ASSIGNED, TIER_1, TestDataSource.WIKI));
     RowKey metricKey = RowKey.with(Dimension.DATASOURCE, TestDataSource.WIKI)
                              .with(Dimension.TIER, TIER_1)
+                             .with(Dimension.SERVER, serverWithNoDiskSpace.getServer().getName())
                              .and(Dimension.DESCRIPTION, "Not enough disk space");
     Assert.assertEquals(1L, stats.get(Stats.Segments.ASSIGN_SKIPPED, metricKey));
 
     metricKey = RowKey.with(Dimension.DATASOURCE, TestDataSource.WIKI)
                       .with(Dimension.TIER, TIER_1)
+                      .with(Dimension.SERVER, serverWithFullQueue.getServer().getName())
                       .and(Dimension.DESCRIPTION, "Load queue is full");
     Assert.assertEquals(1L, stats.get(Stats.Segments.ASSIGN_SKIPPED, metricKey));
   }

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/SegmentBalancingTest.java
@@ -296,7 +296,7 @@ public class SegmentBalancingTest extends CoordinatorSimulationBaseTest
     runCoordinatorCycle();
     verifyValue(Metric.ASSIGNED_COUNT, 10_000L);
     verifyNotEmitted(Metric.MOVED_COUNT);
-    verifyValue(Metric.MOVE_SKIPPED, 100L);
+    verifySum(Metric.MOVE_SKIPPED, 100L);
 
     // Run 2: Add 10 more historicals, some segments are moved to them
     for (int i = 11; i <= 20; ++i) {


### PR DESCRIPTION
### Changes

- Add dimension `server` (when available) to the following metrics
  - `segment/assignSkipped/count`
  - `segment/dropSkipped/count`
  - `segment/moveSkipped/count`


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
