### PR TITLE
Make KubernetesWorkItem.shutdown idempotent

### DIFF
--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesWorkItem.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesWorkItem.java
@@ -36,7 +36,7 @@ public class KubernetesWorkItem extends TaskRunnerWorkItem
   private final Task task;
   private final KubernetesPeonLifecycle kubernetesPeonLifecycle;
 
-  private final AtomicBoolean isShuttingDown = new AtomicBoolean(false);
+  private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
   public KubernetesWorkItem(Task task, ListenableFuture<TaskStatus> statusFuture, KubernetesPeonLifecycle kubernetesPeonLifecycle)
   {
@@ -50,7 +50,7 @@ public class KubernetesWorkItem extends TaskRunnerWorkItem
    */
   protected void shutdown()
   {
-    if (isShuttingDown.compareAndSet(false, true)) {
+    if (isShutdown.compareAndSet(false, true)) {
       synchronized (this) {
         this.kubernetesPeonLifecycle.startWatchingLogs();
         this.kubernetesPeonLifecycle.shutdown();

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesWorkItem.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesWorkItem.java
@@ -48,11 +48,13 @@ public class KubernetesWorkItem extends TaskRunnerWorkItem
   /**
    * Shuts down this work item. Subsequent calls to this method return immediately.
    */
-  protected synchronized void shutdown()
+  protected void shutdown()
   {
     if (isShuttingDown.compareAndSet(false, true)) {
-      this.kubernetesPeonLifecycle.startWatchingLogs();
-      this.kubernetesPeonLifecycle.shutdown();
+      synchronized (this) {
+        this.kubernetesPeonLifecycle.startWatchingLogs();
+        this.kubernetesPeonLifecycle.shutdown();
+      }
     }
   }
 


### PR DESCRIPTION
### Description

This patch tries to address the following condition due to a [bug in fabric8 client](https://github.com/fabric8io/kubernetes-client/issues/7163).

The callback executor in `TaskQueue` can get stuck in the following scenario.
- `TaskQueue` tries to shutdown a task via `notifyStatus()` and queues up a `TaskRunner.shutdown()` on the callback executor.
- `TaskQueue` then removes the entry for this task from its in-memory data-structures
- `TaskRunner.shutdown()` remains stuck due to the fabric8 bug
- `TaskRunner` still has the task in its memory
- When the `TaskQueue` periodically manages itself via `startPendingTasksOnRunner()`,
it realizes that the `TaskRunner` has this unknown task and tries to shut it down again.

### Fix

Subsequent calls to `KubernetesWorkItem.shutdown()` should not block and return immediately.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
