### PR TITLE
Speed up HttpEmitterEventCollectorTest and EmbeddedMSQRealtimeQueryTest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/BaseRealtimeQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/BaseRealtimeQueryTest.java
@@ -41,14 +41,13 @@ import org.apache.druid.testing.embedded.indexing.MoreResources;
 import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.joda.time.Period;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Base test for Kafka related embedded test.
@@ -71,12 +70,20 @@ public class BaseRealtimeQueryTest extends EmbeddedClusterTestBase
         .addResource(kafka);
   }
 
-  @BeforeEach
-  void setupCreateKafkaTopic()
+  @BeforeAll
+  void setupCreateKafkaTopicAndDatasource()
   {
     // Create Kafka topic.
     topic = EmbeddedClusterApis.createTestDatasourceName();
     kafka.createTopicWithPartitions(topic, 2);
+
+    super.refreshDatasourceName();
+  }
+
+  @Override
+  protected void refreshDatasourceName()
+  {
+    // Do not refresh datasource name to allow reuse
   }
 
   /**
@@ -123,8 +130,8 @@ public class BaseRealtimeQueryTest extends EmbeddedClusterTestBase
     );
   }
 
-  @AfterEach
-  void tearDownEach() throws ExecutionException, InterruptedException, IOException
+  @AfterAll
+  void tearDownAll() throws IOException
   {
     final Map<String, String> terminateSupervisorResult =
         cluster.callApi().onLeaderOverlord(o -> o.terminateSupervisor(dataSource));

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDurableShuffleStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDurableShuffleStorageTest.java
@@ -111,7 +111,7 @@ public class EmbeddedDurableShuffleStorageTest extends EmbeddedClusterTestBase
   }
 
   @Override
-  protected void beforeEachTest()
+  protected void refreshDatasourceName()
   {
     // do nothing here, the super version of this method generates a new value for dataSource field each time, but
     // we are setting that in our @BeforeAll where we are just inserting data once and re-using between runs

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeQueryTest.java
@@ -40,7 +40,6 @@ import org.hamcrest.MatcherAssert;
 import org.junit.internal.matchers.ThrowableMessageMatcher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -91,11 +90,9 @@ public class EmbeddedMSQRealtimeQueryTest extends BaseRealtimeQueryTest
 
     coordinator.addProperty("druid.manager.segments.useIncrementalCache", "always");
 
-    overlord.addProperty("druid.manager.segments.useIncrementalCache", "always")
-            .addProperty("druid.manager.segments.pollDuration", "PT0.1s");
-
     broker.addProperty("druid.msq.dart.controller.heapFraction", "0.9")
-          .addProperty("druid.query.default.context.maxConcurrentStages", "1");
+          .addProperty("druid.query.default.context.maxConcurrentStages", "1")
+          .addProperty("druid.sql.planner.metadataRefreshPeriod", "PT0.1s");
 
     historical.addProperty("druid.msq.dart.worker.heapFraction", "0.9")
               .addProperty("druid.msq.dart.worker.concurrentQueries", "1")
@@ -141,11 +138,7 @@ public class EmbeddedMSQRealtimeQueryTest extends BaseRealtimeQueryTest
     broker.start();
     indexer.start();
     historical.start();
-  }
 
-  @BeforeEach
-  void setUpEach()
-  {
     msqApis = new EmbeddedMSQApis(cluster, overlord);
     submitSupervisor();
     publishToKafka(TestIndex.getMMappedWikipediaIndex());

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeUnnestQueryTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedMSQRealtimeUnnestQueryTest.java
@@ -33,7 +33,7 @@ import org.apache.druid.testing.embedded.EmbeddedIndexer;
 import org.apache.druid.testing.embedded.EmbeddedOverlord;
 import org.apache.druid.testing.embedded.EmbeddedRouter;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -57,9 +57,6 @@ public class EmbeddedMSQRealtimeUnnestQueryTest extends BaseRealtimeQueryTest
     EmbeddedDruidCluster clusterWithKafka = super.createCluster();
 
     coordinator.addProperty("druid.manager.segments.useIncrementalCache", "always");
-
-    overlord.addProperty("druid.manager.segments.useIncrementalCache", "always")
-            .addProperty("druid.manager.segments.pollDuration", "PT0.1s");
 
     broker.addProperty("druid.msq.dart.controller.heapFraction", "0.9")
           .addProperty("druid.query.default.context.maxConcurrentStages", "1");
@@ -86,8 +83,8 @@ public class EmbeddedMSQRealtimeUnnestQueryTest extends BaseRealtimeQueryTest
         .addServer(indexer);
   }
 
-  @BeforeEach
-  void setUpEach()
+  @BeforeAll
+  void setupAll()
   {
     msqApis = new EmbeddedMSQApis(cluster, overlord);
 

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/HttpEmitterEventCollectorTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/server/HttpEmitterEventCollectorTest.java
@@ -42,6 +42,8 @@ public class HttpEmitterEventCollectorTest extends EmbeddedClusterTestBase
 {
   private final EmbeddedOverlord overlord = new EmbeddedOverlord();
   private final EmbeddedCoordinator coordinator = new EmbeddedCoordinator();
+  private final EmbeddedBroker broker = new EmbeddedBroker()
+      .addProperty("druid.sql.planner.metadataRefreshPeriod", "PT0.1s");
   private final EmbeddedEventCollector eventCollector = new EmbeddedEventCollector()
       .addProperty("druid.emitter", "latching");
 
@@ -59,8 +61,8 @@ public class HttpEmitterEventCollectorTest extends EmbeddedClusterTestBase
         .addServer(overlord)
         .addServer(eventCollector)
         .addServer(coordinator)
+        .addServer(broker)
         .addServer(new EmbeddedHistorical())
-        .addServer(new EmbeddedBroker())
         .addServer(new EmbeddedIndexer());
   }
 

--- a/services/src/test/java/org/apache/druid/testing/embedded/junit5/EmbeddedClusterTestBase.java
+++ b/services/src/test/java/org/apache/druid/testing/embedded/junit5/EmbeddedClusterTestBase.java
@@ -76,8 +76,11 @@ public abstract class EmbeddedClusterTestBase
     }
   }
 
+  /**
+   * Assigns a new value to the {@link #dataSource} before each test.
+   */
   @BeforeEach
-  protected void beforeEachTest()
+  protected void refreshDatasourceName()
   {
     dataSource = EmbeddedClusterApis.createTestDatasourceName();
   }


### PR DESCRIPTION
### Description

The `HttpEmitterEventCollectorTest` timed out recently on [master](https://github.com/apache/druid/actions/runs/17434192694/job/49499550461#step:6:13570)

### Changes

- Add config to reduce test run time and avoid unnecessary timeouts
- Reduce runtime of `HttpEmitterEventCollectorTest` from 1 minute to 1 second
- Reuse ingested data to reduce runtime of `EmbeddedMSQRealtimeQueryTest` from 25s to 9s