### PR TITLE
Add stopTaskCountPercent field to LagBasedAutoscaler

### DIFF
--- a/docs/ingestion/supervisor.md
+++ b/docs/ingestion/supervisor.md
@@ -80,7 +80,7 @@ The following table outlines the configuration properties for `autoScalerConfig`
 |`taskCountStart`|Optional config to specify the number of ingestion tasks to start with. When you enable the autoscaler, Druid ignores the value of `taskCount` in `ioConfig` and, if specified, starts with the `taskCountStart` number of tasks. Otherwise, defaults to `taskCountMin`.|No|`taskCountMin`|
 |`minTriggerScaleActionFrequencyMillis`|The minimum time interval between two scale actions.| No|600000|
 |`autoScalerStrategy`|The algorithm of autoscaler. Druid only supports the `lagBased` strategy. See [Autoscaler strategy](#autoscaler-strategy) for more information.|No|`lagBased`|
-|`stopTaskCountPercent`|A variable version of `ioConfig.stopTaskCount`. Allows the maximum number of stoppable tasks in steady state to be proportional to the # of tasks running.|No||
+|`stopTaskCountRatio`|A variable version of `ioConfig.stopTaskCount` with a valid range of (0.0, 1.0]. Allows the maximum number of stoppable tasks in steady state to be proportional to the number of tasks currently running.|No||
 
 ##### Autoscaler strategy
 

--- a/docs/ingestion/supervisor.md
+++ b/docs/ingestion/supervisor.md
@@ -80,6 +80,7 @@ The following table outlines the configuration properties for `autoScalerConfig`
 |`taskCountStart`|Optional config to specify the number of ingestion tasks to start with. When you enable the autoscaler, Druid ignores the value of `taskCount` in `ioConfig` and, if specified, starts with the `taskCountStart` number of tasks. Otherwise, defaults to `taskCountMin`.|No|`taskCountMin`|
 |`minTriggerScaleActionFrequencyMillis`|The minimum time interval between two scale actions.| No|600000|
 |`autoScalerStrategy`|The algorithm of autoscaler. Druid only supports the `lagBased` strategy. See [Autoscaler strategy](#autoscaler-strategy) for more information.|No|`lagBased`|
+|`stopTaskCountPercent`|A variable version of `ioConfig.stopTaskCount`. Allows the maximum number of stoppable tasks in steady state to be proportional to the # of tasks running.|No||
 
 ##### Autoscaler strategy
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
@@ -233,8 +233,8 @@ public abstract class SeekableStreamSupervisorIOConfig
 
   public int getMaxAllowedStops()
   {
-    if (autoScalerEnabled && autoScalerConfig.getStopTaskCountPercent() != null) {
-      return (int) Math.floor(taskCount * autoScalerConfig.getStopTaskCountPercent());
+    if (autoScalerEnabled && autoScalerConfig.getStopTaskCountRatio() != null) {
+      return (int) Math.floor(taskCount * autoScalerConfig.getStopTaskCountRatio());
     }
     return stopTaskCount == null ? taskCount : stopTaskCount;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
@@ -53,6 +53,7 @@ public abstract class SeekableStreamSupervisorIOConfig
   @Nullable private final Integer stopTaskCount;
 
   private final LagAggregator lagAggregator;
+  private final boolean autoScalerEnabled;
 
   public SeekableStreamSupervisorIOConfig(
       String stream,
@@ -84,8 +85,9 @@ public abstract class SeekableStreamSupervisorIOConfig
     this.lagAggregator = lagAggregator;
     // Could be null
     this.autoScalerConfig = autoScalerConfig;
-    // if autoscaler is enable then taskcount will be ignored here. and init taskcount will be equal to taskCountMin
-    if (autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler()) {
+    this.autoScalerEnabled = autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler();
+    // if autoscaler is enabled then taskcount will be ignored here. and init taskcount will be equal to taskCountMin
+    if (autoScalerEnabled) {
       final Integer startTaskCount = autoScalerConfig.getTaskCountStart();
       this.taskCount = startTaskCount != null ? startTaskCount : autoScalerConfig.getTaskCountMin();
     } else {
@@ -231,6 +233,9 @@ public abstract class SeekableStreamSupervisorIOConfig
 
   public int getMaxAllowedStops()
   {
+    if (autoScalerEnabled && autoScalerConfig.getStopTaskCountPercent() != null) {
+      return (int) Math.floor(taskCount * autoScalerConfig.getStopTaskCountPercent());
+    }
     return stopTaskCount == null ? taskCount : stopTaskCount;
   }
 }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
@@ -234,7 +234,7 @@ public abstract class SeekableStreamSupervisorIOConfig
   public int getMaxAllowedStops()
   {
     if (autoScalerEnabled && autoScalerConfig.getStopTaskCountRatio() != null) {
-      return (int) Math.floor(taskCount * autoScalerConfig.getStopTaskCountRatio());
+      return (int) Math.max(1, Math.floor(taskCount * autoScalerConfig.getStopTaskCountRatio()));
     }
     return stopTaskCount == null ? taskCount : stopTaskCount;
   }

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfig.java
@@ -86,7 +86,7 @@ public abstract class SeekableStreamSupervisorIOConfig
     // Could be null
     this.autoScalerConfig = autoScalerConfig;
     this.autoScalerEnabled = autoScalerConfig != null && autoScalerConfig.getEnableTaskAutoScaler();
-    // if autoscaler is enabled then taskcount will be ignored here. and init taskcount will be equal to taskCountMin
+    // if autoscaler is enabled then taskCount will be ignored here and initial taskCount will equal to taskCountStart/taskCountMin
     if (autoScalerEnabled) {
       final Integer startTaskCount = autoScalerConfig.getTaskCountStart();
       this.taskCount = startTaskCount != null ? startTaskCount : autoScalerConfig.getTaskCountMin();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
@@ -40,7 +40,7 @@ public interface AutoScalerConfig
   int getTaskCountMax();
   int getTaskCountMin();
   Integer getTaskCountStart();
-  Double getStopTaskCountPercent();
+  Double getStopTaskCountRatio();
   SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec, ServiceEmitter emitter);
 }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/AutoScalerConfig.java
@@ -40,6 +40,7 @@ public interface AutoScalerConfig
   int getTaskCountMax();
   int getTaskCountMin();
   Integer getTaskCountStart();
+  Double getStopTaskCountPercent();
   SupervisorTaskAutoScaler createAutoScaler(Supervisor supervisor, SupervisorSpec spec, ServiceEmitter emitter);
 }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.seekablestream.supervisor.autoscaler;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.autoscaler.AggregateFunction;
@@ -102,6 +103,8 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
     this.scaleOutStep = scaleOutStep != null ? scaleOutStep : 2;
     this.minTriggerScaleActionFrequencyMillis = minTriggerScaleActionFrequencyMillis
         != null ? minTriggerScaleActionFrequencyMillis : 600000;
+
+    Preconditions.checkArgument(stopTaskCountPercent == null || (stopTaskCountPercent > 0.0 && stopTaskCountPercent <= 1.0), "0.0 < stopTaskCountPercent <= 1.0");
     this.stopTaskCountPercent = stopTaskCountPercent;
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerConfig.java
@@ -49,6 +49,7 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
   private final boolean enableTaskAutoScaler;
   private final long minTriggerScaleActionFrequencyMillis;
   private final AggregateFunction lagAggregate;
+  @Nullable private Double stopTaskCountPercent;
 
   @JsonCreator
   public LagBasedAutoScalerConfig(
@@ -67,7 +68,8 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
           @Nullable @JsonProperty("scaleOutStep") Integer scaleOutStep,
           @Nullable @JsonProperty("enableTaskAutoScaler") Boolean enableTaskAutoScaler,
           @Nullable @JsonProperty("minTriggerScaleActionFrequencyMillis") Long minTriggerScaleActionFrequencyMillis,
-          @Nullable @JsonProperty("lagAggregate") AggregateFunction lagAggregate
+          @Nullable @JsonProperty("lagAggregate") AggregateFunction lagAggregate,
+          @Nullable @JsonProperty("stopTaskCountPercent") Double stopTaskCountPercent
   )
   {
     this.enableTaskAutoScaler = enableTaskAutoScaler != null ? enableTaskAutoScaler : false;
@@ -100,6 +102,7 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
     this.scaleOutStep = scaleOutStep != null ? scaleOutStep : 2;
     this.minTriggerScaleActionFrequencyMillis = minTriggerScaleActionFrequencyMillis
         != null ? minTriggerScaleActionFrequencyMillis : 600000;
+    this.stopTaskCountPercent = stopTaskCountPercent;
   }
 
   @JsonProperty
@@ -213,6 +216,15 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
   }
 
   @Override
+  @JsonProperty
+  @Nullable
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Double getStopTaskCountPercent()
+  {
+    return stopTaskCountPercent;
+  }
+
+  @Override
   public String toString()
   {
     return "autoScalerConfig{" +
@@ -232,6 +244,7 @@ public class LagBasedAutoScalerConfig implements AutoScalerConfig
             ", scaleInStep=" + scaleInStep +
             ", scaleOutStep=" + scaleOutStep +
             ", lagAggregate=" + lagAggregate +
+            ", stopTaskCountPercent=" + stopTaskCountPercent +
             '}';
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/autoscaler/LagBasedAutoScalerConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/autoscaler/LagBasedAutoScalerConfigTest.java
@@ -282,4 +282,50 @@ public class LagBasedAutoScalerConfigTest
     );
     Assert.assertEquals(Double.valueOf(0.5), config.getStopTaskCountRatio());
   }
+
+  @Test
+  public void testEqualsAndHashCode()
+  {
+    LagBasedAutoScalerConfig config1 = new LagBasedAutoScalerConfig(
+        1000L,
+        2000L,
+        3000L,
+        4000L,
+        5000L,
+        6000L,
+        0.1,
+        0.2,
+        10,
+        5,
+        1,
+        2,
+        3,
+        true,
+        7000L,
+        AggregateFunction.SUM,
+        0.5
+    );
+    LagBasedAutoScalerConfig config2 = new LagBasedAutoScalerConfig(
+        2000L,
+        2000L,
+        5000L,
+        4500L,
+        5000L,
+        6000L,
+        0.2,
+        0.4,
+        40,
+        20,
+        1,
+        4,
+        1,
+        true,
+        7000L,
+        AggregateFunction.AVERAGE,
+        0.5
+    );
+
+    Assert.assertNotEquals(config1, config2);
+    Assert.assertNotEquals(config1.hashCode(), config2.hashCode());
+  }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/autoscaler/LagBasedAutoScalerConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/autoscaler/LagBasedAutoScalerConfigTest.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.supervisor.autoscaler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.LagBasedAutoScalerConfig;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LagBasedAutoScalerConfigTest
+{
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @Test
+  public void testSerdeWithDefaults() throws Exception
+  {
+    String jsonStr = "{\n"
+                     + "  \"enableTaskAutoScaler\": false\n"
+                     + "}";
+
+    LagBasedAutoScalerConfig config = OBJECT_MAPPER.readValue(
+        OBJECT_MAPPER.writeValueAsString(
+            OBJECT_MAPPER.readValue(
+                jsonStr,
+                LagBasedAutoScalerConfig.class
+            )
+        ), LagBasedAutoScalerConfig.class
+    );
+
+    Assert.assertFalse(config.getEnableTaskAutoScaler());
+    Assert.assertEquals(30000, config.getLagCollectionIntervalMillis());
+    Assert.assertEquals(600000, config.getLagCollectionRangeMillis());
+    Assert.assertEquals(300000, config.getScaleActionStartDelayMillis());
+    Assert.assertEquals(60000, config.getScaleActionPeriodMillis());
+    Assert.assertEquals(6000000, config.getScaleOutThreshold());
+    Assert.assertEquals(1000000, config.getScaleInThreshold());
+    Assert.assertEquals(0.3, config.getTriggerScaleOutFractionThreshold(), 0.00001);
+    Assert.assertEquals(0.9, config.getTriggerScaleInFractionThreshold(), 0.00001);
+    Assert.assertEquals(1, config.getScaleInStep());
+    Assert.assertEquals(2, config.getScaleOutStep());
+    Assert.assertEquals(600000, config.getMinTriggerScaleActionFrequencyMillis());
+    Assert.assertNull(config.getLagAggregate());
+    Assert.assertNull(config.getStopTaskCountPercent());
+    Assert.assertEquals(0, config.getTaskCountMax());
+    Assert.assertEquals(0, config.getTaskCountMin());
+    Assert.assertNull(config.getTaskCountStart());
+  }
+
+  @Test
+  public void testSerdeWithOverrides() throws Exception
+  {
+    String jsonStr = "{\n"
+                     + "  \"lagCollectionIntervalMillis\": 111,\n"
+                     + "  \"lagCollectionRangeMillis\": 222,\n"
+                     + "  \"scaleActionStartDelayMillis\": 333,\n"
+                     + "  \"scaleActionPeriodMillis\": 444,\n"
+                     + "  \"scaleOutThreshold\": 555,\n"
+                     + "  \"scaleInThreshold\": 666,\n"
+                     + "  \"triggerScaleOutFractionThreshold\": 0.12,\n"
+                     + "  \"triggerScaleInFractionThreshold\": 0.34,\n"
+                     + "  \"taskCountMax\": 10,\n"
+                     + "  \"taskCountMin\": 5,\n"
+                     + "  \"taskCountStart\": 7,\n"
+                     + "  \"scaleInStep\": 3,\n"
+                     + "  \"scaleOutStep\": 4,\n"
+                     + "  \"enableTaskAutoScaler\": true,\n"
+                     + "  \"minTriggerScaleActionFrequencyMillis\": 777,\n"
+                     + "  \"lagAggregate\": \"AVERAGE\",\n"
+                     + "  \"stopTaskCountPercent\": 0.5\n"
+                     + "}";
+
+    LagBasedAutoScalerConfig config = OBJECT_MAPPER.readValue(
+        OBJECT_MAPPER.writeValueAsString(
+            OBJECT_MAPPER.readValue(
+                jsonStr,
+                LagBasedAutoScalerConfig.class
+            )
+        ), LagBasedAutoScalerConfig.class
+    );
+
+    Assert.assertTrue(config.getEnableTaskAutoScaler());
+    Assert.assertEquals(111, config.getLagCollectionIntervalMillis());
+    Assert.assertEquals(222, config.getLagCollectionRangeMillis());
+    Assert.assertEquals(333, config.getScaleActionStartDelayMillis());
+    Assert.assertEquals(444, config.getScaleActionPeriodMillis());
+    Assert.assertEquals(555, config.getScaleOutThreshold());
+    Assert.assertEquals(666, config.getScaleInThreshold());
+    Assert.assertEquals(0.12, config.getTriggerScaleOutFractionThreshold(), 0.00001);
+    Assert.assertEquals(0.34, config.getTriggerScaleInFractionThreshold(), 0.00001);
+    Assert.assertEquals(10, config.getTaskCountMax());
+    Assert.assertEquals(5, config.getTaskCountMin());
+    Assert.assertEquals(Integer.valueOf(7), config.getTaskCountStart());
+    Assert.assertEquals(3, config.getScaleInStep());
+    Assert.assertEquals(4, config.getScaleOutStep());
+    Assert.assertEquals(777, config.getMinTriggerScaleActionFrequencyMillis());
+    Assert.assertEquals(AggregateFunction.AVERAGE, config.getLagAggregate());
+    Assert.assertEquals(Double.valueOf(0.5), config.getStopTaskCountPercent());
+  }
+
+  @Test
+  public void testEnabledTaskCountChecks()
+  {
+    // Should throw if taskCountMax or taskCountMin is missing
+    try {
+      new LagBasedAutoScalerConfig(
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          1,
+          null,
+          null,
+          null,
+          true,
+          null,
+          null,
+          null
+      );
+      Assert.fail("Expected exception for null taskCountMax or taskCountMin");
+    }
+    catch (RuntimeException ex) {
+      Assert.assertTrue(ex.getMessage().contains("taskCountMax or taskCountMin can't be null"));
+    }
+
+    // Should throw if taskCountMax < taskCountMin
+    try {
+      new LagBasedAutoScalerConfig(
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          2,
+          1,
+          3,
+          null,
+          null,
+          true,
+          null,
+          null,
+          null
+      );
+      Assert.fail("Expected exception for taskCountMax < taskCountMin");
+    }
+    catch (RuntimeException ex) {
+      Assert.assertTrue(ex.getMessage().contains("taskCountMax can't lower than taskCountMin"));
+    }
+
+    // Should throw if taskCountStart out of range
+    try {
+      new LagBasedAutoScalerConfig(
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          5,
+          10,
+          3,
+          null,
+          null,
+          true,
+          null,
+          null,
+          null
+      );
+      Assert.fail("Expected exception for taskCountStart out of range");
+    }
+    catch (RuntimeException ex) {
+      Assert.assertTrue(ex.getMessage().contains("taskCountMin <= taskCountStart <= taskCountMax"));
+    }
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
@@ -292,6 +292,10 @@ public class SeekableStreamSupervisorIOConfigTest
 
     Assert.assertEquals(5, config.getMaxAllowedStops());
 
+    // Ensure never goes below 1
+    when(autoScalerConfig.getStopTaskCountRatio()).thenReturn(0.05);
+    Assert.assertEquals(1, config.getMaxAllowedStops());
+
     // Autoscaler enabled, stopTaskCountRatio unset, stopTaskCount set
     when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
     when(autoScalerConfig.getTaskCountStart()).thenReturn(10);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.seekablestream.supervisor;
+
+import org.apache.druid.data.input.InputFormat;
+import org.apache.druid.error.DruidException;
+import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
+import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.IAE;
+import org.joda.time.Duration;
+import org.joda.time.Period;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SeekableStreamSupervisorIOConfigTest
+{
+  @Test
+  public void testAllDefaults()
+  {
+    LagAggregator lagAggregator = mock(LagAggregator.class);
+    InputFormat inputFormat = mock(InputFormat.class);
+
+    SeekableStreamSupervisorIOConfig config = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        inputFormat,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        lagAggregator,
+        null,
+        null,
+        null
+    )
+    {
+    };
+
+    Assert.assertEquals("stream", config.getStream());
+    Assert.assertEquals(inputFormat, config.getInputFormat());
+    Assert.assertEquals(Integer.valueOf(1), config.getReplicas());
+    Assert.assertEquals(Integer.valueOf(1), config.getTaskCount());
+    Assert.assertEquals(Duration.standardHours(1), config.getTaskDuration());
+    Assert.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
+    Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());
+    Assert.assertFalse(config.isUseEarliestSequenceNumber());
+    Assert.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
+    Assert.assertFalse(config.getEarlyMessageRejectionPeriod().isPresent());
+    Assert.assertFalse(config.getLateMessageRejectionPeriod().isPresent());
+    Assert.assertFalse(config.getLateMessageRejectionStartDateTime().isPresent());
+    Assert.assertNull(config.getIdleConfig());
+    Assert.assertNull(config.getStopTaskCount());
+    Assert.assertEquals(lagAggregator, config.getLagAggregator());
+    Assert.assertEquals(1, config.getMaxAllowedStops());
+  }
+
+  @Test
+  public void testAutoScalerEnabledTrueAndFalse()
+  {
+    LagAggregator lagAggregator = mock(LagAggregator.class);
+
+    // autoScalerEnabled = true
+    AutoScalerConfig autoScalerConfig = mock(AutoScalerConfig.class);
+    when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
+    when(autoScalerConfig.getTaskCountStart()).thenReturn(5);
+    when(autoScalerConfig.getTaskCountMin()).thenReturn(3);
+
+    SeekableStreamSupervisorIOConfig configAuto = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        2,
+        10, // (taskCount should be ignored)
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        autoScalerConfig,
+        lagAggregator,
+        null,
+        null,
+        null
+    )
+    {
+    };
+
+    Assert.assertEquals(Integer.valueOf(5), configAuto.getTaskCount()); // taskCountStart
+    Assert.assertEquals(2, configAuto.getReplicas().intValue());
+
+    // autoScalerEnabled = false
+    SeekableStreamSupervisorIOConfig configNoAuto = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        2,
+        10,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        lagAggregator,
+        null,
+        null,
+        null
+    )
+    {
+    };
+
+    Assert.assertEquals(Integer.valueOf(10), configNoAuto.getTaskCount());
+    Assert.assertEquals(2, configNoAuto.getReplicas().intValue());
+  }
+
+  @Test(expected = IAE.class)
+  public void testBothLateMessageRejectionPeriodAndStartDateTime()
+  {
+    LagAggregator lagAggregator = mock(LagAggregator.class);
+
+    new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Period.seconds(10),
+        null,
+        null,
+        lagAggregator,
+        DateTimes.nowUtc(),
+        null,
+        null
+    )
+    {
+    };
+  }
+
+  @Test(expected = DruidException.class)
+  public void testNullAggregatorThrows()
+  {
+    new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+    )
+    {
+    };
+  }
+
+  @Test
+  public void testGetMaxAllowedStopsScalingDisabled()
+  {
+    LagAggregator lagAggregator = mock(LagAggregator.class);
+
+    // Autoscaler disabled, no stopTaskCount
+    SeekableStreamSupervisorIOConfig config1 = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        null,
+        7,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        lagAggregator,
+        null,
+        null,
+        null
+    )
+    {
+    };
+    Assert.assertEquals(7, config1.getMaxAllowedStops());
+
+    // Autoscaler disabled, stopTaskCount set
+    SeekableStreamSupervisorIOConfig config2 = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        null,
+        7,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        lagAggregator,
+        null,
+        null,
+        3
+    )
+    {
+    };
+    Assert.assertEquals(3, config2.getMaxAllowedStops());
+  }
+
+  @Test
+  public void testGetMaxAllowedStopsScalingEnabled()
+  {
+    LagAggregator lagAggregator = mock(LagAggregator.class);
+
+    AutoScalerConfig autoScalerConfig = mock(AutoScalerConfig.class);
+
+    // Autoscaler enabled, stopTaskCountPercent set
+    when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
+    when(autoScalerConfig.getTaskCountStart()).thenReturn(10);
+    when(autoScalerConfig.getStopTaskCountPercent()).thenReturn(0.5);
+
+    SeekableStreamSupervisorIOConfig config = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        null,
+        10,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        autoScalerConfig,
+        lagAggregator,
+        null,
+        null,
+        1
+    )
+    {
+    };
+
+    Assert.assertEquals(5, config.getMaxAllowedStops());
+
+    // Autoscaler enabled, stopTaskCountPercent unset, stopTaskCount set
+    when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
+    when(autoScalerConfig.getTaskCountStart()).thenReturn(10);
+    when(autoScalerConfig.getStopTaskCountPercent()).thenReturn(null);
+
+    SeekableStreamSupervisorIOConfig config2 = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        null,
+        10,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        autoScalerConfig,
+        lagAggregator,
+        null,
+        null,
+        1
+    )
+    {
+    };
+
+    Assert.assertEquals(1, config2.getMaxAllowedStops());
+
+
+    // Autoscaler enabled, stopTaskCountPercent unset, stopTaskCount set
+    when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
+    when(autoScalerConfig.getTaskCountStart()).thenReturn(10);
+    when(autoScalerConfig.getStopTaskCountPercent()).thenReturn(null);
+
+    SeekableStreamSupervisorIOConfig config3 = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        null,
+        10,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        autoScalerConfig,
+        lagAggregator,
+        null,
+        null,
+        null
+    )
+    {
+    };
+
+    Assert.assertEquals(10, config3.getMaxAllowedStops());
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
@@ -264,10 +264,10 @@ public class SeekableStreamSupervisorIOConfigTest
 
     AutoScalerConfig autoScalerConfig = mock(AutoScalerConfig.class);
 
-    // Autoscaler enabled, stopTaskCountPercent set
+    // Autoscaler enabled, stopTaskCountRatio set
     when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
     when(autoScalerConfig.getTaskCountStart()).thenReturn(10);
-    when(autoScalerConfig.getStopTaskCountPercent()).thenReturn(0.5);
+    when(autoScalerConfig.getStopTaskCountRatio()).thenReturn(0.5);
 
     SeekableStreamSupervisorIOConfig config = new SeekableStreamSupervisorIOConfig(
         "stream",
@@ -292,10 +292,10 @@ public class SeekableStreamSupervisorIOConfigTest
 
     Assert.assertEquals(5, config.getMaxAllowedStops());
 
-    // Autoscaler enabled, stopTaskCountPercent unset, stopTaskCount set
+    // Autoscaler enabled, stopTaskCountRatio unset, stopTaskCount set
     when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
     when(autoScalerConfig.getTaskCountStart()).thenReturn(10);
-    when(autoScalerConfig.getStopTaskCountPercent()).thenReturn(null);
+    when(autoScalerConfig.getStopTaskCountRatio()).thenReturn(null);
 
     SeekableStreamSupervisorIOConfig config2 = new SeekableStreamSupervisorIOConfig(
         "stream",
@@ -321,10 +321,10 @@ public class SeekableStreamSupervisorIOConfigTest
     Assert.assertEquals(1, config2.getMaxAllowedStops());
 
 
-    // Autoscaler enabled, stopTaskCountPercent unset, stopTaskCount unset
+    // Autoscaler enabled, stopTaskCountRatio unset, stopTaskCount unset
     when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
     when(autoScalerConfig.getTaskCountStart()).thenReturn(10);
-    when(autoScalerConfig.getStopTaskCountPercent()).thenReturn(null);
+    when(autoScalerConfig.getStopTaskCountRatio()).thenReturn(null);
 
     SeekableStreamSupervisorIOConfig config3 = new SeekableStreamSupervisorIOConfig(
         "stream",

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -2735,9 +2735,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     };
 
     Assert.assertEquals(2, config.getMaxAllowedStops());
-
     config.setTaskCount(30);
-
     Assert.assertEquals(12, config.getMaxAllowedStops());
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -2691,7 +2691,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   }
 
   @Test
-  public void testMaxAllowedStopsWithStopTaskCountPercent()
+  public void testMaxAllowedStopsWithStopTaskCountRatio()
   {
     LagAggregator lagAggregator = createMock(LagAggregator.class);
     AutoScalerConfig autoScalerConfig = new LagBasedAutoScalerConfig(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -2634,6 +2634,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         null,
         true,
         null,
+        null,
         null
     );
     SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(1, autoScalerConfig);
@@ -2687,6 +2688,57 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).anyTimes();
 
     replayAll();
+  }
+
+  @Test
+  public void testMaxAllowedStopsWithStopTaskCountPercent()
+  {
+    LagAggregator lagAggregator = createMock(LagAggregator.class);
+    AutoScalerConfig autoScalerConfig = new LagBasedAutoScalerConfig(
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        45,
+        null,
+        5,
+        null,
+        null,
+        true,
+        null,
+        null,
+        0.4
+    );
+    SeekableStreamSupervisorIOConfig config = new SeekableStreamSupervisorIOConfig(
+        "stream",
+        null,
+        1,
+        99,
+        new Period("PT1H"),
+        new Period("PT1S"),
+        new Period("PT30S"),
+        false,
+        new Period("PT30M"),
+        null,
+        null,
+        autoScalerConfig,
+        lagAggregator,
+        null,
+        null,
+        1 // ensure this is overridden
+    )
+    {
+    };
+
+    Assert.assertEquals(2, config.getMaxAllowedStops());
+
+    config.setTaskCount(30);
+
+    Assert.assertEquals(12, config.getMaxAllowedStops());
   }
 
   private static DataSchema getDataSchema()


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->
<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Perf improvement that allows the maximum number of stopped tasks to scale proportional to the task autoscaler. This is useful in cases where scaling up/down a lot can mess up the (over/under) # of tasks being marked for publishing.

Also adds some long-overdue isolated test files for `LagBasedAutoscalerConfig` and `SeekableStreamSupervisorIOConfig`.

Example:
- You have `taskCountStart=10`, `stopTaskCount=1`, but auto-scale up to `taskCount=100`. In this case, you may want to instead stop at most 10 tasks.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Support proportional stopTaskCount with task count auto-scaler

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
