### PR TITLE
fixes for filtered projections that produce empty projection tables

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexTimeBoundaryInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexTimeBoundaryInspector.java
@@ -84,7 +84,7 @@ public class QueryableIndexTimeBoundaryInspector implements TimeBoundaryInspecto
 
   private void populateMinMaxTime()
   {
-    if (timeOrdered) {
+    if (timeOrdered && index.getNumRows() > 0) {
       // Compute and cache minTime, maxTime.
       final ColumnHolder columnHolder = index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME);
       try (NumericColumn column = (NumericColumn) columnHolder.getColumn()) {

--- a/processing/src/main/java/org/apache/druid/segment/QueryableIndexTimeBoundaryInspector.java
+++ b/processing/src/main/java/org/apache/druid/segment/QueryableIndexTimeBoundaryInspector.java
@@ -54,6 +54,9 @@ public class QueryableIndexTimeBoundaryInspector implements TimeBoundaryInspecto
   @MonotonicNonNull
   private volatile DateTime maxTime;
 
+  @MonotonicNonNull
+  private volatile Integer numRows;
+
   @Override
   public DateTime getMinTime()
   {
@@ -79,12 +82,15 @@ public class QueryableIndexTimeBoundaryInspector implements TimeBoundaryInspecto
   @Override
   public boolean isMinMaxExact()
   {
-    return timeOrdered;
+    if (numRows == null) {
+      numRows = index.getNumRows();
+    }
+    return timeOrdered && numRows > 0;
   }
 
   private void populateMinMaxTime()
   {
-    if (timeOrdered && index.getNumRows() > 0) {
+    if (isMinMaxExact()) {
       // Compute and cache minTime, maxTime.
       final ColumnHolder columnHolder = index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME);
       try (NumericColumn column = (NumericColumn) columnHolder.getColumn()) {

--- a/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
@@ -1646,6 +1646,13 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
         results
     );
 
+    Assertions.assertEquals(TIMESTAMP, projectionsTimeBoundaryInspector.getMinTime());
+    if (isRealtime || segmentSortedByTime) {
+      Assertions.assertEquals(TIMESTAMP.plusHours(1).plusMinutes(1), projectionsTimeBoundaryInspector.getMaxTime());
+    } else {
+      Assertions.assertEquals(TIMESTAMP.plusHours(1).plusMinutes(1).plusMillis(1), projectionsTimeBoundaryInspector.getMaxTime());
+    }
+
     Assume.assumeTrue(segmentSortedByTime);
     final Sequence<Result<TimeseriesResultValue>> resultRowsNoProjection = timeseriesEngine.process(
         query.withOverriddenContext(Map.of(QueryContexts.NO_PROJECTIONS, true)),

--- a/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
@@ -1650,7 +1650,10 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
     if (isRealtime || segmentSortedByTime) {
       Assertions.assertEquals(TIMESTAMP.plusHours(1).plusMinutes(1), projectionsTimeBoundaryInspector.getMaxTime());
     } else {
-      Assertions.assertEquals(TIMESTAMP.plusHours(1).plusMinutes(1).plusMillis(1), projectionsTimeBoundaryInspector.getMaxTime());
+      Assertions.assertEquals(
+          TIMESTAMP.plusHours(1).plusMinutes(1).plusMillis(1),
+          projectionsTimeBoundaryInspector.getMaxTime()
+      );
     }
 
     Assume.assumeTrue(segmentSortedByTime);


### PR DESCRIPTION
### Description
This PR fixes a bug that can occur when a filtered projection results in an empty dataset, where during a query the time boundary inspector assumes that there is at least 1 row in the dataset. A follow-up PR will optimize storage to not write out empty projections and instead only store metadata and produce an synthetic empty cursor at query time.