### PR TITLE
Decouple AllTrue, AllUnknown BitmapColumnIndex from ColumnIndexSelector.

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/index/AllTrueBitmapColumnIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/index/AllTrueBitmapColumnIndex.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.index;
 
+import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.query.BitmapResultFactory;
 import org.apache.druid.query.filter.ColumnIndexSelector;
 import org.apache.druid.segment.column.ColumnIndexCapabilities;
@@ -26,11 +27,18 @@ import org.apache.druid.segment.column.SimpleColumnIndexCapabilities;
 
 public class AllTrueBitmapColumnIndex implements BitmapColumnIndex
 {
-  private final ColumnIndexSelector selector;
+  private final BitmapFactory bitmapFactory;
+  private final int numRows;
+
+  public AllTrueBitmapColumnIndex(BitmapFactory bitmapFactory, int numRows)
+  {
+    this.bitmapFactory = bitmapFactory;
+    this.numRows = numRows;
+  }
 
   public AllTrueBitmapColumnIndex(ColumnIndexSelector indexSelector)
   {
-    this.selector = indexSelector;
+    this(indexSelector.getBitmapFactory(), indexSelector.getNumRows());
   }
 
   @Override
@@ -49,8 +57,7 @@ public class AllTrueBitmapColumnIndex implements BitmapColumnIndex
   public <T> T computeBitmapResult(BitmapResultFactory<T> bitmapResultFactory, boolean includeUnknown)
   {
     return bitmapResultFactory.wrapAllTrue(
-        selector.getBitmapFactory()
-                .complement(selector.getBitmapFactory().makeEmptyImmutableBitmap(), selector.getNumRows())
+        bitmapFactory.complement(bitmapFactory.makeEmptyImmutableBitmap(), numRows)
     );
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/index/AllUnknownBitmapColumnIndex.java
+++ b/processing/src/main/java/org/apache/druid/segment/index/AllUnknownBitmapColumnIndex.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.segment.index;
 
+import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.query.BitmapResultFactory;
 import org.apache.druid.query.filter.ColumnIndexSelector;
 import org.apache.druid.segment.column.ColumnIndexCapabilities;
@@ -30,12 +31,18 @@ import org.apache.druid.segment.column.SimpleColumnIndexCapabilities;
  */
 public class AllUnknownBitmapColumnIndex implements BitmapColumnIndex
 {
-  private final ColumnIndexSelector selector;
+  private final BitmapFactory bitmapFactory;
+  private final int numRows;
 
+  public AllUnknownBitmapColumnIndex(BitmapFactory bitmapFactory, int numRows)
+  {
+    this.bitmapFactory = bitmapFactory;
+    this.numRows = numRows;
+  }
 
   public AllUnknownBitmapColumnIndex(ColumnIndexSelector indexSelector)
   {
-    this.selector = indexSelector;
+    this(indexSelector.getBitmapFactory(), indexSelector.getNumRows());
   }
 
   @Override
@@ -55,10 +62,9 @@ public class AllUnknownBitmapColumnIndex implements BitmapColumnIndex
   {
     if (includeUnknown) {
       return bitmapResultFactory.wrapAllTrue(
-          selector.getBitmapFactory()
-                  .complement(selector.getBitmapFactory().makeEmptyImmutableBitmap(), selector.getNumRows())
+          bitmapFactory.complement(bitmapFactory.makeEmptyImmutableBitmap(), numRows)
       );
     }
-    return bitmapResultFactory.wrapAllFalse(selector.getBitmapFactory().makeEmptyImmutableBitmap());
+    return bitmapResultFactory.wrapAllFalse(bitmapFactory.makeEmptyImmutableBitmap());
   }
 }


### PR DESCRIPTION
There is no real need for these objects to require a ColumnIndexSelector for construction. All they need is the bitmap factory and row count. This change makes it easier to use these classes from places where a ColumnIndexSelector is not available, such as implementations of semantic indexes.

This also brings these classes more in line with AllFalseBitmapColumnIndex, which just takes a bitmap factory.