### PR TITLE
Web console: build only if needed

### DIFF
--- a/web-console/script/build
+++ b/web-console/script/build
@@ -18,29 +18,98 @@
 
 set -e
 
-# If needed, build SQL docs
-# Building SQL docs is needed if an argument of `--force` is given to this script, or the file lib/sql-docs.ts does not exist, or if that file has an earlier last modified time than any of the source files used to build the SQL docs which are:
-#
-# ./script/create-sql-docs.mjs
-# script/sql-doc-files.txt
-# Any file listed in script/sql-doc-files.txt
+# Check if --force flag is provided
+FORCE_BUILD=false
+if [[ "$@" == *"--force"* ]]; then
+  FORCE_BUILD=true
+fi
 
-echo "Compiling SQL function docs for the web console..."
-./script/create-sql-docs.mjs
+# Function to check if a file is newer than another
+is_newer_than() {
+  # Returns 0 (true) if $1 is newer than $2, 1 (false) otherwise
+  if [ ! -f "$2" ]; then
+    return 0  # If target doesn't exist, we need to build
+  fi
+  if [ ! -f "$1" ]; then
+    return 1  # If source doesn't exist, we can't build (will error later)
+  fi
+  [ "$1" -nt "$2" ]
+}
 
-# End if
+# Check if SQL docs need to be built
+SQL_DOCS_OUTPUT="lib/sql-docs.ts"
+SQL_DOCS_SCRIPT="script/create-sql-docs.mjs"
+SQL_DOCS_FILELIST="script/sql-doc-files.txt"
 
-# If needed, build the console
-# Building the console is needed if an argument of `--force` is given to this script, or the file public/web-console-{{VERSION}}.js does not exist, or if that file has an earlier modified time than any of the files {src,lib}/**/*.{ts,tsx} where the VERSION is taken as the "version" in package.json or any of these files
-#
-# package.json
-# package-lock.json
-# webpack.config.mjs
-# tsconfig.json
+BUILD_SQL_DOCS=false
 
-echo "Webpacking everything..."
-NODE_ENV=production ./node_modules/.bin/webpack -c webpack.config.mjs --mode=production
+if [ "$FORCE_BUILD" = true ] || [ ! -f "$SQL_DOCS_OUTPUT" ]; then
+  BUILD_SQL_DOCS=true
+else
+  # Check if create-sql-docs.mjs is newer than output
+  if is_newer_than "$SQL_DOCS_SCRIPT" "$SQL_DOCS_OUTPUT"; then
+    BUILD_SQL_DOCS=true
+  fi
 
-# End if
+  # Check if sql-doc-files.txt is newer than output
+  if is_newer_than "$SQL_DOCS_FILELIST" "$SQL_DOCS_OUTPUT"; then
+    BUILD_SQL_DOCS=true
+  fi
 
-echo "Web console building finished."
+  # Check if any file listed in sql-doc-files.txt is newer than output
+  if [ -f "$SQL_DOCS_FILELIST" ] && [ "$BUILD_SQL_DOCS" = false ]; then
+    while read -r file; do
+      # Skip empty lines and comments
+      if [[ -z "$file" ]] || [[ "$file" =~ ^[[:space:]]*# ]]; then
+        continue
+      fi
+      if [ -n "$file" ] && is_newer_than "$file" "$SQL_DOCS_OUTPUT"; then
+        BUILD_SQL_DOCS=true
+        break
+      fi
+    done < "$SQL_DOCS_FILELIST"
+  fi
+fi
+
+if [ "$BUILD_SQL_DOCS" = true ]; then
+  echo "Compiling SQL function docs for the web console..."
+  ./script/create-sql-docs.mjs
+else
+  echo "SQL docs are up to date, skipping..."
+fi
+
+# Get version from package.json
+VERSION=$(node -e "console.log(require('./package.json').version)")
+CONSOLE_OUTPUT="public/web-console-$VERSION.js"
+
+BUILD_CONSOLE=false
+
+if [ "$FORCE_BUILD" = true ] || [ ! -f "$CONSOLE_OUTPUT" ]; then
+  BUILD_CONSOLE=true
+else
+  # Check if any config file is newer than output
+  CONFIG_FILES=("package.json" "package-lock.json" "webpack.config.mjs" "tsconfig.json")
+  for config_file in "${CONFIG_FILES[@]}"; do
+    if is_newer_than "$config_file" "$CONSOLE_OUTPUT"; then
+      BUILD_CONSOLE=true
+      break
+    fi
+  done
+
+  # Check if any source file is newer than output
+  if [ "$BUILD_CONSOLE" = false ]; then
+    # Find the newest source file
+    NEWEST_SOURCE=$(find src lib -name "*.ts" -o -name "*.tsx" | xargs ls -t 2>/dev/null | head -1)
+    if [ -n "$NEWEST_SOURCE" ] && is_newer_than "$NEWEST_SOURCE" "$CONSOLE_OUTPUT"; then
+      BUILD_CONSOLE=true
+    fi
+  fi
+fi
+
+if [ "$BUILD_CONSOLE" = true ]; then
+  echo "Webpacking everything..."
+  NODE_ENV=production ./node_modules/.bin/webpack -c webpack.config.mjs --mode=production
+  echo "Web console build finished."
+else
+  echo "Web console is up to date, skipping webpack..."
+fi

--- a/web-console/script/build
+++ b/web-console/script/build
@@ -18,11 +18,29 @@
 
 set -e
 
-echo "Adding SQL docs..."
+# If needed, build SQL docs
+# Building SQL docs is needed if an argument of `--force` is given to this script, or the file lib/sql-docs.ts does not exist, or if that file has an earlier last modified time than any of the source files used to build the SQL docs which are:
+#
+# ./script/create-sql-docs.mjs
+# script/sql-doc-files.txt
+# Any file listed in script/sql-doc-files.txt
+
+echo "Compiling SQL function docs for the web console..."
 ./script/create-sql-docs.mjs
 
-# add BUNDLE_ANALYZER_PLUGIN='TRUE' here to enable webpack-bundle-analyzer as a plugin
+# End if
+
+# If needed, build the console
+# Building the console is needed if an argument of `--force` is given to this script, or the file public/web-console-{{VERSION}}.js does not exist, or if that file has an earlier modified time than any of the files {src,lib}/**/*.{ts,tsx} where the VERSION is taken as the "version" in package.json or any of these files
+#
+# package.json
+# package-lock.json
+# webpack.config.mjs
+# tsconfig.json
+
 echo "Webpacking everything..."
 NODE_ENV=production ./node_modules/.bin/webpack -c webpack.config.mjs --mode=production
 
-echo "Done! Have a good day."
+# End if
+
+echo "Web console building finished."

--- a/web-console/script/create-sql-docs.mjs
+++ b/web-console/script/create-sql-docs.mjs
@@ -21,6 +21,7 @@
 import fs from 'fs-extra';
 import snarkdown from 'snarkdown';
 
+const INPUT_FILELIST_FILE = 'script/sql-doc-files.txt';
 const OUTPUT_FILE = 'lib/sql-docs.ts';
 
 const MINIMUM_EXPECTED_NUMBER_OF_FUNCTIONS = 198;
@@ -71,16 +72,19 @@ function convertMarkdownToHtml(markdown) {
 }
 
 const readDoc = async () => {
-  const data = [
-    await fs.readFile('../docs/querying/sql-data-types.md', 'utf-8'),
-    await fs.readFile('../docs/querying/sql-scalar.md', 'utf-8'),
-    await fs.readFile('../docs/querying/sql-aggregations.md', 'utf-8'),
-    await fs.readFile('../docs/querying/sql-array-functions.md', 'utf-8'),
-    await fs.readFile('../docs/querying/sql-multivalue-string-functions.md', 'utf-8'),
-    await fs.readFile('../docs/querying/sql-json-functions.md', 'utf-8'),
-    await fs.readFile('../docs/querying/sql-window-functions.md', 'utf-8'),
-    await fs.readFile('../docs/querying/sql-operators.md', 'utf-8'),
-  ].join('\n');
+  // Read the list of files from sql-doc-files.txt
+  const fileList = await fs.readFile(INPUT_FILELIST_FILE, 'utf-8');
+  const filePaths = fileList
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line && !line.startsWith('#')); // Skip empty lines and comments
+
+  // Read all files in parallel
+  const fileContents = await Promise.all(
+    filePaths.map(filePath => fs.readFile(filePath, 'utf-8'))
+  );
+
+  const data = fileContents.join('\n');
 
   const lines = data.split('\n');
 

--- a/web-console/script/sql-doc-files.txt
+++ b/web-console/script/sql-doc-files.txt
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# List of SQL documentation files to process
+# List of SQL documentation files to process relative to the web-console directory
 ../docs/querying/sql-data-types.md
 ../docs/querying/sql-scalar.md
 ../docs/querying/sql-aggregations.md

--- a/web-console/script/sql-doc-files.txt
+++ b/web-console/script/sql-doc-files.txt
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List of SQL documentation files to process
+../docs/querying/sql-data-types.md
+../docs/querying/sql-scalar.md
+../docs/querying/sql-aggregations.md
+../docs/querying/sql-array-functions.md
+../docs/querying/sql-multivalue-string-functions.md
+../docs/querying/sql-json-functions.md
+../docs/querying/sql-window-functions.md
+../docs/querying/sql-operators.md


### PR DESCRIPTION
Make the `script/build` script (the one `mvn` calls) not rebuild if the output is newer than the input. Should save a lot of time on running tests.