### PR TITLE
Fix flakiness in EmbeddedHighAvailabilityTest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/EmbeddedHighAvailabilityTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/EmbeddedHighAvailabilityTest.java
@@ -31,6 +31,7 @@ import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
 import org.apache.druid.java.util.http.client.response.StatusResponseHandler;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
+import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.testing.embedded.EmbeddedBroker;
 import org.apache.druid.testing.embedded.EmbeddedClusterApis;
 import org.apache.druid.testing.embedded.EmbeddedCoordinator;
@@ -69,7 +70,12 @@ public class EmbeddedHighAvailabilityTest extends EmbeddedClusterTestBase
   protected EmbeddedDruidCluster createCluster()
   {
     overlord1.addProperty("druid.plaintextPort", "7090");
-    coordinator1.addProperty("druid.plaintextPort", "7081");
+
+    // Use incremental cache on coordinator1 so that we can wait for the
+    // segment count metric before querying sys.segments for the first time
+    coordinator1
+        .addProperty("druid.plaintextPort", "7081")
+        .addProperty("druid.manager.segments.useIncrementalCache", "always");
 
     return EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper()
                                .useLatchableEmitter()
@@ -115,6 +121,11 @@ public class EmbeddedHighAvailabilityTest extends EmbeddedClusterTestBase
         o -> o.runTask(taskId, EmbeddedClusterApis.createTaskFromPayload(taskId, taskPayload))
     );
     cluster.callApi().waitForTaskToSucceed(taskId, overlord1);
+    coordinator1.latchableEmitter().waitForEvent(
+        event -> event.hasMetricName("segment/metadataCache/used/count")
+                      .hasDimension(DruidMetrics.DATASOURCE, dataSource)
+                      .hasValue(10)
+    );
 
     // Run sys queries, switch leaders, repeat
     ServerPair<EmbeddedOverlord> overlordPair = createServerPair(overlord1, overlord2);


### PR DESCRIPTION
### Description

`EmbeddedHighAvailabilityTest` can sometimes be flaky due to the Coordinator not having synced with the metadata store.

### Fix

- Use incremental cache on the Coordinator
- Wait for the Coordinator to have synced by watching the metric `segment/metadataCache/used/count`

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
