### PR TITLE
Add helper function for vector offset

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/column/ComplexColumn.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ComplexColumn.java
@@ -118,20 +118,9 @@ public interface ComplexColumn extends BaseColumn
           return vector;
         }
 
-        if (offset.isContiguous()) {
-          final int startOffset = offset.getStartOffset();
-          final int vectorSize = offset.getCurrentVectorSize();
-
-          for (int i = 0; i < vectorSize; i++) {
-            vector[i] = getRowValue(startOffset + i);
-          }
-        } else {
-          final int[] offsets = offset.getOffsets();
-          final int vectorSize = offset.getCurrentVectorSize();
-
-          for (int i = 0; i < vectorSize; i++) {
-            vector[i] = getRowValue(offsets[i]);
-          }
+        final int vectorSize = offset.getCurrentVectorSize();
+        for (int i = 0; i < vectorSize; i++) {
+          vector[i] = getRowValue(offset.getOffset(i));
         }
 
         id = offset.getId();

--- a/processing/src/main/java/org/apache/druid/segment/vector/ReadableVectorOffset.java
+++ b/processing/src/main/java/org/apache/druid/segment/vector/ReadableVectorOffset.java
@@ -52,4 +52,17 @@ public interface ReadableVectorOffset extends ReadableVectorInspector
    * Throws an exception if "isContiguous" is true.
    */
   int[] getOffsets();
+
+  /**
+   * Gets the offset at a certain index. To be used in situations where the caller has no optimized path available for
+   * contiguous processing.
+   */
+  default int getOffset(int index)
+  {
+    if (isContiguous()) {
+      return getStartOffset() + index;
+    } else {
+      return getOffsets()[index];
+    }
+  }
 }


### PR DESCRIPTION
Minor PR that adds a helper function to get the offset at a certain index where there isn't a better way to split the contiguous and non contiguous paths. This would be helpful in cutting down on some code.