### PR TITLE
Make the HTTP client that lives beneath fabric8 KubernetesClient configurable

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/pom.xml
+++ b/extensions-core/kubernetes-overlord-extensions/pom.xml
@@ -124,12 +124,16 @@
       <artifactId>kubernetes-client</artifactId>
       <version>${fabric8.version}</version>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.fabric8</groupId>
-          <artifactId>kubernetes-httpclient-okhttp</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-jdk</artifactId>
+      <version>${fabric8.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-httpclient-okhttp</artifactId>
+      <version>${fabric8.version}</version>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesOverlordModule.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesOverlordModule.java
@@ -54,7 +54,13 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
-import org.apache.druid.k8s.overlord.common.DruidKubernetesHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.jdk.DruidKubernetesJdkHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.jdk.DruidKubernetesJdkHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.okhttp.DruidKubernetesOkHttpHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.okhttp.DruidKubernetesOkHttpHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.k8s.overlord.execution.KubernetesTaskExecutionConfigResource;
 import org.apache.druid.k8s.overlord.execution.KubernetesTaskRunnerDynamicConfig;
 import org.apache.druid.k8s.overlord.runnerstrategy.RunnerStrategy;
@@ -79,7 +85,10 @@ public class KubernetesOverlordModule implements DruidModule
                                                                + ".k8sAndWorker";
   private static final String RUNNERSTRATEGY_PROPERTIES_FORMAT_STRING = K8SANDWORKER_PROPERTIES_PREFIX
                                                                         + ".runnerStrategy.%s";
-  private static final String HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_PROPERTIES_PREFIX + ".http";
+  private static final String HTTPCLIENT_TYPE_PROPERTY = K8SANDWORKER_PROPERTIES_PREFIX + ".http.httpClientType";
+  private static final String VERTX_HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_PROPERTIES_PREFIX + ".http.vertx";
+  private static final String OKHTTP_HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_PROPERTIES_PREFIX + ".http.okhttp";
+  public static final String JDK_HTTPCLIENT_PROPERITES_PREFIX = K8SANDWORKER_PROPERTIES_PREFIX + ".http.jdk";
 
   @Override
   public void configure(Binder binder)
@@ -114,14 +123,37 @@ public class KubernetesOverlordModule implements DruidModule
 
     Jerseys.addResource(binder, KubernetesTaskExecutionConfigResource.class);
 
-    JsonConfigProvider.bind(binder, HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesHttpClientConfig.class);
+    PolyBind.createChoiceWithDefault(
+        binder,
+        HTTPCLIENT_TYPE_PROPERTY,
+        Key.get(DruidKubernetesHttpClientFactory.class),
+        DruidKubernetesVertxHttpClientFactory.TYPE_NAME
+    );
+
+    final MapBinder<String, DruidKubernetesHttpClientFactory> factoryBinder =
+        PolyBind.optionBinder(binder, Key.get(DruidKubernetesHttpClientFactory.class));
+
+    factoryBinder.addBinding(DruidKubernetesVertxHttpClientFactory.TYPE_NAME)
+                 .toProvider(VertxHttpClientFactoryProvider.class)
+                 .in(LazySingleton.class);
+
+    factoryBinder.addBinding(DruidKubernetesOkHttpHttpClientFactory.TYPE_NAME)
+                 .toProvider(OkHttpHttpClientFactoryProvider.class)
+                 .in(LazySingleton.class);
+    factoryBinder.addBinding(DruidKubernetesJdkHttpClientFactory.TYPE_NAME)
+                 .toProvider(JdkHttpClientFactoryProvider.class)
+                 .in(LazySingleton.class);
+
+    JsonConfigProvider.bind(binder, VERTX_HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesVertxHttpClientConfig.class);
+    JsonConfigProvider.bind(binder, OKHTTP_HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesOkHttpHttpClientConfig.class);
+    JsonConfigProvider.bind(binder, JDK_HTTPCLIENT_PROPERITES_PREFIX, DruidKubernetesJdkHttpClientConfig.class);
   }
 
   @Provides
   @LazySingleton
   public DruidKubernetesClient makeKubernetesClient(
       KubernetesTaskRunnerConfig kubernetesTaskRunnerConfig,
-      DruidKubernetesHttpClientConfig httpClientConfig,
+      DruidKubernetesHttpClientFactory httpClientFactory,
       Lifecycle lifecycle
   )
   {
@@ -133,7 +165,7 @@ public class KubernetesOverlordModule implements DruidModule
       config.setHttpProxy(null);
     }
 
-    client = new DruidKubernetesClient(httpClientConfig, config);
+    client = new DruidKubernetesClient(httpClientFactory, config);
 
     lifecycle.addHandler(
         new Lifecycle.Handler()
@@ -278,6 +310,57 @@ public class KubernetesOverlordModule implements DruidModule
       provider.inject(props, configurator);
 
       return provider.get();
+    }
+  }
+
+  private static class VertxHttpClientFactoryProvider implements Provider<DruidKubernetesHttpClientFactory>
+  {
+    private DruidKubernetesVertxHttpClientConfig config;
+
+    @Inject
+    public void inject(DruidKubernetesVertxHttpClientConfig config)
+    {
+      this.config = config;  // Guice injects the Vertx-specific config
+    }
+
+    @Override
+    public DruidKubernetesHttpClientFactory get()
+    {
+      return new DruidKubernetesVertxHttpClientFactory(config);
+    }
+  }
+
+  private static class OkHttpHttpClientFactoryProvider implements Provider<DruidKubernetesHttpClientFactory>
+  {
+    private DruidKubernetesOkHttpHttpClientConfig config;
+
+    @Inject
+    public void inject(DruidKubernetesOkHttpHttpClientConfig config)
+    {
+      this.config = config;  // Guice injects the OkHttp-specific config
+    }
+
+    @Override
+    public DruidKubernetesHttpClientFactory get()
+    {
+      return new DruidKubernetesOkHttpHttpClientFactory(config);
+    }
+  }
+
+  private static class JdkHttpClientFactoryProvider implements Provider<DruidKubernetesHttpClientFactory>
+  {
+    private DruidKubernetesJdkHttpClientConfig config;
+
+    @Inject
+    public void inject(DruidKubernetesJdkHttpClientConfig config)
+    {
+      this.config = config;
+    }
+
+    @Override
+    public DruidKubernetesHttpClientFactory get()
+    {
+      return new DruidKubernetesJdkHttpClientFactory(config);
     }
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesClient.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidKubernetesClient.java
@@ -22,15 +22,16 @@ package org.apache.druid.k8s.overlord.common;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
 
 public class DruidKubernetesClient implements KubernetesClientApi
 {
   private final KubernetesClient kubernetesClient;
 
-  public DruidKubernetesClient(DruidKubernetesHttpClientConfig httpClientConfig, Config kubernetesClientConfig)
+  public DruidKubernetesClient(DruidKubernetesHttpClientFactory httpClientFactory, Config kubernetesClientConfig)
   {
     this.kubernetesClient = new KubernetesClientBuilder()
-        .withHttpClientFactory(new DruidKubernetesHttpClientFactory(httpClientConfig))
+        .withHttpClientFactory(httpClientFactory)
         .withConfig(kubernetesClientConfig)
         .build();
   }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/DruidKubernetesHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/DruidKubernetesHttpClientFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient;
+
+import io.fabric8.kubernetes.client.http.HttpClient;
+
+public interface DruidKubernetesHttpClientFactory extends HttpClient.Factory
+{
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.jdk;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DruidKubernetesJdkHttpClientConfig
+{
+
+  @JsonProperty
+  private int maxWorkerThreads = 100;
+
+  @JsonProperty
+  private int coreWorkerThreads = 20;
+
+  @JsonProperty
+  private long workerThreadKeepAliveTime = 60L;
+
+  public int getMaxWorkerThreads()
+  {
+    return maxWorkerThreads;
+  }
+
+  public int getCoreWorkerThreads()
+  {
+    return coreWorkerThreads;
+  }
+
+  public long getWorkerThreadKeepAliveTime()
+  {
+    return workerThreadKeepAliveTime;
+  }
+
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/jdk/DruidKubernetesJdkHttpClientFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.jdk;
+
+import io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
+
+import java.net.http.HttpClient;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class DruidKubernetesJdkHttpClientFactory extends JdkHttpClientFactory implements DruidKubernetesHttpClientFactory
+{
+  public static final String TYPE_NAME = "jdk";
+  private final DruidKubernetesJdkHttpClientConfig config;
+
+  public DruidKubernetesJdkHttpClientFactory(DruidKubernetesJdkHttpClientConfig config)
+  {
+    super();
+    this.config = config;
+  }
+
+  @Override
+  protected HttpClient.Builder createNewHttpClientBuilder()
+  {
+    ExecutorService executorService = new ThreadPoolExecutor(
+        config.getCoreWorkerThreads(),
+        config.getMaxWorkerThreads(),
+        config.getWorkerThreadKeepAliveTime(),
+        TimeUnit.SECONDS,
+        new LinkedBlockingQueue<>(),
+        Execs.makeThreadFactory("JdkHttpClient-%d")
+    );
+    return HttpClient.newBuilder().executor(executorService);
+  }
+
+  @Override
+  protected void additionalConfig(HttpClient.Builder builder)
+  {
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientConfig.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.okhttp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DruidKubernetesOkHttpHttpClientConfig
+{
+  @JsonProperty
+  private boolean useCustomDispatcherExecutor = false;
+
+  @JsonProperty
+  private int maxWorkerThreads = 100;
+
+  @JsonProperty
+  private int coreWorkerThreads = 20;
+
+  @JsonProperty
+  private long workerThreadKeepAliveTime = 60L;
+
+  public boolean isUseCustomDispatcherExecutor()
+  {
+    return useCustomDispatcherExecutor;
+  }
+
+  public int getMaxWorkerThreads()
+  {
+    return maxWorkerThreads;
+  }
+
+  public int getCoreWorkerThreads()
+  {
+    return coreWorkerThreads;
+  }
+
+  public long getWorkerThreadKeepAliveTime()
+  {
+    return workerThreadKeepAliveTime;
+  }
+
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/okhttp/DruidKubernetesOkHttpHttpClientFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord.common.httpclient.okhttp;
+
+import io.fabric8.kubernetes.client.okhttp.OkHttpClientFactory;
+import okhttp3.Dispatcher;
+import okhttp3.OkHttpClient;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class DruidKubernetesOkHttpHttpClientFactory extends OkHttpClientFactory implements DruidKubernetesHttpClientFactory
+{
+  public static final String TYPE_NAME = "okhttp";
+  private final DruidKubernetesOkHttpHttpClientConfig config;
+
+  public DruidKubernetesOkHttpHttpClientFactory(DruidKubernetesOkHttpHttpClientConfig config)
+  {
+    super();
+    this.config = config;
+  }
+
+  @Override
+  protected void additionalConfig(OkHttpClient.Builder builder)
+  {
+    if (config.isUseCustomDispatcherExecutor()) {
+      ExecutorService executorService = new ThreadPoolExecutor(
+          config.getCoreWorkerThreads(),
+          config.getMaxWorkerThreads(),
+          config.getWorkerThreadKeepAliveTime(),
+          TimeUnit.SECONDS,
+          new LinkedBlockingQueue<>(),
+          Execs.makeThreadFactory("OkHttpHttpClient-%d")
+      );
+      Dispatcher dispatcher = new Dispatcher(executorService);
+      dispatcher.setMaxRequests(config.getMaxWorkerThreads());
+      dispatcher.setMaxRequestsPerHost(config.getMaxWorkerThreads());
+      builder.dispatcher(dispatcher);
+    }
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientConfig.java
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-package org.apache.druid.k8s.overlord.common;
+package org.apache.druid.k8s.overlord.common.httpclient.vertx;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.vertx.core.VertxOptions;
 
-public class DruidKubernetesHttpClientConfig
+public class DruidKubernetesVertxHttpClientConfig
 {
   @JsonProperty
   private int workerPoolSize = VertxOptions.DEFAULT_WORKER_POOL_SIZE;

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/httpclient/vertx/DruidKubernetesVertxHttpClientFactory.java
@@ -17,30 +17,31 @@
  * under the License.
  */
 
-package org.apache.druid.k8s.overlord.common;
+package org.apache.druid.k8s.overlord.common.httpclient.vertx;
 
-import io.fabric8.kubernetes.client.http.HttpClient;
 import io.fabric8.kubernetes.client.vertx.VertxHttpClientBuilder;
 import io.fabric8.kubernetes.client.vertx.VertxHttpClientFactory;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.file.FileSystemOptions;
 import io.vertx.core.spi.resolver.ResolverProvider;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
 
 /**
  * Similar to {@link VertxHttpClientFactory} but allows us to override thread pool configurations.
  */
-public class DruidKubernetesHttpClientFactory implements HttpClient.Factory
+public class DruidKubernetesVertxHttpClientFactory implements DruidKubernetesHttpClientFactory
 {
+  public static final String TYPE_NAME = "vertx";
   private final Vertx vertx;
 
-  public DruidKubernetesHttpClientFactory(final DruidKubernetesHttpClientConfig httpClientConfig)
+  public DruidKubernetesVertxHttpClientFactory(final DruidKubernetesVertxHttpClientConfig httpClientConfig)
   {
     this.vertx = createVertxInstance(httpClientConfig);
   }
 
   @Override
-  public VertxHttpClientBuilder<DruidKubernetesHttpClientFactory> newBuilder()
+  public VertxHttpClientBuilder<DruidKubernetesVertxHttpClientFactory> newBuilder()
   {
     return new VertxHttpClientBuilder<>(this, vertx);
   }
@@ -49,7 +50,7 @@ public class DruidKubernetesHttpClientFactory implements HttpClient.Factory
    * Adapted from fabric8 kubernetes-client 7.1.0. We bring this here so we can customize thread pool sizes
    * and force usage of daemon threads.
    */
-  private static Vertx createVertxInstance(final DruidKubernetesHttpClientConfig httpClientConfig)
+  private static Vertx createVertxInstance(final DruidKubernetesVertxHttpClientConfig httpClientConfig)
   {
     // fabric8 disables the async DNS resolver while creating Vertx.
     // I'm not sure if we really need to do this, but I'm keeping it to align behavior with upstream.

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesOverlordModuleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesOverlordModuleTest.java
@@ -39,6 +39,11 @@ import org.apache.druid.indexing.overlord.hrtr.HttpRemoteTaskRunnerFactory;
 import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
+import org.apache.druid.k8s.overlord.common.httpclient.DruidKubernetesHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.jdk.DruidKubernetesJdkHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.okhttp.DruidKubernetesOkHttpHttpClientFactory;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.k8s.overlord.taskadapter.MultiContainerTaskAdapter;
 import org.apache.druid.k8s.overlord.taskadapter.PodTemplateTaskAdapter;
 import org.apache.druid.k8s.overlord.taskadapter.SingleContainerTaskAdapter;
@@ -52,6 +57,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.net.URL;
 import java.util.Properties;
 
@@ -198,6 +205,117 @@ public class KubernetesOverlordModuleTest
 
     Assert.assertNotNull(adapter);
     Assert.assertTrue(adapter instanceof PodTemplateTaskAdapter);
+  }
+
+  @Test
+  public void test_httpClientFactory_defaultsToVertx()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    // Don't set httpClientType - should default to vertx
+
+    injector = makeInjectorWithProperties(props, false, true);
+    DruidKubernetesHttpClientFactory factory = injector.getInstance(DruidKubernetesHttpClientFactory.class);
+
+    Assert.assertNotNull(factory);
+    Assert.assertTrue("Should default to Vertx HTTP client",
+                     factory instanceof DruidKubernetesVertxHttpClientFactory);
+  }
+
+  @Test
+  public void test_httpClientFactory_okhttpSelection()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    props.setProperty("druid.indexer.runner.k8sAndWorker.http.httpClientType", "okhttp");
+
+    injector = makeInjectorWithProperties(props, false, true);
+    DruidKubernetesHttpClientFactory factory = injector.getInstance(DruidKubernetesHttpClientFactory.class);
+
+    Assert.assertNotNull(factory);
+    Assert.assertTrue("Should select OkHttp HTTP client",
+                     factory instanceof DruidKubernetesOkHttpHttpClientFactory);
+  }
+
+  @Test
+  public void test_httpClientFactory_vertxExplicitSelection()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    props.setProperty("druid.indexer.runner.k8sAndWorker.http.httpClientType", "vertx");
+
+    injector = makeInjectorWithProperties(props, false, true);
+    DruidKubernetesHttpClientFactory factory = injector.getInstance(DruidKubernetesHttpClientFactory.class);
+
+    Assert.assertNotNull(factory);
+    Assert.assertTrue("Should explicitly select Vertx HTTP client",
+                     factory instanceof DruidKubernetesVertxHttpClientFactory);
+  }
+
+  @Test
+  public void test_httpClientFactory_jdkSelection()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    props.setProperty("druid.indexer.runner.k8sAndWorker.http.httpClientType", "jdk");
+
+    injector = makeInjectorWithProperties(props, false, true);
+    DruidKubernetesHttpClientFactory factory = injector.getInstance(DruidKubernetesHttpClientFactory.class);
+
+    Assert.assertNotNull(factory);
+    Assert.assertTrue("Should select JDK HTTP client",
+                     factory instanceof DruidKubernetesJdkHttpClientFactory);
+  }
+
+  @Test(expected = ProvisionException.class)
+  public void test_httpClientFactory_invalidTypeThrowsException()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    props.setProperty("druid.indexer.runner.k8sAndWorker.http.httpClientType", "invalid");
+
+    injector = makeInjectorWithProperties(props, false, true);
+    injector.getInstance(DruidKubernetesHttpClientFactory.class);
+  }
+
+  @Test
+  public void test_druidKubernetesClient_createdWithVertxClient()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    // Don't set httpClientType - should default to vertx
+
+    injector = makeInjectorWithProperties(props, false, true);
+    DruidKubernetesClient client = injector.getInstance(DruidKubernetesClient.class);
+
+    Assert.assertNotNull("DruidKubernetesClient should be created successfully", client);
+    Assert.assertNotNull("Underlying Kubernetes client should be created", client.getClient());
+  }
+
+  @Test
+  public void test_druidKubernetesClient_createdWithOkHttpClient_honorsAdditionalConfig()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    props.setProperty("druid.indexer.runner.k8sAndWorker.http.httpClientType", "okhttp");
+    injector = makeInjectorWithProperties(props, false, true);
+    DruidKubernetesClient client = injector.getInstance(DruidKubernetesClient.class);
+    Assert.assertNotNull("DruidKubernetesClient should be created successfully", client);
+    Assert.assertNotNull("Underlying Kubernetes client should be created", client.getClient());
+  }
+
+  @Test
+  public void test_druidKubernetesClient_createdWithJdkClient_honorsAdditionalConfig()
+  {
+    Properties props = new Properties();
+    props.setProperty("druid.indexer.runner.namespace", "NAMESPACE");
+    props.setProperty("druid.indexer.runner.k8sAndWorker.http.httpClientType", "jdk");
+
+    injector = makeInjectorWithProperties(props, false, true);
+    DruidKubernetesClient client = injector.getInstance(DruidKubernetesClient.class);
+
+    Assert.assertNotNull("DruidKubernetesClient should be created successfully", client);
+    Assert.assertNotNull("Underlying Kubernetes client should be created", client.getClient());
   }
 
   private Injector makeInjectorWithProperties(

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesOverlordModuleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesOverlordModuleTest.java
@@ -57,8 +57,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.net.URL;
 import java.util.Properties;
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactoryTest.java
@@ -26,8 +26,9 @@ import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
-import org.apache.druid.k8s.overlord.common.DruidKubernetesHttpClientConfig;
 import org.apache.druid.k8s.overlord.common.K8sTaskId;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.k8s.overlord.taskadapter.TaskAdapter;
 import org.apache.druid.tasklogs.NoopTaskLogs;
 import org.apache.druid.tasklogs.TaskLogs;
@@ -57,7 +58,7 @@ public class KubernetesTaskRunnerFactoryTest
         .build();
     taskLogs = new NoopTaskLogs();
     druidKubernetesClient =
-        new DruidKubernetesClient(new DruidKubernetesHttpClientConfig(), new ConfigBuilder().build());
+        new DruidKubernetesClient(new DruidKubernetesVertxHttpClientFactory(new DruidKubernetesVertxHttpClientConfig()), new ConfigBuilder().build());
     taskAdapter = new TestTaskAdapter();
   }
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/taskadapter/DruidPeonClientIntegrationTest.java
@@ -35,7 +35,6 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.k8s.overlord.KubernetesTaskRunnerConfig;
 import org.apache.druid.k8s.overlord.common.DruidKubernetesClient;
-import org.apache.druid.k8s.overlord.common.DruidKubernetesHttpClientConfig;
 import org.apache.druid.k8s.overlord.common.JobResponse;
 import org.apache.druid.k8s.overlord.common.K8sTaskId;
 import org.apache.druid.k8s.overlord.common.K8sTestUtils;
@@ -43,6 +42,8 @@ import org.apache.druid.k8s.overlord.common.KubernetesClientApi;
 import org.apache.druid.k8s.overlord.common.KubernetesPeonClient;
 import org.apache.druid.k8s.overlord.common.PeonCommandContext;
 import org.apache.druid.k8s.overlord.common.PeonPhase;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientConfig;
+import org.apache.druid.k8s.overlord.common.httpclient.vertx.DruidKubernetesVertxHttpClientFactory;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.log.StartupLoggingConfig;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
@@ -87,7 +88,7 @@ public class DruidPeonClientIntegrationTest
         new NamedType(ParallelIndexTuningConfig.class, "index_parallel"),
         new NamedType(IndexTask.IndexTuningConfig.class, "index")
     );
-    k8sClient = new DruidKubernetesClient(new DruidKubernetesHttpClientConfig(), new ConfigBuilder().build());
+    k8sClient = new DruidKubernetesClient(new DruidKubernetesVertxHttpClientFactory(new DruidKubernetesVertxHttpClientConfig()), new ConfigBuilder().build());
     peonClient = new KubernetesPeonClient(k8sClient, "default", false, new NoopServiceEmitter());
     druidNode = new DruidNode(
         "test",


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Allow an operator to select which HTTP client they want to use for their instance of fabric8 `KubernetesClient`

#### Http Client Selector

`druid.indexer.runner.k8sAndWorker.http.httpClientType`

Valid values: `vertx` (default), `okhttp`, `jdk`

> why no jetty?
* As of now no jetty http client support due to jetty dependency version clashing. It could be possible to look into this in the future though.

##### vertx

Extra configuration stays the same as it was in terms of key names and defaults, but the prefix changes to `druid.indexer.runner.k8sAndWorker.http.vertx`

##### okhttp

This is the old client that we used before #17913. Drawbacks are the default unbounded thread pool underpinning the client. This was a big reason behind making the change to vert.x in the first place (in addition to vert.x being the new default for fabric8 KubernetesClient in newer versions).

Extra configuration:

* `druid.indexer.runner.k8sAndWorker.http.okhttp.useCustomDispatcherExecutor`
    * Whether or not you want to override the default unbounded dispatcher.
    * default = `false` 
* `druid.indexer.runner.k8sAndWorker.http.okhttp.maxWorkerThreads`
    * The upper bound on the thread pool if you use the custom dispatcher
    * default `100`
* `druid.indexer.runner.k8sAndWorker.http.okhttp.coreWorkerThreads`
    * The lower bound on the thread pool size if you use the custom dispatcher 
    * default = `20`
* `druid.indexer.runner.k8sAndWorker.http.okhttp.workerThreadKeepAliveTime`
    * default = `60` (seconds)
    * how long idle threads will live for the thread pool if you use the custom dispatcher

##### jdk

This uses the native http client in Java. Not recommended if runtime is java11.

Extra configuration:

* `druid.indexer.runner.k8sAndWorker.http.jdk.maxWorkerThreads`
    * The upper bound on the thread pool
    * default `100`
* `druid.indexer.runner.k8sAndWorker.http.jdk.coreWorkerThreads`
    * The lower bound on the thread pool size
    * default = `20`
* `druid.indexer.runner.k8sAndWorker.http.jdk.workerThreadKeepAliveTime`
    * default = `60` (seconds)
    * how long idle threads will live for the thread pool.


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
