### PR TITLE
fix: HyperLogLogCollector returns zero cardinality when a single element overflows into sparse mode

### DIFF
--- a/processing/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
+++ b/processing/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
@@ -171,7 +171,8 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
       final byte minNum,
       final byte overflowValue,
       final short overflowPosition,
-      final boolean isUpperNibble
+      final boolean isUpperNibble,
+      final int numHeaderBytes
   )
   {
     final ByteBuffer copy = buf.asReadOnlyBuffer();
@@ -181,7 +182,10 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
     while (copy.hasRemaining()) {
       short position = copy.getShort();
       final int register = (int) copy.get() & 0xff;
-      if (overflowValue != 0 && position == overflowPosition) {
+      // `position` is the serialized offset: the payload byte index plus the header size. Normalize it back to the
+      // payload byte index before comparing with overflowPosition (overflowRegister >>> 1); otherwise the overflow
+      // bucket's own entry is never matched here and the fallback below double-counts that register.
+      if (overflowValue != 0 && (position - numHeaderBytes) == overflowPosition) {
         int upperNibble = ((register & 0xf0) >>> BITS_PER_BUCKET) + minNum;
         int lowerNibble = (register & 0x0f) + minNum;
         if (isUpperNibble) {
@@ -546,7 +550,8 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
             registerOffset,
             overflowValue,
             overflowPosition,
-            isUpperNibble
+            isUpperNibble,
+            getNumHeaderBytes()
         );
       } else {
         estimatedCardinality = estimateDense(

--- a/processing/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
+++ b/processing/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
@@ -194,7 +194,9 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
           lowerNibble = Math.max(lowerNibble, overflowValue);
         }
         e += 1.0d / Math.pow(2, upperNibble) + 1.0d / Math.pow(2, lowerNibble);
-        zeroCount += (((upperNibble & 0xf0) == 0) ? 1 : 0) + (((lowerNibble & 0x0f) == 0) ? 1 : 0);
+        // upperNibble/lowerNibble hold decoded scalar values here (nibble + minNum, possibly the overflow value),
+        // so test them against zero directly: nibble masks would wrongly flag decoded values like 16 as empty.
+        zeroCount += ((upperNibble == 0) ? 1 : 0) + ((lowerNibble == 0) ? 1 : 0);
         overflowRegisterApplied = true;
       } else {
         e += MIN_NUM_REGISTER_LOOKUP[minNum][register];
@@ -238,7 +240,9 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
           lowerNibble = Math.max(lowerNibble, overflowValue);
         }
         e += 1.0d / Math.pow(2, upperNibble) + 1.0d / Math.pow(2, lowerNibble);
-        zeroCount += (((upperNibble & 0xf0) == 0) ? 1 : 0) + (((lowerNibble & 0x0f) == 0) ? 1 : 0);
+        // upperNibble/lowerNibble hold decoded scalar values here (nibble + minNum, possibly the overflow value),
+        // so test them against zero directly: nibble masks would wrongly flag decoded values like 16 as empty.
+        zeroCount += ((upperNibble == 0) ? 1 : 0) + ((lowerNibble == 0) ? 1 : 0);
       } else {
         e += MIN_NUM_REGISTER_LOOKUP[minNum][register];
         zeroCount += NUM_ZERO_LOOKUP[register];

--- a/processing/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
+++ b/processing/src/main/java/org/apache/druid/hll/HyperLogLogCollector.java
@@ -177,6 +177,7 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
     final ByteBuffer copy = buf.asReadOnlyBuffer();
     double e = 0.0d;
     int zeroCount = NUM_BUCKETS - 2 * (buf.remaining() / 3);
+    boolean overflowRegisterApplied = false;
     while (copy.hasRemaining()) {
       short position = copy.getShort();
       final int register = (int) copy.get() & 0xff;
@@ -190,10 +191,20 @@ public abstract class HyperLogLogCollector implements Comparable<HyperLogLogColl
         }
         e += 1.0d / Math.pow(2, upperNibble) + 1.0d / Math.pow(2, lowerNibble);
         zeroCount += (((upperNibble & 0xf0) == 0) ? 1 : 0) + (((lowerNibble & 0x0f) == 0) ? 1 : 0);
+        overflowRegisterApplied = true;
       } else {
         e += MIN_NUM_REGISTER_LOOKUP[minNum][register];
         zeroCount += NUM_ZERO_LOOKUP[register];
       }
+    }
+
+    // A sparse buffer only stores registers set through the regular nibble range. When the only information about
+    // a bucket lives in the overflow register (positionOf1 exceeded registerOffset + RANGE) and that bucket is not
+    // among the entries above, it was implicitly counted as an empty register. Account for it explicitly so linear
+    // counting does not treat the collector as empty and estimate a cardinality of zero.
+    if (overflowValue != 0 && !overflowRegisterApplied) {
+      zeroCount -= 1;
+      e += 1.0d / Math.pow(2, overflowValue);
     }
 
     e += zeroCount;

--- a/processing/src/test/java/org/apache/druid/hll/HyperLogLogCollectorTest.java
+++ b/processing/src/test/java/org/apache/druid/hll/HyperLogLogCollectorTest.java
@@ -665,6 +665,52 @@ public class HyperLogLogCollectorTest
   }
 
   @Test
+  public void testSparseOverflowRegisterOnOddBucket()
+  {
+    // Odd bucket: the overflow value is folded into the decoded lowerNibble (16), which is a scalar and no longer
+    // fits the 4-bit nibble mask. zeroCount must treat it as populated, otherwise the single register is counted
+    // as empty and the estimate collapses to 0.
+    HyperLogLogCollector source = HyperLogLogCollector.makeLatestCollector();
+    source.add((short) 5, (byte) 3);   // in-range value -> lower nibble of byte 2
+    source.add((short) 5, (byte) 16);  // overflow on the same odd bucket
+
+    HyperLogLogCollector sparse = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(source.toByteArray()));
+    Assert.assertEquals(1L, sparse.estimateCardinalityRound());
+  }
+
+  @Test
+  public void testSparseOverflowRegisterOnOddBucketWithPopulatedNeighbor()
+  {
+    // The overflow byte also holds an in-range value for the neighboring even bucket. Both decoded nibbles are
+    // non-zero scalars (2 and 16), so neither register may be counted as empty: two populated registers should
+    // estimate as 2.
+    HyperLogLogCollector source = HyperLogLogCollector.makeLatestCollector();
+    source.add((short) 4, (byte) 2);   // neighbor bucket in the same byte, upper nibble
+    source.add((short) 5, (byte) 3);   // odd bucket in-range value, lower nibble
+    source.add((short) 5, (byte) 16);  // overflow on the odd bucket
+
+    HyperLogLogCollector sparse = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(source.toByteArray()));
+    Assert.assertEquals(2L, sparse.estimateCardinalityRound());
+  }
+
+  @Test
+  public void testDenseOverflowRegisterEstimation()
+  {
+    // Adding an in-range value converts the collector to dense storage, so estimating without a sparse round-trip
+    // exercises estimateDense's overflow handling. The same decoded-scalar zero check applies there: one populated
+    // register must estimate as 1 for both nibble parities.
+    HyperLogLogCollector even = HyperLogLogCollector.makeLatestCollector();
+    even.add((short) 4, (byte) 3);
+    even.add((short) 4, (byte) 16);
+    Assert.assertEquals(1L, even.estimateCardinalityRound());
+
+    HyperLogLogCollector odd = HyperLogLogCollector.makeLatestCollector();
+    odd.add((short) 5, (byte) 3);
+    odd.add((short) 5, (byte) 16);
+    Assert.assertEquals(1L, odd.estimateCardinalityRound());
+  }
+
+  @Test
   public void testEstimationReadOnlyByteBuffers()
   {
     Random random = new Random(0L);

--- a/processing/src/test/java/org/apache/druid/hll/HyperLogLogCollectorTest.java
+++ b/processing/src/test/java/org/apache/druid/hll/HyperLogLogCollectorTest.java
@@ -610,6 +610,49 @@ public class HyperLogLogCollectorTest
   }
 
   @Test
+  public void testSparseOverflowRegisterEstimation()
+  {
+    // Reproduces the case where a single element whose positionOf1 exceeds the 4-bit nibble range
+    // (registerOffset 0 + RANGE 15) is stored only in the overflow register, leaving the sparse buffer empty.
+    // estimateSparse() must still account for that one non-empty register instead of reporting a cardinality of 0.
+
+    // Direct form: bucket 5 with positionOf1 = 16 (> RANGE) goes straight to the overflow register.
+    HyperLogLogCollector direct = HyperLogLogCollector.makeLatestCollector();
+    direct.add((short) 5, (byte) 16);
+    Assert.assertEquals(1L, direct.estimateCardinalityRound());
+    Assert.assertEquals(1.0d, direct.estimateCardinality(), 0.05d);
+
+    // Same situation reached through the byte[] hashing path used during ingestion: leading bytes 0x00 0x80
+    // give positionOf1 = 16, and the trailing bytes select the bucket.
+    byte[] hashedValue = new byte[16];
+    hashedValue[1] = (byte) 0x80;
+    hashedValue[15] = 0x05;
+    HyperLogLogCollector hashed = HyperLogLogCollector.makeLatestCollector();
+    hashed.add(hashedValue);
+    Assert.assertEquals(1L, hashed.estimateCardinalityRound());
+  }
+
+  @Test
+  public void testSparseOverflowRegisterSharesByteWithEntry()
+  {
+    // Adding regular (in-range) registers converts the collector to dense storage, so estimateSparse's overflow
+    // handling can only be reached via a sparse-serialized buffer. Build a low-cardinality collector holding both
+    // regular registers and an overflow register, then round-trip it through toByteArray() (which serializes
+    // sparsely while numNonZeroRegisters < DENSE_THRESHOLD). The restored collector uses estimateSparse, and the
+    // overflow register coincides with a populated sparse entry, so the in-loop overflow branch runs instead of the
+    // standalone compensation added for the empty-overflow case.
+    HyperLogLogCollector source = HyperLogLogCollector.makeLatestCollector();
+    for (int bucket = 0; bucket < 60; bucket++) {
+      source.add((short) bucket, (byte) 1);
+    }
+    source.add((short) 30, (byte) 16); // overflow register lands on an already-populated byte
+
+    HyperLogLogCollector sparse = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(source.toByteArray()));
+    long estimate = sparse.estimateCardinalityRound();
+    Assert.assertTrue("expected a sane non-zero estimate near 60, got " + estimate, estimate >= 40 && estimate <= 90);
+  }
+
+  @Test
   public void testEstimationReadOnlyByteBuffers()
   {
     Random random = new Random(0L);

--- a/processing/src/test/java/org/apache/druid/hll/HyperLogLogCollectorTest.java
+++ b/processing/src/test/java/org/apache/druid/hll/HyperLogLogCollectorTest.java
@@ -633,23 +633,35 @@ public class HyperLogLogCollectorTest
   }
 
   @Test
-  public void testSparseOverflowRegisterSharesByteWithEntry()
+  public void testSparseOverflowRegisterOnPopulatedBucket()
   {
-    // Adding regular (in-range) registers converts the collector to dense storage, so estimateSparse's overflow
-    // handling can only be reached via a sparse-serialized buffer. Build a low-cardinality collector holding both
-    // regular registers and an overflow register, then round-trip it through toByteArray() (which serializes
-    // sparsely while numNonZeroRegisters < DENSE_THRESHOLD). The restored collector uses estimateSparse, and the
-    // overflow register coincides with a populated sparse entry, so the in-loop overflow branch runs instead of the
-    // standalone compensation added for the empty-overflow case.
+    // Adding an in-range value converts the collector to dense storage, so estimateSparse's overflow handling is
+    // only reachable through a sparse-serialized buffer. A single bucket that first receives an in-range value and
+    // then an overflow value is still one populated register (the overflow value supersedes the nibble). After a
+    // sparse round-trip that register must be counted exactly once: estimateSparse has to recognize that the
+    // overflow register already has a sparse entry (comparing positions in the same coordinate system) and skip the
+    // standalone compensation, otherwise the register is counted twice and a single element estimates as 2.
     HyperLogLogCollector source = HyperLogLogCollector.makeLatestCollector();
-    for (int bucket = 0; bucket < 60; bucket++) {
-      source.add((short) bucket, (byte) 1);
-    }
-    source.add((short) 30, (byte) 16); // overflow register lands on an already-populated byte
+    source.add((short) 4, (byte) 3);   // in-range value -> nibble for bucket 4
+    source.add((short) 4, (byte) 16);  // overflow on the same bucket -> overflow register
 
     HyperLogLogCollector sparse = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(source.toByteArray()));
-    long estimate = sparse.estimateCardinalityRound();
-    Assert.assertTrue("expected a sane non-zero estimate near 60, got " + estimate, estimate >= 40 && estimate <= 90);
+    Assert.assertEquals(1L, sparse.estimateCardinalityRound());
+  }
+
+  @Test
+  public void testSparseOverflowRegisterAmongOtherEntries()
+  {
+    // A sparse buffer holding an overflow register plus other populated registers: estimateSparse must fold the
+    // overflow into the overflow bucket's own entry and leave the other entries untouched, which exercises both
+    // sides of the normalized position comparison. Two distinct populated registers should estimate as 2.
+    HyperLogLogCollector source = HyperLogLogCollector.makeLatestCollector();
+    source.add((short) 4, (byte) 3);   // bucket 4 in-range value
+    source.add((short) 4, (byte) 16);  // overflow on bucket 4 -> overflow register
+    source.add((short) 20, (byte) 5);  // an unrelated populated register in a different byte
+
+    HyperLogLogCollector sparse = HyperLogLogCollector.makeCollector(ByteBuffer.wrap(source.toByteArray()));
+    Assert.assertEquals(2L, sparse.estimateCardinalityRound());
   }
 
   @Test


### PR DESCRIPTION
Fixes #19649.

### Description

`HyperLogLogCollector.estimateSparse()` could return a cardinality estimate of `0` even after the collector had received data. In Hadoop-based ingestion this surfaces as `DetermineHashedPartitionsJob` reporting `Found approximately [0] rows in data` and the job failing with `No buckets?? seems there is no data to index.`, even though the input records were read correctly.

#### Root cause

When an element's `positionOf1` exceeds the 4-bit nibble range (`registerOffset + RANGE`, i.e. 16 on a fresh collector), its value is kept only in the global overflow register and no entry is written to the sparse storage buffer. When that overflow register is the only information the collector holds — the typical case for a single such element — the sparse buffer is empty, so the scan in `estimateSparse()` never visits the overflow register: `zeroCount` stays equal to `NUM_BUCKETS` and the linear-counting correction evaluates `m * ln(m / m) = 0`.

The pre-existing in-loop handling for the overflow register (the `position == overflowPosition` branch) only runs when the overflow bucket shares a byte with a populated sparse entry, so it does not cover the empty-buffer case.

#### Fix

`estimateSparse()` now records whether the overflow register was already folded into a visited entry. If a non-zero overflow register was not accounted for during the scan, it is added explicitly: `zeroCount` is decremented by one (the register is not empty) and `1 / 2^overflowValue` is added to the harmonic sum, mirroring how the dense path and the in-loop sparse path already handle the overflow register. Every other case — no overflow, an overflow register folded into an entry, and the dense path — is unchanged.

#### Release note

Fixed a bug where a `hyperUnique`/HLL sketch built from a very small number of values could estimate a cardinality of `0` when the only populated register was the overflow register. This could also cause Hadoop-based ingestion to fail with `No buckets?? seems there is no data to index.`

<hr>

##### Key changed/added classes in this PR
 * `HyperLogLogCollector`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] a release note entry in the PR description.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for code coverage is met.
