### PR TITLE
fix: address CodeQL concurrency warnings

### DIFF
--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
@@ -115,8 +115,10 @@ public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionC
 
     private void doDispose()
     {
-      if (!mmapDB.isClosed()) {
-        mmapDB.delete(mapDbKey);
+      synchronized (mmapDB) {
+        if (!mmapDB.isClosed()) {
+          mmapDB.delete(mapDbKey);
+        }
       }
       cacheCount.decrementAndGet();
     }
@@ -150,6 +152,10 @@ public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionC
     }
   }
 
+  /**
+   * MapDB synchronizes its state-changing methods on the {@link DB} instance. Check-and-use sequences must hold the
+   * same monitor to prevent the database from closing between the two calls.
+   */
   private final DB mmapDB;
   private final File tmpFile;
   private AtomicLong mapDbKeyCounter = new AtomicLong(0);
@@ -192,12 +198,14 @@ public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionC
             }
 
             @Override
-            public synchronized void stop()
+            public void stop()
             {
-              if (!mmapDB.isClosed()) {
-                mmapDB.close();
-                if (!tmpFile.delete()) {
-                  log.warn("Unable to delete file at [%s]", tmpFile.getAbsolutePath());
+              synchronized (mmapDB) {
+                if (!mmapDB.isClosed()) {
+                  mmapDB.close();
+                  if (!tmpFile.delete()) {
+                    log.warn("Unable to delete file at [%s]", tmpFile.getAbsolutePath());
+                  }
                 }
               }
             }

--- a/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
+++ b/extensions-core/lookups-cached-global/src/main/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManager.java
@@ -158,8 +158,8 @@ public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionC
    */
   private final DB mmapDB;
   private final File tmpFile;
-  private AtomicLong mapDbKeyCounter = new AtomicLong(0);
-  private AtomicInteger cacheCount = new AtomicInteger(0);
+  private final AtomicLong mapDbKeyCounter = new AtomicLong(0);
+  private final AtomicInteger cacheCount = new AtomicInteger(0);
 
   @Inject
   public OffHeapNamespaceExtractionCacheManager(
@@ -200,13 +200,15 @@ public class OffHeapNamespaceExtractionCacheManager extends NamespaceExtractionC
             @Override
             public void stop()
             {
+              final boolean shouldDelete;
               synchronized (mmapDB) {
-                if (!mmapDB.isClosed()) {
+                shouldDelete = !mmapDB.isClosed();
+                if (shouldDelete) {
                   mmapDB.close();
-                  if (!tmpFile.delete()) {
-                    log.warn("Unable to delete file at [%s]", tmpFile.getAbsolutePath());
-                  }
                 }
+              }
+              if (shouldDelete && !tmpFile.delete()) {
+                log.warn("Unable to delete file at [%s]", tmpFile.getAbsolutePath());
               }
             }
           }

--- a/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
+++ b/processing/src/main/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannel.java
@@ -217,7 +217,7 @@ public class ReadableInputStreamFrameChannel implements ReadableFrameChannel
                       () -> {
                         synchronized (readMonitor) {
                           keepReading = true;
-                          readMonitor.notify();
+                          readMonitor.notifyAll();
                         }
                       },
                       Execs.directExecutor()

--- a/processing/src/main/java/org/apache/druid/java/util/http/client/io/AppendableByteArrayInputStream.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/io/AppendableByteArrayInputStream.java
@@ -51,7 +51,7 @@ public class AppendableByteArrayInputStream extends InputStream
     synchronized (singleByteReaderDoer) {
       bytes.addLast(bytesToAdd);
       available += bytesToAdd.length;
-      singleByteReaderDoer.notifyAll();
+      singleByteReaderDoer.notify();
     }
   }
 

--- a/processing/src/main/java/org/apache/druid/java/util/http/client/io/AppendableByteArrayInputStream.java
+++ b/processing/src/main/java/org/apache/druid/java/util/http/client/io/AppendableByteArrayInputStream.java
@@ -51,7 +51,7 @@ public class AppendableByteArrayInputStream extends InputStream
     synchronized (singleByteReaderDoer) {
       bytes.addLast(bytesToAdd);
       available += bytesToAdd.length;
-      singleByteReaderDoer.notify();
+      singleByteReaderDoer.notifyAll();
     }
   }
 
@@ -59,7 +59,7 @@ public class AppendableByteArrayInputStream extends InputStream
   {
     synchronized (singleByteReaderDoer) {
       done = true;
-      singleByteReaderDoer.notify();
+      singleByteReaderDoer.notifyAll();
     }
   }
 
@@ -68,7 +68,7 @@ public class AppendableByteArrayInputStream extends InputStream
     synchronized (singleByteReaderDoer) {
       done = true;
       throwable = t;
-      singleByteReaderDoer.notify();
+      singleByteReaderDoer.notifyAll();
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/java/util/http/client/io/AppendableByteArrayInputStreamTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/http/client/io/AppendableByteArrayInputStreamTest.java
@@ -257,4 +257,89 @@ public class AppendableByteArrayInputStreamTest
     }
 
   }
+
+  @Test
+  public void testDoneUnblocksAllReaders() throws Exception
+  {
+    final AppendableByteArrayInputStream in = new AppendableByteArrayInputStream();
+    final AtomicReference<Integer> firstResult = new AtomicReference<>();
+    final AtomicReference<Integer> secondResult = new AtomicReference<>();
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final AtomicReference<Throwable> secondError = new AtomicReference<>();
+    final Thread firstReader = readerThread(in, firstResult, firstError);
+    final Thread secondReader = readerThread(in, secondResult, secondError);
+
+    firstReader.start();
+    secondReader.start();
+    waitUntilWaiting(firstReader, secondReader);
+
+    in.done();
+
+    firstReader.join(1_000);
+    secondReader.join(1_000);
+    Assertions.assertFalse(firstReader.isAlive());
+    Assertions.assertFalse(secondReader.isAlive());
+    Assertions.assertNull(firstError.get());
+    Assertions.assertNull(secondError.get());
+    Assertions.assertEquals(-1, firstResult.get());
+    Assertions.assertEquals(-1, secondResult.get());
+  }
+
+  @Test
+  public void testExceptionUnblocksAllReaders() throws Exception
+  {
+    final AppendableByteArrayInputStream in = new AppendableByteArrayInputStream();
+    final AtomicReference<Integer> firstResult = new AtomicReference<>();
+    final AtomicReference<Integer> secondResult = new AtomicReference<>();
+    final AtomicReference<Throwable> firstError = new AtomicReference<>();
+    final AtomicReference<Throwable> secondError = new AtomicReference<>();
+    final Thread firstReader = readerThread(in, firstResult, firstError);
+    final Thread secondReader = readerThread(in, secondResult, secondError);
+
+    firstReader.start();
+    secondReader.start();
+    waitUntilWaiting(firstReader, secondReader);
+
+    final Exception expected = new Exception();
+    in.exceptionCaught(expected);
+
+    firstReader.join(1_000);
+    secondReader.join(1_000);
+    Assertions.assertFalse(firstReader.isAlive());
+    Assertions.assertFalse(secondReader.isAlive());
+    Assertions.assertNull(firstResult.get());
+    Assertions.assertNull(secondResult.get());
+    Assertions.assertSame(expected, firstError.get().getCause());
+    Assertions.assertSame(expected, secondError.get().getCause());
+  }
+
+  private static Thread readerThread(
+      final AppendableByteArrayInputStream in,
+      final AtomicReference<Integer> result,
+      final AtomicReference<Throwable> error
+  )
+  {
+    final Thread reader = new Thread(() -> {
+      try {
+        result.set(in.read());
+      }
+      catch (Throwable t) {
+        error.set(t);
+      }
+    });
+    reader.setDaemon(true);
+    return reader;
+  }
+
+  private static void waitUntilWaiting(final Thread... readers) throws InterruptedException
+  {
+    for (int i = 0; i < 100; i++) {
+      if (Arrays.stream(readers).allMatch(reader -> reader.getState() == Thread.State.WAITING)) {
+        return;
+      }
+      Thread.sleep(10);
+    }
+
+    Assertions.fail("Readers did not all block on the input stream");
+  }
 }


### PR DESCRIPTION
## What

- wake every blocked reader when input is added, completed, or failed
- prove terminal stream transitions release multiple waiting readers
- synchronize MapDB check/use sequences on MapDB's own monitor

## Why

This addresses all five CodeQL warnings in the concurrency group:

- 4 `java/notify-instead-of-notify-all`
- 1 `java/toctou-race-condition`

## Impact

Terminal input-stream transitions can no longer leave additional readers blocked. MapDB close and cache disposal cannot interleave between `isClosed()` and the corresponding state-changing operation.

## Root cause

The stream implementations relied on an implicit single-waiter assumption. The MapDB lifecycle method was synchronized on the anonymous handler instance rather than on the database object used by MapDB's own synchronized APIs.

## Checks

- affected-module compilation and Checkstyle passed
- processing concurrency tests: 17 passed
- lookup cache lifecycle/concurrency tests: 57 passed
- `git diff --check`

Created by GPT-5.6-Sol.
