### PR TITLE
set version of dorny/paths-filter to 3.0.2

### DIFF
--- a/.github/workflows/revised-its.yml
+++ b/.github/workflows/revised-its.yml
@@ -51,7 +51,7 @@ jobs:
       # the common extension in revised ITs is different from the one in standard ITs
       common-extensions: ${{ steps.filter.outputs.common-extensions }}
     steps:
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         if: github.event_name == 'pull_request'
         id: filter
         with:

--- a/.github/workflows/revised-its.yml
+++ b/.github/workflows/revised-its.yml
@@ -51,7 +51,7 @@ jobs:
       # the common extension in revised ITs is different from the one in standard ITs
       common-extensions: ${{ steps.filter.outputs.common-extensions }}
     steps:
-      - uses: dorny/paths-filter@v3.0.0
+      - uses: dorny/paths-filter@v3.0.2
         if: github.event_name == 'pull_request'
         id: filter
         with:

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -32,7 +32,7 @@ jobs:
       core: ${{ steps.filter.outputs.core || github.event_name != 'pull_request'}}
       common-extensions: ${{ steps.filter.outputs.common-extensions }}
     steps:
-      - uses: dorny/paths-filter@v3.0.0
+      - uses: dorny/paths-filter@v3.0.2
         if: github.event_name == 'pull_request'
         id: filter
         with:

--- a/.github/workflows/standard-its.yml
+++ b/.github/workflows/standard-its.yml
@@ -32,7 +32,7 @@ jobs:
       core: ${{ steps.filter.outputs.core || github.event_name != 'pull_request'}}
       common-extensions: ${{ steps.filter.outputs.common-extensions }}
     steps:
-      - uses: dorny/paths-filter@v3.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         if: github.event_name == 'pull_request'
         id: filter
         with:


### PR DESCRIPTION
### Description
unit tests seems broken with an error like

```
dorny/paths-filter@v3.0.0 is not allowed to be used in apache/druid. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, verified in the GitHub Marketplace, or matching the following:
...
```

trying to fix by setting the specific version listed in https://github.com/apache/infrastructure-actions/blob/main/actions.yml#L344