### PR TITLE
remove storage location lock from segment cache mount in favor of duplicate reserved check

### DIFF
--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
@@ -128,7 +128,7 @@ public class StorageLocation
    * {@link #linkNewWeakEntry(WeakCacheEntry)} or {@link #unlinkWeakEntry(WeakCacheEntry)}, including calling
    * {@link #canHandle(CacheEntry)} which can unlink entries
    */
-  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
   public StorageLocation(File path, long maxSizeBytes, @Nullable Double freeSpacePercent)
   {


### PR DESCRIPTION
### Description
Follow-up to #18176 to improve segment cache mount throughput by not holding the storage location lock, which isn't really necessary as long as we check that the entry is still reserved on both ends of the synchronized mount block.

Also improved a test to make it test what the test name said it should be testing.