### PR TITLE
minor: Add segment debug logging to CachingClusteredClient

### DIFF
--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -346,18 +346,17 @@ public class CachingClusteredClient implements QuerySegmentWalker
 
       final Set<SegmentServerSelector> segmentServers = computeSegmentsToQuery(timeline, specificSegments);
       log.info("Query[%s] found [%d] segments from timeline lookup.", query.getId(), segmentServers.size());
-      if (query.context().isDebug()) {
-        segmentServers.stream()
-                      .collect(Collectors.groupingBy(
-                          s -> s.getSegmentDescriptor().getInterval()
-                               + "_" + s.getSegmentDescriptor().getVersion()
-                               + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
-                          Collectors.counting()
-                      ))
-                      .forEach((key, count) ->
-                          log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
-                      );
-      }
+      segmentServers.stream()
+                    .collect(Collectors.groupingBy(
+                        s -> s.getSegmentDescriptor().getInterval()
+                             + "_" + s.getSegmentDescriptor().getVersion()
+                             + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
+                        Collectors.counting()
+                    ))
+                    .forEach((key, count) ->
+                        log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
+                    );
+
       final CloneQueryMode cloneQueryMode = query.context().getCloneQueryMode();
       @Nullable
       final byte[] queryCacheKey = cacheKeyManager.computeSegmentLevelQueryCacheKey();

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -345,19 +345,18 @@ public class CachingClusteredClient implements QuerySegmentWalker
       }
 
       final Set<SegmentServerSelector> segmentServers = computeSegmentsToQuery(timeline, specificSegments);
-      log.info("Query[%s] found [%d] segments from timeline lookup.", query.getId(), segmentServers.size());
       if (query.context().isDebug()) {
-        final Map<String, Long> segmentCountByKey = segmentServers.stream().collect(
-            Collectors.groupingBy(
-                s -> s.getSegmentDescriptor().getInterval()
-                     + "_" + s.getSegmentDescriptor().getVersion()
-                     + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
-                Collectors.counting()
-            )
-        );
-        segmentCountByKey.forEach(
-            (key, count) ->
-                log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
+        final String dataSource = ev.getBaseTableDataSource().getName();
+        log.infoSegmentIds(
+            segmentServers.stream().map(
+                s -> SegmentId.of(
+                    dataSource,
+                    s.getSegmentDescriptor().getInterval(),
+                    s.getSegmentDescriptor().getVersion(),
+                    s.getSegmentDescriptor().getPartitionNumber()
+                )
+            ),
+            StringUtils.format("Query[%s] found segments from timeline lookup", query.getId())
         );
       }
       final CloneQueryMode cloneQueryMode = query.context().getCloneQueryMode();

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -346,16 +346,10 @@ public class CachingClusteredClient implements QuerySegmentWalker
 
       final Set<SegmentServerSelector> segmentServers = computeSegmentsToQuery(timeline, specificSegments);
       if (query.context().isDebug()) {
-        final String dataSource = ev.getBaseTableDataSource().getName();
         log.infoSegmentIds(
-            segmentServers.stream().map(
-                s -> SegmentId.of(
-                    dataSource,
-                    s.getSegmentDescriptor().getInterval(),
-                    s.getSegmentDescriptor().getVersion(),
-                    s.getSegmentDescriptor().getPartitionNumber()
-                )
-            ),
+            segmentServers.stream()
+                          .filter(s -> s.getServer() != null)
+                          .map(s -> s.getServer().getSegment().getId()),
             StringUtils.format("Query[%s] found segments from timeline lookup", query.getId())
         );
       }

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -345,6 +345,19 @@ public class CachingClusteredClient implements QuerySegmentWalker
       }
 
       final Set<SegmentServerSelector> segmentServers = computeSegmentsToQuery(timeline, specificSegments);
+      log.info("Query[%s] found [%d] segments from timeline lookup.", query.getId(), segmentServers.size());
+      if (query.context().isDebug()) {
+        segmentServers.stream()
+                      .collect(Collectors.groupingBy(
+                          s -> s.getSegmentDescriptor().getInterval()
+                               + "_" + s.getSegmentDescriptor().getVersion()
+                               + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
+                          Collectors.counting()
+                      ))
+                      .forEach((key, count) ->
+                          log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
+                      );
+      }
       final CloneQueryMode cloneQueryMode = query.context().getCloneQueryMode();
       @Nullable
       final byte[] queryCacheKey = cacheKeyManager.computeSegmentLevelQueryCacheKey();

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -347,16 +347,18 @@ public class CachingClusteredClient implements QuerySegmentWalker
       final Set<SegmentServerSelector> segmentServers = computeSegmentsToQuery(timeline, specificSegments);
       log.info("Query[%s] found [%d] segments from timeline lookup.", query.getId(), segmentServers.size());
       if (query.context().isDebug()) {
-        segmentServers.stream()
-                      .collect(Collectors.groupingBy(
-                          s -> s.getSegmentDescriptor().getInterval()
-                               + "_" + s.getSegmentDescriptor().getVersion()
-                               + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
-                          Collectors.counting()
-                      ))
-                      .forEach((key, count) ->
-                          log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
-                      );
+        final Map<String, Long> segmentCountByKey = segmentServers.stream().collect(
+            Collectors.groupingBy(
+                s -> s.getSegmentDescriptor().getInterval()
+                     + "_" + s.getSegmentDescriptor().getVersion()
+                     + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
+                Collectors.counting()
+            )
+        );
+        segmentCountByKey.forEach(
+            (key, count) ->
+                log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
+        );
       }
       final CloneQueryMode cloneQueryMode = query.context().getCloneQueryMode();
       @Nullable

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -346,17 +346,18 @@ public class CachingClusteredClient implements QuerySegmentWalker
 
       final Set<SegmentServerSelector> segmentServers = computeSegmentsToQuery(timeline, specificSegments);
       log.info("Query[%s] found [%d] segments from timeline lookup.", query.getId(), segmentServers.size());
-      segmentServers.stream()
-                    .collect(Collectors.groupingBy(
-                        s -> s.getSegmentDescriptor().getInterval()
-                             + "_" + s.getSegmentDescriptor().getVersion()
-                             + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
-                        Collectors.counting()
-                    ))
-                    .forEach((key, count) ->
-                        log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
-                    );
-
+      if (query.context().isDebug()) {
+        segmentServers.stream()
+                      .collect(Collectors.groupingBy(
+                          s -> s.getSegmentDescriptor().getInterval()
+                               + "_" + s.getSegmentDescriptor().getVersion()
+                               + "_" + (s.getServer() != null && s.getServer().isRealtimeSegment() ? "realtime" : "historical"),
+                          Collectors.counting()
+                      ))
+                      .forEach((key, count) ->
+                          log.info("Query[%s] interval/version/type[%s] partitions[%d]", query.getId(), key, count)
+                      );
+      }
       final CloneQueryMode cloneQueryMode = query.context().getCloneQueryMode();
       @Nullable
       final byte[] queryCacheKey = cacheKeyManager.computeSegmentLevelQueryCacheKey();


### PR DESCRIPTION
 
### Description
When debugging slow or incorrect queries on the broker, it's useful to know how many segments were found during timeline lookup and how they break down by interval, version, and server type (realtime vs historical).


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.