### PR TITLE
MSQ: Fix excessive retention of writable stage output channels.

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/RunWorkOrder.java
@@ -327,7 +327,6 @@ public class RunWorkOrder
                 stageOutputChannels.sort(Comparator.comparing(OutputChannel::getPartitionNumber));
                 outputChannels = OutputChannels.wrap(
                     stageOutputChannels.stream()
-                                       .map(OutputChannel::readOnly)
                                        .sorted(Comparator.comparing(OutputChannel::getPartitionNumber))
                                        .collect(Collectors.toList()));
                 stageOutputChannels.clear();
@@ -493,7 +492,7 @@ public class RunWorkOrder
         outputChannelFactory,
         channel -> {
           synchronized (stageOutputChannels) {
-            stageOutputChannels.add(channel);
+            stageOutputChannels.add(channel.readOnly());
           }
         }
     );

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/std/ProcessorsAndChannels.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/std/ProcessorsAndChannels.java
@@ -41,7 +41,7 @@ public class ProcessorsAndChannels<T, R>
   )
   {
     this.processorManager = processorManager;
-    this.outputChannels = outputChannels;
+    this.outputChannels = outputChannels.readOnly();
   }
 
   public ProcessorManager<T, R> getProcessorManager()

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/std/ResultAndChannels.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/std/ResultAndChannels.java
@@ -42,7 +42,7 @@ public class ResultAndChannels<T>
   )
   {
     this.result = result;
-    this.outputChannels = outputChannels;
+    this.outputChannels = outputChannels.readOnly();
   }
 
   /**

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/std/StandardShuffleOperations.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/exec/std/StandardShuffleOperations.java
@@ -523,7 +523,7 @@ public class StandardShuffleOperations
         ),
         newResultAndChannels -> new ResultAndChannels<>(
             newResultAndChannels.resultFuture(),
-            newResultAndChannels.outputChannels().readOnly()
+            newResultAndChannels.outputChannels()
         )
     );
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafStageProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/BaseLeafStageProcessor.java
@@ -176,7 +176,7 @@ public abstract class BaseLeafStageProcessor extends BasicStandardStageProcessor
     }
 
     //noinspection unchecked,rawtypes
-    return new ProcessorsAndChannels<>(processorManager, OutputChannels.wrapReadOnly(outputChannels));
+    return new ProcessorsAndChannels<>(processorManager, OutputChannels.wrap(outputChannels));
   }
 
   private ProcessorManager<Object, Long> createBaseLeafProcessorManagerWithHandoff(

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryStageProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/WindowOperatorQueryStageProcessor.java
@@ -172,7 +172,7 @@ public class WindowOperatorQueryStageProcessor extends BasicStandardStageProcess
 
     return new ProcessorsAndChannels<>(
         ProcessorManagers.of(processors),
-        OutputChannels.wrapReadOnly(ImmutableList.copyOf(outputChannels.values()))
+        OutputChannels.wrap(ImmutableList.copyOf(outputChannels.values()))
     );
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/common/OffsetLimitStageProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/common/OffsetLimitStageProcessor.java
@@ -135,7 +135,7 @@ public class OffsetLimitStageProcessor extends BasicStandardStageProcessor
 
     return new ProcessorsAndChannels<>(
         ProcessorManagers.of(workerSupplier),
-        OutputChannels.wrapReadOnly(Collections.singletonList(outputChannel))
+        OutputChannels.wrap(Collections.singletonList(outputChannel))
     );
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPostShuffleStageProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/groupby/GroupByPostShuffleStageProcessor.java
@@ -128,7 +128,7 @@ public class GroupByPostShuffleStageProcessor extends BasicStandardStageProcesso
 
     return new ProcessorsAndChannels<>(
         ProcessorManagers.of(processors),
-        OutputChannels.wrapReadOnly(ImmutableList.copyOf(outputChannels.values()))
+        OutputChannels.wrap(ImmutableList.copyOf(outputChannels.values()))
     );
   }
 

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/QueryResultStageProcessor.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/querykit/results/QueryResultStageProcessor.java
@@ -111,7 +111,7 @@ public class QueryResultStageProcessor extends BasicStandardStageProcessor
 
     return new ProcessorsAndChannels<>(
         ProcessorManagers.of(processors),
-        OutputChannels.wrapReadOnly(ImmutableList.copyOf(outputChannels.values()))
+        OutputChannels.wrap(ImmutableList.copyOf(outputChannels.values()))
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/frame/processor/OutputChannels.java
+++ b/processing/src/main/java/org/apache/druid/frame/processor/OutputChannels.java
@@ -67,15 +67,6 @@ public class OutputChannels
   }
 
   /**
-   * Creates an instance wrapping read-only versions (see {@link OutputChannel#readOnly()}) of all the
-   * provided channels.
-   */
-  public static OutputChannels wrapReadOnly(final List<OutputChannel> outputChannels)
-  {
-    return new OutputChannels(outputChannels.stream().map(OutputChannel::readOnly).collect(Collectors.toList()));
-  }
-
-  /**
    * Verifies there is exactly one channel per partition.
    */
   public OutputChannels verifySingleChannel()
@@ -139,6 +130,24 @@ public class OutputChannels
    */
   public OutputChannels readOnly()
   {
-    return wrapReadOnly(outputChannels);
+    if (isReadOnly()) {
+      return this;
+    } else {
+      return new OutputChannels(outputChannels.stream().map(OutputChannel::readOnly).collect(Collectors.toList()));
+    }
+  }
+
+  /**
+   * Returns whether this instance is read-only (all channels have {@link OutputChannel#isReadOnly()}).
+   */
+  public boolean isReadOnly()
+  {
+    for (final OutputChannel channel : outputChannels) {
+      if (!channel.isReadOnly()) {
+        return false;
+      }
+    }
+
+    return true;
   }
 }

--- a/processing/src/test/java/org/apache/druid/frame/channel/ComposingWritableFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ComposingWritableFrameChannelTest.java
@@ -22,10 +22,10 @@ package org.apache.druid.frame.channel;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.allocation.ArenaMemoryAllocator;
 import org.apache.druid.frame.processor.OutputChannel;
-import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.query.ResourceLimitExceededException;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
@@ -95,22 +95,20 @@ public class ComposingWritableFrameChannelTest
 
 
     // Test if the older channel has been converted to read only
-    Assert.assertThrows(ISE.class, outputChannel1::getWritableChannel);
+    Assert.assertThrows(DruidException.class, outputChannel1::getWritableChannel);
     composingWritableFrameChannel.close();
 
-    Exception ise1 = Assert.assertThrows(IllegalStateException.class, () -> outputChannel1.getFrameMemoryAllocator());
+    Exception ise1 = Assert.assertThrows(DruidException.class, outputChannel1::getFrameMemoryAllocator);
     MatcherAssert.assertThat(
         ise1,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
-            "Frame allocator is not available. The output channel might be marked as read-only, hence memory allocator is not required."))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Frame memory allocator is not available."))
     );
 
 
-    Exception ise2 = Assert.assertThrows(IllegalStateException.class, () -> outputChannel2.getFrameMemoryAllocator());
+    Exception ise2 = Assert.assertThrows(DruidException.class, outputChannel2::getFrameMemoryAllocator);
     MatcherAssert.assertThat(
         ise2,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
-            "Frame allocator is not available. The output channel might be marked as read-only, hence memory allocator is not required."))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Frame memory allocator is not available."))
     );
 
   }

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelFactoryTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.frame.processor;
 
 import com.google.common.collect.Iterables;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.Frame;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.frame.channel.FrameWithPartition;
@@ -177,6 +178,6 @@ public abstract class OutputChannelFactoryTest extends InitializedNullHandlingTe
 
     Assert.assertEquals(1, channel.getPartitionNumber());
     Assert.assertTrue(channel.getReadableChannel().isFinished());
-    Assert.assertThrows(IllegalStateException.class, channel::getWritableChannel);
+    Assert.assertThrows(DruidException.class, channel::getWritableChannel);
   }
 }

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.frame.processor;
 
+import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.allocation.HeapMemoryAllocator;
 import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
 import org.apache.druid.frame.channel.WritableFrameFileChannel;
@@ -39,19 +40,17 @@ public class OutputChannelTest
     Assert.assertTrue(channel.getReadableChannel().isFinished());
 
     // No writable channel: cannot call getWritableChannel.
-    final IllegalStateException e1 = Assert.assertThrows(IllegalStateException.class, channel::getWritableChannel);
+    final DruidException e1 = Assert.assertThrows(DruidException.class, channel::getWritableChannel);
     MatcherAssert.assertThat(
         e1,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
-            "Writable channel is not available. The output channel might be marked as read-only, hence no writes are allowed."))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Writable channel is not available."))
     );
 
     // No writable channel: cannot call getFrameMemoryAllocator.
-    final IllegalStateException e2 = Assert.assertThrows(IllegalStateException.class, channel::getFrameMemoryAllocator);
+    final DruidException e2 = Assert.assertThrows(DruidException.class, channel::getFrameMemoryAllocator);
     MatcherAssert.assertThat(
         e2,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
-            "Frame allocator is not available. The output channel might be marked as read-only, hence memory allocator is not required."))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Frame memory allocator is not available."))
     );
 
     // Mapping the writable channel of a nil channel has no effect, because there is no writable channel.

--- a/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelsTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/OutputChannelsTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.ints.IntSets;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.frame.allocation.HeapMemoryAllocator;
 import org.apache.druid.frame.channel.BlockingQueueFrameChannel;
 import org.hamcrest.CoreMatchers;
@@ -76,26 +77,24 @@ public class OutputChannelsTest
     Assert.assertEquals(1, readOnlyChannels.getAllChannels().size());
     Assert.assertEquals(1, channels.getChannelsForPartition(1).size());
 
-    final IllegalStateException e = Assert.assertThrows(
-        IllegalStateException.class,
+    final DruidException e = Assert.assertThrows(
+        DruidException.class,
         () -> Iterables.getOnlyElement(readOnlyChannels.getAllChannels()).getWritableChannel()
     );
 
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
-            "Writable channel is not available. The output channel might be marked as read-only, hence no writes are allowed."))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Writable channel is not available."))
     );
 
-    final IllegalStateException e2 = Assert.assertThrows(
-        IllegalStateException.class,
+    final DruidException e2 = Assert.assertThrows(
+        DruidException.class,
         () -> Iterables.getOnlyElement(readOnlyChannels.getAllChannels()).getFrameMemoryAllocator()
     );
 
     MatcherAssert.assertThat(
         e2,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo(
-            "Frame allocator is not available. The output channel might be marked as read-only, hence memory allocator is not required."))
+        ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Frame memory allocator is not available."))
     );
   }
 


### PR DESCRIPTION
Fixes a regression from #18144. The refactoring in that patch lost some logic that ensured stage output channels were stored in read-only form. This is important, because the writable form includes a 1MB frame memory allocation buffer. It can add up to a lot of memory if retained across lots of channels.

This patch simplifies things by unconditionally converting all stage outputs to read-only before they are retained, by replacing the channel in "stageOutputChannels.add(channel)" with "channel.readOnly()". It also simplifies various other bits of code that deal with intermediate output channels, by converting them to read-only in the constructors of ProcessorsAndChannels and ResultAndChannels, rather than at only some call sites.