### PR TITLE
Hll Sketch estimate with error bounds and Theta sketch estimate with error bounds can now be used as an expression

### DIFF
--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
@@ -71,6 +71,7 @@ public class HllSketchModule implements DruidModule
     SqlBindings.addOperatorConversion(binder, HllSketchToStringOperatorConversion.class);
 
     ExpressionModule.addExprMacro(binder, HllPostAggExprMacros.HLLSketchEstimateExprMacro.class);
+    ExpressionModule.addExprMacro(binder, HllPostAggExprMacros.HllSketchEstimateWithErrorBoundExprMacro.class);
     SqlBindings.addApproxCountDistinctChoice(
         binder,
         HllSketchApproxCountDistinctSqlAggregator.NAME,

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchModule.java
@@ -71,7 +71,7 @@ public class HllSketchModule implements DruidModule
     SqlBindings.addOperatorConversion(binder, HllSketchToStringOperatorConversion.class);
 
     ExpressionModule.addExprMacro(binder, HllPostAggExprMacros.HLLSketchEstimateExprMacro.class);
-    ExpressionModule.addExprMacro(binder, HllPostAggExprMacros.HllSketchEstimateWithErrorBoundExprMacro.class);
+    ExpressionModule.addExprMacro(binder, HllPostAggExprMacros.HllSketchEstimateWithErrorBoundsExprMacro.class);
     SqlBindings.addApproxCountDistinctChoice(
         binder,
         HllSketchApproxCountDistinctSqlAggregator.NAME,

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllPostAggExprMacros.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllPostAggExprMacros.java
@@ -24,6 +24,7 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchHolder;
+import org.apache.druid.query.aggregation.datasketches.hll.HllSketchToEstimateWithBoundsPostAggregator;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -31,10 +32,10 @@ import java.util.List;
 public class HllPostAggExprMacros
 {
   public static final String HLL_SKETCH_ESTIMATE = "hll_sketch_estimate";
+  public static final String HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS = "hll_sketch_estimate_with_error_bounds";
 
   public static class HLLSketchEstimateExprMacro implements ExprMacroTable.ExprMacro
   {
-
     @Override
     public Expr apply(List<Expr> args)
     {
@@ -46,6 +47,22 @@ public class HllPostAggExprMacros
     public String name()
     {
       return HLL_SKETCH_ESTIMATE;
+    }
+  }
+
+  public static class HllSketchEstimateWithErrorBoundExprMacro implements ExprMacroTable.ExprMacro
+  {
+    @Override
+    public Expr apply(List<Expr> args)
+    {
+      validationHelperCheckAnyOfArgumentCount(args, 1, 2);
+      return new HllSketchEstimateWithErrorBoundExpr(this, args);
+    }
+
+    @Override
+    public String name()
+    {
+      return HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS;
     }
   }
 
@@ -86,6 +103,45 @@ public class HllPostAggExprMacros
       HllSketchHolder h = HllSketchHolder.fromObj(valObj);
       double estimate = h.getEstimate();
       return round ? ExprEval.of(Math.round(estimate)) : ExprEval.of(estimate);
+    }
+  }
+
+  public static class HllSketchEstimateWithErrorBoundExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
+  {
+    private Expr estimateExpr;
+    private Expr numStdDev;
+
+    public HllSketchEstimateWithErrorBoundExpr(HllSketchEstimateWithErrorBoundExprMacro macro, List<Expr> args)
+    {
+      super(macro, args);
+      this.estimateExpr = args.get(0);
+      if (args.size() == 2) {
+        numStdDev = args.get(1);
+      }
+    }
+
+    @Nullable
+    @Override
+    public ExpressionType getOutputType(InputBindingInspector inspector)
+    {
+      return ExpressionType.DOUBLE_ARRAY;
+    }
+
+    @Override
+    public ExprEval eval(ObjectBinding bindings)
+    {
+      int numStdDevs = HllSketchToEstimateWithBoundsPostAggregator.DEFAULT_NUM_STD_DEVS;
+      ExprEval eval = estimateExpr.eval(bindings);
+      if (numStdDev != null) {
+        numStdDevs = numStdDev.eval(bindings).asInt();
+      }
+
+      final Object valObj = eval.value();
+      if (valObj == null) {
+        return ExprEval.ofDoubleArray(new Double[]{0.0D, 0.0D, 0.0D});
+      }
+      HllSketchHolder sketch = HllSketchHolder.fromObj(valObj);
+      return ExprEval.ofDoubleArray(new Double[]{sketch.getEstimate(), sketch.getLowerBound(numStdDevs), sketch.getUpperBound(numStdDevs)});
     }
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllPostAggExprMacros.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllPostAggExprMacros.java
@@ -50,13 +50,13 @@ public class HllPostAggExprMacros
     }
   }
 
-  public static class HllSketchEstimateWithErrorBoundExprMacro implements ExprMacroTable.ExprMacro
+  public static class HllSketchEstimateWithErrorBoundsExprMacro implements ExprMacroTable.ExprMacro
   {
     @Override
     public Expr apply(List<Expr> args)
     {
       validationHelperCheckAnyOfArgumentCount(args, 1, 2);
-      return new HllSketchEstimateWithErrorBoundExpr(this, args);
+      return new HllSketchEstimateWithErrorBoundsExpr(this, args);
     }
 
     @Override
@@ -106,12 +106,12 @@ public class HllPostAggExprMacros
     }
   }
 
-  public static class HllSketchEstimateWithErrorBoundExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
+  public static class HllSketchEstimateWithErrorBoundsExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
   {
     private Expr estimateExpr;
     private Expr numStdDev;
 
-    public HllSketchEstimateWithErrorBoundExpr(HllSketchEstimateWithErrorBoundExprMacro macro, List<Expr> args)
+    public HllSketchEstimateWithErrorBoundsExpr(HllSketchEstimateWithErrorBoundsExprMacro macro, List<Expr> args)
     {
       super(macro, args);
       this.estimateExpr = args.get(0);

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchEstimateWithErrorBoundsOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchEstimateWithErrorBoundsOperatorConversion.java
@@ -42,7 +42,7 @@ import java.util.List;
 
 public class HllSketchEstimateWithErrorBoundsOperatorConversion implements SqlOperatorConversion
 {
-  private static final String FUNCTION_NAME = "HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS";
+  private static final String FUNCTION_NAME = "hll_sketch_estimate_with_error_bounds";
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
       .operandTypes(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)
@@ -63,7 +63,12 @@ public class HllSketchEstimateWithErrorBoundsOperatorConversion implements SqlOp
       RexNode rexNode
   )
   {
-    return null;
+    return OperatorConversions.convertDirectCall(
+        plannerContext,
+        rowSignature,
+        rexNode,
+        FUNCTION_NAME
+    );
   }
 
   @Nullable

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchModule.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/SketchModule.java
@@ -75,6 +75,7 @@ public class SketchModule implements DruidModule
         ThetaSketchApproxCountDistinctSqlAggregator.class
     );
     ExpressionModule.addExprMacro(binder, ThetaPostAggMacros.ThetaSketchEstimateExprMacro.class);
+    ExpressionModule.addExprMacro(binder, ThetaPostAggMacros.ThetaSketchEstimateWithErrorBoundsExprMacro.class);
   }
 
   @Override

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaPostAggMacros.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaPostAggMacros.java
@@ -26,18 +26,16 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchEstimateWithErrorBounds;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchHolder;
+import org.apache.druid.query.aggregation.datasketches.theta.SketchModule;
 
 import javax.annotation.Nullable;
 import java.util.List;
-
-import static org.apache.druid.query.aggregation.datasketches.theta.SketchModule.MERGE_TYPE;
-import static org.apache.druid.query.aggregation.datasketches.theta.SketchModule.THETA_SKETCH_TYPE;
 
 public class ThetaPostAggMacros
 {
   public static final String THETA_SKETCH_ESTIMATE = "theta_sketch_estimate";
   public static final String THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS = "theta_sketch_estimate_with_error_bounds";
-  public static final ExpressionType THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS_TYPE = ExpressionType.fromColumnType(MERGE_TYPE);
+  public static final ExpressionType THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS_TYPE = ExpressionType.fromColumnType(SketchModule.MERGE_TYPE);
 
   public static class ThetaSketchEstimateExprMacro implements ExprMacroTable.ExprMacro
   {

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaPostAggMacros.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaPostAggMacros.java
@@ -24,18 +24,23 @@ import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionType;
+import org.apache.druid.query.aggregation.datasketches.theta.SketchEstimateWithErrorBounds;
 import org.apache.druid.query.aggregation.datasketches.theta.SketchHolder;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static org.apache.druid.query.aggregation.datasketches.theta.SketchModule.MERGE_TYPE;
+import static org.apache.druid.query.aggregation.datasketches.theta.SketchModule.THETA_SKETCH_TYPE;
+
 public class ThetaPostAggMacros
 {
   public static final String THETA_SKETCH_ESTIMATE = "theta_sketch_estimate";
+  public static final String THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS = "theta_sketch_estimate_with_error_bounds";
+  public static final ExpressionType THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS_TYPE = ExpressionType.fromColumnType(MERGE_TYPE);
 
   public static class ThetaSketchEstimateExprMacro implements ExprMacroTable.ExprMacro
   {
-
     @Override
     public Expr apply(List<Expr> args)
     {
@@ -47,6 +52,22 @@ public class ThetaPostAggMacros
     public String name()
     {
       return THETA_SKETCH_ESTIMATE;
+    }
+  }
+
+  public static class ThetaSketchEstimateWithErrorBoundsExprMacro implements ExprMacroTable.ExprMacro
+  {
+    @Override
+    public Expr apply(List<Expr> args)
+    {
+      validationHelperCheckArgumentCount(args, 2);
+      return new ThetaSketchEstimateWithErrorBoundsExpr(this, args);
+    }
+
+    @Override
+    public String name()
+    {
+      return THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS;
     }
   }
 
@@ -82,6 +103,53 @@ public class ThetaPostAggMacros
     public ExpressionType getOutputType(InputBindingInspector inspector)
     {
       return ExpressionType.DOUBLE;
+    }
+  }
+
+  public static class ThetaSketchEstimateWithErrorBoundsExpr extends ExprMacroTable.BaseScalarMacroFunctionExpr
+  {
+    private Expr estimateExpr;
+    private Expr numStdDev;
+
+    public ThetaSketchEstimateWithErrorBoundsExpr(ThetaSketchEstimateWithErrorBoundsExprMacro macro, List<Expr> args)
+    {
+      super(macro, args);
+      this.estimateExpr = args.get(0);
+      this.numStdDev = args.get(1);
+    }
+
+    @Override
+    public ExprEval eval(ObjectBinding bindings)
+    {
+      int numStdDevs = numStdDev.eval(bindings).asInt();
+      ExprEval eval = estimateExpr.eval(bindings);
+
+      final Object valObj = eval.value();
+      if (valObj == null) {
+        return ExprEval.ofComplex(
+            THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS_TYPE,
+            new SketchEstimateWithErrorBounds(
+                0.0D,
+                0.0D,
+                0.0D,
+                numStdDevs
+            )
+        );
+      }
+
+      if (valObj instanceof SketchHolder) {
+        SketchHolder thetaSketchHolder = (SketchHolder) valObj;
+        return ExprEval.ofComplex(THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS_TYPE, thetaSketchHolder.getEstimateWithErrorBounds(numStdDevs));
+      } else {
+        throw new IllegalArgumentException("requires a ThetaSketch as the argument");
+      }
+    }
+
+    @Nullable
+    @Override
+    public ExpressionType getOutputType(InputBindingInspector inspector)
+    {
+      return THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS_TYPE;
     }
   }
 }

--- a/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchEstimateWithErrorBoundsOperatorConversion.java
+++ b/extensions-core/datasketches/src/main/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchEstimateWithErrorBoundsOperatorConversion.java
@@ -43,7 +43,7 @@ import java.util.List;
 
 public class ThetaSketchEstimateWithErrorBoundsOperatorConversion implements SqlOperatorConversion
 {
-  private static final String FUNCTION_NAME = "THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS";
+  private static final String FUNCTION_NAME = "theta_sketch_estimate_with_error_bounds";
   private static final SqlFunction SQL_FUNCTION = OperatorConversions
       .operatorBuilder(StringUtils.toUpperCase(FUNCTION_NAME))
       .operandTypes(SqlTypeFamily.ANY, SqlTypeFamily.INTEGER)
@@ -65,7 +65,7 @@ public class ThetaSketchEstimateWithErrorBoundsOperatorConversion implements Sql
       RexNode rexNode
   )
   {
-    return null;
+    return OperatorConversions.convertDirectCall(plannerContext, rowSignature, rexNode, FUNCTION_NAME);
   }
 
   @Nullable


### PR DESCRIPTION
### Description

Similar to https://github.com/apache/druid/pull/14312, Hll Sketch estimate with error bounds and Theta sketch estimate with error bounds can now be used as an expression. Hll Sketch estimate with error bounds and Theta sketch estimate with error bound have been used only as PostAggs as they work on groupBy and TopN queries. But postAggs are not supported for scan queries. In this PR we introduce HLL_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS and THETA_SKETCH_ESTIMATE_WITH_ERROR_BOUNDS as expressions. These estimates work on a sketch column and has the same behavior as the postAggs. New test cases have been added to show how scan queries can work with these estimates.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
