### PR TITLE
Add version to sys server

### DIFF
--- a/docs/querying/sql-metadata-tables.md
+++ b/docs/querying/sql-metadata-tables.md
@@ -236,7 +236,7 @@ Servers table lists all discovered servers in the cluster.
 |max_size|BIGINT|Max size in bytes this server recommends to assign to segments see [druid.server.maxSize](../configuration/index.md#historical-general-configuration). Only valid for HISTORICAL type, for other types it's 0|
 |is_leader|BIGINT|1 if the server is currently the 'leader' (for services which have the concept of leadership), otherwise 0 if the server is not the leader, or null if the server type does not have the concept of leadership|
 |start_time|STRING|Timestamp in ISO8601 format when the server was announced in the cluster|
-|version|VARCHAR|Version of the server|
+|version|VARCHAR|Druid version running on the server|
 To retrieve information about all servers, use the query:
 
 ```sql

--- a/docs/querying/sql-metadata-tables.md
+++ b/docs/querying/sql-metadata-tables.md
@@ -236,6 +236,7 @@ Servers table lists all discovered servers in the cluster.
 |max_size|BIGINT|Max size in bytes this server recommends to assign to segments see [druid.server.maxSize](../configuration/index.md#historical-general-configuration). Only valid for HISTORICAL type, for other types it's 0|
 |is_leader|BIGINT|1 if the server is currently the 'leader' (for services which have the concept of leadership), otherwise 0 if the server is not the leader, or null if the server type does not have the concept of leadership|
 |start_time|STRING|Timestamp in ISO8601 format when the server was announced in the cluster|
+|version|VARCHAR|Version of the server|
 To retrieve information about all servers, use the query:
 
 ```sql

--- a/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
+++ b/integration-tests/src/test/java/org/apache/druid/tests/security/AbstractAuthConfigurationTest.java
@@ -284,7 +284,7 @@ public abstract class AbstractAuthConfigurationTest
     verifySystemSchemaServerQuery(
         adminClient,
         SYS_SCHEMA_SERVERS_QUERY,
-        getServersWithoutCurrentSizeAndStartTime(adminServers)
+        getServersWithoutNonConfigurableFields(adminServers)
     );
 
     LOG.info("Checking sys.server_segments query as admin...");
@@ -858,7 +858,7 @@ public abstract class AbstractAuthConfigurationTest
     String content = responseHolder.getContent();
     List<Map<String, Object>> responseMap = jsonMapper.readValue(content, SYS_SCHEMA_RESULTS_TYPE_REFERENCE);
     if (isServerQuery) {
-      responseMap = getServersWithoutCurrentSizeAndStartTime(responseMap);
+      responseMap = getServersWithoutNonConfigurableFields(responseMap);
     }
     Assert.assertEquals(responseMap, expectedResults);
   }
@@ -1005,7 +1005,7 @@ public abstract class AbstractAuthConfigurationTest
         SYS_SCHEMA_RESULTS_TYPE_REFERENCE
     );
 
-    adminServers = getServersWithoutCurrentSizeAndStartTime(
+    adminServers = getServersWithoutNonConfigurableFields(
         jsonMapper.readValue(
             fillServersTemplate(
                 config,
@@ -1025,10 +1025,12 @@ public abstract class AbstractAuthConfigurationTest
   }
 
   /**
-   * curr_size on historicals changes because cluster state is not isolated across different
+   * curr_size on historicals changes because cluster state is not isolated across
+   * different
    * integration tests, zero it out for consistent test results
+   * version and start_time are not configurable therefore we zero them as well
    */
-  protected static List<Map<String, Object>> getServersWithoutCurrentSizeAndStartTime(List<Map<String, Object>> servers)
+  protected static List<Map<String, Object>> getServersWithoutNonConfigurableFields(List<Map<String, Object>> servers)
   {
     return Lists.transform(
         servers,
@@ -1036,6 +1038,7 @@ public abstract class AbstractAuthConfigurationTest
           Map<String, Object> newServer = new HashMap<>(server);
           newServer.put("curr_size", 0);
           newServer.put("start_time", "0");
+          newServer.put("version", "0.0.0");
           return newServer;
         }
     );

--- a/integration-tests/src/test/resources/results/auth_test_sys_schema_servers.json
+++ b/integration-tests/src/test/resources/results/auth_test_sys_schema_servers.json
@@ -9,7 +9,8 @@
     "curr_size": 2208932412,
     "max_size": 5000000000,
     "is_leader": null,
-    "start_time": "0"
+    "start_time": "0",
+    "version": "0.0.0"
   },
   {
     "server": "%%BROKER%%:8282",
@@ -21,6 +22,7 @@
     "curr_size": 0,
     "max_size": 1000000000,
     "is_leader": null,
-    "start_time": "0"
+    "start_time": "0",
+    "version": "0.0.0"
   }
 ]

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -44,6 +44,8 @@ import java.util.Objects;
  */
 public class DruidNode
 {
+  public static final String UNKNOWN_VERSION = "unknown";
+
   @JsonProperty("service")
   @NotNull
   private String serviceName;
@@ -86,7 +88,7 @@ public class DruidNode
   @NotNull
   private final String version = GuavaUtils.firstNonNull(
       DruidNode.class.getPackage().getImplementationVersion(),
-      "unknown"
+      UNKNOWN_VERSION
   );
 
   public DruidNode(

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -53,7 +53,7 @@ public class DruidNodeTest
     // Hosts which report only ipv6 will have getDefaultHost() report something like fe80::6e40:8ff:fe93:9230
     // but getHostAndPort() reports [fe80::6e40:8ff:fe93:9230]
     Assert.assertEquals(HostAndPort.fromString(DruidNode.getDefaultHost()).toString(), node.getHostAndPort());
-    Assert.assertEquals("unknown", node.getVersion()); // unknown because not compiled with version
+    Assert.assertEquals(DruidNode.UNKNOWN_VERSION, node.getVersion()); // unknown because not compiled with version
 
     node = new DruidNode(service, "2001:db8:85a3::8a2e:370:7334", false, -1, null, true, false);
     Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", node.getHost());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -700,6 +700,7 @@ public class SystemSchema extends AbstractSchema
           currentSize,
           druidServerToUse.getMaxSize(),
           null,
+          toStringOrNull(discoveryDruidNode.getStartTime())
           node.getVersion()
       };
     }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -180,6 +180,7 @@ public class SystemSchema extends AbstractSchema
       .add("max_size", ColumnType.LONG)
       .add("is_leader", ColumnType.LONG)
       .add("start_time", ColumnType.STRING)
+      .add("version", ColumnType.STRING)
       .build();
 
   static final RowSignature SERVER_SEGMENTS_SIGNATURE = RowSignature
@@ -639,7 +640,8 @@ public class SystemSchema extends AbstractSchema
           UNKNOWN_SIZE,
           UNKNOWN_SIZE,
           null,
-          toStringOrNull(discoveryDruidNode.getStartTime())
+          toStringOrNull(discoveryDruidNode.getStartTime()),
+          node.getVersion()
       };
     }
 
@@ -662,7 +664,8 @@ public class SystemSchema extends AbstractSchema
           UNKNOWN_SIZE,
           UNKNOWN_SIZE,
           isLeader ? 1L : 0L,
-          toStringOrNull(discoveryDruidNode.getStartTime())
+          toStringOrNull(discoveryDruidNode.getStartTime()),
+          node.getVersion()
       };
     }
 
@@ -697,7 +700,7 @@ public class SystemSchema extends AbstractSchema
           currentSize,
           druidServerToUse.getMaxSize(),
           null,
-          toStringOrNull(discoveryDruidNode.getStartTime())
+          node.getVersion()
       };
     }
 

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -700,7 +700,7 @@ public class SystemSchema extends AbstractSchema
           currentSize,
           druidServerToUse.getMaxSize(),
           null,
-          toStringOrNull(discoveryDruidNode.getStartTime())
+          toStringOrNull(discoveryDruidNode.getStartTime()),
           node.getVersion()
       };
     }

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -384,7 +384,8 @@ public class SystemSchemaTest extends CalciteTestBase
 
   private final String version = GuavaUtils.firstNonNull(
           SystemSchemaTest.class.getPackage().getImplementationVersion(),
-          DruidNode.UNKNOWN_VERSION);
+          DruidNode.UNKNOWN_VERSION
+      );
 
   private final DiscoveryDruidNode coordinator = new DiscoveryDruidNode(
       new DruidNode("s1", "localhost", false, 8081, null, true, false),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -381,6 +381,8 @@ public class SystemSchemaTest extends CalciteTestBase
 
   private final DateTime startTime = DateTimes.nowUtc();
 
+  private final String version = new DruidNode("s1", "localhost", false, 8081, null, true, false).getVersion();
+
   private final DiscoveryDruidNode coordinator = new DiscoveryDruidNode(
       new DruidNode("s1", "localhost", false, 8081, null, true, false),
       NodeRole.COORDINATOR,
@@ -851,7 +853,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -865,7 +868,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             1000L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -879,7 +883,8 @@ public class SystemSchemaTest extends CalciteTestBase
             400L,
             1000L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -893,7 +898,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             1000L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -907,7 +913,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             1000L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(createExpectedRow(
@@ -920,7 +927,8 @@ public class SystemSchemaTest extends CalciteTestBase
         0L,
         1000L,
         nonLeader,
-        startTimeStr
+        startTimeStr,
+        version
     ));
     expectedRows.add(
         createExpectedRow(
@@ -933,7 +941,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             1L,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -947,7 +956,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -961,7 +971,8 @@ public class SystemSchemaTest extends CalciteTestBase
             200L,
             1000L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -975,7 +986,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             1L,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -989,7 +1001,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             0L,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -1003,7 +1016,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             0L,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -1017,7 +1031,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(
@@ -1031,7 +1046,8 @@ public class SystemSchemaTest extends CalciteTestBase
             0L,
             0L,
             nonLeader,
-            startTimeStr
+            startTimeStr,
+            version
         )
     );
     expectedRows.add(createExpectedRow(
@@ -1044,7 +1060,8 @@ public class SystemSchemaTest extends CalciteTestBase
         0L,
         1000L,
         nonLeader,
-        startTimeStr
+        startTimeStr,
+        version
     ));
     Assert.assertEquals(expectedRows.size(), rows.size());
     for (int i = 0; i < rows.size(); i++) {
@@ -1077,7 +1094,8 @@ public class SystemSchemaTest extends CalciteTestBase
       @Nullable Long currSize,
       @Nullable Long maxSize,
       @Nullable Long isLeader,
-      String startTime
+      String startTime,
+      String version
   )
   {
     return new Object[]{
@@ -1090,7 +1108,8 @@ public class SystemSchemaTest extends CalciteTestBase
         currSize,
         maxSize,
         isLeader,
-        startTime
+        startTime,
+        version
     };
   }
 

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -44,6 +44,7 @@ import org.apache.druid.client.InternalQueryConfig;
 import org.apache.druid.client.TimelineServerView;
 import org.apache.druid.client.coordinator.CoordinatorClient;
 import org.apache.druid.client.coordinator.NoopCoordinatorClient;
+import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
@@ -381,7 +382,10 @@ public class SystemSchemaTest extends CalciteTestBase
 
   private final DateTime startTime = DateTimes.nowUtc();
 
-  private final String version = new DruidNode("s1", "localhost", false, 8081, null, true, false).getVersion();
+  private final String version = GuavaUtils.firstNonNull(
+    SystemSchemaTest.class.getPackage().getImplementationVersion(),
+    "unknown"
+);
 
   private final DiscoveryDruidNode coordinator = new DiscoveryDruidNode(
       new DruidNode("s1", "localhost", false, 8081, null, true, false),

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -384,7 +384,7 @@ public class SystemSchemaTest extends CalciteTestBase
 
   private final String version = GuavaUtils.firstNonNull(
     SystemSchemaTest.class.getPackage().getImplementationVersion(),
-    "unknown"
+    DruidNode.UNKNOWN_VERSION
 );
 
   private final DiscoveryDruidNode coordinator = new DiscoveryDruidNode(

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -383,9 +383,8 @@ public class SystemSchemaTest extends CalciteTestBase
   private final DateTime startTime = DateTimes.nowUtc();
 
   private final String version = GuavaUtils.firstNonNull(
-    SystemSchemaTest.class.getPackage().getImplementationVersion(),
-    DruidNode.UNKNOWN_VERSION
-);
+          SystemSchemaTest.class.getPackage().getImplementationVersion(),
+          DruidNode.UNKNOWN_VERSION);
 
   private final DiscoveryDruidNode coordinator = new DiscoveryDruidNode(
       new DruidNode("s1", "localhost", false, 8081, null, true, false),
@@ -558,7 +557,7 @@ public class SystemSchemaTest extends CalciteTestBase
     final SystemSchema.ServersTable serversTable = (SystemSchema.ServersTable) schema.getTableMap().get("servers");
     final RelDataType serverRowType = serversTable.getRowType(new JavaTypeFactoryImpl());
     final List<RelDataTypeField> serverFields = serverRowType.getFieldList();
-    Assert.assertEquals(10, serverFields.size());
+    Assert.assertEquals(11, serverFields.size());
     Assert.assertEquals("server", serverFields.get(0).getName());
     Assert.assertEquals(SqlTypeName.VARCHAR, serverFields.get(0).getType().getSqlTypeName());
   }

--- a/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
+++ b/web-console/src/views/services-view/__snapshots__/services-view.spec.tsx.snap
@@ -58,6 +58,7 @@ exports[`ServicesView renders data 1`] = `
           "Max size",
           "Usage",
           "Start time",
+          "Version",
           "Detail",
         ]
       }
@@ -205,6 +206,14 @@ exports[`ServicesView renders data 1`] = `
             "Cell": [Function],
             "Header": "Start time",
             "accessor": "start_time",
+            "show": true,
+            "width": 200,
+          },
+          {
+            "Aggregated": [Function],
+            "Cell": [Function],
+            "Header": "Version",
+            "accessor": "version",
             "show": true,
             "width": 200,
           },

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -84,6 +84,7 @@ const TABLE_COLUMNS_BY_MODE: Record<CapabilitiesMode, TableColumnSelectorColumn[
     'Max size',
     'Usage',
     'Start time',
+    'Version',
     'Detail',
   ],
   'no-sql': [
@@ -107,6 +108,7 @@ const TABLE_COLUMNS_BY_MODE: Record<CapabilitiesMode, TableColumnSelectorColumn[
     'Max size',
     'Usage',
     'Start time',
+    'Version',
   ],
 };
 
@@ -143,6 +145,7 @@ interface ServiceResultRow {
   readonly plaintext_port: number;
   readonly tls_port: number;
   readonly start_time: string;
+  readonly version: string;
 }
 
 interface ServicesWithAuxiliaryInfo {
@@ -238,7 +241,8 @@ export class ServicesView extends React.PureComponent<ServicesViewProps, Service
   "curr_size",
   "max_size",
   "is_leader",
-  "start_time"
+  "start_time",
+  "version"
 FROM sys.servers
 ORDER BY
   (
@@ -614,6 +618,14 @@ ORDER BY
           accessor: 'start_time',
           width: 200,
           Cell: this.renderFilterableCell('start_time'),
+          Aggregated: () => '',
+        },
+        {
+          Header: 'Version',
+          show: visibleColumns.shown('Version'),
+          accessor: 'version',
+          width: 200,
+          Cell: this.renderFilterableCell('version'),
           Aggregated: () => '',
         },
         {

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -291,7 +291,7 @@ ORDER BY
                 max_size: s.maxSize,
                 start_time: '1970:01:01T00:00:00Z',
                 is_leader: 0,
-                version: ''
+                version: '',
               };
             },
           );

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -291,6 +291,7 @@ ORDER BY
                 max_size: s.maxSize,
                 start_time: '1970:01:01T00:00:00Z',
                 is_leader: 0,
+                version: ''
               };
             },
           );


### PR DESCRIPTION
This PR adds the Druid version information to the web console, so that each service displays the version it is running.

This is especially useful during rolling upgrades, since it allows operators to easily verify which services have been updated and to track version mismatches across the cluster.

Changes include:

- Adding a new `version` column to sys.server
- Displaying this new column in the "Services" tab.

<img width="953" height="346" alt="Screenshot 2025-09-18 at 5 02 29 PM" src="https://github.com/user-attachments/assets/1c695ac1-86a9-4dfd-9e2a-10a3fd53c0b6" />