### PR TITLE
fix: cost autoscaler flaky test

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Timeout;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -285,6 +286,10 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
           "supervisor task count to scale down"
       );
     }
+    catch (Exception e) {
+      throwPublisherFailureIfDone(publisherFuture);
+      throw e;
+    }
     finally {
       keepPublishing.set(false);
       publisher.shutdownNow();
@@ -391,5 +396,27 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
     );
     Assertions.assertNotNull(supervisorSpec);
     return supervisorSpec.getSpec().getIOConfig().getTaskCount();
+  }
+
+  private static void throwPublisherFailureIfDone(Future<?> publisherFuture)
+      throws Exception
+  {
+    if (!publisherFuture.isDone()) {
+      return;
+    }
+
+    try {
+      publisherFuture.get();
+    }
+    catch (ExecutionException e) {
+      final Throwable cause = e.getCause();
+      if (cause instanceof Error) {
+        throw (Error) cause;
+      } else if (cause instanceof Exception) {
+        throw (Exception) cause;
+      } else {
+        throw e;
+      }
+    }
   }
 }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
@@ -67,6 +67,8 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
   private static final int PARTITION_COUNT = 50;
   private static final int MAX_SCALE_UP_RECORD_BATCHES = 30;
   private static final long SCALE_UP_PUBLISH_INTERVAL_MILLIS = 100;
+  private static final long TASK_COUNT_RETRY_INTERVAL_MILLIS = 1_000;
+  private static final int TASK_COUNT_RETRY_COUNT = 60;
 
   private String topic;
   private final KafkaResource kafkaServer = new KafkaResource();
@@ -189,6 +191,7 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
   }
 
   @Test
+  @Timeout(value = 20, unit = TimeUnit.MINUTES)
   public void test_autoScaler_scalesUpAndDown_withSlowPublish()
       throws Exception
   {
@@ -258,8 +261,11 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
       );
       keepPublishing.set(false);
       publisherFuture.get(30, TimeUnit.SECONDS);
-      ITRetryUtil.retryUntilTrue(
+      ITRetryUtil.retryUntil(
           () -> getCurrentTaskCount(supervisor.getId()) > 1,
+          true,
+          TASK_COUNT_RETRY_INTERVAL_MILLIS,
+          TASK_COUNT_RETRY_COUNT,
           "supervisor task count to scale up"
       );
       waitUntilPublishedRecordsAreIngested(totalRecords.get());
@@ -274,6 +280,8 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
       ITRetryUtil.retryUntilEquals(
           () -> getCurrentTaskCount(supervisor.getId()),
           1,
+          TASK_COUNT_RETRY_INTERVAL_MILLIS,
+          TASK_COUNT_RETRY_COUNT,
           "supervisor task count to scale down"
       );
     }

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.testing.embedded.EmbeddedClusterApis;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
 import org.apache.druid.testing.embedded.indexing.StreamIndexTestBase;
+import org.apache.druid.testing.embedded.utils.ITRetryUtil;
 import org.hamcrest.Matchers;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.joda.time.Duration;
@@ -228,7 +229,10 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
                       .hasDimension(DruidMetrics.SUPERVISOR_ID, supervisor.getId())
                       .hasValueMatching(Matchers.greaterThan(1L))
     );
-    Assertions.assertEquals(4, getCurrentTaskCount(supervisor.getId()));
+    ITRetryUtil.retryUntilTrue(
+        () -> getCurrentTaskCount(supervisor.getId()) > 1,
+        "supervisor task count to scale up"
+    );
     waitUntilPublishedRecordsAreIngested(totalRecords);
 
     // Let the tasks work through the lag.
@@ -238,7 +242,11 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
                       .hasDimension(DruidMetrics.SUPERVISOR_ID, supervisor.getId())
                       .hasValueMatching(Matchers.equalTo(1L))
     );
-    Assertions.assertEquals(1, getCurrentTaskCount(supervisor.getId()));
+    ITRetryUtil.retryUntilEquals(
+        () -> getCurrentTaskCount(supervisor.getId()),
+        1,
+        "supervisor task count to scale down"
+    );
 
     cluster.callApi().postSupervisor(supervisor.createSuspendedSpec());
     cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator, broker);

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/indexing/autoscaler/CostBasedAutoScalerIntegrationTest.java
@@ -47,7 +47,12 @@ import org.junit.jupiter.api.Timeout;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScaler.OPTIMAL_TASK_COUNT_METRIC;
 
@@ -60,6 +65,8 @@ import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.Cos
 public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
 {
   private static final int PARTITION_COUNT = 50;
+  private static final int MAX_SCALE_UP_RECORD_BATCHES = 30;
+  private static final long SCALE_UP_PUBLISH_INTERVAL_MILLIS = 100;
 
   private String topic;
   private final KafkaResource kafkaServer = new KafkaResource();
@@ -183,6 +190,7 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
 
   @Test
   public void test_autoScaler_scalesUpAndDown_withSlowPublish()
+      throws Exception
   {
     final String topic = EmbeddedClusterApis.createTestDatasourceName();
     kafkaServer.createTopicWithPartitions(topic, 4);
@@ -216,41 +224,67 @@ public class CostBasedAutoScalerIntegrationTest extends StreamIndexTestBase
         .build(dataSource, topic);
     cluster.callApi().postSupervisor(supervisor);
 
-    // Ingest a large number of records to trigger a scale-up
-    // 10k records = 100 segments to publish * 100 rows per segment
-    int totalRecords = 0;
-    for (int i = 0; i < 10; ++i) {
-      totalRecords += publish1kRecords(topic, false);
+    overlord.latchableEmitter()
+            .waitForEvent(event -> event.hasMetricName("task/run/time")
+                                        .hasDimension(DruidMetrics.DATASOURCE, dataSource));
+
+    final AtomicBoolean keepPublishing = new AtomicBoolean(true);
+    final AtomicInteger totalRecords = new AtomicInteger();
+    final ExecutorService publisher = Executors.newSingleThreadExecutor();
+    final Future<?> publisherFuture = publisher.submit(() -> {
+      for (int i = 0; i < MAX_SCALE_UP_RECORD_BATCHES && keepPublishing.get(); ++i) {
+        totalRecords.addAndGet(publish1kRecords(topic, false));
+        try {
+          TimeUnit.MILLISECONDS.sleep(SCALE_UP_PUBLISH_INTERVAL_MILLIS);
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+      }
+    });
+
+    try {
+      overlord.latchableEmitter().waitForEvent(
+          event -> event.hasMetricName(OPTIMAL_TASK_COUNT_METRIC)
+                        .hasDimension(DruidMetrics.SUPERVISOR_ID, supervisor.getId())
+                        .hasValueMatching(Matchers.greaterThan(1L))
+      );
+
+      overlord.latchableEmitter().waitForEvent(
+          event -> event.hasMetricName("task/autoScaler/updatedCount")
+                        .hasDimension(DruidMetrics.SUPERVISOR_ID, supervisor.getId())
+                        .hasValueMatching(Matchers.greaterThan(1L))
+      );
+      keepPublishing.set(false);
+      publisherFuture.get(30, TimeUnit.SECONDS);
+      ITRetryUtil.retryUntilTrue(
+          () -> getCurrentTaskCount(supervisor.getId()) > 1,
+          "supervisor task count to scale up"
+      );
+      waitUntilPublishedRecordsAreIngested(totalRecords.get());
+
+      // Let the tasks work through the lag.
+      // Do not publish any more records so that the idleness causes scale-down
+      overlord.latchableEmitter().waitForEvent(
+          event -> event.hasMetricName("task/autoScaler/updatedCount")
+                        .hasDimension(DruidMetrics.SUPERVISOR_ID, supervisor.getId())
+                        .hasValueMatching(Matchers.equalTo(1L))
+      );
+      ITRetryUtil.retryUntilEquals(
+          () -> getCurrentTaskCount(supervisor.getId()),
+          1,
+          "supervisor task count to scale down"
+      );
+    }
+    finally {
+      keepPublishing.set(false);
+      publisher.shutdownNow();
+      cluster.callApi().postSupervisor(supervisor.createSuspendedSpec());
     }
 
-    // Wait for tasks to scale up
-    overlord.latchableEmitter().waitForEvent(
-        event -> event.hasMetricName("task/autoScaler/updatedCount")
-                      .hasDimension(DruidMetrics.SUPERVISOR_ID, supervisor.getId())
-                      .hasValueMatching(Matchers.greaterThan(1L))
-    );
-    ITRetryUtil.retryUntilTrue(
-        () -> getCurrentTaskCount(supervisor.getId()) > 1,
-        "supervisor task count to scale up"
-    );
-    waitUntilPublishedRecordsAreIngested(totalRecords);
-
-    // Let the tasks work through the lag.
-    // Do not publish any more records so that the idleness causes scale-down
-    overlord.latchableEmitter().waitForEvent(
-        event -> event.hasMetricName("task/autoScaler/updatedCount")
-                      .hasDimension(DruidMetrics.SUPERVISOR_ID, supervisor.getId())
-                      .hasValueMatching(Matchers.equalTo(1L))
-    );
-    ITRetryUtil.retryUntilEquals(
-        () -> getCurrentTaskCount(supervisor.getId()),
-        1,
-        "supervisor task count to scale down"
-    );
-
-    cluster.callApi().postSupervisor(supervisor.createSuspendedSpec());
     cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator, broker);
-    Assertions.assertEquals("10000", cluster.runSql("SELECT COUNT(*) FROM %s", dataSource));
+    Assertions.assertEquals(String.valueOf(totalRecords.get()), cluster.runSql("SELECT COUNT(*) FROM %s", dataSource));
 
     final List<TaskStatusPlus> tasks = cluster.callApi().getTasks(dataSource, "complete");
     Assertions.assertFalse(tasks.isEmpty());


### PR DESCRIPTION
Ref. https://github.com/apache/druid/issues/19517


### Description
Fixes flaky `CostBasedAutoScalerIntegrationTest` scale-up wait.


This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.