### PR TITLE
Consolidate ObjectMappers in MSQTestBase.

### DIFF
--- a/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
+++ b/extensions-core/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestBase.java
@@ -155,6 +155,8 @@ import org.apache.druid.segment.loading.LocalLoadSpec;
 import org.apache.druid.segment.loading.SegmentCacheManager;
 import org.apache.druid.segment.realtime.appenderator.AppenderatorsManager;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
+import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
+import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.server.SegmentManager;
 import org.apache.druid.server.SpecificSegmentsQuerySegmentWalker;
 import org.apache.druid.server.coordination.DataSegmentAnnouncer;
@@ -373,6 +375,31 @@ public class MSQTestBase extends BaseCalciteQueryTest
       );
     }
 
+    @Override
+    public DruidModule getOverrideModule()
+    {
+      return new DruidModule() {
+        @Override
+        public void configure(Binder binder)
+        {
+          binder.bind(StorageConfig.class).toInstance(new StorageConfig("/"));
+          binder.bind(SegmentWriteOutMediumFactory.class)
+                .toInstance(TmpFileSegmentWriteOutMediumFactory.instance());
+        }
+
+        @Override
+        public List<? extends com.fasterxml.jackson.databind.Module> getJacksonModules()
+        {
+          return ImmutableList.<com.fasterxml.jackson.databind.Module>builder()
+                              .addAll(new StorageConnectorModule().getJacksonModules())
+                              .addAll(new MSQIndexingModule().getJacksonModules())
+                              .addAll(new MSQSqlModule().getJacksonModules())
+                              .addAll(BuiltInTypesModule.getJacksonModulesList())
+                              .build();
+        }
+      };
+    }
+
     private static final class LocalMsqSqlModule implements DruidModule
     {
       // Small subset of MsqSqlModule
@@ -429,13 +456,10 @@ public class MSQTestBase extends BaseCalciteQueryTest
 
     SqlTestFramework qf = queryFramework();
 
-    ObjectMapper secondMapper = setupObjectMapper(qf.injector());
-    indexIO = new IndexIO(secondMapper, ColumnConfig.DEFAULT);
+    objectMapper = setupObjectMapper(qf.injector());
+    indexIO = new IndexIO(objectMapper, ColumnConfig.DEFAULT);
 
-    segmentCacheManager = new SegmentCacheManagerFactory(TestIndex.INDEX_IO, secondMapper).manufacturate(newTempFolder("cacheManager"));
-
-    MSQSqlModule sqlModule = new MSQSqlModule();
-
+    segmentCacheManager = new SegmentCacheManagerFactory(TestIndex.INDEX_IO, objectMapper).manufacturate(newTempFolder("cacheManager"));
     segmentManager = new MSQTestSegmentManager(segmentCacheManager);
 
     List<Module> modules = ImmutableList.of(
@@ -474,6 +498,8 @@ public class MSQTestBase extends BaseCalciteQueryTest
           }).annotatedWith(Self.class).toInstance(ImmutableSet.of(NodeRole.PEON));
           binder.bind(QueryProcessingPool.class)
                 .toInstance(new ForwardingQueryProcessingPool(Execs.singleThreaded("Test-runner-processing-pool")));
+          binder.bind(SegmentWriteOutMediumFactory.class)
+                .toInstance(TmpFileSegmentWriteOutMediumFactory.instance());
           binder.bind(DataSegmentProvider.class)
                 .toInstance((segmentId, channelCounters, isReindex) -> getSupplierForSegment(this::newTempFolder, segmentId));
           binder.bind(DataServerQueryHandlerFactory.class).toInstance(getTestDataServerQueryHandlerFactory());
@@ -505,7 +531,6 @@ public class MSQTestBase extends BaseCalciteQueryTest
             );
             binder.bind(Key.get(StorageConnector.class, MultiStageQuery.class))
                   .toProvider(() -> localFileStorageConnector);
-            binder.bind(StorageConfig.class).toInstance(new StorageConfig("/"));
           }
           catch (IOException e) {
             throw new ISE(e, "Unable to create setup storage connector");
@@ -544,12 +569,6 @@ public class MSQTestBase extends BaseCalciteQueryTest
     injector = new CoreInjectorBuilder(new StartupInjectorBuilder().build(), ImmutableSet.of(NodeRole.PEON))
         .addAll(modules)
         .build();
-
-    objectMapper = setupObjectMapper(injector);
-    objectMapper.registerModules(new StorageConnectorModule().getJacksonModules());
-    objectMapper.registerModules(new MSQIndexingModule().getJacksonModules());
-    objectMapper.registerModules(sqlModule.getJacksonModules());
-    objectMapper.registerModules(BuiltInTypesModule.getJacksonModulesList());
 
     testTaskActionClient = Mockito.spy(new MSQTestTaskActionClient(objectMapper, injector));
     indexingServiceClient = new MSQTestOverlordServiceClient(


### PR DESCRIPTION
This patch consolidates the two ObjectMappers in MSQTestBase into a single ObjectMapper. The single ObjectMapper is based on the modules from the test class's ComponentSupplier. In addition to simplification, this has the benefit of making it easier to create subclasses that provide additional Jackson modules.