### PR TITLE
Sort /status/properties keys alphabetically

### DIFF
--- a/server/src/main/java/org/apache/druid/server/StatusResource.java
+++ b/server/src/main/java/org/apache/druid/server/StatusResource.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  *
@@ -81,7 +82,10 @@ public class StatusResource
   {
     Map<String, String> allProperties = Maps.fromProperties(properties);
     Set<String> hiddenProperties = druidServerConfig.getHiddenProperties();
-    return filterHiddenProperties(hiddenProperties, allProperties);
+    Map<String, String> filtered = filterHiddenProperties(hiddenProperties, allProperties);
+
+    //    Return the properties in sorted order
+    return new TreeMap<>(filtered);
   }
 
   /**


### PR DESCRIPTION
This PR sorts the keys in the response of `/status/properties` in alphabetical order. This improves readability and makes it easier to debug by grouping keys which are related together


```
...
	"druid.emitter.logging.logLevel": "info",
	"druid.expressions.useStrictBooleans": "true",
	"druid.global.http.eagerInitialization": "false",
	"druid.host": "localhost",
	"druid.indexer.logs.directory": "var/druid/indexing-logs",
	"druid.indexer.logs.type": "file",
	"druid.indexing.doubleStorage": "double",
	"druid.lookup.enableLookupSyncOnStartup": "false",
	"druid.metadata.storage.connector.host": "localhost",
	"druid.metadata.storage.connector.port": "1527",
	"druid.metadata.storage.type": "derby",
...
```
