### PR TITLE
Use apache/kafka image instead of bitnami

### DIFF
--- a/integration-tests-ex/cases/cluster/Common/dependencies.yaml
+++ b/integration-tests-ex/cases/cluster/Common/dependencies.yaml
@@ -41,10 +41,10 @@ services:
     environment:
        ZOO_LOG4J_PROP: INFO,ROLLINGFILE
 
-  # Uses the Bitnami Kafka image
-  # See https://hub.docker.com/r/bitnami/kafka/
+  # Uses the Apache Kafka image
+  # See https://hub.docker.com/r/apache/kafka/
   kafka:
-    image: bitnami/kafka:${KAFKA_VERSION}
+    image: apache/kafka:${KAFKA_VERSION}
     container_name: kafka
     # platform: linux/x86_64
     labels:
@@ -56,7 +56,7 @@ services:
       druid-it-net:
         ipv4_address: 172.172.172.2
     volumes:
-      - ${SHARED_DIR}/kafka:/bitnami/kafka
+      - ${SHARED_DIR}/kafka:/apache/kafka
     environment:
       - KAFKA_CFG_NODE_ID=1001
       - KAFKA_CFG_PROCESS_ROLES=controller,broker

--- a/integration-tests-ex/docs/dependencies.md
+++ b/integration-tests-ex/docs/dependencies.md
@@ -55,8 +55,7 @@ As described in the [Docker](docker.md) section, we use third-party
 * [MySQL](https://hub.docker.com/_/mysql). This image is configured
   to create the Druid database and user upon startup.
 * [ZooKeeper](https://hub.docker.com/_/zookeeper).
-* [Kafka](https://hub.docker.com/r/bitnami/kafka/). There is no
-  "official" image so we use the one from Bitnami.
+* [Kafka](https://hub.docker.com/r/apache/kafka/).
 
 See `compose/dependencies.yaml` for the Docker Compose configuration
 for each of these services.

--- a/integration-tests-ex/image/pom.xml
+++ b/integration-tests-ex/image/pom.xml
@@ -204,7 +204,6 @@ Reference: https://dzone.com/articles/build-docker-image-from-maven
                                         <MARIADB_VERSION>${mariadb.version}</MARIADB_VERSION>
                                         <MYSQL_IMAGE_VERSION>${mysql.image.version}</MYSQL_IMAGE_VERSION>
                                         <CONFLUENT_VERSION>${confluent-version}</CONFLUENT_VERSION>
-                                        <!-- bitnami currently does not offer 3.9.1 image -->
                                         <KAFKA_VERSION>4.0.0</KAFKA_VERSION>
                                         <ZK_VERSION>${zookeeper.version}</ZK_VERSION>
                                         <HADOOP_VERSION>${hadoop.compile.version}</HADOOP_VERSION>


### PR DESCRIPTION
### Description

Pull of the bitnami/kafka image seems to be failing recently:
```
kafka Error manifest for bitnami/kafka:4.0.0 not found: manifest unknown: manifest unknown
```

Example run:
https://github.com/apache/druid/actions/runs/17288422541/job/49162653293?pr=18436

Using the `apache/kafka:4.0.0` image instead as it is already being used in embedded tests `KafkaResource`.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
