### PR TITLE
Remove `hadoop.indexer.libs.version` in `indexing-service`

### DIFF
--- a/indexing-service/src/main/resources/hadoop.indexer.libs.version
+++ b/indexing-service/src/main/resources/hadoop.indexer.libs.version
@@ -1,1 +1,0 @@
-${hadoop-task-libs}


### PR DESCRIPTION
 
### Description
Remove `indexing-service/src/main/resources/hadoop.indexer.libs.version` since #18247 has moved `hadoop-task-libs` to `indexing-hadoop`, so this file no longer compiles properly based on the property value. Further more, this would cause resource file conflict in `pull-deps` tool, since currently we have two `hadoop.indexer.libs.version` resources.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
