### PR TITLE
Remove ordering direction requirement on projection match

### DIFF
--- a/processing/src/main/java/org/apache/druid/segment/CursorBuildSpec.java
+++ b/processing/src/main/java/org/apache/druid/segment/CursorBuildSpec.java
@@ -235,7 +235,7 @@ public class CursorBuildSpec
       return false;
     }
     for (int i = 0; i < preferredOrdering.size(); i++) {
-      if (!ordering.get(i).equals(preferredOrdering.get(i))) {
+      if (!ordering.get(i).getColumnName().equals(preferredOrdering.get(i).getColumnName())) {
         return false;
       }
     }


### PR DESCRIPTION
 

### Description
Remove ordering direction requirement on projection match. Also updated `CursorFactoryProjectionTest`:
- use `groupingEngine.mergeRunners` to enable result sorting, since segment sorting push down is not enabled in `groupingEngine.process`.
- update all ArrayResultSet to use List<Object[]> instead.
- prefer `Map.of` over `ImmutableMap.of`.


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
