### PR TITLE
feat: support user identity forwarding to tasks via TaskAuthContext

### DIFF
--- a/extensions-contrib/druid-iceberg-extensions/pom.xml
+++ b/extensions-contrib/druid-iceberg-extensions/pom.xml
@@ -280,7 +280,7 @@
       <artifactId>iceberg-aws</artifactId>
       <version>${iceberg.core.version}</version>
     </dependency>
-   <!--  GlueCatalog needs AWS SDK STS module compile time  -->
+    <!--  GlueCatalog needs AWS SDK STS module compile time  -->
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>glue</artifactId>
@@ -644,6 +644,7 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-core</artifactId>
       <scope>runtime</scope>
+      <version>${hadoop.compile.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergCatalog.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergCatalog.java
@@ -20,6 +20,7 @@
 package org.apache.druid.iceberg.input;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.iceberg.filter.IcebergFilter;
@@ -28,6 +29,7 @@ import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -37,6 +39,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,11 +81,43 @@ public abstract class IcebergCatalog
       ResidualFilterMode residualFilterMode
   )
   {
+    return extractSnapshotDataFilesWithCredentials(
+        tableNamespace,
+        tableName,
+        icebergFilter,
+        snapshotTime,
+        residualFilterMode
+    ).getDataFilePaths();
+  }
+
+  /**
+   * Extract the iceberg data files and any vended credentials from the catalog.
+   *
+   * <p>For REST catalogs with credential vending enabled, this method will return
+   * temporary S3 credentials alongside the file paths. These credentials should be
+   * used to access the data files.
+   *
+   * @param tableNamespace     The catalog namespace under which the table is defined
+   * @param tableName          The iceberg table name
+   * @param icebergFilter      The iceberg filter that needs to be applied before reading the files
+   * @param snapshotTime       Datetime that will be used to fetch the most recent snapshot as of this time
+   * @param residualFilterMode Controls how residual filters are handled
+   * @return data file paths with optional vended credentials
+   */
+  public IcebergDataFilesWithCredentials extractSnapshotDataFilesWithCredentials(
+      String tableNamespace,
+      String tableName,
+      IcebergFilter icebergFilter,
+      DateTime snapshotTime,
+      ResidualFilterMode residualFilterMode
+  )
+  {
     Catalog catalog = retrieveCatalog();
     Namespace namespace = Namespace.of(tableNamespace);
     String tableIdentifier = tableNamespace + "." + tableName;
 
     List<String> dataFilePaths = new ArrayList<>();
+    VendedCredentials vendedCredentials;
 
     ClassLoader currCtxClassloader = Thread.currentThread().getContextClassLoader();
     try {
@@ -96,7 +131,15 @@ public abstract class IcebergCatalog
                                                       ));
 
       long start = System.currentTimeMillis();
-      TableScan tableScan = catalog.loadTable(icebergTableIdentifier).newScan();
+      Table table = catalog.loadTable(icebergTableIdentifier);
+
+      // Extract vended credentials from the table (subclasses can override)
+      vendedCredentials = extractCredentials(table);
+      if (vendedCredentials != null && !vendedCredentials.isEmpty()) {
+        log.info("Extracted vended credentials for table [%s]", tableIdentifier);
+      }
+
+      TableScan tableScan = table.newScan();
 
       if (icebergFilter != null) {
         tableScan = icebergFilter.filter(tableScan);
@@ -151,6 +194,30 @@ public abstract class IcebergCatalog
     finally {
       Thread.currentThread().setContextClassLoader(currCtxClassloader);
     }
-    return dataFilePaths;
+    return new IcebergDataFilesWithCredentials(dataFilePaths, vendedCredentials);
+  }
+
+  /**
+   * Extracts vended credentials from the loaded table.
+   *
+   * <p>Subclasses (like RestIcebergCatalog) can override this to extract
+   * credentials from table properties or FileIO configuration.
+   *
+   * @param table the loaded Iceberg table
+   * @return vended credentials, or null if none available
+   */
+  @Nullable
+  protected VendedCredentials extractCredentials(Table table)
+  {
+    return null;
+  }
+
+  /**
+   * Sets the task auth context. Subclasses that need credentials (e.g., {@link RestIcebergCatalog})
+   * should override this.
+   */
+  public void setTaskAuthContext(@Nullable TaskAuthContext taskAuthContext)
+  {
+    // no-op by default
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergDataFilesWithCredentials.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergDataFilesWithCredentials.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.iceberg.input;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Holds the result of extracting data files from an Iceberg table, including
+ * both the file paths and any vended credentials from the catalog.
+ */
+public class IcebergDataFilesWithCredentials
+{
+  private final List<String> dataFilePaths;
+  private final VendedCredentials vendedCredentials;
+
+  public IcebergDataFilesWithCredentials(
+      List<String> dataFilePaths,
+      @Nullable VendedCredentials vendedCredentials
+  )
+  {
+    this.dataFilePaths = dataFilePaths;
+    this.vendedCredentials = vendedCredentials;
+  }
+
+  public List<String> getDataFilePaths()
+  {
+    return dataFilePaths;
+  }
+
+  @Nullable
+  public VendedCredentials getVendedCredentials()
+  {
+    return vendedCredentials;
+  }
+
+  public boolean hasVendedCredentials()
+  {
+    return vendedCredentials != null && !vendedCredentials.isEmpty();
+  }
+}

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergInputSource.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/IcebergInputSource.java
@@ -22,7 +22,7 @@ package org.apache.druid.iceberg.input;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import org.apache.druid.common.config.Configs;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowListPlusRawValues;
@@ -33,6 +33,7 @@ import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.InputStats;
 import org.apache.druid.data.input.SplitHintSpec;
+import org.apache.druid.data.input.TaskAuthContextAware;
 import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.iceberg.filter.IcebergFilter;
 import org.apache.druid.java.util.common.CloseableIterators;
@@ -51,7 +52,7 @@ import java.util.stream.Stream;
  * This inputsource talks to the configured catalog, executes any configured filters and retrieves the data file paths upto the latest snapshot associated with the iceberg table.
  * The data file paths are then provided to a native {@link SplittableInputSource} implementation depending on the warehouse source defined.
  */
-public class IcebergInputSource implements SplittableInputSource<List<String>>
+public class IcebergInputSource implements SplittableInputSource<List<String>>, TaskAuthContextAware
 {
   public static final String TYPE_KEY = "iceberg";
 
@@ -97,7 +98,7 @@ public class IcebergInputSource implements SplittableInputSource<List<String>>
     this.icebergFilter = icebergFilter;
     this.warehouseSource = Preconditions.checkNotNull(warehouseSource, "warehouseSource cannot be null");
     this.snapshotTime = snapshotTime;
-    this.residualFilterMode = Configs.valueOrDefault(residualFilterMode, ResidualFilterMode.IGNORE);
+    this.residualFilterMode = residualFilterMode != null ? residualFilterMode : ResidualFilterMode.IGNORE;
   }
 
   @Override
@@ -183,6 +184,7 @@ public class IcebergInputSource implements SplittableInputSource<List<String>>
     return snapshotTime;
   }
 
+  @Nullable
   @JsonProperty
   public ResidualFilterMode getResidualFilterMode()
   {
@@ -194,19 +196,31 @@ public class IcebergInputSource implements SplittableInputSource<List<String>>
     return delegateInputSource;
   }
 
+  @Override
+  public void setTaskAuthContext(@Nullable TaskAuthContext taskAuthContext)
+  {
+    icebergCatalog.setTaskAuthContext(taskAuthContext);
+  }
+
   protected void retrieveIcebergDatafiles()
   {
-    List<String> snapshotDataFiles = icebergCatalog.extractSnapshotDataFiles(
+    IcebergDataFilesWithCredentials result = icebergCatalog.extractSnapshotDataFilesWithCredentials(
         getNamespace(),
         getTableName(),
         getIcebergFilter(),
         getSnapshotTime(),
         getResidualFilterMode()
     );
-    if (snapshotDataFiles.isEmpty()) {
+
+    if (result.getDataFilePaths().isEmpty()) {
       delegateInputSource = new EmptyInputSource();
     } else {
-      delegateInputSource = warehouseSource.create(snapshotDataFiles);
+      // Pass vended credentials to the warehouse source if available
+      VendedCredentials vendedCreds = result.getVendedCredentials();
+      delegateInputSource = warehouseSource.create(
+          result.getDataFilePaths(),
+          vendedCreds != null ? vendedCreds.getRawCredentials() : null
+      );
     }
     isLoaded = true;
   }

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/RestIcebergCatalog.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/RestIcebergCatalog.java
@@ -21,27 +21,38 @@ package org.apache.druid.iceberg.input;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.iceberg.guice.HiveConf;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog;
-import org.apache.iceberg.rest.HTTPClient;
-import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.rest.RESTSessionCatalog;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Catalog implementation for Iceberg REST catalogs.
+ *
+ * <p>Uses {@link RESTSessionCatalog} so that a per-request {@link SessionCatalog.SessionContext}
+ * carrying credentials from {@link TaskAuthContext} is passed to every catalog operation.
  */
 public class RestIcebergCatalog extends IcebergCatalog
 {
+  private static final Logger log = new Logger(RestIcebergCatalog.class);
+
   public static final String TYPE_KEY = "rest";
 
   @JsonProperty
@@ -52,13 +63,16 @@ public class RestIcebergCatalog extends IcebergCatalog
 
   private final Configuration configuration;
 
-  private Catalog restCatalog;
+  @JsonIgnore
+  private transient TaskAuthContext taskAuthContext;
+
+  private volatile RESTSessionCatalog restSessionCatalog;
 
   @JsonCreator
   public RestIcebergCatalog(
       @JsonProperty("catalogUri") String catalogUri,
       @JsonProperty("catalogProperties") @Nullable
-          Map<String, Object> catalogProperties,
+      Map<String, Object> catalogProperties,
       @JacksonInject @Json ObjectMapper mapper,
       @JacksonInject @HiveConf Configuration configuration
   )
@@ -75,13 +89,15 @@ public class RestIcebergCatalog extends IcebergCatalog
     this.configuration = configuration;
   }
 
+  /**
+   * Returns a Catalog instance that uses the current session context for all operations.
+   * The returned Catalog wraps the underlying RESTSessionCatalog and passes session
+   * credentials to all catalog operations (listTables, loadTable, etc.).
+   */
   @Override
   public Catalog retrieveCatalog()
   {
-    if (restCatalog == null) {
-      restCatalog = setupCatalog();
-    }
-    return restCatalog;
+    return getOrCreateSessionCatalog().asCatalog(buildSessionContext());
   }
 
   public String getCatalogUri()
@@ -94,15 +110,73 @@ public class RestIcebergCatalog extends IcebergCatalog
     return catalogProperties;
   }
 
-  private RESTCatalog setupCatalog()
+  @Override
+  public void setTaskAuthContext(@Nullable TaskAuthContext taskAuthContext)
   {
-    RESTCatalog restCatalog = new RESTCatalog(
-        SessionCatalog.SessionContext.createEmpty(),
-        config -> HTTPClient.builder(config).uri(config.get(CatalogProperties.URI)).build()
-    );
-    restCatalog.setConf(configuration);
-    catalogProperties.put(CatalogProperties.URI, catalogUri);
-    restCatalog.initialize("rest", catalogProperties);
-    return restCatalog;
+    this.taskAuthContext = taskAuthContext;
+  }
+
+  private RESTSessionCatalog getOrCreateSessionCatalog()
+  {
+    RESTSessionCatalog catalog = restSessionCatalog;
+    if (catalog == null) {
+      synchronized (this) {
+        catalog = restSessionCatalog;
+        if (catalog == null) {
+          catalog = setupCatalog();
+          restSessionCatalog = catalog;
+        }
+      }
+    }
+    return catalog;
+  }
+
+  private RESTSessionCatalog setupCatalog()
+  {
+    RESTSessionCatalog catalog = new RESTSessionCatalog();
+    catalog.setConf(configuration);
+    Map<String, String> props = new HashMap<>(catalogProperties);
+    props.put(CatalogProperties.URI, catalogUri);
+    catalog.initialize("rest", props);
+    return catalog;
+  }
+
+  /**
+   * Builds a session context from TaskAuthContext credentials if available,
+   * or an empty context otherwise.
+   */
+  private SessionCatalog.SessionContext buildSessionContext()
+  {
+    if (taskAuthContext != null) {
+      Map<String, String> credentials = taskAuthContext.getCredentials();
+      if (credentials != null && !credentials.isEmpty()) {
+        return new SessionCatalog.SessionContext(
+            UUID.randomUUID().toString(),
+            taskAuthContext.getIdentity(),
+            credentials,
+            Collections.emptyMap()
+        );
+      }
+    }
+    return SessionCatalog.SessionContext.createEmpty();
+  }
+
+  @Override
+  @Nullable
+  protected VendedCredentials extractCredentials(Table table)
+  {
+    VendedCredentials credentials = VendedCredentials.extractFrom(table.properties());
+    if (credentials != null) {
+      return credentials;
+    }
+
+    // Fall back to FileIO properties; don't let extraction failures block the scan
+    try {
+      return VendedCredentials.extractFrom(table.io().properties());
+    }
+    catch (Exception e) {
+      log.warn(e, "Failed to extract vended credentials from FileIO properties");
+      return null;
+    }
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/VendedCredentials.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/main/java/org/apache/druid/iceberg/input/VendedCredentials.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.iceberg.input;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Represents vended credentials from a catalog for accessing storage.
+ * Provides typed accessors for different cloud storage credential types.
+ */
+public class VendedCredentials
+{
+  /**
+   * All known credential keys, derived from each credential type's {@code allKeys()}.
+   */
+  private static final List<String> ALL_CREDENTIAL_KEYS = Stream.of(
+      S3Credentials.allKeys(),
+      GcsCredentials.allKeys(),
+      AzureCredentials.allKeys()
+  ).flatMap(Collection::stream).collect(Collectors.toList());
+
+  private final Map<String, String> rawCredentials;
+
+  public VendedCredentials(@Nullable Map<String, String> rawCredentials)
+  {
+    this.rawCredentials = rawCredentials;
+  }
+
+  /**
+   * Extracts known credential keys from the given properties map.
+   *
+   * @param properties the source map to extract credentials from
+   * @return VendedCredentials containing any found credentials, or null if none found
+   */
+  @Nullable
+  public static VendedCredentials extractFrom(@Nullable Map<String, String> properties)
+  {
+    if (properties == null || properties.isEmpty()) {
+      return null;
+    }
+
+    Map<String, String> extracted = new HashMap<>();
+    for (String key : ALL_CREDENTIAL_KEYS) {
+      String value = properties.get(key);
+      if (value != null && !value.isEmpty()) {
+        extracted.put(key, value);
+      }
+    }
+
+    return extracted.isEmpty() ? null : new VendedCredentials(extracted);
+  }
+
+  /**
+   * Returns the raw credential map for custom extraction.
+   */
+  @Nullable
+  public Map<String, String> getRawCredentials()
+  {
+    return rawCredentials;
+  }
+
+  public boolean isEmpty()
+  {
+    return rawCredentials == null || rawCredentials.isEmpty();
+  }
+
+  /**
+   * S3 temporary credentials from catalog vending.
+   */
+  public static class S3Credentials
+  {
+    public static final String ACCESS_KEY_ID = "s3.access-key-id";
+    public static final String SECRET_ACCESS_KEY = "s3.secret-access-key";
+    public static final String SESSION_TOKEN = "s3.session-token";
+
+    private final String accessKeyId;
+    private final String secretAccessKey;
+    private final String sessionToken;
+
+    public S3Credentials(String accessKeyId, String secretAccessKey, @Nullable String sessionToken)
+    {
+      this.accessKeyId = accessKeyId;
+      this.secretAccessKey = secretAccessKey;
+      this.sessionToken = sessionToken;
+    }
+
+    static List<String> allKeys()
+    {
+      return Arrays.asList(ACCESS_KEY_ID, SECRET_ACCESS_KEY, SESSION_TOKEN);
+    }
+
+    @Nullable
+    public static S3Credentials extract(Map<String, String> props)
+    {
+      String ak = props.get(ACCESS_KEY_ID);
+      String sk = props.get(SECRET_ACCESS_KEY);
+      if (ak == null || sk == null) {
+        return null;
+      }
+      return new S3Credentials(ak, sk, props.get(SESSION_TOKEN));
+    }
+
+    public String getAccessKeyId()
+    {
+      return accessKeyId;
+    }
+
+    public String getSecretAccessKey()
+    {
+      return secretAccessKey;
+    }
+
+    @Nullable
+    public String getSessionToken()
+    {
+      return sessionToken;
+    }
+  }
+
+  /**
+   * GCS OAuth2 credentials from catalog vending.
+   */
+  public static class GcsCredentials
+  {
+    public static final String OAUTH2_TOKEN = "gcs.oauth2.token";
+    public static final String OAUTH2_TOKEN_EXPIRES_AT = "gcs.oauth2.token-expires-at";
+
+    private final String oauth2Token;
+    private final String expiresAt;
+
+    public GcsCredentials(String oauth2Token, @Nullable String expiresAt)
+    {
+      this.oauth2Token = oauth2Token;
+      this.expiresAt = expiresAt;
+    }
+
+    static List<String> allKeys()
+    {
+      return Arrays.asList(OAUTH2_TOKEN, OAUTH2_TOKEN_EXPIRES_AT);
+    }
+
+    @Nullable
+    public static GcsCredentials extract(Map<String, String> props)
+    {
+      String token = props.get(OAUTH2_TOKEN);
+      if (token == null) {
+        return null;
+      }
+      return new GcsCredentials(token, props.get(OAUTH2_TOKEN_EXPIRES_AT));
+    }
+
+    public String getOauth2Token()
+    {
+      return oauth2Token;
+    }
+
+    @Nullable
+    public String getExpiresAt()
+    {
+      return expiresAt;
+    }
+  }
+
+  /**
+   * Azure/ADLS credentials from catalog vending.
+   */
+  public static class AzureCredentials
+  {
+    public static final String SAS_TOKEN = "adls.sas-token";
+
+    private final String sasToken;
+
+    public AzureCredentials(String sasToken)
+    {
+      this.sasToken = sasToken;
+    }
+
+    static List<String> allKeys()
+    {
+      return Arrays.asList(SAS_TOKEN);
+    }
+
+    @Nullable
+    public static AzureCredentials extract(Map<String, String> props)
+    {
+      String token = props.get(SAS_TOKEN);
+      if (token == null) {
+        return null;
+      }
+      return new AzureCredentials(token);
+    }
+
+    public String getSasToken()
+    {
+      return sasToken;
+    }
+  }
+}

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
@@ -24,7 +24,7 @@ import com.google.common.net.HttpHeaders;
 import com.sun.net.httpserver.HttpServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.catalog.Catalog;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -79,12 +79,11 @@ public class RestCatalogTest
         mapper,
         new Configuration()
     );
-    RESTCatalog innerCatalog = (RESTCatalog) testRestCatalog.retrieveCatalog();
+    Catalog innerCatalog = testRestCatalog.retrieveCatalog();
 
     Assert.assertEquals("rest", innerCatalog.name());
-    Assert.assertNotNull(innerCatalog.properties());
     Assert.assertNotNull(testRestCatalog.getCatalogProperties());
-    Assert.assertEquals(testRestCatalog.getCatalogUri(), innerCatalog.properties().get("uri"));
+    Assert.assertEquals(catalogUri, testRestCatalog.getCatalogUri());
   }
   @After
   public void tearDown() throws IOException

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/VendedCredentialsTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/VendedCredentialsTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.iceberg.input;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class VendedCredentialsTest
+{
+  @Test
+  public void testExtractFromNull()
+  {
+    Assert.assertNull(VendedCredentials.extractFrom(null));
+  }
+
+  @Test
+  public void testExtractFromEmpty()
+  {
+    Assert.assertNull(VendedCredentials.extractFrom(Collections.emptyMap()));
+  }
+
+  @Test
+  public void testExtractFromUnrelatedKeys()
+  {
+    Map<String, String> props = Map.of("foo", "bar", "baz", "qux");
+    Assert.assertNull(VendedCredentials.extractFrom(props));
+  }
+
+  @Test
+  public void testExtractS3Credentials()
+  {
+    Map<String, String> props = Map.of(
+        "s3.access-key-id", "AKIAIOSFODNN7EXAMPLE",
+        "s3.secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "s3.session-token", "FwoGZXIvYXdzEBYaDHqa0AP"
+    );
+
+    VendedCredentials creds = VendedCredentials.extractFrom(props);
+    Assert.assertNotNull(creds);
+    Assert.assertFalse(creds.isEmpty());
+
+    VendedCredentials.S3Credentials s3 = VendedCredentials.S3Credentials.extract(creds.getRawCredentials());
+    Assert.assertNotNull(s3);
+    Assert.assertEquals("AKIAIOSFODNN7EXAMPLE", s3.getAccessKeyId());
+    Assert.assertEquals("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY", s3.getSecretAccessKey());
+    Assert.assertEquals("FwoGZXIvYXdzEBYaDHqa0AP", s3.getSessionToken());
+  }
+
+  @Test
+  public void testExtractS3CredentialsWithoutSessionToken()
+  {
+    Map<String, String> props = Map.of(
+        "s3.access-key-id", "AKIAIOSFODNN7EXAMPLE",
+        "s3.secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    );
+
+    VendedCredentials creds = VendedCredentials.extractFrom(props);
+    Assert.assertNotNull(creds);
+
+    VendedCredentials.S3Credentials s3 = VendedCredentials.S3Credentials.extract(creds.getRawCredentials());
+    Assert.assertNotNull(s3);
+    Assert.assertNull(s3.getSessionToken());
+  }
+
+  @Test
+  public void testExtractS3CredentialsMissingSecretKey()
+  {
+    Map<String, String> props = Map.of("s3.access-key-id", "AKIAIOSFODNN7EXAMPLE");
+
+    VendedCredentials creds = VendedCredentials.extractFrom(props);
+    Assert.assertNotNull(creds);
+
+    VendedCredentials.S3Credentials s3 = VendedCredentials.S3Credentials.extract(creds.getRawCredentials());
+    Assert.assertNull(s3);
+  }
+
+  @Test
+  public void testExtractGcsCredentials()
+  {
+    Map<String, String> props = Map.of(
+        "gcs.oauth2.token", "ya29.a0AfH6SMBx",
+        "gcs.oauth2.token-expires-at", "1680000000000"
+    );
+
+    VendedCredentials creds = VendedCredentials.extractFrom(props);
+    Assert.assertNotNull(creds);
+
+    VendedCredentials.GcsCredentials gcs = VendedCredentials.GcsCredentials.extract(creds.getRawCredentials());
+    Assert.assertNotNull(gcs);
+    Assert.assertEquals("ya29.a0AfH6SMBx", gcs.getOauth2Token());
+    Assert.assertEquals("1680000000000", gcs.getExpiresAt());
+  }
+
+  @Test
+  public void testExtractGcsCredentialsWithoutExpiry()
+  {
+    Map<String, String> props = Map.of("gcs.oauth2.token", "ya29.a0AfH6SMBx");
+
+    VendedCredentials creds = VendedCredentials.extractFrom(props);
+    Assert.assertNotNull(creds);
+
+    VendedCredentials.GcsCredentials gcs = VendedCredentials.GcsCredentials.extract(creds.getRawCredentials());
+    Assert.assertNotNull(gcs);
+    Assert.assertNull(gcs.getExpiresAt());
+  }
+
+  @Test
+  public void testExtractAzureCredentials()
+  {
+    Map<String, String> props = Map.of("adls.sas-token", "sv=2021-06-08&ss=bfqt&sig=xxx");
+
+    VendedCredentials creds = VendedCredentials.extractFrom(props);
+    Assert.assertNotNull(creds);
+
+    VendedCredentials.AzureCredentials azure = VendedCredentials.AzureCredentials.extract(creds.getRawCredentials());
+    Assert.assertNotNull(azure);
+    Assert.assertEquals("sv=2021-06-08&ss=bfqt&sig=xxx", azure.getSasToken());
+  }
+
+  @Test
+  public void testExtractAzureCredentialsMissing()
+  {
+    Map<String, String> props = Map.of("s3.access-key-id", "AKIAIOSFODNN7EXAMPLE");
+
+    VendedCredentials creds = VendedCredentials.extractFrom(props);
+    Assert.assertNotNull(creds);
+
+    VendedCredentials.AzureCredentials azure = VendedCredentials.AzureCredentials.extract(creds.getRawCredentials());
+    Assert.assertNull(azure);
+  }
+
+  @Test
+  public void testIsEmpty()
+  {
+    VendedCredentials empty = new VendedCredentials(null);
+    Assert.assertTrue(empty.isEmpty());
+
+    VendedCredentials alsoEmpty = new VendedCredentials(new HashMap<>());
+    Assert.assertTrue(alsoEmpty.isEmpty());
+
+    VendedCredentials notEmpty = new VendedCredentials(Map.of("s3.access-key-id", "AKIA"));
+    Assert.assertFalse(notEmpty.isEmpty());
+  }
+
+  @Test
+  public void testExtractFromEmptyValues()
+  {
+    Map<String, String> props = Map.of("s3.access-key-id", "", "s3.secret-access-key", "");
+    Assert.assertNull(VendedCredentials.extractFrom(props));
+  }
+}

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceFactory.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSourceFactory.java
@@ -30,6 +30,7 @@ import org.apache.druid.data.input.InputSourceFactory;
 import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.apache.druid.storage.s3.S3InputDataConfig;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -38,6 +39,7 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class S3InputSourceFactory implements InputSourceFactory
@@ -76,6 +78,15 @@ public class S3InputSourceFactory implements InputSourceFactory
   @Override
   public SplittableInputSource create(List<String> inputFilePaths)
   {
+    return create(inputFilePaths, null);
+  }
+
+  @Override
+  public SplittableInputSource create(List<String> inputFilePaths, @Nullable Map<String, String> vendedCredentials)
+  {
+    // Use vended credentials if provided, otherwise fall back to configured credentials
+    S3InputSourceConfig effectiveConfig = buildConfigWithVendedCredentials(vendedCredentials);
+
     return new S3InputSource(
         s3Client,
         s3ClientBuilder,
@@ -94,11 +105,44 @@ public class S3InputSourceFactory implements InputSourceFactory
         null,
         null,
         SystemFields.none(),
-        s3InputSourceConfig,
+        effectiveConfig,
         awsProxyConfig,
         awsEndpointConfig,
         awsClientConfig
     );
+  }
+
+  /**
+   * Builds an S3InputSourceConfig using vended credentials from the catalog.
+   * Falls back to the configured s3InputSourceConfig if no credentials are vended.
+   *
+   * @param vendedCredentials credential map from Iceberg catalog, may be null
+   * @return S3InputSourceConfig with vended credentials or the original config
+   */
+  @Nullable
+  private S3InputSourceConfig buildConfigWithVendedCredentials(@Nullable Map<String, String> vendedCredentials)
+  {
+    if (vendedCredentials == null || vendedCredentials.isEmpty()) {
+      return s3InputSourceConfig;
+    }
+
+    // Iceberg REST catalog credential keys (from REST spec)
+    String accessKeyId = vendedCredentials.get("s3.access-key-id");
+    String secretAccessKey = vendedCredentials.get("s3.secret-access-key");
+    String sessionToken = vendedCredentials.get("s3.session-token");
+
+    if (accessKeyId != null && secretAccessKey != null) {
+      return new S3InputSourceConfig(
+          new DefaultPasswordProvider(accessKeyId),
+          new DefaultPasswordProvider(secretAccessKey),
+          null, // assumeRoleArn - not needed with vended credentials
+          null, // assumeRoleExternalId
+          sessionToken != null ? new DefaultPasswordProvider(sessionToken) : null
+      );
+    }
+
+    // No S3 credentials in the vended map, fall back to configured config
+    return s3InputSourceConfig;
   }
 
   @Nullable

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceFactoryVendedCredentialsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceFactoryVendedCredentialsTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input.s3;
+
+import org.apache.druid.data.input.impl.SplittableInputSource;
+import org.apache.druid.storage.s3.S3InputDataConfig;
+import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class S3InputSourceFactoryVendedCredentialsTest
+{
+  private S3InputSourceFactory factory;
+  private List<String> testPaths;
+
+  @Before
+  public void setUp()
+  {
+    ServerSideEncryptingAmazonS3.Builder builder =
+        EasyMock.createMock(ServerSideEncryptingAmazonS3.Builder.class);
+    ServerSideEncryptingAmazonS3 service = EasyMock.createMock(ServerSideEncryptingAmazonS3.class);
+    S3InputDataConfig dataConfig = EasyMock.createMock(S3InputDataConfig.class);
+
+    factory = new S3InputSourceFactory(
+        service,
+        builder,
+        dataConfig,
+        null,
+        null,
+        null,
+        null,
+        null
+    );
+
+    testPaths = Arrays.asList("s3://bucket/path/file1.parquet", "s3://bucket/path/file2.parquet");
+  }
+
+  @Test
+  public void testCreateWithNullCredentials()
+  {
+    SplittableInputSource result = factory.create(testPaths, null);
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result instanceof S3InputSource);
+  }
+
+  @Test
+  public void testCreateWithEmptyCredentials()
+  {
+    SplittableInputSource result = factory.create(testPaths, Collections.emptyMap());
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result instanceof S3InputSource);
+  }
+
+  @Test
+  public void testCreateWithS3VendedCredentials()
+  {
+    Map<String, String> vendedCreds = Map.of(
+        "s3.access-key-id", "AKIAIOSFODNN7EXAMPLE",
+        "s3.secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "s3.session-token", "FwoGZXIvYXdzEBYaDHqa0AP"
+    );
+
+    SplittableInputSource result = factory.create(testPaths, vendedCreds);
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result instanceof S3InputSource);
+  }
+
+  @Test
+  public void testCreateWithS3CredentialsWithoutSessionToken()
+  {
+    Map<String, String> vendedCreds = Map.of(
+        "s3.access-key-id", "AKIAIOSFODNN7EXAMPLE",
+        "s3.secret-access-key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    );
+
+    SplittableInputSource result = factory.create(testPaths, vendedCreds);
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result instanceof S3InputSource);
+  }
+
+  @Test
+  public void testCreateWithNonS3CredentialsFallsBack()
+  {
+    Map<String, String> vendedCreds = Map.of(
+        "gcs.oauth2.token", "ya29.a0AfH6SMBx"
+    );
+
+    SplittableInputSource result = factory.create(testPaths, vendedCreds);
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result instanceof S3InputSource);
+  }
+
+  @Test
+  public void testCreateWithOnlyAccessKeyMissingSecretFallsBack()
+  {
+    Map<String, String> vendedCreds = new HashMap<>();
+    vendedCreds.put("s3.access-key-id", "AKIAIOSFODNN7EXAMPLE");
+
+    SplittableInputSource result = factory.create(testPaths, vendedCreds);
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result instanceof S3InputSource);
+  }
+
+  @Test
+  public void testDefaultCreateDelegatesToVendedVersion()
+  {
+    SplittableInputSource result1 = factory.create(testPaths);
+    SplittableInputSource result2 = factory.create(testPaths, null);
+    Assert.assertTrue(result1 instanceof S3InputSource);
+    Assert.assertTrue(result2 instanceof S3InputSource);
+  }
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractTask.java
@@ -21,9 +21,11 @@ package org.apache.druid.indexing.common.task;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
@@ -96,6 +98,17 @@ public abstract class AbstractTask implements Task
   private final String dataSource;
 
   private final Map<String, Object> context;
+
+  /**
+   * Task auth context for accessing external services that require user credentials.
+   * Serialized with the task payload so it survives the Overlord -> worker boundary,
+   * but credentials are redacted before metadata storage via
+   * {@link org.apache.druid.auth.TaskAuthContextRedactionMixIn}.
+   */
+  @JsonProperty
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Nullable
+  private TaskAuthContext taskAuthContext;
 
   private File reportsFile;
   private File statusFile;
@@ -293,6 +306,19 @@ public abstract class AbstractTask implements Task
   public String getDataSource()
   {
     return dataSource;
+  }
+
+  @Override
+  @Nullable
+  public TaskAuthContext getTaskAuthContext()
+  {
+    return taskAuthContext;
+  }
+
+  @Override
+  public void setTaskAuthContext(@Nullable TaskAuthContext authContext)
+  {
+    this.taskAuthContext = authContext;
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.indexer.TaskIdStatus;
 import org.apache.druid.indexer.TaskIdentifier;
 import org.apache.druid.indexer.TaskInfo;
@@ -307,6 +308,31 @@ public interface Task
   {
     final ContextValueType value = getContextValue(key);
     return value == null ? defaultValue : value;
+  }
+
+  /**
+   * Returns the task auth context containing credentials for external services.
+   * This is transient and not serialized to metadata storage.
+   *
+   * <p>The auth context is injected by {@link TaskAuthContextProvider} during task submission
+   * and is available during task execution for accessing external services that require
+   * user credentials (e.g., Iceberg REST Catalog with OAuth).
+   *
+   * @return the task auth context, or null if not set
+   */
+  default TaskAuthContext getTaskAuthContext()
+  {
+    return null;
+  }
+
+  /**
+   * Sets the task auth context. Called by OverlordResource during task submission.
+   *
+   * @param authContext the auth context to set, may be null
+   */
+  default void setTaskAuthContext(TaskAuthContext authContext)
+  {
+    // Default no-op for backward compatibility with existing Task implementations
   }
 
   default TaskIdentifier getMetadata()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/TaskAuthContextProvider.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/TaskAuthContextProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task;
+
+import org.apache.druid.auth.TaskAuthContext;
+import org.apache.druid.guice.annotations.ExtensionPoint;
+import org.apache.druid.server.security.AuthenticationResult;
+
+import javax.annotation.Nullable;
+
+/**
+ * Creates {@link TaskAuthContext} from authentication results during task submission.
+ *
+ * <p>Implementations extract relevant credentials from the {@link AuthenticationResult}
+ * (populated by the Authenticator) and create a TaskAuthContext that will be passed
+ * to the task for use during execution.
+ *
+ * <p>This interface is bound optionally via Guice. If no implementation is configured,
+ * no auth context will be injected into tasks.
+ *
+ * @see TaskAuthContext
+ */
+@ExtensionPoint
+public interface TaskAuthContextProvider
+{
+  /**
+   * Extract auth context from the authentication result for the given task.
+   *
+   * @param authenticationResult the authentication result from the Authenticator,
+   *                             containing identity and context map with credentials
+   * @param task                 the task being submitted, can be used to make decisions
+   *                             based on task type, datasource, etc.
+   * @return TaskAuthContext to inject into the task, or null to skip injection
+   */
+  @Nullable
+  TaskAuthContext createTaskAuthContext(AuthenticationResult authenticationResult, Task task);
+}

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTask.java
@@ -34,6 +34,7 @@ import org.apache.datasketches.memory.Memory;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputSource;
+import org.apache.druid.data.input.TaskAuthContextAware;
 import org.apache.druid.indexer.IngestionState;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
@@ -539,6 +540,11 @@ public class ParallelIndexSupervisorTask extends AbstractBatchIndexTask
 
       initializeSubTaskCleaner();
       this.toolbox = toolbox;
+
+      // Propagate auth context to input source for credential vending (e.g., Iceberg REST Catalog)
+      if (baseInputSource instanceof TaskAuthContextAware) {
+        ((TaskAuthContextAware) baseInputSource).setTaskAuthContext(getTaskAuthContext());
+      }
 
       if (isParallelMode()) {
         // emit metric for parallel batch ingestion mode:

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/TaskQueue.java
@@ -32,6 +32,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import org.apache.druid.annotations.SuppressFBWarnings;
+import org.apache.druid.auth.TaskAuthContext;
+import org.apache.druid.auth.TaskAuthContextRedactionMixIn;
 import org.apache.druid.common.utils.IdUtils;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.EntryAlreadyExists;
@@ -197,7 +199,8 @@ public class TaskQueue
         "TaskQueue-OnComplete-%d"
     );
     this.passwordRedactingMapper = mapper.copy()
-                                         .addMixIn(PasswordProvider.class, PasswordProviderRedactionMixIn.class);
+                                         .addMixIn(PasswordProvider.class, PasswordProviderRedactionMixIn.class)
+                                         .addMixIn(TaskAuthContext.class, TaskAuthContextRedactionMixIn.class);
     this.taskContextEnricher = Preconditions.checkNotNull(taskContextEnricher, "taskContextEnricher");
   }
 

--- a/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/overlord/http/OverlordResource.java
@@ -30,6 +30,7 @@ import com.google.inject.Inject;
 import com.sun.jersey.spi.container.ResourceFilters;
 import org.apache.druid.audit.AuditEntry;
 import org.apache.druid.audit.AuditManager;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.client.indexing.ClientTaskQuery;
 import org.apache.druid.common.config.ConfigManager.SetResult;
 import org.apache.druid.common.config.Configs;
@@ -43,6 +44,7 @@ import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.actions.TaskActionHolder;
 import org.apache.druid.indexing.common.task.Task;
+import org.apache.druid.indexing.common.task.TaskAuthContextProvider;
 import org.apache.druid.indexing.overlord.DruidOverlord;
 import org.apache.druid.indexing.overlord.IndexerMetadataStorageAdapter;
 import org.apache.druid.indexing.overlord.TaskMaster;
@@ -67,6 +69,7 @@ import org.apache.druid.server.http.security.DatasourceResourceFilter;
 import org.apache.druid.server.http.security.StateResourceFilter;
 import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.AuthorizationResult;
 import org.apache.druid.server.security.AuthorizationUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
@@ -122,6 +125,13 @@ public class OverlordResource
 
   private final AuthConfig authConfig;
 
+  /**
+   * Optional provider for injecting auth context into tasks.
+   * If not bound, no auth context will be injected.
+   */
+  @Nullable
+  private TaskAuthContextProvider taskAuthContextProvider;
+
   private static final List<String> API_TASK_STATES = ImmutableList.of("pending", "waiting", "running", "complete");
   private static final Set<String> AUDITED_TASK_TYPES
       = ImmutableSet.of("index", "index_parallel", "compact", "kill");
@@ -150,6 +160,16 @@ public class OverlordResource
     this.authorizerMapper = authorizerMapper;
     this.workerTaskRunnerQueryAdapter = workerTaskRunnerQueryAdapter;
     this.authConfig = authConfig;
+  }
+
+  /**
+   * Optional setter for TaskAuthContextProvider. If bound in Guice, this will be called
+   * to enable auth context injection into tasks.
+   */
+  @Inject(optional = true)
+  public void setTaskAuthContextProvider(@Nullable TaskAuthContextProvider provider)
+  {
+    this.taskAuthContextProvider = provider;
   }
 
   /**
@@ -183,6 +203,27 @@ public class OverlordResource
     );
     if (!authResult.allowAccessWithNoRestriction()) {
       throw new ForbiddenException(authResult.getErrorMessage());
+    }
+
+    // Inject auth context if provider is configured
+    if (taskAuthContextProvider != null) {
+      final AuthenticationResult authenticationResult = AuthorizationUtils.authenticationResultFromRequest(req);
+      if (authenticationResult != null) {
+        final TaskAuthContext taskAuthContext = taskAuthContextProvider.createTaskAuthContext(
+            authenticationResult,
+            task
+        );
+        if (taskAuthContext != null) {
+          task.setTaskAuthContext(taskAuthContext);
+          if (task.getTaskAuthContext() == null) {
+            log.warn(
+                "Auth context was provided but task type [%s] does not support it (dropped for task [%s])",
+                task.getType(),
+                task.getId()
+            );
+          }
+        }
+      }
     }
 
     return asLeaderWith(

--- a/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycle.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycle.java
@@ -26,6 +26,8 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Inject;
+import org.apache.druid.auth.TaskAuthContext;
+import org.apache.druid.auth.TaskAuthContextRedactionMixIn;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.actions.TaskActionClientFactory;
 import org.apache.druid.indexing.common.config.TaskConfig;
@@ -83,7 +85,9 @@ public class ExecutorLifecycle
     this.taskConfig = taskConfig;
     this.taskActionClientFactory = taskActionClientFactory;
     this.taskRunner = taskRunner;
-    this.jsonMapper = jsonMapper.copy().addMixIn(PasswordProvider.class, PasswordProviderRedactionMixIn.class);
+    this.jsonMapper = jsonMapper.copy()
+        .addMixIn(PasswordProvider.class, PasswordProviderRedactionMixIn.class)
+        .addMixIn(TaskAuthContext.class, TaskAuthContextRedactionMixIn.class);
   }
 
   @LifecycleStart

--- a/indexing-service/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/indexing-service/src/main/java/org/apache/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -27,6 +27,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
+import org.apache.druid.auth.TaskAuthContext;
+import org.apache.druid.auth.TaskAuthContextRedactionMixIn;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.error.InvalidInput;
 import org.apache.druid.indexer.TaskIdStatus;
@@ -96,7 +98,9 @@ public abstract class SQLMetadataStorageActionHandler
   )
   {
     this.connector = connector;
-    this.jsonMapper = jsonMapper.copy().addMixIn(PasswordProvider.class, PasswordProviderRedactionMixIn.class);
+    this.jsonMapper = jsonMapper.copy()
+        .addMixIn(PasswordProvider.class, PasswordProviderRedactionMixIn.class)
+        .addMixIn(TaskAuthContext.class, TaskAuthContextRedactionMixIn.class);
     this.entryTable = entryTable;
     this.lockTable = lockTable;
     this.taskInfoMapper = new TaskInfoMapper(jsonMapper);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskAuthContextSerializationTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskAuthContextSerializationTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.common.task;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.apache.druid.auth.TaskAuthContext;
+import org.apache.druid.auth.TaskAuthContextRedactionMixIn;
+import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.metadata.PasswordProvider;
+import org.apache.druid.metadata.PasswordProviderRedactionMixIn;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class TaskAuthContextSerializationTest
+{
+  private ObjectMapper mapper;
+  private ObjectMapper redactingMapper;
+
+  @Before
+  public void setUp()
+  {
+    mapper = new DefaultObjectMapper();
+    mapper.registerSubtypes(
+        new NamedType(NoopTask.class, "noop"),
+        new NamedType(TestTaskAuthContext.class, "test")
+    );
+
+    redactingMapper = mapper.copy()
+        .addMixIn(PasswordProvider.class, PasswordProviderRedactionMixIn.class)
+        .addMixIn(TaskAuthContext.class, TaskAuthContextRedactionMixIn.class);
+  }
+
+  @Test
+  public void testNullAuthContextIsOmittedFromJson() throws Exception
+  {
+    NoopTask task = NoopTask.create();
+    Assert.assertNull(task.getTaskAuthContext());
+
+    String json = mapper.writeValueAsString(task);
+    Assert.assertFalse(json.contains("taskAuthContext"));
+  }
+
+  @Test
+  public void testAuthContextSerializedWhenPresent() throws Exception
+  {
+    NoopTask task = NoopTask.create();
+    task.setTaskAuthContext(new TestTaskAuthContext(
+        "user@test.com",
+        Map.of("token", "my-secret-token"),
+        null
+    ));
+
+    String json = mapper.writeValueAsString(task);
+    Assert.assertTrue(json.contains("taskAuthContext"));
+    Assert.assertTrue(json.contains("user@test.com"));
+    Assert.assertTrue(json.contains("my-secret-token"));
+  }
+
+  @Test
+  public void testRedactingMapperRemovesCredentialsFromTask() throws Exception
+  {
+    NoopTask task = NoopTask.create();
+    task.setTaskAuthContext(new TestTaskAuthContext(
+        "user@test.com",
+        Map.of("token", "my-secret-token"),
+        Map.of("scope", "catalog")
+    ));
+
+    String json = redactingMapper.writeValueAsString(task);
+
+    Assert.assertFalse(json.contains("my-secret-token"));
+    Assert.assertTrue(json.contains("user@test.com"));
+    Assert.assertTrue(json.contains("catalog"));
+  }
+
+  @Test
+  public void testRoundTripSerializationPreservesAuthContext() throws Exception
+  {
+    NoopTask original = NoopTask.create();
+    original.setTaskAuthContext(new TestTaskAuthContext(
+        "user@test.com",
+        Map.of("token", "my-secret-token"),
+        null
+    ));
+
+    String json = mapper.writeValueAsString(original);
+    Task deserialized = mapper.readValue(json, Task.class);
+
+    Assert.assertNotNull(deserialized.getTaskAuthContext());
+    Assert.assertEquals("user@test.com", deserialized.getTaskAuthContext().getIdentity());
+    Assert.assertEquals("my-secret-token", deserialized.getTaskAuthContext().getCredentials().get("token"));
+  }
+
+  @Test
+  public void testRedactedJsonDoesNotDeserializeCredentials() throws Exception
+  {
+    NoopTask original = NoopTask.create();
+    original.setTaskAuthContext(new TestTaskAuthContext(
+        "user@test.com",
+        Map.of("token", "my-secret-token"),
+        null
+    ));
+
+    String redactedJson = redactingMapper.writeValueAsString(original);
+    Task deserialized = mapper.readValue(redactedJson, Task.class);
+    Assert.assertNotNull(deserialized.getTaskAuthContext());
+    Assert.assertEquals("user@test.com", deserialized.getTaskAuthContext().getIdentity());
+    Assert.assertNull(deserialized.getTaskAuthContext().getCredentials());
+  }
+
+  @Test
+  public void testSetAndGetAuthContext()
+  {
+    NoopTask task = NoopTask.create();
+    Assert.assertNull(task.getTaskAuthContext());
+
+    TestTaskAuthContext ctx = new TestTaskAuthContext("user", Map.of("k", "v"), null);
+    task.setTaskAuthContext(ctx);
+    Assert.assertSame(ctx, task.getTaskAuthContext());
+
+    task.setTaskAuthContext(null);
+    Assert.assertNull(task.getTaskAuthContext());
+  }
+
+  @JsonTypeName("test")
+  public static class TestTaskAuthContext implements TaskAuthContext
+  {
+    private final String identity;
+    private final Map<String, String> credentials;
+    private final Map<String, Object> metadata;
+
+    public TestTaskAuthContext(
+        @JsonProperty("identity") String identity,
+        @JsonProperty("credentials") @Nullable Map<String, String> credentials,
+        @JsonProperty("metadata") @Nullable Map<String, Object> metadata
+    )
+    {
+      this.identity = identity;
+      this.credentials = credentials;
+      this.metadata = metadata;
+    }
+
+    @Override
+    @JsonProperty
+    public String getIdentity()
+    {
+      return identity;
+    }
+
+    @Override
+    @JsonProperty
+    @Nullable
+    public Map<String, String> getCredentials()
+    {
+      return credentials;
+    }
+
+    @Override
+    @JsonProperty
+    @Nullable
+    public Map<String, Object> getMetadata()
+    {
+      return metadata;
+    }
+  }
+}

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceAuthContextTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/OverlordResourceAuthContextTest.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.indexing.overlord.http;
+
+import com.google.common.base.Optional;
+import org.apache.druid.audit.AuditManager;
+import org.apache.druid.auth.TaskAuthContext;
+import org.apache.druid.common.config.JacksonConfigManager;
+import org.apache.druid.indexing.common.task.NoopTask;
+import org.apache.druid.indexing.overlord.DruidOverlord;
+import org.apache.druid.indexing.overlord.IndexerMetadataStorageAdapter;
+import org.apache.druid.indexing.overlord.TaskMaster;
+import org.apache.druid.indexing.overlord.TaskQueryTool;
+import org.apache.druid.indexing.overlord.TaskQueue;
+import org.apache.druid.indexing.overlord.TaskRunner;
+import org.apache.druid.indexing.overlord.WorkerTaskRunnerQueryAdapter;
+import org.apache.druid.server.security.Access;
+import org.apache.druid.server.security.Action;
+import org.apache.druid.server.security.AuthConfig;
+import org.apache.druid.server.security.AuthenticationResult;
+import org.apache.druid.server.security.Authorizer;
+import org.apache.druid.server.security.AuthorizerMapper;
+import org.apache.druid.server.security.Resource;
+import org.easymock.EasyMock;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
+
+public class OverlordResourceAuthContextTest
+{
+  private OverlordResource overlordResource;
+  private TaskMaster taskMaster;
+  private TaskQueue taskQueue;
+  private TaskRunner taskRunner;
+  private HttpServletRequest req;
+  private AuthConfig authConfig;
+  private DruidOverlord overlord;
+  private JacksonConfigManager configManager;
+  private AuditManager auditManager;
+  private WorkerTaskRunnerQueryAdapter workerTaskRunnerQueryAdapter;
+
+  @Before
+  public void setUp()
+  {
+    taskRunner = EasyMock.createMock(TaskRunner.class);
+    taskQueue = EasyMock.createStrictMock(TaskQueue.class);
+    taskMaster = EasyMock.createStrictMock(TaskMaster.class);
+    overlord = EasyMock.createStrictMock(DruidOverlord.class);
+    configManager = EasyMock.createMock(JacksonConfigManager.class);
+    auditManager = EasyMock.createMock(AuditManager.class);
+    authConfig = EasyMock.createMock(AuthConfig.class);
+    req = EasyMock.createStrictMock(HttpServletRequest.class);
+    workerTaskRunnerQueryAdapter = EasyMock.createStrictMock(WorkerTaskRunnerQueryAdapter.class);
+
+    EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
+
+    AuthorizerMapper authMapper = new AuthorizerMapper(null)
+    {
+      @Override
+      public Authorizer getAuthorizer(String name)
+      {
+        return (AuthenticationResult authenticationResult, Resource resource, Action action) ->
+            Access.allow();
+      }
+    };
+
+    overlordResource = new OverlordResource(
+        overlord,
+        taskMaster,
+        new TaskQueryTool(
+            EasyMock.createMock(org.apache.druid.indexing.overlord.TaskStorage.class),
+            EasyMock.createMock(org.apache.druid.indexing.overlord.GlobalTaskLockbox.class),
+            taskMaster,
+            () -> null
+        ),
+        EasyMock.createMock(IndexerMetadataStorageAdapter.class),
+        null,
+        configManager,
+        auditManager,
+        authMapper,
+        workerTaskRunnerQueryAdapter,
+        authConfig
+    );
+  }
+
+  @After
+  public void tearDown()
+  {
+  }
+
+  @Test
+  public void testTaskPostWithAuthContextProvider()
+  {
+    final TestTaskAuthContext expectedAuthContext = new TestTaskAuthContext(
+        "testUser",
+        Map.of("token", "secret-token")
+    );
+    overlordResource.setTaskAuthContextProvider(
+        (authResult, task) -> expectedAuthContext
+    );
+
+    AuthenticationResult authResult = expectAuthorizationTokenCheck("testUser");
+    EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(false);
+    // Auth context injection calls authenticationResultFromRequest again
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+            .andReturn(authResult).once();
+    EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
+    EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).once();
+
+    replayAll();
+
+    NoopTask task = NoopTask.forDatasource("allow");
+    overlordResource.taskPost(task, req);
+
+    Assert.assertNotNull(task.getTaskAuthContext());
+    Assert.assertEquals("testUser", task.getTaskAuthContext().getIdentity());
+    Assert.assertEquals("secret-token", task.getTaskAuthContext().getCredentials().get("token"));
+  }
+
+  @Test
+  public void testTaskPostWithoutAuthContextProvider()
+  {
+    expectAuthorizationTokenCheck("testUser");
+    EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(false);
+    EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
+    EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).once();
+
+    replayAll();
+
+    NoopTask task = NoopTask.forDatasource("allow");
+    overlordResource.taskPost(task, req);
+
+    Assert.assertNull(task.getTaskAuthContext());
+  }
+
+  @Test
+  public void testTaskPostWithProviderReturningNull()
+  {
+    overlordResource.setTaskAuthContextProvider((ar, t) -> null);
+
+    AuthenticationResult authResult = expectAuthorizationTokenCheck("testUser");
+    EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(false);
+    // Auth context injection calls authenticationResultFromRequest again
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+            .andReturn(authResult).once();
+    EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
+    EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andReturn(true).once();
+
+    replayAll();
+
+    NoopTask task = NoopTask.forDatasource("allow");
+    overlordResource.taskPost(task, req);
+
+    Assert.assertNull(task.getTaskAuthContext());
+  }
+
+  private AuthenticationResult expectAuthorizationTokenCheck(String username)
+  {
+    AuthenticationResult authenticationResult = new AuthenticationResult(username, "druid", null, null);
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH)).andReturn(null).anyTimes();
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED)).andReturn(null).atLeastOnce();
+    EasyMock.expect(req.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+            .andReturn(authenticationResult)
+            .atLeastOnce();
+    req.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, false);
+    EasyMock.expectLastCall().anyTimes();
+    req.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, true);
+    EasyMock.expectLastCall().anyTimes();
+    return authenticationResult;
+  }
+
+  private void replayAll()
+  {
+    EasyMock.replay(
+        taskRunner,
+        taskQueue,
+        taskMaster,
+        overlord,
+        req,
+        authConfig,
+        configManager,
+        auditManager,
+        workerTaskRunnerQueryAdapter
+    );
+  }
+
+  private static class TestTaskAuthContext implements TaskAuthContext
+  {
+    private final String identity;
+    private final Map<String, String> credentials;
+
+    TestTaskAuthContext(String identity, Map<String, String> credentials)
+    {
+      this.identity = identity;
+      this.credentials = credentials;
+    }
+
+    @Override
+    public String getIdentity()
+    {
+      return identity;
+    }
+
+    @Override
+    @Nullable
+    public Map<String, String> getCredentials()
+    {
+      return credentials;
+    }
+  }
+}

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerContext.java
@@ -21,6 +21,7 @@ package org.apache.druid.msq.exec;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Injector;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.java.util.common.io.Closer;
@@ -32,6 +33,7 @@ import org.apache.druid.msq.input.table.TableInputSpec;
 import org.apache.druid.msq.kernel.controller.ControllerQueryKernelConfig;
 import org.apache.druid.server.DruidNode;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -123,4 +125,14 @@ public interface ControllerContext
    * Client for communicating with workers.
    */
   WorkerClient newWorkerClient();
+
+  /**
+   * Returns the task auth context for accessing external resources that require authentication.
+   * May be null if no auth context is available.
+   */
+  @Nullable
+  default TaskAuthContext taskAuthContext()
+  {
+    return null;
+  }
 }

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerImpl.java
@@ -36,6 +36,7 @@ import it.unimi.dsi.fastutil.ints.IntArraySet;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.fastutil.ints.IntObjectPair;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.client.broker.BrokerClient;
 import org.apache.druid.common.guava.FutureUtils;
 import org.apache.druid.data.input.StringTuple;
@@ -424,7 +425,7 @@ public class ControllerImpl implements Controller
 
       // Execution-related: run the multi-stage QueryDefinition.
       final InputSpecSlicerFactory inputSpecSlicerFactory =
-          makeInputSpecSlicerFactory(context.newTableInputSpecSlicer(workerManager));
+          makeInputSpecSlicerFactory(context.newTableInputSpecSlicer(workerManager), context.taskAuthContext());
 
       final Pair<ControllerQueryKernel, ListenableFuture<?>> queryRunResult =
           new RunQueryUntilDone(
@@ -2143,12 +2144,15 @@ public class ControllerImpl implements Controller
     );
   }
 
-  private static InputSpecSlicerFactory makeInputSpecSlicerFactory(final InputSpecSlicer tableInputSpecSlicer)
+  private static InputSpecSlicerFactory makeInputSpecSlicerFactory(
+      final InputSpecSlicer tableInputSpecSlicer,
+      @Nullable final TaskAuthContext taskAuthContext
+  )
   {
     return (stagePartitionsMap, stageOutputChannelModeMap) -> new MapInputSpecSlicer(
         ImmutableMap.<Class<? extends InputSpec>, InputSpecSlicer>builder()
                     .put(StageInputSpec.class, new StageInputSpecSlicer(stagePartitionsMap, stageOutputChannelModeMap))
-                    .put(ExternalInputSpec.class, new ExternalInputSpecSlicer())
+                    .put(ExternalInputSpec.class, new ExternalInputSpecSlicer(taskAuthContext))
                     .put(InlineInputSpec.class, new InlineInputSpecSlicer())
                     .put(LookupInputSpec.class, new LookupInputSpecSlicer())
                     .put(TableInputSpec.class, tableInputSpecSlicer)

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerControllerContext.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.frame.FrameType;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.indexing.common.TaskLockType;
@@ -201,6 +202,12 @@ public class IndexerControllerContext implements ControllerContext
   public WorkerClient newWorkerClient()
   {
     return new IndexerWorkerClient(clientFactory, overlordClient, jsonMapper());
+  }
+
+  @Override
+  public TaskAuthContext taskAuthContext()
+  {
+    return task.getTaskAuthContext();
   }
 
   @Override

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicer.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicer.java
@@ -20,11 +20,13 @@
 package org.apache.druid.msq.input.external;
 
 import com.google.common.collect.Iterators;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.data.input.FilePerSplitHintSpec;
 import org.apache.druid.data.input.InputFileAttribute;
 import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.SplitHintSpec;
+import org.apache.druid.data.input.TaskAuthContextAware;
 import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.msq.input.InputSpec;
@@ -47,6 +49,19 @@ import java.util.stream.Collectors;
  */
 public class ExternalInputSpecSlicer implements InputSpecSlicer
 {
+  @Nullable
+  private final TaskAuthContext taskAuthContext;
+
+  public ExternalInputSpecSlicer()
+  {
+    this(null);
+  }
+
+  public ExternalInputSpecSlicer(@Nullable TaskAuthContext taskAuthContext)
+  {
+    this.taskAuthContext = taskAuthContext;
+  }
+
   @Override
   public boolean canSliceDynamic(InputSpec inputSpec)
   {
@@ -108,7 +123,7 @@ public class ExternalInputSpecSlicer implements InputSpecSlicer
   /**
    * Slice a {@link SplittableInputSource} using a {@link SplitHintSpec}.
    */
-  private static List<InputSlice> sliceSplittableInputSource(
+  private List<InputSlice> sliceSplittableInputSource(
       final ExternalInputSpec inputSpec,
       final SplitHintSpec splitHintSpec,
       final int maxNumSlices
@@ -116,6 +131,11 @@ public class ExternalInputSpecSlicer implements InputSpecSlicer
   {
     final SplittableInputSource<Object> splittableInputSource =
         (SplittableInputSource<Object>) inputSpec.getInputSource();
+
+    // Inject auth context if the input source supports it
+    if (splittableInputSource instanceof TaskAuthContextAware) {
+      ((TaskAuthContextAware) splittableInputSource).setTaskAuthContext(taskAuthContext);
+    }
 
     try {
       final List<InputSplit<Object>> splitList =

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/sql/MSQTaskQueryMaker.java
@@ -81,6 +81,7 @@ import org.apache.druid.sql.destination.IngestDestination;
 import org.apache.druid.sql.destination.TableDestination;
 import org.apache.druid.sql.hook.DruidHook;
 import org.apache.druid.sql.http.ResultFormat;
+import org.apache.druid.utils.CollectionUtils;
 import org.joda.time.Interval;
 
 import javax.annotation.Nullable;
@@ -171,7 +172,13 @@ public class MSQTaskQueryMaker implements QueryMaker
         taskContext
     );
 
-    FutureUtils.getUnchecked(overlordClient.runTask(taskId, controllerTask), true);
+    // Propagate auth context headers to Overlord for consumption
+    if (plannerContext.getAuthenticationResult() != null && plannerContext.getAuthenticationResult().getContext() != null) {
+      final Map<String, String> extraHeaders = CollectionUtils.mapValues(plannerContext.getAuthenticationResult().getContext(), String::valueOf);
+      FutureUtils.getUnchecked(overlordClient.runTask(taskId, controllerTask, extraHeaders), true);
+    } else {
+      FutureUtils.getUnchecked(overlordClient.runTask(taskId, controllerTask), true);
+    }
     return QueryResponse.withEmptyContext(Sequences.simple(Collections.singletonList(new Object[]{taskId})));
   }
 

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicerTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/input/external/ExternalInputSpecSlicerTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.msq.input.external;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.auth.TaskAuthContext;
 import org.apache.druid.data.input.InputFileAttribute;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRowSchema;
@@ -27,8 +28,10 @@ import org.apache.druid.data.input.InputSource;
 import org.apache.druid.data.input.InputSourceReader;
 import org.apache.druid.data.input.InputSplit;
 import org.apache.druid.data.input.SplitHintSpec;
+import org.apache.druid.data.input.TaskAuthContextAware;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.SplittableInputSource;
+import org.apache.druid.msq.input.InputSlice;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.utils.Streams;
@@ -42,6 +45,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -427,6 +431,135 @@ public class ExternalInputSpecSlicerTest
       return "TestSplittableInputSource{" +
              "strings=" + strings +
              '}';
+    }
+  }
+
+  @Test
+  public void test_sliceStatic_authContextPropagatedToTaskAuthContextAware()
+  {
+    TaskAuthContext authContext = new TaskAuthContext()
+    {
+      @Override
+      public String getIdentity()
+      {
+        return "testUser";
+      }
+
+      @Override
+      public Map<String, String> getCredentials()
+      {
+        return Map.of("token", "secret");
+      }
+    };
+
+    ExternalInputSpecSlicer slicerWithAuth = new ExternalInputSpecSlicer(authContext);
+
+    AuthAwareSplittableInputSource source = new AuthAwareSplittableInputSource(
+        Arrays.asList("a", "b"),
+        false
+    );
+    ExternalInputSpec spec = new ExternalInputSpec(source, INPUT_FORMAT, SIGNATURE);
+
+    List<InputSlice> slices = slicerWithAuth.sliceStatic(spec, null, 2);
+    Assert.assertFalse(slices.isEmpty());
+    Assert.assertNotNull(source.getReceivedAuthContext());
+    Assert.assertEquals("testUser", source.getReceivedAuthContext().getIdentity());
+  }
+
+  @Test
+  public void test_sliceStatic_noAuthContextDoesNotFailNonAwareSources()
+  {
+    ExternalInputSpecSlicer slicerNoAuth = new ExternalInputSpecSlicer();
+
+    TestSplittableInputSource source = new TestSplittableInputSource(
+        Arrays.asList("a", "b"),
+        false
+    );
+    ExternalInputSpec spec = new ExternalInputSpec(source, INPUT_FORMAT, SIGNATURE);
+
+    List<InputSlice> slices = slicerNoAuth.sliceStatic(spec, null, 2);
+    Assert.assertFalse(slices.isEmpty());
+  }
+
+  private static class AuthAwareSplittableInputSource
+      implements SplittableInputSource<List<String>>, TaskAuthContextAware
+  {
+    private final List<String> strings;
+    private final boolean useSplitHintSpec;
+    private TaskAuthContext receivedAuthContext;
+
+    public AuthAwareSplittableInputSource(final List<String> strings, final boolean useSplitHintSpec)
+    {
+      this.strings = strings;
+      this.useSplitHintSpec = useSplitHintSpec;
+    }
+
+    @Override
+    public void setTaskAuthContext(@Nullable TaskAuthContext taskAuthContext)
+    {
+      this.receivedAuthContext = taskAuthContext;
+    }
+
+    @Nullable
+    public TaskAuthContext getReceivedAuthContext()
+    {
+      return receivedAuthContext;
+    }
+
+    @Override
+    public boolean needsFormat()
+    {
+      return false;
+    }
+
+    @Override
+    public InputSourceReader reader(
+        InputRowSchema inputRowSchema,
+        @Nullable InputFormat inputFormat,
+        File temporaryDirectory
+    )
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Stream<InputSplit<List<String>>> createSplits(
+        InputFormat inputFormat,
+        @Nullable SplitHintSpec splitHintSpec
+    )
+    {
+      return strings.stream().map(s -> new InputSplit<>(Collections.singletonList(s)));
+    }
+
+    @Override
+    public int estimateNumSplits(InputFormat inputFormat, @Nullable SplitHintSpec splitHintSpec)
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InputSource withSplit(InputSplit<List<String>> split)
+    {
+      return new AuthAwareSplittableInputSource(split.get(), useSplitHintSpec);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      AuthAwareSplittableInputSource that = (AuthAwareSplittableInputSource) o;
+      return Objects.equals(strings, that.strings);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(strings);
     }
   }
 }

--- a/processing/src/main/java/org/apache/druid/auth/TaskAuthContext.java
+++ b/processing/src/main/java/org/apache/druid/auth/TaskAuthContext.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.auth;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.druid.guice.annotations.ExtensionPoint;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+/**
+ * Holds authentication context that can be passed to tasks for accessing external services
+ * that require user credentials (e.g., Iceberg REST Catalog with OAuth).
+ *
+ * <p>Implementations must ensure credentials are redacted during serialization by applying
+ * {@link TaskAuthContextRedactionMixIn} to the ObjectMapper used for persistence/logging.
+ * This follows the same pattern as {@link org.apache.druid.metadata.PasswordProvider} and
+ * {@link org.apache.druid.metadata.PasswordProviderRedactionMixIn}.
+ *
+ * <p>The auth context is injected into tasks at submission time by {@code TaskAuthContextProvider}
+ * and is available during task execution. It is NOT persisted to metadata storage - only the
+ * non-sensitive fields (identity, metadata) are serialized.
+ *
+ * <p><b>Credential lifetime:</b> Vended credentials (OAuth tokens, STS session tokens) have
+ * limited lifetimes, typically 1-12 hours. There is currently no credential refresh mechanism,
+ * so long-running tasks may fail when credentials expire. Task restarts are also not supported
+ * since the original credentials are not preserved.
+ *
+ * @see TaskAuthContextRedactionMixIn
+ */
+@ExtensionPoint
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public interface TaskAuthContext
+{
+  /**
+   * Returns the authenticated identity (e.g., username, email, service account name).
+   * This value is safe to serialize and log.
+   *
+   * @return the identity string
+   */
+  String getIdentity();
+
+  /**
+   * Returns sensitive credentials (e.g., OAuth tokens, API keys).
+   * This method MUST be redacted during serialization via {@link TaskAuthContextRedactionMixIn}.
+   *
+   * <p>The map keys are credential identifiers (e.g., "token", "oauth2-token") and values
+   * are the actual credential strings. The specific keys expected depend on the consumer
+   * (e.g., Iceberg REST Catalog may expect "token").
+   *
+   * @return map of credential name to credential value, or null if no credentials
+   */
+  @Nullable
+  Map<String, String> getCredentials();
+
+  /**
+   * Returns non-sensitive metadata about the auth context (e.g., token expiry time, scopes, roles).
+   * This value is safe to serialize and log.
+   *
+   * @return map of metadata, or null if no metadata
+   */
+  @Nullable
+  default Map<String, Object> getMetadata()
+  {
+    return null;
+  }
+}

--- a/processing/src/main/java/org/apache/druid/auth/TaskAuthContextRedactionMixIn.java
+++ b/processing/src/main/java/org/apache/druid/auth/TaskAuthContextRedactionMixIn.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.auth;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.util.Map;
+
+/**
+ * Jackson MixIn to redact credentials when serializing {@link TaskAuthContext}.
+ *
+ * <p>This MixIn should be applied to ObjectMappers used for:
+ * <ul>
+ *   <li>Task persistence to metadata storage</li>
+ *   <li>Task logging</li>
+ *   <li>API responses that include task payloads</li>
+ * </ul>
+ *
+ * <p>This follows the same pattern as {@link org.apache.druid.metadata.PasswordProviderRedactionMixIn}.
+ *
+ * @see TaskAuthContext
+ */
+public interface TaskAuthContextRedactionMixIn
+{
+  @SuppressWarnings("unused")
+  @JsonIgnore
+  Map<String, String> getCredentials();
+}

--- a/processing/src/main/java/org/apache/druid/data/input/InputSourceFactory.java
+++ b/processing/src/main/java/org/apache/druid/data/input/InputSourceFactory.java
@@ -25,7 +25,9 @@ import org.apache.druid.data.input.impl.LocalInputSourceFactory;
 import org.apache.druid.data.input.impl.SplittableInputSource;
 import org.apache.druid.guice.annotations.UnstableApi;
 
+import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An interface to generate a {@link SplittableInputSource} objects on the fly.
@@ -41,4 +43,27 @@ import java.util.List;
 public interface InputSourceFactory
 {
   SplittableInputSource create(List<String> inputFilePaths);
+
+  /**
+   * Creates a SplittableInputSource with optional credentials.
+   *
+   * <p>This method is used when reading data files from a catalog (like Iceberg REST catalog)
+   * that vends temporary credentials for accessing the underlying storage. The credentials
+   * map contains storage-specific keys that the implementing factory should interpret.
+   *
+   * <p>Common credential keys by storage type:
+   * <ul>
+   *   <li>S3: {@code s3.access-key-id}, {@code s3.secret-access-key}, {@code s3.session-token}</li>
+   *   <li>GCS: {@code gcs.oauth2.token}, {@code gcs.oauth2.token-expires-at}</li>
+   *   <li>Azure: {@code adls.sas-token.*}, {@code adls.connection-string.*}</li>
+   * </ul>
+   *
+   * @param inputFilePaths list of file paths to read
+   * @param vendedCredentials map of credential properties from the catalog, or null if no credentials vended
+   * @return a SplittableInputSource configured with the credentials if provided
+   */
+  default SplittableInputSource create(List<String> inputFilePaths, @Nullable Map<String, String> vendedCredentials)
+  {
+    return create(inputFilePaths);
+  }
 }

--- a/processing/src/main/java/org/apache/druid/data/input/TaskAuthContextAware.java
+++ b/processing/src/main/java/org/apache/druid/data/input/TaskAuthContextAware.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.data.input;
+
+import org.apache.druid.auth.TaskAuthContext;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface for InputSources that need access to task authentication context
+ * (e.g., for authenticating with external catalogs like Iceberg REST Catalog).
+ *
+ * <p>When an InputSource implements this interface, the task execution framework
+ * will call {@link #setTaskAuthContext(TaskAuthContext)} before the input source
+ * is used, passing the authentication context from the task.
+ *
+ * <p>This allows input sources to access user credentials for operations like:
+ * <ul>
+ *   <li>Authenticating with Iceberg REST Catalog for OAuth token-based access</li>
+ *   <li>Vending temporary S3 credentials from the catalog</li>
+ *   <li>Other external service authentication scenarios</li>
+ * </ul>
+ *
+ * @see TaskAuthContext
+ */
+public interface TaskAuthContextAware
+{
+  /**
+   * Sets the task authentication context for this input source.
+   * Called by the task execution framework before the input source is used.
+   *
+   * @param taskAuthContext the auth context containing credentials, may be null
+   *                        if no auth context is available for the task
+   */
+  void setTaskAuthContext(@Nullable TaskAuthContext taskAuthContext);
+}

--- a/processing/src/test/java/org/apache/druid/auth/TaskAuthContextRedactionTest.java
+++ b/processing/src/test/java/org/apache/druid/auth/TaskAuthContextRedactionTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class TaskAuthContextRedactionTest
+{
+  private ObjectMapper mapper;
+  private ObjectMapper redactingMapper;
+
+  @Before
+  public void setUp()
+  {
+    mapper = new ObjectMapper();
+    mapper.registerSubtypes(new NamedType(TestTaskAuthContext.class, "test"));
+
+    redactingMapper = mapper.copy()
+        .addMixIn(TaskAuthContext.class, TaskAuthContextRedactionMixIn.class);
+  }
+
+  @Test
+  public void testSerializationIncludesCredentials() throws Exception
+  {
+    TaskAuthContext ctx = new TestTaskAuthContext(
+        "user@example.com",
+        Map.of("token", "secret-oauth-token"),
+        Map.of("expiry", "2026-12-31")
+    );
+    String json = mapper.writeValueAsString(ctx);
+    Assert.assertTrue(json.contains("secret-oauth-token"));
+    Assert.assertTrue(json.contains("user@example.com"));
+    Assert.assertTrue(json.contains("2026-12-31"));
+  }
+
+  @Test
+  public void testRedactingMapperRemovesCredentials() throws Exception
+  {
+    TaskAuthContext ctx = new TestTaskAuthContext(
+        "user@example.com",
+        Map.of("token", "secret-oauth-token"),
+        Map.of("expiry", "2026-12-31")
+    );
+    String json = redactingMapper.writeValueAsString(ctx);
+    Assert.assertFalse(json.contains("secret-oauth-token"));
+    Assert.assertFalse(json.contains("\"credentials\""));
+    Assert.assertTrue(json.contains("user@example.com"));
+    Assert.assertTrue(json.contains("2026-12-31"));
+  }
+
+  @Test
+  public void testRedactionWithNullCredentials() throws Exception
+  {
+    TaskAuthContext ctx = new TestTaskAuthContext("user@example.com", null, null);
+    String json = redactingMapper.writeValueAsString(ctx);
+    Assert.assertFalse(json.contains("\"credentials\""));
+    Assert.assertTrue(json.contains("user@example.com"));
+  }
+
+  @JsonTypeName("test")
+  public static class TestTaskAuthContext implements TaskAuthContext
+  {
+    private final String identity;
+    private final Map<String, String> credentials;
+    private final Map<String, Object> metadata;
+
+    public TestTaskAuthContext(
+        @JsonProperty("identity") String identity,
+        @JsonProperty("credentials") @Nullable Map<String, String> credentials,
+        @JsonProperty("metadata") @Nullable Map<String, Object> metadata
+    )
+    {
+      this.identity = identity;
+      this.credentials = credentials;
+      this.metadata = metadata;
+    }
+
+    @Override
+    @JsonProperty
+    public String getIdentity()
+    {
+      return identity;
+    }
+
+    @Override
+    @JsonProperty
+    @Nullable
+    public Map<String, String> getCredentials()
+    {
+      return credentials;
+    }
+
+    @Override
+    @JsonProperty
+    @Nullable
+    public Map<String, Object> getMetadata()
+    {
+      return metadata;
+    }
+  }
+}

--- a/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClient.java
+++ b/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClient.java
@@ -79,6 +79,19 @@ public interface OverlordClient
   ListenableFuture<Void> runTask(String taskId, Object taskObject);
 
   /**
+   * Run a task with the provided ID, payload, and additional HTTP headers to include on the request.
+   * Used for forwarding caller identity context (e.g., auth tokens) from Broker to Overlord during
+   * MSQ task submission.
+   *
+   * <p><b>Internal use only.</b> The {@code extraHeaders} map is applied directly to the HTTP request
+   * without validation. Callers must not pass user-controlled input as header names or values.
+   */
+  default ListenableFuture<Void> runTask(String taskId, Object taskObject, Map<String, String> extraHeaders)
+  {
+    return runTask(taskId, taskObject);
+  }
+
+  /**
    * Run a "kill" task for a particular datasource and interval. Shortcut to {@link #runTask(String, Object)}.
    * The kill task deletes all unused segment records from deep storage and the metadata store. The task runs
    * asynchronously after the API call returns. The resolved future is the ID of the task, which can be used to

--- a/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClientImpl.java
+++ b/server/src/main/java/org/apache/druid/rpc/indexing/OverlordClientImpl.java
@@ -99,12 +99,23 @@ public class OverlordClientImpl implements OverlordClient
   @Override
   public ListenableFuture<Void> runTask(final String taskId, final Object taskObject)
   {
+    return runTask(taskId, taskObject, Collections.emptyMap());
+  }
+
+  @Override
+  public ListenableFuture<Void> runTask(
+      final String taskId,
+      final Object taskObject,
+      final Map<String, String> extraHeaders
+  )
+  {
+    final RequestBuilder requestBuilder = new RequestBuilder(HttpMethod.POST, "/druid/indexer/v1/task")
+        .jsonContent(jsonMapper, taskObject);
+    for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {
+      requestBuilder.header(entry.getKey(), entry.getValue());
+    }
     return FutureUtils.transform(
-        client.asyncRequest(
-            new RequestBuilder(HttpMethod.POST, "/druid/indexer/v1/task")
-                .jsonContent(jsonMapper, taskObject),
-            new BytesFullResponseHandler()
-        ),
+        client.asyncRequest(requestBuilder, new BytesFullResponseHandler()),
         holder -> {
           final Map<String, Object> map =
               JacksonUtils.readValue(jsonMapper, holder.getContent(), JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT);


### PR DESCRIPTION
Closes https://github.com/apache/druid/issues/18957.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

Create a mechanism to propagate user identity context from authenticator to tasks. This allows tasks to safely operate with a sort of per-task identity, allowing tasks to access information dynamically that would be hard to setup in the current state of things. This allows for auth mechanisms like catalog credential vending (through Iceberg Catalog, etc.) and allows Druid to operate more like a standalone engine that can integrate with other things within a larger data ecosystem.


#### Design

#### Constraints

This currently does NOT support task restarts.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Create a mechanism to propagate user identity context from authenticator to tasks to support things like credential vending, etc.

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.