### PR TITLE
Change segment state on HttpLoadQueuePeon from "moving from" to "dropping" atomically

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
@@ -35,7 +35,16 @@ public interface LoadQueuePeon
 
   Set<DataSegment> getSegmentsToLoad();
 
-  Set<SegmentHolder> getSegmentsInQueue();
+  /**
+   * Returns the segments currently queued on this peon for a load or drop operation.
+   * This also includes segments that are being moved from this server to another
+   * for balancing, and have currently only been marked with {@link #markSegmentToDrop}.
+   *
+   * @param segmentsLoadedOnServer Segments which are known to be currently loaded
+   *                               on the corresponding server. Used by the peon
+   *                               to reconcile its internal state.
+   */
+  Set<SegmentHolder> getSegmentsInQueue(Set<DataSegment> segmentsLoadedOnServer);
 
   Set<DataSegment> getSegmentsToDrop();
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
@@ -82,6 +82,7 @@ public class SegmentHolder implements Comparable<SegmentHolder>
   // Guaranteed to store only non-null elements
   private final List<LoadPeonCallback> callbacks = new ArrayList<>();
   private final Stopwatch sinceRequestSentToServer = Stopwatch.createUnstarted();
+  private final Stopwatch sinceRequestSucceeded = Stopwatch.createUnstarted();
   private int runsInQueue = 0;
 
   public SegmentHolder(
@@ -153,6 +154,13 @@ public class SegmentHolder implements Comparable<SegmentHolder>
     }
   }
 
+  public void markRequestSucceeded()
+  {
+    if (!sinceRequestSucceeded.isRunning()) {
+      sinceRequestSucceeded.start();
+    }
+  }
+
   /**
    * A request is considered to have timed out if the time elapsed since it was
    * first sent to the server is greater than the configured load timeout.
@@ -162,6 +170,15 @@ public class SegmentHolder implements Comparable<SegmentHolder>
   public boolean hasRequestTimedOut()
   {
     return sinceRequestSentToServer.millisElapsed() > requestTimeout.getMillis();
+  }
+
+  /**
+   * Returns true if it has already been {@link HttpLoadQueuePeonConfig#getLoadTimeout()}
+   * since this request completed successfully.
+   */
+  public boolean isStaleSuccessfulRequest()
+  {
+    return sinceRequestSucceeded.millisElapsed() > requestTimeout.getMillis();
   }
 
   public int incrementAndGetRunsInQueue()

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
@@ -125,7 +125,6 @@ public class SegmentLoadQueueManager
                 && !peonA.getSegmentsToDrop().contains(segment)
                 && (taskMaster.isHttpLoading()
                     || serverInventoryView.isSegmentLoadedByServer(serverNameB, segment))) {
-              peonA.unmarkSegmentToDrop(segment);
               peonA.dropSegment(segment, moveFinishCallback);
             } else {
               moveFinishCallback.execute(success);

--- a/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/duty/RunRulesTest.java
@@ -495,7 +495,7 @@ public class RunRulesTest
         )
         .atLeastOnce();
 
-    EasyMock.expect(mockPeon.getSegmentsInQueue()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(mockPeon.getSegmentsInQueue(EasyMock.anyObject())).andReturn(Set.of()).anyTimes();
     EasyMock.expect(mockPeon.getSegmentsMarkedToDrop()).andReturn(Collections.emptySet()).anyTimes();
     EasyMock.replay(databaseRuleManager, mockPeon);
 
@@ -736,7 +736,7 @@ public class RunRulesTest
 
     LoadQueuePeon anotherMockPeon = EasyMock.createMock(LoadQueuePeon.class);
     EasyMock.expect(anotherMockPeon.getSegmentsMarkedToDrop()).andReturn(Collections.emptySet()).anyTimes();
-    EasyMock.expect(anotherMockPeon.getSegmentsInQueue()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(anotherMockPeon.getSegmentsInQueue(EasyMock.anyObject())).andReturn(Set.of()).anyTimes();
     EasyMock.expect(anotherMockPeon.getSegmentsToLoad()).andReturn(Collections.emptySet()).anyTimes();
 
     EasyMock.replay(anotherMockPeon);
@@ -1296,7 +1296,7 @@ public class RunRulesTest
   {
     EasyMock.expect(mockPeon.getSegmentsToLoad()).andReturn(Collections.emptySet()).anyTimes();
     EasyMock.expect(mockPeon.getSegmentsMarkedToDrop()).andReturn(Collections.emptySet()).anyTimes();
-    EasyMock.expect(mockPeon.getSegmentsInQueue()).andReturn(Collections.emptySet()).anyTimes();
+    EasyMock.expect(mockPeon.getSegmentsInQueue(EasyMock.anyObject())).andReturn(Set.of()).anyTimes();
     EasyMock.replay(mockPeon);
   }
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/TestLoadQueuePeon.java
@@ -93,9 +93,9 @@ public class TestLoadQueuePeon implements LoadQueuePeon
   }
 
   @Override
-  public Set<SegmentHolder> getSegmentsInQueue()
+  public Set<SegmentHolder> getSegmentsInQueue(Set<DataSegment> segmentsLoadedOnServer)
   {
-    return Collections.emptySet();
+    return Set.of();
   }
 
   @Override


### PR DESCRIPTION
### Description

Based on discussions with @jtuglu1 in #18764 , there seem to be some race conditions in segment balancing between the duty run thread and the segment drop callback thread (triggered by segment balancing).

#### Race condition 1

Duty takes snapshot of peon when segment is in the middle of being transitioned from state `MOVING_FROM` to `DROPPING`.

- The result is that the `ServerHolder` assumes that this segment actually has state `LOADED` (when in fact it should be `DROPPING`)
- This leads the `StrategicSegmentAssigner` to assume that the segment is over-replicated (being loaded on both A and B) and then trigger a drop from either A (no-op since we were going to start a drop from A anyway) or B (segment becomes briefly unavailable).

#### Race condition 2

Duty takes snapshot of peon after the `DROP` operation has succeeded but it is not yet reflected in the inventory (since the inventory was snapshotted earlier in the flow).

- This would again cause the `StrategicSegmentAssigner` to consider this segment as over-replicated.
- Something similar may happen with a load operation as well.

### Changes

- Use a synchronized block to ensure that a segment is moved from the set `segmentsMarkedToDrop` to `segmentsToDrop` atomically
- Use `@GuardedBy` to ensure that these fields remain thread-safe
- Pass the list of segments already loaded on a server to `LoadQueuePeon.getSegmentsInQueue()` so that we track completed requests inside the peon until the inventory has confirmed success of the same.

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.