### PR TITLE
fix bug causing wrong dimension merger order leading to exceptions or wrong data being used for a projection

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapAggregateProjection.java
+++ b/processing/src/main/java/org/apache/druid/segment/incremental/OnHeapAggregateProjection.java
@@ -52,7 +52,6 @@ import org.apache.druid.segment.column.ValueType;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +102,7 @@ public class OnHeapAggregateProjection implements IncrementalIndexRowSelector
     // always have its time-like column in the grouping columns list, so its position in this array specifies -1
     this.parentDimensionIndex = new int[projectionSpec.getGroupingColumns().size()];
     Arrays.fill(parentDimensionIndex, -1);
-    this.dimensionsMap = new HashMap<>();
+    this.dimensionsMap = new LinkedHashMap<>();
     this.columnFormats = new LinkedHashMap<>();
 
     initializeAndValidateDimensions(projectionSpec, getBaseTableDimensionDesc);

--- a/processing/src/main/java/org/apache/druid/segment/projections/Projections.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/Projections.java
@@ -126,10 +126,6 @@ public class Projections
       return null;
     }
 
-    matchBuilder = matchFilter(projection, queryCursorBuildSpec, physicalColumnChecker, matchBuilder);
-    if (matchBuilder == null) {
-      return null;
-    }
 
     matchBuilder = matchGrouping(projection, queryCursorBuildSpec, physicalColumnChecker, matchBuilder);
     if (matchBuilder == null) {
@@ -137,6 +133,11 @@ public class Projections
     }
 
     matchBuilder = matchAggregators(projection, queryCursorBuildSpec, matchBuilder);
+    if (matchBuilder == null) {
+      return null;
+    }
+
+    matchBuilder = matchFilter(projection, queryCursorBuildSpec, physicalColumnChecker, matchBuilder);
     if (matchBuilder == null) {
       return null;
     }

--- a/processing/src/main/java/org/apache/druid/segment/projections/Projections.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/Projections.java
@@ -20,6 +20,7 @@
 package org.apache.druid.segment.projections;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.druid.data.input.impl.AggregateProjectionSpec;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -183,6 +184,7 @@ public class Projections
     if (projection.getFilter() != null) {
       final Filter queryFilter = queryCursorBuildSpec.getFilter();
       if (queryFilter != null) {
+        final Set<String> originalRequired = queryFilter.getRequiredColumns();
         // try to rewrite the query filter into a projection filter, if the rewrite is valid, we can proceed
         final Filter projectionFilter = projection.getFilter().toOptimizedFilter(false);
         final Map<String, String> filterRewrites = new HashMap<>();
@@ -204,9 +206,11 @@ public class Projections
         if (rewritten == ProjectionFilterMatch.INSTANCE) {
           // we can remove the whole thing since the query filter exactly matches the projection filter
           matchBuilder.rewriteFilter(null);
+          matchBuilder.addMatchedQueryColumns(originalRequired);
         } else {
           // otherwise, we partially rewrote the query filter to eliminate the projection filter since it is baked in
           matchBuilder.rewriteFilter(rewritten);
+          matchBuilder.addMatchedQueryColumns(Sets.difference(originalRequired, rewritten.getRequiredColumns()));
         }
       } else {
         // projection has a filter, but the query doesn't, no good


### PR DESCRIPTION
### Description
Fixes accidental use of `HashMap` instead of `LinkedHashMap` causing projection column merger order to be unstable during segment merging. The added test would fail prior to this change (well really the projection added to the base set of projections would cause the test file to fail to initialize all the data since it could no longer persist the segment)