### PR TITLE
fix: handle unstructured upstream query error responses

### DIFF
--- a/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
+++ b/server/src/main/java/org/apache/druid/client/DirectDruidClient.java
@@ -43,7 +43,10 @@ import org.apache.druid.java.util.http.client.response.StatusResponseHandler;
 import org.apache.druid.java.util.http.client.response.StatusResponseHolder;
 import org.apache.druid.query.Queries;
 import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryContext;
+import org.apache.druid.query.QueryException;
+import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryMetrics;
 import org.apache.druid.query.QueryPlus;
 import org.apache.druid.query.QueryRunner;
@@ -65,8 +68,10 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.joda.time.Duration;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.core.MediaType;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -92,6 +97,8 @@ public class DirectDruidClient<T> implements QueryRunner<T>
 
   private static final Logger log = new Logger(DirectDruidClient.class);
   private static final int VAL_TO_REDUCE_REMAINING_RESPONSES = -1;
+  private static final int HTTP_TOO_MANY_REQUESTS = 429;
+  private static final int HTTP_SERVICE_UNAVAILABLE = 503;
 
   private final QueryRunnerFactoryConglomerate conglomerate;
   private final QueryWatcher queryWatcher;
@@ -253,6 +260,20 @@ public class DirectDruidClient<T> implements QueryRunner<T>
             if (responseContext != null) {
               context.merge(ResponseContext.deserialize(responseContext, objectMapper));
             }
+
+            final int statusCode = response.getStatus().getCode();
+            final String contentType = response.headers().get(HttpHeaders.Names.CONTENT_TYPE);
+            if (statusCode >= 400 && !isStructuredResponseContent(contentType, response.getContent())) {
+              totalByteCount.addAndGet(response.getContent().readableBytes());
+              return ClientResponse.finished(
+                  new ByteArrayInputStream(
+                      objectMapper.writeValueAsBytes(
+                          makeSyntheticExceptionForUnstructuredErrorResponse(statusCode, contentType)
+                      )
+                  )
+              );
+            }
+
             continueReading = enqueue(response.getContent(), 0L);
           }
           catch (final IOException e) {
@@ -312,6 +333,59 @@ public class DirectDruidClient<T> implements QueryRunner<T>
               ),
               continueReading
           );
+        }
+
+        private QueryException makeSyntheticExceptionForUnstructuredErrorResponse(
+            int statusCode,
+            @Nullable String contentType
+        )
+        {
+          final String errorMessage = StringUtils.format(
+              "Query[%s] to url[%s] failed with HTTP status[%d] and unstructured content type[%s].",
+              query.getId(),
+              url,
+              statusCode,
+              contentType
+          );
+          if (statusCode == HTTP_TOO_MANY_REQUESTS || statusCode == HTTP_SERVICE_UNAVAILABLE) {
+            // Jetty and proxy overload paths commonly surface 429/503 as HTML error pages.
+            return new QueryCapacityExceededException(
+                QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE,
+                errorMessage,
+                QueryCapacityExceededException.class.getName(),
+                host
+            );
+          }
+          return new QueryInterruptedException(
+              QueryException.UNKNOWN_EXCEPTION_ERROR_CODE,
+              errorMessage,
+              QueryInterruptedException.class.getName(),
+              host
+          );
+        }
+
+        private boolean isStructuredResponseContent(
+            @Nullable String contentType,
+            ChannelBuffer content
+        )
+        {
+          if (contentType != null) {
+            final String normalizedContentType = StringUtils.toLowerCase(contentType);
+            if (normalizedContentType.contains(MediaType.APPLICATION_JSON)
+                || normalizedContentType.contains("+json")
+                || normalizedContentType.contains(SmileMediaTypes.APPLICATION_JACKSON_SMILE)
+                || normalizedContentType.contains("application/smile")) {
+              return true;
+            }
+          }
+
+          for (int i = content.readerIndex(); i < content.writerIndex(); i++) {
+            final byte value = content.getByte(i);
+            if (!Character.isWhitespace(value)) {
+              return value == '{' || value == '[';
+            }
+          }
+          return false;
         }
 
         @Override

--- a/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
+++ b/server/src/test/java/org/apache/druid/client/DirectDruidClientTest.java
@@ -31,9 +31,13 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.http.client.HttpClient;
 import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.ClientResponse;
+import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
 import org.apache.druid.query.Druids;
 import org.apache.druid.query.NestedDataTestUtils;
+import org.apache.druid.query.QueryCapacityExceededException;
 import org.apache.druid.query.QueryContexts;
+import org.apache.druid.query.QueryException;
 import org.apache.druid.query.QueryInterruptedException;
 import org.apache.druid.query.QueryPlus;
 import org.apache.druid.query.QueryRunnerTestHelper;
@@ -53,8 +57,15 @@ import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorSer
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
+import org.jboss.netty.buffer.HeapChannelBufferFactory;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.jboss.netty.handler.timeout.ReadTimeoutException;
+import org.joda.time.Duration;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -345,6 +356,92 @@ public class DirectDruidClientTest
         actualException.getMessage());
   }
 
+  @Test
+  public void testHttp429WithHtmlBodyThrowsQueryCapacityExceededException()
+  {
+    final DirectDruidClient client = makeDirectDruidClient(
+        initHttpClientWithRawErrorResponse(
+            HttpResponseStatus.valueOf(429),
+            "text/html;charset=ISO-8859-1",
+            "<html><body><h2>HTTP ERROR 429 Too Many Requests</h2></body></html>"
+        )
+    );
+
+    Sequence results = client.run(getQueryPlus(), responseContext);
+    QueryCapacityExceededException actualException =
+        Assert.assertThrows(QueryCapacityExceededException.class, results::toList);
+
+    Assert.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, actualException.getErrorCode());
+    Assert.assertEquals(hostName, actualException.getHost());
+    Assert.assertTrue(actualException.getMessage().contains("HTTP status[429]"));
+  }
+
+  @Test
+  public void testHttp503WithHtmlBodyThrowsQueryCapacityExceededException()
+  {
+    final DirectDruidClient client = makeDirectDruidClient(
+        initHttpClientWithRawErrorResponse(
+            HttpResponseStatus.SERVICE_UNAVAILABLE,
+            "text/html;charset=ISO-8859-1",
+            "<html><body><h2>HTTP ERROR 503 Service Unavailable</h2></body></html>"
+        )
+    );
+
+    Sequence results = client.run(getQueryPlus(), responseContext);
+    QueryCapacityExceededException actualException =
+        Assert.assertThrows(QueryCapacityExceededException.class, results::toList);
+
+    Assert.assertEquals(QueryException.QUERY_CAPACITY_EXCEEDED_ERROR_CODE, actualException.getErrorCode());
+    Assert.assertEquals(hostName, actualException.getHost());
+    Assert.assertTrue(actualException.getMessage().contains("HTTP status[503]"));
+  }
+
+  @Test
+  public void testHttp500WithHtmlBodyThrowsQueryInterruptedException()
+  {
+    final DirectDruidClient client = makeDirectDruidClient(
+        initHttpClientWithRawErrorResponse(
+            HttpResponseStatus.INTERNAL_SERVER_ERROR,
+            "text/html;charset=ISO-8859-1",
+            "<html><body><h2>HTTP ERROR 500 Server Error</h2></body></html>"
+        )
+    );
+
+    Sequence results = client.run(getQueryPlus(), responseContext);
+    QueryInterruptedException actualException =
+        Assert.assertThrows(QueryInterruptedException.class, results::toList);
+
+    Assert.assertEquals(QueryException.UNKNOWN_EXCEPTION_ERROR_CODE, actualException.getErrorCode());
+    Assert.assertEquals(hostName, actualException.getHost());
+    Assert.assertTrue(actualException.getMessage().contains("HTTP status[500]"));
+  }
+
+  @Test
+  public void testJsonErrorWithoutContentTypeUsesOriginalQueryException() throws Exception
+  {
+    final DirectDruidClient client = makeDirectDruidClient(
+        initHttpClientWithRawErrorResponse(
+            HttpResponseStatus.INTERNAL_SERVER_ERROR,
+            null,
+            objectMapper.writeValueAsString(
+                new QueryInterruptedException(
+                    QueryException.UNKNOWN_EXCEPTION_ERROR_CODE,
+                    "original structured error",
+                    "test",
+                    "remote-host"
+                )
+            )
+        )
+    );
+
+    Sequence results = client.run(getQueryPlus(), responseContext);
+    QueryInterruptedException actualException =
+        Assert.assertThrows(QueryInterruptedException.class, results::toList);
+
+    Assert.assertEquals("original structured error", actualException.getMessage());
+    Assert.assertEquals(QueryException.UNKNOWN_EXCEPTION_ERROR_CODE, actualException.getErrorCode());
+  }
+
   private DirectDruidClient makeDirectDruidClient(HttpClient httpClient)
   {
     return new DirectDruidClient(
@@ -367,6 +464,51 @@ public class DirectDruidClientTest
   private HttpClient initHttpClientWithSuccessfulQuery()
   {
     return initHttpClientFromExistingClient(new TestHttpClient(objectMapper), false);
+  }
+
+  private HttpClient initHttpClientWithRawErrorResponse(
+      HttpResponseStatus status,
+      String contentType,
+      String body
+  )
+  {
+    return new HttpClient()
+    {
+      @Override
+      public <Intermediate, Final> ListenableFuture<Final> go(
+          Request request,
+          HttpResponseHandler<Intermediate, Final> handler
+      )
+      {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <Intermediate, Final> ListenableFuture<Final> go(
+          Request request,
+          HttpResponseHandler<Intermediate, Final> handler,
+          Duration readTimeout
+      )
+      {
+        final HttpResponse response = new DefaultHttpResponse(HttpVersion.HTTP_1_1, status);
+        if (contentType != null) {
+          response.headers().set(HttpHeaders.Names.CONTENT_TYPE, contentType);
+        }
+
+        final byte[] serializedContent = StringUtils.toUtf8(body);
+        response.setContent(
+            HeapChannelBufferFactory.getInstance().getBuffer(
+                serializedContent,
+                0,
+                serializedContent.length
+            )
+        );
+
+        final ClientResponse<Intermediate> intermClientResponse = handler.handleResponse(response, checkNum -> 0L);
+        final ClientResponse<Final> finalClientResponse = handler.done(intermClientResponse);
+        return Futures.immediateFuture(finalClientResponse.getObj());
+      }
+    };
   }
 
   private HttpClient initHttpClientFromExistingClient(ListenableFuture future)


### PR DESCRIPTION
Fixes #19407.

### Description

This updates `DirectDruidClient` so HTTP error responses with unstructured bodies, such as Jetty HTML 429/503 pages, are converted into Druid query exceptions before the response stream reaches the JSON parser.

Structured JSON/Smile error responses still use the existing parsing path. For unstructured 429/503 responses, the client now reports a query capacity error since those statuses indicate upstream rate limiting or overload. If `Content-Type` is missing, the response body is sniffed so JSON-looking error bodies still take the existing path.

#### Release note

Broker query failures caused by upstream 429/503 HTML error responses now surface as query capacity errors instead of raw JSON parse errors.

<hr>

##### Key changed/added classes in this PR
 * `DirectDruidClient`
 * `DirectDruidClientTest`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage is met.

Tested with:

`mvn -pl server -am -Dtest=DirectDruidClientTest -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs`

Result: 13 tests passed.