### PR TITLE
Making optional configs mandatory

### DIFF
--- a/docs/development/extensions-core/druid-kerberos.md
+++ b/docs/development/extensions-core/druid-kerberos.md
@@ -48,13 +48,13 @@ druid.auth.authenticator.<authenticatorName>.<authenticatorProperty>
 The configuration examples in the rest of this document will use "kerberos" as the name of the authenticator being configured.
 
 ### Properties
-|Property|Possible Values|Description|Default|required|
-|--------|---------------|-----------|-------|--------|
-|`druid.auth.authenticator.kerberos.serverPrincipal`|`HTTP/_HOST@EXAMPLE.COM`| SPNEGO service principal used by druid processes|empty|Yes|
-|`druid.auth.authenticator.kerberos.serverKeytab`|`/etc/security/keytabs/spnego.service.keytab`|SPNego service keytab used by druid processes|empty|Yes|
-|`druid.auth.authenticator.kerberos.authToLocal`|`RULE:[1:$1@$0](druid@EXAMPLE.COM)s/.*/druid DEFAULT`|It allows you to set a general rule for mapping principal names to local user names. It will be used if there is not an explicit mapping for the principal name that is being translated.|DEFAULT|No|
-|`druid.auth.authenticator.kerberos.cookieSignatureSecret`|`secretString`| Secret used to sign authentication cookies. It is advisable to explicitly set it, if you have multiple druid nodes running on same machine with different ports as the Cookie Specification does not guarantee isolation by port.|Random value|No|
-|`druid.auth.authenticator.kerberos.authorizerName`|Depends on available authorizers|Authorizer that requests should be directed to|Empty|Yes|
+|Property|Possible Values|Description| Default | required |
+|--------|---------------|-----------|---------|----------|
+|`druid.auth.authenticator.kerberos.serverPrincipal`|`HTTP/_HOST@EXAMPLE.COM`| SPNEGO service principal used by druid processes| Empty   | Yes      |
+|`druid.auth.authenticator.kerberos.serverKeytab`|`/etc/security/keytabs/spnego.service.keytab`|SPNego service keytab used by druid processes| Empty   | Yes      |
+|`druid.auth.authenticator.kerberos.authToLocal`|`RULE:[1:$1@$0](druid@EXAMPLE.COM)s/.*/druid DEFAULT`|It allows you to set a general rule for mapping principal names to local user names. It will be used if there is not an explicit mapping for the principal name that is being translated.| DEFAULT | No       |
+|`druid.auth.authenticator.kerberos.cookieSignatureSecret`|`secretString`| Secret used to sign authentication cookies| Empty   | Yes      |
+|`druid.auth.authenticator.kerberos.authorizerName`|Depends on available authorizers|Authorizer that requests should be directed to| Empty   | Yes      |
 
 As a note, it is required that the SPNego principal in use by the druid processes must start with HTTP (This specified by [RFC-4559](https://tools.ietf.org/html/rfc4559)) and must be of the form "HTTP/_HOST@REALM".
 The special string _HOST will be replaced automatically with the value of config `druid.host`

--- a/docs/development/extensions-core/druid-kerberos.md
+++ b/docs/development/extensions-core/druid-kerberos.md
@@ -49,12 +49,12 @@ The configuration examples in the rest of this document will use "kerberos" as t
 
 ### Properties
 |Property|Possible Values|Description| Default | required |
-|--------|---------------|-----------|---------|----------|
-|`druid.auth.authenticator.kerberos.serverPrincipal`|`HTTP/_HOST@EXAMPLE.COM`| SPNEGO service principal used by druid processes| Empty   | Yes      |
-|`druid.auth.authenticator.kerberos.serverKeytab`|`/etc/security/keytabs/spnego.service.keytab`|SPNego service keytab used by druid processes| Empty   | Yes      |
-|`druid.auth.authenticator.kerberos.authToLocal`|`RULE:[1:$1@$0](druid@EXAMPLE.COM)s/.*/druid DEFAULT`|It allows you to set a general rule for mapping principal names to local user names. It will be used if there is not an explicit mapping for the principal name that is being translated.| DEFAULT | No       |
-|`druid.auth.authenticator.kerberos.cookieSignatureSecret`|`secretString`| Secret used to sign authentication cookies| Empty   | Yes      |
-|`druid.auth.authenticator.kerberos.authorizerName`|Depends on available authorizers|Authorizer that requests should be directed to| Empty   | Yes      |
+|--------|---------------|-----------|-----|--|
+|`druid.auth.authenticator.kerberos.serverPrincipal`|`HTTP/_HOST@EXAMPLE.COM`| SPNEGO service principal used by druid processes|Empty|Yes|
+|`druid.auth.authenticator.kerberos.serverKeytab`|`/etc/security/keytabs/spnego.service.keytab`|SPNego service keytab used by druid processes|Empty|Yes|
+|`druid.auth.authenticator.kerberos.authToLocal`|`RULE:[1:$1@$0](druid@EXAMPLE.COM)s/.*/druid DEFAULT`|It allows you to set a general rule for mapping principal names to local user names. It will be used if there is not an explicit mapping for the principal name that is being translated.|DEFAULT|No|
+|`druid.auth.authenticator.kerberos.cookieSignatureSecret`|`secretString`| Secret used to sign authentication cookies|Empty|Yes|
+|`druid.auth.authenticator.kerberos.authorizerName`|Depends on available authorizers|Authorizer that requests should be directed to|Empty|Yes|
 
 As a note, it is required that the SPNego principal in use by the druid processes must start with HTTP (This specified by [RFC-4559](https://tools.ietf.org/html/rfc4559)) and must be of the form "HTTP/_HOST@REALM".
 The special string _HOST will be replaced automatically with the value of config `druid.host`

--- a/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
+++ b/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.security.kerberos;
+
+import org.apache.druid.error.DruidException;
+import org.apache.druid.server.DruidNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class KerberosAuthenticatorTest
+{
+  private static final String TEST_SERVER_PRINCIPAL = "HTTP/localhost@EXAMPLE.COM";
+  private static final String TEST_SERVER_KEYTAB = "/path/to/keytab";
+  private static final String TEST_AUTH_TO_LOCAL = "RULE:[1:$1@$0](.*@EXAMPLE.COM)s/@.*//";
+  private static final String TEST_AUTHORIZER_NAME = "testAuthorizer";
+  private static final String TEST_NAME = "testKerberos";
+  private static final String TEST_COOKIE_SECRET = "test-secret-key";
+
+  private DruidNode createTestNode()
+  {
+    return new DruidNode("test", "localhost", false, 8080, null, true, false);
+  }
+
+
+  @Test
+  public void testConstructorWithNullCookieSignatureSecret()
+  {
+    DruidNode node = createTestNode();
+
+    DruidException exception = Assert.assertThrows(
+        DruidException.class,
+        () -> new KerberosAuthenticator(
+            TEST_SERVER_PRINCIPAL,
+            TEST_SERVER_KEYTAB,
+            TEST_AUTH_TO_LOCAL,
+            null, // null cookie signature secret
+            TEST_AUTHORIZER_NAME,
+            TEST_NAME,
+            node
+        )
+    );
+
+    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assert.assertTrue(
+        "Exception message should mention cookieSignatureSecret",
+        exception.getMessage().contains("cookieSignatureSecret")
+    );
+    Assert.assertTrue(
+        "Exception message should mention 'is not set'",
+        exception.getMessage().contains("is not set")
+    );
+  }
+
+  @Test
+  public void testConstructorWithEmptyCookieSignatureSecret()
+  {
+    DruidNode node = createTestNode();
+
+    DruidException exception = Assert.assertThrows(
+        DruidException.class,
+        () -> new KerberosAuthenticator(
+            TEST_SERVER_PRINCIPAL,
+            TEST_SERVER_KEYTAB,
+            TEST_AUTH_TO_LOCAL,
+            "", // empty cookie signature secret
+            TEST_AUTHORIZER_NAME,
+            TEST_NAME,
+            node
+        )
+    );
+
+    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assert.assertTrue(
+        "Exception message should mention cookieSignatureSecret",
+        exception.getMessage().contains("cookieSignatureSecret")
+    );
+    Assert.assertTrue(
+        "Exception message should mention 'is not set'",
+        exception.getMessage().contains("is not set")
+    );
+  }
+}


### PR DESCRIPTION
Fixing a busted cluster setup while running multiple brokers causes the cluster to be unusable. Adjusting to make some optional configs mandatory. 