### PR TITLE
Add an option to write a mid-flight exception as a response row

### DIFF
--- a/server/src/main/java/org/apache/druid/server/QueryResource.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResource.java
@@ -84,6 +84,7 @@ public class QueryResource implements QueryCountStatsProvider
   public static final String ERROR_MESSAGE_TRAILER_HEADER = "X-Error-Message";
   public static final String RESPONSE_COMPLETE_TRAILER_HEADER = "X-Druid-Response-Complete";
   public static final String HEADER_ETAG = "ETag";
+  public static final String WRITE_EXCEPTION_BODY_AS_RESPONSE_ROW = "writeExceptionBodyAsResponseRow";
 
   protected final QueryLifecycleFactory queryLifecycleFactory;
   protected final ObjectMapper jsonMapper;

--- a/server/src/main/java/org/apache/druid/server/QueryResourceQueryResultPusherFactory.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResourceQueryResultPusherFactory.java
@@ -105,7 +105,8 @@ public class QueryResourceQueryResultPusherFactory
           counter,
           queryLifecycle.getQueryId(),
           MediaType.valueOf(io.getResponseWriter().getResponseType()),
-          ImmutableMap.of()
+          ImmutableMap.of(),
+          queryLifecycle.getQuery().getContext()
       );
       this.req = req;
       this.queryLifecycle = queryLifecycle;

--- a/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
@@ -26,7 +26,6 @@ import com.google.common.io.CountingOutputStream;
 import org.apache.druid.client.DirectDruidClient;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.ErrorResponse;
-import org.apache.druid.error.InvalidInput;
 import org.apache.druid.error.QueryExceptionCompat;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;

--- a/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
+++ b/server/src/main/java/org/apache/druid/server/QueryResultPusher.java
@@ -26,6 +26,7 @@ import com.google.common.io.CountingOutputStream;
 import org.apache.druid.client.DirectDruidClient;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.ErrorResponse;
+import org.apache.druid.error.InvalidInput;
 import org.apache.druid.error.QueryExceptionCompat;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
@@ -67,6 +68,7 @@ public abstract class QueryResultPusher
   private final QueryResource.QueryMetricCounter counter;
   private final MediaType contentType;
   private final Map<String, String> extraHeaders;
+  private final Map<String, Object> queryContext;
   private final Map<String, String> trailerFields;
 
   private StreamingHttpResponseAccumulator accumulator;
@@ -81,7 +83,8 @@ public abstract class QueryResultPusher
       QueryResource.QueryMetricCounter counter,
       String queryId,
       MediaType contentType,
-      Map<String, String> extraHeaders
+      Map<String, String> extraHeaders,
+      Map<String, Object> queryContext
   )
   {
     this.request = request;
@@ -92,6 +95,7 @@ public abstract class QueryResultPusher
     this.counter = counter;
     this.contentType = contentType;
     this.extraHeaders = extraHeaders;
+    this.queryContext = queryContext;
     this.trailerFields = new HashMap<>();
   }
 
@@ -254,11 +258,25 @@ public abstract class QueryResultPusher
       resultsWriter.recordFailure(e);
 
       if (accumulator != null && accumulator.isInitialized()) {
-        // We already started sending a response when we got the error message.  In this case we just give up
-        // and hope that the partial stream generates a meaningful failure message for our client.  We could consider
-        // also throwing the exception body into the response to make it easier for the client to choke if it manages
-        // to parse a meaningful object out, but that's potentially an API change so we leave that as an exercise for
-        // the future.
+        // We already started sending a response when we got the error message.  In this case we write the exception
+        // message as a row, assuming the caller (SqlResource, QueryResource or a custom endpoint) would be able to
+        // parse it and throw an exception on their side. It's assumed that if the caller is setting the
+        // WRITE_EXCEPTION_BODY_AS_RESPONSE_ROW context value, they are able to handle this kind of response. If it's
+        // not set, caller will continue to see a json parsing exception.
+        if (queryContext != null
+            && Boolean.parseBoolean(String.valueOf(queryContext.get(QueryResource.WRITE_EXCEPTION_BODY_AS_RESPONSE_ROW)))) {
+          try {
+            accumulator.writer.writeRow(e);
+            accumulator.writer.writeResponseEnd();
+          }
+          catch (IOException ioException) {
+            log.warn(
+                ioException,
+                "Suppressing IOException thrown writing error response for query [%s]",
+                queryId
+            );
+          }
+        }
         trailerFields.put(QueryResource.ERROR_MESSAGE_TRAILER_HEADER, e.getMessage());
         trailerFields.put(QueryResource.RESPONSE_COMPLETE_TRAILER_HEADER, "false");
         return null;

--- a/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryResultPusherTest.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
 import java.io.OutputStream;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -114,7 +115,8 @@ public class QueryResultPusherTest
         counter,
         queryId,
         contentType,
-        extraHeaders)
+        extraHeaders,
+        Collections.emptyMap())
     {
 
       @Override

--- a/sql/src/main/java/org/apache/druid/sql/http/SqlResourceQueryResultPusher.java
+++ b/sql/src/main/java/org/apache/druid/sql/http/SqlResourceQueryResultPusher.java
@@ -70,7 +70,8 @@ class SqlResourceQueryResultPusher extends QueryResultPusher
         SqlResource.QUERY_METRIC_COUNTER,
         stmt.sqlQueryId(),
         MediaType.APPLICATION_JSON_TYPE,
-        headers
+        headers,
+        sqlQuery.getContext()
     );
     this.serverConfig = serverConfig;
     this.jsonMapper = jsonMapper;


### PR DESCRIPTION
As of now, if historical has already started streaming results and run into an error after that, we see a json parser exception on broker since the response is truncated. This PR adds an option where the said exception is serialized as a row, leaving caller to decide how to distinguish the error row from a genuine result row. Only if the caller has such ability, it should set the option in query context. 