### PR TITLE
Update to ZooKeeper 3.8.5.

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -2071,7 +2071,7 @@ name: Apache Zookeeper
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 3.8.4
+version: 3.8.5
 libraries:
   - org.apache.zookeeper: zookeeper
   - org.apache.zookeeper: zookeeper-jute

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
         <httpclient.version>4.5.13</httpclient.version>
         <!-- When upgrading ZK, edit docs and integration tests as well (integration-tests/docker-base/setup.sh) -->
-        <zookeeper.version>3.8.4</zookeeper.version>
+        <zookeeper.version>3.8.5</zookeeper.version>
         <checkerframework.version>3.48.1</checkerframework.version>
         <com.google.apis.client.version>2.2.0</com.google.apis.client.version>
         <com.google.http.client.apis.version>1.42.3</com.google.http.client.apis.version>


### PR DESCRIPTION
It was released today. ZooKeeper 3.8.4 has already been removed from the download mirrors, so our integration tests are failing. Might as well upgrade.