### PR TITLE
Start building out more robust fabric8 retries

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
@@ -19,12 +19,7 @@
 
 package org.apache.druid.k8s.overlord.common;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.vertx.core.http.HttpClosedException;
-
 
 public class DruidK8sConstants
 {
@@ -60,10 +55,5 @@ public class DruidK8sConstants
       // Catches exceeded quota error: https://github.com/kubernetes/kubernetes/blob/818b7ae68119c0932d7714502ce58f1b56606c8d/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go#L622
       // exceeded quota: {value}, requested: {value}, used: {value}, limited: {value}
       "exceeded quota:"
-  );
-
-  public static final ImmutableMap<Class<? extends RuntimeException>, Optional<String>> TRANSITIVE_CONNECTION_POOL_EXCEPTIONS = ImmutableMap.of(
-      KubernetesClientException.class, Optional.of("Connection was closed"),
-      HttpClosedException.class, Optional.absent()
   );
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
@@ -19,7 +19,12 @@
 
 package org.apache.druid.k8s.overlord.common;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.vertx.core.http.HttpClosedException;
+
 
 public class DruidK8sConstants
 {
@@ -55,5 +60,10 @@ public class DruidK8sConstants
       // Catches exceeded quota error: https://github.com/kubernetes/kubernetes/blob/818b7ae68119c0932d7714502ce58f1b56606c8d/staging/src/k8s.io/apiserver/pkg/admission/plugin/resourcequota/controller.go#L622
       // exceeded quota: {value}, requested: {value}, used: {value}, limited: {value}
       "exceeded quota:"
+  );
+
+  public static final ImmutableMap<Class<? extends RuntimeException>, Optional<String>> TRANSITIVE_CONNECTION_POOL_EXCEPTIONS = ImmutableMap.of(
+      KubernetesClientException.class, Optional.of("Connection was closed"),
+      HttpClosedException.class, Optional.absent()
   );
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClient.java
@@ -88,29 +88,20 @@ public class KubernetesPeonClient
       String jobName = job.getMetadata().getName();
 
       log.info("Submitting job[%s] for task[%s].", jobName, task.getId());
-      client.batch()
-            .v1()
-            .jobs()
-            .inNamespace(namespace)
-            .resource(job)
-            .create();
+      createK8sJobWithRetries(job);
       log.info("Submitted job[%s] for task[%s]. Waiting for POD to launch.", jobName, task.getId());
 
-      // wait until the pod is running or complete or failed, any of those is fine
+      // Wait for the pod to be available
       Pod mainPod = getPeonPodWithRetries(jobName);
-      Pod result = client.pods()
-                         .inNamespace(namespace)
-                         .withName(mainPod.getMetadata().getName())
-                         .waitUntilCondition(pod -> {
-                           if (pod == null) {
-                             return true;
-                           }
-                           return pod.getStatus() != null && pod.getStatus().getPodIP() != null;
-                         }, howLong, timeUnit);
-      
+      log.info("Pod for job[%s] launched for task[%s]. Waiting for pod to be in running state.", jobName, task.getId());
+
+      // Wait for the pod to be in state running, completed, or failed.
+      Pod result = waitForPodResultWithRetries(mainPod, howLong, timeUnit);
+
       if (result == null) {
         throw new ISE("K8s pod for the task [%s] appeared and disappeared. It can happen if the task was canceled", task.getId());
       }
+      log.info("Pod for job[%s] is in state [%s] for task[%s].", jobName, result.getStatus().getPhase(), task.getId());
       long duration = System.currentTimeMillis() - start;
       emitK8sPodMetrics(task, "k8s/peon/startup/time", duration);
       return result;
@@ -290,11 +281,139 @@ public class KubernetesPeonClient
     return pods.isEmpty() ? Optional.absent() : Optional.of(pods.get(0));
   }
 
+  public Pod waitForPodResultWithRetries(final Pod pod, long howLong, TimeUnit timeUnit)
+  {
+    return clientApi.executeRequest(client -> waitForPodResultWithRetries(client, pod, howLong, timeUnit, 5, RetryUtils.DEFAULT_MAX_TRIES));
+  }
+
   public Pod getPeonPodWithRetries(String jobName)
   {
     return clientApi.executeRequest(client -> getPeonPodWithRetries(client, jobName, 5, RetryUtils.DEFAULT_MAX_TRIES));
   }
 
+  public void createK8sJobWithRetries(Job job)
+  {
+    clientApi.executeRequest(client -> {
+      createK8sJobWithRetries(client, job, 5, RetryUtils.DEFAULT_MAX_TRIES);
+      return null;
+    });
+  }
+
+  /**
+   * Creates a Kubernetes job with retry logic for transient connection pool exceptions.
+   * <p>
+   * This method attempts to create the specified job in Kubernetes with built-in retry logic
+   * for transient connection pool issues. If the job already exists (HTTP 409 conflict),
+   * the method returns successfully without throwing an exception, assuming the job was
+   * already submitted by a previous request.
+   * <p>
+   * The retry logic only applies to transient connection pool exceptions as defined in
+   * {@link DruidK8sConstants#TRANSITIVE_CONNECTION_POOL_EXCEPTIONS}. Other exceptions
+   * will cause the method to fail immediately.
+   *
+   * @param client the Kubernetes client to use for job creation
+   * @param job the Kubernetes job to create
+   * @param quietTries number of initial retry attempts without logging warnings
+   * @param maxTries maximum total number of retry attempts
+   * @throws DruidException if job creation fails after all retry attempts or encounters non-retryable errors
+   */
+  @VisibleForTesting
+  void createK8sJobWithRetries(KubernetesClient client, Job job, int quietTries, int maxTries)
+  {
+    try {
+      RetryUtils.retry(
+          () -> {
+            try {
+              client.batch()
+                    .v1()
+                    .jobs()
+                    .inNamespace(namespace)
+                    .resource(job)
+                    .create();
+              return null;
+            }
+            catch (KubernetesClientException e) {
+              if (e.getCode() == 409) {
+                // Job already exists, return successfully
+                log.info("K8s job[%s] already exists, skipping creation", job.getMetadata().getName());
+                return null;
+              }
+              throw e;
+            }
+          },
+          this::isRetryableTransientConnectionPoolException, quietTries, maxTries
+      );
+    }
+    catch (Exception e) {
+      throw DruidException.defensive(e, "Error when creating K8s job[%s]", job.getMetadata().getName());
+    }
+  }
+
+  /**
+   * Waits for a Kubernetes pod to reach a ready state with retry logic for transient connection pool exceptions.
+   * <p>
+   * This method waits for the specified pod to have a valid status with a pod IP assigned, indicating
+   * it has been scheduled and is in a ready state. The method includes retry logic to handle transient
+   * connection pool exceptions that may occur during the wait operation.
+   * <p>
+   * The retry logic only applies to transient connection pool exceptions as defined in
+   * {@link DruidK8sConstants#TRANSITIVE_CONNECTION_POOL_EXCEPTIONS}. The method will wait up to the
+   * specified timeout for the pod to become ready, and retry the entire wait operation if transient
+   * connection issues are encountered.
+   *
+   * @param client the Kubernetes client to use for pod operations
+   * @param pod the pod to wait for
+   * @param howLong the maximum time to wait for the pod to become ready
+   * @param timeUnit the time unit for the wait timeout
+   * @param quietTries number of initial retry attempts without logging warnings
+   * @param maxTries maximum total number of retry attempts
+   * @return the pod in its ready state, or null if the pod disappeared or wait operation failed
+   * @throws DruidException if waiting fails after all retry attempts or encounters non-retryable errors
+   */
+  @VisibleForTesting
+  Pod waitForPodResultWithRetries(KubernetesClient client, Pod pod, long howLong, TimeUnit timeUnit, int quietTries, int maxTries)
+  {
+    try {
+      return RetryUtils.retry(
+          () -> client.pods()
+                    .inNamespace(namespace)
+                    .withName(pod.getMetadata().getName())
+                    .waitUntilCondition(
+                        p -> {
+                          if (p == null) {
+                            return true;
+                          }
+                          return p.getStatus() != null && p.getStatus().getPodIP() != null;
+                        }, howLong, timeUnit),
+          this::isRetryableTransientConnectionPoolException, quietTries, maxTries);
+    }
+    catch (Exception e) {
+      throw DruidException.defensive(e, "Error when waiting for pod[%s] to start", pod.getMetadata().getName());
+    }
+  }
+
+  /**
+   * Retrieves the pod associated with a Kubernetes job with retry logic for transient failures.
+   * <p>
+   * This method searches for a pod with the specified job name label and includes retry logic
+   * to handle both transient connection pool exceptions and cases where the pod may not be
+   * immediately available after job creation. If no pod is found, the method examines job
+   * events to provide detailed error information about pod creation failures.
+   * <p>
+   * The retry logic applies to:
+   * <ul>
+   *   <li>Transient connection pool exceptions as defined in {@link DruidK8sConstants#TRANSITIVE_CONNECTION_POOL_EXCEPTIONS}</li>
+   *   <li>Pod not found scenarios, except when blacklisted error messages from {@link DruidK8sConstants#BLACKLISTED_PEON_POD_ERROR_MESSAGES} are encountered</li>
+   * </ul>
+   *
+   * @param client the Kubernetes client to use for pod and event operations
+   * @param jobName the name of the job whose pod should be retrieved
+   * @param quietTries number of initial retry attempts without logging warnings
+   * @param maxTries maximum total number of retry attempts
+   * @return the pod associated with the job
+   * @throws KubernetesResourceNotFoundException if the pod cannot be found after all retry attempts
+   * @throws DruidException if retrieval fails due to other errors
+   */
   @VisibleForTesting
   Pod getPeonPodWithRetries(KubernetesClient client, String jobName, int quietTries, int maxTries)
   {
@@ -317,7 +436,7 @@ public class KubernetesPeonClient
                   "Job[%s] failed to create pods. Message[%s]", jobName, latestEvent.getMessage());
             }
           },
-          this::shouldRetryStartingPeonPod, quietTries, maxTries
+          this::shouldRetryWaitForStartingPeonPod, quietTries, maxTries
       );
     }
     catch (KubernetesResourceNotFoundException e) {
@@ -337,8 +456,12 @@ public class KubernetesPeonClient
    * These substrings, found in {@link DruidK8sConstants#BLACKLISTED_PEON_POD_ERROR_MESSAGES},
    * represent Kubernetes event that indicate a retry for starting the Peon Pod would likely be futile.
    */
-  private boolean shouldRetryStartingPeonPod(Throwable e)
+  private boolean shouldRetryWaitForStartingPeonPod(Throwable e)
   {
+    if (isRetryableTransientConnectionPoolException(e)) {
+      return true;
+    }
+
     if (!(e instanceof KubernetesResourceNotFoundException)) {
       return false;
     }
@@ -351,6 +474,32 @@ public class KubernetesPeonClient
     }
 
     return true;
+  }
+
+  /**
+   * Checks if the exception is a potentially transient connection pool exception.
+   * <p>
+   * This method checks if the exception is one of the known transient connection pool exceptions
+   * and whether it contains a specific message substring, if applicable.
+   * <p>
+   * We have experienced connections in the pool being closed by the server-side but remaining in the pool. These issues
+   * should be safe to retry in many cases.
+   */
+  private boolean isRetryableTransientConnectionPoolException(Throwable e)
+  {
+    for (var entry : DruidK8sConstants.TRANSITIVE_CONNECTION_POOL_EXCEPTIONS.entrySet()) {
+      Class<? extends RuntimeException> exceptionClass = entry.getKey();
+      Optional<String> messageSubstring = entry.getValue();
+      
+      if (exceptionClass.isInstance(e)) {
+        if (messageSubstring.isPresent()) {
+          return e.getMessage() != null && e.getMessage().contains(messageSubstring.get());
+        } else {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   private List<Event> getPeonEvents(KubernetesClient client, String jobName)

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/common/KubernetesPeonClientTest.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.api.model.PodListBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
 import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
@@ -145,7 +144,7 @@ public class KubernetesPeonClientTest
     client.pods().inNamespace(NAMESPACE).resource(pod).create();
 
     Assertions.assertThrows(
-        KubernetesClientTimeoutException.class,
+        DruidException.class,
         () -> instance.launchPeonJobAndWaitForStart(job, NoopTask.create(), 1, TimeUnit.SECONDS)
     );
   }
@@ -712,5 +711,140 @@ public class KubernetesPeonClientTest
 
     Optional<LogWatch> maybeLogWatch = instance.getPeonLogWatcher(new K8sTaskId(TASK_NAME_PREFIX, ID));
     Assertions.assertFalse(maybeLogWatch.isPresent());
+  }
+
+  @Test
+  void test_createK8sJobWithRetries_withSuccessfulCreation_createsJob()
+  {
+    Job job = new JobBuilder()
+        .withNewMetadata()
+        .withName(KUBERNETES_JOB_NAME)
+        .endMetadata()
+        .build();
+
+    // Should not throw any exception
+    instance.createK8sJobWithRetries(job);
+
+    // Verify job was created
+    Job createdJob = client.batch().v1().jobs().inNamespace(NAMESPACE).withName(KUBERNETES_JOB_NAME).get();
+    Assertions.assertNotNull(createdJob);
+    Assertions.assertEquals(KUBERNETES_JOB_NAME, createdJob.getMetadata().getName());
+  }
+
+  @Test
+  void test_createK8sJobWithRetries_withNonRetryableException_failsImmediately()
+  {
+    Job job = new JobBuilder()
+        .withNewMetadata()
+        .withName(KUBERNETES_JOB_NAME)
+        .endMetadata()
+        .build();
+
+    String jobPath = "/apis/batch/v1/namespaces/" + NAMESPACE + "/jobs";
+
+    // Return 403 Forbidden - this is not a retryable exception
+    server.expect().post()
+        .withPath(jobPath)
+        .andReturn(HttpURLConnection.HTTP_FORBIDDEN, "Forbidden: insufficient permissions")
+        .once();
+
+    // Should fail immediately without retries
+    DruidException e = Assertions.assertThrows(
+        DruidException.class,
+        () -> instance.createK8sJobWithRetries(clientApi.getClient(), job, 0, 5)
+    );
+
+    // Verify the error message contains our job name
+    Assertions.assertTrue(e.getMessage().contains(KUBERNETES_JOB_NAME));
+  }
+
+  @Test
+  void test_createK8sJobWithRetries_withJobAlreadyExists_succeedsGracefully()
+  {
+    Job job = new JobBuilder()
+        .withNewMetadata()
+        .withName(KUBERNETES_JOB_NAME)
+        .endMetadata()
+        .build();
+
+    String jobPath = "/apis/batch/v1/namespaces/" + NAMESPACE + "/jobs";
+
+    // Return 409 Conflict - job already exists
+    server.expect().post()
+        .withPath(jobPath)
+        .andReturn(HttpURLConnection.HTTP_CONFLICT, "Job already exists")
+        .once();
+
+    // Should succeed gracefully without throwing exception
+    Assertions.assertDoesNotThrow(
+        () -> instance.createK8sJobWithRetries(clientApi.getClient(), job, 0, 5)
+    );
+  }
+
+  @Test
+  void test_waitForPodResultWithRetries_withSuccessfulPodReady_returnsPod()
+  {
+    Pod pod = new PodBuilder()
+        .withNewMetadata()
+        .withName(POD_NAME)
+        .endMetadata()
+        .withNewStatus()
+        .withPodIP("192.168.1.100")
+        .endStatus()
+        .build();
+
+    // Create the pod in the mock client
+    client.pods().inNamespace(NAMESPACE).resource(pod).create();
+
+    // Should return the pod successfully
+    Pod result = instance.waitForPodResultWithRetries(
+        clientApi.getClient(), 
+        pod, 
+        1, 
+        TimeUnit.SECONDS, 
+        0, 
+        3
+    );
+
+    Assertions.assertNotNull(result);
+    Assertions.assertEquals(POD_NAME, result.getMetadata().getName());
+    Assertions.assertEquals("192.168.1.100", result.getStatus().getPodIP());
+  }
+
+  @Test
+  void test_waitForPodResultWithRetries_withNonRetryableFailure_throwsDruidException()
+  {
+    Pod pod = new PodBuilder()
+        .withNewMetadata()
+        .withName(POD_NAME)
+        .endMetadata()
+        .withNewStatus()
+        .withPodIP(null) // Pod without IP, will timeout
+        .endStatus()
+        .build();
+
+    String podPath = "/api/v1/namespaces/" + NAMESPACE + "/pods/" + POD_NAME;
+
+    // Mock server to return the pod without IP, causing timeout
+    server.expect().get()
+        .withPath(podPath + "?watch=true")
+        .andReturn(HttpURLConnection.HTTP_INTERNAL_ERROR, "Internal server error")
+        .once();
+
+    // Should throw DruidException after failure
+    DruidException e = Assertions.assertThrows(
+        DruidException.class,
+        () -> instance.waitForPodResultWithRetries(
+            clientApi.getClient(), 
+            pod, 
+            1, 
+            TimeUnit.MILLISECONDS, // Very short timeout to force failure
+            0, 
+            1
+        )
+    );
+
+    // Verify the error message contains our pod name
+    Assertions.assertTrue(e.getMessage().contains(POD_NAME));
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Improve transient fault tolerance of `KubernetesPeonClient#launchPeonJobAndWaitForStart` by adding retry mechanism to two fabric8 calls to external k8s service that will retry in the event of connection closed exceptions.

#### Background

When we switched to vert.x from okhttp for the connection pool underlying fabric8 KubernetesClient, we lost the okhttp feature that sends periodic keepalives on the connections in the k8s connection pool. This feature of okhttp connection pool, proactively kept connections between druid and k8s open. vert.x does not have this keepalive feature, and instead will check connection health on a timed loop, and clean up any connections that are no longer healthy. The default interval of checking these connections is 1 hour. If a connection is closed on the server side in less than an hour, the connection pool is liable to try and use it, which will fail immediately. I have seen this happen in the aforementioned `KubernetesPeonClient#launchPeonJobAndWaitForStart`. This is a mitigation for that issue.

The pattern we see when this happens is usually a prolonged period of heavy traffic between Druid and k8s that expands the vert.x connection pool out to its max allowed size. This is followed by a lull in traffic, where we expect the server is closing idle connections. Finally, a spike in Druid --> k8s traffic results in druid trying to use all of the connections for operations, and any that are closed result in exceptions and hard failures. A retry on this exception should help prevent jobs from failing just because they got a bad connection from the pool.

#### Future work

##### Low level vert.x config exposure

Add more knobs for configuring vert.x connection pool. For instance, have a more aggressive interval to clean up bad connections. Right now we are stuck with mostly all defaults from Vert.x and fabric8 is not making the configs easily modifiable.

##### Refactor of all fabric8 --> k8s interactions in this druid extension

Longer term, cleaning up this extension and standardizing retry mechanisms for all contact with external k8s service is probably needed. I'm sure we can come up with a way to more nicely re-use basic retry code to avoid duplication like my PR + we may want to expose retry logic to configuration somehow (via exception list or something?) or have different modes that dictate how eager druid is to retry vs fail k8s operations.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
