### PR TITLE
test(processing): stabilize flaky IndexIOTest execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2062,6 +2062,9 @@
                         <trimStackTrace>${surefire.trimStackTrace}</trimStackTrace>
                         <!-- our tests are very verbose, let's keep the volume down -->
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                        <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                            <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                        </statelessTestsetReporter>
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         <!-- Surefire default is to exclude static inner classes; which may lead to the ignore of static inner classes
                              https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes -->

--- a/pom.xml
+++ b/pom.xml
@@ -2062,9 +2062,6 @@
                         <trimStackTrace>${surefire.trimStackTrace}</trimStackTrace>
                         <!-- our tests are very verbose, let's keep the volume down -->
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
-                            <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
-                        </statelessTestsetReporter>
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
                         <!-- Surefire default is to exclude static inner classes; which may lead to the ignore of static inner classes
                              https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#excludes -->

--- a/processing/src/test/java/org/apache/druid/segment/IndexIOTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexIOTest.java
@@ -247,9 +247,7 @@ public class IndexIOTest extends InitializedNullHandlingTest
         .build();
   }
 
-  @ParameterizedTest(
-      name = "[{index}] schema={0}, rows={1}, dimensions={2}"
-  )
+  @ParameterizedTest
   @MethodSource("constructionFeeder")
   public void testRowValidatorEquals(
       Collection<Map<String, Object>> events1,

--- a/processing/src/test/java/org/apache/druid/segment/IndexIOTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexIOTest.java
@@ -41,10 +41,7 @@ import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.Interval;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.Parameter;
-import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
@@ -63,8 +60,6 @@ import java.util.stream.StreamSupport;
 /**
  * This is mostly a test of the validator
  */
-@ParameterizedClass
-@MethodSource("constructionFeeder")
 public class IndexIOTest extends InitializedNullHandlingTest
 {
   private static Interval DEFAULT_INTERVAL = Intervals.of("1970-01-01/2000-01-01");
@@ -236,48 +231,35 @@ public class IndexIOTest extends InitializedNullHandlingTest
     return Lists.transform(mapList, (Function<Map, Map>) input -> Maps.filterValues(input, Objects::nonNull));
   }
 
-  @Parameter(0)
-  public Collection<Map<String, Object>> events1;
-
-  @Parameter(1)
-  public Collection<Map<String, Object>> events2;
-
-  @Parameter(2)
-  public Class<? extends Exception> exception;
-
-
-  final IncrementalIndex incrementalIndex1 = new OnheapIncrementalIndex.Builder()
-      .setIndexSchema(
-          new IncrementalIndexSchema.Builder()
-              .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
-              .withMetrics(new CountAggregatorFactory("count"))
-              .withDimensionsSpec(
-                  new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")))
-              )
-              .build()
-      )
-      .setMaxRowCount(1000000)
-      .build();
-
-  final IncrementalIndex incrementalIndex2 = new OnheapIncrementalIndex.Builder()
-      .setIndexSchema(
-          new IncrementalIndexSchema.Builder()
-              .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
-              .withMetrics(new CountAggregatorFactory("count"))
-              .withDimensionsSpec(
-                  new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")))
-              )
-              .build()
-      )
-      .setMaxRowCount(1000000)
-      .build();
-
-  IndexableAdapter adapter1;
-  IndexableAdapter adapter2;
-
-  @BeforeEach
-  public void setUp()
+  private static IncrementalIndex createIncrementalIndex()
   {
+    return new OnheapIncrementalIndex.Builder()
+        .setIndexSchema(
+            new IncrementalIndexSchema.Builder()
+                .withMinTimestamp(DEFAULT_INTERVAL.getStart().getMillis())
+                .withMetrics(new CountAggregatorFactory("count"))
+                .withDimensionsSpec(
+                    new DimensionsSpec(DimensionsSpec.getDefaultSchemas(Arrays.asList("dim0", "dim1")))
+                )
+                .build()
+        )
+        .setMaxRowCount(1000000)
+        .build();
+  }
+
+  @ParameterizedTest(
+      name = "[{index}] schema={0}, rows={1}, dimensions={2}"
+  )
+  @MethodSource("constructionFeeder")
+  public void testRowValidatorEquals(
+      Collection<Map<String, Object>> events1,
+      Collection<Map<String, Object>> events2,
+      Class<? extends Exception> exception
+  ) throws Exception
+  {
+    final IncrementalIndex incrementalIndex1 = createIncrementalIndex();
+    final IncrementalIndex incrementalIndex2 = createIncrementalIndex();
+
     long timestamp = 0L;
     for (Map<String, Object> event : events1) {
       incrementalIndex1.add(new MapBasedInputRow(timestamp++, Lists.newArrayList(event.keySet()), event));
@@ -288,22 +270,18 @@ public class IndexIOTest extends InitializedNullHandlingTest
       incrementalIndex2.add(new MapBasedInputRow(timestamp++, Lists.newArrayList(event.keySet()), event));
     }
 
-    adapter2 = new IncrementalIndexAdapter(
+    final IndexableAdapter adapter2 = new IncrementalIndexAdapter(
         DEFAULT_INTERVAL,
         incrementalIndex2,
         INDEX_SPEC.getBitmapSerdeFactory().getBitmapFactory()
     );
 
-    adapter1 = new IncrementalIndexAdapter(
+    final IndexableAdapter adapter1 = new IncrementalIndexAdapter(
         DEFAULT_INTERVAL,
         incrementalIndex1,
         INDEX_SPEC.getBitmapSerdeFactory().getBitmapFactory()
     );
-  }
 
-  @Test
-  public void testRowValidatorEquals() throws Exception
-  {
     Exception ex = null;
     try {
       TestHelper.getTestIndexIO().validateTwoSegments(adapter1, adapter2);


### PR DESCRIPTION
### Description

`IndexIOTest` used JUnit 5 `@ParameterizedClass`, which caused each of its 5,925 method-source tuples to be reported as a separate Surefire test set. The resulting stream of `Running` and `Tests run: 1` events can overwhelm the Surefire fork communication channel; the failing master run timed out after 60 minutes while the fork was blocked in that channel.

This patch:

- converts `IndexIOTest` to one `@ParameterizedTest` while preserving all generated cases and assertions;
- creates fresh incremental indexes for each invocation.

The change does not alter Druid runtime behavior or reduce test coverage.

### CI findings

The failure on the latest `master` push was a CI execution flake, not a failing assertion in the commit's changed test. The push commit only changed `IncrementalIndexCursorFactoryTest`; the failing job was the JDK 25 `I*,A*,U*` shard running `IndexIOTest` as part of the unit-test matrix.

- [Failed run](https://github.com/apache/druid/actions/runs/30784678753), [failed job](https://github.com/apache/druid/actions/runs/30784678753/job/91595884375)
- The Execute step timed out after 60 minutes.
- The log repeatedly emitted `Running org.apache.druid.segment.IndexIOTest` and `Tests run: 1` without an assertion failure.
- The fork JVM's diagnostic stack was blocked in Surefire's `Channels$1.write` while completing a test set; Maven's parent process was waiting for the fork. This indicates Surefire event-channel backpressure from the per-parameter test-set reporting.
- The same shard completed successfully in roughly three minutes on the [preceding run](https://github.com/apache/druid/actions/runs/30732135263), supporting the infrastructure/reporting-flake classification.

`IndexIOTest` is a functional correctness test, not a benchmark. It generates 5,925 combinations of input maps and expected validation outcomes. The refactor keeps those cases and assertions intact while reducing the number of Surefire test sets from one per combination to one parameterized test method. The standard Surefire XML report still records the individual invocations without adding custom name formatting.

### Performance comparison

Measured locally on the same checkout with JDK 25 and the same Maven command:

```text
mvn -B -pl processing -Dtest=IndexIOTest \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dweb.console.skip=true -P skip-static-checks test
```

| Configuration | Tests | Surefire test time | Wall-clock time |
| --- | ---: | ---: | ---: |
| `@ParameterizedClass` baseline | 5,925 passed | 189.5 s | 3:31.95 |
| `@ParameterizedTest` | 5,925 passed | 3.559 s | 26.6 s |

The method-level parameterization reduced the local Surefire test phase by roughly 53x. The report contains all 5,925 testcase entries using the standard Surefire naming.

### Verification

- Ran the complete `IndexIOTest` parameter stream: 5,925 passed.
- Confirmed the standard Surefire XML report contains 5,925 testcase entries.
- Ran `git diff --check`.
- Self-reviewed the complete diff against `master`.

<hr>

##### Key changed/added classes in this PR

 * `processing/src/test/java/org/apache/druid/segment/IndexIOTest.java`

<hr>

This PR has:

- [x] been self-reviewed.
- [x] added or modified existing unit tests to preserve coverage.
