### PR TITLE
fix: Update grpc-bom to 1.80.0, addressing CVE-2026-33186

### DIFF
--- a/embedded-tests/pom.xml
+++ b/embedded-tests/pom.xml
@@ -142,6 +142,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+      <version>2.66.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <scope>test</scope>

--- a/embedded-tests/pom.xml
+++ b/embedded-tests/pom.xml
@@ -138,13 +138,7 @@
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>2.29.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-core</artifactId>
-      <version>2.27.0</version>
+      <version>${com.google.cloud.storage.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-contrib/druid-ranger-security/pom.xml
+++ b/extensions-contrib/druid-ranger-security/pom.xml
@@ -39,7 +39,7 @@
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
-                <version>6.4.0</version>
+                <version>7.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/extensions-contrib/grpc-query/pom.xml
+++ b/extensions-contrib/grpc-query/pom.xml
@@ -50,7 +50,7 @@
       <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-bom</artifactId>
-        <version>1.70.0</version>
+        <version>1.80.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -39,7 +39,7 @@
     <!-- These guava and grpc versions are used only in the opentelemetry-extension.
       Look at build section for more details about shading. -->
     <shade.guava.version>32.1.3-jre</shade.guava.version>
-    <shade.grpc.version>1.65.1</shade.grpc.version>
+    <shade.grpc.version>1.80.0</shade.grpc.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -38,7 +38,7 @@
     <opentelemetry.instrumentation.version>1.14.0-alpha</opentelemetry.instrumentation.version>
     <!-- These guava and grpc versions are used only in the opentelemetry-extension.
       Look at build section for more details about shading. -->
-    <shade.guava.version>32.1.3-jre</shade.guava.version>
+    <shade.guava.version>${guava.version}</shade.guava.version>
     <shade.grpc.version>1.80.0</shade.grpc.version>
   </properties>
   <dependencyManagement>
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>io.perfmark</groupId>
       <artifactId>perfmark-api</artifactId>
-      <version>0.26.0</version>
+      <version>0.27.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/extensions-core/google-extensions/pom.xml
+++ b/extensions-core/google-extensions/pom.xml
@@ -108,16 +108,16 @@
             <artifactId>jsr305</artifactId>
             <scope>provided</scope>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>com.google.api</groupId>-->
-<!--            <artifactId>gax</artifactId>-->
-<!--            <version>2.76.0</version>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>com.google.cloud</groupId>-->
-<!--            <artifactId>google-cloud-core</artifactId>-->
-<!--            <version>2.66.0</version>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>com.google.api</groupId>
+            <artifactId>gax</artifactId>
+            <version>2.76.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core</artifactId>
+            <version>2.66.0</version>
+        </dependency>
         <!-- Tests -->
         <dependency>
             <groupId>org.apache.druid</groupId>

--- a/extensions-core/google-extensions/pom.xml
+++ b/extensions-core/google-extensions/pom.xml
@@ -89,11 +89,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>failureaccess</artifactId>
-            <version>1.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>

--- a/extensions-core/google-extensions/pom.xml
+++ b/extensions-core/google-extensions/pom.xml
@@ -51,6 +51,7 @@
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
             <version>${com.google.cloud.storage.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -88,6 +89,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>failureaccess</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
@@ -107,16 +113,16 @@
             <artifactId>jsr305</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.google.api</groupId>
-            <artifactId>gax</artifactId>
-            <version>2.37.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-core</artifactId>
-            <version>2.27.0</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.google.api</groupId>-->
+<!--            <artifactId>gax</artifactId>-->
+<!--            <version>2.76.0</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>com.google.cloud</groupId>-->
+<!--            <artifactId>google-cloud-core</artifactId>-->
+<!--            <version>2.66.0</version>-->
+<!--        </dependency>-->
         <!-- Tests -->
         <dependency>
             <groupId>org.apache.druid</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -444,7 +444,7 @@ name: Guava
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 32.1.3-jre
+version: 33.1.0-jre
 libraries:
   - com.google.guava: guava
 
@@ -454,7 +454,7 @@ name: Failureaccess
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 1.0.1
+version: 1.0.2
 libraries:
   - com.google.guava: failureaccess
 
@@ -1972,7 +1972,7 @@ name: Apache HttpClient
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.5.13
+version: 4.5.14
 libraries:
   - org.apache.httpcomponents: httpclient
 notices:
@@ -2995,7 +2995,7 @@ libraries:
 
 name: org.codehaus.woodstox stax2-api
 license_category: binary
-version: 4.2.1
+version: 4.2.2
 module: druid-kerberos
 license_name: BSD-3-Clause License
 libraries:
@@ -3525,7 +3525,7 @@ name: j2objc
 license_category: binary
 module: extensions/protobuf-extensions
 license_name: Apache License version 2.0
-version: 2.8
+version: 3.1
 libraries:
   - com.google.j2objc: j2objc-annotations
 
@@ -3535,7 +3535,7 @@ name: Checker Qual
 license_category: binary
 module: java-core
 license_name: MIT License
-version: 3.48.1
+version: 3.49.0
 copyright: the Checker Framework developers
 license_file_path: licenses/bin/checker-qual.MIT
 libraries:
@@ -4636,7 +4636,7 @@ name: Woodstox
 license_category: binary
 module: extensions/druid-azure-extensions
 license_name: Apache License version 2.0
-version: 6.2.4
+version: 7.0.0
 libraries:
   - com.fasterxml.woodstox: woodstox-core
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -434,7 +434,7 @@ name: Error Prone Annotations
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 2.41.0
+version: 2.45.0
 libraries:
   - com.google.errorprone: error_prone_annotations
 
@@ -3795,7 +3795,7 @@ name: Protocol Buffers
 license_category: binary
 module: extensions/druid-protobuf-extensions
 license_name: BSD-3-Clause License
-version: 3.25.8
+version: 4.33.2
 copyright: Google, Inc.
 license_file_path: licenses/bin/protobuf-java.BSD3
 libraries:
@@ -4186,7 +4186,7 @@ name: Google Cloud Storage JSON API
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: v1-rev20231028-2.0.0
+version: v1-rev20260204-2.0.0
 libraries:
   - com.google.apis: google-api-services-storage
 
@@ -4206,7 +4206,7 @@ name: Google Storage Client Library For Java
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache-2.0
-version: 2.29.1
+version: 2.64.1
 libraries:
   - com.google.cloud: google-cloud-storage
 
@@ -4216,7 +4216,7 @@ name: Google Cloud Storage API
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: BSD-3-Clause License
-version: 2.20.0
+version: 2.59.0
 libraries:
   - com.google.cloud: google-cloud-storage
   - com.google.api: api-common
@@ -4227,7 +4227,7 @@ name: gax
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: BSD-3-Clause License
-version: 2.37.0
+version: 2.76.0
 libraries:
   - com.google.api: gax
   - com.google.api: gax-grpc
@@ -4239,7 +4239,7 @@ name: grpc-api
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: 2.29.1-alpha
+version: 2.64.1
 libraries:
   - com.google.api.grpc: gapic-google-cloud-storage-v2
   - com.google.api.grpc: grpc-google-cloud-storage-v2
@@ -4271,7 +4271,7 @@ name: proto-google-common-protos
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: 2.28.0
+version: 2.67.0
 libraries:
   - com.google.api.grpc: proto-google-common-protos
 
@@ -4281,7 +4281,7 @@ name: proto-google-iam-v1
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: 1.23.0
+version: 1.62.0
 libraries:
   - com.google.api.grpc: proto-google-iam-v1
 
@@ -4291,7 +4291,7 @@ name: google-auth
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: BSD-3-Clause License
-version: 1.20.0
+version: 1.43.0
 libraries:
   - com.google.auth: google-auth-library-credentials
   - com.google.auth: google-auth-library-oauth2-http
@@ -4302,7 +4302,7 @@ name: google-auto-value
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: 1.10.4
+version: 1.11.0
 libraries:
   - com.google.auto.value: auto-value-annotations
 
@@ -4312,7 +4312,7 @@ name: google-cloud
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: 2.27.0
+version: 2.66.0
 libraries:
   - com.google.cloud: google-cloud-core
   - com.google.cloud: google-cloud-core-grpc
@@ -4334,7 +4334,7 @@ name: google-http-client
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: Apache License version 2.0
-version: 1.43.3
+version: 2.1.0
 libraries:
   - com.google.http-client: google-http-client-apache-v2
   - com.google.http-client: google-http-client-appengine
@@ -4377,7 +4377,7 @@ name: threetenbp
 license_category: binary
 module: extensions/druid-google-extensions
 license_name: BSD-3-Clause License
-version: 1.6.8
+version: 1.7.0
 libraries:
   - org.threeten: threetenbp
 

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -4249,15 +4249,16 @@ libraries:
 
 name: grpc-io
 license_category: binary
-module: extensions/druid-google-extensions
+module: extensions-contrib/grpc-query
 license_name: Apache License version 2.0
-version: 1.59.0
+version: 1.80.0
 libraries:
   - io.grpc: grpc-alts
   - io.grpc: grpc-api
   - io.grpc: grpc-auth
   - io.grpc: grpc-context
   - io.grpc: grpc-core
+  - io.grpc: grpc-grpclb
   - io.grpc: grpc-grpclib
   - io.grpc: grpc-inprocess
   - io.grpc: grpc-protobuf
@@ -4348,16 +4349,6 @@ license_name: BSD-3-Clause License
 version: 3.24.4
 libraries:
   - com.google.protobuf: protobuf-java-util
-
----
-
-name: google-grpc
-license_category: binary
-module: extensions/druid-google-extensions
-license_name: Apache License version 2.0
-version: 1.59.0
-libraries:
-  - io.grpc: grpc-grpclb
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <datasketches.memory.version>2.2.0</datasketches.memory.version>
         <derby.version>10.14.2.0</derby.version>
         <dropwizard.metrics.version>4.2.22</dropwizard.metrics.version>
-        <errorprone.version>2.41.0</errorprone.version>
+        <errorprone.version>2.45.0</errorprone.version>
         <fabric8.version>7.6.0</fabric8.version>
         <fastutil.version>8.5.4</fastutil.version>
         <guava.version>32.1.3-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1405,10 +1405,6 @@
                 <version>${com.google.apis.client.version}</version>
                 <exclusions>
                     <exclusion>
-                      <groupId>com.google.http-client</groupId>
-                      <artifactId>google-http-client-gson</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>jsr305</artifactId>
                     </exclusion>
@@ -1434,6 +1430,11 @@
                 <groupId>com.google.http-client</groupId>
                 <artifactId>google-http-client</artifactId>
                 <version>${com.google.http.client.apis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.http-client</groupId>
+                <artifactId>google-http-client-gson</artifactId>
+                <version>2.1.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.http-client</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <netty3.version>3.10.6.Final</netty3.version>
         <netty4.version>4.2.12.Final</netty4.version>
         <postgresql.version>42.7.2</postgresql.version>
-        <protobuf.version>3.25.8</protobuf.version>
+        <protobuf.version>4.33.2</protobuf.version>
         <resilience4j.version>1.3.1</resilience4j.version>
         <slf4j.version>2.0.17</slf4j.version>
         <jna.version>5.18.1</jna.version>
@@ -133,10 +133,10 @@
         <kubernetes.client.version>25.0.0-legacy</kubernetes.client.version>
         <zookeeper.version>3.8.6</zookeeper.version>
         <checkerframework.version>3.48.1</checkerframework.version>
-        <com.google.apis.client.version>2.2.0</com.google.apis.client.version>
-        <com.google.http.client.apis.version>1.42.3</com.google.http.client.apis.version>
+        <com.google.apis.client.version>2.9.0</com.google.apis.client.version>
+        <com.google.http.client.apis.version>2.1.0</com.google.http.client.apis.version>
         <com.google.apis.compute.version>v1-rev20230606-2.0.0</com.google.apis.compute.version>
-        <com.google.cloud.storage.version>2.29.1</com.google.cloud.storage.version>
+        <com.google.cloud.storage.version>2.64.1</com.google.cloud.storage.version>
         <jdk.strong.encapsulation.argLine>
             <!-- Strong encapsulation parameters -->
             <!-- When updating this list, update all four locations: -->
@@ -344,6 +344,13 @@
               <groupId>com.github.seancfoley</groupId>
               <artifactId>ipaddress</artifactId>
               <version>5.3.4</version>
+          </dependency>
+          <dependency>
+              <groupId>io.grpc</groupId>
+              <artifactId>grpc-bom</artifactId>
+              <version>1.80.0</version>
+              <type>pom</type>
+              <scope>import</scope>
           </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -1382,6 +1389,10 @@
                 <artifactId>google-api-client</artifactId>
                 <version>${com.google.apis.client.version}</version>
                 <exclusions>
+                    <exclusion>
+                      <groupId>com.google.http-client</groupId>
+                      <artifactId>google-http-client-gson</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>
                         <artifactId>jsr305</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <errorprone.version>2.45.0</errorprone.version>
         <fabric8.version>7.6.0</fabric8.version>
         <fastutil.version>8.5.4</fastutil.version>
-        <guava.version>32.1.3-jre</guava.version>
+        <guava.version>33.1.0-jre</guava.version>
         <guice.version>6.0.0</guice.version>
         <hamcrest.version>2.2</hamcrest.version>
         <jetty.version>12.1.8</jetty.version>
@@ -128,11 +128,11 @@
         <jacoco.version>0.8.14</jacoco.version>
         <testcontainers.version>2.0.3</testcontainers.version>
         <hibernate-validator.version>6.2.5.Final</hibernate-validator.version>
-        <httpclient.version>4.5.13</httpclient.version>
+        <httpclient.version>4.5.14</httpclient.version>
         <okhttp.version>5.3.2</okhttp.version>
         <kubernetes.client.version>25.0.0-legacy</kubernetes.client.version>
         <zookeeper.version>3.8.6</zookeeper.version>
-        <checkerframework.version>3.48.1</checkerframework.version>
+        <checkerframework.version>3.49.0</checkerframework.version>
         <com.google.apis.client.version>2.9.0</com.google.apis.client.version>
         <com.google.http.client.apis.version>2.1.0</com.google.http.client.apis.version>
         <com.google.apis.compute.version>v1-rev20230606-2.0.0</com.google.apis.compute.version>
@@ -650,6 +650,11 @@
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-storage-api</artifactId>
                 <version>2.8.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.auto.value</groupId>
+                <artifactId>auto-value-annotations</artifactId>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -1183,6 +1188,16 @@
                 <version>${codehaus.jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-annotations</artifactId>
+                <version>1.26</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.woodstox</groupId>
+                <artifactId>stax2-api</artifactId>
+                <version>4.2.2</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.servlet</groupId>
                 <artifactId>javax.servlet-api</artifactId>
                 <version>4.0.1</version>
@@ -1438,7 +1453,7 @@
             <dependency>
                 <groupId>com.google.j2objc</groupId>
                 <artifactId>j2objc-annotations</artifactId>
-                <version>2.8</version>
+                <version>3.1</version>
             </dependency>
             <dependency>
                 <groupId>io.github.resilience4j</groupId>
@@ -1579,6 +1594,11 @@
                         <artifactId>jaxb-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.woodstox</groupId>
+                <artifactId>woodstox-core</artifactId>
+                <version>7.0.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
 
### Description
Update grpc-bom to 1.80.0, addressing CVE-2026-33186  

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.