### PR TITLE
Fix up metrics.md: OshiSysMonitor doesn't emit sys/storage/used metric

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -265,7 +265,7 @@ batch ingestion emit the following metrics. These metrics are deltas for each em
 |`ingest/events/processed`|Number of events processed per emission period.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Equal to the number of events per emission period.|
 |`ingest/events/processedWithError`|Number of events processed with some partial errors per emission period. Events processed with partial errors are counted towards both this metric and `ingest/events/processed`.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|0|
 |`ingest/events/unparseable`|Number of events rejected because the events are unparseable.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|0|
-|`ingest/events/thrownAway`|Number of events rejected because they are null, or filtered by `transformSpec`, or outside one of `lateMessageRejectionPeriod`, `earlyMessageRejectionPeriod`, or `windowPeriod`.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|0|
+|`ingest/events/thrownAway`|Number of events rejected because they are null, or filtered by `transformSpec`, or outside one of `lateMessageRejectionPeriod`, `earlyMessageRejectionPeriod`.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|0|
 |`ingest/events/duplicate`|Number of events rejected because the events are duplicated.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|0|
 |`ingest/input/bytes`|Number of bytes read from input sources, after decompression but prior to parsing. This covers all data read, including data that does not end up being fully processed and ingested. For example, this includes data that ends up being rejected for being unparseable or filtered out.|`dataSource`, `taskId`, `taskType`, `groupId`, `tags`|Depends on the amount of data read.|
 |`ingest/rows/output`|Number of Druid rows persisted.|`dataSource`, `taskId`, `taskType`, `groupId`|Your number of events with rollup.|
@@ -558,7 +558,6 @@ These metrics are only available if the `OshiSysMonitor` module is included.
 |`sys/mem/used`|Memory used||< max|
 |`sys/mem/max`|Memory max||Varies|
 |`sys/mem/free`|Memory free||Varies|
-|`sys/storage/used`|Disk space used|`fsDirName`|Varies|
 |`sys/cpu`|CPU used|`cpuName`, `cpuTime`|Varies|
 |`sys/uptime`|Total system uptime||Varies|
 |`sys/la/{i}`|System CPU load averages over past `i` minutes, where `i={1,5,15}`||Varies|


### PR DESCRIPTION
Currently, OshiSysMonitor doesn't [emit](https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/java/util/metrics/OshiSysMonitor.java#L254) the `sys/storage/used` metric. Must probably be a copy-paste from the `SysMonitor` metrics.

Also, there's no such supervisor `ioConfig` called `windowPeriod`, so remove that reference from the `ingest/events/thrownAway` metric.

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
