### PR TITLE
build: remove redundant license download step to speed up distribution building

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -276,18 +276,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>license-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>download-licenses</id>
-                                <goals>
-                                    <goal>download-licenses</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
## Summary

- Remove the legacy `license-maven-plugin` from the `dist` profile.
- Keep Druid's existing `licenses.yaml`-based license and notice generation unchanged.

## Motivation

The distribution build currently invokes the plugin's `download-licenses` goal:

```text
[INFO] --- license:2.7.1:download-licenses (download-licenses) @ distribution ---
```

This goal reads license URLs from dependency POMs and attempts to download them. During distribution builds, it produces numerous warnings for missing or unreachable URLs, including:

```text
[WARNING] No URL for license at index 0 in dependency aopalliance:aopalliance:1.0
[WARNING] No URL for license at index 0 in dependency org.tukaani:xz:1.9
[WARNING] Unable to retrieve license from URL 'http://glassfish.java.net/public/CDDL+GPL_1_1.html' for dependency 'com.sun.jersey:jersey-core:1.19.4': Connect timed out
[WARNING] Unable to retrieve license from URL 'https://www.gnu.org/software/classpath/license.html' for dependency 'jakarta.transaction:jakarta.transaction-api:1.3.3': No route to host
[WARNING] Unable to retrieve license from URL 'https://www.gnu.org/licenses/old-licenses/lgpl-2.1' for dependency 'net.java.dev.jna:jna:5.18.1': No route to host
[WARNING] There were 15 download errors - check the warnings above
```

The generated files under `target/generated-resources` are not consumed by the distribution assembly. The download phase takes approximately one minute and delays the build while waiting for network timeouts.

In the reported build, removing the plugin reduced the distribution module time by approximately 1 minute and 10 seconds:

| Configuration | Distribution module time |
| --- | ---: |
| With `download-licenses` | `02:11` |
| Without `download-licenses` | `01:01` |

This change therefore eliminates the warnings and significantly reduces distribution build time.

## Why this is safe

The legacy `license-maven-plugin` was introduced in the original distribution packaging in 2015, before PR numbers were consistently recorded in the repository.

- PR #7998 introduced Druid's curated `licenses.yaml` registry and license-generation workflow.
- PR #8436 split that workflow into the current `generate-binary-license.py` and `check-licenses.py` scripts.

The distribution assembly packages `LICENSE.BINARY` as `LICENSE`, `NOTICE.BINARY` as `NOTICE`, and the curated `licenses/**` files. It does not package the plugin's `target/generated-resources` output.

Therefore, this change removes only an obsolete network-download step. The shipped license files and Apache release license validation remain unchanged.

## Verification

- Ran `mvn -o -pl distribution -Pdist validate -DskipTests -Dweb.console.skip=true -Pskip-static-checks` successfully.
- Validated the effective `dist` POM.
- Confirmed the binary license and notice generators remain configured.
- Confirmed `license-maven-plugin` and `download-licenses` are no longer present.
- Confirmed the change has no whitespace errors with `git diff --check`.
