### PR TITLE
Perform auth check in /compaction/status/datasources API

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/AutoCompactionTest.java
@@ -111,7 +111,6 @@ import java.util.stream.Collectors;
 /**
  * Embedded mode of integration-tests originally present in {@code ITAutoCompactionTest}.
  */
-@Disabled("Disabled due to issues with compaction task not publishing schema to broker")
 public class AutoCompactionTest extends CompactionTestBase
 {
   private static final Logger LOG = new Logger(AutoCompactionTest.class);
@@ -201,8 +200,10 @@ public class AutoCompactionTest extends CompactionTestBase
   @Override
   protected EmbeddedDruidCluster createCluster()
   {
+    // Use timeout required for hash partitioning task
     return EmbeddedDruidCluster.withEmbeddedDerbyAndZookeeper()
                                .useLatchableEmitter()
+                               .useDefaultTimeoutForLatchableEmitter(30)
                                .addExtension(SketchModule.class)
                                .addExtension(HllSketchModule.class)
                                .addExtension(DoublesSketchModule.class)
@@ -620,6 +621,17 @@ public class AutoCompactionTest extends CompactionTestBase
           0,
           2,
           0);
+
+      final List<AutoCompactionSnapshot> allSnapshots = compactionResource.getAllCompactionSnapshots();
+      Assertions.assertFalse(allSnapshots.isEmpty());
+
+      AutoCompactionSnapshot snapshot = allSnapshots
+          .stream()
+          .filter(s -> s.getDataSource().equals(fullDatasourceName))
+          .findFirst()
+          .orElse(null);
+      Assertions.assertNotNull(snapshot);
+      Assertions.assertEquals(snapshot.getBytesAwaitingCompaction(), 0L);
     }
   }
 
@@ -778,6 +790,7 @@ public class AutoCompactionTest extends CompactionTestBase
 
   @MethodSource("getEngine")
   @ParameterizedTest(name = "compactionEngine={0}")
+  @Disabled("Disabled due to issues with compaction task not publishing schema to broker")
   public void testAutoCompactionDutyWithSegmentGranularityAndWithDropExistingTrue(CompactionEngine engine) throws Exception
   {
     // Interval is "2013-08-31/2013-09-02", segment gran is DAY,
@@ -901,6 +914,7 @@ public class AutoCompactionTest extends CompactionTestBase
 
   @MethodSource("getEngine")
   @ParameterizedTest(name = "compactionEngine={0}")
+  @Disabled("Disabled due to issues with compaction task not publishing schema to broker")
   public void testAutoCompactionDutyWithSegmentGranularityAndWithDropExistingTrueThenFalse(CompactionEngine engine) throws Exception
   {
     // Interval is "2013-08-31/2013-09-02", segment gran is DAY,
@@ -1175,6 +1189,7 @@ public class AutoCompactionTest extends CompactionTestBase
 
   @MethodSource("getEngine")
   @ParameterizedTest(name = "compactionEngine={0}")
+  @Disabled("Disabled due to issues with compaction task not publishing schema to broker")
   public void testAutoCompactionDutyWithSegmentGranularityAndSmallerSegmentGranularityCoveringMultipleSegmentsInTimelineAndDropExistingTrue(CompactionEngine engine) throws Exception
   {
     loadData(INDEX_TASK);

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionResourceTestClient.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/compact/CompactionResourceTestClient.java
@@ -193,6 +193,22 @@ public class CompactionResourceTestClient
     }
   }
 
+  public List<AutoCompactionSnapshot> getAllCompactionSnapshots()
+  {
+    String url = StringUtils.format("%s/compaction/status/datasources", getOverlordURL());
+
+    try {
+      final CompactionStatusResponse latestSnapshots = client.onLeaderOverlord(
+          mapper -> new RequestBuilder(HttpMethod.GET, url),
+          new TypeReference<>() {}
+      );
+      return Objects.requireNonNull(latestSnapshots).getLatestStatus();
+    }
+    catch (Exception e) {
+      return ServletResourceUtils.getDefaultValueIfCauseIs404ElseThrow(e, () -> null);
+    }
+  }
+
   public CompactionSimulateResult simulateRunOnCoordinator()
   {
     final ClusterCompactionConfig clusterConfig = getClusterConfig();

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordCompactionResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordCompactionResource.java
@@ -158,7 +158,21 @@ public class OverlordCompactionResource
         );
       });
     } else {
-      return buildResponse(coordinatorClient.getCompactionSnapshots(null));
+      return ServletResourceUtils.buildReadResponse(() -> {
+        final CompactionStatusResponse response = FutureUtils.getUnchecked(
+            coordinatorClient.getCompactionSnapshots(null),
+            true
+        );
+
+        return new CompactionStatusResponse(
+            AuthorizationUtils.filterByAuthorizedDatasources(
+                request,
+                response.getLatestStatus(),
+                AutoCompactionSnapshot::getDataSource,
+                authorizerMapper
+            )
+        );
+      });
     }
   }
 


### PR DESCRIPTION
### Changes

- Perform auth check in `/druid/indexer/v1/compaction/status/datasources` API when supervisor is disabled
- Verify the change via embedded tests
- Enable most test methods in `AutoCompactionTest`

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
