### PR TITLE
Use archive.apache.org for integration test dependencies.

### DIFF
--- a/examples/quickstart/tutorial/hadoop/docker/Dockerfile
+++ b/examples/quickstart/tutorial/hadoop/docker/Dockerfile
@@ -62,7 +62,7 @@ ENV PATH=$PATH:$JAVA_HOME/bin
 
 # hadoop
 # Using archive.apache.org instead of downloads.apache.org to avoid build failures, see https://github.com/apache/druid/pull/18548
-ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org/dist
 RUN curl -s ${APACHE_ARCHIVE_MIRROR_HOST}/hadoop/core/hadoop-3.3.6/hadoop-3.3.6.tar.gz | tar -xz -C /usr/local/
 RUN cd /usr/local && ln -s ./hadoop-3.3.6 hadoop
 

--- a/examples/quickstart/tutorial/hadoop/docker/Dockerfile
+++ b/examples/quickstart/tutorial/hadoop/docker/Dockerfile
@@ -61,7 +61,8 @@ ENV JAVA_HOME=/usr/lib/jvm/zulu11
 ENV PATH=$PATH:$JAVA_HOME/bin
 
 # hadoop
-ARG APACHE_ARCHIVE_MIRROR_HOST=https://downloads.apache.org
+# Using archive.apache.org instead of downloads.apache.org to avoid build failures, see https://github.com/apache/druid/pull/18548
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
 RUN curl -s ${APACHE_ARCHIVE_MIRROR_HOST}/hadoop/core/hadoop-3.3.6/hadoop-3.3.6.tar.gz | tar -xz -C /usr/local/
 RUN cd /usr/local && ln -s ./hadoop-3.3.6 hadoop
 

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -46,7 +46,7 @@ environment variable to localhost on your system, as follows:
 export DOCKER_IP=127.0.0.1
 ```
 
-Optionally, you can also set `APACHE_ARCHIVE_MIRROR_HOST` to override `https://downloads.apache.org` host. This host is used to download archives such as hadoop and kafka during building docker images:
+Optionally, you can also set `APACHE_ARCHIVE_MIRROR_HOST` to override the default host. This host is used to download archives such as hadoop and kafka during building docker images:
 
 ```bash
 export APACHE_ARCHIVE_MIRROR_HOST=https://example.com/remote-generic-repo

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -23,8 +23,9 @@ COPY base-setup.sh /root/base-setup.sh
 ARG KAFKA_VERSION
 # ZooKeeper version to install in the base image
 # This is passed in by maven at build time to align with the client version we depend on in the pom file
+# Using archive.apache.org instead of downloads.apache.org to avoid build failures, see https://github.com/apache/druid/pull/18548
 ARG ZK_VERSION
-ARG APACHE_ARCHIVE_MIRROR_HOST=https://downloads.apache.org
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
 RUN APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh
 
 FROM druidbase

--- a/integration-tests/docker/Dockerfile
+++ b/integration-tests/docker/Dockerfile
@@ -25,7 +25,7 @@ ARG KAFKA_VERSION
 # This is passed in by maven at build time to align with the client version we depend on in the pom file
 # Using archive.apache.org instead of downloads.apache.org to avoid build failures, see https://github.com/apache/druid/pull/18548
 ARG ZK_VERSION
-ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org
+ARG APACHE_ARCHIVE_MIRROR_HOST=https://archive.apache.org/dist
 RUN APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST} /root/base-setup.sh && rm -f /root/base-setup.sh
 
 FROM druidbase

--- a/integration-tests/docker/base-setup.sh
+++ b/integration-tests/docker/base-setup.sh
@@ -18,7 +18,9 @@ set -e
 set -u
 
 export DEBIAN_FRONTEND=noninteractive
-APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST:-https://downloads.apache.org}
+
+# Using archive.apache.org instead of downloads.apache.org to avoid build failures, see https://github.com/apache/druid/pull/18548
+APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST:-https://archive.apache.org}
 
 apt-get update
 

--- a/integration-tests/docker/base-setup.sh
+++ b/integration-tests/docker/base-setup.sh
@@ -20,7 +20,7 @@ set -u
 export DEBIAN_FRONTEND=noninteractive
 
 # Using archive.apache.org instead of downloads.apache.org to avoid build failures, see https://github.com/apache/druid/pull/18548
-APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST:-https://archive.apache.org}
+APACHE_ARCHIVE_MIRROR_HOST=${APACHE_ARCHIVE_MIRROR_HOST:-https://archive.apache.org/dist}
 
 apt-get update
 


### PR DESCRIPTION
In #17585 the download url was changed from archive.apache.org to downloads.apache.org, due to the fact that downloads.apache.org is more recommended.

However, currently, downloads.apache.org only has ZooKeeper 3.8.5, which was released today and not yet available on Docker Hub (which we also need). Therefore, to get our tests running again, we need to revert back to archive.apache.org.