### PR TITLE
Suppress stack trace for failing K8s tasks due to pod creation

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunner.java
@@ -224,6 +224,7 @@ public class KubernetesTaskRunner implements TaskLogStreamer, TaskRunner
       return taskStatus;
     }
     catch (KubernetesResourceNotFoundException e) {
+      // The stack trace of this error is less informative than the message, in surfacing the root cause of the problem.
       log.error("Task[%s] failed because %s", task.getId(), e.getMessage());
       throw DruidException.forPersona(DruidException.Persona.OPERATOR)
                           .ofCategory(DruidException.Category.NOT_FOUND)

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
@@ -321,9 +321,7 @@ public class KubernetesPeonClient
       );
     }
     catch (KubernetesResourceNotFoundException e) {
-      throw DruidException.forPersona(DruidException.Persona.OPERATOR)
-                          .ofCategory(DruidException.Category.NOT_FOUND)
-                          .build(e, e.getMessage());
+      throw e;
     }
     catch (Exception e) {
       throw DruidException.defensive(e, "Error when looking for K8s pod with label[job-name=%s]", jobName);

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesResourceNotFoundException.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesResourceNotFoundException.java
@@ -23,11 +23,6 @@ import org.apache.druid.java.util.common.StringUtils;
 
 public class KubernetesResourceNotFoundException extends RuntimeException
 {
-  public KubernetesResourceNotFoundException(String message)
-  {
-    super(message);
-  }
-
   public KubernetesResourceNotFoundException(String formatText, Object... arguments)
   {
     super(StringUtils.nonStrictFormat(formatText, arguments));

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
@@ -593,8 +593,8 @@ public class KubernetesPeonClientTest
   void test_getPeonPodWithRetries_withoutPod_raisesKubernetesResourceNotFoundException()
   {
     String k8sJobName = new K8sTaskId(TASK_NAME_PREFIX, ID).getK8sJobName();
-    DruidException e = Assertions.assertThrows(
-        DruidException.class,
+    KubernetesResourceNotFoundException e = Assertions.assertThrows(
+        KubernetesResourceNotFoundException.class,
         () -> instance.getPeonPodWithRetries(clientApi.getClient(), k8sJobName, 1, 1)
     );
 
@@ -630,9 +630,9 @@ public class KubernetesPeonClientTest
           // Test will fail if task is retried more than once.
           .once();
 
-    // Task declared to retry for 3 times should only try once when blacklisted event message is found.
-    DruidException e = Assertions.assertThrows(
-        DruidException.class,
+    // Task declared to retry for 3 times should only try once when a blacklisted event message is found.
+    KubernetesResourceNotFoundException e = Assertions.assertThrows(
+        KubernetesResourceNotFoundException.class,
         () -> instance.getPeonPodWithRetries(clientApi.getClient(), k8sJobName, 0, 3)
     );
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
@@ -31,7 +31,6 @@ import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
-import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Failures due to Kubernetes pod creation will print a stack trace. However, the error message is more informative than the stack trace, so I am trying to do away with the stack trace now.

```
2025-06-02T06:53:02,910 ERROR [k8s-task-runner-0] org.apache.druid.k8s.overlord.KubernetesTaskRunner - Task [index_parallel_wikipedia_heckhoam_2025-06-02T06:53:02.588Z] execution caught an exception
org.apache.druid.k8s.overlord.common.KubernetesResourceNotFoundException: Job[indexparallelwikipediaheckhoam-191cf565e92f7fa565fb63885bf4d3fd] failed to start up pods. Reason: [FailedCreate], Message: [Error creating: pods "indexparallelwikipediaheckhoam-191cf565e92f7fa565fb638--1-plg69" is forbidden: memory max limit to request ratio per Container is 1, but provided ratio is 1.333333]
	at org.apache.druid.k8s.overlord.common.KubernetesPeonClient.lambda$getPeonPodWithRetries$11(KubernetesPeonClient.java:282) ~[?:?]
	at org.apache.druid.java.util.common.RetryUtils.retry(RetryUtils.java:129) ~[druid-processing-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
	at org.apache.druid.java.util.common.RetryUtils.retry(RetryUtils.java:81) ~[druid-processing-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
	at org.apache.druid.java.util.common.RetryUtils.retry(RetryUtils.java:163) ~[druid-processing-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
	at org.apache.druid.k8s.overlord.common.KubernetesPeonClient.getPeonPodWithRetries(KubernetesPeonClient.java:264) ~[?:?]
	at org.apache.druid.k8s.overlord.common.KubernetesPeonClient.lambda$getPeonPodWithRetries$10(KubernetesPeonClient.java:257) ~[?:?]
	at org.apache.druid.k8s.overlord.common.DruidKubernetesClient.executeRequest(DruidKubernetesClient.java:47) ~[?:?]
	at org.apache.druid.k8s.overlord.common.KubernetesPeonClient.getPeonPodWithRetries(KubernetesPeonClient.java:257) ~[?:?]
	at org.apache.druid.k8s.overlord.common.KubernetesPeonClient.lambda$launchPeonJobAndWaitForStart$1(KubernetesPeonClient.java:82) ~[?:?]
	at org.apache.druid.k8s.overlord.common.DruidKubernetesClient.executeRequest(DruidKubernetesClient.java:47) ~[?:?]
	at org.apache.druid.k8s.overlord.common.KubernetesPeonClient.launchPeonJobAndWaitForStart(KubernetesPeonClient.java:77) ~[?:?]
	at org.apache.druid.k8s.overlord.KubernetesPeonLifecycle.run(KubernetesPeonLifecycle.java:134) ~[?:?]
	at org.apache.druid.k8s.overlord.KubernetesTaskRunner.doTask(KubernetesTaskRunner.java:193) ~[?:?]
	at org.apache.druid.k8s.overlord.KubernetesTaskRunner.runTask(KubernetesTaskRunner.java:164) ~[?:?]
	at org.apache.druid.k8s.overlord.KubernetesTaskRunner.lambda$run$0(KubernetesTaskRunner.java:149) ~[?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]

```

#### Release note
Add less-verbose error logs when K8s jobs are unable to create task pods, causing task failure. 

<hr>

##### Key changed/added classes in this PR
 * `KubernetesTaskRunner`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] been tested in a test Druid cluster.
