### PR TITLE
Remove dependency jackson-mapper-asl:1.9.13 which has lots of CVEs

### DIFF
--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -114,7 +114,7 @@ jobs:
       group: other
 
   security_vulnerabilities:
-    if: github.repository == 'apache/druid'
+    # if: github.repository == 'apache/druid'
     name: security vulnerabilities
     runs-on: ubuntu-latest
     env:
@@ -131,11 +131,11 @@ jobs:
           cache: maven
 
       - name: maven build # needed to rebuild in case of maven snapshot resolution fails
-        run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true
+        run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true -ntp
 
       - name: security vulnerabilities check
         run: |
-          mvn dependency-check:purge dependency-check:check || { echo "
+          mvn -ntp dependency-check:purge dependency-check:check --fail-at-end || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version
           of the dependency that does not have vulnerabilities. To see a report run
           `mvn dependency-check:check`

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -116,9 +116,9 @@ jobs:
   security_vulnerabilities:
     if: github.repository == 'apache/druid'
     name: security vulnerabilities
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
+    env:
+      NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4

--- a/.github/workflows/cron-job-its.yml
+++ b/.github/workflows/cron-job-its.yml
@@ -117,8 +117,6 @@ jobs:
     # if: github.repository == 'apache/druid'
     name: security vulnerabilities
     runs-on: ubuntu-latest
-    env:
-      NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY }}
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -134,6 +132,8 @@ jobs:
         run: mvn clean install -P dist -P skip-static-checks,skip-tests -Dmaven.javadoc.skip=true -Dcyclonedx.skip=true -Dweb.console.skip=true -ntp
 
       - name: security vulnerabilities check
+        env:
+          NIST_NVD_API_KEY: ${{ secrets.NIST_NVD_API_KEY }}
         run: |
           mvn -ntp dependency-check:purge dependency-check:check --fail-at-end || { echo "
           The OWASP dependency check has found security vulnerabilities. Please use a newer version

--- a/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -125,12 +125,6 @@
       <version>${codehaus.jackson.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-      <version>${codehaus.jackson.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/owasp-dependency-check-suppressions.xml
+++ b/owasp-dependency-check-suppressions.xml
@@ -232,15 +232,6 @@
   </suppress>
 
   <suppress>
-    <!-- TODO: Fix by updating curator-x-discovery to > 4.2.0 and updating hadoop -->
-    <notes><![CDATA[
-   file name: jackson-mapper-asl-1.9.13.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-mapper\-asl@1.9.13$</packageUrl>
-    <cvssBelow>10</cvssBelow>  <!-- suppress all CVEs for jackson-mapper-asl:1.9.13 ince it is via curator-x-discovery -->
-  </suppress>
-
-  <suppress>
     <!-- TODO: Fix by updating org.apache.druid.java.util.http.client.NettyHttpClient to use netty 4 -->
     <notes><![CDATA[
    file name: netty-3.10.6.Final.jar

--- a/pom.xml
+++ b/pom.xml
@@ -1823,8 +1823,9 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>7.4.4</version>
+                <version>12.1.3</version>
                 <configuration>
+                    <nvdApiKeyEnvironmentVariable>NIST_NVD_API_KEY</nvdApiKeyEnvironmentVariable>
                     <failBuildOnCVSS>7</failBuildOnCVSS>
                     <skipProvidedScope>true</skipProvidedScope>
                     <skipSystemScope>true</skipSystemScope>  <!-- avoid error when processing jdk.tools:jdk.tools:jar:1.8:system -->

--- a/pom.xml
+++ b/pom.xml
@@ -1029,11 +1029,6 @@
                 <version>${codehaus.jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.jackson</groupId>
-                <artifactId>jackson-mapper-asl</artifactId>
-                <version>${codehaus.jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>3.1.0</version>


### PR DESCRIPTION
### Description

This dependency has lots of critical CVEs, and these CVEs have been suppressed since #9604 and before.

<img width="1546" height="442" alt="image" src="https://github.com/user-attachments/assets/ca068d55-ad2d-4017-a577-8beefa270b0d" />

Our internal tool constantly reports this problem, So I remove this dependency after I find that it's not used anymore.



This PR has:

- [X] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
