### PR TITLE
fixes for projection matching logic

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/CursorBuildSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/CursorBuildSpec.java
@@ -117,7 +117,7 @@ public class CursorBuildSpec
 
   /**
    * {@link Filter} to supply to the {@link CursorHolder}. Only rows which match will be available through the
-   * selectors created from the {@link Cursor} or {@link org.apache.druid.segment.vector.VectorCursor}
+   * selectors created from the {@link Cursor} or {@link VectorCursor}
    */
   @Nullable
   public Filter getFilter()
@@ -128,7 +128,7 @@ public class CursorBuildSpec
   /**
    * {@link Interval} filter to supply to the {@link CursorHolder}. Only rows whose timestamps fall within this range
    * will be available through the selectors created from the {@link Cursor} or
-   * {@link org.apache.druid.segment.vector.VectorCursor}
+   * {@link VectorCursor}
    */
   public Interval getInterval()
   {
@@ -136,8 +136,8 @@ public class CursorBuildSpec
   }
 
   /**
-   * Set of physical columns required from a cursor. If null, and {@link #groupingColumns} is null or empty and
-   * {@link #aggregators} is null or empty, then a {@link CursorHolder} must assume that ALL columns are required.
+   * Set of physical columns required from a cursor. If null, then a {@link CursorHolder} must assume that ALL columns
+   * are required.
    */
   @Nullable
   public Set<String> getPhysicalColumns()
@@ -156,7 +156,7 @@ public class CursorBuildSpec
 
   /**
    * Any columns which will be used for grouping by a query engine for the {@link CursorHolder}, useful for
-   * specializing the {@link Cursor} or {@link org.apache.druid.segment.vector.VectorCursor} if any pre-aggregated
+   * specializing the {@link Cursor} or {@link VectorCursor} if any pre-aggregated
    * data is available.
    */
   @Nullable
@@ -168,7 +168,7 @@ public class CursorBuildSpec
   /**
    * Any {@link AggregatorFactory} which will be used by a query engine for the {@link CursorHolder}, useful
    * to assist in determining if {@link CursorHolder#canVectorize()}, as well as specializing the {@link Cursor} or
-   * {@link org.apache.druid.segment.vector.VectorCursor} if any pre-aggregated data is available.
+   * {@link VectorCursor} if any pre-aggregated data is available.
    */
   @Nullable
   public List<AggregatorFactory> getAggregators()
@@ -179,7 +179,7 @@ public class CursorBuildSpec
   /**
    * List of all {@link OrderBy} columns which a query engine will use to sort its results to supply to the
    * {@link CursorHolder}, which can allow optimization of the provided {@link Cursor} or
-   * {@link org.apache.druid.segment.vector.VectorCursor} if data matching the preferred ordering is available.
+   * {@link VectorCursor} if data matching the preferred ordering is available.
    * <p>
    * If not specified, the cursor will advance in the native order of the underlying data.
    */
@@ -190,7 +190,7 @@ public class CursorBuildSpec
 
   /**
    * {@link QueryContext} for the {@link CursorHolder} to provide a mechanism to push various data into
-   * {@link Cursor} and {@link org.apache.druid.segment.vector.VectorCursor} such as
+   * {@link Cursor} and {@link VectorCursor} such as
    * {@link org.apache.druid.query.QueryContexts#VECTORIZE_KEY} and
    * {@link org.apache.druid.query.QueryContexts#VECTOR_SIZE_KEY}
    */
@@ -201,7 +201,7 @@ public class CursorBuildSpec
 
   /**
    * {@link QueryMetrics} to use for measuring things involved with {@link Cursor} and
-   * {@link org.apache.druid.segment.vector.VectorCursor} creation.
+   * {@link VectorCursor} creation.
    */
   @Nullable
   public QueryMetrics<?> getQueryMetrics()
@@ -381,8 +381,7 @@ public class CursorBuildSpec
      * @see CursorBuildSpec#getPhysicalColumns() for usage. The backing value is not automatically populated by calls to
      * {@link #setFilter(Filter)}, {@link #setVirtualColumns(VirtualColumns)}, {@link #setAggregators(List)}, or
      * {@link #setPreferredOrdering(List)}, so this must be explicitly set for all required physical columns. If set to
-     * null, and {@link #groupingColumns} is null or empty and {@link #aggregators} is null or empty, then a
-     * {@link CursorHolder} must assume that ALL columns are required
+     * null, then a {@link CursorHolder} must assume that ALL columns are required
      */
     public CursorBuildSpecBuilder setPhysicalColumns(@Nullable Set<String> physicalColumns)
     {

--- a/processing/src/main/java/org/apache/druid/segment/UnnestColumnValueSelectorCursor.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestColumnValueSelectorCursor.java
@@ -70,8 +70,7 @@ public class UnnestColumnValueSelectorCursor implements Cursor
   public UnnestColumnValueSelectorCursor(
       Cursor cursor,
       ColumnSelectorFactory baseColumnSelectorFactory,
-      VirtualColumn unnestColumn,
-      String outputColumnName
+      VirtualColumn unnestColumn
   )
   {
     this.baseCursor = cursor;
@@ -81,8 +80,8 @@ public class UnnestColumnValueSelectorCursor implements Cursor
         this.baseColumnSelectorFactory
     );
     this.unnestColumn = unnestColumn;
+    this.outputName = unnestColumn.getOutputName();
     this.index = 0;
-    this.outputName = outputColumnName;
     this.needInitialization = true;
   }
 

--- a/processing/src/main/java/org/apache/druid/segment/UnnestCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestCursorFactory.java
@@ -22,8 +22,8 @@ package org.apache.druid.segment;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.query.Order;
 import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.filter.BooleanFilter;
 import org.apache.druid.query.filter.DimFilter;
@@ -51,7 +51,6 @@ import org.apache.druid.utils.CloseableUtils;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -79,43 +78,19 @@ public class UnnestCursorFactory implements CursorFactory
   public CursorHolder makeCursorHolder(CursorBuildSpec spec)
   {
     final String input = getUnnestInputIfDirectAccess(unnestColumn);
-    final Pair<Filter, Filter> filterPair = computeBaseAndPostUnnestFilters(
+    final UnnestFilterSplit filterSplit = computeBaseAndPostUnnestFilters(
         spec.getFilter(),
         filter != null ? filter.toFilter() : null,
         spec.getVirtualColumns(),
+        unnestColumn,
         input,
-        input == null ? null : spec.getVirtualColumns()
-                                   .getColumnCapabilitiesWithFallback(baseCursorFactory, input)
+        input == null ? null : spec.getVirtualColumns().getColumnCapabilitiesWithFallback(baseCursorFactory, input)
     );
-    final Set<String> physicalColumns;
-    if (spec.getPhysicalColumns() == null) {
-      physicalColumns = null;
-    } else {
-      physicalColumns = new HashSet<>();
-      for (String column : unnestColumn.requiredColumns()) {
-        if (!spec.getVirtualColumns().exists(column)) {
-          physicalColumns.add(column);
-        }
-      }
-      if (filter != null) {
-        for (String column : filter.getRequiredColumns()) {
-          if (!spec.getVirtualColumns().exists(column)) {
-            physicalColumns.add(column);
-          }
-        }
-      }
-      for (String column : spec.getPhysicalColumns()) {
-        if (!column.equals(unnestColumn.getOutputName())) {
-          physicalColumns.add(column);
-        }
-      }
-    }
-    final CursorBuildSpec unnestBuildSpec =
-        CursorBuildSpec.builder(spec)
-                       .setFilter(filterPair.lhs)
-                       .setPhysicalColumns(physicalColumns)
-                       .setVirtualColumns(VirtualColumns.create(Collections.singletonList(unnestColumn)))
-                       .build();
+    final CursorBuildSpec unnestBuildSpec = transformCursorBuildSpec(
+        spec,
+        unnestColumn,
+        filterSplit.getBaseTableFilter()
+    );
 
     return new CursorHolder()
     {
@@ -141,21 +116,19 @@ public class UnnestCursorFactory implements CursorFactory
           unnestCursor = new UnnestDimensionCursor(
               cursor,
               cursor.getColumnSelectorFactory(),
-              unnestColumn,
-              unnestColumn.getOutputName()
+              unnestColumn
           );
         } else {
           unnestCursor = new UnnestColumnValueSelectorCursor(
               cursor,
               cursor.getColumnSelectorFactory(),
-              unnestColumn,
-              unnestColumn.getOutputName()
+              unnestColumn
           );
         }
         return PostJoinCursor.wrap(
             unnestCursor,
             spec.getVirtualColumns(),
-            filterPair.rhs
+            filterSplit.getPostUnnestFilter()
         );
       }
 
@@ -235,10 +208,11 @@ public class UnnestCursorFactory implements CursorFactory
    * @return pair of pre- and post-unnest filters
    */
   @VisibleForTesting
-  public Pair<Filter, Filter> computeBaseAndPostUnnestFilters(
+  static UnnestFilterSplit computeBaseAndPostUnnestFilters(
       @Nullable final Filter queryFilter,
       @Nullable final Filter unnestFilter,
       final VirtualColumns queryVirtualColumns,
+      final VirtualColumn unnestColumn,
       @Nullable final String inputColumn,
       @Nullable final ColumnCapabilities inputColumnCapabilites
   )
@@ -290,6 +264,7 @@ public class UnnestCursorFactory implements CursorFactory
         if (queryFilter instanceof BooleanFilter) {
           List<Filter> preFilterList = recursiveRewriteOnUnnestFilters(
               (BooleanFilter) queryFilter,
+              unnestColumn,
               inputColumn,
               inputColumnCapabilites,
               filterSplitter
@@ -316,7 +291,7 @@ public class UnnestCursorFactory implements CursorFactory
     }
     filterSplitter.addPostFilterWithPreFilterIfRewritePossible(unnestFilter, false);
 
-    return Pair.of(
+    return new UnnestFilterSplit(
         Filters.maybeAnd(filterSplitter.filtersPushedDownToBaseCursor).orElse(null),
         Filters.maybeAnd(filterSplitter.filtersForPostUnnestCursor).orElse(null)
     );
@@ -343,8 +318,9 @@ public class UnnestCursorFactory implements CursorFactory
    * @param inputColumn            input column to unnest if it's a direct access; otherwise null
    * @param inputColumnCapabilites input column capabilities if known; otherwise null
    */
-  private List<Filter> recursiveRewriteOnUnnestFilters(
+  private static List<Filter> recursiveRewriteOnUnnestFilters(
       BooleanFilter queryFilter,
+      VirtualColumn unnestColumn,
       final String inputColumn,
       final ColumnCapabilities inputColumnCapabilites,
       final FilterSplitter filterSplitter
@@ -356,6 +332,7 @@ public class UnnestCursorFactory implements CursorFactory
         if (filter instanceof AndFilter) {
           List<Filter> andChildFilters = recursiveRewriteOnUnnestFilters(
               (BooleanFilter) filter,
+              unnestColumn,
               inputColumn,
               inputColumnCapabilites,
               filterSplitter
@@ -366,6 +343,7 @@ public class UnnestCursorFactory implements CursorFactory
         } else if (filter instanceof OrFilter) {
           List<Filter> orChildFilters = recursiveRewriteOnUnnestFilters(
               (BooleanFilter) filter,
+              unnestColumn,
               inputColumn,
               inputColumnCapabilites,
               filterSplitter
@@ -473,6 +451,71 @@ public class UnnestCursorFactory implements CursorFactory
                                    .setDictionaryEncoded(useDimensionCursor)
                                    .setDictionaryValuesUnique(useDimensionCursor);
     }
+  }
+
+  /**
+   * Converts a {@link CursorBuildSpec} to the base table {@link CursorBuildSpec}, ensuring that all required columns
+   * of are added to {@link CursorBuildSpec#getPhysicalColumns()} and the unnest column is added to {@link CursorBuildSpec#getVirtualColumns()}
+   */
+  @VisibleForTesting
+  public static CursorBuildSpec transformCursorBuildSpec(
+      CursorBuildSpec spec,
+      VirtualColumn unnestColumn,
+      @Nullable Filter baseTableFilter
+  )
+  {
+    final Set<String> physicalColumns;
+    if (spec.getPhysicalColumns() == null) {
+      physicalColumns = null;
+    } else {
+      physicalColumns = new HashSet<>();
+
+      // add all physical columns, skip unnest column if specified as a physical column, we'll deal with it next
+      for (String column : spec.getPhysicalColumns()) {
+        if (!column.equals(unnestColumn.getOutputName())) {
+          physicalColumns.add(column);
+        }
+      }
+
+      // add all unnest input physical columns
+      for (String input : unnestColumn.requiredColumns()) {
+        if (!spec.getVirtualColumns().exists(input)) {
+          physicalColumns.add(input);
+        }
+      }
+
+      // add all the base table filter columns. this is probably unecessary - while part of the filter might have been
+      // on the unnest rather than the query and so its required columns missing from the physical column list, it is
+      // likely the unnest filter is only referencing the unnest column, which is already covered by the physical
+      // column substitution... however just in case something wild happened on the spec we add all these too
+      if (baseTableFilter != null) {
+        for (String column : baseTableFilter.getRequiredColumns()) {
+          if (!spec.getVirtualColumns().exists(column)) {
+            physicalColumns.add(column);
+          }
+        }
+      }
+    }
+
+    // trim off the grouping, aggregators, and ordering (other than time) to turn this into a plain scan cursor build
+    // spec this could be improved in the future to be able to match projections. in some cases, we could push this
+    // through as a grouping, but would need to push in all the query virtual columns, and ensure that aggregators do
+    // not refer to the unnest column (the filter has already been preprocessed and passed in as a separate argument to
+    // this method)
+    Order timeOrder = Cursors.getTimeOrdering(spec.getPreferredOrdering());
+    List<OrderBy> maybeOrderByTime = List.of();
+    if (timeOrder == Order.DESCENDING) {
+      maybeOrderByTime = Cursors.descendingTimeOrder();
+    } else if (timeOrder == Order.ASCENDING) {
+      maybeOrderByTime = Cursors.ascendingTimeOrder();
+    }
+    return CursorBuildSpec.builder()
+                          .setInterval(spec.getInterval())
+                          .setFilter(baseTableFilter)
+                          .setPhysicalColumns(physicalColumns)
+                          .setVirtualColumns(VirtualColumns.create(List.of(unnestColumn)))
+                          .setPreferredOrdering(maybeOrderByTime)
+                          .build();
   }
 
   /**
@@ -616,6 +659,33 @@ public class UnnestCursorFactory implements CursorFactory
     public int getPreFilterCount()
     {
       return preFilterCount;
+    }
+  }
+
+  @VisibleForTesting
+  static final class UnnestFilterSplit
+  {
+    @Nullable
+    private final Filter baseTableFilter;
+    @Nullable
+    private final Filter postUnnestFilter;
+
+    private UnnestFilterSplit(@Nullable Filter baseTableFilter, @Nullable Filter postUnnestFilter)
+    {
+      this.baseTableFilter = baseTableFilter;
+      this.postUnnestFilter = postUnnestFilter;
+    }
+
+    @Nullable
+    public Filter getBaseTableFilter()
+    {
+      return baseTableFilter;
+    }
+
+    @Nullable
+    public Filter getPostUnnestFilter()
+    {
+      return postUnnestFilter;
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/segment/UnnestDimensionCursor.java
+++ b/processing/src/main/java/org/apache/druid/segment/UnnestDimensionCursor.java
@@ -81,8 +81,7 @@ public class UnnestDimensionCursor implements Cursor
   public UnnestDimensionCursor(
       Cursor cursor,
       ColumnSelectorFactory baseColumnSelectorFactory,
-      VirtualColumn unnestColumn,
-      String outputColumnName
+      VirtualColumn unnestColumn
   )
   {
     this.baseCursor = cursor;
@@ -91,9 +90,9 @@ public class UnnestDimensionCursor implements Cursor
         DefaultDimensionSpec.of(unnestColumn.getOutputName()),
         this.baseColumnSelectorFactory
     );
-    this.unnestColumn = unnestColumn;
     this.index = 0;
-    this.outputName = outputColumnName;
+    this.unnestColumn = unnestColumn;
+    this.outputName = unnestColumn.getOutputName();
     this.needInitialization = true;
     // this shouldn't happen, but just in case...
     final IdLookup lookup = Preconditions.checkNotNull(dimSelector.idLookup());

--- a/processing/src/main/java/org/apache/druid/segment/projections/ProjectionMatchBuilder.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/ProjectionMatchBuilder.java
@@ -27,7 +27,6 @@ import org.apache.druid.segment.VirtualColumns;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,7 +44,6 @@ public final class ProjectionMatchBuilder
   private final Set<VirtualColumn> referencedVirtualColumns;
   private final Map<String, String> remapColumns;
   private final List<AggregatorFactory> combiningFactories;
-  private final Set<String> matchedQueryColumns;
   @Nullable
   private Filter rewriteFilter;
 
@@ -55,7 +53,6 @@ public final class ProjectionMatchBuilder
     this.referencedVirtualColumns = new HashSet<>();
     this.remapColumns = new HashMap<>();
     this.combiningFactories = new ArrayList<>();
-    this.matchedQueryColumns = new HashSet<>();
   }
 
   /**
@@ -103,18 +100,6 @@ public final class ProjectionMatchBuilder
     return this;
   }
 
-  public ProjectionMatchBuilder addMatchedQueryColumn(String queryColumn)
-  {
-    matchedQueryColumns.add(queryColumn);
-    return this;
-  }
-
-  public ProjectionMatchBuilder addMatchedQueryColumns(Collection<String> queryColumns)
-  {
-    matchedQueryColumns.addAll(queryColumns);
-    return this;
-  }
-
   public ProjectionMatchBuilder rewriteFilter(Filter rewriteFilter)
   {
     this.rewriteFilter = rewriteFilter;
@@ -129,11 +114,6 @@ public final class ProjectionMatchBuilder
   public Map<String, String> getRemapColumns()
   {
     return remapColumns;
-  }
-
-  public Set<String> getMatchedQueryColumns()
-  {
-    return matchedQueryColumns;
   }
 
   public ProjectionMatch build(CursorBuildSpec queryCursorBuildSpec)

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -94,6 +94,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
@@ -3071,6 +3072,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
                                                     ImmutableMap.of(QueryContexts.USE_PROJECTION, "a_hourly_c_sum")
                                                 )
                                             )
+                                            .setPhysicalColumns(Set.of("c", ColumnHolder.TIME_COLUMN_NAME))
                                             .setVirtualColumns(
                                                 VirtualColumns.create(
                                                     Granularities.toVirtualColumn(Granularities.HOUR, "gran")
@@ -3089,6 +3091,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
                                                     ImmutableMap.of(QueryContexts.USE_PROJECTION, "a_c_sum")
                                                 )
                                             )
+                                            .setPhysicalColumns(Set.of("a", "c"))
                                             .setAggregators(
                                                 Collections.singletonList(
                                                     new LongSumAggregatorFactory("c", "c")

--- a/processing/src/test/java/org/apache/druid/segment/UnnestColumnValueSelectorCursorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestColumnValueSelectorCursorTest.java
@@ -58,8 +58,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -91,8 +90,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -123,8 +121,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -157,8 +154,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "mv_to_array(\"dummy\")", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "mv_to_array(\"dummy\")", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -191,8 +187,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING_ARRAY, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING_ARRAY, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -230,8 +225,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -275,8 +269,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING_ARRAY, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING_ARRAY, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -308,8 +301,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -337,8 +329,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -371,8 +362,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", null, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", null, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -404,14 +394,12 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor childCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", null, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", null, ExprMacroTable.nil())
     );
     UnnestColumnValueSelectorCursor parentCursor = new UnnestColumnValueSelectorCursor(
         childCursor,
         childCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"" + OUTPUT_NAME + "\"", null, ExprMacroTable.nil()),
-        "tmp-out"
+        new ExpressionVirtualColumn("tmp-out", "\"" + OUTPUT_NAME + "\"", null, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = parentCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector("tmp-out");
@@ -444,8 +432,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -481,8 +468,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -518,8 +504,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -551,8 +536,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -584,8 +568,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -620,8 +603,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", null, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", null, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);
@@ -655,8 +637,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     // should return a column value selector for this case
     BaseSingleValueDimensionSelector unnestDimSelector = (BaseSingleValueDimensionSelector) unnestCursor.getColumnSelectorFactory()
@@ -697,8 +678,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     UnnestColumnValueSelectorCursor unnestCursor = new UnnestColumnValueSelectorCursor(
         listCursor,
         listCursor.getColumnSelectorFactory(),
-        new ExpressionVirtualColumn("__unnest__", "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil()),
-        OUTPUT_NAME
+        new ExpressionVirtualColumn(OUTPUT_NAME, "\"dummy\"", ColumnType.STRING, ExprMacroTable.nil())
     );
     ColumnValueSelector unnestColumnValueSelector = unnestCursor.getColumnSelectorFactory()
                                                                 .makeColumnValueSelector(OUTPUT_NAME);

--- a/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
@@ -22,7 +22,6 @@ package org.apache.druid.segment;
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.ResourceInputSource;
-import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.java.util.common.io.Closer;
@@ -32,9 +31,11 @@ import org.apache.druid.query.dimension.DefaultDimensionSpec;
 import org.apache.druid.query.filter.DimFilter;
 import org.apache.druid.query.filter.EqualityFilter;
 import org.apache.druid.query.filter.Filter;
+import org.apache.druid.query.filter.RangeFilter;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.query.filter.ValueMatcher;
 import org.apache.druid.segment.column.ColumnCapabilities;
+import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
@@ -61,12 +62,14 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.ToLongFunction;
 
@@ -836,6 +839,190 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
     }
   }
 
+  @Test
+  public void testTransformCursor()
+  {
+    final String inputColumn = "col";
+    final String unnestColumn = "unnest";
+    ExpressionVirtualColumn identifier = new ExpressionVirtualColumn(
+        unnestColumn,
+        "\"" + inputColumn + "\"",
+        ColumnType.STRING_ARRAY,
+        ExprMacroTable.nil()
+    );
+    CursorBuildSpec buildSpec = CursorBuildSpec.builder()
+                                               .setPhysicalColumns(Set.of(unnestColumn))
+                                               .setGroupingColumns(List.of(unnestColumn))
+                                               .build();
+
+
+    CursorBuildSpec expected = CursorBuildSpec.builder()
+                                              .setPhysicalColumns(Set.of(inputColumn))
+                                              .setVirtualColumns(VirtualColumns.create(identifier))
+                                              .build();
+
+    CursorBuildSpec transformed = UnnestCursorFactory.transformCursorBuildSpec(
+        buildSpec,
+        identifier,
+        null
+    );
+
+    Assertions.assertEquals(expected, transformed);
+  }
+
+  @Test
+  public void testTransformCursorMoreGrouping()
+  {
+    final String unnestColumn = "unnest";
+    ExpressionVirtualColumn identifier = new ExpressionVirtualColumn(
+        unnestColumn,
+        "\"a\"",
+        ColumnType.STRING_ARRAY,
+        ExprMacroTable.nil()
+    );
+    CursorBuildSpec buildSpec = CursorBuildSpec.builder()
+                                               .setPhysicalColumns(Set.of(unnestColumn, "b", "c"))
+                                               .setGroupingColumns(List.of(unnestColumn, "b", "c"))
+                                               .build();
+
+
+    CursorBuildSpec expected = CursorBuildSpec.builder()
+                                              .setPhysicalColumns(Set.of("a", "b", "c"))
+                                              .setVirtualColumns(VirtualColumns.create(identifier))
+                                              .build();
+
+    CursorBuildSpec transformed = UnnestCursorFactory.transformCursorBuildSpec(
+        buildSpec,
+        identifier,
+        null
+    );
+
+    Assertions.assertEquals(expected, transformed);
+  }
+
+  @Test
+  public void testTransformCursorFilter()
+  {
+    final String unnestColumn = "unnest";
+    ExpressionVirtualColumn identifier = new ExpressionVirtualColumn(
+        unnestColumn,
+        "\"a\"",
+        ColumnType.STRING_ARRAY,
+        ExprMacroTable.nil()
+    );
+    Filter unnestEquals = new EqualityFilter(unnestColumn, ColumnType.STRING, "value", null);
+    Filter bRange = new RangeFilter("b", ColumnType.LONG, 1L, 10L, false, false, null);
+    CursorBuildSpec buildSpec = CursorBuildSpec.builder()
+                                               .setPhysicalColumns(Set.of(unnestColumn, "b", "c"))
+                                               .setGroupingColumns(List.of(unnestColumn, "b", "c"))
+                                               .setFilter(bRange)
+                                               .build();
+
+    UnnestCursorFactory.UnnestFilterSplit split = UnnestCursorFactory.computeBaseAndPostUnnestFilters(
+        buildSpec.getFilter(),
+        unnestEquals,
+        buildSpec.getVirtualColumns(),
+        identifier,
+        "a",
+        ColumnCapabilitiesImpl.createDefault().setType(ColumnType.STRING_ARRAY)
+    );
+
+    // expect unnest filter not pushed down since is array column
+    CursorBuildSpec expected = CursorBuildSpec.builder()
+                                              .setPhysicalColumns(Set.of("a", "b", "c"))
+                                              .setVirtualColumns(VirtualColumns.create(identifier))
+                                              .setFilter(bRange)
+                                              .build();
+
+    CursorBuildSpec transformed = UnnestCursorFactory.transformCursorBuildSpec(
+        buildSpec,
+        identifier,
+        split.getBaseTableFilter()
+    );
+
+    Assertions.assertEquals(expected, transformed);
+  }
+
+  @Test
+  public void testTransformCursorFilterMvd()
+  {
+    final String unnestColumn = "unnest";
+    ExpressionVirtualColumn identifier = new ExpressionVirtualColumn(
+        unnestColumn,
+        "\"a\"",
+        ColumnType.STRING_ARRAY,
+        ExprMacroTable.nil()
+    );
+    Filter unnestEquals = new EqualityFilter(unnestColumn, ColumnType.STRING, "value", null);
+    Filter bRange = new RangeFilter("b", ColumnType.LONG, 1L, 10L, false, false, null);
+    CursorBuildSpec buildSpec = CursorBuildSpec.builder()
+                                               .setPhysicalColumns(Set.of(unnestColumn, "b", "c"))
+                                               .setGroupingColumns(List.of(unnestColumn, "b", "c"))
+                                               .setFilter(bRange)
+                                               .build();
+
+    UnnestCursorFactory.UnnestFilterSplit split = UnnestCursorFactory.computeBaseAndPostUnnestFilters(
+        buildSpec.getFilter(),
+        unnestEquals,
+        buildSpec.getVirtualColumns(),
+        identifier,
+        "a",
+        ColumnCapabilitiesImpl.createDefault().setHasMultipleValues(true).setType(ColumnType.STRING)
+    );
+
+    // since unnest column is mvd, expect pushdown filter as on base table
+    CursorBuildSpec expected = CursorBuildSpec.builder()
+                                              .setPhysicalColumns(Set.of("a", "b", "c"))
+                                              .setVirtualColumns(VirtualColumns.create(identifier))
+                                              .setFilter(
+                                                  new AndFilter(
+                                                      List.of(
+                                                          bRange,
+                                                          new EqualityFilter("a", ColumnType.STRING, "value", null)
+                                                      )
+                                                  )
+                                              )
+                                              .build();
+
+    CursorBuildSpec transformed = UnnestCursorFactory.transformCursorBuildSpec(
+        buildSpec,
+        identifier,
+        split.getBaseTableFilter()
+    );
+
+    Assertions.assertEquals(expected, transformed);
+  }
+
+  @Test
+  public void testTransformCursorArray()
+  {
+    final String unnestColumn = "unnest";
+    ExpressionVirtualColumn array = new ExpressionVirtualColumn(
+        unnestColumn,
+        "array(x, y, z)",
+        ColumnType.DOUBLE_ARRAY,
+        ExprMacroTable.nil()
+    );
+    CursorBuildSpec buildSpec = CursorBuildSpec.builder()
+                                               .setPhysicalColumns(Set.of(unnestColumn))
+                                               .setGroupingColumns(List.of(unnestColumn))
+                                               .build();
+
+
+    CursorBuildSpec expected = CursorBuildSpec.builder()
+                                              .setPhysicalColumns(Set.of("x", "y", "z"))
+                                              .setVirtualColumns(VirtualColumns.create(array))
+                                              .build();
+
+    CursorBuildSpec transformed = UnnestCursorFactory.transformCursorBuildSpec(
+        buildSpec,
+        array,
+        null
+    );
+
+    Assertions.assertEquals(expected, transformed);
+  }
+
   public void testComputeBaseAndPostUnnestFilters(
       Filter testQueryFilter,
       String expectedBasePushDown,
@@ -858,16 +1045,18 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
   )
   {
     final String inputColumn = cursorFactory.getUnnestInputIfDirectAccess(cursorFactory.getUnnestColumn());
+    Assert.assertNotNull(inputColumn);
     final VirtualColumn vc = cursorFactory.getUnnestColumn();
-    Pair<Filter, Filter> filterPair = cursorFactory.computeBaseAndPostUnnestFilters(
+    UnnestCursorFactory.UnnestFilterSplit filterSplit = UnnestCursorFactory.computeBaseAndPostUnnestFilters(
         testQueryFilter,
         null,
         VirtualColumns.EMPTY,
+        cursorFactory.getUnnestColumn(),
         inputColumn,
         vc.capabilities(cursorFactory, inputColumn)
     );
-    Filter actualPushDownFilter = filterPair.lhs;
-    Filter actualPostUnnestFilter = filterPair.rhs;
+    Filter actualPushDownFilter = filterSplit.getBaseTableFilter();
+    Filter actualPostUnnestFilter = filterSplit.getPostUnnestFilter();
     Assert.assertEquals(
         "Expects only top level child of And Filter to push down to base",
         expectedBasePushDown,

--- a/processing/src/test/java/org/apache/druid/segment/projections/ProjectionsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/projections/ProjectionsTest.java
@@ -56,6 +56,7 @@ class ProjectionsTest
         12345
     );
     CursorBuildSpec cursorBuildSpec = CursorBuildSpec.builder()
+                                                     .setPhysicalColumns(Set.of("c"))
                                                      .setPreferredOrdering(List.of())
                                                      .setAggregators(
                                                          List.of(
@@ -99,6 +100,7 @@ class ProjectionsTest
         12345
     );
     CursorBuildSpec cursorBuildSpecNoFilter = CursorBuildSpec.builder()
+                                                             .setPhysicalColumns(Set.of("c"))
                                                              .setPreferredOrdering(List.of())
                                                              .setAggregators(
                                                                  List.of(
@@ -115,6 +117,7 @@ class ProjectionsTest
         )
     );
     CursorBuildSpec cursorBuildSpecWithFilter = CursorBuildSpec.builder()
+                                                               .setPhysicalColumns(Set.of("b", "c"))
                                                                .setPreferredOrdering(List.of())
                                                                .setFilter(
                                                                    new EqualityFilter(
@@ -166,6 +169,7 @@ class ProjectionsTest
     );
     CursorBuildSpec cursorBuildSpecNoFilter = CursorBuildSpec.builder()
                                                              .setPreferredOrdering(List.of())
+                                                             .setPhysicalColumns(Set.of("a", "b", "c"))
                                                              .setGroupingColumns(List.of("a", "b"))
                                                              .setAggregators(
                                                                  List.of(
@@ -182,6 +186,7 @@ class ProjectionsTest
         )
     );
     CursorBuildSpec cursorBuildSpecWithFilter = CursorBuildSpec.builder()
+                                                               .setPhysicalColumns(Set.of("a", "b", "c"))
                                                                .setGroupingColumns(List.of("a", "b"))
                                                                .setPreferredOrdering(List.of())
                                                                .setFilter(


### PR DESCRIPTION
### Description
Fixes to projection matching logic, simplifying things by removing some match tracking which could cause bugs and was previously necessary to account for what was a flaw in the unnest `CursorBuildSpec` translation (also joins had this same flaw)