### PR TITLE
Use LoadScope to list services where a monitor should be loaded

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1924,16 +1924,11 @@ You can configure Druid services to emit [metrics](../operations/metrics.md) reg
 
 ### Metrics monitors for each service
 
-Metric monitoring is an essential part of Druid operations. Druid includes 
+Metric monitoring is an essential part of Druid operations.
+Monitors can be enabled by configuring the property `druid.monitoring.monitors` in the common configuration file, `common.runtime.properties`.
+If a monitor is not supported on a certain service, it will simply be ignored while starting up that service.
 
-:::caution
-
-The `runtime.properties` file for each service overrides the common configuration file (`common.runtime.properties`). They are not additive. This means that if you add any monitors to a specific service, that service only has the monitors specified in its `runtime.properties` file even if there are additional ones listed in the common file. 
-
-:::
-
-
-The following table lists the monitors that are available and the services you could configure the monitor for:
+The following table lists available monitors and the respective services where they are supported:
 
 |Name|Description|Service|
 |----|-----------|-------|

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedIndexTaskTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedIndexTaskTest.java
@@ -63,6 +63,10 @@ public class EmbeddedIndexTaskTest extends EmbeddedClusterTestBase
   {
     return EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper()
                                .useLatchableEmitter()
+                               .addCommonProperty(
+                                   "druid.monitoring.monitors",
+                                   "[\"org.apache.druid.server.metrics.TaskCountStatsMonitor\"]"
+                               )
                                .addServer(coordinator)
                                .addServer(indexer)
                                .addServer(overlord)

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedIndexTaskTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedIndexTaskTest.java
@@ -63,10 +63,6 @@ public class EmbeddedIndexTaskTest extends EmbeddedClusterTestBase
   {
     return EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper()
                                .useLatchableEmitter()
-                               .addCommonProperty(
-                                   "druid.monitoring.monitors",
-                                   "[\"org.apache.druid.server.metrics.TaskCountStatsMonitor\"]"
-                               )
                                .addServer(coordinator)
                                .addServer(indexer)
                                .addServer(overlord)

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedKafkaClusterMetricsTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/EmbeddedKafkaClusterMetricsTest.java
@@ -119,7 +119,11 @@ public class EmbeddedKafkaClusterMetricsTest extends EmbeddedClusterTestBase
            .addCommonProperty("druid.emitter", "composing")
            .addCommonProperty("druid.emitter.composing.emitters", "[\"latching\",\"kafka\"]")
            .addCommonProperty("druid.monitoring.emissionPeriod", "PT0.1s")
-           .addCommonProperty("druid.monitoring.monitors", "[\"org.apache.druid.java.util.metrics.JvmMonitor\"]")
+           .addCommonProperty(
+               "druid.monitoring.monitors",
+               "[\"org.apache.druid.java.util.metrics.JvmMonitor\","
+               + "\"org.apache.druid.server.metrics.TaskCountStatsMonitor\"]"
+           )
            .addResource(kafkaServer)
            .addServer(coordinator)
            .addServer(overlord)
@@ -208,6 +212,12 @@ public class EmbeddedKafkaClusterMetricsTest extends EmbeddedClusterTestBase
         o -> o.postSupervisor(kafkaSupervisorSpec)
     );
 
+    // Wait for a task to succeed
+    overlord.latchableEmitter().waitForEventAggregate(
+        event -> event.hasMetricName("task/success/count")
+                      .hasDimension(DruidMetrics.DATASOURCE, dataSource),
+        agg -> agg.hasSumAtLeast(1)
+    );
     // Wait for some segments to be published
     overlord.latchableEmitter().waitForEvent(
         event -> event.hasMetricName("segment/txn/success")

--- a/server/src/main/java/org/apache/druid/client/cache/CacheMonitor.java
+++ b/server/src/main/java/org/apache/druid/client/cache/CacheMonitor.java
@@ -20,11 +20,19 @@
 package org.apache.druid.client.cache;
 
 import com.google.inject.Inject;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
 
+@LoadScope(roles = {
+    NodeRole.BROKER_JSON_NAME,
+    NodeRole.HISTORICAL_JSON_NAME,
+    NodeRole.INDEXER_JSON_NAME,
+    NodeRole.PEON_JSON_NAME
+})
 public class CacheMonitor extends AbstractMonitor
 {
   // package private for tests

--- a/server/src/main/java/org/apache/druid/server/metrics/GroupByStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/GroupByStatsMonitor.java
@@ -21,6 +21,8 @@ package org.apache.druid.server.metrics;
 
 import com.google.inject.Inject;
 import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.guice.annotations.Merging;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -29,6 +31,12 @@ import org.apache.druid.query.groupby.GroupByStatsProvider;
 
 import java.nio.ByteBuffer;
 
+@LoadScope(roles = {
+    NodeRole.BROKER_JSON_NAME,
+    NodeRole.HISTORICAL_JSON_NAME,
+    NodeRole.INDEXER_JSON_NAME,
+    NodeRole.PEON_JSON_NAME
+})
 public class GroupByStatsMonitor extends AbstractMonitor
 {
   private final GroupByStatsProvider groupByStatsProvider;

--- a/server/src/main/java/org/apache/druid/server/metrics/HistoricalMetricsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/HistoricalMetricsMonitor.java
@@ -23,6 +23,8 @@ import com.google.inject.Inject;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.druid.client.DruidServerConfig;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
@@ -33,6 +35,7 @@ import org.apache.druid.timeline.DataSegment;
 
 import java.util.Map;
 
+@LoadScope(roles = NodeRole.HISTORICAL_JSON_NAME)
 public class HistoricalMetricsMonitor extends AbstractMonitor
 {
   private final DruidServerConfig serverConfig;

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -22,7 +22,6 @@ package org.apache.druid.server.metrics;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.inject.Binder;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
@@ -34,6 +33,7 @@ import org.apache.druid.guice.DruidBinders;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.guice.ManageLifecycle;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -64,18 +64,14 @@ import java.util.stream.Collectors;
 /**
  * Sets up the {@link MonitorScheduler} to monitor things on a regular schedule.  {@link Monitor}s must be explicitly
  * bound in order to be loaded.
+ * <p>
+ * For any service, a monitor is loaded only if the {@link NodeRole} of the service
+ * is included in the {@link LoadScope} of the monitor.
  */
 public class MetricsModule implements Module
 {
   public static final String MONITORING_PROPERTY_PREFIX = "druid.monitoring";
   private static final Logger log = new Logger(MetricsModule.class);
-  private Set<NodeRole> nodeRoles;
-
-  @Inject
-  public void setNodeRoles(@Self Set<NodeRole> nodeRoles)
-  {
-    this.nodeRoles = nodeRoles;
-  }
 
   public static void register(Binder binder, Class<? extends Monitor> monitorClazz)
   {
@@ -107,6 +103,7 @@ public class MetricsModule implements Module
       Supplier<DruidMonitorSchedulerConfig> config,
       MonitorsConfig monitorsConfig,
       Set<Class<? extends Monitor>> monitorSet,
+      @Self Set<NodeRole> nodeRoles,
       ServiceEmitter emitter,
       Injector injector
   )
@@ -117,12 +114,14 @@ public class MetricsModule implements Module
     // but by injecting DataSourceTaskIdHolder early this cycle is avoided.
     injector.getInstance(DataSourceTaskIdHolder.class);
     for (Class<? extends Monitor> monitorClass : Iterables.concat(monitorsConfig.getMonitors(), monitorSet)) {
-      monitors.add(injector.getInstance(monitorClass));
+      if (shouldLoadMonitor(monitorClass, nodeRoles)) {
+        monitors.add(injector.getInstance(monitorClass));
+      }
     }
 
     if (!monitors.isEmpty()) {
       log.info(
-          "Loaded %d monitors: %s",
+          "Loaded [%d] monitors: %s",
           monitors.size(),
           monitors.stream().map(monitor -> monitor.getClass().getName()).collect(Collectors.joining(", "))
       );
@@ -217,5 +216,23 @@ public class MetricsModule implements Module
       );
       return new OshiSysMonitor(dimensions, oshiSysConfig);
     }
+  }
+
+  /**
+   * Checks if a monitor needs to be loaded on this service based on its node role.
+   */
+  private boolean shouldLoadMonitor(Class<?> monitorClass, Set<NodeRole> nodeRoles)
+  {
+    final LoadScope loadScope = monitorClass.getAnnotation(LoadScope.class);
+    if (loadScope == null) {
+      // always load if annotation is not specified
+      return true;
+    }
+    for (String role : loadScope.roles()) {
+      if (nodeRoles.contains(NodeRole.fromJsonName(role))) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/MetricsModule.java
@@ -225,8 +225,9 @@ public class MetricsModule implements Module
   {
     final LoadScope loadScope = monitorClass.getAnnotation(LoadScope.class);
     if (loadScope == null) {
-      // always load if annotation is not specified
-      return true;
+      // If annotation is not specified, check superclass (if one exists), otherwise load the monitor
+      Class<?> superClass = monitorClass.getSuperclass();
+      return superClass == null || shouldLoadMonitor(superClass, nodeRoles);
     }
     for (String role : loadScope.roles()) {
       if (nodeRoles.contains(NodeRole.fromJsonName(role))) {

--- a/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/QueryCountStatsMonitor.java
@@ -22,6 +22,8 @@ package org.apache.druid.server.metrics;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import org.apache.druid.collections.BlockingPool;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.guice.annotations.Merging;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -31,6 +33,13 @@ import org.apache.druid.java.util.metrics.KeyedDiff;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+@LoadScope(roles = {
+    NodeRole.BROKER_JSON_NAME,
+    NodeRole.HISTORICAL_JSON_NAME,
+    NodeRole.ROUTER_JSON_NAME,
+    NodeRole.INDEXER_JSON_NAME,
+    NodeRole.PEON_JSON_NAME
+})
 public class QueryCountStatsMonitor extends AbstractMonitor
 {
   private final KeyedDiff keyedDiff = new KeyedDiff();

--- a/server/src/main/java/org/apache/druid/server/metrics/SegmentStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/SegmentStatsMonitor.java
@@ -23,6 +23,8 @@ package org.apache.druid.server.metrics;
 
 import com.google.inject.Inject;
 import org.apache.druid.client.DruidServerConfig;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
@@ -39,6 +41,7 @@ import java.util.Map;
  *
  * It keeps track of the average number of rows in a segment and the distribution of segments according to rowCount.
  */
+@LoadScope(roles = NodeRole.HISTORICAL_JSON_NAME)
 public class SegmentStatsMonitor extends AbstractMonitor
 {
   private final DruidServerConfig serverConfig;

--- a/server/src/main/java/org/apache/druid/server/metrics/SubqueryCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/SubqueryCountStatsMonitor.java
@@ -21,6 +21,8 @@ package org.apache.druid.server.metrics;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
@@ -31,6 +33,7 @@ import java.util.Map;
 /**
  * Monitors and emits the metrics corresponding to the subqueries and their materialization.
  */
+@LoadScope(roles = NodeRole.BROKER_JSON_NAME)
 public class SubqueryCountStatsMonitor extends AbstractMonitor
 {
 

--- a/server/src/main/java/org/apache/druid/server/metrics/TaskCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/TaskCountStatsMonitor.java
@@ -20,6 +20,8 @@
 package org.apache.druid.server.metrics;
 
 import com.google.inject.Inject;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
@@ -30,6 +32,7 @@ import org.apache.druid.server.coordinator.stats.RowKey;
 
 import java.util.Map;
 
+@LoadScope(roles = NodeRole.OVERLORD_JSON_NAME)
 public class TaskCountStatsMonitor extends AbstractMonitor
 {
   private final TaskCountStatsProvider statsProvider;

--- a/server/src/main/java/org/apache/druid/server/metrics/TaskSlotCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/TaskSlotCountStatsMonitor.java
@@ -20,12 +20,15 @@
 package org.apache.druid.server.metrics;
 
 import com.google.inject.Inject;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.AbstractMonitor;
 
 import java.util.Map;
 
+@LoadScope(roles = NodeRole.OVERLORD_JSON_NAME)
 public class TaskSlotCountStatsMonitor extends AbstractMonitor
 {
   private final TaskSlotCountStatsProvider statsProvider;

--- a/server/src/main/java/org/apache/druid/server/metrics/WorkerTaskCountStatsMonitor.java
+++ b/server/src/main/java/org/apache/druid/server/metrics/WorkerTaskCountStatsMonitor.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.metrics;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
@@ -31,6 +32,7 @@ import org.apache.druid.query.DruidMetrics;
 import java.util.Map;
 import java.util.Set;
 
+@LoadScope(roles = {NodeRole.INDEXER_JSON_NAME, NodeRole.MIDDLE_MANAGER_JSON_NAME})
 public class WorkerTaskCountStatsMonitor extends AbstractMonitor
 {
   private final WorkerTaskCountStatsProvider statsProvider;


### PR DESCRIPTION
### Description

Defining a load scope safeguards against loading monitors on services where they are not supported.
It also simplifies configuration so that `druid.monitoring.monitors` can always be defined in
`common.runtime.properties` without requiring to override in service-specific `runtime.properties`.

### Changes

- Use `LoadScope` with monitors, same as with `DruidModule`
- Add test in `MetricsModuleTest`
- Use service-specific monitor in `EmbeddedKafkaClusterMetricsTest`

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
