### PR TITLE
Fix NPE in getCacheKey for ListFilteredDimensionSpec

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/dimension/ListFilteredDimensionSpec.java
+++ b/processing/src/main/java/org/apache/druid/query/dimension/ListFilteredDimensionSpec.java
@@ -22,14 +22,12 @@ package org.apache.druid.query.dimension;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
-import org.apache.druid.java.util.common.StringUtils;
-import org.apache.druid.query.filter.DimFilterUtils;
+import org.apache.druid.query.cache.CacheKeyBuilder;
 import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.IdLookup;
 import org.apache.druid.segment.IdMapping;
 
 import javax.annotation.Nullable;
-import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.Set;
 
@@ -52,10 +50,10 @@ public class ListFilteredDimensionSpec extends BaseFilteredDimensionSpec
   {
     super(delegate);
 
-    Preconditions.checkArgument(values != null && values.size() > 0, "values list must be non-empty");
+    Preconditions.checkArgument(values != null && !values.isEmpty(), "values list must be non-empty");
     this.values = values;
 
-    this.isWhitelist = isWhitelist == null ? true : isWhitelist.booleanValue();
+    this.isWhitelist = isWhitelist == null || isWhitelist;
   }
 
   @JsonProperty
@@ -157,27 +155,11 @@ public class ListFilteredDimensionSpec extends BaseFilteredDimensionSpec
   @Override
   public byte[] getCacheKey()
   {
-    byte[] delegateCacheKey = delegate.getCacheKey();
-
-    byte[][] valuesBytes = new byte[values.size()][];
-    int valuesBytesSize = 0;
-    int index = 0;
-    for (String value : values) {
-      valuesBytes[index] = StringUtils.toUtf8(value);
-      valuesBytesSize += valuesBytes[index].length + 1;
-      ++index;
-    }
-
-    ByteBuffer filterCacheKey = ByteBuffer.allocate(3 + delegateCacheKey.length + valuesBytesSize)
-                                          .put(CACHE_TYPE_ID)
-                                          .put(delegateCacheKey)
-                                          .put((byte) (isWhitelist ? 1 : 0))
-                                          .put(DimFilterUtils.STRING_SEPARATOR);
-    for (byte[] bytes : valuesBytes) {
-      filterCacheKey.put(bytes)
-                    .put(DimFilterUtils.STRING_SEPARATOR);
-    }
-    return filterCacheKey.array();
+    CacheKeyBuilder builder = new CacheKeyBuilder(CACHE_TYPE_ID)
+        .appendBoolean(isWhitelist)
+        .appendCacheable(delegate)
+        .appendStringsIgnoringOrder(values);
+    return builder.build();
   }
 
   @Override

--- a/processing/src/test/java/org/apache/druid/query/dimension/ListFilteredDimensionSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/query/dimension/ListFilteredDimensionSpecTest.java
@@ -240,4 +240,22 @@ public class ListFilteredDimensionSpecTest
     Assert.assertEquals(expected, actual);
     Assert.assertArrayEquals(expected.getCacheKey(), actual.getCacheKey());
   }
+
+  @Test
+  public void testListFilteredDimensionSpecValueOrderIsIgnored()
+  {
+    ListFilteredDimensionSpec spec1 = new ListFilteredDimensionSpec(
+        new DefaultDimensionSpec("foo", "bar"),
+        new HashSet<>(Arrays.asList(null, "A", "B")),
+        true
+    );
+
+    ListFilteredDimensionSpec spec2 = new ListFilteredDimensionSpec(
+        new DefaultDimensionSpec("foo", "bar"),
+        new HashSet<>(Arrays.asList("A", "B", null)),
+        true
+    );
+
+    Assert.assertArrayEquals(spec1.getCacheKey(), spec2.getCacheKey());
+  }
 }


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes https://github.com/apache/druid/issues/18573 and adds a test that reproduces the behavior.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Example:
```json
{
  "dimensions": [
    {
      "type": "listFiltered",
      "delegate": "based_on",
      "values": [
        null,
        "A",
        "B"
      ]
    }
  ],
  "aggregations": [
    {
      "type": "doubleSum",
      "fieldName": "value",
      "name": "value"
    }
  ],
  "intervals": ["2025-01-01T00:00:00.000Z/2025-07-10T23:59:59.999Z"],
  "queryType": "groupBy",
  "granularity": "all",
  "dataSource": "datasource_A"
}
```

will fail with:
```
Error: RUNTIME_FAILURE (OPERATOR)

Cannot invoke "String.getBytes(String)" because "string" is null

java.lang.NullPointerException
```

The line in question is [this](https://github.com/apache/druid/blob/master/processing/src/main/java/org/apache/druid/query/dimension/ListFilteredDimensionSpec.java#L166).

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Fix NPE in getCacheKey for ListFilteredDimensionSpec


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
