### PR TITLE
fix: log uncaught explore module errors with console.error

### DIFF
--- a/web-console/src/views/explore-view/components/error-boundary/error-boundary.tsx
+++ b/web-console/src/views/explore-view/components/error-boundary/error-boundary.tsx
@@ -38,7 +38,7 @@ export class ErrorBoundary extends React.Component<
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.log('Module content error:', error, errorInfo);
+    console.error('Module content error:', error, errorInfo);
   }
 
   render() {


### PR DESCRIPTION
### Description

`ErrorBoundary.componentDidCatch` in the explore view logs the uncaught render error through `console.log`:

```tsx
componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
  console.log('Module content error:', error, errorInfo);
}
```

`componentDidCatch` is React's canonical error-reporting hook — by the
time it runs, an exception has already propagated up the render tree
and the subtree has been swapped out for the `error-boundary` fallback
UI. Logging at `log` severity:

- hides the failure from the browser DevTools **Errors** filter
- is invisible to tooling that watches `console.error` (test harnesses
  that fail on console errors, log scrapers, error-reporting SDKs)

Switching to `console.error` matches the severity at which other
sibling code in the same area logs caught-and-rethrown failures
(e.g. `helpers/execution/sql-task-execution.ts`'s `console.error` on
the reports-endpoint retry path).

No other behavior change — the fallback UI rendering, state handling,
and React's own in-dev `reportError` path are untouched.

#### Release note

Uncaught render errors in explore-view modules are now logged at
`console.error` severity from the error boundary, matching the browser
DevTools "Errors" filter and any tooling that watches for
`console.error`.

##### Key changed/added classes in this PR
- `web-console/src/views/explore-view/components/error-boundary/error-boundary.tsx`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors. *(N/A — internal log-severity fix, no user-facing docs)*
- [x] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. *(N/A — TypeScript)*
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/licenses.yaml) *(N/A — no dependency change)*
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader. *(N/A — one-line severity fix)*
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met. *(no new code path — only the console method changes; the existing fallback-UI render path is unchanged)*
- [x] added integration tests. *(N/A)*
- [x] been tested in a test Druid cluster. *(N/A — verified by inspection: `componentDidCatch` is React's documented error-reporting hook; the catch handler runs only when the subtree has already thrown.)*
