### PR TITLE
Create git hooks directory

### DIFF
--- a/hooks/install-hooks.sh
+++ b/hooks/install-hooks.sh
@@ -33,6 +33,7 @@ fi
 
 DRUID_ROOT=$1
 
+mkdir -p ${DRUID_ROOT}/.git/hooks
 cp_if_not_exist ${DRUID_ROOT}/hooks/run-all-in-dir.py ${DRUID_ROOT}/.git/hooks/run-all-in-dir.py
 cp_if_not_exist ${DRUID_ROOT}/hooks/pre-commit ${DRUID_ROOT}/.git/hooks/pre-commit
 cp_if_not_exist ${DRUID_ROOT}/hooks/pre-push ${DRUID_ROOT}/.git/hooks/pre-push


### PR DESCRIPTION
### Description

Fixes the following when installing git pre-push hooks: `cp: ./.git/hooks/run-all-in-dir.py: No such file or directory`.

No need for users to manually create the `.git/hooks` directory
<hr>

##### Key changed/added classes in this PR
 * `install-hooks.sh`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
