### PR TITLE
Remove java 11 from all-jdks test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ "11", "21.0.4" ]
+        jdk: [ "21.0.4" ]
         pattern: [ "C*", "H*,U*,V*", "N*,Q*,S*", "B*,O*,R*", "G*,J*,K*", "F*,L*,M*", "A*,D*,I*,X*,Y*,Z*", "E*,P*,T*,W*"]
     uses: ./.github/workflows/worker.yml
     with:


### PR DESCRIPTION
Follow up to #18424 which dropped java 11 runtime support due to jetty upgrade. Stop running UTs with java-11 for all-jdk label and post merge to master. 