### PR TITLE
fix projections building and matching allow grouping directly on __time

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/IndexIO.java
+++ b/processing/src/main/java/org/apache/druid/segment/IndexIO.java
@@ -699,7 +699,10 @@ public class IndexIO
         Interval dataInterval
     ) throws IOException
     {
+      final String timeColumnName = projectionSpec.getSchema().getTimeColumnName();
+      final boolean renameTime = !ColumnHolder.TIME_COLUMN_NAME.equals(timeColumnName);
       final Map<String, Supplier<ColumnHolder>> projectionColumns = new LinkedHashMap<>();
+
       for (String groupingColumn : projectionSpec.getSchema().getGroupingColumns()) {
         final String smooshName = Projections.getProjectionSmooshV9FileName(projectionSpec, groupingColumn);
         final ByteBuffer colBuffer = smooshedFiles.mapFile(smooshName);
@@ -721,7 +724,7 @@ public class IndexIO
             loadFailed
         );
 
-        if (groupingColumn.equals(projectionSpec.getSchema().getTimeColumnName())) {
+        if (groupingColumn.equals(timeColumnName) && renameTime) {
           projectionColumns.put(ColumnHolder.TIME_COLUMN_NAME, projectionColumns.get(groupingColumn));
           projectionColumns.remove(groupingColumn);
         }
@@ -740,7 +743,7 @@ public class IndexIO
             loadFailed
         );
       }
-      if (projectionSpec.getSchema().getTimeColumnName() == null) {
+      if (timeColumnName == null) {
         projectionColumns.put(
             ColumnHolder.TIME_COLUMN_NAME,
             ConstantTimeColumn.makeConstantTimeSupplier(projectionSpec.getNumRows(), dataInterval.getStartMillis())

--- a/processing/src/main/java/org/apache/druid/segment/projections/Projections.java
+++ b/processing/src/main/java/org/apache/druid/segment/projections/Projections.java
@@ -416,6 +416,13 @@ public class Projections
       ProjectionMatchBuilder matchBuilder
   )
   {
+    // if we need __time as a physical column, the projection must be grouping on __time directly
+    if (ColumnHolder.TIME_COLUMN_NAME.equals(column)) {
+      if (ColumnHolder.TIME_COLUMN_NAME.equals(projection.getTimeColumnName())) {
+        return matchBuilder.addReferencedPhysicalColumn(ColumnHolder.TIME_COLUMN_NAME);
+      }
+      return null;
+    }
     if (physicalColumnChecker.check(projection.getName(), column)) {
       return matchBuilder.addReferencedPhysicalColumn(column);
     }

--- a/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
@@ -72,6 +72,7 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryEngine;
 import org.apache.druid.query.timeseries.TimeseriesQueryMetrics;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
+import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndex;
@@ -280,6 +281,12 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
                              )
                              .groupingColumns(new LongDimensionSchema("__vc2"), new StringDimensionSchema("__vc3"))
                              .aggregators(new LongSumAggregatorFactory("sum_c", "c"))
+                             .build(),
+      AggregateProjectionSpec.builder("time_and_a")
+                             .groupingColumns(
+                                 new LongDimensionSchema(ColumnHolder.TIME_COLUMN_NAME),
+                                 new StringDimensionSchema("a")
+                             )
                              .build()
   );
 
@@ -1416,6 +1423,48 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
             new Object[]{"baa", 6L},
             new Object[]{"baa", 8L},
             new Object[]{"bbb", 11L}
+        )
+    );
+  }
+
+  @Test
+  public void testProjectionGroupOnTime()
+  {
+    final GroupByQuery query =
+        GroupByQuery.builder()
+                    .setDataSource("test")
+                    .setGranularity(Granularities.ALL)
+                    .setInterval(Intervals.ETERNITY)
+                    .addDimension(new DefaultDimensionSpec(ColumnHolder.TIME_COLUMN_NAME, "d0", ColumnType.LONG))
+                    .addDimension("v0")
+                    .setVirtualColumns(
+                        new ExpressionVirtualColumn(
+                            "v0",
+                            "concat(a, 'aaa')",
+                            ColumnType.STRING,
+                            TestExprMacroTable.INSTANCE
+                        )
+                    )
+                    .build();
+
+    final ExpectedProjectionGroupBy queryMetrics =
+        new ExpectedProjectionGroupBy("time_and_a");
+    final CursorBuildSpec buildSpec = GroupingEngine.makeCursorBuildSpec(query, queryMetrics);
+
+    assertCursorProjection(buildSpec, queryMetrics, 8);
+
+    testGroupBy(
+        query,
+        queryMetrics,
+        makeArrayResultSet(
+            new Object[]{TIMESTAMP.getMillis(), "aaaa"},
+            new Object[]{TIMESTAMP.plusMinutes(2).getMillis(), "aaaa"},
+            new Object[]{TIMESTAMP.plusMinutes(4).getMillis(), "aaaa"},
+            new Object[]{TIMESTAMP.plusMinutes(6).getMillis(), "baaa"},
+            new Object[]{TIMESTAMP.plusMinutes(8).getMillis(), "baaa"},
+            new Object[]{TIMESTAMP.plusMinutes(10).getMillis(), "baaa"},
+            new Object[]{TIMESTAMP.plusHours(1).getMillis(), "aaaa"},
+            new Object[]{TIMESTAMP.plusHours(1).plusMinutes(1).getMillis(), "aaaa"}
         )
     );
   }


### PR DESCRIPTION
### Description
This PR fixes some bugs preventing projections being able to group directly on __time. The first issue was a mistake where during during substituting the projection time columns actual name with __time, if the projection time column was __time itself it resulted in removing it from the list of grouping columns instead ensuring __time was available.

Beyond this, projection matching needed updated to handle matching __time as a physical column, which requires the projection to be grouping on __time directly.