### PR TITLE
druid.storage.type=s3 now honors druid.storage.zip to allow storing segments in s3 without zip compression

### DIFF
--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -57,6 +57,7 @@ To use S3 for Deep Storage, you must supply [connection information](#configurat
 |`druid.storage.type`|Global deep storage provider. Must be set to `s3` to make use of this extension.|Must be set (likely `s3`).|
 |`druid.storage.disableAcl`|Boolean flag for how object permissions are handled. To use ACLs, set this property to `false`. To use Object Ownership, set it to `true`. The permission requirements for ACLs and Object Ownership are different. For more information, see [S3 permissions settings](#s3-permissions-settings).|false|
 |`druid.storage.useS3aSchema`|If true, use the "s3a" filesystem when using Hadoop-based ingestion. If false, the "s3n" filesystem will be used. Only affects Hadoop-based ingestion.|false|
+|`druid.storage.zip`|`true`, `false`|Whether segments in `s3` are written as directories (`false`) or zip files (`true`).|`false`|
 |`druid.storage.transfer.useTransferManager`| If true, use AWS S3 Transfer Manager to upload segments to S3.|true|
 |`druid.storage.transfer.minimumUploadPartSize`| Minimum size (in bytes) of each part in a multipart upload.|20971520 (20 MB)|
 |`druid.storage.transfer.multipartUploadThreshold`| The file size threshold (in bytes) above which a file upload is converted into a multipart upload instead of a single PUT request.| 20971520 (20 MB)|

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
@@ -117,6 +117,7 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
             MSQExternalDataSourceModule.class
         )
         .addResource(storageResource)
+        .addCommonProperty("druid.storage.zip", "false")
         .addServer(coordinator)
         .addServer(overlord)
         .addServer(indexer)

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentKiller.java
@@ -21,7 +21,10 @@ package org.apache.druid.storage.s3;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.MultiObjectDeleteException;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.base.Predicates;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
@@ -88,6 +91,8 @@ public class S3DataSegmentKiller implements DataSegmentKiller
       return;
     }
 
+    final ServerSideEncryptingAmazonS3 s3Client = this.s3ClientSupplier.get();
+
     // create a map of bucket to keys to delete
     Map<String, List<DeleteObjectsRequest.KeyVersion>> bucketToKeysToDelete = new HashMap<>();
     for (DataSegment segment : segments) {
@@ -97,11 +102,20 @@ public class S3DataSegmentKiller implements DataSegmentKiller
           s3Bucket,
           k -> new ArrayList<>()
       );
-      keysToDelete.add(new DeleteObjectsRequest.KeyVersion(path));
-      keysToDelete.add(new DeleteObjectsRequest.KeyVersion(DataSegmentKiller.descriptorPath(path)));
+      if (path.endsWith("/")) {
+        // segment is not compressed, list objects and add them all to delete list
+        final ListObjectsV2Result list = s3Client.listObjectsV2(
+            new ListObjectsV2Request().withBucketName(s3Bucket).withPrefix(path)
+        );
+        for (S3ObjectSummary objectSummary : list.getObjectSummaries()) {
+          keysToDelete.add(new DeleteObjectsRequest.KeyVersion(objectSummary.getKey()));
+        }
+      } else {
+        keysToDelete.add(new DeleteObjectsRequest.KeyVersion(path));
+        keysToDelete.add(new DeleteObjectsRequest.KeyVersion(DataSegmentKiller.descriptorPath(path)));
+      }
     }
 
-    final ServerSideEncryptingAmazonS3 s3Client = this.s3ClientSupplier.get();
     boolean shouldThrowException = false;
     for (Map.Entry<String, List<DeleteObjectsRequest.KeyVersion>> bucketToKeys : bucketToKeysToDelete.entrySet()) {
       String s3Bucket = bucketToKeys.getKey();
@@ -205,18 +219,29 @@ public class S3DataSegmentKiller implements DataSegmentKiller
       Map<String, Object> loadSpec = segment.getLoadSpec();
       String s3Bucket = MapUtils.getString(loadSpec, S3DataSegmentPuller.BUCKET);
       String s3Path = MapUtils.getString(loadSpec, S3DataSegmentPuller.KEY);
-      String s3DescriptorPath = DataSegmentKiller.descriptorPath(s3Path);
-
       final ServerSideEncryptingAmazonS3 s3Client = this.s3ClientSupplier.get();
-      if (s3Client.doesObjectExist(s3Bucket, s3Path)) {
-        log.info("Removing index file[s3://%s/%s] from s3!", s3Bucket, s3Path);
-        s3Client.deleteObject(s3Bucket, s3Path);
-      }
-      // descriptor.json is a file to store segment metadata in deep storage. This file is deprecated and not stored
-      // anymore, but we still delete them if exists.
-      if (s3Client.doesObjectExist(s3Bucket, s3DescriptorPath)) {
-        log.info("Removing descriptor file[s3://%s/%s] from s3!", s3Bucket, s3DescriptorPath);
-        s3Client.deleteObject(s3Bucket, s3DescriptorPath);
+
+      if (s3Path.endsWith("/")) {
+        // segment is not compressed, list objects and delete them all
+        final ListObjectsV2Result list = s3Client.listObjectsV2(
+            new ListObjectsV2Request().withBucketName(s3Bucket).withPrefix(s3Path)
+        );
+        for (S3ObjectSummary objectSummary : list.getObjectSummaries()) {
+          log.info("Removing index file[s3://%s/%s] from s3!", s3Bucket, objectSummary.getKey());
+          s3Client.deleteObject(s3Bucket, objectSummary.getKey());
+        }
+      } else {
+        String s3DescriptorPath = DataSegmentKiller.descriptorPath(s3Path);
+        if (s3Client.doesObjectExist(s3Bucket, s3Path)) {
+          log.info("Removing index file[s3://%s/%s] from s3!", s3Bucket, s3Path);
+          s3Client.deleteObject(s3Bucket, s3Path);
+        }
+        // descriptor.json is a file to store segment metadata in deep storage. This file is deprecated and not stored
+        // anymore, but we still delete them if exists.
+        if (s3Client.doesObjectExist(s3Bucket, s3DescriptorPath)) {
+          log.info("Removing descriptor file[s3://%s/%s] from s3!", s3Bucket, s3DescriptorPath);
+          s3Client.deleteObject(s3Bucket, s3DescriptorPath);
+        }
       }
     }
     catch (AmazonServiceException e) {

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfig.java
@@ -43,6 +43,9 @@ public class S3DataSegmentPusherConfig
   @JsonProperty
   private boolean useS3aSchema = false;
 
+  @JsonProperty
+  private boolean zip = true;
+
   public void setBucket(String bucket)
   {
     this.bucket = bucket;
@@ -91,5 +94,10 @@ public class S3DataSegmentPusherConfig
   public int getMaxListingLength()
   {
     return maxListingLength;
+  }
+
+  public boolean isZip()
+  {
+    return zip;
   }
 }

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -213,10 +213,15 @@ public class S3Utils
 
   static String constructSegmentPath(String baseKey, String storageDir)
   {
+    return constructSegmentBasePath(baseKey, storageDir) + "index.zip";
+  }
+
+  static String constructSegmentBasePath(String baseKey, String storageDir)
+  {
     return JOINER.join(
         baseKey.isEmpty() ? null : baseKey,
         storageDir
-    ) + "/index.zip";
+    ) + "/";
   }
 
   static AccessControlList grantFullControlToBucketOwner(ServerSideEncryptingAmazonS3 s3Client, String bucket)

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -40,7 +40,7 @@ public class S3DataSegmentPusherConfigTest
   public void testSerialization() throws IOException
   {
     String jsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\","
-                        + "\"disableAcl\":false,\"maxListingLength\":2000,\"useS3aSchema\":false}";
+                        + "\"disableAcl\":false,\"maxListingLength\":2000,\"useS3aSchema\":false,\"zip\":true}";
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
     Map<String, String> expected = JSON_MAPPER.readValue(jsonConfig, Map.class);
@@ -53,7 +53,7 @@ public class S3DataSegmentPusherConfigTest
   {
     String jsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\"}";
     String expectedJsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\","
-                                + "\"disableAcl\":false,\"maxListingLength\":1024,\"useS3aSchema\":false}";
+                                + "\"disableAcl\":false,\"maxListingLength\":1024,\"useS3aSchema\":false,\"zip\":true}";
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
     Map<String, String> expected = JSON_MAPPER.readValue(expectedJsonConfig, Map.class);
     Map<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), Map.class);
@@ -64,7 +64,7 @@ public class S3DataSegmentPusherConfigTest
   public void testSerializationValidatingMaxListingLength() throws IOException
   {
     String jsonConfig = "{\"bucket\":\"bucket1\",\"baseKey\":\"dataSource1\","
-                        + "\"disableAcl\":false,\"maxListingLength\":-1}";
+                        + "\"disableAcl\":false,\"maxListingLength\":-1,\"zip\":true}";
     Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);


### PR DESCRIPTION
### Description
This PR adds the capability to store segments in s3 without compressing with zip, similar to the 'local' deep storage option. This is mainly for experimentation at this point, but went ahead and documented it just in case anyone else wants to experiment :shrug:

When `druid.storage.zip` is false, the load spec stores the prefix to use instead of the exact location, and the pullers/killers/movers when for a path that ends with `/` and then do a list operation and iterate over and apply the operation to the results.