### PR TITLE
Migrate Protobuf extension tests to JUnit 5

### DIFF
--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -203,11 +203,6 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>nl.jqno.equalsverifier</groupId>
-      <artifactId>equalsverifier</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -167,8 +167,23 @@
 
     <!-- test -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -179,6 +194,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/protobuf-extensions/pom.xml
+++ b/extensions-core/protobuf-extensions/pom.xml
@@ -197,12 +197,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <version>${mockito.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
@@ -22,14 +22,12 @@ package org.apache.druid.data.input.protobuf;
 import com.google.protobuf.Descriptors;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FileBasedProtobufBytesDecoderTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testShortMessageType()
@@ -49,22 +47,20 @@ public class FileBasedProtobufBytesDecoderTest
     decoder.initDescriptor();
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testBadProto()
   {
     //configure parser with desc file
-    @SuppressWarnings("unused") // expected exception
     FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "BadName");
-    decoder.initDescriptor();
+    assertThrows(ParseException.class, decoder::initDescriptor);
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testMalformedDescriptorUrl()
   {
     //configure parser with non existent desc file
-    @SuppressWarnings("unused") // expected exception
     FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("file:/nonexist.desc", "BadName");
-    decoder.initDescriptor();
+    assertThrows(ParseException.class, decoder::initDescriptor);
   }
 
   @Test

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
@@ -19,39 +19,47 @@
 
 package org.apache.druid.data.input.protobuf;
 
-import com.google.protobuf.Descriptors;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class FileBasedProtobufBytesDecoderTest
 {
-
+  /**
+   * Configure parser with desc file, and specify which file name to use.
+   */
   @Test
   public void testShortMessageType()
   {
-    //configure parser with desc file, and specify which file name to use
-    @SuppressWarnings("unused") // expected to create parser without exception
-    FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent");
-    decoder.initDescriptor();
+    final var decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent");
+
+    assertDoesNotThrow(decoder::initDescriptor);
   }
 
+  /**
+   * Configure parser with desc file, and specify which file name to use
+   */
   @Test
   public void testLongMessageType()
   {
-    //configure parser with desc file, and specify which file name to use
-    @SuppressWarnings("unused") // expected to create parser without exception
-    FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "prototest.ProtoTestEvent");
-    decoder.initDescriptor();
+    final var decoder = new FileBasedProtobufBytesDecoder(
+        "prototest.desc",
+        "prototest.ProtoTestEvent"
+    );
+
+    assertDoesNotThrow(decoder::initDescriptor);
   }
 
   @Test
   public void testBadProto()
   {
     assertThrows(
-        ParseException.class, () -> {
+        ParseException.class,
+        () -> {
           // configure parser with desc file
           final var decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "BadName");
           decoder.initDescriptor();
@@ -63,7 +71,8 @@ public class FileBasedProtobufBytesDecoderTest
   public void testMalformedDescriptorUrl()
   {
     assertThrows(
-        ParseException.class, () -> {
+        ParseException.class,
+        () -> {
           // configure parser with non existent desc file
           final var decoder = new FileBasedProtobufBytesDecoder("file:/nonexist.desc", "BadName");
           decoder.initDescriptor();
@@ -71,30 +80,50 @@ public class FileBasedProtobufBytesDecoderTest
     );
   }
 
+  /**
+   * For the backward compatibility, protoMessageType allows null when the desc file has only one message type.
+   */
   @Test
   public void testSingleDescriptorNoMessageType()
   {
-    // For the backward compatibility, protoMessageType allows null when the desc file has only one message type.
-    @SuppressWarnings("unused") // expected to create parser without exception
-    FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", null);
-    decoder.initDescriptor();
+    final var decoder = new FileBasedProtobufBytesDecoder("prototest.desc", null);
+
+    assertDoesNotThrow(decoder::initDescriptor);
   }
 
   @Test
   public void testEquals()
   {
-    FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent");
-    decoder.initDescriptor();
-    Descriptors.Descriptor descriptorA = decoder.getDescriptor();
+    // Test basic equality
+    final var decoder1 = new FileBasedProtobufBytesDecoder(
+        "prototest.desc",
+        "ProtoTestEvent"
+    );
+    final var decoder2 = new FileBasedProtobufBytesDecoder(
+        "prototest.desc",
+        "ProtoTestEvent"
+    );
+    final var decoder3 = new FileBasedProtobufBytesDecoder(
+        "prototest.desc",
+        "ProtoTestEvent.Foo"
+    );
+    final var decoder4 = new FileBasedProtobufBytesDecoder(
+        "prototest.desc",
+        null
+    );
 
-    decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "ProtoTestEvent.Foo");
-    decoder.initDescriptor();
-    Descriptors.Descriptor descriptorB = decoder.getDescriptor();
+    // Symmetry: x.equals(y) == y.equals(x)
+    assertEquals(decoder1, decoder2);
+    assertEquals(decoder2, decoder1);
 
-    EqualsVerifier.forClass(FileBasedProtobufBytesDecoder.class)
-                  .usingGetClass()
-                  .withIgnoredFields("descriptor")
-                  .withPrefabValues(Descriptors.Descriptor.class, descriptorA, descriptorB)
-                  .verify();
+    // Inequality tests
+    assertNotEquals(decoder1, decoder3); // different protoMessageType (short vs long form)
+    assertNotEquals(decoder1, decoder4); // different protoMessageType (non-null vs null)
+    assertNotEquals(null, decoder1);
+
+    // HashCode consistency
+    assertEquals(decoder1.hashCode(), decoder2.hashCode());
+    assertNotEquals(decoder1.hashCode(), decoder3.hashCode());
+    assertNotEquals(decoder1.hashCode(), decoder4.hashCode());
   }
 }

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/FileBasedProtobufBytesDecoderTest.java
@@ -50,17 +50,25 @@ public class FileBasedProtobufBytesDecoderTest
   @Test
   public void testBadProto()
   {
-    //configure parser with desc file
-    FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "BadName");
-    assertThrows(ParseException.class, decoder::initDescriptor);
+    assertThrows(
+        ParseException.class, () -> {
+          // configure parser with desc file
+          final var decoder = new FileBasedProtobufBytesDecoder("prototest.desc", "BadName");
+          decoder.initDescriptor();
+        }
+    );
   }
 
   @Test
   public void testMalformedDescriptorUrl()
   {
-    //configure parser with non existent desc file
-    FileBasedProtobufBytesDecoder decoder = new FileBasedProtobufBytesDecoder("file:/nonexist.desc", "BadName");
-    assertThrows(ParseException.class, decoder::initDescriptor);
+    assertThrows(
+        ParseException.class, () -> {
+          // configure parser with non existent desc file
+          final var decoder = new FileBasedProtobufBytesDecoder("file:/nonexist.desc", "BadName");
+          decoder.initDescriptor();
+        }
+    );
   }
 
   @Test

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
@@ -25,16 +25,18 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InlineDescriptorProtobufBytesDecoderTest
 {
   private String descString;
 
-  @Before
+  @BeforeEach
   public void initDescriptorString() throws Exception
   {
     File descFile = new File(this.getClass()
@@ -66,31 +68,28 @@ public class InlineDescriptorProtobufBytesDecoderTest
     decoder.initDescriptor();
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testBadProto()
   {
-    @SuppressWarnings("unused") // expected exception
     InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "BadName");
-    decoder.initDescriptor();
+    assertThrows(ParseException.class, decoder::initDescriptor);
   }
 
-  @Test(expected = IAE.class)
+  @Test
   public void testMalformedDescriptorBase64()
   {
-    @SuppressWarnings("unused") // expected exception
     InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder("invalidString", "BadName");
-    decoder.initDescriptor();
+    assertThrows(IAE.class, decoder::initDescriptor);
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testMalformedDescriptorValidBase64InvalidDescriptor()
   {
-    @SuppressWarnings("unused") // expected exception
     InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(
         "aGVsbG8gd29ybGQ=",
         "BadName"
     );
-    decoder.initDescriptor();
+    assertThrows(ParseException.class, decoder::initDescriptor);
   }
 
   @Test

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/InlineDescriptorProtobufBytesDecoderTest.java
@@ -71,25 +71,38 @@ public class InlineDescriptorProtobufBytesDecoderTest
   @Test
   public void testBadProto()
   {
-    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(descString, "BadName");
-    assertThrows(ParseException.class, decoder::initDescriptor);
+    assertThrows(
+        ParseException.class, () -> {
+          final var decoder = new InlineDescriptorProtobufBytesDecoder(descString, "BadName");
+          decoder.initDescriptor();
+        }
+    );
   }
 
   @Test
   public void testMalformedDescriptorBase64()
   {
-    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder("invalidString", "BadName");
-    assertThrows(IAE.class, decoder::initDescriptor);
+    assertThrows(
+        IAE.class, () -> {
+          final var decoder = new InlineDescriptorProtobufBytesDecoder("invalidString", "BadName");
+          decoder.initDescriptor();
+        }
+    );
   }
 
   @Test
   public void testMalformedDescriptorValidBase64InvalidDescriptor()
   {
-    InlineDescriptorProtobufBytesDecoder decoder = new InlineDescriptorProtobufBytesDecoder(
-        "aGVsbG8gd29ybGQ=",
-        "BadName"
+    assertThrows(
+        ParseException.class, () -> {
+          final var decoder = new InlineDescriptorProtobufBytesDecoder(
+              "aGVsbG8gd29ybGQ=",
+              "BadName"
+          );
+
+          decoder.initDescriptor();
+        }
     );
-    assertThrows(ParseException.class, decoder::initDescriptor);
   }
 
   @Test

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -48,7 +48,6 @@ import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.transform.TransformingInputEntityReader;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -56,6 +55,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ProtobufInputFormatTest
 {
@@ -117,7 +119,7 @@ public class ProtobufInputFormatTest
         NestedInputFormat.class
     );
 
-    Assertions.assertEquals(inputFormat, inputFormat2);
+    assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -131,7 +133,7 @@ public class ProtobufInputFormatTest
         jsonMapper.writeValueAsString(inputFormat),
         NestedInputFormat.class
     );
-    Assertions.assertEquals(inputFormat, inputFormat2);
+    assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -152,7 +154,7 @@ public class ProtobufInputFormatTest
         null
     ).read().next();
 
-    Assertions.assertEquals(
+    assertEquals(
         ImmutableList.builder()
                      .add("event")
                      .add("id")
@@ -194,7 +196,7 @@ public class ProtobufInputFormatTest
         null
     ).read().next();
 
-    Assertions.assertEquals(
+    assertEquals(
         ImmutableList.builder()
                      .add("event")
                      .add("id")
@@ -226,7 +228,7 @@ public class ProtobufInputFormatTest
         null
     ).read().next();
 
-    Assertions.assertEquals(
+    assertEquals(
         ImmutableSet.builder()
                      .add("eventType")
                      .add("foobar")
@@ -296,7 +298,7 @@ public class ProtobufInputFormatTest
 
     InputRow row = transformingReader.read().next();
 
-    Assertions.assertEquals(
+    assertEquals(
         ImmutableList.builder()
                      .add("event")
                      .add("id")
@@ -310,12 +312,12 @@ public class ProtobufInputFormatTest
         row.getDimensions()
     );
 
-    Assertions.assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
-    Assertions.assertEquals(
+    assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
+    assertEquals(
         ImmutableList.of(ImmutableMap.of("bar", "bar0"), ImmutableMap.of("bar", "bar1")),
         row.getRaw("bar")
     );
-    Assertions.assertArrayEquals(
+    assertArrayEquals(
         new byte[]{0x01, 0x02, 0x03, 0x04},
         (byte[]) row.getRaw("someBytesColumn")
     );
@@ -363,7 +365,7 @@ public class ProtobufInputFormatTest
 
     InputRow row = transformingReader.read().next();
 
-    Assertions.assertEquals(
+    assertEquals(
         ImmutableSet.of(
             "someOtherId",
             "someIntColumn",
@@ -380,12 +382,12 @@ public class ProtobufInputFormatTest
         new HashSet<>(row.getDimensions())
     );
 
-    Assertions.assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
-    Assertions.assertEquals(
+    assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
+    assertEquals(
         ImmutableList.of(ImmutableMap.of("bar", "bar0"), ImmutableMap.of("bar", "bar1")),
         row.getRaw("bar")
     );
-    Assertions.assertArrayEquals(
+    assertArrayEquals(
         new byte[]{0x01, 0x02, 0x03, 0x04},
         (byte[]) row.getRaw("someBytesColumn")
     );

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputFormatTest.java
@@ -48,11 +48,9 @@ import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.transform.TransformingInputEntityReader;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -61,8 +59,6 @@ import java.util.HashSet;
 
 public class ProtobufInputFormatTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private TimestampSpec timestampSpec;
   private DimensionsSpec dimensionsSpec;
@@ -72,7 +68,7 @@ public class ProtobufInputFormatTest
 
   private final ObjectMapper jsonMapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     ExpressionProcessing.initializeForTests();
@@ -121,7 +117,7 @@ public class ProtobufInputFormatTest
         NestedInputFormat.class
     );
 
-    Assert.assertEquals(inputFormat, inputFormat2);
+    Assertions.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -135,7 +131,7 @@ public class ProtobufInputFormatTest
         jsonMapper.writeValueAsString(inputFormat),
         NestedInputFormat.class
     );
-    Assert.assertEquals(inputFormat, inputFormat2);
+    Assertions.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -156,7 +152,7 @@ public class ProtobufInputFormatTest
         null
     ).read().next();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.builder()
                      .add("event")
                      .add("id")
@@ -198,7 +194,7 @@ public class ProtobufInputFormatTest
         null
     ).read().next();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.builder()
                      .add("event")
                      .add("id")
@@ -230,7 +226,7 @@ public class ProtobufInputFormatTest
         null
     ).read().next();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.builder()
                      .add("eventType")
                      .add("foobar")
@@ -300,7 +296,7 @@ public class ProtobufInputFormatTest
 
     InputRow row = transformingReader.read().next();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.builder()
                      .add("event")
                      .add("id")
@@ -314,12 +310,12 @@ public class ProtobufInputFormatTest
         row.getDimensions()
     );
 
-    Assert.assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
+    Assertions.assertEquals(
         ImmutableList.of(ImmutableMap.of("bar", "bar0"), ImmutableMap.of("bar", "bar1")),
         row.getRaw("bar")
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new byte[]{0x01, 0x02, 0x03, 0x04},
         (byte[]) row.getRaw("someBytesColumn")
     );
@@ -367,7 +363,7 @@ public class ProtobufInputFormatTest
 
     InputRow row = transformingReader.read().next();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             "someOtherId",
             "someIntColumn",
@@ -384,12 +380,12 @@ public class ProtobufInputFormatTest
         new HashSet<>(row.getDimensions())
     );
 
-    Assert.assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableMap.of("bar", "baz"), row.getRaw("foo"));
+    Assertions.assertEquals(
         ImmutableList.of(ImmutableMap.of("bar", "bar0"), ImmutableMap.of("bar", "bar1")),
         row.getRaw("bar")
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new byte[]{0x01, 0x02, 0x03, 0x04},
         (byte[]) row.getRaw("someBytesColumn")
     );

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParserTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParserTest.java
@@ -37,7 +37,6 @@ import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.js.JavaScriptConfig;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +45,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ProtobufInputRowParserTest
 {
@@ -169,7 +171,7 @@ public class ProtobufInputRowParserTest
     );
     final ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, decoder, null, null);
 
-    Assertions.assertThrows(IllegalStateException.class, () -> {
+    assertThrows(IllegalStateException.class, () -> {
       parser.parseBatch(ByteBuffer.allocate(1)).get(0);
     }, "JavaScript is disabled");
   }
@@ -192,8 +194,8 @@ public class ProtobufInputRowParserTest
   private static void assertDimensionEquals(InputRow row, String dimension, Object expected)
   {
     List<String> values = row.getDimension(dimension);
-    Assertions.assertEquals(1, values.size());
-    Assertions.assertEquals(expected, values.get(0));
+    assertEquals(1, values.size());
+    assertEquals(expected, values.get(0));
   }
 
   static ProtoTestEventWrapper.ProtoTestEvent buildFlatData(DateTime dateTime)
@@ -214,7 +216,7 @@ public class ProtobufInputRowParserTest
 
   static void verifyFlatData(InputRow row, DateTime dateTime, boolean badBytesConversion)
   {
-    Assertions.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+    assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
 
     assertDimensionEquals(row, "id", "4711");
     assertDimensionEquals(row, "isValid", "true");
@@ -228,9 +230,9 @@ public class ProtobufInputRowParserTest
       assertDimensionEquals(row, "someBytesColumn", StringUtils.encodeBase64String(new byte[]{0x01, 0x02, 0x03, 0x04}));
     }
 
-    Assertions.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
-    Assertions.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
-    Assertions.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
+    assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
+    assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
+    assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
   }
 
   static ProtoTestEventWrapper.ProtoTestEvent buildNestedData(DateTime dateTime)
@@ -260,7 +262,7 @@ public class ProtobufInputRowParserTest
 
   static void verifyNestedData(InputRow row, DateTime dateTime)
   {
-    Assertions.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+    assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
 
     assertDimensionEquals(row, "id", "4711");
     assertDimensionEquals(row, "isValid", "true");
@@ -272,9 +274,9 @@ public class ProtobufInputRowParserTest
     assertDimensionEquals(row, "bar0", "bar0");
     assertDimensionEquals(row, "someBytesColumn", StringUtils.encodeBase64String(new byte[]{0x01, 0x02, 0x03, 0x04}));
 
-    Assertions.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
-    Assertions.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
-    Assertions.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
+    assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
+    assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
+    assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
   }
 
   static ProtoTestEventWrapper.ProtoTestEvent buildFlatDataWithComplexTimestamp(DateTime dateTime)

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParserTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufInputRowParserTest.java
@@ -35,31 +35,27 @@ import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.js.JavaScriptConfig;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Objects;
 
 public class ProtobufInputRowParserTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private ParseSpec parseSpec;
   private ParseSpec flatParseSpec;
   private ParseSpec flatParseSpecWithComplexTimestamp;
   private FileBasedProtobufBytesDecoder decoder;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     parseSpec = new JSONParseSpec(
@@ -173,11 +169,9 @@ public class ProtobufInputRowParserTest
     );
     final ProtobufInputRowParser parser = new ProtobufInputRowParser(parseSpec, decoder, null, null);
 
-    expectedException.expect(CoreMatchers.instanceOf(IllegalStateException.class));
-    expectedException.expectMessage("JavaScript is disabled");
-
-    //noinspection ResultOfMethodCallIgnored (this method call will trigger the expected exception)
-    parser.parseBatch(ByteBuffer.allocate(1)).get(0);
+    Assertions.assertThrows(IllegalStateException.class, () -> {
+      parser.parseBatch(ByteBuffer.allocate(1)).get(0);
+    }, "JavaScript is disabled");
   }
 
   @Test
@@ -198,8 +192,8 @@ public class ProtobufInputRowParserTest
   private static void assertDimensionEquals(InputRow row, String dimension, Object expected)
   {
     List<String> values = row.getDimension(dimension);
-    Assert.assertEquals(1, values.size());
-    Assert.assertEquals(expected, values.get(0));
+    Assertions.assertEquals(1, values.size());
+    Assertions.assertEquals(expected, values.get(0));
   }
 
   static ProtoTestEventWrapper.ProtoTestEvent buildFlatData(DateTime dateTime)
@@ -220,7 +214,7 @@ public class ProtobufInputRowParserTest
 
   static void verifyFlatData(InputRow row, DateTime dateTime, boolean badBytesConversion)
   {
-    Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+    Assertions.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
 
     assertDimensionEquals(row, "id", "4711");
     assertDimensionEquals(row, "isValid", "true");
@@ -229,15 +223,14 @@ public class ProtobufInputRowParserTest
     if (badBytesConversion) {
       // legacy flattener used by parser doesn't convert bytes, instead calls tostring
       // this can be removed if we update the parser to use the protobuf flattener used by the input format/reader
-      assertDimensionEquals(row, "someBytesColumn", row.getRaw("someBytesColumn").toString());
+      assertDimensionEquals(row, "someBytesColumn", Objects.requireNonNull(row.getRaw("someBytesColumn")).toString());
     } else {
       assertDimensionEquals(row, "someBytesColumn", StringUtils.encodeBase64String(new byte[]{0x01, 0x02, 0x03, 0x04}));
     }
 
-
-    Assert.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
-    Assert.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
-    Assert.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
+    Assertions.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
+    Assertions.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
+    Assertions.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
   }
 
   static ProtoTestEventWrapper.ProtoTestEvent buildNestedData(DateTime dateTime)
@@ -267,7 +260,7 @@ public class ProtobufInputRowParserTest
 
   static void verifyNestedData(InputRow row, DateTime dateTime)
   {
-    Assert.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
+    Assertions.assertEquals(dateTime.getMillis(), row.getTimestampFromEpoch());
 
     assertDimensionEquals(row, "id", "4711");
     assertDimensionEquals(row, "isValid", "true");
@@ -279,10 +272,9 @@ public class ProtobufInputRowParserTest
     assertDimensionEquals(row, "bar0", "bar0");
     assertDimensionEquals(row, "someBytesColumn", StringUtils.encodeBase64String(new byte[]{0x01, 0x02, 0x03, 0x04}));
 
-
-    Assert.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
-    Assert.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
-    Assert.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
+    Assertions.assertEquals(47.11F, row.getMetric("someFloatColumn").floatValue(), 0.0);
+    Assertions.assertEquals(815.0F, row.getMetric("someIntColumn").floatValue(), 0.0);
+    Assertions.assertEquals(816.0F, row.getMetric("someLongColumn").floatValue(), 0.0);
   }
 
   static ProtoTestEventWrapper.ProtoTestEvent buildFlatDataWithComplexTimestamp(DateTime dateTime)

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufReaderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/ProtobufReaderTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -42,7 +42,7 @@ public class ProtobufReaderTest
   private JSONPathSpec flattenSpec;
   private FileBasedProtobufBytesDecoder decoder;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     TimestampSpec timestampSpec = new TimestampSpec("timestamp", "iso", null);

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
@@ -33,7 +33,6 @@ import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
@@ -45,6 +44,11 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SchemaRegistryBasedProtobufBytesDecoderTest
 {
@@ -67,7 +71,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     // When
     DynamicMessage actual = new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb);
     // Then
-    Assertions.assertEquals(actual.getField(actual.getDescriptorForType().findFieldByName("id")), event.getId());
+    assertEquals(actual.getField(actual.getDescriptorForType().findFieldByName("id")), event.getId());
   }
 
   @Test
@@ -78,7 +82,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 6).put((byte) 0).putInt(1234).put((bytes), 5, 10);
     bb.rewind();
     // When & Then
-    Assertions.assertThrows(ParseException.class, () -> new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb));
+    assertThrows(ParseException.class, () -> new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb));
   }
 
   @Test
@@ -90,7 +94,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 6).put((byte) 0).putInt(1234).put((byte) 0).put(bytes);
     bb.rewind();
     // When & Then
-    Assertions.assertThrows(ParseException.class, () -> new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb));
+    assertThrows(ParseException.class, () -> new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb));
   }
 
   @Test
@@ -99,7 +103,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     // Given
     SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", null, null, null, null, null);
     // When
-    Assertions.assertEquals(Integer.MAX_VALUE, schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity());
+    assertEquals(Integer.MAX_VALUE, schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity());
   }
 
   @Test
@@ -109,7 +113,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     // Given
     SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", capacity, null, null, null, null);
     // When
-    Assertions.assertEquals(capacity, schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity());
+    assertEquals(capacity, schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity());
   }
 
   private ProtoTestEventWrapper.ProtoTestEvent getTestEvent()
@@ -133,7 +137,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         .readValue(json);
 
     // Then
-    Assertions.assertNotEquals(0, decoder.hashCode());
+    assertNotEquals(0, decoder.hashCode());
   }
 
   @Test
@@ -150,7 +154,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         .readValue(json);
 
     // Then
-    Assertions.assertNotEquals(0, decoder.hashCode());
+    assertNotEquals(0, decoder.hashCode());
   }
 
   @Test
@@ -167,7 +171,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         .readValue(json);
 
     // Then
-    Assertions.assertNotEquals(0, decoder.hashCode());
+    assertNotEquals(0, decoder.hashCode());
   }
 
   @Test
@@ -186,10 +190,10 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     Map<String, String> header = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
-    Assertions.assertEquals(3, header.size());
-    Assertions.assertEquals("value.1", header.get("registry.header.prop.1"));
-    Assertions.assertEquals("value.2", header.get("registry.header.prop.2"));
-    Assertions.assertEquals("value.3", header.get("registry.header.prop.3"));
+    assertEquals(3, header.size());
+    assertEquals("value.1", header.get("registry.header.prop.1"));
+    assertEquals("value.2", header.get("registry.header.prop.2"));
+    assertEquals("value.3", header.get("registry.header.prop.3"));
   }
 
   @Test
@@ -208,26 +212,29 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     Map<String, ?> heaeder = DynamicConfigProviderUtils.extraConfigAndSetObjectMap(decoder.getConfig(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
-    Assertions.assertEquals(3, heaeder.size());
-    Assertions.assertEquals("value.1", heaeder.get("registry.config.prop.1"));
-    Assertions.assertEquals("value.2", heaeder.get("registry.config.prop.2"));
-    Assertions.assertEquals("value.3", heaeder.get("registry.config.prop.3"));
+    assertEquals(3, heaeder.size());
+    assertEquals("value.1", heaeder.get("registry.config.prop.1"));
+    assertEquals("value.2", heaeder.get("registry.config.prop.2"));
+    assertEquals("value.3", heaeder.get("registry.config.prop.3"));
   }
 
   private ProtobufSchema parseProtobufSchema() throws IOException
   {
     InputStream fin;
     fin = this.getClass().getClassLoader().getResourceAsStream("ProtoTest.proto");
-    Assertions.assertNotNull(fin);
+    assertNotNull(fin);
     String protobufString = IOUtils.toString(fin, StandardCharsets.UTF_8);
 
     fin = this.getClass().getClassLoader().getResourceAsStream("google/protobuf/timestamp.proto");
-    Assertions.assertNotNull(fin);
+    assertNotNull(fin);
     String timestampProtobufString = IOUtils.toString(fin, StandardCharsets.UTF_8);
 
     return new ProtobufSchema(
-        protobufString, Collections.emptyList(),
-        ImmutableMap.of("google/protobuf/timestamp.proto", timestampProtobufString), null, null
+        protobufString,
+        Collections.emptyList(),
+        ImmutableMap.of("google/protobuf/timestamp.proto", timestampProtobufString),
+        null,
+        null
     );
   }
 }

--- a/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
+++ b/extensions-core/protobuf-extensions/src/test/java/org/apache/druid/data/input/protobuf/SchemaRegistryBasedProtobufBytesDecoderTest.java
@@ -33,9 +33,9 @@ import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -50,7 +50,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
 {
   private SchemaRegistryClient registry;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     registry = Mockito.mock(CachedSchemaRegistryClient.class);
@@ -59,7 +59,6 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
   @Test
   public void testParse() throws Exception
   {
-
     Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234))).thenReturn(parseProtobufSchema());
     ProtoTestEventWrapper.ProtoTestEvent event = getTestEvent();
     byte[] bytes = event.toByteArray();
@@ -68,21 +67,21 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     // When
     DynamicMessage actual = new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb);
     // Then
-    Assert.assertEquals(actual.getField(actual.getDescriptorForType().findFieldByName("id")), event.getId());
+    Assertions.assertEquals(actual.getField(actual.getDescriptorForType().findFieldByName("id")), event.getId());
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testParseCorrupted() throws Exception
   {
     Mockito.when(registry.getSchemaById(ArgumentMatchers.eq(1234))).thenReturn(parseProtobufSchema());
     byte[] bytes = getTestEvent().toByteArray();
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 6).put((byte) 0).putInt(1234).put((bytes), 5, 10);
     bb.rewind();
-    // When
-    new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb);
+    // When & Then
+    Assertions.assertThrows(ParseException.class, () -> new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb));
   }
 
-  @Test(expected = ParseException.class)
+  @Test
   public void testParseWrongId() throws Exception
   {
     // Given
@@ -90,8 +89,8 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     byte[] bytes = getTestEvent().toByteArray();
     ByteBuffer bb = ByteBuffer.allocate(bytes.length + 6).put((byte) 0).putInt(1234).put((byte) 0).put(bytes);
     bb.rewind();
-    // When
-    new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb);
+    // When & Then
+    Assertions.assertThrows(ParseException.class, () -> new SchemaRegistryBasedProtobufBytesDecoder(registry).parse(bb));
   }
 
   @Test
@@ -100,7 +99,7 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     // Given
     SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", null, null, null, null, null);
     // When
-    Assert.assertEquals(schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity(), Integer.MAX_VALUE);
+    Assertions.assertEquals(Integer.MAX_VALUE, schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity());
   }
 
   @Test
@@ -110,14 +109,13 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
     // Given
     SchemaRegistryBasedProtobufBytesDecoder schemaRegistryBasedProtobufBytesDecoder = new SchemaRegistryBasedProtobufBytesDecoder("http://test", capacity, null, null, null, null);
     // When
-    Assert.assertEquals(schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity(), capacity);
+    Assertions.assertEquals(capacity, schemaRegistryBasedProtobufBytesDecoder.getIdentityMapCapacity());
   }
 
   private ProtoTestEventWrapper.ProtoTestEvent getTestEvent()
   {
     DateTime dateTime = new DateTime(2012, 7, 12, 9, 30, ISOChronology.getInstanceUTC());
-    ProtoTestEventWrapper.ProtoTestEvent event = ProtobufInputRowParserTest.buildFlatData(dateTime);
-    return event;
+    return ProtobufInputRowParserTest.buildFlatData(dateTime);
   }
 
 
@@ -130,12 +128,12 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
+    decoder = mapper
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
     // Then
-    Assert.assertNotEquals(decoder.hashCode(), 0);
+    Assertions.assertNotEquals(0, decoder.hashCode());
   }
 
   @Test
@@ -147,12 +145,12 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
+    decoder = mapper
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
     // Then
-    Assert.assertNotEquals(decoder.hashCode(), 0);
+    Assertions.assertNotEquals(0, decoder.hashCode());
   }
 
   @Test
@@ -164,12 +162,12 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
+    decoder = mapper
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
     // Then
-    Assert.assertNotEquals(decoder.hashCode(), 0);
+    Assertions.assertNotEquals(0, decoder.hashCode());
   }
 
   @Test
@@ -181,17 +179,17 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
+    decoder = mapper
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
     Map<String, String> header = DynamicConfigProviderUtils.extraConfigAndSetStringMap(decoder.getHeaders(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
-    Assert.assertEquals(3, header.size());
-    Assert.assertEquals("value.1", header.get("registry.header.prop.1"));
-    Assert.assertEquals("value.2", header.get("registry.header.prop.2"));
-    Assert.assertEquals("value.3", header.get("registry.header.prop.3"));
+    Assertions.assertEquals(3, header.size());
+    Assertions.assertEquals("value.1", header.get("registry.header.prop.1"));
+    Assertions.assertEquals("value.2", header.get("registry.header.prop.2"));
+    Assertions.assertEquals("value.3", header.get("registry.header.prop.3"));
   }
 
   @Test
@@ -203,29 +201,33 @@ public class SchemaRegistryBasedProtobufBytesDecoderTest
         new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper())
     );
     SchemaRegistryBasedProtobufBytesDecoder decoder;
-    decoder = (SchemaRegistryBasedProtobufBytesDecoder) mapper
+    decoder = mapper
         .readerFor(ProtobufBytesDecoder.class)
         .readValue(json);
 
     Map<String, ?> heaeder = DynamicConfigProviderUtils.extraConfigAndSetObjectMap(decoder.getConfig(), SchemaRegistryBasedProtobufBytesDecoder.DRUID_DYNAMIC_CONFIG_PROVIDER_KEY, new DefaultObjectMapper());
 
     // Then
-    Assert.assertEquals(3, heaeder.size());
-    Assert.assertEquals("value.1", heaeder.get("registry.config.prop.1"));
-    Assert.assertEquals("value.2", heaeder.get("registry.config.prop.2"));
-    Assert.assertEquals("value.3", heaeder.get("registry.config.prop.3"));
+    Assertions.assertEquals(3, heaeder.size());
+    Assertions.assertEquals("value.1", heaeder.get("registry.config.prop.1"));
+    Assertions.assertEquals("value.2", heaeder.get("registry.config.prop.2"));
+    Assertions.assertEquals("value.3", heaeder.get("registry.config.prop.3"));
   }
 
   private ProtobufSchema parseProtobufSchema() throws IOException
   {
-    // Given
     InputStream fin;
     fin = this.getClass().getClassLoader().getResourceAsStream("ProtoTest.proto");
+    Assertions.assertNotNull(fin);
     String protobufString = IOUtils.toString(fin, StandardCharsets.UTF_8);
 
     fin = this.getClass().getClassLoader().getResourceAsStream("google/protobuf/timestamp.proto");
+    Assertions.assertNotNull(fin);
     String timestampProtobufString = IOUtils.toString(fin, StandardCharsets.UTF_8);
-    return new ProtobufSchema(protobufString, Collections.emptyList(),
-        ImmutableMap.of("google/protobuf/timestamp.proto", timestampProtobufString), null, null);
+
+    return new ProtobufSchema(
+        protobufString, Collections.emptyList(),
+        ImmutableMap.of("google/protobuf/timestamp.proto", timestampProtobufString), null, null
+    );
   }
 }

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3619,7 +3619,7 @@ name: Protocol Buffers
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: BSD-3-Clause License
-version: 3.25.5
+version: 3.25.8
 copyright: Google, Inc.
 license_file_path: licenses/bin/protobuf-java.BSD3
 libraries:
@@ -4169,7 +4169,7 @@ name: google-protobuf
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: BSD-3-Clause License
-version: 3.25.8
+version: 3.24.4
 libraries:
   - com.google.protobuf: protobuf-java-util
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4169,7 +4169,7 @@ name: google-protobuf
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: BSD-3-Clause License
-version: 3.24.4
+version: 3.25.8
 libraries:
   - com.google.protobuf: protobuf-java-util
 

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -392,14 +392,6 @@
 
    <suppress>
      <notes><![CDATA[
-     file name: protobuf-java-util-3.11.0.jar
-     ]]></notes>
-     <packageUrl regex="true">^pkg:maven/com\.google\.protobuf/protobuf\-java\-util@.*$</packageUrl>
-     <cve>CVE-2022-3171</cve>
-   </suppress>
-
-   <suppress>
-     <notes><![CDATA[
      file name: ansi-regex:5.0.0
      ]]></notes>
      <packageUrl regex="true">^pkg:npm/ansi\-regex@.*$</packageUrl>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <netty3.version>3.10.6.Final</netty3.version>
         <netty4.version>4.1.122.Final</netty4.version>
         <postgresql.version>42.7.2</postgresql.version>
-        <protobuf.version>3.25.5</protobuf.version>
+        <protobuf.version>3.25.8</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>2.0.16</slf4j.version>
         <jna.version>5.13.0</jna.version>


### PR DESCRIPTION
### Description

Similar to work I did previously in #16521, this PR migrates the tests in the protobuf extension to JUnit 5.

In addition, I also bumped the version of protobuf to the latest version (`3.25.5` -> `3.25.8`).

<hr>

This PR has:

- [x] been self-reviewed.
