### PR TITLE
Add utility method to EmbeddedClusterApis to run tasks

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
@@ -70,10 +70,7 @@ public abstract class CompactionTestBase extends EmbeddedClusterTestBase
   protected String runTask(TaskBuilder<?, ?, ?> taskBuilder)
   {
     final String taskId = IdUtils.getRandomId();
-    cluster.callApi().runTask(
-        taskBuilder.dataSource(dataSource).withId(IdUtils.getRandomId()),
-        overlord
-    );
+    cluster.callApi().runTask(taskBuilder.dataSource(dataSource).withId(taskId), overlord);
     cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator);
 
     return taskId;

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.testing.embedded.compact;
 
+import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.indexing.common.task.TaskBuilder;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.testing.embedded.EmbeddedBroker;
@@ -68,12 +69,14 @@ public abstract class CompactionTestBase extends EmbeddedClusterTestBase
    */
   protected String runTask(TaskBuilder<?, ?, ?> taskBuilder)
   {
-    return cluster.callApi().runTask(
-        (ds, taskId) -> taskBuilder.dataSource(ds).withId(taskId),
-        dataSource,
-        overlord,
-        coordinator
+    final String taskId = IdUtils.getRandomId();
+    cluster.callApi().runTask(
+        taskBuilder.dataSource(dataSource).withId(IdUtils.getRandomId()),
+        overlord
     );
+    cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator);
+
+    return taskId;
   }
 
   protected void verifySegmentIntervals(List<Interval> expectedIntervals)

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/ConcurrentAppendReplaceTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/ConcurrentAppendReplaceTest.java
@@ -68,10 +68,7 @@ public class ConcurrentAppendReplaceTest extends EmbeddedClusterTestBase
                    .appendToExisting(true)
                    .context("useConcurrentLocks", true)
                    .dimensions();
-    cluster.callApi().onLeaderOverlord(
-        o -> o.runTask(task1, taskBuilder.withId(task1))
-    );
-    cluster.callApi().waitForTaskToSucceed(task1, overlord);
+    cluster.callApi().runTask(taskBuilder.withId(task1), overlord);
 
     List<DataSegment> usedSegments = getAllUsedSegments();
     Assertions.assertEquals(1, usedSegments.size());
@@ -87,10 +84,7 @@ public class ConcurrentAppendReplaceTest extends EmbeddedClusterTestBase
 
     // Run the APPEND task again with a different taskId
     final String task2 = EmbeddedClusterApis.newTaskId(dataSource);
-    cluster.callApi().onLeaderOverlord(
-        o -> o.runTask(task2, taskBuilder.withId(task2))
-    );
-    cluster.callApi().waitForTaskToSucceed(task2, overlord);
+    cluster.callApi().runTask(taskBuilder.withId(task2), overlord);
 
     // Verify that the new segment gets appended with the same version but a different ID
     usedSegments = getAllUsedSegments();

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IndexParallelTaskTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IndexParallelTaskTest.java
@@ -214,9 +214,7 @@ public class IndexParallelTaskTest extends EmbeddedClusterTestBase
   private String runTask(TaskBuilder.IndexParallel taskBuilder, String dataSource)
   {
     final String taskId = EmbeddedClusterApis.newTaskId(dataSource);
-    cluster.callApi().onLeaderOverlord(o -> o.runTask(taskId, taskBuilder.withId(taskId)));
-    cluster.callApi().waitForTaskToSucceed(taskId, overlord);
-
+    cluster.callApi().runTask(taskBuilder.withId(taskId), overlord);
     return taskId;
   }
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IndexTaskTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/IndexTaskTest.java
@@ -81,8 +81,7 @@ public class IndexTaskTest extends EmbeddedClusterTestBase
         Resources.InlineData.CSV_10_DAYS
     );
 
-    cluster.callApi().submitTask(task, overlord);
-    cluster.callApi().waitForTaskToSucceed(taskId, overlord);
+    cluster.callApi().runTask(task, overlord);
 
     // Verify that the task created 10 DAY-granularity segments
     final List<DataSegment> segments = new ArrayList<>(

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaClusterMetricsTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/KafkaClusterMetricsTest.java
@@ -156,10 +156,10 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
         maxRowsPerSegment
     );
 
-    final Map<String, String> startSupervisorResult = cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec)
+    Assertions.assertEquals(
+        supervisorId,
+        cluster.callApi().postSupervisor(kafkaSupervisorSpec, overlord)
     );
-    Assertions.assertEquals(Map.of("id", supervisorId), startSupervisorResult);
 
     // Wait for segments to be handed off
     indexer.latchableEmitter().waitForEventAggregate(
@@ -183,9 +183,7 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
     verifyIngestedMetricCountMatchesEmittedCount("coordinator/time", coordinator);
 
     // Suspend the supervisor
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec.createSuspendedSpec())
-    );
+    cluster.callApi().postSupervisor(kafkaSupervisorSpec.createSuspendedSpec(), overlord);
   }
 
   @Test
@@ -208,9 +206,7 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
         taskCompletionTimeoutMillis,
         maxRowsPerSegment
     );
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec)
-    );
+    cluster.callApi().postSupervisor(kafkaSupervisorSpec, overlord);
 
     // Wait for a task to succeed
     overlord.latchableEmitter().waitForEventAggregate(
@@ -248,9 +244,7 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
         false,
         null
     );
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(compactionSupervisorSpec)
-    );
+    cluster.callApi().postSupervisor(compactionSupervisorSpec, overlord);
 
     // Wait until some compaction tasks have finished
     overlord.latchableEmitter().waitForEventAggregate(
@@ -309,12 +303,8 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
     );
 
     // Suspend the supervisors
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(compactionSupervisorSpec.createSuspendedSpec())
-    );
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec.createSuspendedSpec())
-    );
+    cluster.callApi().postSupervisor(compactionSupervisorSpec.createSuspendedSpec(), overlord);
+    cluster.callApi().postSupervisor(kafkaSupervisorSpec.createSuspendedSpec(), overlord);
   }
 
   @Test
@@ -337,9 +327,7 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
         taskCompletionTimeoutMillis,
         maxRowsPerSegment
     );
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec)
-    );
+    cluster.callApi().postSupervisor(kafkaSupervisorSpec, overlord);
 
     // Wait for some segments to be published
     overlord.latchableEmitter().waitForEvent(
@@ -371,9 +359,7 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
         false,
         null
     );
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(compactionSupervisorSpec)
-    );
+    cluster.callApi().postSupervisor(compactionSupervisorSpec, overlord);
 
     // Wait until some skipped metrics have been emitted
     overlord.latchableEmitter().waitForEventAggregate(
@@ -388,12 +374,8 @@ public class KafkaClusterMetricsTest extends EmbeddedClusterTestBase
     );
 
     // Suspend the supervisors
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(compactionSupervisorSpec.createSuspendedSpec())
-    );
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec.createSuspendedSpec())
-    );
+    cluster.callApi().postSupervisor(compactionSupervisorSpec.createSuspendedSpec(), overlord);
+    cluster.callApi().postSupervisor(kafkaSupervisorSpec.createSuspendedSpec(), overlord);
   }
 
   /**

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/BaseRealtimeQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/BaseRealtimeQueryTest.java
@@ -40,6 +40,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.testing.embedded.EmbeddedClusterApis;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
+import org.apache.druid.testing.embedded.EmbeddedOverlord;
 import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.joda.time.Period;
@@ -84,13 +85,14 @@ public class BaseRealtimeQueryTest extends EmbeddedClusterTestBase
   /**
    * Submits a supervisor spec to the Overlord.
    */
-  protected void submitSupervisor()
+  protected void submitSupervisor(EmbeddedOverlord overlord)
   {
     // Submit a supervisor.
     final KafkaSupervisorSpec kafkaSupervisorSpec = createKafkaSupervisor();
-    final Map<String, String> startSupervisorResult =
-        cluster.callApi().onLeaderOverlord(o -> o.postSupervisor(kafkaSupervisorSpec));
-    Assertions.assertEquals(Map.of("id", dataSource), startSupervisorResult);
+    Assertions.assertEquals(
+        dataSource,
+        cluster.callApi().postSupervisor(kafkaSupervisorSpec, overlord)
+    );
   }
 
   /**

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
@@ -167,7 +167,7 @@ public class EmbeddedMSQRealtimeQueryTest extends BaseRealtimeQueryTest
   void setUpEach()
   {
     msqApis = new EmbeddedMSQApis(cluster, overlord);
-    submitSupervisor();
+    submitSupervisor(overlord);
     publishToKafka(TestIndex.getMMappedWikipediaIndex());
 
     // Wait for it to be loaded.

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeUnnestQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeUnnestQueryTest.java
@@ -113,7 +113,7 @@ public class EmbeddedMSQRealtimeUnnestQueryTest extends BaseRealtimeQueryTest
 
     QueryableIndex index = TestIndex.getMMappedTestIndex();
 
-    submitSupervisor();
+    submitSupervisor(overlord);
     publishToKafka(index);
 
     final int totalRows = index.getNumRows();

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/CoordinatorClientTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/CoordinatorClientTest.java
@@ -192,8 +192,7 @@ public class CoordinatorClientTest extends EmbeddedClusterTestBase
                                  .dimensions()
                                  .withId(taskId);
 
-    cluster.callApi().onLeaderOverlord(o -> o.runTask(taskId, task));
-    cluster.callApi().waitForTaskToSucceed(taskId, overlord);
+    cluster.callApi().runTask(task, overlord);
     cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator);
   }
 }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/HighAvailabilityTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/HighAvailabilityTest.java
@@ -121,8 +121,7 @@ public class HighAvailabilityTest extends EmbeddedClusterTestBase
         .inlineInputSourceWithData(Resources.InlineData.CSV_10_DAYS)
         .dimensions()
         .withId(taskId);
-    cluster.callApi().onLeaderOverlord(o -> o.runTask(taskId, task));
-    cluster.callApi().waitForTaskToSucceed(taskId, overlord1);
+    cluster.callApi().runTask(task, overlord1);
     coordinator1.latchableEmitter().waitForEvent(
         event -> event.hasMetricName("segment/metadataCache/used/count")
                       .hasDimension(DruidMetrics.DATASOURCE, dataSource)

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/HistoricalCloningTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/HistoricalCloningTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.testing.embedded.server;
 
 import org.apache.druid.common.utils.IdUtils;
+import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.TaskBuilder;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
@@ -128,13 +129,12 @@ public class HistoricalCloningTest extends EmbeddedClusterTestBase
   private void runIngestion()
   {
     final String taskId = IdUtils.getRandomId();
-    final Object task = createIndexTaskForInlineData(taskId);
+    final IndexTask task = createIndexTaskForInlineData(taskId);
 
-    cluster.callApi().onLeaderOverlord(o -> o.runTask(taskId, task));
-    cluster.callApi().waitForTaskToSucceed(taskId, overlord);
+    cluster.callApi().runTask(task, overlord);
   }
 
-  private Object createIndexTaskForInlineData(String taskId)
+  private IndexTask createIndexTaskForInlineData(String taskId)
   {
     return TaskBuilder.ofTypeIndex()
                       .dataSource(dataSource)

--- a/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/compact/CatalogCompactionTest.java
+++ b/extensions-core/druid-catalog/src/test/java/org/apache/druid/catalog/compact/CatalogCompactionTest.java
@@ -26,6 +26,7 @@ import org.apache.druid.catalog.model.TableMetadata;
 import org.apache.druid.catalog.model.table.TableBuilder;
 import org.apache.druid.catalog.sync.CatalogClient;
 import org.apache.druid.common.utils.IdUtils;
+import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.TaskBuilder;
 import org.apache.druid.indexing.compact.CompactionSupervisorSpec;
 import org.apache.druid.indexing.overlord.Segments;
@@ -113,7 +114,7 @@ public class CatalogCompactionTest extends EmbeddedClusterTestBase
 
     final CompactionSupervisorSpec compactionSupervisor
         = new CompactionSupervisorSpec(compactionConfig, false, null);
-    cluster.callApi().onLeaderOverlord(o -> o.postSupervisor(compactionSupervisor));
+    cluster.callApi().postSupervisor(compactionSupervisor, overlord);
 
     // Wait for compaction to finish
     overlord.latchableEmitter().waitForEvent(
@@ -136,13 +137,12 @@ public class CatalogCompactionTest extends EmbeddedClusterTestBase
   private void runIngestionAtDayGranularity()
   {
     final String taskId = IdUtils.getRandomId();
-    final Object task = createIndexTaskForInlineData(taskId);
+    final IndexTask task = createIndexTaskForInlineData(taskId);
 
-    cluster.callApi().onLeaderOverlord(o -> o.runTask(taskId, task));
-    cluster.callApi().waitForTaskToSucceed(taskId, overlord);
+    cluster.callApi().runTask(task, overlord);
   }
 
-  private Object createIndexTaskForInlineData(String taskId)
+  private IndexTask createIndexTaskForInlineData(String taskId)
   {
     final String inlineDataCsv =
         "2025-06-01T00:00:00.000Z,shirt,105"

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/EmbeddedKafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/EmbeddedKafkaSupervisorTest.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class EmbeddedKafkaSupervisorTest extends EmbeddedClusterTestBase
@@ -91,10 +90,7 @@ public class EmbeddedKafkaSupervisorTest extends EmbeddedClusterTestBase
     final String supervisorId = dataSource + "_supe";
     final KafkaSupervisorSpec kafkaSupervisorSpec = createKafkaSupervisor(supervisorId, topic);
 
-    final Map<String, String> startSupervisorResult = cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec)
-    );
-    Assertions.assertEquals(Map.of("id", supervisorId), startSupervisorResult);
+    Assertions.assertEquals(supervisorId, cluster.callApi().postSupervisor(kafkaSupervisorSpec, overlord));
 
     // Wait for the broker to discover the realtime segments
     broker.latchableEmitter().waitForEvent(
@@ -120,9 +116,7 @@ public class EmbeddedKafkaSupervisorTest extends EmbeddedClusterTestBase
     Assertions.assertEquals("10", cluster.runSql("SELECT COUNT(*) FROM %s", dataSource));
 
     // Suspend the supervisor and verify the state
-    cluster.callApi().onLeaderOverlord(
-        o -> o.postSupervisor(kafkaSupervisorSpec.createSuspendedSpec())
-    );
+    cluster.callApi().postSupervisor(kafkaSupervisorSpec.createSuspendedSpec(), overlord);
     supervisorStatus = cluster.callApi().getSupervisorStatus(supervisorId);
     Assertions.assertTrue(supervisorStatus.isSuspended());
   }

--- a/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/EmbeddedClusterApis.java
@@ -362,9 +362,7 @@ public class EmbeddedClusterApis
   public static Map<String, Object> deserializeJsonToMap(String payload)
   {
     try {
-      return TestHelper.JSON_MAPPER.readValue(payload, new TypeReference<>()
-      {
-      });
+      return TestHelper.JSON_MAPPER.readValue(payload, new TypeReference<>() {});
     }
     catch (Exception e) {
       throw new ISE(e, "Could not deserialize payload[%s]", payload);


### PR DESCRIPTION
### Description

Embedded tests currently run into serialization when submitting a `Task` or `CompactionSupervisorSpec` payload to the cluster using any `OverlordClient`.
This can happen because the `ObjectMapper` instance used by the `OverlordClient` might not have the necessary
Jackson modules loaded.
The hack so far has been to ensure that the first server in an embedded cluster is always an Overlord.
But this can quickly run into issues, e.g. when running a cluster with basic auth enabled where a
Coordinator must be started before all other servers.

### Fix

- Add utility methods in `EmbeddedClusterApis` to `submitTask`, `runTask`, `postSupervisor`
- Accept an `EmbeddedOverlord` in these methods so that the appropriate `OverlordClient` can be used
- The request is still sent over the wire since an Overlord also uses a regular HTTP-based `OverlordClient`,
even if it might end up calling itself.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
