### PR TITLE
Fix a typo in the compaction dialog when inputSegmentSizeBytes is set

### DIFF
--- a/web-console/src/dialogs/compaction-config-dialog/compaction-config-dialog.tsx
+++ b/web-console/src/dialogs/compaction-config-dialog/compaction-config-dialog.tsx
@@ -84,7 +84,7 @@ export const CompactionConfigDialog = React.memo(function CompactionConfigDialog
       {compactionConfigHasLegacyInputSegmentSizeBytesSet(currentConfig) && (
         <Callout className="legacy-callout" intent={Intent.WARNING}>
           <p>
-            You current config sets the legacy <Code>inputSegmentSizeBytes</Code> to{' '}
+            Your current config sets the legacy <Code>inputSegmentSizeBytes</Code> to{' '}
             <Code>{formatBytesCompact(currentConfig.inputSegmentSizeBytes!)}</Code> it is
             recommended to unset this property.
           </p>


### PR DESCRIPTION
Fix a typo in the compaction config dialog when `inputSegmentSizeBytes` is set.

