### PR TITLE
feat: Add additional context about the authorization request that can be passed to Authorizer

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/http/security/SupervisorResourceFilterTest.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
@@ -193,7 +194,8 @@ public class SupervisorResourceFilterTest
         authorizer.authorize(
             authResult,
             new Resource(datasource, ResourceType.DATASOURCE),
-            expectedAction
+            expectedAction,
+            Map.of()
         )
     ).andReturn(new Access(userHasAccess)).anyTimes();
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/SamplerResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/sampler/SamplerResourceTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Collections;
+import java.util.Map;
 
 public class SamplerResourceTest
 {
@@ -98,7 +99,8 @@ public class SamplerResourceTest
     EasyMock.expect(mockAuthorizer.authorize(
         EasyMock.anyObject(AuthenticationResult.class),
         EasyMock.eq(Resource.STATE_RESOURCE),
-        EasyMock.eq(Action.WRITE))).andReturn(Access.OK);
+        EasyMock.eq(Action.WRITE),
+        EasyMock.eq(Map.of()))).andReturn(Access.OK);
     EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(false);
     EasyMock.expect(samplerSpec.sample()).andReturn(null);
     EasyMock.replay(

--- a/server/src/main/java/org/apache/druid/server/security/AuthorizationUtils.java
+++ b/server/src/main/java/org/apache/druid/server/security/AuthorizationUtils.java
@@ -46,6 +46,11 @@ import java.util.Set;
  */
 public class AuthorizationUtils
 {
+  /**
+   * Key used in the authorization context map to indicate the caller path that triggered the authorization check.
+   */
+  public static final String AUTHORIZATION_CONTEXT_CALLER_PATH_CONTEXT_KEY = "callerPath";
+
   public static final ImmutableSet<String> RESTRICTION_APPLICABLE_RESOURCE_TYPES = ImmutableSet.of(
       ResourceType.DATASOURCE
   );
@@ -71,6 +76,35 @@ public class AuthorizationUtils
         request,
         Collections.singletonList(resourceAction),
         authorizerMapper
+    );
+  }
+
+  /**
+   * Performs authorization check on a single resource-action based on the authentication fields from the request,
+   * with additional context about the authorization request.
+   * <p>
+   * This function will set the DRUID_AUTHORIZATION_CHECKED attribute in the request. If this attribute is already set
+   * when this function is called, an exception is thrown.
+   *
+   * @param request          HTTP request to be authorized
+   * @param resourceAction   A resource identifier and the action to be taken the resource.
+   * @param authorizerMapper The singleton AuthorizerMapper instance
+   * @param context          Additional context about the authorization request, such as information about the
+   *                         caller path to be authorized.
+   * @return AuthorizationResult containing allow/deny access to the resource action, along with policy restrictions.
+   */
+  public static AuthorizationResult authorizeResourceAction(
+      final HttpServletRequest request,
+      final ResourceAction resourceAction,
+      final AuthorizerMapper authorizerMapper,
+      final Map<String, Object> context
+  )
+  {
+    return authorizeAllResourceActions(
+        request,
+        Collections.singletonList(resourceAction),
+        authorizerMapper,
+        context
     );
   }
 
@@ -182,6 +216,29 @@ public class AuthorizationUtils
       final AuthorizerMapper authorizerMapper
   )
   {
+    return authorizeAllResourceActions(authenticationResult, resourceActions, authorizerMapper, Map.of());
+  }
+
+  /**
+   * Performs authorization check on a list of resource-actions based on the authenticationResult, with additional
+   * context about the authorization request.
+   * <p>
+   * If one of the resource-actions denys access, returns deny access immediately.
+   *
+   * @param authenticationResult Authentication result representing identity of requester
+   * @param resourceActions      An Iterable of resource-actions to authorize
+   * @param authorizerMapper     The singleton AuthorizerMapper instance
+   * @param context              Additional context about the authorization request, such as information about the
+   *                             caller path to be authorized.
+   * @return AuthorizationResult containing allow/deny access to the resource actions, along with policy restrictions.
+   */
+  public static AuthorizationResult authorizeAllResourceActions(
+      final AuthenticationResult authenticationResult,
+      final Iterable<ResourceAction> resourceActions,
+      final AuthorizerMapper authorizerMapper,
+      final Map<String, Object> context
+  )
+  {
     final Authorizer authorizer = authorizerMapper.getAuthorizer(authenticationResult.getAuthorizerName());
     if (authorizer == null) {
       throw new ISE("No authorizer found with name: [%s].", authenticationResult.getAuthorizerName());
@@ -198,7 +255,8 @@ public class AuthorizationUtils
       final Access access = authorizer.authorize(
           authenticationResult,
           resourceAction.getResource(),
-          resourceAction.getAction()
+          resourceAction.getAction(),
+          context
       );
       if (!access.isAllowed()) {
         return AuthorizationResult.deny(access.getMessage());
@@ -261,6 +319,32 @@ public class AuthorizationUtils
       final AuthorizerMapper authorizerMapper
   )
   {
+    return authorizeAllResourceActions(request, resourceActions, authorizerMapper, Map.of());
+  }
+
+  /**
+   * Performs authorization check on a list of resource-actions based on the authentication fields from the request,
+   * with additional context about the authorization request.
+   * <p>
+   * If one of the resource-actions denys access, returns deny access immediately.
+   * <p>
+   * This function will set the DRUID_AUTHORIZATION_CHECKED attribute in the request. If this attribute is already set
+   * when this function is called, an exception is thrown.
+   *
+   * @param request          HTTP request to be authorized
+   * @param resourceActions  An Iterable of resource-actions to authorize
+   * @param authorizerMapper The singleton AuthorizerMapper instance
+   * @param context          Additional context about the authorization request, such as information about the
+   *                         caller path to be authorized.
+   * @return AuthorizationResult containing allow/deny access to the resource actions, along with policy restrictions.
+   */
+  public static AuthorizationResult authorizeAllResourceActions(
+      final HttpServletRequest request,
+      final Iterable<ResourceAction> resourceActions,
+      final AuthorizerMapper authorizerMapper,
+      final Map<String, Object> context
+  )
+  {
     if (request.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH) != null) {
       return AuthorizationResult.ALLOW_NO_RESTRICTION;
     }
@@ -272,7 +356,8 @@ public class AuthorizationUtils
     AuthorizationResult authResult = authorizeAllResourceActions(
         authenticationResultFromRequest(request),
         resourceActions,
-        authorizerMapper
+        authorizerMapper,
+        context
     );
 
     request.setAttribute(AuthConfig.DRUID_AUTHORIZATION_CHECKED, authResult.allowBasicAccess());
@@ -322,6 +407,38 @@ public class AuthorizationUtils
       final AuthorizerMapper authorizerMapper
   )
   {
+    return filterAuthorizedResources(request, resources, resourceActionGenerator, authorizerMapper, Map.of());
+  }
+
+  /**
+   * Return an iterable of authorized resources, by filtering the input resources with authorization checks based on the
+   * authentication fields from the request, with additional context about the authorization request. This method does:
+   * <li>
+   * For every resource, resourceActionGenerator generates an Iterable of ResourceAction or null.
+   * <li>
+   * If null, continue with next resource. If any resource-action in the iterable has deny-access, continue with next
+   * resource. Only when every resource-action has allow-access, add the resource to the result.
+   * </li>
+   * <p>
+   * This function will set the DRUID_AUTHORIZATION_CHECKED attribute in the request. If this attribute is already set
+   * when this function is called, an exception is thrown.
+   *
+   * @param request                 HTTP request to be authorized
+   * @param resources               resources to be processed into resource-actions
+   * @param resourceActionGenerator Function that creates an iterable of resource-actions from a resource
+   * @param authorizerMapper        authorizer mapper
+   * @param context                 Additional context about the authorization request, such as information about the
+   *                                caller path to be authorized.
+   * @return Iterable containing resources that were authorized
+   */
+  public static <ResType> Iterable<ResType> filterAuthorizedResources(
+      final HttpServletRequest request,
+      final Iterable<ResType> resources,
+      final Function<? super ResType, Iterable<ResourceAction>> resourceActionGenerator,
+      final AuthorizerMapper authorizerMapper,
+      final Map<String, Object> context
+  )
+  {
     if (request.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH) != null) {
       return resources;
     }
@@ -336,7 +453,8 @@ public class AuthorizationUtils
         authenticationResult,
         resources,
         resourceActionGenerator,
-        authorizerMapper
+        authorizerMapper,
+        context
     );
 
     // We're filtering, so having access to none of the objects isn't an authorization failure (in terms of whether
@@ -368,6 +486,34 @@ public class AuthorizationUtils
       final AuthorizerMapper authorizerMapper
   )
   {
+    return filterAuthorizedResources(authenticationResult, resources, resourceActionGenerator, authorizerMapper, Map.of());
+  }
+
+  /**
+   * Return an iterable of authorized resources, by filtering the input resources with authorization checks based on
+   * authenticationResult, with additional context about the authorization request. This method does:
+   * <li>
+   * For every resource, resourceActionGenerator generates an Iterable of ResourceAction or null.
+   * <li>
+   * If null, continue with next resource. If any resource-action in the iterable has deny-access, continue with next
+   * resource. Only when every resource-action has allow-access, add the resource to the result.
+   *
+   * @param authenticationResult    Authentication result representing identity of requester
+   * @param resources               resources to be processed into resource-actions
+   * @param resourceActionGenerator Function that creates an iterable of resource-actions from a resource
+   * @param authorizerMapper        authorizer mapper
+   * @param context                 Additional context about the authorization request, such as information about the
+   *                                caller path to be authorized.
+   * @return Iterable containing resources that were authorized
+   */
+  public static <ResType> Iterable<ResType> filterAuthorizedResources(
+      final AuthenticationResult authenticationResult,
+      final Iterable<ResType> resources,
+      final Function<? super ResType, Iterable<ResourceAction>> resourceActionGenerator,
+      final AuthorizerMapper authorizerMapper,
+      final Map<String, Object> context
+  )
+  {
     final Authorizer authorizer = authorizerMapper.getAuthorizer(authenticationResult.getAuthorizerName());
     if (authorizer == null) {
       throw new ISE("No authorizer found with name: [%s].", authenticationResult.getAuthorizerName());
@@ -390,7 +536,8 @@ public class AuthorizationUtils
                 ra -> authorizer.authorize(
                     authenticationResult,
                     ra.getResource(),
-                    ra.getAction()
+                    ra.getAction(),
+                    context
                 )
             );
             if (!access.isAllowed()) {
@@ -428,6 +575,38 @@ public class AuthorizationUtils
       final AuthorizerMapper authorizerMapper
   )
   {
+    return filterAuthorizedResources(request, unfilteredResources, resourceActionGenerator, authorizerMapper, Map.of());
+  }
+
+  /**
+   * Return a map of authorized resources, by filtering the input resources with authorization checks based on the
+   * authentication fields from the request, with additional context about the authorization request. This method does:
+   * <li>
+   * For every resource, resourceActionGenerator generates an Iterable of ResourceAction or null.
+   * <li>
+   * If null, continue with next resource. If any resource-action in the iterable has deny-access, continue with next
+   * resource. Only when every resource-action has allow-access, add the resource to the result.
+   * </li>
+   * <p>
+   * This function will set the DRUID_AUTHORIZATION_CHECKED attribute in the request. If this attribute is already set
+   * when this function is called, an exception is thrown.
+   *
+   * @param request                 HTTP request to be authorized
+   * @param unfilteredResources     Map of resource lists to be filtered
+   * @param resourceActionGenerator Function that creates an iterable of resource-actions from a resource
+   * @param authorizerMapper        authorizer mapper
+   * @param context                 Additional context about the authorization request, such as information about the
+   *                                caller path to be authorized.
+   * @return Map containing lists of resources that were authorized
+   */
+  public static <KeyType, ResType> Map<KeyType, List<ResType>> filterAuthorizedResources(
+      final HttpServletRequest request,
+      final Map<KeyType, List<ResType>> unfilteredResources,
+      final Function<? super ResType, Iterable<ResourceAction>> resourceActionGenerator,
+      final AuthorizerMapper authorizerMapper,
+      final Map<String, Object> context
+  )
+  {
 
     if (request.getAttribute(AuthConfig.DRUID_ALLOW_UNSECURED_PATH) != null) {
       return unfilteredResources;
@@ -450,7 +629,8 @@ public class AuthorizationUtils
               authenticationResult,
               entry.getValue(),
               resourceActionGenerator,
-              authorizerMapper
+              authorizerMapper,
+              context
           )
       );
 

--- a/server/src/main/java/org/apache/druid/server/security/Authorizer.java
+++ b/server/src/main/java/org/apache/druid/server/security/Authorizer.java
@@ -22,6 +22,8 @@ package org.apache.druid.server.security;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.Map;
+
 /**
  * An Authorizer is responsible for performing authorization checks for resource accesses.
  * <p>
@@ -51,4 +53,33 @@ public interface Authorizer
    * @return An {@link Access} object representing the result of the authorization check. Must not be null.
    */
   Access authorize(AuthenticationResult authenticationResult, Resource resource, Action action);
+
+  /**
+   * Check if the entity represented by the authentication result is authorized to perform the given action on the
+   * given resource, with additional context about the authorization request.
+   * <p>
+   * The {@code context} map can be used to provide supplementary information about the caller path to be authorized.
+   * For example, it may contain details about the API endpoint or query context that triggered the authorization
+   * check, allowing authorizer implementations to make more informed decisions.
+   * <p>
+   * If the action involves reading a table, the outcome could include {@link org.apache.druid.query.policy.Policy} restrictions.
+   * However, if the action does not involve reading a table, there must be no {@link org.apache.druid.query.policy.Policy} restrictions.
+   *
+   * @param authenticationResult The authentication result of the request
+   * @param resource             The resource to be accessed
+   * @param action               The action to perform on the resource
+   * @param context              Additional context about the authorization request, such as information about the
+   *                             caller path to be authorized. Implementations that do not need this context can
+   *                             safely ignore it.
+   * @return An {@link Access} object representing the result of the authorization check. Must not be null.
+   */
+  default Access authorize(
+      AuthenticationResult authenticationResult,
+      Resource resource,
+      Action action,
+      Map<String, Object> context
+  )
+  {
+    return authorize(authenticationResult, resource, action);
+  }
 }

--- a/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
+++ b/server/src/test/java/org/apache/druid/server/QueryLifecycleTest.java
@@ -403,7 +403,7 @@ public class QueryLifecycleTest
     EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
     EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
     EasyMock.expect(authenticationResult.getAuthorizerName()).andReturn(AUTHORIZER).anyTimes();
-    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ))
+    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ, Map.of()))
             .andReturn(access).anyTimes();
     EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject()))
             .andReturn(toolChest).anyTimes();
@@ -443,7 +443,7 @@ public class QueryLifecycleTest
     EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
     EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
     EasyMock.expect(authenticationResult.getAuthorizerName()).andReturn(AUTHORIZER).anyTimes();
-    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ))
+    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ, Map.of()))
             .andReturn(access).anyTimes();
     EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject()))
             .andReturn(toolChest).anyTimes();
@@ -477,7 +477,7 @@ public class QueryLifecycleTest
     EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
     EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
     EasyMock.expect(authenticationResult.getAuthorizerName()).andReturn(AUTHORIZER).anyTimes();
-    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ))
+    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ, Map.of()))
             .andReturn(access).anyTimes();
     EasyMock.expect(conglomerate.getToolChest(EasyMock.anyObject()))
             .andReturn(toolChest).anyTimes();
@@ -506,19 +506,22 @@ public class QueryLifecycleTest
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource(DATASOURCE, ResourceType.DATASOURCE),
-                Action.READ
+                Action.READ,
+                Map.of()
             ))
             .andReturn(Access.OK).times(2);
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource("foo", ResourceType.QUERY_CONTEXT),
-                Action.WRITE
+                Action.WRITE,
+                Map.of()
             ))
             .andReturn(Access.OK).times(2);
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource("baz", ResourceType.QUERY_CONTEXT),
-                Action.WRITE
+                Action.WRITE,
+                Map.of()
             ))
             .andReturn(Access.OK).times(2);
 
@@ -564,14 +567,16 @@ public class QueryLifecycleTest
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource(DATASOURCE, ResourceType.DATASOURCE),
-                Action.READ
+                Action.READ,
+                Map.of()
             ))
             .andReturn(Access.OK)
             .times(2);
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource("foo", ResourceType.QUERY_CONTEXT),
-                Action.WRITE
+                Action.WRITE,
+                Map.of()
             ))
             .andReturn(Access.DENIED)
             .times(2);
@@ -605,7 +610,7 @@ public class QueryLifecycleTest
     EasyMock.expect(queryConfig.getContext()).andReturn(ImmutableMap.of()).anyTimes();
     EasyMock.expect(authenticationResult.getIdentity()).andReturn(IDENTITY).anyTimes();
     EasyMock.expect(authenticationResult.getAuthorizerName()).andReturn(AUTHORIZER).anyTimes();
-    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ))
+    EasyMock.expect(authorizer.authorize(authenticationResult, RESOURCE, Action.READ, Map.of()))
             .andReturn(Access.OK)
             .times(2);
 
@@ -654,7 +659,8 @@ public class QueryLifecycleTest
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource(DATASOURCE, ResourceType.DATASOURCE),
-                Action.READ
+                Action.READ,
+                Map.of()
             ))
             .andReturn(Access.OK)
             .times(2);
@@ -705,14 +711,16 @@ public class QueryLifecycleTest
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource(DATASOURCE, ResourceType.DATASOURCE),
-                Action.READ
+                Action.READ,
+                Map.of()
             ))
             .andReturn(Access.OK)
             .times(2);
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource("foo", ResourceType.QUERY_CONTEXT),
-                Action.WRITE
+                Action.WRITE,
+                Map.of()
             ))
             .andReturn(Access.DENIED)
             .times(2);
@@ -754,21 +762,24 @@ public class QueryLifecycleTest
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource("fake", ResourceType.DATASOURCE),
-                Action.READ
+                Action.READ,
+                Map.of()
             ))
             .andReturn(Access.OK)
             .times(2);
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource("foo", ResourceType.QUERY_CONTEXT),
-                Action.WRITE
+                Action.WRITE,
+                Map.of()
             ))
             .andReturn(Access.OK)
             .times(2);
     EasyMock.expect(authorizer.authorize(
                 authenticationResult,
                 new Resource("baz", ResourceType.QUERY_CONTEXT),
-                Action.WRITE
+                Action.WRITE,
+                Map.of()
             ))
             .andReturn(Access.OK)
             .times(2);

--- a/server/src/test/java/org/apache/druid/server/security/AuthorizationUtilsTest.java
+++ b/server/src/test/java/org/apache/druid/server/security/AuthorizationUtilsTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.security;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.query.filter.EqualityFilter;
 import org.apache.druid.query.policy.NoRestrictionPolicy;
@@ -39,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class AuthorizationUtilsTest
 {
@@ -242,5 +244,183 @@ public class AuthorizationUtilsTest
         () -> AuthorizationUtils.authorizeAllResourceActions(authenticationResult, resourceActions, mapper)
     );
     Assert.assertTrue(exception.getMessage().contains("Policy should only present when reading a table"));
+  }
+
+
+  @Test
+  public void testAuthorizeAllResourceActions_contextPassedToAuthorizer()
+  {
+    final String authorizerName = "testAuthorizer";
+    final AuthenticationResult authenticationResult =
+        new AuthenticationResult("identity", authorizerName, "authenticator", null);
+
+    final Map<String, Object> expectedContext = ImmutableMap.of("testKey", "testValue");
+    final AtomicReference<Map<String, Object>> capturedContext = new AtomicReference<>();
+
+    final Authorizer authorizer = new Authorizer()
+    {
+      @Override
+      public Access authorize(AuthenticationResult authResult, Resource resource, Action action)
+      {
+        return Access.OK;
+      }
+
+      @Override
+      public Access authorize(
+          AuthenticationResult authResult,
+          Resource resource,
+          Action action,
+          Map<String, Object> context
+      )
+      {
+        capturedContext.set(context);
+        return Access.OK;
+      }
+    };
+
+    final Map<String, Authorizer> authorizerMap = new HashMap<>();
+    authorizerMap.put(authorizerName, authorizer);
+    final AuthorizerMapper mapper = new AuthorizerMapper(authorizerMap);
+
+    final List<ResourceAction> resourceActions = Collections.singletonList(
+        new ResourceAction(Resource.STATE_RESOURCE, Action.READ)
+    );
+
+    AuthorizationUtils.authorizeAllResourceActions(
+        authenticationResult,
+        resourceActions,
+        mapper,
+        expectedContext
+    );
+
+    Assert.assertEquals(expectedContext, capturedContext.get());
+  }
+
+  @Test
+  public void testAuthorizeAllResourceActions_emptyContextByDefault()
+  {
+    final String authorizerName = "testAuthorizer";
+    final AuthenticationResult authenticationResult =
+        new AuthenticationResult("identity", authorizerName, "authenticator", null);
+
+    final AtomicReference<Map<String, Object>> capturedContext = new AtomicReference<>();
+
+    final Authorizer authorizer = new Authorizer()
+    {
+      @Override
+      public Access authorize(AuthenticationResult authResult, Resource resource, Action action)
+      {
+        return Access.OK;
+      }
+
+      @Override
+      public Access authorize(
+          AuthenticationResult authResult,
+          Resource resource,
+          Action action,
+          Map<String, Object> context
+      )
+      {
+        capturedContext.set(context);
+        return Access.OK;
+      }
+    };
+
+    final Map<String, Authorizer> authorizerMap = new HashMap<>();
+    authorizerMap.put(authorizerName, authorizer);
+    final AuthorizerMapper mapper = new AuthorizerMapper(authorizerMap);
+
+    final List<ResourceAction> resourceActions = Collections.singletonList(
+        new ResourceAction(Resource.STATE_RESOURCE, Action.READ)
+    );
+
+    AuthorizationUtils.authorizeAllResourceActions(
+        authenticationResult,
+        resourceActions,
+        mapper
+    );
+
+    Assert.assertEquals(Map.of(), capturedContext.get());
+  }
+
+  @Test
+  public void testFilterAuthorizedResources_contextPassedToAuthorizer()
+  {
+    final String authorizerName = "testAuthorizer";
+    final AuthenticationResult authenticationResult =
+        new AuthenticationResult("identity", authorizerName, "authenticator", null);
+
+    final Map<String, Object> expectedContext = ImmutableMap.of("testKey", "testValue");
+    final List<Map<String, Object>> capturedContext = new ArrayList<>();
+
+    final Authorizer authorizer = new Authorizer()
+    {
+      @Override
+      public Access authorize(AuthenticationResult authResult, Resource resource, Action action)
+      {
+        return Access.OK;
+      }
+
+      @Override
+      public Access authorize(
+          AuthenticationResult authResult,
+          Resource resource,
+          Action action,
+          Map<String, Object> context
+      )
+      {
+        capturedContext.add(context);
+        return Access.OK;
+      }
+    };
+
+    final Map<String, Authorizer> authorizerMap = new HashMap<>();
+    authorizerMap.put(authorizerName, authorizer);
+    final AuthorizerMapper mapper = new AuthorizerMapper(authorizerMap);
+
+    final List<String> resources = Arrays.asList("resource1", "resource2");
+    final Function<String, Iterable<ResourceAction>> raGenerator =
+        input -> Collections.singletonList(new ResourceAction(new Resource(input, ResourceType.DATASOURCE), Action.READ));
+
+    Iterable<String> filtered = AuthorizationUtils.filterAuthorizedResources(
+        authenticationResult,
+        resources,
+        raGenerator,
+        mapper,
+        expectedContext
+    );
+
+    // Consume the iterable to trigger authorization
+    Iterator<String> itr = filtered.iterator();
+    while (itr.hasNext()) {
+      itr.next();
+    }
+    Assert.assertEquals(2, capturedContext.size());
+    for (Map<String, Object> context : capturedContext) {
+      Assert.assertEquals(expectedContext, context);
+    }
+  }
+
+  @Test
+  public void testAuthorizerDefaultMethodDelegatesToThreeArgMethod()
+  {
+    final AtomicReference<String> capturedResource = new AtomicReference<>();
+
+    // An authorizer that only implements the 3-arg method (simulating existing subclasses)
+    final Authorizer authorizer = (authResult, resource, action) -> {
+      capturedResource.set(resource.getName());
+      return Access.OK;
+    };
+
+    final AuthenticationResult authResult =
+        new AuthenticationResult("identity", "authorizerName", "authenticator", null);
+    final Resource resource = new Resource("testResource", ResourceType.DATASOURCE);
+    final Map<String, Object> context = ImmutableMap.of("callerPath", "TestCaller");
+
+    // Calling the 4-arg default method should delegate to the 3-arg method
+    Access access = authorizer.authorize(authResult, resource, Action.READ, context);
+
+    Assert.assertTrue(access.isAllowed());
+    Assert.assertEquals("testResource", capturedResource.get());
   }
 }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/InformationSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/InformationSchema.java
@@ -79,6 +79,14 @@ public class InformationSchema extends AbstractSchema
   private static final String COLUMNS_TABLE = "COLUMNS";
   private static final String ROUTINES_TABLE = "ROUTINES";
 
+  /**
+   * Context map passed to {@link AuthorizationUtils} methods to indicate that authorization
+   * is being performed from the InformationSchema.
+   */
+  static final String AUTHORIZATION_CONTEXT_CALLER_PATH_VALUE = InformationSchema.class.getSimpleName();
+  private static final Map<String, Object> INFORMATION_SCHEMA_AUTHORIZATION_CONTEXT =
+      ImmutableMap.of(AuthorizationUtils.AUTHORIZATION_CONTEXT_CALLER_PATH_CONTEXT_KEY, AUTHORIZATION_CONTEXT_CALLER_PATH_VALUE);
+
   private static class RowTypeBuilder
   {
     final RelDataTypeFactory typeFactory = DruidTypeSystem.TYPE_FACTORY;
@@ -615,7 +623,8 @@ public class InformationSchema extends AbstractSchema
                   new ResourceAction(new Resource(name, resourseType), Action.READ)
               );
             },
-            authorizerMapper
+            authorizerMapper,
+            INFORMATION_SCHEMA_AUTHORIZATION_CONTEXT
         )
     );
   }

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -121,6 +121,14 @@ public class SystemSchema extends AbstractSchema
           segment.getDataSource())
       );
 
+  /**
+   * Context map passed to {@link AuthorizationUtils} methods to indicate that authorization
+   * is being performed from the SystemSchema.
+   */
+  static final String AUTHORIZATION_CONTEXT_CALLER_PATH_VALUE = SystemSchema.class.getSimpleName();
+  private static final Map<String, Object> SYSTEM_SCHEMA_AUTHORIZATION_CONTEXT =
+      ImmutableMap.of(AuthorizationUtils.AUTHORIZATION_CONTEXT_CALLER_PATH_CONTEXT_KEY, AUTHORIZATION_CONTEXT_CALLER_PATH_VALUE);
+
   private static final long REPLICATION_FACTOR_UNKNOWN = -1L;
 
   /**
@@ -486,7 +494,8 @@ public class SystemSchema extends AbstractSchema
               authenticationResult,
               () -> it,
               SEGMENT_STATUS_IN_CLUSTER_RA_GENERATOR,
-              authorizerMapper
+              authorizerMapper,
+              SYSTEM_SCHEMA_AUTHORIZATION_CONTEXT
           );
       return authorizedSegments.iterator();
     }
@@ -511,7 +520,8 @@ public class SystemSchema extends AbstractSchema
               authenticationResult,
               () -> availableSegmentEntries,
               raGenerator,
-              authorizerMapper
+              authorizerMapper,
+              SYSTEM_SCHEMA_AUTHORIZATION_CONTEXT
           );
 
       return authorizedSegments.iterator();
@@ -848,7 +858,8 @@ public class SystemSchema extends AbstractSchema
             authenticationResult,
             druidServer.iterateAllSegments(),
             SEGMENT_RA_GENERATOR,
-            authorizerMapper
+            authorizerMapper,
+            SYSTEM_SCHEMA_AUTHORIZATION_CONTEXT
         );
 
         for (DataSegment segment : authorizedServerSegments) {
@@ -983,7 +994,8 @@ public class SystemSchema extends AbstractSchema
           authenticationResult,
           () -> it,
           raGenerator,
-          authorizerMapper
+          authorizerMapper,
+          SYSTEM_SCHEMA_AUTHORIZATION_CONTEXT
       );
 
       return wrap(authorizedTasks.iterator(), it);
@@ -1107,7 +1119,8 @@ public class SystemSchema extends AbstractSchema
           authenticationResult,
           () -> it,
           raGenerator,
-          authorizerMapper
+          authorizerMapper,
+          SYSTEM_SCHEMA_AUTHORIZATION_CONTEXT
       );
 
       return wrap(authorizedSupervisors.iterator(), it);
@@ -1276,7 +1289,8 @@ public class SystemSchema extends AbstractSchema
       final AuthorizationResult stateReadAuthorization = AuthorizationUtils.authorizeAllResourceActions(
           authenticationResult,
           Collections.singletonList(new ResourceAction(Resource.STATE_RESOURCE, Action.READ)),
-          authorizerMapper
+          authorizerMapper,
+          SYSTEM_SCHEMA_AUTHORIZATION_CONTEXT
       );
 
       // Get queries from all engines


### PR DESCRIPTION
Add additional context about the authorization request that can be passed to Authorizer

### Description
Currently, the `Authorizer#authorize` interface only accepts `AuthenticationResult`, `Resource`, and `Action`, which provides no context about where an authorization request originated. As a result, authorization requests for the same resource from different code paths look identical. For example, an authorization request for a resource initiated by a user query is indistinguishable from one initiated by a `SystemSchema` request triggered by the UI.

This becomes a problem when analyzing authorization denials. If a user wants to investigate denials for their datasource, those denials are aggregated with denials from `SystemSchema`/`InformationSchema`, making it difficult to distinguish genuine unauthorized access attempts from routine internal checks. When a user refreshes the UI, it iterates over all datasources and issues an internal authorization check for each one; this happens in many places, such as the Supervisors tab, Query tab, and others. As a result, metrics emitted by the `Authorizer` (such as authorization outcomes) become noisy, since denials from internal UI-driven checks are mixed together with denials from actual user queries.

This change adds an optional `Map<String, Object>` `context` parameter to `Authorizer#authorize`. Callers such as `InformationSchema` and `SystemSchema` populate this context map with a `callerPath` key to indicate the source of the authorization request. This context can then be included in the metrics emitted by `Authorizer#authorize`, allowing users to filter out internal authorization checks from user-initiated ones.

##### Key changed/added classes in this PR
 * `server/src/main/java/org/apache/druid/server/security/Authorizer.java`
 * `server/src/main/java/org/apache/druid/server/security/AuthorizationUtils.java`
 * `sql/src/main/java/org/apache/druid/sql/calcite/schema/InformationSchema.java`
 * `sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java`


This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.