### PR TITLE
Poll from memory before fetching task information from DB

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/HeapMemoryTaskStorage.java
@@ -76,7 +76,7 @@ public class HeapMemoryTaskStorage implements TaskStorage
   }
 
   @Override
-  public void insert(Task task, TaskStatus status)
+  public TaskInfo<Task, TaskStatus> insert(Task task, TaskStatus status)
   {
     Preconditions.checkNotNull(task, "task");
     Preconditions.checkNotNull(status, "status");
@@ -94,6 +94,7 @@ public class HeapMemoryTaskStorage implements TaskStorage
     }
 
     log.info("Inserted task[%s] with status[%s]", task.getId(), status);
+    return TaskStuff.toTaskInfo(newTaskStuff);
   }
 
   @Override
@@ -154,6 +155,18 @@ public class HeapMemoryTaskStorage implements TaskStorage
     for (final TaskStuff taskStuff : tasks.values()) {
       if (taskStuff.getStatus().isRunnable()) {
         listBuilder.add(taskStuff.getTask());
+      }
+    }
+    return listBuilder.build();
+  }
+
+  @Override
+  public List<TaskInfo<Task, TaskStatus>> getActiveTaskInfos()
+  {
+    final ImmutableList.Builder<TaskInfo<Task, TaskStatus>> listBuilder = ImmutableList.builder();
+    for (final TaskStuff taskStuff : tasks.values()) {
+      if (taskStuff.getStatus().isRunnable()) {
+        listBuilder.add(TaskStuff.toTaskInfo(taskStuff));
       }
     }
     return listBuilder.build();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
@@ -192,7 +192,7 @@ public class MetadataTaskStorage implements TaskStorage
   {
     // filter out taskInfo with a null 'task' which should only happen in practice if we are missing a jackson module
     // and don't know what to do with the payload, so we won't be able to make use of it anyway
-    return handler.getTaskInfos(Collections.singletonMap(TaskLookupType.ACTIVE, ActiveTaskLookup.getInstance()), null)
+    return handler.getTaskInfos(Map.of(TaskLookupType.ACTIVE, ActiveTaskLookup.getInstance()), null)
                   .stream()
                   .filter(taskInfo -> taskInfo.getStatus().isRunnable() && taskInfo.getTask() != null)
                   .map(TaskInfo::getTask)
@@ -202,7 +202,7 @@ public class MetadataTaskStorage implements TaskStorage
   @Override
   public List<TaskInfo<Task, TaskStatus>> getActiveTaskInfos()
   {
-    return handler.getTaskInfos(Collections.singletonMap(TaskLookupType.ACTIVE, ActiveTaskLookup.getInstance()), null)
+    return handler.getTaskInfos(Map.of(TaskLookupType.ACTIVE, ActiveTaskLookup.getInstance()), null)
                   .stream()
                   .filter(taskInfo -> taskInfo.getStatus().isRunnable() && taskInfo.getTask() != null)
                   .collect(Collectors.toList());

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/MetadataTaskStorage.java
@@ -192,11 +192,9 @@ public class MetadataTaskStorage implements TaskStorage
   {
     // filter out taskInfo with a null 'task' which should only happen in practice if we are missing a jackson module
     // and don't know what to do with the payload, so we won't be able to make use of it anyway
-    return handler.getTaskInfos(Map.of(TaskLookupType.ACTIVE, ActiveTaskLookup.getInstance()), null)
-                  .stream()
-                  .filter(taskInfo -> taskInfo.getStatus().isRunnable() && taskInfo.getTask() != null)
-                  .map(TaskInfo::getTask)
-                  .collect(Collectors.toList());
+    return getActiveTaskInfos().stream()
+                               .map(TaskInfo::getTask)
+                               .collect(Collectors.toList());
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
@@ -33,7 +33,6 @@ import org.apache.druid.indexing.overlord.autoscaling.ProvisioningStrategy;
 import org.apache.druid.indexing.overlord.http.TaskStateLookup;
 import org.apache.druid.indexing.overlord.http.TotalWorkerCapacityResponse;
 import org.apache.druid.indexing.overlord.setup.WorkerBehaviorConfig;
-import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
@@ -41,7 +40,6 @@ import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.metadata.LockFilterPolicy;
 import org.apache.druid.metadata.TaskLookup;
 import org.apache.druid.metadata.TaskLookup.TaskLookupType;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 
@@ -106,6 +104,10 @@ public class TaskQueryTool
 
   public List<TaskInfo<Task, TaskStatus>> getActiveTaskInfo(@Nullable String dataSource)
   {
+    final Optional<TaskQueue> taskQueue = taskMaster.getTaskQueue();
+    if (taskQueue.isPresent()) {
+      taskQueue.get().getActiveTasksForDatasource(dataSource);
+    }
     return storage.getTaskInfos(TaskLookup.activeTasksOnly(), dataSource);
   }
 
@@ -147,6 +149,13 @@ public class TaskQueryTool
   @Nullable
   public TaskInfo<Task, TaskStatus> getTaskInfo(String taskId)
   {
+    final Optional<TaskQueue> taskQueue = taskMaster.getTaskQueue();
+    if (taskQueue.isPresent()) {
+      final Optional<TaskInfo<Task, TaskStatus>> taskStatus = taskQueue.get().getActiveTaskInfo(taskId);
+      if (taskStatus.isPresent()) {
+        return taskStatus.get();
+      }
+    }
     return storage.getTaskInfo(taskId);
   }
 
@@ -156,12 +165,10 @@ public class TaskQueryTool
     if (taskQueue.isPresent()) {
       // Serve active task statuses from memory
       final List<TaskStatusPlus> taskStatusPlusList = new ArrayList<>();
+      final List<TaskInfo<Task, TaskStatus>> activeTasks = taskQueue.get().getTaskInfos();
 
-      // Use a dummy created time as this is not used by the caller, just needs to be non-null
-      final DateTime createdTime = DateTimes.nowUtc();
-
-      final List<Task> activeTasks = taskQueue.get().getTasks();
-      for (Task task : activeTasks) {
+      for (TaskInfo<Task, TaskStatus> taskInfo : activeTasks) {
+        final Task task = taskInfo.getTask();
         final Optional<TaskStatus> statusOptional = taskQueue.get().getTaskStatus(task.getId());
         if (statusOptional.isPresent()) {
           final TaskStatus status = statusOptional.get();
@@ -170,8 +177,8 @@ public class TaskQueryTool
                   task.getId(),
                   task.getGroupId(),
                   task.getType(),
-                  createdTime,
-                  createdTime,
+                  taskInfo.getCreatedTime(),
+                  taskInfo.getCreatedTime(),
                   status.getStatusCode(),
                   null,
                   status.getDuration(),

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueryTool.java
@@ -104,10 +104,6 @@ public class TaskQueryTool
 
   public List<TaskInfo<Task, TaskStatus>> getActiveTaskInfo(@Nullable String dataSource)
   {
-    final Optional<TaskQueue> taskQueue = taskMaster.getTaskQueue();
-    if (taskQueue.isPresent()) {
-      taskQueue.get().getActiveTasksForDatasource(dataSource);
-    }
     return storage.getTaskInfos(TaskLookup.activeTasksOnly(), dataSource);
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -426,7 +426,7 @@ public class TaskQueue
   {
     // Don't do anything with tasks that have recently finished; notifyStatus will handle it.
     if (entry != null && !entry.isComplete) {
-      final Task task = entry.taskInfo.getTask();
+      final Task task = entry.getTask();
 
       if (entry.future == null) {
         if (runnerTaskFuture == null) {
@@ -569,7 +569,7 @@ public class TaskQueue
 
     if (added.get()) {
       taskLockbox.add(taskInfo.getTask());
-    } else if (!entry.taskInfo.getTask().equals(taskInfo.getTask())) {
+    } else if (!entry.getTask().equals(taskInfo.getTask())) {
       throw new ISE("Cannot add task[%s] as a different task for the same ID has already been added.", taskInfo.getTask().getId());
     }
   }
@@ -688,7 +688,7 @@ public class TaskQueue
       return;
     }
 
-    final Task task = entry.taskInfo.getTask();
+    final Task task = entry.getTask();
     Preconditions.checkNotNull(task, "task");
     Preconditions.checkNotNull(taskStatus, "status");
     Preconditions.checkState(active, "Queue is not active!");
@@ -925,7 +925,7 @@ public class TaskQueue
   {
     return activeTasks.values().stream()
                       .filter(entry -> !entry.isComplete)
-                      .map(entry -> entry.taskInfo.getTask())
+                      .map(entry -> entry.getTask())
                       .collect(Collectors.toMap(Task::getId, TaskQueue::getMetricKey));
   }
 
@@ -962,7 +962,7 @@ public class TaskQueue
 
     return activeTasks.values().stream()
                       .filter(entry -> !entry.isComplete)
-                      .map(entry -> entry.taskInfo.getTask())
+                      .map(entry -> entry.getTask())
                       .filter(task -> !runnerKnownTaskIds.contains(task.getId()))
                       .collect(Collectors.toMap(TaskQueue::getMetricKey, task -> 1L, Long::sum));
   }
@@ -1061,7 +1061,7 @@ public class TaskQueue
         entry -> !entry.isComplete
                  && entry.taskInfo.getDataSource().equals(datasource)
     ).map(
-        entry -> entry.taskInfo.getTask()
+        entry -> entry.getTask()
     ).collect(
         Collectors.toMap(Task::getId, Function.identity())
     );
@@ -1174,6 +1174,14 @@ public class TaskQueue
     {
       this.taskInfo = taskInfo;
       this.lastUpdatedTime = DateTimes.nowUtc();
+    }
+
+    /**
+     * Returns the task associated with this {@link TaskEntry}
+     */
+    public Task getTask()
+    {
+      return taskInfo.getTask();
     }
 
     /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -37,6 +37,7 @@ import org.apache.druid.error.DruidException;
 import org.apache.druid.error.EntryAlreadyExists;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.RunnerTaskState;
+import org.apache.druid.indexer.TaskInfo;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.Counters;
@@ -425,7 +426,7 @@ public class TaskQueue
   {
     // Don't do anything with tasks that have recently finished; notifyStatus will handle it.
     if (entry != null && !entry.isComplete) {
-      final Task task = entry.task;
+      final Task task = entry.taskInfo.getTask();
 
       if (entry.future == null) {
         if (runnerTaskFuture == null) {
@@ -535,10 +536,10 @@ public class TaskQueue
       // If this throws with any sort of exception, including TaskExistsException, we don't want to
       // insert the task into our queue. So don't catch it.
       final DateTime insertTime = DateTimes.nowUtc();
-      taskStorage.insert(task, TaskStatus.running(task.getId()));
+      final TaskInfo<Task, TaskStatus> taskInfo = taskStorage.insert(task, TaskStatus.running(task.getId()));
       // Note: the TaskEntry created for this task doesn't actually use the `insertTime` timestamp, it uses a new
       // timestamp created in the ctor. This prevents races from occurring while syncFromStorage() is happening.
-      addTaskInternal(task, insertTime);
+      addTaskInternal(taskInfo, insertTime);
       requestManagement();
       return true;
     }
@@ -548,17 +549,22 @@ public class TaskQueue
   }
 
   @GuardedBy("startStopLock")
-  private void addTaskInternal(final Task task, final DateTime updateTime)
+  private void addTaskInternal(final TaskInfo<Task, TaskStatus> taskInfo, final DateTime updateTime)
   {
     final AtomicBoolean added = new AtomicBoolean(false);
     final TaskEntry entry = addOrUpdateTaskEntry(
-        task.getId(),
+        taskInfo.getId(),
         prevEntry -> {
           if (prevEntry == null) {
             added.set(true);
-            return new TaskEntry(task);
+            return new TaskEntry(taskInfo);
           } else if (prevEntry.lastUpdatedTime.isBefore(updateTime)) {
             prevEntry.lastUpdatedTime = updateTime;
+          }
+
+          // Ensure we keep the current status up-to-date
+          if (!prevEntry.taskInfo.getStatus().equals(taskInfo.getStatus())) {
+            prevEntry.taskInfo = taskInfo;
           }
 
           return prevEntry;
@@ -566,9 +572,9 @@ public class TaskQueue
     );
 
     if (added.get()) {
-      taskLockbox.add(task);
-    } else if (!entry.task.equals(task)) {
-      throw new ISE("Cannot add task[%s] as a different task for the same ID has already been added.", task.getId());
+      taskLockbox.add(taskInfo.getTask());
+    } else if (!entry.taskInfo.getTask().equals(taskInfo.getTask())) {
+      throw new ISE("Cannot add task[%s] as a different task for the same ID has already been added.", taskInfo.getId());
     }
   }
 
@@ -584,14 +590,14 @@ public class TaskQueue
   @GuardedBy("startStopLock")
   private boolean removeTaskInternal(final String taskId, final DateTime deleteTime)
   {
-    final AtomicReference<Task> removedTask = new AtomicReference<>();
+    final AtomicReference<TaskInfo<Task, TaskStatus>> removedTask = new AtomicReference<>();
 
     addOrUpdateTaskEntry(
         taskId,
         prevEntry -> {
           // Remove the task only if it is complete OR it doesn't have a more recent update
           if (prevEntry != null && (prevEntry.isComplete || prevEntry.lastUpdatedTime.isBefore(deleteTime))) {
-            removedTask.set(prevEntry.task);
+            removedTask.set(prevEntry.taskInfo);
             // Remove this taskId from activeTasks by mapping it to null
             return null;
           }
@@ -601,7 +607,7 @@ public class TaskQueue
     );
 
     if (removedTask.get() != null) {
-      removeTaskLock(removedTask.get());
+      removeTaskLock(removedTask.get().getTask());
       return true;
     }
     return false;
@@ -686,7 +692,7 @@ public class TaskQueue
       return;
     }
 
-    final Task task = entry.task;
+    final Task task = entry.taskInfo.getTask();
     Preconditions.checkNotNull(task, "task");
     Preconditions.checkNotNull(taskStatus, "status");
     Preconditions.checkState(active, "Queue is not active!");
@@ -696,6 +702,9 @@ public class TaskQueue
         task.getId(),
         taskStatus.getId()
     );
+
+    // Always update the task status associated with this entry
+    entry.taskInfo = entry.taskInfo.withStatus(taskStatus);
 
     if (!taskStatus.isComplete()) {
       // Nothing to do for incomplete statuses.
@@ -835,26 +844,24 @@ public class TaskQueue
 
     try {
       if (active) {
-        final Map<String, Task> newTasks =
-            CollectionUtils.toMap(taskStorage.getActiveTasks(), Task::getId, Function.identity());
-        final Map<String, Task> oldTasks =
-            CollectionUtils.mapValues(activeTasks, entry -> entry.task);
+        final Map<String, TaskInfo<Task, TaskStatus>> newTasks = CollectionUtils.toMap(taskStorage.getActiveTaskInfos(), (taskInfo) -> taskInfo.getTask().getId(), Function.identity());
+        final Map<String, TaskInfo<Task, TaskStatus>> oldTasks = CollectionUtils.mapValues(activeTasks, entry -> entry.taskInfo);
 
         // Identify the tasks that have been added or removed from the storage
-        final MapDifference<String, Task> mapDifference = Maps.difference(oldTasks, newTasks);
-        final Collection<Task> addedTasks = mapDifference.entriesOnlyOnRight().values();
-        final Collection<Task> removedTasks = mapDifference.entriesOnlyOnLeft().values();
+        final MapDifference<String, TaskInfo<Task, TaskStatus>> mapDifference = Maps.difference(oldTasks, newTasks);
+        final Collection<TaskInfo<Task, TaskStatus>> addedTasks = mapDifference.entriesOnlyOnRight().values();
+        final Collection<TaskInfo<Task, TaskStatus>> removedTasks = mapDifference.entriesOnlyOnLeft().values();
 
         // Remove tasks not present in metadata store if their lastUpdatedTime is before syncStartTime
         int numTasksRemoved = 0;
-        for (Task task : removedTasks) {
+        for (TaskInfo<Task, TaskStatus> task : removedTasks) {
           if (removeTaskInternal(task.getId(), syncStartTime)) {
             ++numTasksRemoved;
           }
         }
 
         // Add new tasks present in metadata store if their lastUpdatedTime is before syncStartTime
-        for (Task task : addedTasks) {
+        for (TaskInfo<Task, TaskStatus> task : addedTasks) {
           addTaskInternal(task, syncStartTime);
         }
 
@@ -921,7 +928,7 @@ public class TaskQueue
   {
     return activeTasks.values().stream()
                       .filter(entry -> !entry.isComplete)
-                      .map(entry -> entry.task)
+                      .map(entry -> entry.taskInfo.getTask())
                       .collect(Collectors.toMap(Task::getId, TaskQueue::getMetricKey));
   }
 
@@ -958,7 +965,7 @@ public class TaskQueue
 
     return activeTasks.values().stream()
                       .filter(entry -> !entry.isComplete)
-                      .map(entry -> entry.task)
+                      .map(entry -> entry.taskInfo.getTask())
                       .filter(task -> !runnerKnownTaskIds.contains(task.getId()))
                       .collect(Collectors.toMap(TaskQueue::getMetricKey, task -> 1L, Long::sum));
   }
@@ -998,16 +1005,16 @@ public class TaskQueue
    */
   public Optional<Task> getActiveTask(String id)
   {
-    final TaskEntry entry = activeTasks.get(id);
-    if (entry == null) {
+    final Optional<TaskInfo<Task, TaskStatus>> taskInfo = getActiveTaskInfo(id);
+    if (!taskInfo.isPresent()) {
       return Optional.absent();
     }
 
-    Task task = entry.task;
+    Task task = taskInfo.get().getTask();
     if (task != null) {
       try {
         // Write and read the value using a mapper with password redaction mixin.
-        task = passwordRedactingMapper.readValue(passwordRedactingMapper.writeValueAsString(entry.task), Task.class);
+        task = passwordRedactingMapper.readValue(passwordRedactingMapper.writeValueAsString(task), Task.class);
       }
       catch (JsonProcessingException e) {
         log.error(e, "Failed to serialize or deserialize task with id [%s].", task.getId());
@@ -1020,12 +1027,33 @@ public class TaskQueue
   }
 
   /**
-   * List of all active and completed tasks currently being managed by this
-   * TaskQueue.
+   * Returns an optional TaskInfo
+   * @param taskId
+   * @return
+   */
+  public Optional<TaskInfo<Task, TaskStatus>> getActiveTaskInfo(String taskId)
+  {
+    final TaskEntry entry = activeTasks.get(taskId);
+    if (entry == null) {
+      return Optional.absent();
+    }
+    return Optional.of(entry.taskInfo);
+  }
+
+  /**
+   * List of all active and completed tasks currently being managed by this TaskQueue.
+   */
+  public List<TaskInfo<Task, TaskStatus>> getTaskInfos()
+  {
+    return activeTasks.values().stream().map(entry -> entry.taskInfo).collect(Collectors.toList());
+  }
+
+  /**
+   * List of all active and completed tasks currently being managed by this TaskQueue.
    */
   public List<Task> getTasks()
   {
-    return activeTasks.values().stream().map(entry -> entry.task).collect(Collectors.toList());
+    return activeTasks.values().stream().map(entry -> entry.taskInfo.getTask()).collect(Collectors.toList());
   }
 
   /**
@@ -1035,9 +1063,9 @@ public class TaskQueue
   {
     return activeTasks.values().stream().filter(
         entry -> !entry.isComplete
-                 && entry.task.getDataSource().equals(datasource)
+                 && entry.taskInfo.getDataSource().equals(datasource)
     ).map(
-        entry -> entry.task
+        entry -> entry.taskInfo.getTask()
     ).collect(
         Collectors.toMap(Task::getId, Function.identity())
     );
@@ -1140,15 +1168,15 @@ public class TaskQueue
    */
   static class TaskEntry
   {
-    private final Task task;
+    private TaskInfo<Task, TaskStatus> taskInfo;
 
     private DateTime lastUpdatedTime;
     private ListenableFuture<TaskStatus> future = null;
     private boolean isComplete = false;
 
-    TaskEntry(Task task)
+    TaskEntry(TaskInfo<Task, TaskStatus> taskInfo)
     {
-      this.task = task;
+      this.taskInfo = taskInfo;
       this.lastUpdatedTime = DateTimes.nowUtc();
     }
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
@@ -40,8 +40,9 @@ public interface TaskStorage
    *
    * @param task   task to add
    * @param status task status
+   * @return A TaskInfo object representing the task information that was committed
    */
-  void insert(Task task, TaskStatus status);
+  TaskInfo<Task, TaskStatus> insert(Task task, TaskStatus status);
 
   /**
    * Persists task status in the storage facility. This method should throw an exception if the task status lifecycle
@@ -116,6 +117,14 @@ public interface TaskStorage
    * @return list of active tasks
    */
   List<Task> getActiveTasks();
+
+  /**
+   * Returns a list of currently running or pending tasks as stored in the storage facility. No particular order
+   * is guaranteed, but implementations are encouraged to return tasks in ascending order of creation.
+   *
+   * @return list of active tasks
+   */
+  List<TaskInfo<Task, TaskStatus>> getActiveTaskInfos();
 
   /**
    * Returns a list of currently running or pending tasks as stored in the storage facility. No particular order

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskStorage.java
@@ -40,7 +40,7 @@ public interface TaskStorage
    *
    * @param task   task to add
    * @param status task status
-   * @return A TaskInfo object representing the task information that was committed
+   * @return a TaskInfo object representing the task information that was committed to the storage facility
    */
   TaskInfo<Task, TaskStatus> insert(Task task, TaskStatus status);
 
@@ -119,10 +119,10 @@ public interface TaskStorage
   List<Task> getActiveTasks();
 
   /**
-   * Returns a list of currently running or pending tasks as stored in the storage facility. No particular order
+   * Returns a list of currently running or pending task infos as stored in the storage facility. No particular order
    * is guaranteed, but implementations are encouraged to return tasks in ascending order of creation.
    *
-   * @return list of active tasks
+   * @return list of active task infos
    */
   List<TaskInfo<Task, TaskStatus>> getActiveTaskInfos();
 

--- a/processing/src/main/java/org/apache/druid/indexer/TaskInfo.java
+++ b/processing/src/main/java/org/apache/druid/indexer/TaskInfo.java
@@ -77,7 +77,12 @@ public class TaskInfo<EntryType, StatusType>
     return task;
   }
 
-  public TaskInfo<EntryType, StatusType> withStatus(StatusType newStatus)
+  /**
+   * Returns a copy of this TaskInfo object with a new StatusType
+   * @param newStatus
+   * @return a new TaskInfo
+   */
+  public TaskInfo<EntryType, StatusType> withNewStatus(StatusType newStatus)
   {
     return new TaskInfo<>(id, createdTime, newStatus, dataSource, task);
   }

--- a/processing/src/main/java/org/apache/druid/indexer/TaskInfo.java
+++ b/processing/src/main/java/org/apache/druid/indexer/TaskInfo.java
@@ -76,4 +76,9 @@ public class TaskInfo<EntryType, StatusType>
   {
     return task;
   }
+
+  public TaskInfo<EntryType, StatusType> withStatus(StatusType newStatus)
+  {
+    return new TaskInfo<>(id, createdTime, newStatus, dataSource, task);
+  }
 }

--- a/processing/src/main/java/org/apache/druid/indexer/TaskInfo.java
+++ b/processing/src/main/java/org/apache/druid/indexer/TaskInfo.java
@@ -78,12 +78,10 @@ public class TaskInfo<EntryType, StatusType>
   }
 
   /**
-   * Returns a copy of this TaskInfo object with a new StatusType
-   * @param newStatus
-   * @return a new TaskInfo
+   * Returns a copy of this TaskInfo object with the given status.
    */
-  public TaskInfo<EntryType, StatusType> withNewStatus(StatusType newStatus)
+  public TaskInfo<EntryType, StatusType> withStatus(StatusType status)
   {
-    return new TaskInfo<>(id, createdTime, newStatus, dataSource, task);
+    return new TaskInfo<>(id, createdTime, status, dataSource, task);
   }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

When running high #s of tasks in a cluster, the Overlord can become bottlenecked by the endpoint `/task/{taskid}/status`.
Because `taskQueryTool.getTaskInfo(taskid)` currently only issues a direct I/O to the underlying task storage, this results in heavy I/O + serde from the metadata store to pull the associated task information.

This change stores/updates the `TaskInfo` information inside the `activeTasks` queue's `TaskEntry` type, allowing the requests to fetch from memory if the task entry exists, otherwise falling back to the DB.

Some lingering questions:

#### Code Style/Smell
I didn't really like the idea of shoving the `TaskInfo` into the `TaskEntry`, but it felt like the most convenient way of storing all the necessary information needed. We're really just relying on the `TaskInfo` for the creation time as well as some up-to-date value of the current `TaskStatus`. It might be worth standardizing on `TaskInfo` as `Task` and `TaskStatus` are often paired with each other.

#### Consistency
##### `TaskStatus`
Despite updating the task status on `TaskQueue::notifyStatus` callbacks, I wonder whether it may be possible for the respective states in task storage and memory to diverge for a given task's status. 
- In normal state, my initial thought is that the value returned from `TaskQueryTool::getActiveTaskInfo` and `TaskQueryTool::getTaskInfo` should always return state that is *at least* as recent as the latest commit to the DB, since the status updates to the DB in `TaskQueue::notifyStatus` are in the same critical section as those to the `TaskEntry` value. There might be merit in updating the task status in the critical section once it's been committed to the DB, however.
- In a failure scenario, the overlord could receive requests prior to initially (or recently) syncing with DB, resulting in partial/incorrect results. 

##### `TaskQueryTool::getAllActiveTasks`
Prior to this change, the function would use a dummy timestamp for both creation/queue insertion timestamps in the returned payload. Now that we can serve accurate timestamps, I believe we can still use the same timestamp for both fields.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 


If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Poll from memory before fetching task information from DB


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
