### PR TITLE
Use a smaller dedup bloom filter for `PartialDimensionDistributionTask` in unit tests

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -423,6 +423,10 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
           SinglePhaseParallelIndexTaskRunner.CTX_USE_LINEAGE_BASED_SEGMENT_ALLOCATION_KEY,
           SinglePhaseParallelIndexTaskRunner.DEFAULT_USE_LINEAGE_BASED_SEGMENT_ALLOCATION
       );
+      task.addToContextIfAbsent(
+          PartialDimensionDistributionTask.CTX_BLOOM_FILTER_EXPECTED_INSERTIONS,
+          1_000
+      );
       final ListenableFuture<TaskStatus> statusFuture = service.submit(
           () -> {
             try {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -469,7 +469,9 @@ public class PartialDimensionDistributionTaskTest
       Supplier<PartialDimensionDistributionTask.DedupInputRowFilter> supplier =
           dedupRowDimValueFilterSupplier == null
           ? () -> new PartialDimensionDistributionTask.DedupInputRowFilter(
-              dataSchema.getGranularitySpec().getQueryGranularity()
+              dataSchema.getGranularitySpec().getQueryGranularity(),
+              null,
+              null
           )
           : dedupRowDimValueFilterSupplier;
 


### PR DESCRIPTION
### Description

Some unit tests failed recently due to OOM caused by a large number and size of bloom filters.
This happened after https://github.com/apache/druid/pull/18482 where the number of concurrent
tasks was increased to allow tests to finish faster.

This patch allows controlling the bloom filter size in tests using a task context parameter.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
