### PR TITLE
Fix null InvocationTargetException for Lifecycle

### DIFF
--- a/processing/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
+++ b/processing/src/main/java/org/apache/druid/java/util/common/lifecycle/Lifecycle.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.logger.Logger;
 
 import java.io.Closeable;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -443,7 +444,11 @@ public class Lifecycle
         }
         if (doStart) {
           log.info("Starting lifecycle [%s#%s]", o.getClass().getSimpleName(), method.getName());
-          method.invoke(o);
+          try {
+            method.invoke(o);
+          } catch (InvocationTargetException e) {
+            throw new RuntimeException(e.getCause());
+          }
         }
       }
     }


### PR DESCRIPTION
### Description

This PR is part of a move to simplify logging, and better surface root causes to the users. In this case, we are removing the null log from the InvocationTargetException, which is handled by Guice and having those logs aren't that useful, and immediately surface the underlying problem: failure to access HDFS. 

```
2025-02-25T03:27:24,408 ERROR [main] org.apache.druid.cli.CliOverlord - Error when starting up.  Failing.
java.lang.reflect.InvocationTargetException: null
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
    at java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
    at org.apache.druid.java.util.common.lifecycle.Lifecycle$AnnotationBasedHandler.start(Lifecycle.java:446) ~[druid-processing-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
    at org.apache.druid.java.util.common.lifecycle.Lifecycle.start(Lifecycle.java:341) ~[druid-processing-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
    at org.apache.druid.guice.LifecycleModule$2.start(LifecycleModule.java:152) ~[druid-processing-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
    at org.apache.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:136) ~[druid-services-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
    at org.apache.druid.cli.GuiceRunnable.initLifecycle(GuiceRunnable.java:94) ~[druid-services-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
    at org.apache.druid.cli.ServerRunnable.run(ServerRunnable.java:63) ~[druid-services-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
    at org.apache.druid.cli.Main.main(Main.java:112) ~[druid-services-27.0.0-SNAPSHOT.jar:27.0.0-SNAPSHOT]
Caused by: org.apache.druid.java.util.common.ISE: Failed to access hdfs.
    at org.apache.druid.storage.hdfs.HdfsStorageAvailabilityChecker.checkHdfsAvailability(HdfsStorageAvailabilityChecker.java:59) ~[?:?]
    ... 11 more
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `Lifecycle.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] been tested in a test Druid cluster.
