### PR TITLE
Restoring support for parameters in media types for the sql query endpoint

### DIFF
--- a/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/query/ITSqlQueryTest.java
@@ -220,6 +220,17 @@ public class ITSqlQueryTest
           Assert.assertEquals(responseBody, "[{\"EXPR$0\":567}]");
         }
     );
+
+    executeQuery(
+        "application/json; charset=UTF-8",
+        "{\"query\":\"select 567\"}",
+        (request) -> {
+        },
+        (statusCode, responseBody) -> {
+          Assert.assertEquals(statusCode, 200, responseBody);
+          Assert.assertEquals(responseBody, "[{\"EXPR$0\":567}]");
+        }
+    );
   }
 
   @Test

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlQuery.java
@@ -277,26 +277,25 @@ public class SqlQuery
       ISqlQueryExtractor<String> rawQueryExtractor
   ) throws HttpException
   {
+    if (contentType == null) {
+      throw new HttpException(Response.Status.BAD_REQUEST, "Missing Content-Type header");
+    }
     try {
-      if (MediaType.APPLICATION_JSON.equals(contentType)) {
+      final MediaType requestMediaType = MediaType.valueOf(contentType);
+      if (MediaType.APPLICATION_JSON_TYPE.isCompatible(requestMediaType)) {
 
         SqlQuery sqlQuery = jsonQueryExtractor.extract();
         if (sqlQuery == null) {
           throw new HttpException(Response.Status.BAD_REQUEST, "Empty query");
         }
         return sqlQuery;
-
-      } else if (MediaType.TEXT_PLAIN.equals(contentType)) {
-
+      } else if (MediaType.TEXT_PLAIN_TYPE.isCompatible(requestMediaType)) {
         String sql = rawQueryExtractor.extract().trim();
         if (sql.isEmpty()) {
           throw new HttpException(Response.Status.BAD_REQUEST, "Empty query");
         }
-
         return new SqlQuery(sql, null, false, false, false, null, null);
-
-      } else if (MediaType.APPLICATION_FORM_URLENCODED.equals(contentType)) {
-
+      } else if (MediaType.APPLICATION_FORM_URLENCODED_TYPE.isCompatible(requestMediaType)) {
         String sql = rawQueryExtractor.extract().trim();
         if (sql.isEmpty()) {
           throw new HttpException(Response.Status.BAD_REQUEST, "Empty query");
@@ -313,13 +312,12 @@ public class SqlQuery
         }
 
         return new SqlQuery(sql, null, false, false, false, null, null);
-
       } else {
         throw new HttpException(
             Response.Status.UNSUPPORTED_MEDIA_TYPE,
             StringUtils.format(
                 "Unsupported Content-Type: %s. Only application/json, text/plain or application/x-www-form-urlencoded is supported.",
-                contentType
+                requestMediaType.toString()
             )
         );
       }
@@ -342,6 +340,9 @@ public class SqlQuery
     }
     catch (IOException e) {
       throw new HttpException(Response.Status.BAD_REQUEST, "Unable to read query from request: " + e.getMessage());
+    }
+    catch (IllegalArgumentException e) {
+      throw new HttpException(Response.Status.BAD_REQUEST, "Invalid Content-Type header: " + e.getMessage());
     }
   }
 }


### PR DESCRIPTION
The PR: https://github.com/apache/druid/pull/17937 added new functionality to the sql query endpoints.




A bug was introduced with this PR where a sql query request going to the router with content type parameters such as ` Content-Type: application/json; text/plain` will always fail.

```
org.apache.druid.server.initialization.jetty.HttpException: Unsupported Content-Type: application/json; charset=UTF-8. Only application/json, text/plain or application/x-www-form-urlencoded is supported.
```

This patch restores the correct original behavior. 


