### PR TITLE
Add labels to sys.server

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -740,6 +740,7 @@ These Coordinator static configurations can be defined in the `coordinator/runti
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8081|
 |`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.md) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative integer.|8281|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services.|`druid/coordinator`|
+|`druid.labels`|Optional JSON object of key-value pairs that define custom labels for the server. These labels are displayed in the web console under the "Services" tab.|`null`|
 
 ##### Coordinator operation
 
@@ -983,6 +984,7 @@ These Overlord static configurations can be defined in the `overlord/runtime.pro
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`.|8090|
 |`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.md) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8290|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services.|`druid/overlord`|
+|`druid.labels`|Optional JSON object of key-value pairs that define custom labels for the server. These labels are displayed in the web console under the "Services" tab.|`null`|
 
 ##### Overlord operations
 
@@ -1334,6 +1336,7 @@ These Middle Manager and Peon configurations can be defined in the `middleManage
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8091|
 |`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.md) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8291|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|`druid/middlemanager`|
+|`druid.labels`|Optional JSON object of key-value pairs that define custom labels for the server. These labels are displayed in the web console under the "Services" tab.|`null`|
 
 #### Middle Manager configuration
 
@@ -1461,6 +1464,7 @@ For most types of tasks, `SegmentWriteOutMediumFactory` can be configured per-ta
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8091|
 |`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.md) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8283|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|`druid/indexer`|
+|`druid.labels`|Optional JSON object of key-value pairs that define custom labels for the server. These labels are displayed in the web console under the "Services" tab.|`null`|
 
 #### Indexer general configuration
 
@@ -1554,6 +1558,7 @@ These Historical configurations can be defined in the `historical/runtime.proper
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8083|
 |`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.md) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8283|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|`druid/historical`|
+|`druid.labels`|Optional JSON object of key-value pairs that define custom labels for the server. These labels are displayed in the web console under the "Services" tab.|`null`|
 
 #### Historical general configuration
 
@@ -1666,6 +1671,7 @@ These Broker configurations can be defined in the `broker/runtime.properties` fi
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8082|
 |`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.md) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|8282|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|`druid/broker`|
+|`druid.labels`|Optional JSON object of key-value pairs that define custom labels for the server. These labels are displayed in the web console under the "Services" tab.|`null`|
 
 #### Query configuration
 
@@ -2285,6 +2291,7 @@ Supported query contexts:
 |`druid.plaintextPort`|This is the port to actually listen on; unless port mapping is used, this will be the same port as is on `druid.host`|8888|
 |`druid.tlsPort`|TLS port for HTTPS connector, if [druid.enableTlsPort](../operations/tls-support.md) is set then this config will be used. If `druid.host` contains port then that port will be ignored. This should be a non-negative Integer.|9088|
 |`druid.service`|The name of the service. This is used as a dimension when emitting metrics and alerts to differentiate between the various services|`druid/router`|
+|`druid.labels`|Optional JSON object of key-value pairs that define custom labels for the server. These labels are displayed in the web console under the "Services" tab.|`null`|
 
 #### Runtime configuration
 

--- a/docs/querying/sql-metadata-tables.md
+++ b/docs/querying/sql-metadata-tables.md
@@ -236,6 +236,7 @@ Servers table lists all discovered servers in the cluster.
 |max_size|BIGINT|Max size in bytes this server recommends to assign to segments see [druid.server.maxSize](../configuration/index.md#historical-general-configuration). Only valid for HISTORICAL type, for other types it's 0|
 |is_leader|BIGINT|1 if the server is currently the 'leader' (for services which have the concept of leadership), otherwise 0 if the server is not the leader, or null if the server type does not have the concept of leadership|
 |start_time|STRING|Timestamp in ISO8601 format when the server was announced in the cluster|
+|labels|VARCHAR|Labels for the server see [druid.labels](../configuration/index.md)| 
 To retrieve information about all servers, use the query:
 
 ```sql

--- a/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/config/Initializer.java
+++ b/integration-tests-ex/cases/src/test/java/org/apache/druid/testsEx/config/Initializer.java
@@ -148,7 +148,7 @@ public class Initializer
           .in(LazySingleton.class);
 
       // Dummy DruidNode instance to make Guice happy. This instance is unused.
-      DruidNode dummy = new DruidNode("integration-tests", "localhost", false, 9191, null, null, true, false);
+      DruidNode dummy = new DruidNode("integration-tests", "localhost", false, 9191, null, null, true, false, null);
       binder
           .bind(DruidNode.class)
           .annotatedWith(Self.class)

--- a/integration-tests/src/main/java/org/apache/druid/testing/guice/DruidTestModule.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/guice/DruidTestModule.java
@@ -56,7 +56,7 @@ public class DruidTestModule implements Module
 
     // Bind DruidNode instance to make Guice happy. This instance is currently unused.
     binder.bind(DruidNode.class).annotatedWith(Self.class).toInstance(
-        new DruidNode("integration-tests", "localhost", false, 9191, null, null, true, false)
+        new DruidNode("integration-tests", "localhost", false, 9191, null, null, true, false, null)
     );
 
     // Required for MSQIndexingModule

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -32,11 +32,12 @@ import org.apache.druid.java.util.common.ISE;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
-
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -89,6 +90,9 @@ public class DruidNode
       "unknown"
   );
 
+  @JsonProperty
+  private Map<String, String> labels = new HashMap<>();
+
   public DruidNode(
       String serviceName,
       String host,
@@ -99,7 +103,7 @@ public class DruidNode
       boolean enableTlsPort
   )
   {
-    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort);
+    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, null);
   }
 
   /**
@@ -127,7 +131,8 @@ public class DruidNode
       @JacksonInject @Named("servicePort") @JsonProperty("port") Integer port,
       @JacksonInject @Named("tlsServicePort") @JsonProperty("tlsPort") Integer tlsPort,
       @JsonProperty("enablePlaintextPort") Boolean enablePlaintextPort,
-      @JsonProperty("enableTlsPort") boolean enableTlsPort
+      @JsonProperty("enableTlsPort") boolean enableTlsPort,
+      @JsonProperty("labels") Map<String, String> labels
   )
   {
     init(
@@ -137,7 +142,8 @@ public class DruidNode
         plaintextPort != null ? plaintextPort : port,
         tlsPort,
         enablePlaintextPort == null ? true : enablePlaintextPort.booleanValue(),
-        enableTlsPort
+        enableTlsPort,
+        labels
     );
   }
 
@@ -148,7 +154,8 @@ public class DruidNode
       Integer plainTextPort,
       Integer tlsPort,
       boolean enablePlaintextPort,
-      boolean enableTlsPort
+      boolean enableTlsPort,
+      Map<String, String> labels
   )
   {
     Preconditions.checkNotNull(serviceName);
@@ -208,6 +215,12 @@ public class DruidNode
     this.serviceName = serviceName;
     this.host = host;
     this.bindOnHost = bindOnHost;
+    this.labels = labels;
+  }
+
+  public Map<String, String> getLabels()
+  {
+    return labels;
   }
 
   public String getServiceName()

--- a/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/DiscoveryDruidNodeTest.java
@@ -112,7 +112,8 @@ public class DiscoveryDruidNodeTest
             -1,
             8282,
             true,
-            true
+            true,
+            null
         ),
         NodeRole.BROKER,
         ImmutableMap.of(
@@ -167,7 +168,8 @@ public class DiscoveryDruidNodeTest
                 -1,
                 8282,
                 true,
-                true
+                true,
+                null
             ),
             NodeRole.BROKER,
             ImmutableMap.of(
@@ -216,7 +218,8 @@ public class DiscoveryDruidNodeTest
                 -1,
                 8282,
                 true,
-                true
+                true,
+                null
             ),
             NodeRole.BROKER,
             ImmutableMap.of(
@@ -266,7 +269,8 @@ public class DiscoveryDruidNodeTest
                 -1,
                 8282,
                 true,
-                true
+                true,
+                null
             ),
             NodeRole.BROKER,
             ImmutableMap.of()

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -285,7 +285,7 @@ public class DruidNodeTest
   public void testSerde1() throws Exception
   {
     DruidNode actual = mapper.readValue(
-        mapper.writeValueAsString(new DruidNode("service", "host", true, 1234, null, 5678, true, true)),
+        mapper.writeValueAsString(new DruidNode("service", "host", true, 1234, null, 5678, true, true, null)),
         DruidNode.class
     );
     Assert.assertEquals("service", actual.getServiceName());
@@ -301,7 +301,7 @@ public class DruidNodeTest
   public void testSerde2() throws Exception
   {
     DruidNode actual = mapper.readValue(
-        mapper.writeValueAsString(new DruidNode("service", "host", false, 1234, null, 5678, null, false)),
+        mapper.writeValueAsString(new DruidNode("service", "host", false, 1234, null, 5678, null, false, null)),
         DruidNode.class
     );
     Assert.assertEquals("service", actual.getServiceName());
@@ -317,7 +317,7 @@ public class DruidNodeTest
   public void testSerde3() throws Exception
   {
     DruidNode actual = mapper.readValue(
-        mapper.writeValueAsString(new DruidNode("service", "host", true, 1234, null, 5678, false, true)),
+        mapper.writeValueAsString(new DruidNode("service", "host", true, 1234, null, 5678, false, true, null)),
         DruidNode.class
     );
     Assert.assertEquals("service", actual.getServiceName());
@@ -344,7 +344,7 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", true, 1234, null, 5678, true, true), actual);
+    Assert.assertEquals(new DruidNode("service", "host", true, 1234, null, 5678, true, true, null), actual);
 
     Assert.assertEquals("https", actual.getServiceScheme());
     Assert.assertEquals("host:1234", actual.getHostAndPort());
@@ -365,7 +365,7 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, true, false), actual);
+    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, true, false, null), actual);
 
     Assert.assertEquals("http", actual.getServiceScheme());
     Assert.assertEquals("host:1234", actual.getHostAndPort());
@@ -385,7 +385,7 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, null, false), actual);
+    Assert.assertEquals(new DruidNode("service", "host", false, 1234, null, 5678, null, false, null), actual);
 
     Assert.assertEquals("http", actual.getServiceScheme());
     Assert.assertEquals("host:1234", actual.getHostAndPort());
@@ -405,7 +405,7 @@ public class DruidNodeTest
 
 
     DruidNode actual = mapper.readValue(json, DruidNode.class);
-    Assert.assertEquals(new DruidNode("service", "host", false, null, 1234, 5678, null, false), actual);
+    Assert.assertEquals(new DruidNode("service", "host", false, null, 1234, 5678, null, false, null), actual);
 
     Assert.assertEquals("http", actual.getServiceScheme());
     Assert.assertEquals("host:1234", actual.getHostAndPort());

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -180,6 +180,7 @@ public class SystemSchema extends AbstractSchema
       .add("max_size", ColumnType.LONG)
       .add("is_leader", ColumnType.LONG)
       .add("start_time", ColumnType.STRING)
+      .add("labels", ColumnType.STRING)
       .build();
 
   static final RowSignature SERVER_SEGMENTS_SIGNATURE = RowSignature
@@ -244,7 +245,8 @@ public class SystemSchema extends AbstractSchema
             serverInventoryView,
             authorizerMapper,
             overlordClient,
-            coordinatorClient
+            coordinatorClient,
+            jsonMapper
         ),
         SERVER_SEGMENTS_TABLE,
         new ServerSegmentsTable(serverView, authorizerMapper),
@@ -525,13 +527,15 @@ public class SystemSchema extends AbstractSchema
     private final FilteredServerInventoryView serverInventoryView;
     private final OverlordClient overlordClient;
     private final CoordinatorClient coordinatorClient;
+    private final ObjectMapper jsonMapper;
 
     public ServersTable(
         DruidNodeDiscoveryProvider druidNodeDiscoveryProvider,
         FilteredServerInventoryView serverInventoryView,
         AuthorizerMapper authorizerMapper,
         OverlordClient overlordClient,
-        CoordinatorClient coordinatorClient
+        CoordinatorClient coordinatorClient,
+        ObjectMapper jsonMapper
     )
     {
       this.authorizerMapper = authorizerMapper;
@@ -539,6 +543,7 @@ public class SystemSchema extends AbstractSchema
       this.serverInventoryView = serverInventoryView;
       this.overlordClient = overlordClient;
       this.coordinatorClient = coordinatorClient;
+      this.jsonMapper = jsonMapper;
     }
 
     @Override
@@ -626,44 +631,56 @@ public class SystemSchema extends AbstractSchema
     /**
      * Returns a row for all node types which don't serve data. The returned row contains only static information.
      */
-    private static Object[] buildRowForNonDataServer(DiscoveryDruidNode discoveryDruidNode)
+    private Object[] buildRowForNonDataServer(DiscoveryDruidNode discoveryDruidNode)
     {
       final DruidNode node = discoveryDruidNode.getDruidNode();
-      return new Object[]{
-          node.getHostAndPortToUse(),
-          node.getHost(),
-          (long) node.getPlaintextPort(),
-          (long) node.getTlsPort(),
-          StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
-          null,
-          UNKNOWN_SIZE,
-          UNKNOWN_SIZE,
-          null,
-          toStringOrNull(discoveryDruidNode.getStartTime())
-      };
+      try {
+        return new Object[]{
+            node.getHostAndPortToUse(),
+            node.getHost(),
+            (long) node.getPlaintextPort(),
+            (long) node.getTlsPort(),
+            StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
+            null,
+            UNKNOWN_SIZE,
+            UNKNOWN_SIZE,
+            null,
+            toStringOrNull(discoveryDruidNode.getStartTime()),
+            node.getLabels() == null ? null : jsonMapper.writeValueAsString(node.getLabels())
+        };
+      }
+      catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     /**
      * Returns a row for all node types which don't serve data. The returned row contains only static information.
      */
-    private static Object[] buildRowForNonDataServerWithLeadership(
+    private Object[] buildRowForNonDataServerWithLeadership(
         DiscoveryDruidNode discoveryDruidNode,
         boolean isLeader
     )
     {
       final DruidNode node = discoveryDruidNode.getDruidNode();
-      return new Object[]{
-          node.getHostAndPortToUse(),
-          node.getHost(),
-          (long) node.getPlaintextPort(),
-          (long) node.getTlsPort(),
-          StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
-          null,
-          UNKNOWN_SIZE,
-          UNKNOWN_SIZE,
-          isLeader ? 1L : 0L,
-          toStringOrNull(discoveryDruidNode.getStartTime())
-      };
+      try {
+        return new Object[]{
+            node.getHostAndPortToUse(),
+            node.getHost(),
+            (long) node.getPlaintextPort(),
+            (long) node.getTlsPort(),
+            StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
+            null,
+            UNKNOWN_SIZE,
+            UNKNOWN_SIZE,
+            isLeader ? 1L : 0L,
+            toStringOrNull(discoveryDruidNode.getStartTime()),
+            node.getLabels() == null ? null : jsonMapper.writeValueAsString(node.getLabels())
+        };
+      }
+      catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     /**
@@ -671,7 +688,7 @@ public class SystemSchema extends AbstractSchema
      * {@code serverFromInventoryView} if available which is the current state of the server. Otherwise, it
      * will get the information from {@code discoveryDruidNode} which has only static configurations.
      */
-    private static Object[] buildRowForDiscoverableDataServer(
+    private Object[] buildRowForDiscoverableDataServer(
         DiscoveryDruidNode discoveryDruidNode,
         @Nullable DruidServer serverFromInventoryView
     )
@@ -687,18 +704,24 @@ public class SystemSchema extends AbstractSchema
       } else {
         currentSize = serverFromInventoryView.getCurrSize();
       }
-      return new Object[]{
-          node.getHostAndPortToUse(),
-          node.getHost(),
-          (long) node.getPlaintextPort(),
-          (long) node.getTlsPort(),
-          StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
-          druidServerToUse.getTier(),
-          currentSize,
-          druidServerToUse.getMaxSize(),
-          null,
-          toStringOrNull(discoveryDruidNode.getStartTime())
-      };
+      try {
+        return new Object[]{
+            node.getHostAndPortToUse(),
+            node.getHost(),
+            (long) node.getPlaintextPort(),
+            (long) node.getTlsPort(),
+            StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
+            druidServerToUse.getTier(),
+            currentSize,
+            druidServerToUse.getMaxSize(),
+            null,
+            toStringOrNull(discoveryDruidNode.getStartTime()),
+            node.getLabels() == null ? null : jsonMapper.writeValueAsString(node.getLabels())
+        };
+      }
+      catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     private static boolean isDiscoverableDataServer(DataNodeService dataNodeService)

--- a/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/calcite/schema/SystemSchemaTest.java
@@ -755,7 +755,8 @@ public class SystemSchemaTest extends CalciteTestBase
                                                          serverInventoryView,
                                                          authMapper,
                                                          overlordClient,
-                                                         coordinatorClient
+                                                         coordinatorClient,
+                                                         MAPPER
                                                      )
                                                      .createMock();
     EasyMock.replay(serversTable);

--- a/web-console/src/react-table/react-table-extra.scss
+++ b/web-console/src/react-table/react-table-extra.scss
@@ -19,6 +19,13 @@
 @import '../variables';
 
 .ReactTable {
+  &.centered-table {
+  
+      .rt-th,
+      .rt-td {
+        align-content: center;
+      }
+    }
   .rt-tr {
     min-height: 38px;
 

--- a/web-console/src/views/services-view/services-view.scss
+++ b/web-console/src/views/services-view/services-view.scss
@@ -36,4 +36,14 @@
   ul {
     line-height: 20px;
   }
+.labels-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0;
+
+  li {
+    margin: 0;
+    padding: 0;
+  }
+}
 }

--- a/web-console/src/views/services-view/services-view.tsx
+++ b/web-console/src/views/services-view/services-view.tsx
@@ -41,6 +41,7 @@ import type { QueryWithContext } from '../../druid-models';
 import { getConsoleViewIcon } from '../../druid-models';
 import type { Capabilities, CapabilitiesMode } from '../../helpers';
 import {
+  DEFAULT_TABLE_CLASS_NAME,
   STANDARD_TABLE_PAGE_SIZE,
   STANDARD_TABLE_PAGE_SIZE_OPTIONS,
   suggestibleFilterInput,
@@ -84,6 +85,7 @@ const TABLE_COLUMNS_BY_MODE: Record<CapabilitiesMode, TableColumnSelectorColumn[
     'Max size',
     'Usage',
     'Start time',
+    'Labels',
     'Detail',
   ],
   'no-sql': [
@@ -143,6 +145,7 @@ interface ServiceResultRow {
   readonly plaintext_port: number;
   readonly tls_port: number;
   readonly start_time: string;
+  readonly labels: string;
 }
 
 interface ServicesWithAuxiliaryInfo {
@@ -238,7 +241,8 @@ export class ServicesView extends React.PureComponent<ServicesViewProps, Service
   "curr_size",
   "max_size",
   "is_leader",
-  "start_time"
+  "start_time",
+  "labels"
 FROM sys.servers
 ORDER BY
   (
@@ -415,6 +419,7 @@ ORDER BY
           }
           filterable
           filtered={filters}
+          className={`centered-table ${DEFAULT_TABLE_CLASS_NAME}`}
           onFilteredChange={onFiltersChange}
           pivotBy={groupServicesBy ? [groupServicesBy] : []}
           defaultPageSize={STANDARD_TABLE_PAGE_SIZE}
@@ -615,6 +620,28 @@ ORDER BY
           width: 200,
           Cell: this.renderFilterableCell('start_time'),
           Aggregated: () => '',
+        },
+        {
+          Header: 'Labels',
+          show: visibleColumns.shown('Labels'),
+          accessor: 'labels',
+          className: 'padded',
+          filterable: false,
+          width: 200,
+          Cell: ({ value }) => {
+            if (!value) return '';
+            return (
+              <ul className="labels-list">
+                {Object.entries(JSON.parse(value)).map(([key, val]) => {
+                  return (
+                    <li key={String(key)}>
+                      {key}: {String(val)}
+                    </li>
+                  );
+                })}
+              </ul>
+            );
+          },
         },
         {
           Header: 'Detail',


### PR DESCRIPTION
This MR adds support for labels being configured in the config file. It uses the key druid.labels and expects the value to be a JSON structure of key-value pairs.
The labels will be displayed in the web-console under the "Services" tab.

Example: `druid.labels={"broker-label":"broker-value","location": "Airtrunk"}`

Below is a screenshot of the implementation with different labels for different node types. Note that some columns have been hidden to capture the important details.

<img width="1067" height="382" alt="Screenshot 2025-09-18 at 5 42 01 PM" src="https://github.com/user-attachments/assets/232f9497-1808-42c6-9391-5a8d8b217e9b" />
