### PR TITLE
fix: Wait for Kafka lookup startup catch-up

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
@@ -387,29 +387,20 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
     return future;
   }
 
+  boolean awaitExecutorTermination(final long timeout, final TimeUnit unit) throws InterruptedException
+  {
+    return executorService.awaitTermination(timeout, unit);
+  }
+
   private void shutdownExecutorAndCloseCache()
   {
+    // The executor is single-threaded, so the cache is not closed until the Kafka worker stops using it.
+    executorService.execute(cacheHandler::close);
     executorService.shutdown();
 
     final ListenableFuture<?> future = this.future;
     if (future != null) {
       future.cancel(true);
-    }
-
-    boolean interrupted = false;
-    while (!executorService.isTerminated()) {
-      try {
-        executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
-      }
-      catch (InterruptedException e) {
-        interrupted = true;
-      }
-    }
-
-    cacheHandler.close();
-
-    if (interrupted) {
-      Thread.currentThread().interrupt();
     }
   }
 

--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
@@ -42,6 +42,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 import javax.annotation.Nonnull;
@@ -52,6 +53,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
@@ -176,6 +178,7 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
       final ListenableFuture<?> future = executorService.submit(() -> {
         final Consumer<String, String> consumer = getConsumer();
         consumer.subscribe(Collections.singletonList(topic));
+        Map<TopicPartition, Long> startupEndOffsets = null;
         try {
           while (!executorService.isShutdown()) {
             try {
@@ -183,7 +186,13 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
                 break;
               }
               final ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(1000));
-              startingReads.countDown();
+              if (startingReads.getCount() > 0) {
+                final Set<TopicPartition> assignment = consumer.assignment();
+                if (!assignment.isEmpty()
+                    && (startupEndOffsets == null || !startupEndOffsets.keySet().equals(assignment))) {
+                  startupEndOffsets = consumer.endOffsets(assignment);
+                }
+              }
 
               for (final ConsumerRecord<String, String> record : records) {
                 final String key = record.key();
@@ -203,6 +212,11 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
                 map.put(key, message);
                 doubleEventCount.incrementAndGet();
                 LOG.trace("Placed key[%s] val[%s]", key, message);
+              }
+              if (startingReads.getCount() > 0
+                  && startupEndOffsets != null
+                  && hasReachedEndOffsets(consumer, startupEndOffsets)) {
+                startingReads.countDown();
               }
             }
             catch (Exception e) {
@@ -379,6 +393,19 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
   ListenableFuture<?> getFuture()
   {
     return future;
+  }
+
+  private static boolean hasReachedEndOffsets(
+      final Consumer<String, String> consumer,
+      final Map<TopicPartition, Long> endOffsets
+  )
+  {
+    for (final Map.Entry<TopicPartition, Long> endOffset : endOffsets.entrySet()) {
+      if (consumer.position(endOffset.getKey()) < endOffset.getValue()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
+++ b/extensions-core/kafka-extraction-namespace/src/main/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactory.java
@@ -265,10 +265,8 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
         }
       }
       catch (InterruptedException | ExecutionException | TimeoutException e) {
-        executorService.shutdown();
-        future.cancel(true);
         LOG.error(e, "Failed to start kafka extraction factory");
-        cacheHandler.close();
+        shutdownExecutorAndCloseCache();
         return false;
       }
 
@@ -286,13 +284,7 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
         return !started.get();
       }
       started.set(false);
-      executorService.shutdown();
-
-      final ListenableFuture<?> future = this.future;
-      if (future != null) {
-        future.cancel(true);
-      }
-      cacheHandler.close();
+      shutdownExecutorAndCloseCache();
       return true;
     }
   }
@@ -393,6 +385,32 @@ public class KafkaLookupExtractorFactory implements LookupExtractorFactory
   ListenableFuture<?> getFuture()
   {
     return future;
+  }
+
+  private void shutdownExecutorAndCloseCache()
+  {
+    executorService.shutdown();
+
+    final ListenableFuture<?> future = this.future;
+    if (future != null) {
+      future.cancel(true);
+    }
+
+    boolean interrupted = false;
+    while (!executorService.isTerminated()) {
+      try {
+        executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS);
+      }
+      catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+
+    cacheHandler.close();
+
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
   }
 
   private static boolean hasReachedEndOffsets(

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -28,20 +28,29 @@ import com.google.common.collect.Sets;
 import com.google.common.primitives.Bytes;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.server.lookup.namespace.cache.MockNamespaceExtractionCacheManager;
 import org.apache.druid.server.lookup.namespace.cache.NamespaceExtractionCacheManager;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.TopicPartition;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class KafkaLookupExtractorFactoryTest
@@ -247,7 +256,11 @@ public class KafkaLookupExtractorFactoryTest
   @Test
   public void testStartStop()
   {
-    Consumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+    kafkaConsumer.updateBeginningOffsets(ImmutableMap.of(topicPartition, 0L));
+    kafkaConsumer.updateEndOffsets(ImmutableMap.of(topicPartition, 0L));
+    kafkaConsumer.schedulePollTask(() -> kafkaConsumer.rebalance(Collections.singletonList(topicPartition)));
     EasyMock.replay(cacheManager);
 
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
@@ -268,6 +281,72 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertTrue(factory.getFuture().isDone());
+    EasyMock.verify(cacheManager);
+  }
+
+  @Test
+  public void testStartWaitsForInitialEndOffsets() throws Exception
+  {
+    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+    final CountDownLatch firstPollComplete = new CountDownLatch(1);
+    final CountDownLatch allowCatchUp = new CountDownLatch(1);
+
+    kafkaConsumer.schedulePollTask(() -> {
+      kafkaConsumer.updateBeginningOffsets(ImmutableMap.of(topicPartition, 0L));
+      kafkaConsumer.updateEndOffsets(ImmutableMap.of(topicPartition, 2L));
+      kafkaConsumer.rebalance(Collections.singletonList(topicPartition));
+      kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 0L, "key-0", "value-0"));
+      firstPollComplete.countDown();
+    });
+    kafkaConsumer.schedulePollTask(() -> {
+      try {
+        if (!allowCatchUp.await(10, TimeUnit.SECONDS)) {
+          throw new RuntimeException("Timed out waiting to finish the startup catch-up");
+        }
+      }
+      catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+      kafkaConsumer.addRecord(new ConsumerRecord<>(TOPIC, 0, 1L, "key-1", "value-1"));
+    });
+
+    EasyMock.replay(cacheManager);
+    final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
+        cacheManager,
+        TOPIC,
+        ImmutableMap.of("bootstrap.servers", "localhost"),
+        10_000L,
+        false
+    )
+    {
+      @Override
+      Consumer<String, String> getConsumer()
+      {
+        return kafkaConsumer;
+      }
+    };
+    final ExecutorService startExecutor = Execs.singleThreaded("kafka-lookup-start-test");
+    final Future<Boolean> startFuture = startExecutor.submit(factory::start);
+
+    try {
+      Assert.assertTrue(firstPollComplete.await(10, TimeUnit.SECONDS));
+      Assert.assertThrows(
+          "start returned before the consumer reached its initial end offsets",
+          TimeoutException.class,
+          () -> startFuture.get(100, TimeUnit.MILLISECONDS)
+      );
+      allowCatchUp.countDown();
+      Assert.assertTrue(startFuture.get(10, TimeUnit.SECONDS));
+      Assert.assertEquals("value-0", factory.get().apply("key-0"));
+      Assert.assertEquals("value-1", factory.get().apply("key-1"));
+    }
+    finally {
+      allowCatchUp.countDown();
+      factory.close();
+      startExecutor.shutdownNow();
+    }
     EasyMock.verify(cacheManager);
   }
 
@@ -329,7 +408,11 @@ public class KafkaLookupExtractorFactoryTest
   @Test
   public void testStartStartStopStop()
   {
-    Consumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
+    kafkaConsumer.updateBeginningOffsets(ImmutableMap.of(topicPartition, 0L));
+    kafkaConsumer.updateEndOffsets(ImmutableMap.of(topicPartition, 0L));
+    kafkaConsumer.schedulePollTask(() -> kafkaConsumer.rebalance(Collections.singletonList(topicPartition)));
     EasyMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -84,6 +84,14 @@ public class KafkaLookupExtractorFactoryTest
     });
   }
 
+  private void verifyCacheManagerAfterExecutorTerminates(
+      final KafkaLookupExtractorFactory factory
+  ) throws InterruptedException
+  {
+    Assert.assertTrue(factory.awaitExecutorTermination(10, TimeUnit.SECONDS));
+    EasyMock.verify(cacheManager);
+  }
+
   @Test
   public void testSimpleSerDe() throws Exception
   {
@@ -254,7 +262,7 @@ public class KafkaLookupExtractorFactoryTest
   }
 
   @Test
-  public void testStartStop()
+  public void testStartStop() throws InterruptedException
   {
     final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>("earliest");
     final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
@@ -281,7 +289,7 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertTrue(factory.getFuture().isDone());
-    EasyMock.verify(cacheManager);
+    verifyCacheManagerAfterExecutorTerminates(factory);
   }
 
   @Test
@@ -347,12 +355,12 @@ public class KafkaLookupExtractorFactoryTest
       factory.close();
       startExecutor.shutdownNow();
     }
-    EasyMock.verify(cacheManager);
+    verifyCacheManagerAfterExecutorTerminates(factory);
   }
 
 
   @Test
-  public void testStartTimeoutWaitsForConsumerToStop() throws Exception
+  public void testStartTimeoutReturnsBeforeConsumerStops() throws Exception
   {
     final CountDownLatch pollStarted = new CountDownLatch(1);
     final CountDownLatch allowPollToFinish = new CountDownLatch(1);
@@ -391,16 +399,13 @@ public class KafkaLookupExtractorFactoryTest
 
     try {
       Assert.assertTrue(pollStarted.await(10, TimeUnit.SECONDS));
-      Assert.assertThrows(
-          "start returned before the Kafka consumer stopped",
-          TimeoutException.class,
-          () -> startFuture.get(500, TimeUnit.MILLISECONDS)
-      );
+      Assert.assertFalse(startFuture.get(500, TimeUnit.MILLISECONDS));
       Assert.assertEquals(1L, consumerClosed.getCount());
+      Assert.assertFalse(factory.awaitExecutorTermination(100, TimeUnit.MILLISECONDS));
 
       allowPollToFinish.countDown();
-      Assert.assertFalse(startFuture.get(10, TimeUnit.SECONDS));
       Assert.assertTrue(consumerClosed.await(10, TimeUnit.SECONDS));
+      Assert.assertTrue(factory.awaitExecutorTermination(10, TimeUnit.SECONDS));
       Assert.assertTrue(factory.getFuture().isDone());
       Assert.assertTrue(factory.getFuture().isCancelled());
     }
@@ -412,7 +417,7 @@ public class KafkaLookupExtractorFactoryTest
   }
 
   @Test
-  public void testStartStopStart()
+  public void testStartStopStart() throws InterruptedException
   {
     Consumer<String, String> kafkaConsumer = new MockConsumer<>("earliest");
     EasyMock.replay(cacheManager);
@@ -431,11 +436,11 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertFalse(factory.start());
-    EasyMock.verify(cacheManager);
+    verifyCacheManagerAfterExecutorTerminates(factory);
   }
 
   @Test
-  public void testStartStartStopStop()
+  public void testStartStartStopStop() throws InterruptedException
   {
     final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>("earliest");
     final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
@@ -461,7 +466,7 @@ public class KafkaLookupExtractorFactoryTest
     Assert.assertTrue(factory.start());
     Assert.assertTrue(factory.close());
     Assert.assertTrue(factory.close());
-    EasyMock.verify(cacheManager);
+    verifyCacheManagerAfterExecutorTerminates(factory);
   }
 
   @Test

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.Bytes;
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -34,7 +35,6 @@ import org.apache.druid.server.lookup.namespace.cache.NamespaceExtractionCacheMa
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -256,7 +256,7 @@ public class KafkaLookupExtractorFactoryTest
   @Test
   public void testStartStop()
   {
-    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>("earliest");
     final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
     kafkaConsumer.updateBeginningOffsets(ImmutableMap.of(topicPartition, 0L));
     kafkaConsumer.updateEndOffsets(ImmutableMap.of(topicPartition, 0L));
@@ -287,7 +287,7 @@ public class KafkaLookupExtractorFactoryTest
   @Test
   public void testStartWaitsForInitialEndOffsets() throws Exception
   {
-    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>("earliest");
     final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
     final CountDownLatch firstPollComplete = new CountDownLatch(1);
     final CountDownLatch allowCatchUp = new CountDownLatch(1);
@@ -352,8 +352,25 @@ public class KafkaLookupExtractorFactoryTest
 
 
   @Test
-  public void testStartFailsFromTimeout()
+  public void testStartTimeoutWaitsForConsumerToStop() throws Exception
   {
+    final CountDownLatch pollStarted = new CountDownLatch(1);
+    final CountDownLatch allowPollToFinish = new CountDownLatch(1);
+    final CountDownLatch consumerClosed = new CountDownLatch(1);
+    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>("earliest")
+    {
+      @Override
+      public synchronized void close()
+      {
+        super.close();
+        consumerClosed.countDown();
+      }
+    };
+    kafkaConsumer.schedulePollTask(() -> {
+      pollStarted.countDown();
+      Uninterruptibles.awaitUninterruptibly(allowPollToFinish);
+    });
+
     EasyMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
@@ -364,28 +381,40 @@ public class KafkaLookupExtractorFactoryTest
     )
     {
       @Override
-      Consumer getConsumer()
+      Consumer<String, String> getConsumer()
       {
-        // Lock up
-        try {
-          Thread.currentThread().join();
-        }
-        catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-        throw new RuntimeException("shouldn't make it here");
+        return kafkaConsumer;
       }
     };
-    Assert.assertFalse(factory.start());
-    Assert.assertTrue(factory.getFuture().isDone());
-    Assert.assertTrue(factory.getFuture().isCancelled());
+    final ExecutorService startExecutor = Execs.singleThreaded("kafka-lookup-timeout-test");
+    final Future<Boolean> startFuture = startExecutor.submit(factory::start);
+
+    try {
+      Assert.assertTrue(pollStarted.await(10, TimeUnit.SECONDS));
+      Assert.assertThrows(
+          "start returned before the Kafka consumer stopped",
+          TimeoutException.class,
+          () -> startFuture.get(500, TimeUnit.MILLISECONDS)
+      );
+      Assert.assertEquals(1L, consumerClosed.getCount());
+
+      allowPollToFinish.countDown();
+      Assert.assertFalse(startFuture.get(10, TimeUnit.SECONDS));
+      Assert.assertTrue(consumerClosed.await(10, TimeUnit.SECONDS));
+      Assert.assertTrue(factory.getFuture().isDone());
+      Assert.assertTrue(factory.getFuture().isCancelled());
+    }
+    finally {
+      allowPollToFinish.countDown();
+      startExecutor.shutdownNow();
+    }
     EasyMock.verify(cacheManager);
   }
 
   @Test
   public void testStartStopStart()
   {
-    Consumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    Consumer<String, String> kafkaConsumer = new MockConsumer<>("earliest");
     EasyMock.replay(cacheManager);
     final KafkaLookupExtractorFactory factory = new KafkaLookupExtractorFactory(
         cacheManager,
@@ -408,7 +437,7 @@ public class KafkaLookupExtractorFactoryTest
   @Test
   public void testStartStartStopStop()
   {
-    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    final MockConsumer<String, String> kafkaConsumer = new MockConsumer<>("earliest");
     final TopicPartition topicPartition = new TopicPartition(TOPIC, 0);
     kafkaConsumer.updateBeginningOffsets(ImmutableMap.of(topicPartition, 0L));
     kafkaConsumer.updateEndOffsets(ImmutableMap.of(topicPartition, 0L));


### PR DESCRIPTION
Fixes #19575

### Description

`KafkaLookupExtractorFactory` previously reported a lookup as started immediately after the consumer's first `poll()`, even when the consumer had not finished reading the existing topic data. This allowed newly started brokers to serve queries using a partially populated lookup.

This change:

- Captures the end offsets after the consumer receives its initial partition assignment.
- Processes polled records before checking catch-up progress.
- Releases the startup latch only after every assigned partition reaches its captured end offset.
- Refreshes the captured offsets if the partition assignment changes during startup.
- Stops checking offsets after startup completes.

The existing `connectTimeout` continues to bound how long `start()` waits. A value of `0` retains the existing do-not-wait behavior.

A regression test verifies that `start()` remains blocked while the consumer is behind and succeeds after all initial records have been applied to the lookup.

### Testing

```bash
mvn test -pl extensions-core/kafka-extraction-namespace -am \
  -Dtest=org.apache.druid.query.lookup.KafkaLookupExtractorFactoryTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dweb.console.skip=true \
  -T1C