### PR TITLE
Fix overly-strict VirtualColumns cycle detection.

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/VirtualColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/VirtualColumnsTest.java
@@ -353,6 +353,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   @Test
   public void testCycleDetection()
   {
+    // expr depends on expr2
+    // expr2 depends on expr
+
     final ExpressionVirtualColumn expr = new ExpressionVirtualColumn(
         "expr",
         "x + expr2",
@@ -372,6 +375,38 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         () -> VirtualColumns.create(ImmutableList.of(expr, expr2))
     );
     Assert.assertEquals("Self-referential column[expr]", t.getMessage());
+  }
+
+  @Test
+  public void testNotACycle()
+  {
+    // Not a cycle, although at one point our cycle detection code believed it was.
+    // expr3 depends on expr, expr2
+    // expr2 depends on expr
+    // expr depends on physical columns x, y
+    final ExpressionVirtualColumn expr = new ExpressionVirtualColumn(
+        "expr",
+        "x + y",
+        ColumnType.FLOAT,
+        TestExprMacroTable.INSTANCE
+    );
+
+    final ExpressionVirtualColumn expr2 = new ExpressionVirtualColumn(
+        "expr2",
+        "expr",
+        ColumnType.FLOAT,
+        TestExprMacroTable.INSTANCE
+    );
+
+    final ExpressionVirtualColumn expr3 = new ExpressionVirtualColumn(
+        "expr3",
+        "expr + expr2",
+        ColumnType.FLOAT,
+        TestExprMacroTable.INSTANCE
+    );
+
+    final VirtualColumns virtualColumns = VirtualColumns.create(ImmutableList.of(expr, expr2, expr3));
+    Assert.assertEquals(3, virtualColumns.getColumnNames().size());
   }
 
   @Test


### PR DESCRIPTION
The prior code was overly strict at detecting cycles. It would flag situations where the same virtual column was depended on in two different pathways, even if there was no cycle.

This patch fixes it by removing dependency columns from the already-visited list once they have been checked.