### PR TITLE
Excercise release build during CI execution

### DIFF
--- a/.github/scripts/validate-dist
+++ b/.github/scripts/validate-dist
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -x
+
+mvn -B clean install -Papache-release,dist,rat -DskipTests -Ddependency-check.skip -Dgpg.skip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       artifact_prefix: "unit-test-reports"
       key: "test-jdk17-[${{ matrix.pattern }}]"
 
+  validate-dist:
+    uses: ./.github/workflows/worker.yml
+    with:
+      script: .github/scripts/validate-dist
+      key: "validate-dist"
+
   test-report:
     name: "test-report"
     needs: run-unit-tests


### PR DESCRIPTION
Adds a workflow to excercise the distribution builds - to ensure that issues like #18317 will be caught before a release is about to happen.