### PR TITLE
Expand use of Druid side timeouts for fabric8 kubernetesclient timeouts

### DIFF
--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -793,7 +793,7 @@ Should you require the needed permissions for interacting across Kubernetes name
 | `druid.indexer.runner.capacity` | `Integer` | Number of concurrent jobs that can be sent to Kubernetes. | `2147483647` | No |
 | `druid.indexer.runner.cpuCoreInMicro` | `Integer` | Number of CPU micro core for the task. | `1000` | No |
 | `druid.indexer.runner.logSaveTimeout` | `Duration` | How long to wait for task logs to be saved before giving up. | `PT300S` | NO |
-| `druid.indexer.runner.logWatchInitializationTimeout` | `Duration` | How long to wait for Initializing a LogWatch on k8s peon pod before giving up. | `PT30S` | NO |
+| `druid.indexer.runner.logWatchInitializationTimeout` | `Duration` | How long to wait when initializing a log watch for a peon pod before giving up. | `PT30S` | NO |
 
 
 ### Metrics added

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -792,8 +792,7 @@ Should you require the needed permissions for interacting across Kubernetes name
 | `druid.indexer.runner.graceTerminationPeriodSeconds` | `Long` | Number of seconds you want to wait after a sigterm for container lifecycle hooks to complete. Keep at a smaller value if you want tasks to hold locks for shorter periods. | `PT30S` (K8s default) | No |
 | `druid.indexer.runner.capacity` | `Integer` | Number of concurrent jobs that can be sent to Kubernetes. | `2147483647` | No |
 | `druid.indexer.runner.cpuCoreInMicro` | `Integer` | Number of CPU micro core for the task. | `1000` | No |
-| `druid.indexer.runner.logSaveTimeout` | `Duration` | How long to wait for task logs to be saved before giving up. | `PT300S` | NO |
-| `druid.indexer.runner.logWatchInitializationTimeout` | `Duration` | How long to wait when initializing a log watch for a peon pod before giving up. | `PT30S` | NO |
+| `druid.indexer.runner.podLogOperationTimeout` | `Duration` | Timeout for async operations that interact with `k8s` pod logs  | `PT300S` | NO |
 
 
 ### Metrics added

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -792,6 +792,9 @@ Should you require the needed permissions for interacting across Kubernetes name
 | `druid.indexer.runner.graceTerminationPeriodSeconds` | `Long` | Number of seconds you want to wait after a sigterm for container lifecycle hooks to complete. Keep at a smaller value if you want tasks to hold locks for shorter periods. | `PT30S` (K8s default) | No |
 | `druid.indexer.runner.capacity` | `Integer` | Number of concurrent jobs that can be sent to Kubernetes. | `2147483647` | No |
 | `druid.indexer.runner.cpuCoreInMicro` | `Integer` | Number of CPU micro core for the task. | `1000` | No |
+| `druid.indexer.runner.logSaveTimeout` | `Duration` | How long to wait for task logs to be saved before giving up. | `PT300S` | NO |
+| `druid.indexer.runner.logWatchInitializationTimeout` | `Duration` | How long to wait for Initializing a LogWatch on k8s peon pod before giving up. | `PT30S` | NO |
+
 
 ### Metrics added
 

--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -792,7 +792,6 @@ Should you require the needed permissions for interacting across Kubernetes name
 | `druid.indexer.runner.graceTerminationPeriodSeconds` | `Long` | Number of seconds you want to wait after a sigterm for container lifecycle hooks to complete. Keep at a smaller value if you want tasks to hold locks for shorter periods. | `PT30S` (K8s default) | No |
 | `druid.indexer.runner.capacity` | `Integer` | Number of concurrent jobs that can be sent to Kubernetes. | `2147483647` | No |
 | `druid.indexer.runner.cpuCoreInMicro` | `Integer` | Number of CPU micro core for the task. | `1000` | No |
-| `druid.indexer.runner.logSaveTimeout` | `Duration` | How long to wait for task logs to be saved before giving up. | `PT300S` | NO |
 
 ### Metrics added
 

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
@@ -30,22 +30,19 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
   private final KubernetesPeonClient client;
   private final TaskLogs taskLogs;
   private final ObjectMapper mapper;
-  private final long logSaveTimeoutMs;
-  private final long logWatchInitTimeoutMs;
+  private final long podLogOperationTimeout;
 
   public KubernetesPeonLifecycleFactory(
       KubernetesPeonClient client,
       TaskLogs taskLogs,
       ObjectMapper mapper,
-      long logSaveTimeoutMs,
-      long logWatchInitTimeoutMs
+      long podLogOperationTimeout
   )
   {
     this.client = client;
     this.taskLogs = taskLogs;
     this.mapper = mapper;
-    this.logSaveTimeoutMs = logSaveTimeoutMs;
-    this.logWatchInitTimeoutMs = logWatchInitTimeoutMs;
+    this.podLogOperationTimeout = podLogOperationTimeout;
   }
 
   @Override
@@ -58,8 +55,7 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
         taskLogs,
         mapper,
         stateListener,
-        logSaveTimeoutMs,
-        logWatchInitTimeoutMs
+        podLogOperationTimeout
     );
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
@@ -30,16 +30,22 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
   private final KubernetesPeonClient client;
   private final TaskLogs taskLogs;
   private final ObjectMapper mapper;
+  private final long logSaveTimeoutMs;
+  private final long logWatchInitTimeoutMs;
 
   public KubernetesPeonLifecycleFactory(
       KubernetesPeonClient client,
       TaskLogs taskLogs,
-      ObjectMapper mapper
+      ObjectMapper mapper,
+      long logSaveTimeoutMs,
+      long logWatchInitTimeoutMs
   )
   {
     this.client = client;
     this.taskLogs = taskLogs;
     this.mapper = mapper;
+    this.logSaveTimeoutMs = logSaveTimeoutMs;
+    this.logWatchInitTimeoutMs = logWatchInitTimeoutMs;
   }
 
   @Override
@@ -51,7 +57,9 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
         client,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        logSaveTimeoutMs,
+        logWatchInitTimeoutMs
     );
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleFactory.java
@@ -30,19 +30,16 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
   private final KubernetesPeonClient client;
   private final TaskLogs taskLogs;
   private final ObjectMapper mapper;
-  private final long logSaveTimeoutMs;
 
   public KubernetesPeonLifecycleFactory(
       KubernetesPeonClient client,
       TaskLogs taskLogs,
-      ObjectMapper mapper,
-      long logSaveTimeoutMs
+      ObjectMapper mapper
   )
   {
     this.client = client;
     this.taskLogs = taskLogs;
     this.mapper = mapper;
-    this.logSaveTimeoutMs = logSaveTimeoutMs;
   }
 
   @Override
@@ -54,8 +51,7 @@ public class KubernetesPeonLifecycleFactory implements PeonLifecycleFactory
         client,
         taskLogs,
         mapper,
-        stateListener,
-        logSaveTimeoutMs
+        stateListener
     );
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
@@ -106,6 +106,16 @@ public class KubernetesTaskRunnerConfig
   private Period k8sjobLaunchTimeout = new Period("PT1H");
 
   @JsonProperty
+  @NotNull
+  // how long to wait for log saving operations to complete
+  private Period logSaveTimeout = new Period("PT300S");
+
+  @JsonProperty
+  @NotNull
+  // how long to wait for log saving operations to complete
+  private Period logWatchInitializationTimeout = new Period("PT30S");
+
+  @JsonProperty
   // ForkingTaskRunner inherits the monitors from the MM, in k8s mode
   // the peon inherits the monitors from the overlord, so if someone specifies
   // a TaskCountStatsMonitor in the overlord for example, the peon process
@@ -158,7 +168,9 @@ public class KubernetesTaskRunnerConfig
       Map<String, String> labels,
       Map<String, String> annotations,
       Integer capacity,
-      Period taskJoinTimeout
+      Period taskJoinTimeout,
+      Period logSaveTimeout,
+      Period logWatchInitTimeout
   )
   {
     this.namespace = namespace;
@@ -231,6 +243,14 @@ public class KubernetesTaskRunnerConfig
     this.capacity = ObjectUtils.defaultIfNull(
         capacity,
         this.capacity
+    );
+    this.logSaveTimeout = ObjectUtils.defaultIfNull(
+        logSaveTimeout,
+        this.logSaveTimeout
+    );
+    this.logWatchInitializationTimeout = ObjectUtils.defaultIfNull(
+        logWatchInitTimeout,
+        this.logWatchInitializationTimeout
     );
   }
 
@@ -336,6 +356,16 @@ public class KubernetesTaskRunnerConfig
     return capacity;
   }
 
+  public Period getLogSaveTimeout()
+  {
+    return logSaveTimeout;
+  }
+
+  public Period getLogWatchInitializationTimeout()
+  {
+    return logWatchInitializationTimeout;
+  }
+
   public static Builder builder()
   {
     return new Builder();
@@ -363,6 +393,8 @@ public class KubernetesTaskRunnerConfig
     private Map<String, String> annotations;
     private Integer capacity;
     private Period taskJoinTimeout;
+    private Period logSaveTimeout;
+    private Period logWatchInitializationTimeout;
 
     public Builder()
     {
@@ -489,6 +521,18 @@ public class KubernetesTaskRunnerConfig
       return this;
     }
 
+    public Builder withLogSaveTimeout(Period logSaveTimeout)
+    {
+      this.logSaveTimeout = logSaveTimeout;
+      return this;
+    }
+
+    public Builder withLogWatchInitializationTimeout(Period logWatchInitTimeout)
+    {
+      this.logWatchInitializationTimeout = logWatchInitTimeout;
+      return this;
+    }
+
     public KubernetesTaskRunnerConfig build()
     {
       return new KubernetesTaskRunnerConfig(
@@ -511,7 +555,9 @@ public class KubernetesTaskRunnerConfig
           this.labels,
           this.annotations,
           this.capacity,
-          this.taskJoinTimeout
+          this.taskJoinTimeout,
+          this.logSaveTimeout,
+          this.logWatchInitializationTimeout
       );
     }
   }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
@@ -106,11 +106,6 @@ public class KubernetesTaskRunnerConfig
   private Period k8sjobLaunchTimeout = new Period("PT1H");
 
   @JsonProperty
-  @NotNull
-  // how long to wait for log saving operations to complete
-  private Period logSaveTimeout = new Period("PT300S");
-
-  @JsonProperty
   // ForkingTaskRunner inherits the monitors from the MM, in k8s mode
   // the peon inherits the monitors from the overlord, so if someone specifies
   // a TaskCountStatsMonitor in the overlord for example, the peon process
@@ -157,7 +152,6 @@ public class KubernetesTaskRunnerConfig
       Period taskCleanupDelay,
       Period taskCleanupInterval,
       Period k8sjobLaunchTimeout,
-      Period logSaveTimeout,
       List<String> peonMonitors,
       List<String> javaOptsArray,
       int cpuCoreInMicro,
@@ -213,10 +207,6 @@ public class KubernetesTaskRunnerConfig
     this.taskJoinTimeout = ObjectUtils.defaultIfNull(
         taskJoinTimeout,
         this.taskJoinTimeout
-    );
-    this.logSaveTimeout = ObjectUtils.defaultIfNull(
-        logSaveTimeout,
-        this.logSaveTimeout
     );
     this.peonMonitors = ObjectUtils.defaultIfNull(
         peonMonitors,
@@ -316,11 +306,6 @@ public class KubernetesTaskRunnerConfig
     return k8sjobLaunchTimeout;
   }
 
-  public Period getLogSaveTimeout()
-  {
-    return logSaveTimeout;
-  }
-
   public List<String> getPeonMonitors()
   {
     return peonMonitors;
@@ -378,7 +363,6 @@ public class KubernetesTaskRunnerConfig
     private Map<String, String> annotations;
     private Integer capacity;
     private Period taskJoinTimeout;
-    private Period logSaveTimeout;
 
     public Builder()
     {
@@ -505,12 +489,6 @@ public class KubernetesTaskRunnerConfig
       return this;
     }
 
-    public Builder withLogSaveTimeout(Period logSaveTimeout)
-    {
-      this.logSaveTimeout = logSaveTimeout;
-      return this;
-    }
-
     public KubernetesTaskRunnerConfig build()
     {
       return new KubernetesTaskRunnerConfig(
@@ -527,7 +505,6 @@ public class KubernetesTaskRunnerConfig
           this.taskCleanupDelay,
           this.taskCleanupInterval,
           this.k8sjobLaunchTimeout,
-          this.logSaveTimeout,
           this.peonMonitors,
           this.javaOptsArray,
           this.cpuCoreInMicro,

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerConfig.java
@@ -108,12 +108,7 @@ public class KubernetesTaskRunnerConfig
   @JsonProperty
   @NotNull
   // how long to wait for log saving operations to complete
-  private Period logSaveTimeout = new Period("PT300S");
-
-  @JsonProperty
-  @NotNull
-  // how long to wait for log saving operations to complete
-  private Period logWatchInitializationTimeout = new Period("PT30S");
+  private Period podLogOperationTimeout = new Period("PT300S");
 
   @JsonProperty
   // ForkingTaskRunner inherits the monitors from the MM, in k8s mode
@@ -169,8 +164,7 @@ public class KubernetesTaskRunnerConfig
       Map<String, String> annotations,
       Integer capacity,
       Period taskJoinTimeout,
-      Period logSaveTimeout,
-      Period logWatchInitTimeout
+      Period podLogOperationTimeout
   )
   {
     this.namespace = namespace;
@@ -244,13 +238,9 @@ public class KubernetesTaskRunnerConfig
         capacity,
         this.capacity
     );
-    this.logSaveTimeout = ObjectUtils.defaultIfNull(
-        logSaveTimeout,
-        this.logSaveTimeout
-    );
-    this.logWatchInitializationTimeout = ObjectUtils.defaultIfNull(
-        logWatchInitTimeout,
-        this.logWatchInitializationTimeout
+    this.podLogOperationTimeout = ObjectUtils.defaultIfNull(
+        podLogOperationTimeout,
+        this.podLogOperationTimeout
     );
   }
 
@@ -356,14 +346,9 @@ public class KubernetesTaskRunnerConfig
     return capacity;
   }
 
-  public Period getLogSaveTimeout()
+  public Period getPodLogOperationTimeout()
   {
-    return logSaveTimeout;
-  }
-
-  public Period getLogWatchInitializationTimeout()
-  {
-    return logWatchInitializationTimeout;
+    return podLogOperationTimeout;
   }
 
   public static Builder builder()
@@ -393,8 +378,7 @@ public class KubernetesTaskRunnerConfig
     private Map<String, String> annotations;
     private Integer capacity;
     private Period taskJoinTimeout;
-    private Period logSaveTimeout;
-    private Period logWatchInitializationTimeout;
+    private Period podLogOperationTimeout;
 
     public Builder()
     {
@@ -521,15 +505,9 @@ public class KubernetesTaskRunnerConfig
       return this;
     }
 
-    public Builder withLogSaveTimeout(Period logSaveTimeout)
+    public Builder withPodLogOperationTimeout(Period podLogOperationTimeout)
     {
-      this.logSaveTimeout = logSaveTimeout;
-      return this;
-    }
-
-    public Builder withLogWatchInitializationTimeout(Period logWatchInitTimeout)
-    {
-      this.logWatchInitializationTimeout = logWatchInitTimeout;
+      this.podLogOperationTimeout = podLogOperationTimeout;
       return this;
     }
 
@@ -556,8 +534,7 @@ public class KubernetesTaskRunnerConfig
           this.annotations,
           this.capacity,
           this.taskJoinTimeout,
-          this.logSaveTimeout,
-          this.logWatchInitializationTimeout
+          this.podLogOperationTimeout
       );
     }
   }

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
@@ -93,7 +93,13 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
         kubernetesTaskRunnerConfig,
         peonClient,
         httpClient,
-        new KubernetesPeonLifecycleFactory(peonClient, taskLogs, smileMapper),
+        new KubernetesPeonLifecycleFactory(
+            peonClient,
+            taskLogs,
+            smileMapper,
+            kubernetesTaskRunnerConfig.getLogSaveTimeout().toStandardDuration().getMillis(),
+            kubernetesTaskRunnerConfig.getLogWatchInitializationTimeout().toStandardDuration().getMillis()
+        ),
         emitter
     );
     return runner;

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
@@ -93,12 +93,7 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
         kubernetesTaskRunnerConfig,
         peonClient,
         httpClient,
-        new KubernetesPeonLifecycleFactory(
-            peonClient,
-            taskLogs,
-            smileMapper,
-            kubernetesTaskRunnerConfig.getLogSaveTimeout().toStandardDuration().getMillis()
-        ),
+        new KubernetesPeonLifecycleFactory(peonClient, taskLogs, smileMapper),
         emitter
     );
     return runner;

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesTaskRunnerFactory.java
@@ -97,8 +97,7 @@ public class KubernetesTaskRunnerFactory implements TaskRunnerFactory<Kubernetes
             peonClient,
             taskLogs,
             smileMapper,
-            kubernetesTaskRunnerConfig.getLogSaveTimeout().toStandardDuration().getMillis(),
-            kubernetesTaskRunnerConfig.getLogWatchInitializationTimeout().toStandardDuration().getMillis()
+            kubernetesTaskRunnerConfig.getPodLogOperationTimeout().toStandardDuration().getMillis()
         ),
         emitter
     );

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -60,10 +60,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
 {
   private static final String ID = "id";
   private static final TaskStatus SUCCESS = TaskStatus.success(ID);
-  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
-  private static final Period SHORT_LOG_SAVE_TIMEOUT = new Period("PT1S");
-  private static final Period LOGWATCH_INIT_TIMEOUT = new Period("PT300S");
-  private static final Period SHORT_LOGWATCH_INIT_TIMEOUT = new Period("PT1S");
+  private static final Period POD_LOG_OPERATION_TIMEOUT = new Period("PT300S");
 
   @Mock KubernetesPeonClient kubernetesClient;
   @Mock TaskLogs taskLogs;
@@ -94,8 +91,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -142,8 +138,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -189,8 +184,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -241,8 +235,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -288,8 +281,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -338,8 +330,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -379,8 +370,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Assert.assertFalse(peonLifecycle.getTaskStartedSuccessfullyFuture().isDone());
@@ -435,8 +425,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -498,8 +487,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -548,8 +536,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -601,8 +588,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -654,8 +640,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -696,8 +681,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     peonLifecycle.shutdown();
   }
@@ -712,8 +696,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -736,8 +719,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -760,8 +742,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -778,8 +759,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -796,8 +776,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -814,8 +793,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -840,8 +818,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -859,8 +836,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -878,8 +854,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -897,8 +872,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -922,8 +896,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -953,8 +926,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -992,8 +964,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -1031,8 +1002,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -1071,8 +1041,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         taskLogs,
         mapper,
         stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
-        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
+        POD_LOG_OPERATION_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
     EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.absent()).once();

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -41,7 +41,6 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
-import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,8 +59,6 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
 {
   private static final String ID = "id";
   private static final TaskStatus SUCCESS = TaskStatus.success(ID);
-  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
-  private static final Period SHORT_LOG_SAVE_TIMEOUT = new Period("PT1S");
 
   @Mock KubernetesPeonClient kubernetesClient;
   @Mock TaskLogs taskLogs;
@@ -91,8 +88,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     )
     {
       @Override
@@ -138,8 +134,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     )
     {
       @Override
@@ -184,8 +179,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     )
     {
       @Override
@@ -235,8 +229,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     )
     {
       @Override
@@ -281,8 +274,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     )
     {
       @Override
@@ -330,8 +322,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -370,8 +361,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
 
     Assert.assertFalse(peonLifecycle.getTaskStartedSuccessfullyFuture().isDone());
@@ -402,7 +392,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expectLastCall();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -425,8 +415,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
 
     Job job = new JobBuilder()
@@ -452,11 +441,13 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     taskLogs.pushTaskLog(EasyMock.eq(ID), EasyMock.anyObject(File.class));
     EasyMock.expectLastCall();
     logWatch.close();
-    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expectLastCall();
     stateListener.stateChanged(KubernetesPeonLifecycle.State.RUNNING, ID);
     EasyMock.expectLastCall().once();
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
+    logWatch.close();
+    EasyMock.expectLastCall();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -485,8 +476,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
 
     Job job = new JobBuilder()
@@ -534,8 +524,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
 
     Job job = new JobBuilder()
@@ -561,7 +550,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expectLastCall();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -586,8 +575,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
 
     Job job = new JobBuilder()
@@ -615,7 +603,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expectLastCall();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -638,8 +626,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -657,7 +644,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
     EasyMock.expectLastCall().once();
     logWatch.close();
-    EasyMock.expectLastCall().atLeastOnce();
+    EasyMock.expectLastCall();
 
     Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
 
@@ -679,8 +666,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     peonLifecycle.shutdown();
   }
@@ -694,8 +680,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -717,8 +702,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -740,8 +724,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -757,8 +740,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -774,8 +756,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -791,8 +772,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -816,8 +796,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -834,8 +813,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -852,8 +830,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -870,8 +847,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -894,8 +870,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -924,8 +899,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -962,8 +936,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -1000,8 +973,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -1039,8 +1011,7 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        stateListener
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
     EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.absent()).once();
@@ -1048,74 +1019,6 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
     replayAll();
     Assert.assertEquals(TaskLocation.unknown(), peonLifecycle.getTaskLocation());
     verifyAll();
-  }
-
-  @Test
-  public void test_join_saveLogsTimeout_handledGracefully() throws IOException
-  {
-    KubernetesPeonLifecycle peonLifecycle = new KubernetesPeonLifecycle(
-        task,
-        k8sTaskId,
-        kubernetesClient,
-        taskLogs,
-        mapper,
-        stateListener,
-        SHORT_LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()  // 1 second timeout for task log save
-    );
-
-    Job job = new JobBuilder()
-        .withNewMetadata()
-        .withName(ID)
-        .endMetadata()
-        .withNewStatus()
-        .withSucceeded(1)
-        .withStartTime("2022-09-19T23:31:50Z")
-        .withCompletionTime("2022-09-19T23:32:48Z")
-        .endStatus()
-        .build();
-
-    EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
-        EasyMock.eq(k8sTaskId),
-        EasyMock.anyLong(),
-        EasyMock.eq(TimeUnit.MILLISECONDS)
-    )).andReturn(new JobResponse(job, PeonPhase.SUCCEEDED));
-
-    EasyMock.expect(kubernetesClient.getPeonLogWatcher(k8sTaskId)).andReturn(Optional.of(logWatch));
-    EasyMock.expect(taskLogs.streamTaskStatus(ID)).andReturn(Optional.of(
-        IOUtils.toInputStream(mapper.writeValueAsString(SUCCESS), StandardCharsets.UTF_8)
-    ));
-
-    // Mock pushTaskLog to sleep longer than the timeout (2 seconds > 1 second timeout)
-    taskLogs.pushTaskLog(EasyMock.eq(ID), EasyMock.anyObject(File.class));
-    EasyMock.expectLastCall().andAnswer(() -> {
-      Thread.sleep(2000); // Sleep for 2 seconds
-      return null;
-    });
-
-    stateListener.stateChanged(KubernetesPeonLifecycle.State.RUNNING, ID);
-    EasyMock.expectLastCall().once();
-    stateListener.stateChanged(KubernetesPeonLifecycle.State.STOPPED, ID);
-    EasyMock.expectLastCall().once();
-    logWatch.close();
-    EasyMock.expectLastCall().atLeastOnce();
-
-    Assert.assertEquals(KubernetesPeonLifecycle.State.NOT_STARTED, peonLifecycle.getState());
-
-    replayAll();
-
-    // The test should complete without hanging, even though log save times out
-    long startTime = System.currentTimeMillis();
-    TaskStatus taskStatus = peonLifecycle.join(0L);
-    long duration = System.currentTimeMillis() - startTime;
-
-    // Should complete in ~1 second (timeout), not 5+ seconds (sleep duration)
-    Assert.assertTrue("Test should complete quickly due to timeout", duration < 1500);
-
-    verifyAll();
-
-    // Task should still succeed - log timeout doesn't affect task result
-    Assert.assertEquals(SUCCESS.withDuration(58000), taskStatus);
-    Assert.assertEquals(KubernetesPeonLifecycle.State.STOPPED, peonLifecycle.getState());
   }
 
   private void setPeonLifecycleState(KubernetesPeonLifecycle peonLifecycle, KubernetesPeonLifecycle.State state)

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonLifecycleTest.java
@@ -41,6 +41,7 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -59,6 +60,10 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
 {
   private static final String ID = "id";
   private static final TaskStatus SUCCESS = TaskStatus.success(ID);
+  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
+  private static final Period SHORT_LOG_SAVE_TIMEOUT = new Period("PT1S");
+  private static final Period LOGWATCH_INIT_TIMEOUT = new Period("PT300S");
+  private static final Period SHORT_LOGWATCH_INIT_TIMEOUT = new Period("PT1S");
 
   @Mock KubernetesPeonClient kubernetesClient;
   @Mock TaskLogs taskLogs;
@@ -88,7 +93,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -134,7 +141,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -179,7 +188,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -229,7 +240,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -274,7 +287,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     )
     {
       @Override
@@ -322,7 +337,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -361,7 +378,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Assert.assertFalse(peonLifecycle.getTaskStartedSuccessfullyFuture().isDone());
@@ -415,7 +434,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -476,7 +497,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -524,7 +547,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -575,7 +600,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
 
     Job job = new JobBuilder()
@@ -626,7 +653,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
 
     EasyMock.expect(kubernetesClient.waitForPeonJobCompletion(
@@ -666,7 +695,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     peonLifecycle.shutdown();
   }
@@ -680,7 +711,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -702,7 +735,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -724,7 +759,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -740,7 +777,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -756,7 +795,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -772,7 +813,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -796,7 +839,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
 
@@ -813,7 +858,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.NOT_STARTED);
 
@@ -830,7 +877,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.PENDING);
 
@@ -847,7 +896,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -870,7 +921,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -899,7 +952,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -936,7 +991,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -973,7 +1030,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.RUNNING);
 
@@ -1011,7 +1070,9 @@ public class KubernetesPeonLifecycleTest extends EasyMockSupport
         kubernetesClient,
         taskLogs,
         mapper,
-        stateListener
+        stateListener,
+        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis(),
+        LOGWATCH_INIT_TIMEOUT.toStandardDuration().getMillis()
     );
     setPeonLifecycleState(peonLifecycle, KubernetesPeonLifecycle.State.STOPPED);
     EasyMock.expect(kubernetesClient.getPeonPod(k8sTaskId.getK8sJobName())).andReturn(Optional.absent()).once();

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
@@ -28,7 +28,6 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
-import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,8 +36,6 @@ import org.junit.runner.RunWith;
 @RunWith(EasyMockRunner.class)
 public class KubernetesWorkItemTest extends EasyMockSupport
 {
-  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
-
   private KubernetesWorkItem workItem;
   private Task task;
   private K8sTaskId taskId;
@@ -133,8 +130,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        null
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 
@@ -150,8 +146,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        null
     ) {
       @Override
       protected State getState()
@@ -174,8 +169,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        null
     ) {
       @Override
       protected State getState()
@@ -198,8 +192,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        null
     ) {
       @Override
       protected State getState()
@@ -222,8 +215,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        null
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
     Assert.assertFalse(workItem.streamTaskLogs().isPresent());
@@ -238,8 +230,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null,
-        LOG_SAVE_TIMEOUT.toStandardDuration().getMillis()
+        null
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
@@ -28,6 +28,7 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockRunner;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
+import org.joda.time.Period;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +40,8 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   private KubernetesWorkItem workItem;
   private Task task;
   private K8sTaskId taskId;
+  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
+  private static final Period LOG_WATCH_INIT_TIMEOUT = new Period("PT30S");
 
   @Mock
   KubernetesPeonLifecycle kubernetesPeonLifecycle;
@@ -130,7 +133,9 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.getMillis(),
+        LOG_WATCH_INIT_TIMEOUT.getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 
@@ -146,7 +151,9 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.getMillis(),
+        LOG_WATCH_INIT_TIMEOUT.getMillis()
     ) {
       @Override
       protected State getState()
@@ -169,7 +176,9 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.getMillis(),
+        LOG_WATCH_INIT_TIMEOUT.getMillis()
     ) {
       @Override
       protected State getState()
@@ -192,7 +201,9 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.getMillis(),
+        LOG_WATCH_INIT_TIMEOUT.getMillis()
     ) {
       @Override
       protected State getState()
@@ -215,7 +226,9 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.getMillis(),
+        LOG_WATCH_INIT_TIMEOUT.getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
     Assert.assertFalse(workItem.streamTaskLogs().isPresent());
@@ -230,7 +243,9 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        null
+        null,
+        LOG_SAVE_TIMEOUT.getMillis(),
+        LOG_WATCH_INIT_TIMEOUT.getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesWorkItemTest.java
@@ -40,8 +40,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
   private KubernetesWorkItem workItem;
   private Task task;
   private K8sTaskId taskId;
-  private static final Period LOG_SAVE_TIMEOUT = new Period("PT300S");
-  private static final Period LOG_WATCH_INIT_TIMEOUT = new Period("PT30S");
+  private static final Period POD_LOG_OPERATION_TIMEOUT = new Period("PT30S");
 
   @Mock
   KubernetesPeonLifecycle kubernetesPeonLifecycle;
@@ -134,8 +133,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        LOG_SAVE_TIMEOUT.getMillis(),
-        LOG_WATCH_INIT_TIMEOUT.getMillis()
+        POD_LOG_OPERATION_TIMEOUT.getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 
@@ -152,8 +150,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        LOG_SAVE_TIMEOUT.getMillis(),
-        LOG_WATCH_INIT_TIMEOUT.getMillis()
+        POD_LOG_OPERATION_TIMEOUT.getMillis()
     ) {
       @Override
       protected State getState()
@@ -177,8 +174,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        LOG_SAVE_TIMEOUT.getMillis(),
-        LOG_WATCH_INIT_TIMEOUT.getMillis()
+        POD_LOG_OPERATION_TIMEOUT.getMillis()
     ) {
       @Override
       protected State getState()
@@ -202,8 +198,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        LOG_SAVE_TIMEOUT.getMillis(),
-        LOG_WATCH_INIT_TIMEOUT.getMillis()
+        POD_LOG_OPERATION_TIMEOUT.getMillis()
     ) {
       @Override
       protected State getState()
@@ -227,8 +222,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        LOG_SAVE_TIMEOUT.getMillis(),
-        LOG_WATCH_INIT_TIMEOUT.getMillis()
+        POD_LOG_OPERATION_TIMEOUT.getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
     Assert.assertFalse(workItem.streamTaskLogs().isPresent());
@@ -244,8 +238,7 @@ public class KubernetesWorkItemTest extends EasyMockSupport
         null,
         null,
         null,
-        LOG_SAVE_TIMEOUT.getMillis(),
-        LOG_WATCH_INIT_TIMEOUT.getMillis()
+        POD_LOG_OPERATION_TIMEOUT.getMillis()
     );
     workItem = new KubernetesWorkItem(task, null, peonLifecycle);
 


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Expand on https://github.com/apache/druid/pull/18444 to cover more surface area. While putting saveLogs on a strict timer, helped prevent some issues with LogWatch interaction hanging, I have still seen issues in the path where `KubernetesWorkItem` calls shutdown which starts a LogWatch. Even the initialization of a LogWatch object can hang indefinitely.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

new config for users of the `kubernetes-overlord-extensions` for K8s TaskRunner. `druid.indexer.runner.logWatchInitializationTimeout`. This puts a strict timeout on initializing a LogWatch object for a K8s task pod.


<hr>

##### Key changed/added classes in this PR
 * `KubernetesPeonLifecycle`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.
