### PR TITLE
Configure producer shutdown timeout for kafka emitter

### DIFF
--- a/docs/development/extensions-contrib/kafka-emitter.md
+++ b/docs/development/extensions-contrib/kafka-emitter.md
@@ -48,6 +48,7 @@ All the configuration parameters for the Kafka emitter are under `druid.emitter.
 | `druid.emitter.kafka.clusterName`                  | Optional value to specify the name of your Druid cluster. It can help make groups in your monitoring environment.                         | no        | none                  |
 | `druid.emitter.kafka.extra.dimensions` | Optional JSON configuration to specify a map of extra string dimensions for the events emitted. These can help make groups in your monitoring environment. | no | none |
 | `druid.emitter.kafka.producer.hiddenProperties`    | JSON configuration to specify sensitive Kafka producer properties such as username and password.  This property accepts a [DynamicConfigProvider](../../operations/dynamic-config-provider.md) implementation. | no | none |
+| `druid.emitter.kafka.producer.shutdownTimeout`    | Duration in milliseconds the Kafka producer waits for pending requests to finish before shutting down. | no | Long.MAX_VALUE |
 
 ### Example
 

--- a/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
+++ b/extensions-contrib/kafka-emitter/src/main/java/org/apache/druid/emitter/kafka/KafkaEmitter.java
@@ -41,6 +41,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 
+import java.time.Duration;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -293,7 +294,7 @@ public class KafkaEmitter implements Emitter
   public void close()
   {
     scheduler.shutdownNow();
-    producer.close();
+    producer.close(Duration.ofMillis(config.getShutdownTimeout()));
   }
 
   public long getMetricLostCount()

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -58,7 +58,8 @@ public class KafkaEmitterConfigTest
         ImmutableMap.of("env", "preProd"),
         ImmutableMap.<String, String>builder()
                     .put("testKey", "testValue").build(),
-        DEFAULT_PRODUCER_SECRETS
+        DEFAULT_PRODUCER_SECRETS,
+        50L
     );
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
@@ -80,7 +81,8 @@ public class KafkaEmitterConfigTest
         null,
         ImmutableMap.<String, String>builder()
                     .put("testKey", "testValue").build(),
-        DEFAULT_PRODUCER_SECRETS
+        DEFAULT_PRODUCER_SECRETS,
+        null
     );
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
@@ -104,7 +106,8 @@ public class KafkaEmitterConfigTest
         null,
         ImmutableMap.<String, String>builder()
                     .put("testKey", "testValue").build(),
-        DEFAULT_PRODUCER_SECRETS
+        DEFAULT_PRODUCER_SECRETS,
+        null
     );
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
@@ -124,6 +127,7 @@ public class KafkaEmitterConfigTest
         "metadataTest",
         null,
         ImmutableMap.of("env", "preProd"),
+        null,
         null,
         null
     );
@@ -179,6 +183,7 @@ public class KafkaEmitterConfigTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         ),
@@ -196,6 +201,7 @@ public class KafkaEmitterConfigTest
             () -> new KafkaEmitterConfig(
                 "foo",
                 new HashSet<>(Collections.singletonList(KafkaEmitterConfig.EventType.METRICS)),
+                null,
                 null,
                 null,
                 null,
@@ -221,6 +227,7 @@ public class KafkaEmitterConfigTest
                 "foo",
                 null,
                 "foo",
+                null,
                 null,
                 null,
                 null,
@@ -253,6 +260,7 @@ public class KafkaEmitterConfigTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         ),
@@ -279,6 +287,7 @@ public class KafkaEmitterConfigTest
                 null,
                 null,
                 null,
+                null,
                 null
             )
         ),
@@ -287,6 +296,31 @@ public class KafkaEmitterConfigTest
                 "druid.emitter.kafka.segmentMetadata.topic must be specified if druid.emitter.kafka.event.types contains segment_metadata."
             )
     );
+  }
+
+  @Test
+  public void testDefaultShutdownTimeout() throws IOException
+  {
+    Set<KafkaEmitterConfig.EventType> eventTypeSet = new HashSet<>();
+    eventTypeSet.add(KafkaEmitterConfig.EventType.SEGMENT_METADATA);
+    KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
+        "hostname",
+        eventTypeSet,
+        null,
+        null,
+        null,
+        "shutdownTest",
+        "clusterNameTest",
+        null,
+        ImmutableMap.<String, String>builder()
+                    .put("testKey", "testValue").build(),
+        DEFAULT_PRODUCER_SECRETS,
+        null
+    );
+    String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
+    KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
+                                                          .readValue(kafkaEmitterConfigString);
+    Assert.assertEquals(Long.MAX_VALUE, (long) kafkaEmitterConfigExpected.getShutdownTimeout());
   }
 
   private DruidExceptionMatcher operatorExceptionMatcher()

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -149,6 +149,7 @@ public class KafkaEmitterTest
         "clusterName",
         ImmutableMap.of("clusterId", "cluster-101"),
         null,
+        null,
         null
     );
 
@@ -202,6 +203,7 @@ public class KafkaEmitterTest
         null,
         ImmutableMap.of("clusterId", "cluster-101", "env", "staging"),
         null,
+        null,
         null
     );
 
@@ -251,6 +253,7 @@ public class KafkaEmitterTest
         "clusterName",
         null,
         null,
+        null,
         null
     );
 
@@ -297,6 +300,7 @@ public class KafkaEmitterTest
         "requests",
         "segment_metadata",
         "clusterName",
+        null,
         null,
         null,
         null
@@ -373,6 +377,7 @@ public class KafkaEmitterTest
         null,
         null,
         null,
+        null,
         null
     );
 
@@ -423,6 +428,7 @@ public class KafkaEmitterTest
         null,
         "cluster-102",
         ImmutableMap.of("clusterName", "cluster-101", "env", "staging"), // clusterName again, extraDimensions should take precedence
+        null,
         null,
         null
     );
@@ -517,6 +523,7 @@ public class KafkaEmitterTest
         null,
         extraDimensions,
         ImmutableMap.of(ProducerConfig.BUFFER_MEMORY_CONFIG, String.valueOf(totalBufferSize)),
+        null,
         null
     );
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->
### Description

Introduces a new Kafka emitter config: `druid.emitter.kafka.producer.shutdownTimeout` which controls how long the Kafka producer waits for pending requests to finish before shutting down.
Ref: https://kafka.apache.org/39/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#close(java.time.Duration)

When the kafka emitter is enabled, the Kafka producer by default waits indefinitely for the pending requests to finish. 
In busy clusters, this can delay the shutdown process of realtime tasks and the overlord eventually ends up killing the task.
Configuring a shorter close timeout ensures that the task shutdown isn't stalled by the Kafka producer and the task completes with the correct status.

#### Release note
Introduces a new Kafka emitter config: `druid.emitter.kafka.producer.shutdownTimeout` which controls how long the Kafka producer waits for pending requests to finish before shutting down.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] been tested in a test Druid cluster.
