### PR TITLE
MSQ: Add "maxThreads" context parameter.

### DIFF
--- a/docs/multi-stage-query/reference.md
+++ b/docs/multi-stage-query/reference.md
@@ -418,6 +418,7 @@ The following table lists the context parameters for the MSQ task engine:
 | `storeCompactionState` | REPLACE<br /><br /> When set to true, a REPLACE query stores as part of each segment's metadata a `lastCompactionState` field that captures the various specs used to create the segment. Future compaction jobs skip segments whose `lastCompactionState` matches the desired compaction state. Works the same as [`storeCompactionState`](../ingestion/tasks.md#context-parameters) task context flag. | `false` |
 | `removeNullBytes` | SELECT, INSERT or REPLACE<br /><br /> The MSQ engine cannot process null bytes in strings and throws `InvalidNullByteFault` if it encounters them in the source data. If the parameter is set to true, The MSQ engine will remove the null bytes in string fields when reading the data. | `false` |
 | `maxFrameSize` | SELECT, INSERT or REPLACE<br /><br />Size of frames used for data transfer within the MSQ engine. You generally do not need to change this unless you have very large rows. | `1000000` (1 MB) |
+| `maxThreads` | SELECT, INSERT or REPLACE<br /><br />Maximum number of threads to use for processing. Acts as a cap on the number of threads that workers will use. If not specified, workers use their default thread count based on system configuration. | Not set (no limit) |
 
 ## Joins
 

--- a/docs/multi-stage-query/reference.md
+++ b/docs/multi-stage-query/reference.md
@@ -418,7 +418,7 @@ The following table lists the context parameters for the MSQ task engine:
 | `storeCompactionState` | REPLACE<br /><br /> When set to true, a REPLACE query stores as part of each segment's metadata a `lastCompactionState` field that captures the various specs used to create the segment. Future compaction jobs skip segments whose `lastCompactionState` matches the desired compaction state. Works the same as [`storeCompactionState`](../ingestion/tasks.md#context-parameters) task context flag. | `false` |
 | `removeNullBytes` | SELECT, INSERT or REPLACE<br /><br /> The MSQ engine cannot process null bytes in strings and throws `InvalidNullByteFault` if it encounters them in the source data. If the parameter is set to true, The MSQ engine will remove the null bytes in string fields when reading the data. | `false` |
 | `maxFrameSize` | SELECT, INSERT or REPLACE<br /><br />Size of frames used for data transfer within the MSQ engine. You generally do not need to change this unless you have very large rows. | `1000000` (1 MB) |
-| `maxThreads` | SELECT, INSERT or REPLACE<br /><br />Maximum number of threads to use for processing. Acts as a cap on the number of threads that workers will use. If not specified, workers use their default thread count based on system configuration. | Not set (no limit) |
+| `maxThreads` | SELECT, INSERT or REPLACE<br /><br />Maximum number of threads to use for processing. This only has an effect if it is greater than zero and less than the default thread count based on system configuration. Otherwise, it is ignored, and workers use the default thread count. | Not set (use default thread count) |
 
 ## Joins
 

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
@@ -80,6 +80,7 @@ public class DartWorkerContext implements WorkerContext
   private final File tempDir;
   private final QueryContext queryContext;
   private final ServiceEmitter emitter;
+  private final int threadCount;
 
   /**
    * Lazy initialized upon call to {@link #frameContext(WorkOrder)}.
@@ -128,6 +129,11 @@ public class DartWorkerContext implements WorkerContext
     this.tempDir = tempDir;
     this.queryContext = Preconditions.checkNotNull(queryContext, "queryContext");
     this.emitter = emitter;
+    
+    // Compute thread count once in constructor
+    final int baseThreadCount = processingConfig.getNumThreads();
+    final Integer maxThreads = MultiStageQueryContext.getMaxThreads(queryContext);
+    this.threadCount = (maxThreads != null) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
   }
 
   @Override
@@ -242,13 +248,7 @@ public class DartWorkerContext implements WorkerContext
   @Override
   public int threadCount()
   {
-    return processingConfig.getNumThreads();
-  }
-
-  @Override
-  public DataServerQueryHandlerFactory dataServerQueryHandlerFactory()
-  {
-    return dataServerQueryHandlerFactory;
+    return threadCount;
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/worker/DartWorkerContext.java
@@ -129,11 +129,11 @@ public class DartWorkerContext implements WorkerContext
     this.tempDir = tempDir;
     this.queryContext = Preconditions.checkNotNull(queryContext, "queryContext");
     this.emitter = emitter;
-    
+
     // Compute thread count once in constructor
     final int baseThreadCount = processingConfig.getNumThreads();
     final Integer maxThreads = MultiStageQueryContext.getMaxThreads(queryContext);
-    this.threadCount = (maxThreads != null) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
+    this.threadCount = (maxThreads != null && maxThreads > 0) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ExecutionContextImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ExecutionContextImpl.java
@@ -148,9 +148,14 @@ public class ExecutionContextImpl implements ExecutionContext
   public Bouncer processingBouncer()
   {
     if (workOrder.getStageDefinition().getProcessor().usesProcessingBuffers()) {
-      return frameContext.processingBuffers().getBouncer();
+      final Bouncer baseBouncer = frameContext.processingBuffers().getBouncer();
+      if (maxOutstandingProcessors < baseBouncer.getMaxCount()) {
+        return new Bouncer(maxOutstandingProcessors, baseBouncer);
+      } else {
+        return baseBouncer;
+      }
     } else {
-      return Bouncer.unlimited();
+      return new Bouncer(maxOutstandingProcessors);
     }
   }
 

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/WorkerContext.java
@@ -97,12 +97,12 @@ public interface WorkerContext extends Closeable
   File tempDir();
 
   /**
-   * Create a context with useful objects required by {@link StageProcessor#makeProcessors}.
+   * Create a context with useful objects required by {@link StageProcessor#execute(ExecutionContext)}.
    */
   FrameContext frameContext(WorkOrder workOrder);
 
   /**
-   * Number of available processing threads.
+   * Number of available processing threads. Workers must not use more than this number of threads.
    */
   int threadCount();
 
@@ -110,11 +110,6 @@ public interface WorkerContext extends Closeable
    * Fetch node info about self.
    */
   DruidNode selfNode();
-
-  /**
-   * Returns the factory for {@link DataServerQueryHandler} from the context. Used to query realtime tasks.
-   */
-  DataServerQueryHandlerFactory dataServerQueryHandlerFactory();
 
   /**
    * Whether to include all counters in reports. See {@link MultiStageQueryContext#CTX_INCLUDE_ALL_COUNTERS} for detail.

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -309,6 +309,7 @@ public class IndexerControllerContext implements ControllerContext
     final boolean includeAllCounters = MultiStageQueryContext.getIncludeAllCounters(queryContext);
     final boolean isReindex = MultiStageQueryContext.isReindex(queryContext);
     final int frameSize = MultiStageQueryContext.getFrameSize(queryContext);
+    final Integer maxThreads = MultiStageQueryContext.getMaxThreads(queryContext);
     final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
 
     builder
@@ -320,6 +321,10 @@ public class IndexerControllerContext implements ControllerContext
         .put(MultiStageQueryContext.CTX_REMOVE_NULL_BYTES, removeNullBytes)
         .put(MultiStageQueryContext.CTX_INCLUDE_ALL_COUNTERS, includeAllCounters)
         .put(MultiStageQueryContext.CTX_MAX_FRAME_SIZE, frameSize);
+
+    if (maxThreads != null) {
+      builder.put(MultiStageQueryContext.CTX_MAX_THREADS, maxThreads);
+    }
 
     if (querySpec.getId() != null) {
       builder.put(BaseQuery.QUERY_ID, querySpec.getId());

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
@@ -122,7 +122,7 @@ public class IndexerWorkerContext implements WorkerContext
     // Compute thread count once in constructor
     final int baseThreadCount = memoryIntrospector.numProcessingThreads();
     final Integer maxThreads = MultiStageQueryContext.getMaxThreads(queryContext);
-    this.threadCount = (maxThreads != null) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
+    this.threadCount = (maxThreads != null && maxThreads > 0) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
     final StorageConnectorProvider storageConnectorProvider = injector.getInstance(Key.get(
         StorageConnectorProvider.class,
         MultiStageQuery.class

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
@@ -30,7 +30,6 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.msq.exec.ControllerClient;
-import org.apache.druid.msq.exec.DataServerQueryHandlerFactory;
 import org.apache.druid.msq.exec.FrameContext;
 import org.apache.druid.msq.exec.FrameWriterSpec;
 import org.apache.druid.msq.exec.MSQMetriceEventBuilder;
@@ -83,6 +82,7 @@ public class IndexerWorkerContext implements WorkerContext
   private final ProcessingBuffersProvider processingBuffersProvider;
   private final int maxConcurrentStages;
   private final boolean includeAllCounters;
+  private final int threadCount;
 
   // Written under synchronized(this) using double-checked locking.
   private volatile ResourceHolder<ProcessingBuffersSet> processingBuffersSet;
@@ -118,6 +118,11 @@ public class IndexerWorkerContext implements WorkerContext
         IndexerControllerContext.DEFAULT_MAX_CONCURRENT_STAGES
     );
     this.includeAllCounters = MultiStageQueryContext.getIncludeAllCounters(queryContext);
+    
+    // Compute thread count once in constructor
+    final int baseThreadCount = memoryIntrospector.numProcessingThreads();
+    final Integer maxThreads = MultiStageQueryContext.getMaxThreads(queryContext);
+    this.threadCount = (maxThreads != null) ? Math.min(baseThreadCount, maxThreads) : baseThreadCount;
     final StorageConnectorProvider storageConnectorProvider = injector.getInstance(Key.get(
         StorageConnectorProvider.class,
         MultiStageQuery.class
@@ -286,19 +291,13 @@ public class IndexerWorkerContext implements WorkerContext
   @Override
   public int threadCount()
   {
-    return memoryIntrospector.numProcessingThreads();
+    return threadCount;
   }
 
   @Override
   public DruidNode selfNode()
   {
     return toolbox.getDruidNode();
-  }
-
-  @Override
-  public DataServerQueryHandlerFactory dataServerQueryHandlerFactory()
-  {
-    return dataServerQueryHandlerFactory;
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/util/MultiStageQueryContext.java
@@ -225,6 +225,11 @@ public class MultiStageQueryContext
    */
   public static final String CTX_MAX_FRAME_SIZE = "maxFrameSize";
 
+  /**
+   * Maximum number of threads to use for processing. Acts as a cap on the value of {@link WorkerContext#threadCount()}.
+   */
+  public static final String CTX_MAX_THREADS = "maxThreads";
+
   private static final Pattern LOOKS_LIKE_JSON_ARRAY = Pattern.compile("^\\s*\\[.*", Pattern.DOTALL);
 
   public static String getMSQMode(final QueryContext queryContext)
@@ -506,6 +511,11 @@ public class MultiStageQueryContext
   public static int getFrameSize(final QueryContext queryContext)
   {
     return queryContext.getInt(CTX_MAX_FRAME_SIZE, WorkerMemoryParameters.DEFAULT_FRAME_SIZE);
+  }
+
+  public static Integer getMaxThreads(final QueryContext queryContext)
+  {
+    return queryContext.getInt(CTX_MAX_THREADS);
   }
 
   /**

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/test/MSQTestWorkerContext.java
@@ -190,12 +190,6 @@ public class MSQTestWorkerContext implements WorkerContext
   }
 
   @Override
-  public DataServerQueryHandlerFactory dataServerQueryHandlerFactory()
-  {
-    return injector.getInstance(DataServerQueryHandlerFactory.class);
-  }
-
-  @Override
   public boolean includeAllCounters()
   {
     return true;

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -48,8 +48,8 @@ import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_DURABLE_SHUFF
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FAULT_TOLERANCE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FINALIZE_AGGREGATIONS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_FRAME_SIZE;
-import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_THREADS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_NUM_TASKS;
+import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_THREADS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MSQ_MODE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_REMOVE_NULL_BYTES;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_ROWS_IN_MEMORY;

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/util/MultiStageQueryContextTest.java
@@ -48,6 +48,7 @@ import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_DURABLE_SHUFF
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FAULT_TOLERANCE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_FINALIZE_AGGREGATIONS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_FRAME_SIZE;
+import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_THREADS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MAX_NUM_TASKS;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_MSQ_MODE;
 import static org.apache.druid.msq.util.MultiStageQueryContext.CTX_REMOVE_NULL_BYTES;
@@ -359,6 +360,19 @@ public class MultiStageQueryContextTest
   {
     Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_FRAME_SIZE, 500000);
     Assert.assertEquals(500000, MultiStageQueryContext.getFrameSize(QueryContext.of(propertyMap)));
+  }
+
+  @Test
+  public void getMaxThreads_unset_returnsNull()
+  {
+    Assert.assertNull(MultiStageQueryContext.getMaxThreads(QueryContext.empty()));
+  }
+
+  @Test
+  public void getMaxThreads_set_returnsCorrectValue()
+  {
+    Map<String, Object> propertyMap = ImmutableMap.of(CTX_MAX_THREADS, 4);
+    Assert.assertEquals(Integer.valueOf(4), MultiStageQueryContext.getMaxThreads(QueryContext.of(propertyMap)));
   }
 
   private static List<String> decodeSortOrder(@Nullable final String input)

--- a/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
@@ -69,7 +69,8 @@ import java.util.stream.IntStream;
 @RunWith(Parameterized.class)
 public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameProcessorExecutorTestSuite
 {
-  private final int bouncerPoolSize;
+  private final int lowerBouncerPoolSize;
+  private final int higherBouncerPoolSize;
   private final int maxOutstandingProcessors;
   private final boolean delayed;
   private final AtomicLong closed = new AtomicLong();
@@ -82,25 +83,46 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
   @GuardedBy("this")
   private int concurrentNow = 0;
 
-  public RunAllFullyWidgetTest(int numThreads, int bouncerPoolSize, int maxOutstandingProcessors, boolean delayed)
+  public RunAllFullyWidgetTest(
+      int numThreads,
+      int lowerBouncerPoolSize,
+      int higherBouncerPoolSize,
+      int maxOutstandingProcessors,
+      boolean delayed
+  )
   {
     super(numThreads);
-    this.bouncerPoolSize = bouncerPoolSize;
+    this.lowerBouncerPoolSize = lowerBouncerPoolSize;
+    this.higherBouncerPoolSize = higherBouncerPoolSize;
     this.maxOutstandingProcessors = maxOutstandingProcessors;
     this.delayed = delayed;
   }
 
   @Parameterized.Parameters(name =
-      "numThreads = {0}, bouncerPoolSize = {1}, maxOutstandingProcessors = {2}, delayed = {3}")
+      "numThreads = {0}, "
+      + "lowerBouncerPoolSize = {1}, "
+      + "higherBouncerPoolSize = {2}, "
+      + "maxOutstandingProcessors = {3}, "
+      + "delayed = {4}")
   public static Collection<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
 
     for (int numThreads : new int[]{1, 3, 12}) {
-      for (int bouncerPoolSize : new int[]{1, 3, 12, Integer.MAX_VALUE}) {
-        for (int maxOutstandingProcessors : new int[]{1, 3, 12}) {
-          for (boolean delayed : new boolean[]{false, true}) {
-            constructors.add(new Object[]{numThreads, bouncerPoolSize, maxOutstandingProcessors, delayed});
+      for (int lowerBouncerPoolSize : new int[]{1, 3, 12, Integer.MAX_VALUE}) {
+        for (int higherBouncerPoolSize : new int[]{-1, 1, 3, 12, Integer.MAX_VALUE}) {
+          for (int maxOutstandingProcessors : new int[]{1, 3, 12}) {
+            for (boolean delayed : new boolean[]{false, true}) {
+              constructors.add(
+                  new Object[]{
+                      numThreads,
+                      lowerBouncerPoolSize,
+                      higherBouncerPoolSize,
+                      maxOutstandingProcessors,
+                      delayed
+                  }
+              );
+            }
           }
         }
       }
@@ -114,7 +136,10 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
   public void setUp() throws Exception
   {
     super.setUp();
-    bouncer = bouncerPoolSize == Integer.MAX_VALUE ? Bouncer.unlimited() : new Bouncer(bouncerPoolSize);
+    bouncer = new Bouncer(lowerBouncerPoolSize);
+    if (higherBouncerPoolSize != -1) {
+      bouncer = new Bouncer(higherBouncerPoolSize, bouncer);
+    }
 
     synchronized (this) {
       concurrentNow = 0;
@@ -130,12 +155,19 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
 
     synchronized (this) {
       Assert.assertEquals(0, concurrentNow);
-      MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(bouncerPoolSize));
+      MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(lowerBouncerPoolSize));
+      if (higherBouncerPoolSize != -1) {
+        MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(higherBouncerPoolSize));
+      }
       MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(maxOutstandingProcessors));
     }
 
     Assert.assertEquals("Bouncer current running count", 0, bouncer.getCurrentCount());
-    Assert.assertEquals("Bouncer max pool size", bouncerPoolSize, bouncer.getMaxCount());
+    Assert.assertEquals(
+        "Bouncer max pool size",
+        higherBouncerPoolSize == -1 ? lowerBouncerPoolSize : Math.min(lowerBouncerPoolSize, higherBouncerPoolSize),
+        bouncer.getMaxCount()
+    );
     Assert.assertEquals("Encountered single close (from ensureClose)", 1, closed.get());
   }
 
@@ -402,7 +434,8 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
   @SuppressWarnings("BusyWait")
   public void test_runAllFully_futureCancel() throws InterruptedException
   {
-    final int expectedRunningProcessors = Math.min(Math.min(bouncerPoolSize, maxOutstandingProcessors), numThreads);
+    final int expectedRunningProcessors =
+        Math.min(Math.min(bouncer.getMaxCount(), maxOutstandingProcessors), numThreads);
 
     final List<SleepyFrameProcessor> processors =
         IntStream.range(0, 10 * expectedRunningProcessors)


### PR DESCRIPTION
Allows users to reduce the number of threads per data server or task. Useful for benchmarking single-threaded performance, or for limiting the impact of a heavyweight query.