### PR TITLE
feat: Handle MRAP URI

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfig.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfig.java
@@ -45,7 +45,7 @@ public class S3DataSegmentPusherConfig
 
   public void setBucket(String bucket)
   {
-    this.bucket = bucket;
+    this.bucket = S3Utils.normalizeBucketName(bucket);
   }
 
   public void setBaseKey(String baseKey)

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3LoadSpec.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3LoadSpec.java
@@ -64,7 +64,7 @@ public class S3LoadSpec implements LoadSpec
   {
     Preconditions.checkNotNull(bucket);
     Preconditions.checkNotNull(key);
-    this.bucket = bucket;
+    this.bucket = S3Utils.normalizeBucketName(bucket);
     this.key = key;
     this.rangeable = rangeable;
     this.puller = puller;

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/S3Utils.java
@@ -54,6 +54,8 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -63,6 +65,7 @@ public class S3Utils
 {
   private static final String SCHEME = S3StorageDruidModule.SCHEME;
   private static final Joiner JOINER = Joiner.on("/").skipNulls();
+  private static final Pattern S3_ARN = Pattern.compile("^arn:(aws|aws-cn|aws-us-gov):s3:[a-z0-9-]*:\\d{12}:accesspoint[:/][A-Za-z0-9.-]+$");
   private static final Logger log = new Logger(S3Utils.class);
 
   /**
@@ -127,6 +130,11 @@ public class S3Utils
   public static <T> T retryS3Operation(Task<T> f) throws Exception
   {
     return RetryUtils.retry(f, S3RETRY, RetryUtils.DEFAULT_MAX_TRIES);
+  }
+
+  public static boolean isS3Arn(String value)
+  {
+    return value != null && S3_ARN.matcher(value).matches();
   }
 
   /**
@@ -262,6 +270,20 @@ public class S3Utils
     }
 
     return null;
+  }
+
+  /**
+   * Normalizes a bucket name or ARN by replacing '/' with ':'.
+   * Some inputs may provide Access Point ARNs in the form
+   * arn:aws:s3::<account>:accesspoint/alias.mrap, which should be normalized to
+   * arn:aws:s3::<account>:accesspoint:alias.mrap.
+   */
+  public static String normalizeBucketName(String bucket)
+  {
+    return Optional.ofNullable(bucket)
+                   .filter(S3Utils::isS3Arn)
+                   .map(arn -> arn.replace('/', ':'))
+                   .orElse(bucket);
   }
 
   public static String extractS3Key(URI uri)

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -449,4 +449,32 @@ public class S3UtilsTest
     // Sanity check: default AWSClientConfig protocol is "https"; schemeless URL inherits "https".
     Assert.assertTrue(S3Utils.useHttps(new AWSClientConfig(), endpointWith("{\"url\":\"s3.example.com\"}")));
   }
+
+  @Test
+  public void testBucketNormalizationForMRAP()
+  {
+    String bucket = "arn:aws:s3::123456789123:accesspoint/bucket.mrap";
+    Assert.assertEquals("arn:aws:s3::123456789123:accesspoint:bucket.mrap", S3Utils.normalizeBucketName(bucket));
+  }
+
+  @Test
+  public void testBucketNormalizationForRegional()
+  {
+    String bucket = "arn:aws:s3:us-east-1:123456789123:accesspoint/bucket";
+    Assert.assertEquals("arn:aws:s3:us-east-1:123456789123:accesspoint:bucket", S3Utils.normalizeBucketName(bucket));
+  }
+
+  @Test
+  public void testAlreadyNormalizedBucket()
+  {
+    String bucket = "arn:aws:s3::123456789123:accesspoint:bucket.mrap";
+    Assert.assertEquals(bucket, S3Utils.normalizeBucketName(bucket));
+  }
+
+  @Test
+  public void testNonS3Bucket()
+  {
+    String bucket = "bucket/subpath";
+    Assert.assertEquals(bucket, S3Utils.normalizeBucketName(bucket));
+  }
 }

--- a/processing/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.StringUtils;
 
 import java.net.URI;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 /**
  * Common type for 'bucket' and 'path' concept of cloud objects to allow code sharing between cloud specific
@@ -46,6 +47,8 @@ import java.util.Objects;
  */
 public class CloudObjectLocation
 {
+  private static final Pattern S3_ARN = Pattern.compile("^arn:(aws|aws-cn|aws-us-gov):s3:[a-z0-9-]*:\\d{12}:accesspoint[:/][A-Za-z0-9.-]+$");
+
   public static URI validateUriScheme(String scheme, URI uri)
   {
     if (!scheme.equalsIgnoreCase(uri.getScheme())) {
@@ -64,14 +67,20 @@ public class CloudObjectLocation
                  "bucket name cannot be null. Please verify if bucket name adheres to naming rules");
     this.path = Preconditions.checkNotNull(StringUtils.maybeRemoveLeadingSlash(path));
     Preconditions.checkArgument(
-        this.bucket.equals(StringUtils.urlEncode(this.bucket)),
-        "bucket must follow DNS-compliant naming conventions"
+      this.bucket.equals(StringUtils.urlEncode(this.bucket)) || isS3Arn(this.bucket),
+      "bucket must follow DNS-compliant naming conventions or be a valid S3 Access Point ARN"
+      + " or S3 Multi-Region Access Point ARN"
     );
   }
 
   public CloudObjectLocation(URI uri)
   {
     this(uri.getHost() != null ? uri.getHost() : uri.getAuthority(), uri.getPath());
+  }
+
+  private static boolean isS3Arn(String value)
+  {
+    return value != null && S3_ARN.matcher(value).matches();
   }
 
   /**

--- a/processing/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
+++ b/processing/src/main/java/org/apache/druid/data/input/impl/CloudObjectLocation.java
@@ -47,7 +47,7 @@ import java.util.regex.Pattern;
  */
 public class CloudObjectLocation
 {
-  private static final Pattern S3_ARN = Pattern.compile("^arn:(aws|aws-cn|aws-us-gov):s3:[a-z0-9-]*:\\d{12}:accesspoint[:/][A-Za-z0-9.-]+$");
+  private static final Pattern S3_ARN = Pattern.compile("^arn:(aws|aws-cn|aws-us-gov):s3:[a-z0-9-]*:\\d{12}:accesspoint:[A-Za-z0-9.-]+$");
 
   public static URI validateUriScheme(String scheme, URI uri)
   {
@@ -69,7 +69,7 @@ public class CloudObjectLocation
     Preconditions.checkArgument(
       this.bucket.equals(StringUtils.urlEncode(this.bucket)) || isS3Arn(this.bucket),
       "bucket must follow DNS-compliant naming conventions or be a valid S3 Access Point ARN"
-      + " or S3 Multi-Region Access Point ARN"
+      + " or S3 Multi-Region Access Point ARN. Use colon form: arn:...:accesspoint:name"
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
@@ -130,4 +130,44 @@ public class CloudObjectLocationTest
     Assertions.assertEquals("test_bucket", s3ValidBucket.getBucket());
     Assertions.assertEquals("path/to/path", s3ValidBucket.getPath());
   }
+
+  @Test
+  void testMRAP()
+  {
+    CloudObjectLocation location = new CloudObjectLocation("arn:aws:s3::123456789123:accesspoint:bucket.mrap", "path/to/path");
+    Assertions.assertEquals("arn:aws:s3::123456789123:accesspoint:bucket.mrap", location.getBucket());
+    Assertions.assertEquals("path/to/path", location.getPath());
+  }
+
+  @Test
+  void testMRAPWithURI()
+  {
+    CloudObjectLocation location = new CloudObjectLocation(URI.create("s3://arn:aws:s3::123456789123:accesspoint:bucket.mrap/path/to/path"));
+    Assertions.assertEquals("arn:aws:s3::123456789123:accesspoint:bucket.mrap", location.getBucket());
+    Assertions.assertEquals("path/to/path", location.getPath());
+  }
+
+  @Test
+  void testRegionalARN()
+  {
+    CloudObjectLocation location = new CloudObjectLocation("arn:aws:s3:us-east-1:123456789123:accesspoint:bucket", "path/to/path");
+    Assertions.assertEquals("arn:aws:s3:us-east-1:123456789123:accesspoint:bucket", location.getBucket());
+    Assertions.assertEquals("path/to/path", location.getPath());
+  }
+
+  @Test
+  void testRegionARNWithURI()
+  {
+    CloudObjectLocation location = new CloudObjectLocation(URI.create("s3://arn:aws:s3:us-east-1:123456789123:accesspoint:bucket/path/to/path"));
+    Assertions.assertEquals("arn:aws:s3:us-east-1:123456789123:accesspoint:bucket", location.getBucket());
+    Assertions.assertEquals("path/to/path", location.getPath());
+  }
+
+  @Test
+  void testMRAPWithPlusInKey()
+  {
+    CloudObjectLocation location = new CloudObjectLocation(URI.create("s3://arn:aws:s3::123456789123:accesspoint:bucket.mrap/path/with+plus"));
+    Assertions.assertEquals("arn:aws:s3::123456789123:accesspoint:bucket.mrap", location.getBucket());
+    Assertions.assertEquals("path/with+plus", location.getPath());
+  }
 }

--- a/processing/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
+++ b/processing/src/test/java/org/apache/druid/data/input/impl/CloudObjectLocationTest.java
@@ -170,4 +170,25 @@ public class CloudObjectLocationTest
     Assertions.assertEquals("arn:aws:s3::123456789123:accesspoint:bucket.mrap", location.getBucket());
     Assertions.assertEquals("path/with+plus", location.getPath());
   }
+
+  @Test
+  void testMRAPSlashFormDirectConstructionRejected()
+  {
+    // Slash-form ARNs are not accepted; callers must normalize to colon form via S3Utils.normalizeBucketName.
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new CloudObjectLocation("arn:aws:s3::123456789123:accesspoint/bucket.mrap", "path/to/path")
+    );
+  }
+
+  @Test
+  void testMRAPSlashFormUriRejected()
+  {
+    // java.net.URI splits the slash-form ARN so the authority becomes "arn:...:accesspoint",
+    // which is not a valid bucket — rejected with IllegalArgumentException.
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new CloudObjectLocation(URI.create("s3://arn:aws:s3::123456789123:accesspoint/bucket.mrap/path/to/path"))
+    );
+  }
 }


### PR DESCRIPTION

Fixes #19608.

Description

Adds support for AWS S3 Multi-Region Access Points (MRAPs) and S3 Access Point ARNs as the bucket value in Druid's S3 extension. Previously, any ARN passed as a bucket name was rejected at startup due to a strict DNS-naming validation check in CloudObjectLocation.

Relaxed bucket validation in `CloudObjectLocation`

The existing check enforces that a bucket name URL-encodes to itself, which is a proxy for DNS compliance. ARNs contain colons and fail that check unconditionally. The validation now accepts a bucket that either passes the existing DNS check or matches a valid S3 Access Point ARN pattern (regional and MRAP, across aws, aws-cn, and aws-us-gov partitions).

Added `S3Utils.isS3Arn()` and `S3Utils.normalizeBucketName()`

Some tooling produces Access Point ARNs with a slash separator (accesspoint/alias) rather than the colon-delimited form (accesspoint:alias) that the AWS SDK expects. `normalizeBucketName()` canonicalizes the slash form to the colon form. It is a no-op for plain bucket names. S3DataSegmentPusherConfig.setBucket() and S3LoadSpec constructor both call this at the point of construction so the rest of the code never sees the unnormalized form.

Release note

Druid's S3 extension now accepts AWS S3 Access Point ARNs and Multi-Region Access Point (MRAP) ARNs as the druid.storage.bucket value. This enables operators to route deep storage traffic through a single global MRAP endpoint for multi-region active-active deployments and regional failover scenarios. Plain bucket names are unaffected.

<hr> 

Key changed/added classes in this PR

- CloudObjectLocation — relaxed bucket validation to permit S3 Access Point ARNs
- S3Utils — added isS3Arn() and normalizeBucketName()
- S3DataSegmentPusherConfig — normalize bucket name on set
- S3LoadSpec — normalize bucket name on constructor

<hr>

This PR has:

This PR has: 

- [x] been self-reviewed. 
- [ ] ~~using the concurrency checklist~~ (no concurrency changes) 
- [ ] added documentation for new or modified features or behaviors. 
- [x] a release note entry in the PR description. 
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links. 
- [ ] ~~added or updated version, license, or notice information in licenses.yaml~~ (no new dependencies) 
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader. 
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage is met. 
- [ ] added integration tests. 
- [x] been tested in a test Druid cluster. 
