### PR TITLE
Re-enable centalized schema with no query embedded tests

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -441,6 +441,7 @@ These metrics are emitted by the Druid Coordinator in every run of the correspon
 |`serverview/sync/unstableTime`|Time in milliseconds for which the Coordinator has been failing to sync with a segment-loading server. Emitted only when [HTTP-based server view](../configuration/index.md#segment-management) is enabled.|`server`, `tier`|Not emitted for synced servers.|
 |`metadatacache/init/time`|Time taken to initialize the coordinator segment metadata cache.||Depends on the number of segments.|
 |`segment/schemaCache/refresh/count`|Number of segments for which schema was refreshed in coordinator segment schema cache.|`dataSource`||
+|`segment/schemaCache/refreshSkipped/count`|Number of segments for which schema refresh was skipped due to presence of segment metadata in datasource polled from coordinator.|`dataSource`||
 |`segment/schemaCache/dataSource/removed`|Emitted when a datasource is removed from the Broker cache due to segments being marked as unused.|`dataSource`||
 |`segment/schemaCache/refresh/time`|Time taken to refresh segments in coordinator segment schema cache.|`dataSource`||
 |`segment/schemaCache/backfill/count`|Number of segments for which schema was back filled in the database.|`dataSource`||

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionTestBase.java
@@ -72,7 +72,8 @@ public abstract class CompactionTestBase extends EmbeddedClusterTestBase
   {
     final String taskId = IdUtils.getRandomId();
     cluster.callApi().runTask(taskBuilder.dataSource(dataSource).withId(taskId), overlord);
-    cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator, broker);
+    boolean useCentralizedSchema = Boolean.parseBoolean((String) cluster.getCommonProperties().getOrDefault("druid.centralizedDatasourceSchema.enabled", "false"));
+    cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator, broker, useCentralizedSchema);
 
     return taskId;
   }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/schema/CentralizedSchemaMetadataQueryDisabledTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/schema/CentralizedSchemaMetadataQueryDisabledTest.java
@@ -23,7 +23,6 @@ import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.compact.CompactionSparseColumnTest;
 import org.apache.druid.testing.embedded.compact.CompactionTaskTest;
 import org.apache.druid.testing.embedded.indexing.KafkaDataFormatsTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 
 /**
@@ -39,6 +38,7 @@ public class CentralizedSchemaMetadataQueryDisabledTest
            .addCommonProperty("druid.centralizedDatasourceSchema.backFillEnabled", "true")
            .addCommonProperty("druid.centralizedDatasourceSchema.backFillPeriod", "500")
            .addCommonProperty("druid.coordinator.segmentMetadata.disableSegmentMetadataQueries", "true")
+           .addCommonProperty("druid.sql.planner.metadataRefreshPeriod", "PT0.1s")
            .addCommonProperty("druid.coordinator.segmentMetadata.metadataRefreshPeriod", "PT0.1s")
            .addCommonProperty("druid.manager.segments.useIncrementalCache", "always");
 
@@ -46,7 +46,6 @@ public class CentralizedSchemaMetadataQueryDisabledTest
   }
 
   @Nested
-  @Disabled("Disabled due to issues with compaction task not publishing schema to broker")
   public class CompactionSparseColumn extends CompactionSparseColumnTest
   {
     @Override
@@ -57,7 +56,6 @@ public class CentralizedSchemaMetadataQueryDisabledTest
   }
 
   @Nested
-  @Disabled("Disabled due to issues with compaction task not publishing schema to broker")
   public class CompactionTask extends CompactionTaskTest
   {
     @Override
@@ -68,7 +66,6 @@ public class CentralizedSchemaMetadataQueryDisabledTest
   }
 
   @Nested
-  @Disabled("Disabled due to issues with compaction task not publishing schema to broker")
   public class KafkaDataFormats extends KafkaDataFormatsTest
   {
     @Override

--- a/server/src/main/java/org/apache/druid/segment/metadata/Metric.java
+++ b/server/src/main/java/org/apache/druid/segment/metadata/Metric.java
@@ -44,6 +44,7 @@ public class Metric
   // Broker-side metrics
   public static final String BROKER_POLL_DURATION_MILLIS = PREFIX + "poll/time";
   public static final String BROKER_POLL_FAILED = PREFIX + "poll/failed";
+  public static final String BROKER_SEGMENTS_SKIPPED_REFRESH = PREFIX + "refreshSkipped/count";
 
   // Schema refresh metrics
   public static final String STARTUP_DURATION_MILLIS = "metadatacache/init/time";


### PR DESCRIPTION
As follow-up of #18497 , this PR re-enables the embedded tests in `CentralizedSchemaMetadataQueryDisabledTest`

- The earlier failures were because if the coordinator returns metadata in data source information, the segment cache skips the update of the relevant segment ids.
- To tackle this, we can wait on the skipped segment count metric instead (introduced in this PR).

Weirdly, this is not unblocking `CentralizedSchemaPublishFailureTest` (the no. of segments skipped and the no. of segments refreshed seems to be changing erratically in tests and is never what we want, will take a look at those tests in separate PR.)