### PR TITLE
Add guard rails for Dart around select destination

### DIFF
--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -384,15 +384,23 @@ public class MultiStageQueryContext
 
   public static MSQSelectDestination getSelectDestination(final QueryContext queryContext)
   {
-    if (isDartQuery(queryContext)) {
-      // Dart does not support any other destination.
-      return MSQSelectDestination.TASKREPORT;
-    }
-    return QueryContexts.getAsEnum(
+    MSQSelectDestination destination = QueryContexts.getAsEnum(
         CTX_SELECT_DESTINATION,
         queryContext.getString(CTX_SELECT_DESTINATION, DEFAULT_SELECT_DESTINATION),
         MSQSelectDestination.class
     );
+
+    if (isDartQuery(queryContext)) {
+      if (!MSQSelectDestination.TASKREPORT.equals(destination)) {
+        log.warn(
+            "Dart does not support [%s]. Using [%s] instead.",
+            destination,
+            MSQSelectDestination.TASKREPORT
+        );
+      }
+      return MSQSelectDestination.TASKREPORT;
+    }
+    return destination;
   }
 
   public static int getRowsInMemory(final QueryContext queryContext)

--- a/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/extensions-core/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -377,9 +377,17 @@ public class MultiStageQueryContext
     return queryContext.getBoolean(CTX_REMOVE_NULL_BYTES, DEFAULT_REMOVE_NULL_BYTES);
   }
 
+  public static boolean isDartQuery(final QueryContext queryContext)
+  {
+    return queryContext.get(QueryContexts.CTX_DART_QUERY_ID) != null;
+  }
 
   public static MSQSelectDestination getSelectDestination(final QueryContext queryContext)
   {
+    if (isDartQuery(queryContext)) {
+      // Dart does not support any other destination.
+      return MSQSelectDestination.TASKREPORT;
+    }
     return QueryContexts.getAsEnum(
         CTX_SELECT_DESTINATION,
         queryContext.getString(CTX_SELECT_DESTINATION, DEFAULT_SELECT_DESTINATION),

--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.msq.indexing.destination.MSQSelectDestination;
 import org.apache.druid.msq.kernel.WorkerAssignmentStrategy;
 import org.apache.druid.query.BadQueryContextException;
 import org.apache.druid.query.QueryContext;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.column.StringEncodingStrategy;
 import org.hamcrest.CoreMatchers;
@@ -323,6 +324,22 @@ public class MultiStageQueryContextTest
     Assert.assertEquals(
         TaskLockType.APPEND,
         MultiStageQueryContext.validateAndGetTaskLockType(context, false)
+    );
+  }
+
+  @Test
+  public void testDartSelectDestination()
+  {
+    final QueryContext context = QueryContext.of(
+        ImmutableMap.of(
+            QueryContexts.CTX_DART_QUERY_ID, "test",
+            MultiStageQueryContext.CTX_SELECT_DESTINATION, "durablestorage"
+        )
+    );
+
+    Assert.assertEquals(
+        MSQSelectDestination.TASKREPORT,
+        MultiStageQueryContext.getSelectDestination(context)
     );
   }
 


### PR DESCRIPTION
Druid currently does not support values of the `selectDestination` other than `taskReport` for Dart. This can cause queries to start failing with cryptic exceptions.

This PR adds a validation when choosing the select destination, to use task report for Dart queries.

I considered having the context be responsible for deciding and returning the destination instead, but kept it in the query context since it:
1. Adds more calls to the context
2. This `getSelectDestination()` method could be called from other places in the future, which causes it to skip this check.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
