### PR TITLE
Handle local "files" in FakeIndexTaskUtil.

### DIFF
--- a/sql/src/test/java/org/apache/druid/sql/calcite/util/FakeIndexTaskUtil.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/util/FakeIndexTaskUtil.java
@@ -84,6 +84,7 @@ public class FakeIndexTaskUtil
     );
   }
 
+  @Nullable
   private static File resolveFile(File projectRoot, @Nullable File file)
   {
     if (file == null || file.isAbsolute()) {


### PR DESCRIPTION
The LocalInputSource can do "baseDir" + "filter", but can also have a list of "files". Previously, FakeIndexTaskUtil would throw NPE when encountering a LocalInputSource that used "files" instead of "baseDir" and "filter".