### PR TITLE
Ensure DruidMeta is closed properly.

### DIFF
--- a/sql/src/test/java/org/apache/druid/quidem/DruidAvaticaTestDriver.java
+++ b/sql/src/test/java/org/apache/druid/quidem/DruidAvaticaTestDriver.java
@@ -27,7 +27,6 @@ import com.google.inject.name.Named;
 import org.apache.calcite.avatica.server.AbstractAvaticaHandler;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.initialization.DruidModule;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.server.DruidNode;
@@ -46,7 +45,6 @@ import org.apache.http.client.utils.URIBuilder;
 import org.eclipse.jetty.server.Server;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.sql.Connection;
@@ -179,6 +177,7 @@ public class DruidAvaticaTestDriver implements Driver
     {
       druidMeta.closeAllConnections();
       try {
+        druidMeta.stop();
         server.stop();
       }
       catch (Exception e) {
@@ -221,25 +220,6 @@ public class DruidAvaticaTestDriver implements Driver
       connectionModule.close();
       super.close();
     }
-  }
-
-  protected File createTempFolder(String prefix)
-  {
-    File tempDir = FileUtils.createTempDir(prefix);
-    Runtime.getRuntime().addShutdownHook(new Thread()
-    {
-      @Override
-      public void run()
-      {
-        try {
-          FileUtils.deleteDirectory(tempDir);
-        }
-        catch (IOException ex) {
-          ex.printStackTrace();
-        }
-      }
-    });
-    return tempDir;
   }
 
   private void register()

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidAvaticaHandlerTest.java
@@ -41,6 +41,7 @@ import org.apache.calcite.avatica.MissingResultsException;
 import org.apache.calcite.avatica.NoSuchStatementException;
 import org.apache.calcite.avatica.server.AbstractAvaticaHandler;
 import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.guice.security.PolicyModule;
 import org.apache.druid.initialization.CoreInjectorBuilder;
@@ -269,6 +270,7 @@ public class DruidAvaticaHandlerTest extends CalciteTestBase
     testRequestLogger = new TestRequestLogger();
 
     injector = new CoreInjectorBuilder(new StartupInjectorBuilder().build())
+        .addModule(new LifecycleModule())
         .addModule(
             binder -> {
               binder.bindConstant().annotatedWith(Names.named("serviceName")).to("test");


### PR DESCRIPTION
DruidMeta owns an executor service, which spawns a thread that retains a reference to it. This service must be shut down for the DruidMeta to be garbage-collectable, which is important when DruidAvaticaTestDriver is closed. Otherwise, any segments retained by the DruidMeta will stick around.

This fix includes a `@LifecycleStop` so the same shutdown happens when an actual server is shutting down. It seems like good hygiene.