### PR TITLE
Enable fallback vectorization by default.

### DIFF
--- a/processing/src/main/java/org/apache/druid/frame/segment/columnar/ColumnarFrameCursorFactory.java
+++ b/processing/src/main/java/org/apache/druid/frame/segment/columnar/ColumnarFrameCursorFactory.java
@@ -132,7 +132,7 @@ public class ColumnarFrameCursorFactory implements CursorFactory
       final VirtualColumns virtualColumns = spec.getVirtualColumns();
       final Filter filter = spec.getFilter();
       final QueryContext queryContext = spec.getQueryContext();
-      final ColumnInspector inspector = virtualColumns.wrapInspector(signature);
+      final ColumnInspector inspector = virtualColumns.wrapInspector(ColumnarFrameCursorFactory.this);
 
       // Check that virtual columns are vectorizable.
       if (!virtualColumns.isEmpty()) {

--- a/processing/src/main/java/org/apache/druid/math/expr/ApplyFunction.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ApplyFunction.java
@@ -52,7 +52,12 @@ public interface ApplyFunction extends NamedFunction
    */
   default boolean canVectorize(Expr.InputBindingInspector inspector, LambdaExpr lambda, List<Expr> args)
   {
-    return FallbackVectorProcessor.canFallbackVectorize(getOutputType(inspector, lambda, args), inspector, args);
+    return FallbackVectorProcessor.canFallbackVectorize(
+        lambda,
+        args,
+        getOutputType(inspector, lambda, args),
+        inspector
+    );
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExprMacroTable.java
@@ -178,7 +178,7 @@ public class ExprMacroTable
     @Override
     public boolean canVectorize(InputBindingInspector inspector)
     {
-      return FallbackVectorProcessor.canFallbackVectorize(getOutputType(inspector), inspector, args);
+      return FallbackVectorProcessor.canFallbackVectorize(args, getOutputType(inspector), inspector);
     }
 
     @Override

--- a/processing/src/main/java/org/apache/druid/math/expr/ExpressionProcessing.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExpressionProcessing.java
@@ -54,12 +54,6 @@ public class ExpressionProcessing
     INSTANCE = new ExpressionProcessingConfig(null, true, null);
   }
 
-  @VisibleForTesting
-  public static void initializeForFallback()
-  {
-    INSTANCE = new ExpressionProcessingConfig(null, null, true);
-  }
-
   /**
    * All {@link ExprType#ARRAY} values will be converted to {@link ExpressionType#STRING} by their column selectors
    * (not within expression processing) to be treated as multi-value strings instead of native arrays.

--- a/processing/src/main/java/org/apache/druid/math/expr/ExpressionProcessingConfig.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/ExpressionProcessingConfig.java
@@ -59,9 +59,10 @@ public class ExpressionProcessingConfig
         homogenizeNullMultiValueStringArrays,
         HOMOGENIZE_NULL_MULTIVALUE_STRING_ARRAYS
     );
-    this.allowVectorizeFallback = getWithPropertyFallbackFalse(
+    this.allowVectorizeFallback = getWithPropertyFallback(
         allowVectorizeFallback,
-        ALLOW_VECTORIZE_FALLBACK
+        ALLOW_VECTORIZE_FALLBACK,
+        "true"
     );
   }
 

--- a/processing/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Function.java
@@ -147,7 +147,7 @@ public interface Function extends NamedFunction
    */
   default boolean canVectorize(Expr.InputBindingInspector inspector, List<Expr> args)
   {
-    return FallbackVectorProcessor.canFallbackVectorize(getOutputType(inspector, args), inspector, args);
+    return FallbackVectorProcessor.canFallbackVectorize(args, getOutputType(inspector, args), inspector);
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/math/expr/Function.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/Function.java
@@ -32,6 +32,7 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.vector.CastToTypeVectorProcessor;
 import org.apache.druid.math.expr.vector.ExprVectorProcessor;
 import org.apache.druid.math.expr.vector.FallbackVectorProcessor;
+import org.apache.druid.math.expr.vector.FunctionErrorReportingExprVectorProcessor;
 import org.apache.druid.math.expr.vector.VectorConditionalProcessors;
 import org.apache.druid.math.expr.vector.VectorMathProcessors;
 import org.apache.druid.math.expr.vector.VectorProcessors;
@@ -1225,12 +1226,6 @@ public interface Function extends NamedFunction
     }
 
     @Override
-    public boolean canVectorize(Expr.InputBindingInspector inspector, List<Expr> args)
-    {
-      return false;
-    }
-
-    @Override
     protected ExprEval eval(final long x, final long y)
     {
       if (y == 0) {
@@ -1285,7 +1280,13 @@ public interface Function extends NamedFunction
     @Override
     public <T> ExprVectorProcessor<T> asVectorProcessor(Expr.VectorInputBindingInspector inspector, List<Expr> args)
     {
-      return VectorMathProcessors.longDivide().asProcessor(inspector, args.get(0), args.get(1));
+      // Div is currently the only math function that wraps its processor in FunctionErrorReportingExprVectorProcessor.
+      // In principle all functions could do this, but it's most useful for Div, because Div throws division by zero
+      // errors in normal operation. The others aren't expected to throw errors.
+      return new FunctionErrorReportingExprVectorProcessor<>(
+          name(),
+          VectorMathProcessors.longDivide().asProcessor(inspector, args.get(0), args.get(1))
+      );
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/math/expr/FunctionalExpr.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/FunctionalExpr.java
@@ -81,8 +81,8 @@ class FunctionExpr implements Expr
     try {
       return function.apply(args, bindings);
     }
-    catch (ExpressionValidationException e) {
-      // ExpressionValidationException already contain function name
+    catch (ExpressionValidationException | ExpressionProcessingException e) {
+      // Already contain function name
       throw DruidException.forPersona(DruidException.Persona.USER)
                           .ofCategory(DruidException.Category.INVALID_INPUT)
                           .build(e, e.getMessage());

--- a/processing/src/main/java/org/apache/druid/math/expr/SettableObjectBinding.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/SettableObjectBinding.java
@@ -75,4 +75,13 @@ public class SettableObjectBinding implements Expr.ObjectBinding
   {
     return bindings;
   }
+
+  @Override
+  public String toString()
+  {
+    return "SettableObjectBinding{" +
+           "bindings=" + bindings +
+           ", inspector=" + inspector +
+           '}';
+  }
 }

--- a/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
@@ -68,9 +68,10 @@ public abstract class FallbackVectorProcessor<T> implements ExprVectorProcessor<
   )
   {
     final List<Expr> adaptedArgs = makeAdaptedArgs(args, inspector);
+    final Function singleThreadedFunction = function.asSingleThreaded(adaptedArgs, inspector);
     return makeFallbackProcessor(
         function.name(),
-        () -> function.apply(adaptedArgs, UnusedBinding.INSTANCE),
+        () -> singleThreadedFunction.apply(adaptedArgs, UnusedBinding.INSTANCE),
         adaptedArgs,
         function.getOutputType(inspector, args),
         inspector
@@ -107,7 +108,7 @@ public abstract class FallbackVectorProcessor<T> implements ExprVectorProcessor<
   )
   {
     final List<Expr> adaptedArgs = makeAdaptedArgs(args, inspector);
-    final Expr adaptedExpr = macro.apply(adaptedArgs);
+    final Expr adaptedExpr = macro.apply(adaptedArgs).asSingleThreaded(inspector);
     return makeFallbackProcessor(
         macro.name(),
         () -> adaptedExpr.eval(UnusedBinding.INSTANCE),

--- a/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
@@ -29,6 +29,7 @@ import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.Function;
 import org.apache.druid.math.expr.LambdaExpr;
+import org.apache.druid.segment.column.ColumnType;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -406,6 +407,9 @@ public abstract class FallbackVectorProcessor<T> implements ExprVectorProcessor<
       } else if (type.is(ExprType.DOUBLE)) {
         final boolean isNull = results.getNullVector() != null && results.getNullVector()[rowNum];
         return ExprEval.ofDouble(isNull ? null : results.getDoubleVector()[rowNum]);
+      } else if (type.is(ExprType.COMPLEX)
+                 && !ColumnType.NESTED_DATA.getComplexTypeName().equals(type.getComplexTypeName())) {
+        return ExprEval.ofType(type, results.getObjectVector()[rowNum]);
       } else {
         return ExprEval.bestEffortOf(results.getObjectVector()[rowNum]).castTo(type);
       }

--- a/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/FallbackVectorProcessor.java
@@ -407,7 +407,7 @@ public abstract class FallbackVectorProcessor<T> implements ExprVectorProcessor<
         final boolean isNull = results.getNullVector() != null && results.getNullVector()[rowNum];
         return ExprEval.ofDouble(isNull ? null : results.getDoubleVector()[rowNum]);
       } else {
-        return ExprEval.bestEffortOf(results.getObjectVector()[rowNum]);
+        return ExprEval.bestEffortOf(results.getObjectVector()[rowNum]).castTo(type);
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/math/expr/vector/FunctionErrorReportingExprVectorProcessor.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/FunctionErrorReportingExprVectorProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.math.expr.vector;
+
+import org.apache.druid.error.DruidException;
+import org.apache.druid.math.expr.Expr;
+import org.apache.druid.math.expr.ExpressionProcessingException;
+import org.apache.druid.math.expr.ExpressionType;
+import org.apache.druid.math.expr.ExpressionValidationException;
+import org.apache.druid.segment.column.Types;
+
+/**
+ * Wrapper around {@link ExprVectorProcessor} that reports errors in the same style as {@code FunctionExpr}.
+ */
+public class FunctionErrorReportingExprVectorProcessor<T> implements ExprVectorProcessor<T>
+{
+  private final String functionName;
+  private final ExprVectorProcessor<T> delegate;
+
+  public FunctionErrorReportingExprVectorProcessor(String functionName, ExprVectorProcessor<T> delegate)
+  {
+    this.functionName = functionName;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ExprEvalVector<T> evalVector(Expr.VectorInputBinding bindings)
+  {
+    try {
+      return delegate.evalVector(bindings);
+    }
+    catch (ExpressionValidationException | ExpressionProcessingException e) {
+      // Already contain function name
+      throw DruidException.forPersona(DruidException.Persona.USER)
+                          .ofCategory(DruidException.Category.INVALID_INPUT)
+                          .build(e, e.getMessage());
+    }
+    catch (Types.InvalidCastException | Types.InvalidCastBooleanException e) {
+      throw DruidException.forPersona(DruidException.Persona.USER)
+                          .ofCategory(DruidException.Category.INVALID_INPUT)
+                          .build(e, "Function[%s] encountered exception: %s", functionName, e.getMessage());
+    }
+    catch (DruidException e) {
+      throw e;
+    }
+    catch (Exception e) {
+      throw DruidException.defensive().build(e, "Function[%s] encountered unknown exception.", functionName);
+    }
+  }
+
+  @Override
+  public ExpressionType getOutputType()
+  {
+    return delegate.getOutputType();
+  }
+
+  @Override
+  public int maxVectorSize()
+  {
+    return delegate.maxVectorSize();
+  }
+}

--- a/processing/src/main/java/org/apache/druid/math/expr/vector/VectorMathProcessors.java
+++ b/processing/src/main/java/org/apache/druid/math/expr/vector/VectorMathProcessors.java
@@ -696,7 +696,10 @@ public class VectorMathProcessors
 
     public GetExponent()
     {
-      super(Math::getExponent, Math::getExponent);
+      super(
+          x -> Math.getExponent((double) x), // Need to cast to (double) otherwise we get the float form
+          Math::getExponent
+      );
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/query/expression/NestedDataExpressions.java
+++ b/processing/src/main/java/org/apache/druid/query/expression/NestedDataExpressions.java
@@ -669,8 +669,8 @@ public class NestedDataExpressions
       @Override
       public ExpressionType getOutputType(InputBindingInspector inspector)
       {
-        // call all the output JSON typed
-        return ExpressionType.NESTED_DATA;
+        // call all the output ARRAY<COMPLEX<json>> typed
+        return JSON_ARRAY;
       }
     }
 

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlanner.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionPlanner.java
@@ -187,7 +187,8 @@ public class ExpressionPlanner
     // this check should also change
     boolean supportsVector = ExpressionPlan.none(
         traits,
-        ExpressionPlan.Trait.INCOMPLETE_INPUTS
+        ExpressionPlan.Trait.INCOMPLETE_INPUTS,
+        ExpressionPlan.Trait.NEEDS_APPLIED
     );
 
     if (supportsVector && expression.canVectorize(inspector)) {

--- a/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionVectorSelectors.java
+++ b/processing/src/main/java/org/apache/druid/segment/virtual/ExpressionVectorSelectors.java
@@ -251,6 +251,15 @@ public class ExpressionVectorSelectors
           case LONG:
             binding.addNumeric(columnName, ExpressionType.LONG, vectorColumnSelectorFactory.makeValueSelector(columnName));
             break;
+          case STRING:
+            binding.addObjectSelector(
+                columnName,
+                columnCapabilities.hasMultipleValues().isTrue()
+                ? ExpressionType.STRING_ARRAY
+                : ExpressionType.fromColumnType(columnCapabilities.toColumnType()),
+                vectorColumnSelectorFactory.makeObjectSelector(columnName)
+            );
+            break;
           default:
             binding.addObjectSelector(
                 columnName,

--- a/processing/src/test/java/org/apache/druid/frame/segment/FrameCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/segment/FrameCursorFactoryTest.java
@@ -349,7 +349,7 @@ public class FrameCursorFactoryTest
     }
 
     @Test
-    public void test_expr_cannotVectorize()
+    public void test_virtualColumn_cannotVectorize()
     {
       final CursorBuildSpec cursorSpec =
           CursorBuildSpec.builder()
@@ -358,7 +358,7 @@ public class FrameCursorFactoryTest
                              VirtualColumns.create(
                                  new ExpressionVirtualColumn(
                                      "expr",
-                                     "substring(quality, 1, 2)",
+                                     "if(isnull(quality),'yes',0)", // Cannot vectorize due to mixed return types
                                      ColumnType.STRING,
                                      ExprMacroTable.nil()
                                  )

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -141,20 +141,21 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     MACRO_TABLE = injector.getInstance(ExprMacroTable.class);
   }
 
-  final Map<String, ExpressionType> types = ImmutableMap.<String, ExpressionType>builder()
-                                                        .put("l1", ExpressionType.LONG)
-                                                        .put("l2", ExpressionType.LONG)
-                                                        .put("l3", ExpressionType.LONG)
-                                                        .put("d1", ExpressionType.DOUBLE)
-                                                        .put("d2", ExpressionType.DOUBLE)
-                                                        .put("d3", ExpressionType.DOUBLE)
-                                                        .put("s1", ExpressionType.STRING)
-                                                        .put("s2", ExpressionType.STRING)
-                                                        .put("s3", ExpressionType.STRING)
-                                                        .put("boolString1", ExpressionType.STRING)
-                                                        .put("boolString2", ExpressionType.STRING)
-                                                        .put("boolString3", ExpressionType.STRING)
-                                                        .build();
+  final Map<String, ExpressionType> types =
+      ImmutableMap.<String, ExpressionType>builder()
+                  .put("l1", ExpressionType.LONG)
+                  .put("l2", ExpressionType.LONG)
+                  .put("l3", ExpressionType.LONG)
+                  .put("d1", ExpressionType.DOUBLE)
+                  .put("d2", ExpressionType.DOUBLE)
+                  .put("d3", ExpressionType.DOUBLE)
+                  .put("s1", ExpressionType.STRING)
+                  .put("s2", ExpressionType.STRING)
+                  .put("s3", ExpressionType.STRING)
+                  .put("boolString1", ExpressionType.STRING)
+                  .put("boolString2", ExpressionType.STRING)
+                  .put("boolString3", ExpressionType.STRING)
+                  .build();
 
 
   @Test
@@ -275,14 +276,16 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     final Set<List<String>> templateInputs = Sets.cartesianProduct(columns, columns2, columns2);
     final List<String> templates = new ArrayList<>();
     for (List<String> template : templateInputs) {
-      templates.add(StringUtils.format(
-          "(%s %s %s) %s %s",
-          template.get(0),
-          "%s",
-          template.get(1),
-          "%s",
-          template.get(2)
-      ));
+      templates.add(
+          StringUtils.format(
+              "(%s %s %s) %s %s",
+              template.get(0),
+              "%s",
+              template.get(1),
+              "%s",
+              template.get(2)
+          )
+      );
     }
     final Set<String> ops = Set.of("+", "-", "*", "/");
     final Set<List<String>> args = Sets.cartesianProduct(ops, ops);
@@ -539,43 +542,13 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
   }
 
   @Test
-  public void testArrayFns()
+  public void testArrayFunctions()
   {
     testExpression("array(s1, s2)", types);
     testExpression("array(l1, l2)", types);
     testExpression("array(d1, d2)", types);
     testExpression("array(l1, d2)", types);
     testExpression("array(s1, l2)", types);
-
-    testExpression("map((x) -> x + 1, array(l1, l2))", types);
-    testExpression("map((x) -> x * 2.0, array(d1, d2))", types);
-    testExpression("map((x) -> concat(x, '_mapped'), array(s1, s2))", types);
-
-    testExpression("cartesian_map((x, y) -> x + y, array(l1, l2), array(d1, d2))", types);
-    testExpression("cartesian_map((x, y) -> concat(x, cast(y, 'STRING')), array(s1, s2), array(l1, l2))", types);
-
-    testExpression("fold((x, acc) -> x + acc, array(l1, l2), 0)", types);
-    testExpression("fold((x, acc) -> x + acc, array(d1, d2), 0.0)", types);
-    testExpression("fold((x, acc) -> concat(acc, x), array(s1, s2), '')", types);
-
-    testExpression("cartesian_fold((x, y, acc) -> acc + x + y, array(l1, l2), array(d1, d2), 0)", types);
-
-    testExpression("filter((x) -> x > 0, array(l1, l2))", types);
-    testExpression("filter((x) -> x > 0.0, array(d1, d2))", types);
-    testExpression("filter((x) -> strlen(x) > 0, array(s1, s2))", types);
-
-    testExpression("any((x) -> x > 0, array(l1, l2))", types);
-    testExpression("any((x) -> x > 0.0, array(d1, d2))", types);
-    testExpression("any((x) -> strlen(x) > 0, array(s1, s2))", types);
-
-    testExpression("all((x) -> x != null, array(l1, l2))", types);
-    testExpression("all((x) -> x != null, array(d1, d2))", types);
-    testExpression("all((x) -> x != null, array(s1, s2))", types);
-  }
-
-  @Test
-  public void testArrayFunctions()
-  {
     testExpression("array_length(array(s1, s2))", types);
     testExpression("array_length(array(l1, l2, l3))", types);
     testExpression("array_offset(array(s1, s2), 0)", types);
@@ -612,6 +585,35 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testArrayHigherOrderFunctions()
+  {
+    testExpression("map((x) -> x + 1, array(l1, l2))", types);
+    testExpression("map((x) -> x * 2.0, array(d1, d2))", types);
+    testExpression("map((x) -> concat(x, '_mapped'), array(s1, s2))", types);
+
+    testExpression("cartesian_map((x, y) -> x + y, array(l1, l2), array(d1, d2))", types);
+    testExpression("cartesian_map((x, y) -> concat(x, cast(y, 'STRING')), array(s1, s2), array(l1, l2))", types);
+
+    testExpression("fold((x, acc) -> x + acc, array(l1, l2), 0)", types);
+    testExpression("fold((x, acc) -> x + acc, array(d1, d2), 0.0)", types);
+    testExpression("fold((x, acc) -> concat(acc, x), array(s1, s2), '')", types);
+
+    testExpression("cartesian_fold((x, y, acc) -> acc + x + y, array(l1, l2), array(d1, d2), 0)", types);
+
+    testExpression("filter((x) -> x > 0, array(l1, l2))", types);
+    testExpression("filter((x) -> x > 0.0, array(d1, d2))", types);
+    testExpression("filter((x) -> strlen(x) > 0, array(s1, s2))", types);
+
+    testExpression("any((x) -> x > 0, array(l1, l2))", types);
+    testExpression("any((x) -> x > 0.0, array(d1, d2))", types);
+    testExpression("any((x) -> strlen(x) > 0, array(s1, s2))", types);
+
+    testExpression("all((x) -> x != null, array(l1, l2))", types);
+    testExpression("all((x) -> x != null, array(d1, d2))", types);
+    testExpression("all((x) -> x != null, array(s1, s2))", types);
+  }
+
+  @Test
   public void testReduceFns()
   {
     testExpression("greatest(s1, s2)", types);
@@ -632,7 +634,6 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
   @Test
   public void testJsonFns()
   {
-    Assume.assumeTrue(ExpressionProcessing.allowVectorizeFallback());
     testExpression("json_object('k1', s1, 'k2', l1)", types);
     testExpression("json_value(json_object('k1', s1, 'k2', l1), '$.k2', 'STRING')", types);
     testExpression("json_query(json_object('k1', s1, 'k2', l1), '$.k1')", types);

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -560,7 +560,11 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     testExpression("array_overlap(array(s1, s2), array(s2, s3))", types);
     testExpression("array_overlap(array(l1, l2), array(l2, l3))", types);
     testExpression("scalar_in_array(s1, array(s1, s2))", types);
+    testExpression("scalar_in_array(s1, array('1', '2'))", types);
+    testExpression("scalar_in_array(s1, array(1, 2))", types);
     testExpression("scalar_in_array(l1, array(l1, l2))", types);
+    testExpression("scalar_in_array(l1, array('1', '2'))", types);
+    testExpression("scalar_in_array(l1, array(1, 2))", types);
     testExpression("array_offset_of(array(s1, s2), s1)", types);
     testExpression("array_offset_of(array(l1, l2), l1)", types);
     testExpression("array_ordinal_of(array(s1, s2), s1)", types);

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -19,20 +19,23 @@
 
 package org.apache.druid.math.expr;
 
-import com.google.common.collect.ImmutableList;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import org.apache.druid.guice.DruidGuiceExtensions;
+import org.apache.druid.guice.ExpressionModule;
+import org.apache.druid.guice.annotations.Json;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.Either;
 import org.apache.druid.java.util.common.NonnullPair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.math.expr.vector.ExprEvalVector;
 import org.apache.druid.math.expr.vector.ExprVectorProcessor;
 import org.apache.druid.query.expression.LookupExprMacro;
-import org.apache.druid.query.expression.NestedDataExpressions;
-import org.apache.druid.query.expression.TimestampCeilExprMacro;
-import org.apache.druid.query.expression.TimestampExtractExprMacro;
-import org.apache.druid.query.expression.TimestampFloorExprMacro;
-import org.apache.druid.query.expression.TimestampShiftExprMacro;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.TestMapLookupExtractorFactory;
@@ -85,52 +88,58 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     }
   };
 
-  private static final ExprMacroTable MACRO_TABLE = new ExprMacroTable(
-      ImmutableList.of(
-          new TimestampCeilExprMacro(),
-          new TimestampExtractExprMacro(),
-          new TimestampFloorExprMacro(),
-          new TimestampShiftExprMacro(),
-          new NestedDataExpressions.JsonObjectExprMacro(),
-          new LookupExprMacro(
-              new LookupExtractorFactoryContainerProvider()
-              {
-                @Override
-                public Set<String> getAllLookupNames()
-                {
-                  return Set.of("test-lookup", "test-lookup-injective");
-                }
+  private static final ExprMacroTable MACRO_TABLE;
 
-                @Override
-                public Optional<LookupExtractorFactoryContainer> get(String lookupName)
-                {
-                  if ("test-lookup".equals(lookupName)) {
-                    return Optional.of(
-                        new LookupExtractorFactoryContainer(
-                            "v0",
-                            new TestMapLookupExtractorFactory(LOOKUP, false)
-                        )
-                    );
-                  } else if ("test-lookup-injective".equals(lookupName)) {
-                    return Optional.of(
-                        new LookupExtractorFactoryContainer(
-                            "v0",
-                            new TestMapLookupExtractorFactory(INJECTIVE_LOOKUP, true)
-                        )
-                    );
-                  }
-                  return Optional.empty();
-                }
+  static {
+    final Injector injector = Guice.createInjector(
+        new DruidGuiceExtensions(),
+        new ExpressionModule(),
+        binder -> {
+          ExpressionModule.addExprMacro(binder, LookupExprMacro.class);
+          binder.bind(Key.get(ObjectMapper.class, Json.class)).toInstance(new DefaultObjectMapper());
+          binder.bind(LookupExtractorFactoryContainerProvider.class)
+                .toInstance(
+                    new LookupExtractorFactoryContainerProvider()
+                    {
+                      @Override
+                      public Set<String> getAllLookupNames()
+                      {
+                        return Set.of("test-lookup", "test-lookup-injective");
+                      }
 
-                @Override
-                public String getCanonicalLookupName(String lookupName)
-                {
-                  return "";
-                }
-              }
-          )
-      )
-  );
+                      @Override
+                      public Optional<LookupExtractorFactoryContainer> get(String lookupName)
+                      {
+                        if ("test-lookup".equals(lookupName)) {
+                          return Optional.of(
+                              new LookupExtractorFactoryContainer(
+                                  "v0",
+                                  new TestMapLookupExtractorFactory(LOOKUP, false)
+                              )
+                          );
+                        } else if ("test-lookup-injective".equals(lookupName)) {
+                          return Optional.of(
+                              new LookupExtractorFactoryContainer(
+                                  "v0",
+                                  new TestMapLookupExtractorFactory(INJECTIVE_LOOKUP, true)
+                              )
+                          );
+                        }
+                        return Optional.empty();
+                      }
+
+                      @Override
+                      public String getCanonicalLookupName(String lookupName)
+                      {
+                        return "";
+                      }
+                    }
+                );
+        }
+    );
+
+    MACRO_TABLE = injector.getInstance(ExprMacroTable.class);
+  }
 
   final Map<String, ExpressionType> types = ImmutableMap.<String, ExpressionType>builder()
       .put("l1", ExpressionType.LONG)
@@ -270,6 +279,14 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testLike()
+  {
+    testExpression("like(s1, '1%')", types);
+    testExpression("like(s1, '%1')", types);
+    testExpression("like(s1, '%1%')", types);
+  }
+
+  @Test
   public void testUnivariateMathFunctions()
   {
     final List<String> functions = List.of(
@@ -322,6 +339,7 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
         "nextAfter",
         "scalb",
         "pow",
+        "safe_divide",
         "bitwiseAnd",
         "bitwiseOr",
         "bitwiseXor",
@@ -445,6 +463,47 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
   }
 
   @Test
+  public void testStringFunctions()
+  {
+    testExpression("format('%s-%d-%.2f', s1, l1, d1)", types);
+    testExpression("format('%s %s', s1, s2)", types);
+    testExpression("regexp_extract(s1, '[0-9]+')", types);
+    testExpression("regexp_extract(s1, '([a-z]+)', 1)", types);
+    testExpression("regexp_like(s1, '[0-9]+')", types);
+    testExpression("regexp_like(s1, '^test.*')", types);
+    testExpression("regexp_replace(s1, '[0-9]+', 'NUM')", types);
+    testExpression("contains_string(s1, '1')", types);
+    testExpression("icontains_string(s1, '1')", types);
+    testExpression("replace(s1, 'test', 'TEST')", types);
+    testExpression("replace(s1, s2, s3)", types);
+    testExpression("substring(s1, 0, 3)", types);
+    testExpression("substring(s1, l1, l2)", types);
+    testExpression("right(s1, 3)", types);
+    testExpression("right(s1, l1)", types);
+    testExpression("left(s1, 3)", types);
+    testExpression("left(s1, l1)", types);
+    testExpression("strlen(s1)", types);
+    testExpression("strpos(s1, 'test')", types);
+    testExpression("strpos(s1, s2)", types);
+    testExpression("strpos(s1, s2, l1)", types);
+    testExpression("trim(s1)", types);
+    testExpression("trim(s1, 'abc')", types);
+    testExpression("ltrim(s1)", types);
+    testExpression("ltrim(s1, 'abc')", types);
+    testExpression("rtrim(s1)", types);
+    testExpression("rtrim(s1, 'abc')", types);
+    testExpression("lower(s1)", types);
+    testExpression("upper(s1)", types);
+    testExpression("reverse(s1)", types);
+    testExpression("repeat(s1, 3)", types);
+    testExpression("repeat(s1, l1 % 10)", types);
+    testExpression("lpad(s1, 10, 'x')", types);
+    testExpression("lpad(s1, l1 % 10, s2)", types);
+    testExpression("rpad(s1, 10, 'x')", types);
+    testExpression("rpad(s1, l1 % 10, s2)", types);
+  }
+
+  @Test
   public void testLookup()
   {
     final List<String> columns = new ArrayList<>(types.keySet());
@@ -453,7 +512,9 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
         "lookup(%s, 'test-lookup')",
         "lookup(%s, 'test-lookup', 'missing')",
         "lookup(%s, 'test-lookup-injective')",
-        "lookup(%s, 'test-lookup-injective', 'missing')"
+        "lookup(%s, 'test-lookup-injective', 'missing')",
+        "lookup(%s, 'nonexistent-lookup')",
+        "lookup(%s, 'nonexistent-lookup', 'missing')"
     );
     testFunctions(types, templates, columns);
   }
@@ -461,66 +522,92 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
   @Test
   public void testArrayFns()
   {
-    try {
-      ExpressionProcessing.initializeForFallback();
-      testExpression("array(s1, s2)", types);
-      testExpression("array(l1, l2)", types);
-      testExpression("array(d1, d2)", types);
-      testExpression("array(l1, d2)", types);
-      testExpression("array(s1, l2)", types);
+    testExpression("array(s1, s2)", types);
+    testExpression("array(l1, l2)", types);
+    testExpression("array(d1, d2)", types);
+    testExpression("array(l1, d2)", types);
+    testExpression("array(s1, l2)", types);
 
-      testExpression("map((x) -> x + 1, array(l1, l2))", types);
-      testExpression("map((x) -> x * 2.0, array(d1, d2))", types);
-      testExpression("map((x) -> concat(x, '_mapped'), array(s1, s2))", types);
+    testExpression("map((x) -> x + 1, array(l1, l2))", types);
+    testExpression("map((x) -> x * 2.0, array(d1, d2))", types);
+    testExpression("map((x) -> concat(x, '_mapped'), array(s1, s2))", types);
 
-      testExpression("cartesian_map((x, y) -> x + y, array(l1, l2), array(d1, d2))", types);
-      testExpression("cartesian_map((x, y) -> concat(x, cast(y, 'STRING')), array(s1, s2), array(l1, l2))", types);
+    testExpression("cartesian_map((x, y) -> x + y, array(l1, l2), array(d1, d2))", types);
+    testExpression("cartesian_map((x, y) -> concat(x, cast(y, 'STRING')), array(s1, s2), array(l1, l2))", types);
 
-      testExpression("fold((x, acc) -> x + acc, array(l1, l2), 0)", types);
-      testExpression("fold((x, acc) -> x + acc, array(d1, d2), 0.0)", types);
-      testExpression("fold((x, acc) -> concat(acc, x), array(s1, s2), '')", types);
+    testExpression("fold((x, acc) -> x + acc, array(l1, l2), 0)", types);
+    testExpression("fold((x, acc) -> x + acc, array(d1, d2), 0.0)", types);
+    testExpression("fold((x, acc) -> concat(acc, x), array(s1, s2), '')", types);
 
-      testExpression("cartesian_fold((x, y, acc) -> acc + x + y, array(l1, l2), array(d1, d2), 0)", types);
+    testExpression("cartesian_fold((x, y, acc) -> acc + x + y, array(l1, l2), array(d1, d2), 0)", types);
 
-      testExpression("filter((x) -> x > 0, array(l1, l2))", types);
-      testExpression("filter((x) -> x > 0.0, array(d1, d2))", types);
-      testExpression("filter((x) -> strlen(x) > 0, array(s1, s2))", types);
+    testExpression("filter((x) -> x > 0, array(l1, l2))", types);
+    testExpression("filter((x) -> x > 0.0, array(d1, d2))", types);
+    testExpression("filter((x) -> strlen(x) > 0, array(s1, s2))", types);
 
-      testExpression("any((x) -> x > 0, array(l1, l2))", types);
-      testExpression("any((x) -> x > 0.0, array(d1, d2))", types);
-      testExpression("any((x) -> strlen(x) > 0, array(s1, s2))", types);
+    testExpression("any((x) -> x > 0, array(l1, l2))", types);
+    testExpression("any((x) -> x > 0.0, array(d1, d2))", types);
+    testExpression("any((x) -> strlen(x) > 0, array(s1, s2))", types);
 
-      testExpression("all((x) -> x != null, array(l1, l2))", types);
-      testExpression("all((x) -> x != null, array(d1, d2))", types);
-      testExpression("all((x) -> x != null, array(s1, s2))", types);
-    }
-    finally {
-      ExpressionProcessing.initializeForTests();
-    }
+    testExpression("all((x) -> x != null, array(l1, l2))", types);
+    testExpression("all((x) -> x != null, array(d1, d2))", types);
+    testExpression("all((x) -> x != null, array(s1, s2))", types);
+  }
+
+  @Test
+  public void testArrayFunctions()
+  {
+    testExpression("array_length(array(s1, s2))", types);
+    testExpression("array_length(array(l1, l2, l3))", types);
+    testExpression("array_offset(array(s1, s2), 0)", types);
+    testExpression("array_offset(array(l1, l2), l1)", types);
+    testExpression("array_ordinal(array(s1, s2), 1)", types);
+    testExpression("array_ordinal(array(l1, l2), l1)", types);
+    testExpression("array_contains(array(s1, s2), s1)", types);
+    testExpression("array_contains(array(l1, l2), l1)", types);
+    testExpression("array_contains(array(s1, s2), array(s1))", types);
+    testExpression("array_overlap(array(s1, s2), array(s2, s3))", types);
+    testExpression("array_overlap(array(l1, l2), array(l2, l3))", types);
+    testExpression("scalar_in_array(s1, array(s1, s2))", types);
+    testExpression("scalar_in_array(l1, array(l1, l2))", types);
+    testExpression("array_offset_of(array(s1, s2), s1)", types);
+    testExpression("array_offset_of(array(l1, l2), l1)", types);
+    testExpression("array_ordinal_of(array(s1, s2), s1)", types);
+    testExpression("array_ordinal_of(array(l1, l2), l1)", types);
+    testExpression("array_prepend(s1, array(s2, s3))", types);
+    testExpression("array_prepend(l1, array(l2, l3))", types);
+    testExpression("array_append(array(s1, s2), s3)", types);
+    testExpression("array_append(array(l1, l2), l3)", types);
+    testExpression("array_concat(array(s1, s2), array(s2, s3))", types);
+    testExpression("array_concat(array(l1, l2), array(l2, l3))", types);
+    testExpression("array_set_add(array(s1, s2), s1)", types);
+    testExpression("array_set_add(array(l1, l2), l3)", types);
+    testExpression("array_set_add_all(array(s1, s2), array(s2, s3))", types);
+    testExpression("array_set_add_all(array(l1, l2), array(l2, l3))", types);
+    testExpression("array_slice(array(s1, s2, s3), 1, 2)", types);
+    testExpression("array_slice(array(l1, l2, l3), 1, 2)", types);
+    testExpression("array_to_string(array(s1, s2), ',')", types);
+    testExpression("array_to_string(array(l1, l2), s1)", types);
+    testExpression("string_to_array(s1, ',')", types);
+    testExpression("string_to_array(s1, s2)", types);
   }
 
   @Test
   public void testReduceFns()
   {
-    try {
-      ExpressionProcessing.initializeForFallback();
-      testExpression("greatest(s1, s2)", types);
-      testExpression("greatest(l1, l2)", types);
-      testExpression("greatest(l1, nonexistent)", types);
-      testExpression("greatest(d1, d2)", types);
-      testExpression("greatest(l1, d2)", types);
-      testExpression("greatest(s1, l2)", types);
+    testExpression("greatest(s1, s2)", types);
+    testExpression("greatest(l1, l2)", types);
+    testExpression("greatest(l1, nonexistent)", types);
+    testExpression("greatest(d1, d2)", types);
+    testExpression("greatest(l1, d2)", types);
+    testExpression("greatest(s1, l2)", types);
 
-      testExpression("least(s1, s2)", types);
-      testExpression("least(l1, l2)", types);
-      testExpression("least(l1, nonexistent)", types);
-      testExpression("least(d1, d2)", types);
-      testExpression("least(l1, d2)", types);
-      testExpression("least(s1, l2)", types);
-    }
-    finally {
-      ExpressionProcessing.initializeForTests();
-    }
+    testExpression("least(s1, s2)", types);
+    testExpression("least(l1, l2)", types);
+    testExpression("least(l1, nonexistent)", types);
+    testExpression("least(d1, d2)", types);
+    testExpression("least(l1, d2)", types);
+    testExpression("least(s1, l2)", types);
   }
 
   @Test
@@ -528,6 +615,15 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
   {
     Assume.assumeTrue(ExpressionProcessing.allowVectorizeFallback());
     testExpression("json_object('k1', s1, 'k2', l1)", types);
+    testExpression("json_value(json_object('k1', s1, 'k2', l1), '$.k2', 'STRING')", types);
+    testExpression("json_query(json_object('k1', s1, 'k2', l1), '$.k1')", types);
+    testExpression("json_query_array(json_object('arr', array(s1, s2)), '$.arr')", types);
+    testExpression("parse_json(s1)", types);
+    testExpression("try_parse_json(s1)", types);
+    testExpression("to_json_string(json_object('k1', s1))", types);
+    testExpression("json_keys(json_object('k1', s1, 'k2', l1), '$')", types);
+    testExpression("json_paths(json_object('k1', s1, 'k2', l1))", types);
+    testExpression("json_merge(json_object('k1', s1), json_object('k2', l1))", types);
   }
 
   @Test
@@ -548,6 +644,41 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     testExpression("timestamp_extract(l1, 'MILLISECOND')", types);
     testExpression("timestamp_extract(l1, 'EPOCH')", types);
     testExpression("timestamp_shift(l1, 'P1M', 1)", types);
+    testExpression("timestamp(s1)", types);
+    testExpression("timestamp(s1, 'yyyy-MM-dd')", types);
+    testExpression("unix_timestamp(s1)", types);
+    testExpression("unix_timestamp(s1, 'yyyy-MM-dd')", types);
+    testExpression("timestamp_parse(s1)", types);
+    testExpression("timestamp_parse(s1, 'yyyy-MM-dd')", types);
+    testExpression("timestamp_parse(s1, 'yyyy-MM-dd', 'UTC')", types);
+    testExpression("timestamp_format(l1)", types);
+    testExpression("timestamp_format(l1, 'yyyy-MM-dd')", types);
+    testExpression("timestamp_format(l1, 'yyyy-MM-dd', 'UTC')", types);
+  }
+
+  @Test
+  public void testIpAddressFunctions()
+  {
+    testExpression("ipv4_match('192.168.1.1', '192.168.0.0/16')", types);
+    testExpression("ipv4_match(s1, '192.168.0.0/16')", types);
+    testExpression("ipv4_parse('192.168.1.1')", types);
+    testExpression("ipv4_parse(s1)", types);
+    testExpression("ipv4_stringify(3232235777)", types);
+    testExpression("ipv4_stringify(l1)", types);
+    testExpression("ipv6_match('2001:db8::1', '2001:db8::/32')", types);
+    testExpression("ipv6_match(s1, '2001:db8::/32')", types);
+  }
+
+  @Test
+  public void testOtherFunctions()
+  {
+    testExpression("human_readable_binary_byte_format(l1)", types);
+    testExpression("human_readable_binary_byte_format(l1, 3)", types);
+    testExpression("human_readable_decimal_byte_format(l1)", types);
+    testExpression("human_readable_decimal_byte_format(l1, 3)", types);
+    testExpression("human_readable_decimal_format(l1)", types);
+    testExpression("human_readable_decimal_format(l1, 3)", types);
+    testExpression("pi()", types);
   }
 
   /**
@@ -604,103 +735,74 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
    * runs expressions against bindings generated by increasing a counter
    */
   public static void testExpressionSequentialBindings(
-      String expr,
-      Expr parsed,
-      Map<String, ExpressionType> types,
-      int numIterations
+      final String expr,
+      final Expr parsed,
+      final Map<String, ExpressionType> types,
+      final int numIterations
   )
   {
     for (int iter = 0; iter < numIterations; iter++) {
-      NonnullPair<Expr.ObjectBinding[], Expr.VectorInputBinding> bindings = makeSequentialBinding(
-          VECTOR_SIZE,
-          types,
-          1 + (iter * VECTOR_SIZE) // the plus 1 is because dividing by zero is sad
+      assertEvalsMatch(
+          expr,
+          parsed,
+          makeSequentialBinding(
+              VECTOR_SIZE,
+              types,
+              -2 + (iter * VECTOR_SIZE) // include negative numbers and zero
+          )
       );
-      Assert.assertTrue(StringUtils.format("Cannot vectorize %s", expr), parsed.canVectorize(bindings.rhs));
-      ExpressionType outputType = parsed.getOutputType(bindings.rhs);
-      ExprEvalVector<?> vectorEval = parsed.asVectorProcessor(bindings.rhs).evalVector(bindings.rhs);
-      // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
-      if (outputType != null) {
-        Assert.assertEquals(expr, outputType, vectorEval.getType());
-      }
-      final Object[] vectorVals = vectorEval.getObjectVector();
-      for (int i = 0; i < VECTOR_SIZE; i++) {
-        ExprEval<?> eval = parsed.eval(bindings.lhs[i]);
-        // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
-        if (outputType != null && !eval.isNumericNull()) {
-          Assert.assertEquals(eval.type(), outputType);
-        }
-        if (outputType != null && outputType.isArray()) {
-          Assert.assertArrayEquals(
-              StringUtils.format("Values do not match for row %s for expression %s", i, expr),
-              (Object[]) eval.value(),
-              (Object[]) vectorVals[i]
-          );
-        } else {
-          Assert.assertEquals(
-              StringUtils.format("Values do not match for row %s for expression %s", i, expr),
-              eval.value(),
-              vectorVals[i]
-          );
-        }
-      }
     }
   }
 
   public static void testExpressionRandomizedBindings(
-      String expr,
-      Expr parsed,
-      Map<String, ExpressionType> types,
-      int numIterations
+      final String expr,
+      final Expr parsed,
+      final Map<String, ExpressionType> types,
+      final int numIterations
   )
   {
-    Expr.InputBindingInspector inspector = InputBindings.inspectorFromTypeMap(types);
-    Expr.VectorInputBindingInspector vectorInputBindingInspector = new Expr.VectorInputBindingInspector()
-    {
-      @Override
-      public int getMaxVectorSize()
-      {
-        return VECTOR_SIZE;
-      }
-
-      @Nullable
-      @Override
-      public ExpressionType getType(String name)
-      {
-        return inspector.getType(name);
-      }
-    };
-    Assert.assertTrue(StringUtils.format("Cannot vectorize %s", expr), parsed.canVectorize(inspector));
-    ExpressionType outputType = parsed.getOutputType(inspector);
-    final ExprVectorProcessor processor = parsed.asVectorProcessor(vectorInputBindingInspector);
-    // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
-    if (outputType != null) {
-      Assert.assertEquals(expr, outputType, processor.getOutputType());
-    }
     for (int iterations = 0; iterations < numIterations; iterations++) {
-      NonnullPair<Expr.ObjectBinding[], Expr.VectorInputBinding> bindings = makeRandomizedBindings(VECTOR_SIZE, types);
-      ExprEvalVector<?> vectorEval = processor.evalVector(bindings.rhs);
-      final Object[] vectorVals = vectorEval.getObjectVector();
-      if (outputType != null) {
-        Assert.assertEquals("vector eval type", outputType, vectorEval.getType());
-      }
+      assertEvalsMatch(expr, parsed, makeRandomizedBindings(VECTOR_SIZE, types));
+    }
+  }
+
+  public static void assertEvalsMatch(
+      String exprString,
+      Expr expr,
+      NonnullPair<Expr.ObjectBinding[], Expr.VectorInputBinding> bindings
+  )
+  {
+    Assert.assertTrue(StringUtils.format("Cannot vectorize[%s]", expr), expr.canVectorize(bindings.rhs));
+
+    final ExpressionType outputType = expr.getOutputType(bindings.rhs);
+    final Either<String, Object[]> vectorEval = evalVector(expr, bindings.rhs, outputType);
+    final Either<String, Object[]> nonVectorEval = evalNonVector(expr, bindings.lhs, outputType);
+
+    Assert.assertEquals(
+        StringUtils.format("Errors do not match for expr[%s], bindings[%s]", exprString, bindings.lhs),
+        nonVectorEval.isError() ? nonVectorEval.error() : "",
+        vectorEval.isError() ? vectorEval.error() : ""
+    );
+
+    if (vectorEval.isValue() && nonVectorEval.isValue()) {
       for (int i = 0; i < VECTOR_SIZE; i++) {
-        ExprEval<?> eval = parsed.eval(bindings.lhs[i]);
-        // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
-        if (outputType != null && eval.value() != null) {
-          Assert.assertEquals("nonvector eval type", eval.type(), outputType);
-        }
+        final String message = StringUtils.format(
+            "Values do not match for row[%s] for expression[%s], bindings[%s]",
+            i,
+            exprString,
+            bindings.lhs[i]
+        );
         if (outputType != null && outputType.isArray()) {
           Assert.assertArrayEquals(
-              StringUtils.format("Values do not match for row %s for expression %s", i, expr),
-              (Object[]) eval.value(),
-              (Object[]) vectorVals[i]
+              message,
+              (Object[]) nonVectorEval.valueOrThrow()[i],
+              (Object[]) vectorEval.valueOrThrow()[i]
           );
         } else {
           Assert.assertEquals(
-              StringUtils.format("Values do not match for row %s for expression %s", i, expr),
-              eval.value(),
-              vectorVals[i]
+              message,
+              nonVectorEval.valueOrThrow()[i],
+              vectorEval.valueOrThrow()[i]
           );
         }
       }
@@ -721,8 +823,8 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     return populateBindings(
         vectorSize,
         types,
-        () -> r.nextLong(0, Integer.MAX_VALUE - 1),
-        r::nextDouble,
+        () -> r.nextLong(Integer.MIN_VALUE, Integer.MAX_VALUE),
+        () -> r.nextDouble() * (r.nextBoolean() ? 10 : -10),
         () -> r.nextDouble(0, 1.0) > 0.9,
         () -> String.valueOf(r.nextInt())
     );
@@ -839,5 +941,63 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     }
 
     return new NonnullPair<>(objectBindings, vectorBinding);
+  }
+
+  private static Either<String, Object[]> evalVector(
+      Expr expr,
+      Expr.VectorInputBinding bindings,
+      @Nullable ExpressionType outputType
+  )
+  {
+    final ExprVectorProcessor<Object> processor = expr.asVectorProcessor(bindings);
+    final ExprEvalVector<?> vectorEval;
+    try {
+      vectorEval = processor.evalVector(bindings);
+    }
+    catch (ArithmeticException e) {
+      // After a few occasions, Java starts throwing ArithmeticException without a message for division by zero.
+      return Either.error(e.getClass().getName());
+    }
+    catch (Exception e) {
+      return Either.error(e.toString());
+    }
+
+    final Object[] vectorVals = vectorEval.getObjectVector();
+    // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
+    if (outputType != null) {
+      Assert.assertEquals("vector eval type", outputType, vectorEval.getType());
+    }
+
+    return Either.value(vectorVals);
+  }
+
+  private static Either<String, Object[]> evalNonVector(
+      Expr expr,
+      Expr.ObjectBinding[] bindings,
+      @Nullable ExpressionType outputType
+  )
+  {
+    final Object[] exprValues = new Object[VECTOR_SIZE];
+
+    for (int i = 0; i < VECTOR_SIZE; i++) {
+      ExprEval<?> eval;
+      try {
+        eval = expr.eval(bindings[i]);
+      }
+      catch (ArithmeticException e) {
+        // After a few occasions, Java starts throwing ArithmeticException without a message for division by zero.
+        return Either.error(e.getClass().getName());
+      }
+      catch (Exception e) {
+        return Either.error(e.toString());
+      }
+      // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
+      if (outputType != null && eval.value() != null) {
+        Assert.assertEquals("nonvector eval type", eval.type(), outputType);
+      }
+      exprValues[i] = eval.value();
+    }
+
+    return Either.value(exprValues);
   }
 }

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -41,7 +41,6 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.TestMapLookupExtractorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
 

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -986,7 +986,7 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     }
 
     final Object[] vectorVals = vectorEval.getObjectVector();
-    // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
+    // if outputType is known, verify the expr returns the correct type
     if (outputType != null) {
       Assert.assertEquals("vector eval type", outputType, vectorEval.getType());
     }
@@ -1014,7 +1014,7 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
       catch (Exception e) {
         return Either.error(e.toString());
       }
-      // 'null' expressions can have an output type of null, but still evaluate in default mode, so skip type checks
+      // if outputType is known, verify the expr returns the correct type
       if (outputType != null && eval.value() != null) {
         Assert.assertEquals("nonvector eval type", eval.type(), outputType);
       }

--- a/processing/src/test/java/org/apache/druid/math/expr/vector/FallbackVectorProcessorTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/vector/FallbackVectorProcessorTest.java
@@ -168,7 +168,7 @@ public class FallbackVectorProcessorTest extends InitializedNullHandlingTest
   @Test
   public void test_case_long_double()
   {
-    final FallbackVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
+    final ExprVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
         new Function.CaseSimpleFunc(),
         ImmutableList.of(
             Parser.parse("long + double", ExprMacroTable.nil()),
@@ -200,7 +200,7 @@ public class FallbackVectorProcessorTest extends InitializedNullHandlingTest
   @Test
   public void test_upper_string()
   {
-    final FallbackVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
+    final ExprVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
         new Function.UpperFunc(),
         ImmutableList.of(
             Parser.parse("str", ExprMacroTable.nil())
@@ -220,7 +220,7 @@ public class FallbackVectorProcessorTest extends InitializedNullHandlingTest
   @Test
   public void test_concat_string_doubleNoNulls()
   {
-    final FallbackVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
+    final ExprVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
         new Function.ConcatFunc(),
         ImmutableList.of(
             Parser.parse("str", ExprMacroTable.nil()),
@@ -241,7 +241,7 @@ public class FallbackVectorProcessorTest extends InitializedNullHandlingTest
   @Test
   public void test_array_length()
   {
-    final FallbackVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
+    final ExprVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
         new Function.ArrayLengthFunction(),
         ImmutableList.of(
             Parser.parse("arr", ExprMacroTable.nil())
@@ -269,7 +269,7 @@ public class FallbackVectorProcessorTest extends InitializedNullHandlingTest
   @Test
   public void test_array_concat()
   {
-    final FallbackVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
+    final ExprVectorProcessor<Object[]> processor = FallbackVectorProcessor.create(
         new Function.ArrayConcatFunction(),
         ImmutableList.of(
             Parser.parse("arr", ExprMacroTable.nil()),

--- a/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/BaseFilterTest.java
@@ -1192,11 +1192,14 @@ public abstract class BaseFilterTest extends InitializedNullHandlingTest
       final List<String> expectedRows
   )
   {
-    final boolean vectorize = ExpressionProcessing.allowVectorizeFallback();
-    assertFilterMatches(filter, expectedRows, vectorize);
-    // test double inverted
-    if (!StringUtils.toLowerCase(testName).contains("concise")) {
-      assertFilterMatches(NotDimFilter.of(NotDimFilter.of(filter)), expectedRows, vectorize);
+    if (ExpressionProcessing.allowVectorizeFallback()) {
+      assertFilterMatches(filter, expectedRows);
+    } else {
+      assertFilterMatches(filter, expectedRows, false);
+      // test double inverted
+      if (!StringUtils.toLowerCase(testName).contains("concise")) {
+        assertFilterMatches(NotDimFilter.of(NotDimFilter.of(filter)), expectedRows, false);
+      }
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
@@ -1152,10 +1152,10 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT,
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
-            ExpressionPlan.Trait.UNKNOWN_INPUTS
+            ExpressionPlan.Trait.UNKNOWN_INPUTS,
+            ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    assertFallbackVectorizable(thePlan);
 
     Assert.assertEquals(
         "array_to_string(map((\"multi_dictionary_string\") -> array_append(\"scalar_string\", \"multi_dictionary_string\"), \"multi_dictionary_string\"), ',')",


### PR DESCRIPTION
This patch updates the default value of druid.expressions.allowVectorizeFallback to true.

In addition, there are the following fixes and improvements:

1) Remove safe_divide's explicit "return false" override for canVectorize,
   allowing it to fallback vectorize.

2) Fix getExponent's long-typed vectorized implementation. (It was casting
   to float, so the exponent was inconsistent with the non-vector version,
   which cast to double.)

3) Fix json_query_array's reported output type (was `COMPLEX<json>`, should
   be `ARRAY<COMPLEX<json>>`).

4) FallbackVectorProcessor and Div now have their errors wrapped using
   FunctionErrorReportingExprVectorProcessor, which handles errors
   similarly to how FunctionExpr does it. (Div is the only already-vectorized
   math function that we expect to throw errors).

5) ColumnarFrameCursorFactory now uses itself as the inspector for
   canVectorize, rather than its signature. The signature returns
   "unknown" for "hasMultipleValues", which leads to things being
   non-vectorizable that really should be vectorizable.

6) Add many more functions to VectorExprResultConsistencyTest, and update
   it to test negative numbers and zero. Because zero can lead to exceptions
   in division functions, the test code is also updated to verify equivalence
   of the thrown exceptions.

7) Call asSingleThreaded on Functions and ExprMacro exprs when they
   run in FallbackVectorProcessor.