### PR TITLE
Cleanup `cron-job-its` action

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -116,8 +116,6 @@ jobs:
   security_vulnerabilities:
     if: github.repository == 'apache/druid'
     name: security vulnerabilities
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout branch

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -130,7 +130,7 @@ jobs:
           distribution: 'zulu'
           cache: maven
 
-      - name: maven build # needed to rebuild incase of maven snapshot resolution fails
+      - name: maven build # needed to rebuild in case of maven snapshot resolution fails
         run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
 
       - name: security vulnerabilities check


### PR DESCRIPTION
### Description

- Address a typo
- Remove the `strategy.fail-fast` directive, which only makes sense when using a `matrix`

<hr>

This PR has:

- [x] been self-reviewed.
