### PR TITLE
Give control of fallback vectorization to each function.

### DIFF
--- a/processing/src/main/java/org/apache/druid/math/expr/Expr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Expr.java
@@ -189,13 +189,6 @@ public interface Expr extends Cacheable
     return false;
   }
 
-
-  default boolean canFallbackVectorize(InputBindingInspector inspector, List<Expr> args)
-  {
-    return ExpressionProcessing.allowVectorizeFallback() &&
-           getOutputType(inspector) != null &&
-           inspector.canVectorize(args);
-  }
   /**
    * Possibly convert the {@link Expr} into an optimized, possibly not thread-safe {@link Expr}. Does not convert
    * child {@link Expr}. Most callers should use {@link Expr#singleThreaded(Expr, InputBindingInspector)} to convert

--- a/processing/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
@@ -178,13 +178,17 @@ public class ExprMacroTable
     @Override
     public boolean canVectorize(InputBindingInspector inspector)
     {
-      return canFallbackVectorize(inspector, args);
+      return FallbackVectorProcessor.canFallbackVectorize(getOutputType(inspector), inspector, args);
     }
 
     @Override
     public <T> ExprVectorProcessor<T> asVectorProcessor(VectorInputBindingInspector inspector)
     {
-      return FallbackVectorProcessor.create(macro, args, inspector);
+      if (ExpressionProcessing.allowVectorizeFallback()) {
+        return FallbackVectorProcessor.create(macro, args, inspector);
+      } else {
+        throw Exprs.cannotVectorize(this);
+      }
     }
 
     /**

--- a/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
@@ -25,6 +25,7 @@ import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExprType;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.Function;
 import org.apache.druid.math.expr.LambdaExpr;
@@ -111,6 +112,21 @@ public abstract class FallbackVectorProcessor<T> implements ExprVectorProcessor<
         adaptedExpr.getOutputType(inspector),
         inspector
     );
+  }
+
+  /**
+   * Returns whether {@link #create(Function, List, Expr.VectorInputBindingInspector)} can be used to make
+   * a fallback vectorized processor.
+   */
+  public static boolean canFallbackVectorize(
+      @Nullable final ExpressionType outputType,
+      final Expr.InputBindingInspector inspector,
+      final List<Expr> args
+  )
+  {
+    return ExpressionProcessing.allowVectorizeFallback() &&
+           outputType != null &&
+           inspector.canVectorize(args);
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -410,6 +410,31 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
       testExpression("array(d1, d2)", types);
       testExpression("array(l1, d2)", types);
       testExpression("array(s1, l2)", types);
+
+      testExpression("map((x) -> x + 1, array(l1, l2))", types);
+      testExpression("map((x) -> x * 2.0, array(d1, d2))", types);
+      testExpression("map((x) -> concat(x, '_mapped'), array(s1, s2))", types);
+
+      testExpression("cartesian_map((x, y) -> x + y, array(l1, l2), array(d1, d2))", types);
+      testExpression("cartesian_map((x, y) -> concat(x, cast(y, 'STRING')), array(s1, s2), array(l1, l2))", types);
+
+      testExpression("fold((x, acc) -> x + acc, array(l1, l2), 0)", types);
+      testExpression("fold((x, acc) -> x + acc, array(d1, d2), 0.0)", types);
+      testExpression("fold((x, acc) -> concat(acc, x), array(s1, s2), '')", types);
+
+      testExpression("cartesian_fold((x, y, acc) -> acc + x + y, array(l1, l2), array(d1, d2), 0)", types);
+
+      testExpression("filter((x) -> x > 0, array(l1, l2))", types);
+      testExpression("filter((x) -> x > 0.0, array(d1, d2))", types);
+      testExpression("filter((x) -> strlen(x) > 0, array(s1, s2))", types);
+
+      testExpression("any((x) -> x > 0, array(l1, l2))", types);
+      testExpression("any((x) -> x > 0.0, array(d1, d2))", types);
+      testExpression("any((x) -> strlen(x) > 0, array(s1, s2))", types);
+
+      testExpression("all((x) -> x != null, array(l1, l2))", types);
+      testExpression("all((x) -> x != null, array(d1, d2))", types);
+      testExpression("all((x) -> x != null, array(s1, s2))", types);
     }
     finally {
       ExpressionProcessing.initializeForTests();


### PR DESCRIPTION
If a function overrides canVectorize, let it decide when it does and doesn't vectorize, rather than always attempting to fall back. In situations like conditionals (#18507, #18512), we are currently refraining from vectorizing when output types are not all aligned.