### PR TITLE
docs: (34.0 branch) update hadoop ingestion deprecation to d37

### DIFF
--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -964,7 +964,7 @@ Each line can be further parsed using [`parseSpec`](#parsespec).
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion).
 
 :::
 
@@ -1032,7 +1032,7 @@ For example, using Avro Hadoop parser with custom reader's schema file:
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion).
 
 :::
 
@@ -1284,7 +1284,7 @@ setting `"mapreduce.job.user.classpath.first": "true"`, then this will not be an
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion).
 
 :::
 
@@ -1435,7 +1435,7 @@ However, the Parquet Avro Hadoop Parser was the original basis for supporting th
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion).
 
 :::
 

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -964,11 +964,14 @@ Each line can be further parsed using [`parseSpec`](#parsespec).
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
 
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239)
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
 
 :::
+
 
 :::info
 You need to include [`druid-avro-extensions`](../development/extensions-core/avro.md) as an extension to use the Avro Hadoop Parser.
@@ -1030,6 +1033,17 @@ For example, using Avro Hadoop parser with custom reader's schema file:
 ```
 
 ### ORC Hadoop Parser
+
+:::caution[Deprecated]
+
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
+
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+
+:::
+
 
 :::info
  You need to include the [`druid-orc-extensions`](../development/extensions-core/orc.md) as an extension to use the ORC Hadoop Parser.
@@ -1276,6 +1290,17 @@ setting `"mapreduce.job.user.classpath.first": "true"`, then this will not be an
 
 ### Parquet Hadoop Parser
 
+:::caution[Deprecated]
+
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
+
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+
+:::
+
+
 :::info
  You need to include the [`druid-parquet-extensions`](../development/extensions-core/parquet.md) as an extension to use the Parquet Hadoop Parser.
 :::
@@ -1419,6 +1444,17 @@ However, the Parquet Avro Hadoop Parser was the original basis for supporting th
 ```
 
 ### Parquet Avro Hadoop Parser
+
+:::caution[Deprecated]
+
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
+
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+
+:::
+
 
 :::info
  Consider using the [Parquet Hadoop Parser](#parquet-hadoop-parser) over this parser to ingest

--- a/docs/ingestion/data-formats.md
+++ b/docs/ingestion/data-formats.md
@@ -964,11 +964,7 @@ Each line can be further parsed using [`parseSpec`](#parsespec).
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
 
 :::
 
@@ -1036,11 +1032,7 @@ For example, using Avro Hadoop parser with custom reader's schema file:
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
 
 :::
 
@@ -1292,11 +1284,7 @@ setting `"mapreduce.job.user.classpath.first": "true"`, then this will not be an
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
 
 :::
 
@@ -1447,11 +1435,7 @@ However, the Parquet Avro Hadoop Parser was the original basis for supporting th
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
 
 :::
 

--- a/docs/ingestion/hadoop.md
+++ b/docs/ingestion/hadoop.md
@@ -25,11 +25,14 @@ sidebar_label: "Hadoop-based"
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
 
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239)
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
 
 :::
+
 
 
 Apache Hadoop-based batch ingestion in Apache Druid is supported via a Hadoop-ingestion task. These tasks can be posted to a running

--- a/docs/ingestion/hadoop.md
+++ b/docs/ingestion/hadoop.md
@@ -25,14 +25,9 @@ sidebar_label: "Hadoop-based"
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion).
 
 :::
-
 
 
 Apache Hadoop-based batch ingestion in Apache Druid is supported via a Hadoop-ingestion task. These tasks can be posted to a running

--- a/docs/operations/other-hadoop.md
+++ b/docs/operations/other-hadoop.md
@@ -25,11 +25,14 @@ title: "Working with different versions of Apache Hadoop"
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
 
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239)
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
 
 :::
+
 
 Apache Druid can interact with Hadoop in two ways:
 

--- a/docs/operations/other-hadoop.md
+++ b/docs/operations/other-hadoop.md
@@ -25,11 +25,7 @@ title: "Working with different versions of Apache Hadoop"
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
 
 :::
 

--- a/docs/release-info/release-notes.md
+++ b/docs/release-info/release-notes.md
@@ -59,9 +59,13 @@ This section contains important information about new and existing features.
 
 ### Java 11 support
 
+**Update**: Support for Java 11 is scheduled to end with Druid 37.0.0. 
+
 Java 11 support has been deprecated since Druid 32.0, and official support will be removed as early as Druid 35.0.0
 
 ### Hadoop-based ingestion
+
+**Update**: Support for Hadoop-based ingestion is scheduled to end with Druid 37.0.0.
 
 Hadoop-based ingestion has been deprecated since Druid 32.0 and will be removed as early as Druid 35.0.0. 
 We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md).
@@ -377,7 +381,15 @@ Additionally, MSQ task engine metrics now include the following dimensions:
 
 ### Upgrade notes
 
+#### Java 11 support
+
+**Update**: Support for Java 11 is scheduled to end with Druid 37.0.0. 
+
+Java 11 support has been deprecated since Druid 32.0, and official support will be removed as early as Druid 35.0.0
+
 #### Hadoop-based ingestion
+
+**Update**: Support for Hadoop-based ingestion is scheduled to end with Druid 37.0.0.
 
 Hadoop-based ingestion has been deprecated since Druid 32.0 and will be removed as early as Druid 35.0.0. 
 

--- a/docs/release-info/upgrade-notes.md
+++ b/docs/release-info/upgrade-notes.md
@@ -42,7 +42,15 @@ If you're already using this feature, you don't need to take any action.
 
 ### Upgrade notes
 
+#### Java 11 support
+
+**Update**: Support for Java 11 is scheduled to end with Druid 37.0.0. 
+
+Java 11 support has been deprecated since Druid 32.0, and official support will be removed as early as Druid 35.0.0
+
 #### Hadoop-based ingestion
+
+**Update**: Support for Hadoop-based ingestion is scheduled to end with Druid 37.0.0.
 
 Hadoop-based ingestion has been deprecated since Druid 32.0 and will be removed as early as Druid 35.0.0. 
 

--- a/docs/tutorials/tutorial-batch-hadoop.md
+++ b/docs/tutorials/tutorial-batch-hadoop.md
@@ -25,11 +25,14 @@ sidebar_label: Load from Apache Hadoop
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
 
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239)
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
 
 :::
+
 
 This tutorial shows you how to load data files into Apache Druid using a remote Hadoop cluster.
 

--- a/docs/tutorials/tutorial-batch-hadoop.md
+++ b/docs/tutorials/tutorial-batch-hadoop.md
@@ -25,11 +25,7 @@ sidebar_label: Load from Apache Hadoop
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
 
 :::
 

--- a/docs/tutorials/tutorial-kerberos-hadoop.md
+++ b/docs/tutorials/tutorial-kerberos-hadoop.md
@@ -25,11 +25,7 @@ sidebar_label: Kerberized HDFS deep storage
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
-
-We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
-
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
+Hadoop-based ingestion is deprecated. For more information, see the [upgrade notes](../release-info/upgrade-notes.md#hadoop-based-ingestion)
 
 :::
 

--- a/docs/tutorials/tutorial-kerberos-hadoop.md
+++ b/docs/tutorials/tutorial-kerberos-hadoop.md
@@ -25,9 +25,11 @@ sidebar_label: Kerberized HDFS deep storage
 
 :::caution[Deprecated]
 
-Hadoop-based ingestion is deprecated. We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+Hadoop-based ingestion is deprecated and scheduled to be removed with Druid 37.0.0.
 
-You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239)
+We recommend one of Druid's other supported ingestion methods, such as [SQL-based ingestion](../multi-stage-query/index.md) or [MiddleManager-less ingestion using Kubernetes](../development/extensions-core/k8s-jobs.md)
+
+You must now explicitly opt-in to using the deprecated `index_hadoop` task type. To opt-in, set `druid.indexer.task.allowHadoopTaskExecution` to `true` in your `common.runtime.properties` file. For more information, see [#18239](https://github.com/apache/druid/pull/18239).
 
 :::
 


### PR DESCRIPTION
Update deprecation for Hadoop to druid 37

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
