### PR TITLE
improve performance of filter bundle building by reusing stuff when possible

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/filter/BooleanFilter.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/BooleanFilter.java
@@ -19,8 +19,13 @@
 
 package org.apache.druid.query.filter;
 
+import org.apache.druid.collections.bitmap.BitmapFactory;
+import org.apache.druid.segment.index.BitmapColumnIndex;
+
+import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 public interface BooleanFilter extends Filter
@@ -42,4 +47,11 @@ public interface BooleanFilter extends Filter
     }
     return allColumns;
   }
+
+  /**
+   * Specialized alternative to {@link #getBitmapColumnIndex(ColumnIndexSelector)} to allow reuse any precomputed
+   * {@link BitmapColumnIndex} created as part of a {@link FilterBundle.Builder}
+   */
+  @Nullable
+  BitmapColumnIndex getBitmapColumnIndex(BitmapFactory bitmapFactory, List<FilterBundle.Builder> childBuilders);
 }

--- a/processing/src/main/java/org/apache/druid/query/filter/FilterBundle.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/FilterBundle.java
@@ -175,16 +175,18 @@ public class FilterBundle
         Collection<Filter> childFilters = bool.getFilters();
         this.childBuilders = new ArrayList<>(childFilters.size());
         for (Filter childFilter : childFilters) {
-          this.childBuilders.add(new FilterBundle.Builder(childFilter, columnIndexSelector, cursorAutoArrangeFilters));
+          childBuilders.add(new FilterBundle.Builder(childFilter, columnIndexSelector, cursorAutoArrangeFilters));
         }
         this.bitmapColumnIndex = bool.getBitmapColumnIndex(columnIndexSelector.getBitmapFactory(), childBuilders);
       } else {
-        this.childBuilders = new ArrayList<>(0);
+        this.childBuilders = List.of();
         this.bitmapColumnIndex = filter.getBitmapColumnIndex(columnIndexSelector);
       }
       if (cursorAutoArrangeFilters) {
-        // Sort child builders by cost in ASCENDING order, should be stable by default.
-        this.childBuilders.sort(Comparator.comparingInt(FilterBundle.Builder::getEstimatedIndexComputeCost));
+        if (!childBuilders.isEmpty()) {
+          // Sort child builders by cost in ASCENDING order, should be stable by default.
+          childBuilders.sort(Comparator.comparingInt(FilterBundle.Builder::getEstimatedIndexComputeCost));
+        }
         this.estimatedIndexComputeCost = calculateEstimatedIndexComputeCost();
       } else {
         this.estimatedIndexComputeCost = Integer.MAX_VALUE;
@@ -193,10 +195,10 @@ public class FilterBundle
 
     private int calculateEstimatedIndexComputeCost()
     {
-      if (this.bitmapColumnIndex == null) {
+      if (bitmapColumnIndex == null) {
         return Integer.MAX_VALUE;
       }
-      int cost = this.bitmapColumnIndex.estimatedComputeCost();
+      int cost = bitmapColumnIndex.estimatedComputeCost();
       if (cost == Integer.MAX_VALUE) {
         return Integer.MAX_VALUE;
       }

--- a/processing/src/main/java/org/apache/druid/query/filter/FilterBundle.java
+++ b/processing/src/main/java/org/apache/druid/query/filter/FilterBundle.java
@@ -169,16 +169,18 @@ public class FilterBundle
     {
       this.filter = filter;
       this.columnIndexSelector = columnIndexSelector;
-      this.bitmapColumnIndex = filter.getBitmapColumnIndex(columnIndexSelector);
       // Construct Builder instances for all child filters recursively.
       if (filter instanceof BooleanFilter) {
-        Collection<Filter> childFilters = ((BooleanFilter) filter).getFilters();
+        final BooleanFilter bool = (BooleanFilter) filter;
+        Collection<Filter> childFilters = bool.getFilters();
         this.childBuilders = new ArrayList<>(childFilters.size());
         for (Filter childFilter : childFilters) {
           this.childBuilders.add(new FilterBundle.Builder(childFilter, columnIndexSelector, cursorAutoArrangeFilters));
         }
+        this.bitmapColumnIndex = bool.getBitmapColumnIndex(columnIndexSelector.getBitmapFactory(), childBuilders);
       } else {
         this.childBuilders = new ArrayList<>(0);
+        this.bitmapColumnIndex = filter.getBitmapColumnIndex(columnIndexSelector);
       }
       if (cursorAutoArrangeFilters) {
         // Sort child builders by cost in ASCENDING order, should be stable by default.


### PR DESCRIPTION
### Description
Improves `FilterBundle.Builder` performance by adding a method to `BooleanFilter` to allow building a `BitmapColumnIndex` using `FilterBundle.Builder` of the child filters instead of directly from the child filters, which allow re-use of things such as `BitmapColumnIndex` which are also computed by the builder.