### PR TITLE
Add advertisedPlaintextPort to DruidNode for sidecar proxy support

### DIFF
--- a/server/src/main/java/org/apache/druid/rpc/ServiceLocation.java
+++ b/server/src/main/java/org/apache/druid/rpc/ServiceLocation.java
@@ -73,7 +73,7 @@ public class ServiceLocation
    */
   public static ServiceLocation fromDruidNode(final DruidNode druidNode)
   {
-    return new ServiceLocation(druidNode.getHost(), druidNode.getPlaintextPort(), druidNode.getTlsPort(), "");
+    return new ServiceLocation(druidNode.getHost(), druidNode.getAdvertisedPlaintextPort(), druidNode.getTlsPort(), "");
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -100,6 +100,10 @@ public class DruidNode
   @JsonProperty
   private Map<String, String> labels;
 
+  @JsonProperty
+  @Max(0xffff)
+  private int advertisedPlaintextPort = -1;
+
   public DruidNode(
       String serviceName,
       String host,
@@ -110,7 +114,21 @@ public class DruidNode
       boolean enableTlsPort
   )
   {
-    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, null);
+    this(serviceName, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, null, null);
+  }
+
+  public DruidNode(
+      String serviceName,
+      String host,
+      boolean bindOnHost,
+      Integer plaintextPort,
+      Integer port,
+      Integer tlsPort,
+      Boolean enablePlaintextPort,
+      boolean enableTlsPort
+  )
+  {
+    this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, null, null);
   }
 
   /**
@@ -139,7 +157,8 @@ public class DruidNode
       @JacksonInject(useInput = OptBoolean.TRUE) @Named("tlsServicePort") @JsonProperty("tlsPort") Integer tlsPort,
       @JsonProperty("enablePlaintextPort") Boolean enablePlaintextPort,
       @JsonProperty("enableTlsPort") boolean enableTlsPort,
-      @JsonProperty("labels") @Nullable Map<String, String> labels
+      @JsonProperty("labels") @Nullable Map<String, String> labels,
+      @JsonProperty("advertisedPlaintextPort") Integer advertisedPlaintextPort
   )
   {
     init(
@@ -150,7 +169,8 @@ public class DruidNode
         tlsPort,
         enablePlaintextPort == null || enablePlaintextPort.booleanValue(),
         enableTlsPort,
-        labels
+        labels,
+        advertisedPlaintextPort
     );
   }
 
@@ -162,7 +182,8 @@ public class DruidNode
       Integer tlsPort,
       boolean enablePlaintextPort,
       boolean enableTlsPort,
-      Map<String, String> labels
+      Map<String, String> labels,
+      Integer advertisedPlaintextPort
   )
   {
     Preconditions.checkNotNull(serviceName);
@@ -210,8 +231,12 @@ public class DruidNode
         }
       }
       this.plaintextPort = plainTextPort;
+      this.advertisedPlaintextPort = advertisedPlaintextPort != null && advertisedPlaintextPort > 0
+                                     ? advertisedPlaintextPort
+                                     : this.plaintextPort;
     } else {
       this.plaintextPort = -1;
+      this.advertisedPlaintextPort = -1;
     }
     if (enableTlsPort) {
       this.tlsPort = tlsPort;
@@ -276,9 +301,14 @@ public class DruidNode
     return buildRevision;
   }
 
+  public int getAdvertisedPlaintextPort()
+  {
+    return advertisedPlaintextPort;
+  }
+
   public DruidNode withService(String service)
   {
-    return new DruidNode(service, host, bindOnHost, plaintextPort, tlsPort, enablePlaintextPort, enableTlsPort);
+    return new DruidNode(service, host, bindOnHost, plaintextPort, null, tlsPort, enablePlaintextPort, enableTlsPort, labels, advertisedPlaintextPort);
   }
 
   public String getServiceScheme()
@@ -292,10 +322,10 @@ public class DruidNode
   public String getHostAndPort()
   {
     if (enablePlaintextPort) {
-      if (plaintextPort < 0) {
+      if (advertisedPlaintextPort < 0) {
         return HostAndPort.fromString(host).toString();
       } else {
-        return HostAndPort.fromParts(host, plaintextPort).toString();
+        return HostAndPort.fromParts(host, advertisedPlaintextPort).toString();
       }
     }
     return null;
@@ -359,6 +389,7 @@ public class DruidNode
            enablePlaintextPort == druidNode.enablePlaintextPort &&
            tlsPort == druidNode.tlsPort &&
            enableTlsPort == druidNode.enableTlsPort &&
+           advertisedPlaintextPort == druidNode.advertisedPlaintextPort &&
            Objects.equals(serviceName, druidNode.serviceName) &&
            Objects.equals(host, druidNode.host) &&
            Objects.equals(labels, druidNode.labels);
@@ -367,7 +398,7 @@ public class DruidNode
   @Override
   public int hashCode()
   {
-    return Objects.hash(serviceName, host, port, plaintextPort, enablePlaintextPort, tlsPort, enableTlsPort, labels);
+    return Objects.hash(serviceName, host, port, plaintextPort, enablePlaintextPort, tlsPort, enableTlsPort, labels, advertisedPlaintextPort);
   }
 
   @Override
@@ -379,6 +410,7 @@ public class DruidNode
            ", bindOnHost=" + bindOnHost +
            ", port=" + port +
            ", plaintextPort=" + plaintextPort +
+           ", advertisedPlaintextPort=" + advertisedPlaintextPort +
            ", enablePlaintextPort=" + enablePlaintextPort +
            ", tlsPort=" + tlsPort +
            ", enableTlsPort=" + enableTlsPort +

--- a/server/src/main/java/org/apache/druid/server/DruidNode.java
+++ b/server/src/main/java/org/apache/druid/server/DruidNode.java
@@ -131,6 +131,21 @@ public class DruidNode
     this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, null, null);
   }
 
+  public DruidNode(
+      String serviceName,
+      String host,
+      boolean bindOnHost,
+      Integer plaintextPort,
+      Integer port,
+      Integer tlsPort,
+      Boolean enablePlaintextPort,
+      boolean enableTlsPort,
+      Map<String, String> labels
+  )
+  {
+    this(serviceName, host, bindOnHost, plaintextPort, port, tlsPort, enablePlaintextPort, enableTlsPort, labels, null);
+  }
+
   /**
    * host = null     , port = null -> host = _default_, port = -1
    * host = "abc:123", port = null -> host = abc, port = 123

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -188,6 +188,118 @@ public class DruidNodeTest
     Assert.assertEquals(-1, node.getTlsPort());
   }
 
+  @Test
+  public void testAdvertisedPlaintextPort()
+  {
+    // When not set, advertisedPlaintextPort defaults to plaintextPort
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, true, false);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(8082, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:8082", node.getHostAndPort());
+    Assert.assertEquals("host:8082", node.getHostAndPortToUse());
+
+    // When set, advertisedPlaintextPort overrides in getHostAndPort() but not getPlaintextPort()
+    node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:9443", node.getHostAndPort());
+    Assert.assertEquals("host:9443", node.getHostAndPortToUse());
+    // getPortToUse() still returns the bind port
+    Assert.assertEquals(8082, node.getPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortWithTls()
+  {
+    // advertisedPlaintextPort with TLS enabled — getHostAndPortToUse() prefers TLS
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 8443, true, true, 9443);
+    Assert.assertEquals(8082, node.getPlaintextPort());
+    Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
+    Assert.assertEquals(8443, node.getTlsPort());
+    Assert.assertEquals("host:9443", node.getHostAndPort());
+    Assert.assertEquals("host:8443", node.getHostAndTlsPort());
+    Assert.assertEquals("host:8443", node.getHostAndPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortDisabledPlaintext()
+  {
+    // When plaintext is disabled, advertisedPlaintextPort is -1 regardless
+    DruidNode node = new DruidNode("test", "host", false, null, null, 8443, false, true, 9443);
+    Assert.assertEquals(-1, node.getPlaintextPort());
+    Assert.assertEquals(-1, node.getAdvertisedPlaintextPort());
+    Assert.assertNull(node.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortSerde() throws Exception
+  {
+    // Serialization roundtrip preserves advertisedPlaintextPort
+    DruidNode original = new DruidNode("service", "host", true, 8082, null, 5678, true, true, 9443);
+    DruidNode actual = mapper.readValue(mapper.writeValueAsString(original), DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(9443, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals(5678, actual.getTlsPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortBackwardCompatDeserialization() throws Exception
+  {
+    // Old JSON without advertisedPlaintextPort — should default to plaintextPort
+    String json = "{\n"
+                  + "  \"service\":\"service\",\n"
+                  + "  \"host\":\"host\",\n"
+                  + "  \"plaintextPort\":8082,\n"
+                  + "  \"enablePlaintextPort\":true,\n"
+                  + "  \"enableTlsPort\":false\n"
+                  + "}\n";
+    DruidNode actual = mapper.readValue(json, DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(8082, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:8082", actual.getHostAndPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortDeserialization() throws Exception
+  {
+    // JSON with advertisedPlaintextPort set
+    String json = "{\n"
+                  + "  \"service\":\"service\",\n"
+                  + "  \"host\":\"host\",\n"
+                  + "  \"plaintextPort\":8082,\n"
+                  + "  \"advertisedPlaintextPort\":9443,\n"
+                  + "  \"enablePlaintextPort\":true,\n"
+                  + "  \"enableTlsPort\":false\n"
+                  + "}\n";
+    DruidNode actual = mapper.readValue(json, DruidNode.class);
+    Assert.assertEquals(8082, actual.getPlaintextPort());
+    Assert.assertEquals(9443, actual.getAdvertisedPlaintextPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPort());
+    Assert.assertEquals("host:9443", actual.getHostAndPortToUse());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortWithService()
+  {
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode copy = node.withService("other");
+    Assert.assertEquals("other", copy.getServiceName());
+    Assert.assertEquals(8082, copy.getPlaintextPort());
+    Assert.assertEquals(9443, copy.getAdvertisedPlaintextPort());
+  }
+
+  @Test
+  public void testAdvertisedPlaintextPortEquality()
+  {
+    DruidNode a = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode b = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode c = new DruidNode("test", "host", false, 8082, null, true, false);
+    Assert.assertEquals(a, b);
+    Assert.assertNotEquals(a, c);
+    Assert.assertEquals(a.hashCode(), b.hashCode());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testConflictingPorts()
   {

--- a/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
+++ b/server/src/test/java/org/apache/druid/server/DruidNodeTest.java
@@ -199,7 +199,7 @@ public class DruidNodeTest
     Assert.assertEquals("host:8082", node.getHostAndPortToUse());
 
     // When set, advertisedPlaintextPort overrides in getHostAndPort() but not getPlaintextPort()
-    node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, null, 9443);
     Assert.assertEquals(8082, node.getPlaintextPort());
     Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
     Assert.assertEquals("host:9443", node.getHostAndPort());
@@ -212,7 +212,7 @@ public class DruidNodeTest
   public void testAdvertisedPlaintextPortWithTls()
   {
     // advertisedPlaintextPort with TLS enabled — getHostAndPortToUse() prefers TLS
-    DruidNode node = new DruidNode("test", "host", false, 8082, null, 8443, true, true, 9443);
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 8443, true, true, null, 9443);
     Assert.assertEquals(8082, node.getPlaintextPort());
     Assert.assertEquals(9443, node.getAdvertisedPlaintextPort());
     Assert.assertEquals(8443, node.getTlsPort());
@@ -225,7 +225,7 @@ public class DruidNodeTest
   public void testAdvertisedPlaintextPortDisabledPlaintext()
   {
     // When plaintext is disabled, advertisedPlaintextPort is -1 regardless
-    DruidNode node = new DruidNode("test", "host", false, null, null, 8443, false, true, 9443);
+    DruidNode node = new DruidNode("test", "host", false, null, null, 8443, false, true, null, 9443);
     Assert.assertEquals(-1, node.getPlaintextPort());
     Assert.assertEquals(-1, node.getAdvertisedPlaintextPort());
     Assert.assertNull(node.getHostAndPort());
@@ -235,7 +235,7 @@ public class DruidNodeTest
   public void testAdvertisedPlaintextPortSerde() throws Exception
   {
     // Serialization roundtrip preserves advertisedPlaintextPort
-    DruidNode original = new DruidNode("service", "host", true, 8082, null, 5678, true, true, 9443);
+    DruidNode original = new DruidNode("service", "host", true, 8082, null, 5678, true, true, null, 9443);
     DruidNode actual = mapper.readValue(mapper.writeValueAsString(original), DruidNode.class);
     Assert.assertEquals(8082, actual.getPlaintextPort());
     Assert.assertEquals(9443, actual.getAdvertisedPlaintextPort());
@@ -282,7 +282,7 @@ public class DruidNodeTest
   @Test
   public void testAdvertisedPlaintextPortWithService()
   {
-    DruidNode node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode node = new DruidNode("test", "host", false, 8082, null, 9443, true, false, null, 9443);
     DruidNode copy = node.withService("other");
     Assert.assertEquals("other", copy.getServiceName());
     Assert.assertEquals(8082, copy.getPlaintextPort());
@@ -292,8 +292,8 @@ public class DruidNodeTest
   @Test
   public void testAdvertisedPlaintextPortEquality()
   {
-    DruidNode a = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
-    DruidNode b = new DruidNode("test", "host", false, 8082, null, 9443, true, false, 9443);
+    DruidNode a = new DruidNode("test", "host", false, 8082, null, 9443, true, false, null, 9443);
+    DruidNode b = new DruidNode("test", "host", false, 8082, null, 9443, true, false, null, 9443);
     DruidNode c = new DruidNode("test", "host", false, 8082, null, true, false);
     Assert.assertEquals(a, b);
     Assert.assertNotEquals(a, c);


### PR DESCRIPTION
## Description

Allow Druid nodes to advertise a different plaintext port for peer discovery while binding Jetty to the actual service port.

### Motivation

When running Druid with a sidecar proxy (e.g. Envoy for east-west mTLS), the port the proxy listens on differs from the port Jetty binds to. Without this change, peer discovery advertises the Jetty bind port, so other nodes try to connect directly — bypassing the sidecar — and mTLS fails.

### Changes

- Added `advertisedPlaintextPort` field to `DruidNode` (JSON property: `advertisedPlaintextPort`, `@Max(0xffff)`)
- When set to a positive value, `getHostAndPort()` returns the advertised port instead of `plaintextPort`
- When unset or ≤ 0, falls back to `plaintextPort` — no behaviour change for existing deployments
- Updated `ServiceLocation` to use the advertised port
- Added tests covering the new field and its fallback semantics

### Testing

- [ ] `mvn test -pl server -Dtest=DruidNodeTest`
- [ ] `mvn test -pl server` (full server module)

<sub>This is a backport of an internal change validated in production.</sub>