### PR TITLE
Get reports file from file writer

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriter.java
@@ -75,6 +75,12 @@ public class MultipleFileTaskReportFileWriter implements TaskReportFileWriter
     this.objectMapper = objectMapper;
   }
 
+  @Override
+  public File getReportsFile(String taskId)
+  {
+    return taskReportFiles.get(taskId);
+  }
+
   public void add(String taskId, File reportsFile)
   {
     taskReportFiles.put(taskId, reportsFile);

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -153,7 +153,7 @@ public abstract class AbstractTask implements Task
       FileUtils.mkdirp(taskDir);
       File attemptDir = Paths.get(taskDir.getAbsolutePath(), "attempt", toolbox.getAttemptId()).toFile();
       FileUtils.mkdirp(attemptDir);
-      reportsFile = new File(attemptDir, "report.json");
+      reportsFile = toolbox.getTaskReportFileWriter().getReportsFile(getId());
       statusFile = new File(attemptDir, "status.json");
       InetAddress hostName = InetAddress.getLocalHost();
       DruidNode node = toolbox.getTaskExecutorNode();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/KillTaskToolbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/KillTaskToolbox.java
@@ -33,6 +33,7 @@ import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.OutputStream;
 
@@ -84,6 +85,7 @@ public class KillTaskToolbox
     }
 
     @Override
+    @Nullable
     public File getReportsFile(String taskId)
     {
       return null;

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/KillTaskToolbox.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/duty/KillTaskToolbox.java
@@ -33,6 +33,7 @@ import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 
+import java.io.File;
 import java.io.OutputStream;
 
 /**
@@ -80,6 +81,12 @@ public class KillTaskToolbox
     public void setObjectMapper(ObjectMapper objectMapper)
     {
       // Do nothing
+    }
+
+    @Override
+    public File getReportsFile(String taskId)
+    {
+      return null;
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriterTest.java
@@ -60,5 +60,7 @@ public class MultipleFileTaskReportFileWriterTest
         reportsMap,
         mapper.readValue(Files.readAllBytes(file.toPath()), new TypeReference<Map<String, TaskReport>>() {})
     );
+
+    Assert.assertEquals(file.getAbsolutePath(), writer.getReportsFile(TASK_ID).getAbsolutePath());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriterTest.java
@@ -57,5 +57,7 @@ public class SingleFileTaskReportFileWriterTest
         reportsMap,
         mapper.readValue(Files.readAllBytes(file.toPath()), new TypeReference<Map<String, TaskReport>>() {})
     );
+
+    Assert.assertEquals(file.getAbsolutePath(), writer.getReportsFile(TASK_ID).getAbsolutePath());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common.task;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.report.SingleFileTaskReportFileWriter;
 import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
@@ -88,6 +89,7 @@ public class AbstractTaskTest
     TaskActionClient taskActionClient = mock(TaskActionClient.class);
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
     when(toolbox.getTaskActionClient()).thenReturn(taskActionClient);
+    when(toolbox.getTaskReportFileWriter()).thenReturn(new SingleFileTaskReportFileWriter(temporaryFolder.newFile()));
 
 
     AbstractTask task = new NoopTask("myID", null, null, 1, 0, null)
@@ -181,6 +183,7 @@ public class AbstractTaskTest
     TaskActionClient taskActionClient = mock(TaskActionClient.class);
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
     when(toolbox.getTaskActionClient()).thenReturn(taskActionClient);
+    when(toolbox.getTaskReportFileWriter()).thenReturn(new SingleFileTaskReportFileWriter(temporaryFolder.newFile()));
 
     TaskStatus taskStatus = TaskStatus.failure("myId", "failed");
     AbstractTask task = new NoopTask("myID", null, null, 1, 0, null)
@@ -201,6 +204,7 @@ public class AbstractTaskTest
   {
     TaskToolbox toolbox = mock(TaskToolbox.class);
     when(toolbox.getAttemptId()).thenReturn("1");
+    when(toolbox.getTaskReportFileWriter()).thenReturn(new SingleFileTaskReportFileWriter(temporaryFolder.newFile()));
 
     DruidNode node = new DruidNode("foo", "foo", false, 1, 2, true, true);
     when(toolbox.getTaskExecutorNode()).thenReturn(node);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTestTaskReportFileWriter.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTestTaskReportFileWriter.java
@@ -24,6 +24,7 @@ import org.apache.druid.indexer.report.TaskReport;
 import org.apache.druid.indexer.report.TaskReportFileWriter;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.OutputStream;
 
 public class NoopTestTaskReportFileWriter implements TaskReportFileWriter
@@ -44,5 +45,11 @@ public class NoopTestTaskReportFileWriter implements TaskReportFileWriter
   public void setObjectMapper(ObjectMapper objectMapper)
   {
 
+  }
+
+  @Override
+  public File getReportsFile(String taskId)
+  {
+    return null;
   }
 }

--- a/processing/src/main/java/org/apache/druid/indexer/report/SingleFileTaskReportFileWriter.java
+++ b/processing/src/main/java/org/apache/druid/indexer/report/SingleFileTaskReportFileWriter.java
@@ -68,6 +68,12 @@ public class SingleFileTaskReportFileWriter implements TaskReportFileWriter
     this.objectMapper = objectMapper;
   }
 
+  @Override
+  public File getReportsFile(String taskId)
+  {
+    return reportsFile;
+  }
+
   public static void writeReportToStream(
       final ObjectMapper objectMapper,
       final OutputStream outputStream,

--- a/processing/src/main/java/org/apache/druid/indexer/report/TaskReportFileWriter.java
+++ b/processing/src/main/java/org/apache/druid/indexer/report/TaskReportFileWriter.java
@@ -21,6 +21,8 @@ package org.apache.druid.indexer.report;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import javax.annotation.Nullable;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -31,4 +33,7 @@ public interface TaskReportFileWriter
   OutputStream openReportOutputStream(String taskId) throws IOException;
 
   void setObjectMapper(ObjectMapper objectMapper);
+
+  @Nullable
+  File getReportsFile(String taskId);
 }

--- a/processing/src/main/java/org/apache/druid/indexer/report/TaskReportFileWriter.java
+++ b/processing/src/main/java/org/apache/druid/indexer/report/TaskReportFileWriter.java
@@ -34,6 +34,9 @@ public interface TaskReportFileWriter
 
   void setObjectMapper(ObjectMapper objectMapper);
 
+  /**
+   * Returns the reports file for the given taskId. Returns null if writer does not write reports to any file.
+   */
   @Nullable
   File getReportsFile(String taskId);
 }


### PR DESCRIPTION
Switch to using the reports file from the reports writer when pushing the reports. This fixes a bug where the AbstractTask could be unable to find the report.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
