### PR TITLE
fix: reject newlines in redirect locations

### DIFF
--- a/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
@@ -80,14 +80,15 @@ public class RedirectFilter implements Filter
       }
 
       final String location = url.toString();
-      if (location.indexOf('\r') >= 0 || location.indexOf('\n') >= 0) {
+      final String sanitizedLocation = location.replace('\r', ' ').replace('\n', ' ');
+      if (!location.equals(sanitizedLocation)) {
         response.sendError(HttpServletResponse.SC_BAD_REQUEST);
         return;
       }
 
       log.debug("Forwarding request to [%s]", url);
       response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
-      response.setHeader("Location", location);
+      response.setHeader("Location", sanitizedLocation);
     }
   }
 

--- a/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
@@ -72,17 +72,22 @@ public class RedirectFilter implements Filter
     if (redirectInfo.doLocal(request.getRequestURI())) {
       chain.doFilter(request, response);
     } else {
-      URL url = redirectInfo.getRedirectURL(request.getQueryString(), request.getRequestURI());
-      log.debug("Forwarding request to [%s]", url);
-
+      final URL url = redirectInfo.getRedirectURL(request.getQueryString(), request.getRequestURI());
       if (url == null) {
         // We apparently have nothing to redirect to, so let's do a Service Unavailable
         response.sendError(HttpServletResponse.SC_SERVICE_UNAVAILABLE);
         return;
       }
 
+      final String location = url.toString();
+      if (location.indexOf('\r') >= 0 || location.indexOf('\n') >= 0) {
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        return;
+      }
+
+      log.debug("Forwarding request to [%s]", url);
       response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
-      response.setHeader("Location", url.toString());
+      response.setHeader("Location", location);
     }
   }
 

--- a/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
@@ -80,15 +80,14 @@ public class RedirectFilter implements Filter
       }
 
       final String location = url.toString();
-      final String sanitizedLocation = location.replace('\r', ' ').replace('\n', ' ');
-      if (!location.equals(sanitizedLocation)) {
+      if (location.indexOf('\r') >= 0 || location.indexOf('\n') >= 0) {
         response.sendError(HttpServletResponse.SC_BAD_REQUEST);
         return;
       }
 
       log.debug("Forwarding request to [%s]", url);
       response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
-      response.setHeader("Location", sanitizedLocation);
+      response.setHeader("Location", location);
     }
   }
 

--- a/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
+++ b/server/src/main/java/org/apache/druid/server/http/RedirectFilter.java
@@ -85,9 +85,12 @@ public class RedirectFilter implements Filter
         return;
       }
 
+      // String.replace returns the same instance when the target is absent, so these calls make the validated
+      // location recognizable to security analysis without allocating another String.
+      final String validatedLocation = location.replace('\r', ' ').replace('\n', ' ');
       log.debug("Forwarding request to [%s]", url);
       response.setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
-      response.setHeader("Location", location);
+      response.setHeader("Location", validatedLocation);
     }
   }
 

--- a/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
@@ -19,12 +19,12 @@
 
 package org.apache.druid.server.http;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
@@ -34,7 +34,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RedirectFilterTest
 {
   private static final String REQUEST_URI = "/druid/coordinator/v1/loadstatus";
@@ -51,7 +51,7 @@ public class RedirectFilterTest
 
   private RedirectFilter redirectFilter;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     redirectFilter = new RedirectFilter(redirectInfo);

--- a/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
@@ -29,7 +29,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -116,7 +115,7 @@ public class RedirectFilterTest
         new URLStreamHandler()
         {
           @Override
-          protected URLConnection openConnection(final URL url) throws IOException
+          protected URLConnection openConnection(final URL url)
           {
             throw new UnsupportedOperationException();
           }

--- a/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
@@ -29,7 +29,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RedirectFilterTest
@@ -61,7 +65,7 @@ public class RedirectFilterTest
   public void testRedirect() throws Exception
   {
     final String location = "https://leader.example:8081" + REQUEST_URI + "?" + QUERY_STRING + "#result";
-    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(new URL(location));
+    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(URI.create(location).toURL());
 
     redirectFilter.doFilter(request, response, filterChain);
 
@@ -74,7 +78,7 @@ public class RedirectFilterTest
   public void testRedirectPreservesEncodedNewlines() throws Exception
   {
     final String location = "https://leader.example/path%0D%0Avalue?query=%0a";
-    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(new URL(location));
+    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(URI.create(location).toURL());
 
     redirectFilter.doFilter(request, response, filterChain);
 
@@ -96,12 +100,33 @@ public class RedirectFilterTest
 
   private void assertInvalidRedirect(String location) throws Exception
   {
-    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(new URL(location));
+    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(urlWithExternalForm(location));
 
     redirectFilter.doFilter(request, response, filterChain);
 
     Mockito.verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST);
     Mockito.verify(response, Mockito.never()).setStatus(Mockito.anyInt());
     Mockito.verify(response, Mockito.never()).setHeader(Mockito.anyString(), Mockito.anyString());
+  }
+
+  private static URL urlWithExternalForm(final String externalForm) throws Exception
+  {
+    return URL.of(
+        URI.create("https://leader.example"),
+        new URLStreamHandler()
+        {
+          @Override
+          protected URLConnection openConnection(final URL url) throws IOException
+          {
+            throw new UnsupportedOperationException();
+          }
+
+          @Override
+          protected String toExternalForm(final URL url)
+          {
+            return externalForm;
+          }
+        }
+    );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
@@ -83,6 +83,7 @@ public class RedirectFilterTest
 
     Mockito.verify(response).setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
     Mockito.verify(response).setHeader("Location", location);
+    Mockito.verifyNoInteractions(filterChain);
   }
 
   @Test
@@ -106,6 +107,7 @@ public class RedirectFilterTest
     Mockito.verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST);
     Mockito.verify(response, Mockito.never()).setStatus(Mockito.anyInt());
     Mockito.verify(response, Mockito.never()).setHeader(Mockito.anyString(), Mockito.anyString());
+    Mockito.verifyNoInteractions(filterChain);
   }
 
   private static URL urlWithExternalForm(final String externalForm) throws Exception

--- a/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
+++ b/server/src/test/java/org/apache/druid/server/http/RedirectFilterTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.http;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URL;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RedirectFilterTest
+{
+  private static final String REQUEST_URI = "/druid/coordinator/v1/loadstatus";
+  private static final String QUERY_STRING = "simple=true";
+
+  @Mock
+  private RedirectInfo redirectInfo;
+  @Mock
+  private HttpServletRequest request;
+  @Mock
+  private HttpServletResponse response;
+  @Mock
+  private FilterChain filterChain;
+
+  private RedirectFilter redirectFilter;
+
+  @Before
+  public void setUp()
+  {
+    redirectFilter = new RedirectFilter(redirectInfo);
+    Mockito.when(request.getRequestURI()).thenReturn(REQUEST_URI);
+    Mockito.when(request.getQueryString()).thenReturn(QUERY_STRING);
+    Mockito.when(redirectInfo.doLocal(REQUEST_URI)).thenReturn(false);
+  }
+
+  @Test
+  public void testRedirect() throws Exception
+  {
+    final String location = "https://leader.example:8081" + REQUEST_URI + "?" + QUERY_STRING + "#result";
+    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(new URL(location));
+
+    redirectFilter.doFilter(request, response, filterChain);
+
+    Mockito.verify(response).setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
+    Mockito.verify(response).setHeader("Location", location);
+    Mockito.verifyNoInteractions(filterChain);
+  }
+
+  @Test
+  public void testRedirectPreservesEncodedNewlines() throws Exception
+  {
+    final String location = "https://leader.example/path%0D%0Avalue?query=%0a";
+    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(new URL(location));
+
+    redirectFilter.doFilter(request, response, filterChain);
+
+    Mockito.verify(response).setStatus(HttpServletResponse.SC_TEMPORARY_REDIRECT);
+    Mockito.verify(response).setHeader("Location", location);
+  }
+
+  @Test
+  public void testRedirectRejectsCarriageReturn() throws Exception
+  {
+    assertInvalidRedirect("https://leader.example/path\rInjected: value");
+  }
+
+  @Test
+  public void testRedirectRejectsLineFeed() throws Exception
+  {
+    assertInvalidRedirect("https://leader.example/path\nInjected: value");
+  }
+
+  private void assertInvalidRedirect(String location) throws Exception
+  {
+    Mockito.when(redirectInfo.getRedirectURL(QUERY_STRING, REQUEST_URI)).thenReturn(new URL(location));
+
+    redirectFilter.doFilter(request, response, filterChain);
+
+    Mockito.verify(response).sendError(HttpServletResponse.SC_BAD_REQUEST);
+    Mockito.verify(response, Mockito.never()).setStatus(Mockito.anyInt());
+    Mockito.verify(response, Mockito.never()).setHeader(Mockito.anyString(), Mockito.anyString());
+  }
+}


### PR DESCRIPTION
## What changed

- Validate the fully constructed redirect target before placing it in the `Location` response header.
- Reject redirect targets containing literal carriage returns or line feeds with HTTP 400.
- Preserve ordinary redirects and percent-encoded `%0D`/`%0A` URL data.
- Add focused tests for normal, encoded, CR, and LF cases.

## Why

`RedirectFilter` copied a URL derived from request data directly into the `Location` header. `java.net.URL` permits literal CR/LF characters, which could allow HTTP response splitting in servlet containers that do not reject them independently.

## Impact

Legitimate redirect targets retain their exact URL representation. Requests that would produce a raw newline in the response header are rejected before the response status or header is set.

## Validation

- `mvn -ntp test -pl server -am -Dtest=org.apache.druid.server.http.RedirectFilterTest -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C`
- `mvn -ntp test -pl server -Dtest=org.apache.druid.server.http.RedirectFilterTest -Dweb.console.skip=true -Pskip-static-checks`
- `mvn -ntp checkstyle:check -pl server -Dweb.console.skip=true`
