### PR TITLE
Create Kubernetes peon lifecycle task log persist timeout

### DIFF
--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -792,6 +792,7 @@ Should you require the needed permissions for interacting across Kubernetes name
 | `druid.indexer.runner.graceTerminationPeriodSeconds` | `Long` | Number of seconds you want to wait after a sigterm for container lifecycle hooks to complete. Keep at a smaller value if you want tasks to hold locks for shorter periods. | `PT30S` (K8s default) | No |
 | `druid.indexer.runner.capacity` | `Integer` | Number of concurrent jobs that can be sent to Kubernetes. | `2147483647` | No |
 | `druid.indexer.runner.cpuCoreInMicro` | `Integer` | Number of CPU micro core for the task. | `1000` | No |
+| `druid.indexer.runner.logSaveTimeout` | `Duration` | How long to wait for task logs to be saved before giving up. | `PT300S` | NO |
 
 ### Metrics added
 

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
@@ -30,16 +30,19 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
   private final KubernetesPeonClient client;
   private final TaskLogs taskLogs;
   private final ObjectMapper mapper;
+  private final long logSaveTimeoutMs;
 
   public KubernetesPeonLifecycleFactory(
       KubernetesPeonClient client,
       TaskLogs taskLogs,
-      ObjectMapper mapper
+      ObjectMapper mapper,
+      long logSaveTimeoutMs
   )
   {
     this.client = client;
     this.taskLogs = taskLogs;
     this.mapper = mapper;
+    this.logSaveTimeoutMs = logSaveTimeoutMs;
   }
 
   @Override
@@ -51,7 +54,8 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
         client,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        logSaveTimeoutMs
     );
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
@@ -106,6 +106,11 @@ public class KubernetesTaskRunnerConfig
   private Period k8sjobLaunchTimeout = new Period("PT1H");
 
   @JsonProperty
+  @NotNull
+  // how long to wait for log saving operations to complete
+  private Period logSaveTimeout = new Period("PT300S");
+
+  @JsonProperty
   // ForkingTaskRunner inherits the monitors from the MM, in k8s mode
   // the peon inherits the monitors from the overlord, so if someone specifies
   // a TaskCountStatsMonitor in the overlord for example, the peon process
@@ -152,6 +157,7 @@ public class KubernetesTaskRunnerConfig
       Period taskCleanupDelay,
       Period taskCleanupInterval,
       Period k8sjobLaunchTimeout,
+      Period logSaveTimeout,
       List<String> peonMonitors,
       List<String> javaOptsArray,
       int cpuCoreInMicro,
@@ -207,6 +213,10 @@ public class KubernetesTaskRunnerConfig
     this.taskJoinTimeout = ObjectUtils.defaultIfNull(
         taskJoinTimeout,
         this.taskJoinTimeout
+    );
+    this.logSaveTimeout = ObjectUtils.defaultIfNull(
+        logSaveTimeout,
+        this.logSaveTimeout
     );
     this.peonMonitors = ObjectUtils.defaultIfNull(
         peonMonitors,
@@ -306,6 +316,11 @@ public class KubernetesTaskRunnerConfig
     return k8sjobLaunchTimeout;
   }
 
+  public Period getLogSaveTimeout()
+  {
+    return logSaveTimeout;
+  }
+
   public List<String> getPeonMonitors()
   {
     return peonMonitors;
@@ -363,6 +378,7 @@ public class KubernetesTaskRunnerConfig
     private Map<String, String> annotations;
     private Integer capacity;
     private Period taskJoinTimeout;
+    private Period logSaveTimeout;
 
     public Builder()
     {
@@ -489,6 +505,12 @@ public class KubernetesTaskRunnerConfig
       return this;
     }
 
+    public Builder withLogSaveTimeout(Period logSaveTimeout)
+    {
+      this.logSaveTimeout = logSaveTimeout;
+      return this;
+    }
+
     public KubernetesTaskRunnerConfig build()
     {
       return new KubernetesTaskRunnerConfig(
@@ -505,6 +527,7 @@ public class KubernetesTaskRunnerConfig
           this.taskCleanupDelay,
           this.taskCleanupInterval,
           this.k8sjobLaunchTimeout,
+          this.logSaveTimeout,
           this.peonMonitors,
           this.javaOptsArray,
           this.cpuCoreInMicro,

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
@@ -93,7 +93,12 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
         kubernetesTaskRunnerConfig,
         peonClient,
         httpClient,
-        new KubernetesPeonLifecycleFactory(peonClient, taskLogs, smileMapper),
+        new KubernetesPeonLifecycleFactory(
+            peonClient,
+            taskLogs,
+            smileMapper,
+            kubernetesTaskRunnerConfig.getLogSaveTimeout().toStandardDuration().getMillis()
+        ),
         emitter
     );
     return runner;

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -1099,7 +1099,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall();
+    EasyMock.expectLastCall().atLeastOnce();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -41,6 +41,7 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,6 +60,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
 {
   private static final String ID = "id";
   private static final TaskStatus SUCCESS = TaskStatus.success(ID);
+  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
+  private static final Period SHORT_LOG_SAVE_TIMEOUT = new Period("PT1S");
 
   @Mock KubernetesPeonClient kubernetesClient;
   @Mock TaskLogs taskLogs;
@@ -88,7 +91,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -134,7 +138,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -179,7 +184,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -229,7 +235,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -274,7 +281,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -322,7 +330,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -361,7 +370,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Assert.assertFalse(peonLifecycle.getTaskStartedSuccessfullyFuture().isDone());
@@ -415,7 +425,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -476,7 +487,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -524,7 +536,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -575,7 +588,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -626,7 +640,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -666,7 +681,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     peonLifecycle.shutdown();
   }
@@ -680,7 +696,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -702,7 +719,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -724,7 +742,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -740,7 +759,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -756,7 +776,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -772,7 +793,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -796,7 +818,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -813,7 +836,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -830,7 +854,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -847,7 +872,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -870,7 +896,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -899,7 +926,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -936,7 +964,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -973,7 +1002,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -1011,7 +1041,8 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
     EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.absent()).once();
@@ -1019,6 +1050,74 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     replayAll();
     Assert.assertEquals(TaskLocation.unknown(), peonLifecycle.getTaskLocation());
     verifyAll();
+  }
+
+  @Test
+  public void test_join_saveLogsTimeout_handledGracefully() throws IOException
+  {
+    KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
+        task,
+        k8sTaskId,
+        kubernetesClient,
+        taskLogs,
+        mapper,
+        stateListener,
+        SHORT_LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()  // 1 second timeout for task log save
+    );
+
+    Job job = new JobBuilder()
+        .withNewMetadata()
+        .withName(ID)
+        .endMetadata()
+        .withNewStatus()
+        .withSucceeded(1)
+        .withStartTime("2022-09-19T23:31:50Z")
+        .withCompletionTime("2022-09-19T23:32:48Z")
+        .endStatus()
+        .build();
+
+    EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
+        EasyMock.eq(k8sTaskId),
+        EasyMock.anyLong(),
+        EasyMock.eq(TimeUnit.MILLISECONDS)
+    )).andReturn(new JobResponse(job, PeonPhase.SUCCEEDED));
+
+    EasyMock.expect(kubernetesClient.getPeonLogWatcher(k8sTaskId)).andReturn(Optional.of(logWatch));
+    EasyMock.expect(taskLogs.streamTaskStatus(ID)).andReturn(Optional.of(
+        IOUtils.toInputStream(mapper.writeValueAsString(SUCCESS), StandardCharsets.UTF_8)
+    ));
+
+    // Mock pushTaskLog to sleep longer than the timeout (2 seconds > 1 second timeout)
+    taskLogs.pushTaskLog(EasyMock.eq(ID), EasyMock.anyObject(File.class));
+    EasyMock.expectLastCall().andAnswer(() -> {
+      Thread.sleep(2000); // Sleep for 2 seconds
+      return null;
+    });
+
+    stateListener.stateChanged(KubernetesPeonLifecycle.State.RUNNING, ID);
+    EasyMock.expectLastCall().once();
+    stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
+    EasyMock.expectLastCall().once();
+    logWatch.close();
+    EasyMock.expectLastCall();
+
+    Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
+
+    replayAll();
+
+    // The test should complete without hanging, even though log save times out
+    long startTime = System.currentTimeMillis();
+    TaskStatus taskStatus = peonLifecycle.join(0L);
+    long duration = System.currentTimeMillis() - startTime;
+
+    // Should complete in ~1 second (timeout), not 5+ seconds (sleep duration)
+    Assert.assertTrue("Test should complete quickly due to timeout", duration < 1500);
+
+    verifyAll();
+
+    // Task should still succeed - log timeout doesn't affect task result
+    Assert.assertEquals(SUCCESS.withDuration(58000), taskStatus);
+    Assert.assertEquals(KubernetesPeonLifecycle.State.STOPPED, peonLifecycle.getState());
   }
 
   private void setPeonLifecycleState(KubernetesPeonLifecycle peonLifecycle, KubernetesPeonLifecycle.State state)

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -402,7 +402,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall();
+    EasyMock.expectLastCall().atLeastOnce();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -452,13 +452,11 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     taskLogs.pushTaskLog(EasyMock.eq(ID), EasyMock.anyObject(File.class));
     EasyMock.expectLastCall();
     logWatch.close();
-    EasyMock.expectLastCall();
+    EasyMock.expectLastCall().atLeastOnce();
     stateListener.stateChanged(KubernetesPeonLifecycle.State.RUNNING, ID);
     EasyMock.expectLastCall().once();
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
-    logWatch.close();
-    EasyMock.expectLastCall();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -563,7 +561,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall();
+    EasyMock.expectLastCall().atLeastOnce();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -617,7 +615,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall();
+    EasyMock.expectLastCall().atLeastOnce();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -659,7 +657,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall();
+    EasyMock.expectLastCall().atLeastOnce();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
@@ -28,6 +28,7 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,6 +37,8 @@ import org.junit.runner.RunWith;
 @RunWith(EasyMockRunner.class)
 public class KubernetesWorkItemTest extends EasyMockSupport
 {
+  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
+
   private KubernetesWorkItem workItem;
   private Task task;
   private K8sTaskId taskId;
@@ -130,7 +133,8 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 
@@ -146,7 +150,8 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     ) {
       @Override
       protected State getState()
@@ -169,7 +174,8 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     ) {
       @Override
       protected State getState()
@@ -192,7 +198,8 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     ) {
       @Override
       protected State getState()
@@ -215,7 +222,8 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
     Assert.assertFalse(workItem.streamTaskLogs().isPresent());
@@ -230,7 +238,8 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Prevents `saveLogs()` from hanging indefinitely when there are fabric8 issues. Read https://github.com/fabric8io/kubernetes-client/issues/7163 for some extra context on how LogWatch processing can be indefinitely blocking situation. Situations like this are suspects in issues around overlord graceful shutdowns being able to complete successfully. The upstream kubernetes-client fix associated with the linked issue is preferable to my implementation, but with that being unreleased, it is not clear when we can integrate the fix into Druid.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Introduce task log saving timeouts for the `kubernetes-overlord-extensions` `mm-less` ingestion framework. Persisting task logs will no longer have the potential to block indefinitely. Instead there is a time limit for persisting logs, that if breached, results in giving up on the persist. The default timeout is 5 minutes, but can be configured by overriding `druid.indexer.runner.logSaveTimeout` with a valid Duration (e.g `PT60S`)


<hr>

##### Key changed/added classes in this PR
 * `KubernetesPeonLifecycle.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
