### PR TITLE
Add support for caching ScanQuery results

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1392,7 +1392,7 @@ You can optionally configure caching to be enabled on the peons by setting cachi
 |--------|---------------|-----------|-------|
 |`druid.realtime.cache.useCache`|true, false|Enable the cache on the realtime.|false|
 |`druid.realtime.cache.populateCache`|true, false|Populate the cache on the realtime.|false|
-|`druid.realtime.cache.unCacheable`|All druid query types|All query types to not cache.|`[]`|
+|`druid.realtime.cache.unCacheable`|All druid query types|All query types to not cache.|`[scan]`|
 |`druid.realtime.cache.maxEntrySize`|positive integer|Maximum cache entry size in bytes.|1_000_000|
 
 See [cache configuration](#cache-configuration) for how to configure cache settings.
@@ -1534,7 +1534,7 @@ You can optionally configure caching to be enabled on the Indexer by setting cac
 |--------|---------------|-----------|-------|
 |`druid.realtime.cache.useCache`|true, false|Enable the cache on the realtime.|false|
 |`druid.realtime.cache.populateCache`|true, false|Populate the cache on the realtime.|false|
-|`druid.realtime.cache.unCacheable`|All druid query types|All query types to not cache.|`[]`|
+|`druid.realtime.cache.unCacheable`|All druid query types|All query types to not cache.|`[scan]`|
 |`druid.realtime.cache.maxEntrySize`|positive integer|Maximum cache entry size in bytes.|1_000_000|
 
 See [cache configuration](#cache-configuration) for how to configure cache settings.
@@ -1642,7 +1642,7 @@ You can optionally only configure caching to be enabled on the Historical by set
 |--------|---------------|-----------|-------|
 |`druid.historical.cache.useCache`|true, false|Enable the cache on the Historical.|false|
 |`druid.historical.cache.populateCache`|true, false|Populate the cache on the Historical.|false|
-|`druid.historical.cache.unCacheable`|All druid query types|All query types to not cache.|`[]`|
+|`druid.historical.cache.unCacheable`|All druid query types|All query types to not cache.|`[scan]`|
 |`druid.historical.cache.maxEntrySize`|positive integer|Maximum cache entry size in bytes.|1_000_000|
 
 See [cache configuration](#cache-configuration) for how to configure cache settings.
@@ -1898,7 +1898,7 @@ You can optionally only configure caching to be enabled on the Broker by setting
 |`druid.broker.cache.useResultLevelCache`|true, false|Enable result level caching on the Broker.|false|
 |`druid.broker.cache.populateResultLevelCache`|true, false|Populate the result level cache on the Broker.|false|
 |`druid.broker.cache.resultLevelCacheLimit`|positive integer|Maximum size of query response that can be cached.|`Integer.MAX_VALUE`|
-|`druid.broker.cache.unCacheable`|All druid query types|All query types to not cache.|`[]`|
+|`druid.broker.cache.unCacheable`|All druid query types|All query types to not cache.|`[scan]`|
 |`druid.broker.cache.cacheBulkMergeLimit`|positive integer or 0|Queries with more segments than this number will not attempt to fetch from cache at the broker level, leaving potential caching fetches (and cache result merging) to the Historicals|`Integer.MAX_VALUE`|
 |`druid.broker.cache.maxEntrySize`|positive integer|Maximum cache entry size in bytes.|1_000_000|
 

--- a/docs/querying/query-execution.md
+++ b/docs/querying/query-execution.md
@@ -51,8 +51,7 @@ and tasks running on Middle Managers) that are currently serving those segments.
 
 4. For all query types except [Scan](scan-query.md), data servers process each segment in parallel and generate partial
 results for each segment. The specific processing that is done depends on the query type. These partial results may be
-cached if [query caching](caching.md) is enabled. For Scan queries, segments are processed in order by a single thread,
-and results are not cached.
+cached if [query caching](caching.md) is enabled. For Scan queries, segments are processed in order by a single thread.
 
 5. The Broker receives partial results from each data server, merges them into the final result set, and returns them
 to the caller. For Timeseries and Scan queries, and for GroupBy queries where there is no sorting, the Broker is able to

--- a/processing/src/main/java/org/apache/druid/query/CacheStrategy.java
+++ b/processing/src/main/java/org/apache/druid/query/CacheStrategy.java
@@ -62,11 +62,11 @@ public interface CacheStrategy<T, CacheType, QueryType extends Query<T>>
    * @param query            the query to be cached
    * @param willMergeRunners indicates that {@link QueryRunnerFactory#mergeRunners(QueryProcessingPool, Iterable)} will be
    *                         called on the cached by-segment results
-   * @param bySegment        segment level or result level cache
+   * @param segmentLevel        segment level or result level cache
    *
    * @return true if the query is cacheable, otherwise false.
    */
-  default boolean isCacheable(QueryType query, boolean willMergeRunners, boolean bySegment)
+  default boolean isCacheable(QueryType query, boolean willMergeRunners, boolean segmentLevel)
   {
     return isCacheable(query, willMergeRunners);
   }

--- a/processing/src/main/java/org/apache/druid/query/Order.java
+++ b/processing/src/main/java/org/apache/druid/query/Order.java
@@ -21,9 +21,10 @@ package org.apache.druid.query;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.druid.java.util.common.Cacheable;
 import org.apache.druid.java.util.common.StringUtils;
 
-public enum Order
+public enum Order implements Cacheable
 {
   ASCENDING,
   DESCENDING,
@@ -40,5 +41,11 @@ public enum Order
   public static Order fromString(String name)
   {
     return valueOf(StringUtils.toUpperCase(name));
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    return StringUtils.toUtf8(toString());
   }
 }

--- a/processing/src/main/java/org/apache/druid/query/OrderBy.java
+++ b/processing/src/main/java/org/apache/druid/query/OrderBy.java
@@ -22,12 +22,13 @@ package org.apache.druid.query;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import org.apache.druid.java.util.common.Cacheable;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 
 import java.util.Objects;
 
-public class OrderBy
+public class OrderBy implements Cacheable
 {
   public static OrderBy ascending(String columnName)
   {
@@ -112,4 +113,9 @@ public class OrderBy
     return StringUtils.format("%s %s", columnName, order == Order.ASCENDING ? "ASC" : "DESC");
   }
 
+  @Override
+  public byte[] getCacheKey()
+  {
+    return StringUtils.toUtf8(toString());
+  }
 }

--- a/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/groupby/GroupByQueryQueryToolChest.java
@@ -559,11 +559,11 @@ public class GroupByQueryQueryToolChest extends QueryToolChest<ResultRow, GroupB
       private final List<DimensionSpec> dims = query.getDimensions();
 
       @Override
-      public boolean isCacheable(GroupByQuery query, boolean willMergeRunners, boolean bySegment)
+      public boolean isCacheable(GroupByQuery query, boolean willMergeRunners, boolean segmentLevel)
       {
         //disable segment-level cache on borker,
         //see PR https://github.com/apache/druid/issues/3820
-        return willMergeRunners || !bySegment;
+        return willMergeRunners || !segmentLevel;
       }
 
       @Override

--- a/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -197,7 +197,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
     return new CacheStrategy<>()
     {
       @Override
-      public boolean isCacheable(SegmentMetadataQuery query, boolean willMergeRunners, boolean bySegment)
+      public boolean isCacheable(SegmentMetadataQuery query, boolean willMergeRunners, boolean segmentLevel)
       {
         return true;
       }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, ScanQuery>
 {
   private static final byte SCAN_QUERY = 0x13;
+  private static final byte CACHE_STRATEGY_VERSION = 0x1;
   private static final TypeReference<ScanResultValue> TYPE_REFERENCE = new TypeReference<>() {};
 
   private final GenericQueryMetricsFactory queryMetricsFactory;
@@ -219,6 +220,8 @@ public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, Sca
       public byte[] computeCacheKey(ScanQuery query)
       {
         CacheKeyBuilder builder = new CacheKeyBuilder(SCAN_QUERY)
+            .appendByte(CACHE_STRATEGY_VERSION)
+            .appendCacheable(query.getDataSource())
             .appendCacheable(query.getVirtualColumns())
             .appendString(query.getResultFormat().toString())
             .appendLong(query.getScanRowsOffset())
@@ -227,8 +230,9 @@ public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, Sca
             .appendStrings(query.getColumns() != null ? query.getColumns() : List.of())
             .appendString(query.getTimeOrder().toString());
 
-        if (query.getOrderBys() != null && !query.getOrderBys().isEmpty()) {
-          for (OrderBy orderBy : query.getOrderBys()) {
+        List<OrderBy> orderBys = query.getOrderBys();
+        if (orderBys != null) {
+          for (OrderBy orderBy : orderBys) {
             builder.appendString(orderBy.getColumnName())
                    .appendString(orderBy.getOrder().toString());
           }

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
@@ -41,6 +41,7 @@ import org.apache.druid.query.QueryRunner;
 import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.aggregation.MetricManipulationFn;
 import org.apache.druid.query.cache.CacheKeyBuilder;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.utils.CloseableUtils;
 
@@ -221,21 +222,22 @@ public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, Sca
       {
         CacheKeyBuilder builder = new CacheKeyBuilder(SCAN_QUERY)
             .appendByte(CACHE_STRATEGY_VERSION)
-            .appendCacheable(query.getDataSource())
             .appendCacheable(query.getVirtualColumns())
             .appendString(query.getResultFormat().toString())
             .appendLong(query.getScanRowsOffset())
             .appendLong(query.getScanRowsLimit())
             .appendCacheable(query.getFilter())
             .appendStrings(query.getColumns() != null ? query.getColumns() : List.of())
-            .appendString(query.getTimeOrder().toString());
+            .appendCacheable(query.getTimeOrder());
 
         List<OrderBy> orderBys = query.getOrderBys();
         if (orderBys != null) {
-          for (OrderBy orderBy : orderBys) {
-            builder.appendString(orderBy.getColumnName())
-                   .appendString(orderBy.getOrder().toString());
-          }
+          builder.appendCacheables(orderBys);
+        }
+
+        List<ColumnType> columnTypes = query.getColumnTypes();
+        if (columnTypes != null) {
+          builder.appendCacheables(columnTypes);
         }
 
         return builder.build();

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.query.scan;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
@@ -30,22 +31,28 @@ import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.guava.BaseSequence;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.guava.Sequences;
+import org.apache.druid.query.CacheStrategy;
 import org.apache.druid.query.FrameSignaturePair;
 import org.apache.druid.query.GenericQueryMetricsFactory;
+import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.QueryRunner;
 import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.aggregation.MetricManipulationFn;
+import org.apache.druid.query.cache.CacheKeyBuilder;
+import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.utils.CloseableUtils;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, ScanQuery>
 {
+  private static final byte SCAN_QUERY = 0x13;
   private static final TypeReference<ScanResultValue> TYPE_REFERENCE = new TypeReference<>() {};
 
   private final GenericQueryMetricsFactory queryMetricsFactory;
@@ -189,6 +196,80 @@ public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, Sca
           return Sequences.simple(arrays);
         }
     );
+  }
+
+  @Override
+  public CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> getCacheStrategy(
+      final ScanQuery query,
+      @Nullable final ObjectMapper objectMapper
+  )
+  {
+    return new CacheStrategy<>()
+    {
+      @Override
+      public boolean isCacheable(ScanQuery query, boolean willMergeRunners, boolean segmentLevel)
+      {
+        // Currently, there is no bijective mapping from ScanResultValue to Result<BySegmentResultValueClass<ScanResultValue>>.
+        // This means queries will fail if:
+        //   - A query is issued with bySegment:true
+        //   - Segment-level cache is enabled on the broker (in which case it sends bySegment queries to data nodes).
+        return !query.context().isBySegment() && (!segmentLevel || willMergeRunners);
+      }
+
+      @Override
+      public byte[] computeCacheKey(ScanQuery query)
+      {
+        CacheKeyBuilder builder = new CacheKeyBuilder(SCAN_QUERY)
+            .appendCacheable(query.getVirtualColumns())
+            .appendString(query.getResultFormat().toString())
+            .appendInt(query.getBatchSize())
+            .appendLong(query.getScanRowsOffset())
+            .appendLong(query.getScanRowsLimit())
+            .appendCacheable(query.getFilter())
+            .appendStrings(query.getColumns() != null ? query.getColumns() : List.of())
+            .appendString(query.getTimeOrder().toString());
+
+        if (query.getOrderBys() != null && !query.getOrderBys().isEmpty()) {
+          for (OrderBy orderBy : query.getOrderBys()) {
+            builder.appendString(orderBy.getColumnName())
+                   .appendString(orderBy.getOrder().toString());
+          }
+        }
+
+        if (query.getColumnTypes() != null && !query.getColumnTypes().isEmpty()) {
+          for (ColumnType columnType : query.getColumnTypes()) {
+            builder.appendString(columnType.toString());
+          }
+        }
+
+        return builder.build();
+      }
+
+      @Override
+      public byte[] computeResultLevelCacheKey(ScanQuery query)
+      {
+        // Use the same key as segment-level cache no result-level transformations like aggregations
+        return computeCacheKey(query);
+      }
+
+      @Override
+      public TypeReference<ScanResultValue> getCacheObjectClazz()
+      {
+        return TYPE_REFERENCE;
+      }
+
+      @Override
+      public Function<ScanResultValue, ScanResultValue> prepareForCache(boolean isResultLevelCache)
+      {
+        return input -> input;
+      }
+
+      @Override
+      public Function<ScanResultValue, ScanResultValue> pullFromCache(boolean isResultLevelCache)
+      {
+        return input -> input;
+      }
+    };
   }
 
   private static Function<?, Object[]> getResultFormatMapper(ScanQuery.ResultFormat resultFormat, List<String> fields)

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryQueryToolChest.java
@@ -41,7 +41,6 @@ import org.apache.druid.query.QueryRunner;
 import org.apache.druid.query.QueryToolChest;
 import org.apache.druid.query.aggregation.MetricManipulationFn;
 import org.apache.druid.query.cache.CacheKeyBuilder;
-import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.utils.CloseableUtils;
 
@@ -222,7 +221,6 @@ public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, Sca
         CacheKeyBuilder builder = new CacheKeyBuilder(SCAN_QUERY)
             .appendCacheable(query.getVirtualColumns())
             .appendString(query.getResultFormat().toString())
-            .appendInt(query.getBatchSize())
             .appendLong(query.getScanRowsOffset())
             .appendLong(query.getScanRowsLimit())
             .appendCacheable(query.getFilter())
@@ -233,12 +231,6 @@ public class ScanQueryQueryToolChest extends QueryToolChest<ScanResultValue, Sca
           for (OrderBy orderBy : query.getOrderBys()) {
             builder.appendString(orderBy.getColumnName())
                    .appendString(orderBy.getOrder().toString());
-          }
-        }
-
-        if (query.getColumnTypes() != null && !query.getColumnTypes().isEmpty()) {
-          for (ColumnType columnType : query.getColumnTypes()) {
-            builder.appendString(columnType.toString());
           }
         }
 

--- a/processing/src/main/java/org/apache/druid/query/search/SearchQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/search/SearchQueryQueryToolChest.java
@@ -142,7 +142,7 @@ public class SearchQueryQueryToolChest extends QueryToolChest<Result<SearchResul
                                                   : Collections.emptyList();
 
       @Override
-      public boolean isCacheable(SearchQuery query, boolean willMergeRunners, boolean bySegment)
+      public boolean isCacheable(SearchQuery query, boolean willMergeRunners, boolean segmentLevel)
       {
         return true;
       }

--- a/processing/src/main/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/timeboundary/TimeBoundaryQueryQueryToolChest.java
@@ -175,7 +175,7 @@ public class TimeBoundaryQueryQueryToolChest
     return new CacheStrategy<>()
     {
       @Override
-      public boolean isCacheable(TimeBoundaryQuery query, boolean willMergeRunners, boolean bySegment)
+      public boolean isCacheable(TimeBoundaryQuery query, boolean willMergeRunners, boolean segmentLevel)
       {
         return true;
       }

--- a/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/timeseries/TimeseriesQueryQueryToolChest.java
@@ -275,7 +275,7 @@ public class TimeseriesQueryQueryToolChest extends QueryToolChest<Result<Timeser
       private final List<AggregatorFactory> aggs = query.getAggregatorSpecs();
 
       @Override
-      public boolean isCacheable(TimeseriesQuery query, boolean willMergeRunners, boolean bySegment)
+      public boolean isCacheable(TimeseriesQuery query, boolean willMergeRunners, boolean segmentLevel)
       {
         return true;
       }

--- a/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
+++ b/processing/src/main/java/org/apache/druid/query/topn/TopNQueryQueryToolChest.java
@@ -287,7 +287,7 @@ public class TopNQueryQueryToolChest extends QueryToolChest<Result<TopNResultVal
       );
 
       @Override
-      public boolean isCacheable(TopNQuery query, boolean willMergeRunners, boolean bySegment)
+      public boolean isCacheable(TopNQuery query, boolean willMergeRunners, boolean segmentLevel)
       {
         return true;
       }

--- a/processing/src/main/java/org/apache/druid/segment/column/ColumnType.java
+++ b/processing/src/main/java/org/apache/druid/segment/column/ColumnType.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.apache.druid.java.util.common.Cacheable;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.nested.NestedDataComplexTypeSerde;
 
 import javax.annotation.Nullable;
@@ -34,7 +36,7 @@ import java.util.Objects;
  * @see TypeSignature
  */
 @JsonSerialize(using = ToStringSerializer.class)
-public class ColumnType extends BaseTypeSignature<ValueType>
+public class ColumnType extends BaseTypeSignature<ValueType> implements Cacheable
 {
   /**
    * Druid string type. Values will be represented as {@link String} or {@link java.util.List<String>} in the case
@@ -243,5 +245,11 @@ public class ColumnType extends BaseTypeSignature<ValueType>
       leastRestrictiveType = leastRestrictiveType(leastRestrictiveType, type);
     }
     return leastRestrictiveType;
+  }
+
+  @Override
+  public byte[] getCacheKey()
+  {
+    return StringUtils.toUtf8(toString());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryQueryToolChestTest.java
@@ -639,32 +639,6 @@ public class ScanQueryQueryToolChestTest
   }
 
   @Test
-  public void testCacheKeyWithColumnTypes()
-  {
-    ScanQuery queryWithColumnTypes = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "metric1")
-        .columnTypes(ColumnType.STRING, ColumnType.LONG)
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
-
-    ScanQuery queryWithoutColumnTypes = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "metric1")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
-
-    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(queryWithColumnTypes, null);
-
-    byte[] cacheKeyWithColumnTypes = strategy.computeCacheKey(queryWithColumnTypes);
-    byte[] cacheKeyWithoutColumnTypes = strategy.computeCacheKey(queryWithoutColumnTypes);
-
-    Assert.assertFalse(Arrays.equals(cacheKeyWithColumnTypes, cacheKeyWithoutColumnTypes));
-  }
-
-  @Test
   public void testCacheKeyWithOffsetAndLimit()
   {
     ScanQuery queryWithOffsetLimit = Druids.newScanQueryBuilder()

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryQueryToolChestTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.FrameBasedInlineDataSource;
 import org.apache.druid.query.FrameSignaturePair;
+import org.apache.druid.query.Order;
 import org.apache.druid.query.OrderBy;
 import org.apache.druid.query.QueryToolChestTestHelper;
 import org.apache.druid.query.filter.EqualityFilter;
@@ -452,14 +453,15 @@ public class ScanQueryQueryToolChestTest
   public void testCacheStrategy()
   {
     ScanQuery query = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2015-01-01/2015-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .batchSize(4096)
-        .offset(10)
-        .limit(100)
-        .build();
+                            .dataSource("foo")
+                            .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                "2015-01-01/2015-01-02"))))
+                            .columns("dim1", "dim2")
+                            .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                            .batchSize(4096)
+                            .offset(10)
+                            .limit(100)
+                            .build();
 
     CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(query, null);
 
@@ -475,7 +477,7 @@ public class ScanQueryQueryToolChestTest
     byte[] resultLevelCacheKey = strategy.computeResultLevelCacheKey(query);
     Assert.assertNotNull(resultLevelCacheKey);
     Assert.assertTrue(resultLevelCacheKey.length > 0);
-    
+
     // For ScanQuery, result-level and segment-level cache keys should be the same
     Assert.assertArrayEquals(cacheKey, resultLevelCacheKey);
 
@@ -499,7 +501,8 @@ public class ScanQueryQueryToolChestTest
   {
     ScanQuery query = Druids.newScanQueryBuilder()
                             .dataSource("foo")
-                            .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2015-01-01/2015-01-02"))))
+                            .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                "2015-01-01/2015-01-02"))))
                             .columns("dim1", "dim2")
                             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
                             .batchSize(4096)
@@ -519,25 +522,28 @@ public class ScanQueryQueryToolChestTest
   public void testCacheKeyDifferentQueries()
   {
     ScanQuery query1 = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
+                             .dataSource("foo")
+                             .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                 "2025-01-01/2025-01-02"))))
+                             .columns("dim1", "dim2")
+                             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                             .build();
 
     ScanQuery query2 = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim3")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
+                             .dataSource("foo")
+                             .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                 "2025-01-01/2025-01-02"))))
+                             .columns("dim1", "dim3")
+                             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                             .build();
 
     ScanQuery query3 = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-        .build();
+                             .dataSource("foo")
+                             .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                 "2025-01-01/2025-01-02"))))
+                             .columns("dim1", "dim2")
+                             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                             .build();
 
     CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(query1, null);
 
@@ -554,21 +560,26 @@ public class ScanQueryQueryToolChestTest
   public void testCacheKeyWithFilters()
   {
     ScanQuery queryWithFilter = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .filters(new EqualityFilter("dim1", ColumnType.STRING, "test", null))
-        .build();
+                                      .dataSource("foo")
+                                      .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                          "2025-01-01/2025-01-02"))))
+                                      .columns("dim1", "dim2")
+                                      .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                      .filters(new EqualityFilter("dim1", ColumnType.STRING, "test", null))
+                                      .build();
 
     ScanQuery queryWithoutFilter = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
+                                         .dataSource("foo")
+                                         .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                             "2025-01-01/2025-01-02"))))
+                                         .columns("dim1", "dim2")
+                                         .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                         .build();
 
-    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(queryWithFilter, null);
+    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(
+        queryWithFilter,
+        null
+    );
 
     byte[] cacheKeyWithFilter = strategy.computeCacheKey(queryWithFilter);
     byte[] cacheKeyWithoutFilter = strategy.computeCacheKey(queryWithoutFilter);
@@ -580,21 +591,31 @@ public class ScanQueryQueryToolChestTest
   public void testCacheKeyWithVirtualColumns()
   {
     ScanQuery queryWithVirtual = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "virtual_col")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .virtualColumns(new ExpressionVirtualColumn("virtual_col", "dim1 + '_suffix'", ColumnType.STRING, ExprMacroTable.nil()))
-        .build();
+                                       .dataSource("foo")
+                                       .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                           "2025-01-01/2025-01-02"))))
+                                       .columns("dim1", "virtual_col")
+                                       .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                       .virtualColumns(new ExpressionVirtualColumn(
+                                           "virtual_col",
+                                           "dim1 + '_suffix'",
+                                           ColumnType.STRING,
+                                           ExprMacroTable.nil()
+                                       ))
+                                       .build();
 
     ScanQuery queryWithoutVirtual = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
+                                          .dataSource("foo")
+                                          .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                              "2025-01-01/2025-01-02"))))
+                                          .columns("dim1")
+                                          .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                          .build();
 
-    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(queryWithVirtual, null);
+    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(
+        queryWithVirtual,
+        null
+    );
 
     byte[] cacheKeyWithVirtual = strategy.computeCacheKey(queryWithVirtual);
     byte[] cacheKeyWithoutVirtual = strategy.computeCacheKey(queryWithoutVirtual);
@@ -606,29 +627,35 @@ public class ScanQueryQueryToolChestTest
   public void testCacheKeyWithOrderBy()
   {
     ScanQuery queryWithOrderBy = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .orderBy(List.of(OrderBy.descending("dim1")))
-        .build();
+                                       .dataSource("foo")
+                                       .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                           "2025-01-01/2025-01-02"))))
+                                       .columns("dim1", "dim2")
+                                       .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                       .orderBy(List.of(OrderBy.descending("dim1")))
+                                       .build();
 
     ScanQuery queryWithoutOrderBy = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
+                                          .dataSource("foo")
+                                          .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                              "2025-01-01/2025-01-02"))))
+                                          .columns("dim1", "dim2")
+                                          .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                          .build();
 
     ScanQuery queryWithDifferentOrderBy = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                                .dataSource("foo")
+                                                .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                                    "2025-01-01/2025-01-02"))))
+                                                .columns("dim1", "dim2")
+                                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
                                                 .orderBy(List.of(OrderBy.ascending("dim1")))
-        .build();
+                                                .build();
 
-    final CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(queryWithOrderBy, null);
+    final CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(
+        queryWithOrderBy,
+        null
+    );
 
     final byte[] cacheKeyWithOrderBy = strategy.computeCacheKey(queryWithOrderBy);
     final byte[] cacheKeyWithoutOrderBy = strategy.computeCacheKey(queryWithoutOrderBy);
@@ -642,22 +669,27 @@ public class ScanQueryQueryToolChestTest
   public void testCacheKeyWithOffsetAndLimit()
   {
     ScanQuery queryWithOffsetLimit = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .offset(10)
-        .limit(100)
-        .build();
+                                           .dataSource("foo")
+                                           .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                               "2025-01-01/2025-01-02"))))
+                                           .columns("dim1", "dim2")
+                                           .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                           .offset(10)
+                                           .limit(100)
+                                           .build();
 
     ScanQuery queryWithoutOffsetLimit = Druids.newScanQueryBuilder()
-        .dataSource("foo")
-        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-        .columns("dim1", "dim2")
-        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-        .build();
+                                              .dataSource("foo")
+                                              .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                                  "2025-01-01/2025-01-02"))))
+                                              .columns("dim1", "dim2")
+                                              .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                              .build();
 
-    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(queryWithOffsetLimit, null);
+    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(
+        queryWithOffsetLimit,
+        null
+    );
 
     byte[] cacheKeyWithOffsetLimit = strategy.computeCacheKey(queryWithOffsetLimit);
     byte[] cacheKeyWithoutOffsetLimit = strategy.computeCacheKey(queryWithoutOffsetLimit);
@@ -669,27 +701,94 @@ public class ScanQueryQueryToolChestTest
   public void testCacheKeyWithDifferentResultFormat()
   {
     ScanQuery queryWithCompactedList = Druids.newScanQueryBuilder()
-                                           .dataSource("foo")
-                                           .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-                                           .columns("dim1", "dim2")
-                                           .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
-                                           .offset(10)
-                                           .limit(100)
-                                           .build();
+                                             .dataSource("foo")
+                                             .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                                 "2025-01-01/2025-01-02"))))
+                                             .columns("dim1", "dim2")
+                                             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                             .offset(10)
+                                             .limit(100)
+                                             .build();
 
     ScanQuery queryWithResultFormatList = Druids.newScanQueryBuilder()
-                                           .dataSource("foo")
-                                           .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
-                                           .columns("dim1", "dim2")
-                                           .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
-                                           .offset(10)
-                                           .limit(100)
-                                           .build();
-    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(queryWithCompactedList, null);
+                                                .dataSource("foo")
+                                                .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                                    "2025-01-01/2025-01-02"))))
+                                                .columns("dim1", "dim2")
+                                                .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                                .offset(10)
+                                                .limit(100)
+                                                .build();
+    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(
+        queryWithCompactedList,
+        null
+    );
 
     byte[] cacheKeyWithCompactedList = strategy.computeCacheKey(queryWithCompactedList);
     byte[] cacheKeyWithResultFormatList = strategy.computeCacheKey(queryWithResultFormatList);
 
     Assert.assertFalse(Arrays.equals(cacheKeyWithCompactedList, cacheKeyWithResultFormatList));
+  }
+
+  @Test
+  public void testCacheKeyWithDifferentTimeOrder()
+  {
+    ScanQuery queryWithOrderDesc = Druids.newScanQueryBuilder()
+                                         .dataSource("foo")
+                                         .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                             "2025-01-01/2025-01-02"))))
+                                         .columns("__time", "dim1", "dim2")
+                                         .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                         .order(Order.DESCENDING)
+                                         .build();
+
+    ScanQuery queryWithOrderAsc = Druids.newScanQueryBuilder()
+                                        .dataSource("foo")
+                                        .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                            "2025-01-01/2025-01-02"))))
+                                        .columns("__time", "dim1", "dim2")
+                                        .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                        .order(Order.ASCENDING)
+                                        .build();
+    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(
+        queryWithOrderDesc,
+        null
+    );
+
+    byte[] cacheKeyWithOrderDesc = strategy.computeCacheKey(queryWithOrderDesc);
+    byte[] cacheKeyWithOrderAsc = strategy.computeCacheKey(queryWithOrderAsc);
+
+    Assert.assertFalse(Arrays.equals(cacheKeyWithOrderDesc, cacheKeyWithOrderAsc));
+  }
+
+  @Test
+  public void testCacheKeyWithDifferentColumnTypes()
+  {
+    ScanQuery query1 = Druids.newScanQueryBuilder()
+                             .dataSource("foo")
+                             .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                 "2025-01-01/2025-01-02"))))
+                             .columns("__time", "dim1", "dim2")
+                             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                             .columnTypes(List.of(ColumnType.LONG, ColumnType.STRING, ColumnType.STRING))
+                             .build();
+
+    ScanQuery query2 = Druids.newScanQueryBuilder()
+                             .dataSource("foo")
+                             .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of(
+                                 "2025-01-01/2025-01-02"))))
+                             .columns("__time", "dim1", "dim2")
+                             .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                             .columnTypes(List.of(ColumnType.LONG, ColumnType.STRING, ColumnType.STRING_ARRAY))
+                             .build();
+    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(
+        query1,
+        null
+    );
+
+    byte[] cacheKeyQuery1 = strategy.computeCacheKey(query1);
+    byte[] cacheKeyQuery2 = strategy.computeCacheKey(query2);
+
+    Assert.assertFalse(Arrays.equals(cacheKeyQuery1, cacheKeyQuery2));
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryQueryToolChestTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryQueryToolChestTest.java
@@ -664,4 +664,32 @@ public class ScanQueryQueryToolChestTest
 
     Assert.assertFalse(Arrays.equals(cacheKeyWithOffsetLimit, cacheKeyWithoutOffsetLimit));
   }
+
+  @Test
+  public void testCacheKeyWithDifferentResultFormat()
+  {
+    ScanQuery queryWithCompactedList = Druids.newScanQueryBuilder()
+                                           .dataSource("foo")
+                                           .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
+                                           .columns("dim1", "dim2")
+                                           .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST)
+                                           .offset(10)
+                                           .limit(100)
+                                           .build();
+
+    ScanQuery queryWithResultFormatList = Druids.newScanQueryBuilder()
+                                           .dataSource("foo")
+                                           .intervals(new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2025-01-01/2025-01-02"))))
+                                           .columns("dim1", "dim2")
+                                           .resultFormat(ScanQuery.ResultFormat.RESULT_FORMAT_LIST)
+                                           .offset(10)
+                                           .limit(100)
+                                           .build();
+    CacheStrategy<ScanResultValue, ScanResultValue, ScanQuery> strategy = toolChest.getCacheStrategy(queryWithCompactedList, null);
+
+    byte[] cacheKeyWithCompactedList = strategy.computeCacheKey(queryWithCompactedList);
+    byte[] cacheKeyWithResultFormatList = strategy.computeCacheKey(queryWithResultFormatList);
+
+    Assert.assertFalse(Arrays.equals(cacheKeyWithCompactedList, cacheKeyWithResultFormatList));
+  }
 }

--- a/server/src/main/java/org/apache/druid/client/CacheUtil.java
+++ b/server/src/main/java/org/apache/druid/client/CacheUtil.java
@@ -29,7 +29,6 @@ import org.apache.druid.query.SegmentDescriptor;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
-
 import java.nio.ByteBuffer;
 
 public class CacheUtil
@@ -174,18 +173,18 @@ public class CacheUtil
    * @param cacheStrategy result of {@link QueryToolChest#getCacheStrategy} on this query
    * @param cacheConfig   current active cache config
    * @param serverType    BROKER or DATA
-   * @param bySegment     segement level or result-level cache
+   * @param segmentLevel     segement level or result-level cache
    */
   static <T> boolean isQueryCacheable(
       final Query<T> query,
       @Nullable final CacheStrategy<T, Object, Query<T>> cacheStrategy,
       final CacheConfig cacheConfig,
       final ServerType serverType,
-      final boolean bySegment
+      final boolean segmentLevel
   )
   {
     return cacheStrategy != null
-           && cacheStrategy.isCacheable(query, serverType.willMergeRunners(), bySegment)
+           && cacheStrategy.isCacheable(query, serverType.willMergeRunners(), segmentLevel)
            && cacheConfig.isQueryCacheable(query)
            && query.getDataSource().isCacheable(serverType == ServerType.BROKER);
   }

--- a/server/src/main/java/org/apache/druid/client/CacheUtil.java
+++ b/server/src/main/java/org/apache/druid/client/CacheUtil.java
@@ -173,7 +173,7 @@ public class CacheUtil
    * @param cacheStrategy result of {@link QueryToolChest#getCacheStrategy} on this query
    * @param cacheConfig   current active cache config
    * @param serverType    BROKER or DATA
-   * @param segmentLevel     segement level or result-level cache
+   * @param segmentLevel  segment level or result-level cache
    */
   static <T> boolean isQueryCacheable(
       final Query<T> query,

--- a/server/src/main/java/org/apache/druid/client/cache/CacheConfig.java
+++ b/server/src/main/java/org/apache/druid/client/cache/CacheConfig.java
@@ -54,8 +54,12 @@ public class CacheConfig
   @JsonProperty
   private int maxEntrySize = 1_000_000;
 
+  /*
+    Disable segment/result-level caching for types:
+      - [scan]: scan query results can be large and fill up small result/segment caches, so disabled by default.
+  */
   @JsonProperty
-  private List<String> unCacheable = ImmutableList.of();
+  private List<String> unCacheable = ImmutableList.of(Query.SCAN);
 
   @JsonProperty
   private int resultLevelCacheLimit = Integer.MAX_VALUE;

--- a/server/src/main/java/org/apache/druid/client/cache/CacheConfig.java
+++ b/server/src/main/java/org/apache/druid/client/cache/CacheConfig.java
@@ -20,7 +20,6 @@
 package org.apache.druid.client.cache;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 import org.apache.druid.query.Query;
 
 import javax.validation.constraints.Min;
@@ -59,7 +58,7 @@ public class CacheConfig
       - [scan]: scan query results can be large and fill up small result/segment caches, so disabled by default.
   */
   @JsonProperty
-  private List<String> unCacheable = ImmutableList.of(Query.SCAN);
+  private List<String> unCacheable = List.of(Query.SCAN);
 
   @JsonProperty
   private int resultLevelCacheLimit = Integer.MAX_VALUE;

--- a/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
+++ b/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
@@ -176,7 +176,7 @@ public class CacheUtilTest
     }
 
     @Override
-    public boolean isCacheable(QueryType query, boolean willMergeRunners, boolean bySegment)
+    public boolean isCacheable(QueryType query, boolean willMergeRunners, boolean segmentLevel)
     {
       return willMergeRunners ? cacheableOnDataServers : cacheableOnBrokers;
     }

--- a/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
+++ b/server/src/test/java/org/apache/druid/client/cache/CacheConfigTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.JsonConfigurator;
 import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.query.Query;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -95,6 +96,7 @@ public class CacheConfigTest
     Assert.assertEquals(true, config.isPopulateCache());
     Assert.assertEquals(true, config.isUseCache());
   }
+
   @Test
   public void testInjection2()
   {
@@ -158,5 +160,22 @@ public class CacheConfigTest
     throw new IllegalStateException("Should have already failed");
   }
 
+  @Test
+  public void testDefaultUnCacheableList()
+  {
+    configProvider.inject(properties, configurator);
+    CacheConfig config = configProvider.get();
+    injector.injectMembers(config);
 
+    Assert.assertFalse(config.isQueryCacheable(Query.SCAN));
+
+    properties.clear();
+    configProvider = JsonConfigProvider.of(PROPERTY_PREFIX, CacheConfig.class);
+
+    properties.put(PROPERTY_PREFIX + ".unCacheable", "[]");
+    configProvider.inject(properties, configurator);
+    CacheConfig config2 = configProvider.get();
+    injector.injectMembers(config2);
+    Assert.assertTrue(config2.isQueryCacheable(Query.SCAN));
+  }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Adds support for result-level caching of scan queries. Despite being a relatively infrequent query type, a small, sustained volume of these queries can put significant load on a cluster as these don't run on processing threads and tend to eat a lot of CPU + return big result sets.

#### Errors/Bugs
This PR also unearthed some bugs w.r.t segment-level cache handling on the Broker, as well as `bySegment` query cache handling in general. All cacheable query types which do not implement a proper mapping of result type `T` to `BySegmentResultValueClass<T>` (in other words, all but `topN` and `search`) will fail in the following scenarios:
- `bySegment:true` is passed in the query context.
- Broker has segment-level cache enabled. This is because [these](https://github.com/apache/druid/blob/-/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java#L313-L314) 2 lines effectively "force" the data node to return in bySegment result format, but caching a bySegment result breaks for all query types except `topN` + `search`, as they have their own custom `BySegmentResultValueClass` classes. This exception is thrown in the [first call](https://github.com/apache/druid/blob/-/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java#L773) to cache entry creation.

An example is as follows:
```
2025-09-28T21:34:48,651 ERROR [main] org.apache.druid.testsEx.indexer.AbstractITBatchIndexTest - Error while running test query at path /indexer/wikipedia_index_schemaless_queries.json
java.lang.RuntimeException: org.apache.druid.java.util.common.ISE: Error while querying[http://localhost:8082/druid/v2/sql] status[500 Server Error] content[{"error":"Unknown exception","errorClass":"java.lang.ClassCastException","host":"historical:8083","errorCode":"legacyQueryException","persona":"OPERATOR","category":"RUNTIME_FAILURE","errorMessage":"class org.apache.druid.query.Result cannot be cast to class org.apache.druid.query.scan.ScanResultValue (org.apache.druid.query.Result and org.apache.druid.query.scan.ScanResultValue are in unnamed module of loader 'app')","context":{"host":"historical:8083","errorClass":"java.lang.ClassCastException","legacyErrorCode":"Unknown exception"}}]
```

Attempts to coerce this new type of object `Result` into `ScanResultValue`, causing errors. Currently, we pin the type of the first template parameter `T` of [CacheStrategy](https://github.com/apache/druid/blob/-/processing/src/main/java/org/apache/druid/query/CacheStrategy.java#L38) to the type of the `Query<T>`, so we cannot support variable input types with `Object` (e.g. sometimes get `ScanResultValue` and sometimes `Result<BySegmentResultValue<ScanResultValue>>`). The conversion between these types is also a bit cumbersome as these return an iterable of `ScanResultValue`, but the segment cache expects a single `ScanResultValue`. Other query types that support `Result<T>` are `Iterable` and therefore are easier to coerce (see [BySegmentTopNResultValue](https://github.com/apache/druid/blob/-/processing/src/main/java/org/apache/druid/query/topn/BySegmentTopNResultValue.java#L33)). I think it would be doable to create a similar BySegment child for each of `ScanResultValue` and `SegmentAnalysis`, if it could be guaranteed that the `getResults()` was always a list of length 1.

#### Behavior changes

##### Before
- Result-level/Segment-level caching did not work for scan queries
##### After
- Result-level caching will work iff:
  - The query is NOT `bySegment`.
- Segment-level caching will work iff:
  - The query is NOT `bySegment`.
  - The node is NOT a broker.

#### Alternatives considered:
I could change `CacheStrategy`'s templating layout and `ScanQuery` and `SegmentMetadataQuery` both get/set their cache values, but given these queries ALREADY return data keyed by segment, it didn't seem worth it. The caching would already be [disabled](https://github.com/apache/druid/blob/-/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java#L805) anyways for these `bySegment` queries. It's also my understanding that `bySegment` is primarily for debugging anyways.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Adds support for result-level caching of scan queries. 

This caching behavior is disabled by default for scan queries. To enable, override the `druid.*.cache.unCacheable` property.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
