### PR TITLE
Add `SqlResourceQueryResultPusherFactory` and `SqlResourceQueryResultPusher` class

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResourceQueryResultPusher.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResourceQueryResultPusher.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.common.exception.SanitizableException;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.QueryLifecycle;
+import org.apache.druid.server.QueryResponse;
+import org.apache.druid.server.QueryResultPusher;
+import org.apache.druid.server.ResponseContextConfig;
+import org.apache.druid.server.initialization.ServerConfig;
+import org.apache.druid.sql.DirectStatement;
+import org.apache.druid.sql.HttpStatement;
+import org.apache.druid.sql.SqlRowTransformer;
+
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+class SqlResourceQueryResultPusher extends QueryResultPusher
+{
+
+  private static final Logger log = new Logger(SqlResourceQueryResultPusher.class);
+
+  private final ObjectMapper jsonMapper;
+  private final String sqlQueryId;
+  private final HttpStatement stmt;
+  private final SqlQuery sqlQuery;
+  private final ServerConfig serverConfig;
+
+  public SqlResourceQueryResultPusher(
+      final ObjectMapper jsonMapper,
+      final ResponseContextConfig responseContextConfig,
+      final DruidNode selfNode,
+      final ServerConfig serverConfig,
+      final HttpServletRequest req,
+      final HttpStatement stmt,
+      final SqlQuery sqlQuery,
+      final Map<String, String> headers
+  )
+  {
+    super(
+        req,
+        jsonMapper,
+        responseContextConfig,
+        selfNode,
+        SqlResource.QUERY_METRIC_COUNTER,
+        stmt.sqlQueryId(),
+        MediaType.APPLICATION_JSON_TYPE,
+        headers
+    );
+    this.serverConfig = serverConfig;
+    this.jsonMapper = jsonMapper;
+    this.sqlQueryId = stmt.sqlQueryId();
+    this.stmt = stmt;
+    this.sqlQuery = sqlQuery;
+  }
+
+  @Override
+  public ResultsWriter start()
+  {
+    return new ResultsWriter()
+    {
+      private QueryResponse<Object[]> queryResponse;
+      private DirectStatement.ResultSet thePlan;
+
+      @Override
+      @Nullable
+      public Response.ResponseBuilder start()
+      {
+        thePlan = stmt.plan();
+        queryResponse = thePlan.run();
+        return null;
+      }
+
+      @Override
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      public QueryResponse<Object> getQueryResponse()
+      {
+        return (QueryResponse) queryResponse;
+      }
+
+      @Override
+      public Writer makeWriter(OutputStream out) throws IOException
+      {
+        ResultFormat.Writer writer = sqlQuery.getResultFormat().createFormatter(out, jsonMapper);
+        final SqlRowTransformer rowTransformer = thePlan.createRowTransformer();
+
+        return new Writer()
+        {
+
+          @Override
+          public void writeResponseStart() throws IOException
+          {
+            writer.writeResponseStart();
+
+            if (sqlQuery.includeHeader()) {
+              writer.writeHeader(
+                  rowTransformer.getRowType(),
+                  sqlQuery.includeTypesHeader(),
+                  sqlQuery.includeSqlTypesHeader()
+              );
+            }
+          }
+
+          @Override
+          public void writeRow(Object obj) throws IOException
+          {
+            Object[] row = (Object[]) obj;
+
+            writer.writeRowStart();
+            for (int i = 0; i < rowTransformer.getFieldList().size(); i++) {
+              final Object value = rowTransformer.transform(row, i);
+              writer.writeRowField(rowTransformer.getFieldList().get(i), value);
+            }
+            writer.writeRowEnd();
+          }
+
+          @Override
+          public void writeResponseEnd() throws IOException
+          {
+            writer.writeResponseEnd();
+          }
+
+          @Override
+          public void close() throws IOException
+          {
+            writer.close();
+          }
+        };
+      }
+
+      @Override
+      public void recordSuccess(long numBytes)
+      {
+        stmt.reporter().succeeded(numBytes);
+      }
+
+      @Override
+      public void recordFailure(Exception e)
+      {
+        if (QueryLifecycle.shouldLogStackTrace(e, sqlQuery.queryContext())) {
+          log.warn(e, "Exception while processing sqlQueryId[%s]", sqlQueryId);
+        } else {
+          log.noStackTrace().warn(e, "Exception while processing sqlQueryId[%s]", sqlQueryId);
+        }
+        stmt.reporter().failed(e);
+      }
+
+      @Override
+      public void close()
+      {
+        stmt.close();
+      }
+    };
+  }
+
+  @Override
+  public void writeException(Exception ex, OutputStream out) throws IOException
+  {
+    if (ex instanceof SanitizableException) {
+      ex = serverConfig.getErrorResponseTransformStrategy().transformIfNeeded((SanitizableException) ex);
+    }
+    out.write(jsonMapper.writeValueAsBytes(ex));
+  }
+}

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResourceQueryResultPusherFactory.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResourceQueryResultPusherFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.sql.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.apache.druid.guice.annotations.Self;
+import org.apache.druid.server.DruidNode;
+import org.apache.druid.server.ResponseContextConfig;
+import org.apache.druid.server.initialization.ServerConfig;
+import org.apache.druid.sql.HttpStatement;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class SqlResourceQueryResultPusherFactory
+{
+  private final ObjectMapper jsonMapper;
+  private final ServerConfig serverConfig;
+  private final ResponseContextConfig responseContextConfig;
+  private final DruidNode selfNode;
+
+  @Inject
+  public SqlResourceQueryResultPusherFactory(
+      ObjectMapper jsonMapper,
+      ServerConfig serverConfig,
+      ResponseContextConfig responseContextConfig,
+      @Self DruidNode selfNode
+  )
+  {
+    this.jsonMapper = jsonMapper;
+    this.serverConfig = serverConfig;
+    this.responseContextConfig = responseContextConfig;
+    this.selfNode = selfNode;
+  }
+
+  public SqlResourceQueryResultPusher factorize(HttpServletRequest req, HttpStatement stmt, SqlQuery sqlQuery)
+  {
+    Map<String, String> headers = new LinkedHashMap<>();
+
+    final String sqlQueryId = stmt.sqlQueryId();
+    headers.put(SqlResource.SQL_QUERY_ID_RESPONSE_HEADER, sqlQueryId);
+
+    if (sqlQuery.includeHeader()) {
+      headers.put(SqlResource.SQL_HEADER_RESPONSE_HEADER, SqlResource.SQL_HEADER_VALUE);
+    }
+
+    return new SqlResourceQueryResultPusher(
+        jsonMapper,
+        responseContextConfig,
+        selfNode,
+        serverConfig,
+        req,
+        stmt,
+        sqlQuery,
+        headers
+    );
+  }
+}


### PR DESCRIPTION
 

### Description
Add `SqlResourceQueryResultPusherFactory` and `SqlResourceQueryResultPusher` class
 

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
