### PR TITLE
feat: support broker node eligibility filter in TieredBrokerSelectorStrategy

### DIFF
--- a/services/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
+++ b/services/src/main/java/org/apache/druid/server/router/TieredBrokerHostSelector.java
@@ -36,6 +36,7 @@ import org.apache.druid.java.util.common.lifecycle.LifecycleStart;
 import org.apache.druid.java.util.common.lifecycle.LifecycleStop;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.query.Query;
+import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.coordinator.rules.LoadRule;
 import org.apache.druid.server.coordinator.rules.Rule;
 import org.apache.druid.sql.http.SqlQuery;
@@ -137,9 +138,10 @@ public class TieredBrokerHostSelector
             {
               nodes.forEach(
                   (node) -> {
-                    NodesHolder nodesHolder = servers.get(node.getDruidNode().getServiceName());
-                    if (nodesHolder != null) {
-                      nodesHolder.add(node.getDruidNode().getHostAndPortToUse(), TO_SERVER.apply(node));
+                    final DruidNode druidNode = node.getDruidNode();
+                    final NodesHolder nodesHolder = servers.get(druidNode.getServiceName());
+                    if (nodesHolder != null && isBrokerEligible(node)) {
+                      nodesHolder.add(druidNode.getHostAndPortToUse(), TO_SERVER.apply(node));
                     }
                   }
               );
@@ -150,9 +152,10 @@ public class TieredBrokerHostSelector
             {
               nodes.forEach(
                   (node) -> {
-                    NodesHolder nodesHolder = servers.get(node.getDruidNode().getServiceName());
+                    final DruidNode druidNode = node.getDruidNode();
+                    final NodesHolder nodesHolder = servers.get(druidNode.getServiceName());
                     if (nodesHolder != null) {
-                      nodesHolder.remove(node.getDruidNode().getHostAndPortToUse());
+                      nodesHolder.remove(druidNode.getHostAndPortToUse());
                     }
                   }
               );
@@ -162,6 +165,16 @@ public class TieredBrokerHostSelector
 
       started = true;
     }
+  }
+
+  private boolean isBrokerEligible(DiscoveryDruidNode brokerNode)
+  {
+    for (TieredBrokerSelectorStrategy strategy : strategies) {
+      if (!strategy.isBrokerEligible(brokerNode)) {
+        return false;
+      }
+    }
+    return true;
   }
 
 

--- a/services/src/main/java/org/apache/druid/server/router/TieredBrokerSelectorStrategy.java
+++ b/services/src/main/java/org/apache/druid/server/router/TieredBrokerSelectorStrategy.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.router;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.base.Optional;
+import org.apache.druid.discovery.DiscoveryDruidNode;
 import org.apache.druid.query.Query;
 import org.apache.druid.sql.http.SqlQuery;
 
@@ -58,5 +59,13 @@ public interface TieredBrokerSelectorStrategy
   default Optional<String> getBrokerServiceName(TieredBrokerConfig config, SqlQuery sqlQuery)
   {
     return Optional.absent();
+  }
+
+  /**
+   * Determines whether a discovered broker node is eligible for query routing.
+   */
+  default boolean isBrokerEligible(DiscoveryDruidNode brokerNode)
+  {
+    return true;
   }
 }

--- a/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.server.router;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -35,6 +36,7 @@ import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.query.Druids;
+import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
@@ -63,6 +65,7 @@ public class TieredBrokerHostSelectorTest
 {
   private DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
   private DruidNodeDiscovery druidNodeDiscovery;
+  private DruidNodeDiscovery.Listener druidNodeDiscoveryListener;
   private TieredBrokerHostSelector brokerSelector;
 
   private DiscoveryDruidNode node1;
@@ -103,6 +106,7 @@ public class TieredBrokerHostSelectorTest
       @Override
       public void registerListener(Listener listener)
       {
+        druidNodeDiscoveryListener = listener;
         listener.nodesAdded(ImmutableList.of(node1, node2, node3));
         listener.nodeViewInitialized();
       }
@@ -139,7 +143,8 @@ public class TieredBrokerHostSelectorTest
         Arrays.asList(
             new ManualTieredBrokerSelectorStrategy(null),
             new TimeBoundaryTieredBrokerSelectorStrategy(),
-            new PriorityTieredBrokerSelectorStrategy(0, 1)
+            new PriorityTieredBrokerSelectorStrategy(0, 1),
+            new BrokerHostFilteringStrategy("coldHost3")
         )
     );
 
@@ -383,6 +388,27 @@ public class TieredBrokerHostSelectorTest
     );
   }
 
+  @Test
+  public void testNodesAddedAppliesStrategyBrokerFilter()
+  {
+    druidNodeDiscoveryListener.nodesAdded(
+        ImmutableList.of(
+            new DiscoveryDruidNode(
+                new DruidNode("coldBroker", "coldHost3", false, 8080, null, true, false),
+                NodeRole.BROKER,
+                ImmutableMap.of()
+            )
+        )
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of("coldHost1:8080", "coldHost2:8080"),
+        ImmutableSet.copyOf(
+            Lists.transform(brokerSelector.getAllBrokers().get("coldBroker"), server -> server.getHost())
+        )
+    );
+  }
+
   private SqlQuery createSqlQueryWithContext(Map<String, Object> queryContext)
   {
     return new SqlQuery(
@@ -394,6 +420,28 @@ public class TieredBrokerHostSelectorTest
         queryContext,
         null
     );
+  }
+
+  private static class BrokerHostFilteringStrategy implements TieredBrokerSelectorStrategy
+  {
+    private final String filteredHost;
+
+    private BrokerHostFilteringStrategy(String filteredHost)
+    {
+      this.filteredHost = filteredHost;
+    }
+
+    @Override
+    public Optional<String> getBrokerServiceName(TieredBrokerConfig config, Query<?> query)
+    {
+      return Optional.absent();
+    }
+
+    @Override
+    public boolean isBrokerEligible(DiscoveryDruidNode brokerNode)
+    {
+      return !filteredHost.equals(brokerNode.getDruidNode().getHost());
+    }
   }
 
   private static class TestRuleManager extends CoordinatorRuleManager


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description

Adds a hook for router routing strategies to hook into which set of brokers are actually valid to route to. Useful for filtering based on other attributes other than service name, for example maintaining version=2 routers only query version=2 brokers.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

Support broker node eligibility filter in TieredBrokerSelectorStrategy.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.