### PR TITLE
fix: Added missing statsd mappings, updated mappings dimensions and metrics docs to reflect the emitted Coordinator stats

### DIFF
--- a/docs/operations/metrics.md
+++ b/docs/operations/metrics.md
@@ -428,14 +428,14 @@ These metrics are emitted by the Druid Coordinator in every run of the correspon
 |`segment/loadQueue/count`|Number of segments to load.|`server`|Varies|
 |`segment/loading/rateKbps`|Current rate of segment loading on a server in kbps (1000 bits per second). The rate is calculated as a moving average over the last 10 GiB or more of successful segment loads on that server.|`server`|Varies|
 |`segment/dropQueue/count`|Number of segments to drop.|`server`|Varies|
-|`segment/loadQueue/assigned`|Number of segments assigned for load or drop to the load queue of a server.|`dataSource`, `server`|Varies|
-|`segment/loadQueue/success`|Number of segment assignments that completed successfully.|`dataSource`, `server`|Varies|
-|`segment/loadQueue/failed`|Number of segment assignments that failed to complete.|`dataSource`, `server`|0|
-|`segment/loadQueue/cancelled`|Number of segment assignments that were canceled before completion.|`dataSource`, `server`|Varies|
+|`segment/loadQueue/assigned`|Number of segments assigned for load or drop to the load queue of a server.|`dataSource`, `description`|Varies|
+|`segment/loadQueue/success`|Number of segment assignments that completed successfully.|`dataSource`, `description`|Varies|
+|`segment/loadQueue/failed`|Number of segment assignments that failed to complete.|`dataSource`, `description`|0|
+|`segment/loadQueue/cancelled`|Number of segment assignments that were canceled before completion.|`dataSource`, `description`|Varies|
 |`segment/size`|Total size of used segments in a data source. Emitted only for data sources to which at least one used segment belongs.|`dataSource`|Varies|
 |`segment/count`|Number of used segments belonging to a data source. Emitted only for data sources to which at least one used segment belongs.|`dataSource`|< max|
 |`segment/overShadowed/count`|Number of segments marked as unused due to being overshadowed.| |Varies|
-|`segment/unneededEternityTombstone/count`|Number of non-overshadowed eternity tombstones marked as unused.| |Varies|
+|`segment/unneededEternityTombstone/count`|Number of non-overshadowed eternity tombstones marked as unused.|`dataSource`|Varies|
 |`segment/unavailable/count`|Number of unique segments left to load until all used segments are available for queries.|`dataSource`|0|
 |`segment/underReplicated/count`|Number of segments, including replicas, left to load until all used segments are available for queries.|`tier`, `dataSource`|0|
 |`segment/availableDeepStorageOnly/count`|Number of unique segments that are only available for querying directly from deep storage.|`dataSource`|Varies|

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -101,19 +101,33 @@
   "segment/moved/bytes" : { "dimensions" : ["dataSource", "taskType"], "type" : "count" },
   "segment/nuked/bytes" : { "dimensions" : ["dataSource", "taskType"], "type" : "count" },
 
-  "segment/assigned/count" : { "dimensions" : ["tier"], "type" : "count" },
-  "segment/moved/count" : { "dimensions" : ["tier"], "type" : "count" },
-  "segment/dropped/count" : { "dimensions" : ["tier"], "type" : "count" },
-  "segment/deleted/count" : { "dimensions" : ["tier"], "type" : "count" },
-  "segment/unneeded/count" : { "dimensions" : ["tier"], "type" : "count" },
+  "segment/assigned/count" : { "dimensions" : ["dataSource", "tier"], "type" : "count" },
+  "segment/moved/count" : { "dimensions" : ["dataSource", "tier"], "type" : "count" },
+  "segment/dropped/count" : { "dimensions" : ["dataSource", "tier"], "type" : "count" },
+  "segment/deleted/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "segment/unneeded/count" : { "dimensions" : ["dataSource", "tier"], "type" : "count" },
   "segment/unavailable/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "segment/underReplicated/count" : { "dimensions" : ["dataSource", "tier"], "type" : "gauge" },
   "segment/loadQueue/size" : { "dimensions" : ["server"], "type" : "gauge" },
-  "segment/loadQueue/failed" : { "dimensions" : ["server"], "type" : "gauge" },
   "segment/loadQueue/count" : { "dimensions" : ["server"], "type" : "gauge" },
   "segment/dropQueue/count" : { "dimensions" : ["server"], "type" : "gauge" },
   "segment/size" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "segment/overShadowed/count" : { "dimensions" : [], "type" : "gauge" },
+  "segment/assignSkipped/count" : { "dimensions" : ["dataSource", "server", "tier", "description"], "type" : "count" },
+  "segment/dropSkipped/count" : { "dimensions" : ["dataSource", "server", "tier", "description"], "type" : "count" },
+  "segment/moveSkipped/count" : { "dimensions" : ["dataSource", "server", "tier", "description"], "type" : "count" },
+
+  "segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "segment/availableDeepStorageOnly/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "segment/unneededEternityTombstone/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "segment/clone/assigned/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "segment/clone/dropped/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+
+  "segment/loading/rateKbps" : { "dimensions" : ["server"], "type" : "gauge" },
+  "segment/loadQueue/assigned" : { "dimensions" : ["dataSource", "description"], "type" : "gauge" },
+  "segment/loadQueue/success" : { "dimensions" : ["dataSource", "description"], "type" : "gauge" },
+  "segment/loadQueue/failed" : { "dimensions" : ["dataSource", "description"], "type" : "gauge" },
+  "segment/loadQueue/cancelled" : { "dimensions" : ["dataSource", "description"], "type" : "gauge" },
 
   "segment/metadataCache/sync/time": { "dimensions": [ "host", "service" ], "type" : "timer" },
 
@@ -178,9 +192,17 @@
   "tier/replication/factor" : { "dimensions" : ["tier"], "type" : "gauge" },
   "tier/historical/count" : { "dimensions" : ["tier"], "type" : "count" },
 
+  "tier/storage/capacity" : { "dimensions" : ["tier"], "type" : "gauge" },
+  "tier/historical/clone/count" : { "dimensions" : ["tier"], "type" : "count" },
+
   "compact/task/count" : { "dimensions" : [], "type" : "count" },
   "compactTask/maxSlot/count" : { "dimensions" : [], "type" : "count" },
   "compactTask/availableSlot/count" : { "dimensions" : [], "type" : "count" },
+
+  "compact/createJobs/time" : { "dimensions" : [], "type" : "timer" },
+  "compact/createJobs/count" : { "dimensions" : [], "type" : "count" },
+  "compact/runScheduler/time" : { "dimensions" : [], "type" : "timer" },
+  "compactTask/cancelled/count" : { "dimensions" : [], "type" : "count" },
 
   "segment/waitCompact/bytes" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "segment/waitCompact/count" : { "dimensions" : ["dataSource"], "type" : "count" },
@@ -199,7 +221,22 @@
 
   "service/heartbeat" : { "dimensions" : ["leader", "workerVersion", "category", "status", "taskId", "groupId", "dataSource", "taskStatus" ], "type" : "count" },
 
+  "metadata/kill/compaction/count" : { "dimensions" : [], "type" : "count" },
+  "metadata/kill/supervisor/count" : { "dimensions" : [], "type" : "count" },
+  "metadata/kill/rule/count" : { "dimensions" : [], "type" : "count" },
+  "metadata/kill/segmentSchema/count" : { "dimensions" : [], "type" : "count" },
+  "metadata/kill/audit/count" : { "dimensions" : [], "type" : "count" },
+  "metadata/kill/datasource/count" : { "dimensions" : [], "type" : "count" },
+  "kill/eligibleUnusedSegments/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
+  "kill/pendingSegments/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+
   "killTask/availableSlot/count" : { "dimensions" : [], "type" : "count" },
   "killTask/maxSlot/count" : { "dimensions" : [], "type" : "count" },
-  "killTask/task/count" : { "dimensions" : [], "type" : "count" }
+  "kill/task/count" : { "dimensions" : [], "type" : "count" },
+
+  "segment/balancer/compute/error" : { "dimensions" : ["tier", "dataSource", "description"], "type" : "count" },
+
+  "config/brokerSync/time" : { "dimensions" : [], "type" : "timer" },
+  "config/brokerSync/total/time" : { "dimensions" : [], "type" : "timer" },
+  "config/brokerSync/error" : { "dimensions" : [], "type" : "count" }
 }

--- a/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
+++ b/extensions-contrib/statsd-emitter/src/main/resources/defaultMetricDimensions.json
@@ -120,8 +120,8 @@
   "segment/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "segment/availableDeepStorageOnly/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "segment/unneededEternityTombstone/count" : { "dimensions" : ["dataSource"], "type" : "gauge" },
-  "segment/clone/assigned/count" : { "dimensions" : ["dataSource"], "type" : "count" },
-  "segment/clone/dropped/count" : { "dimensions" : ["dataSource"], "type" : "count" },
+  "segment/clone/assigned/count" : { "dimensions" : ["dataSource", "server"], "type" : "count" },
+  "segment/clone/dropped/count" : { "dimensions" : ["server"], "type" : "count" },
 
   "segment/loading/rateKbps" : { "dimensions" : ["server"], "type" : "gauge" },
   "segment/loadQueue/assigned" : { "dimensions" : ["dataSource", "description"], "type" : "gauge" },
@@ -202,7 +202,7 @@
   "compact/createJobs/time" : { "dimensions" : [], "type" : "timer" },
   "compact/createJobs/count" : { "dimensions" : [], "type" : "count" },
   "compact/runScheduler/time" : { "dimensions" : [], "type" : "timer" },
-  "compactTask/cancelled/count" : { "dimensions" : [], "type" : "count" },
+  "compactTask/cancelled/count" : { "dimensions" : ["dataSource"], "type" : "count" },
 
   "segment/waitCompact/bytes" : { "dimensions" : ["dataSource"], "type" : "gauge" },
   "segment/waitCompact/count" : { "dimensions" : ["dataSource"], "type" : "count" },
@@ -236,7 +236,7 @@
 
   "segment/balancer/compute/error" : { "dimensions" : ["tier", "dataSource", "description"], "type" : "count" },
 
-  "config/brokerSync/time" : { "dimensions" : [], "type" : "timer" },
-  "config/brokerSync/total/time" : { "dimensions" : [], "type" : "timer" },
-  "config/brokerSync/error" : { "dimensions" : [], "type" : "count" }
+  "config/brokerSync/time" : { "dimensions" : ["configType", "server"], "type" : "timer" },
+  "config/brokerSync/total/time" : { "dimensions" : ["configType"], "type" : "timer" },
+  "config/brokerSync/error" : { "dimensions" : ["configType", "server"], "type" : "count" }
 }

--- a/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/stats/Stats.java
@@ -58,7 +58,7 @@ public class Stats
     public static final CoordinatorStat UNNEEDED
         = CoordinatorStat.toDebugAndEmit("unneeded", "segment/unneeded/count");
     public static final CoordinatorStat OVERSHADOWED
-        = CoordinatorStat.toDebugAndEmit("overshadowed", "segment/overshadowed/count");
+        = CoordinatorStat.toDebugAndEmit("overshadowed", "segment/overShadowed/count");
     public static final CoordinatorStat UNNEEDED_ETERNITY_TOMBSTONE
         = CoordinatorStat.toDebugAndEmit("unneededEternityTombstone", "segment/unneededEternityTombstone/count");
 

--- a/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/simulate/CoordinatorSimulationBaseTest.java
@@ -232,7 +232,7 @@ public abstract class CoordinatorSimulationBaseTest implements
     static final String SUCCESS_ACTIONS = "segment/loadQueue/success";
     static final String CANCELLED_ACTIONS = "segment/loadQueue/cancelled";
 
-    static final String OVERSHADOWED_COUNT = "segment/overshadowed/count";
+    static final String OVERSHADOWED_COUNT = "segment/overShadowed/count";
   }
 
   static class Segments


### PR DESCRIPTION
### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

Metrics published by various Druid services are handled by the configured Emitter to send them to external observability systems. The Statsd Emitter is used to send to StatsD system. This emitter uses a default mapping file (packaged within Druid) to map from Druid metric types to StatsD metric types. If a mapping is not present for a metric, it is not emitted.

A number of metrics are missing mappings or have incomplete or incorrect dimensions specified in the mappings. It is likely because these mappings are not being kept up-to-date, with the additions and changes to published metrics in the code. 

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

This change updates these mappings for Coordinator metrics and fixes documentation where it deviates from what is in the code.

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

<hr>

Fixes missing Coordinator stats not being published to StatsD system

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [x] been tested in a test Druid cluster.