### PR TITLE
docs: Added documentation for fastIntervalSearch setting

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1572,9 +1572,9 @@ Note that if `druid.segmentCache.numLoadingThreads` > 1, multiple threads can do
 
 #### Loading segments
 
-| Property                  | Description                                                                                                                                                                                                                                                                                                 | Default |
-|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
-| `druid.segment.timeline.fastIntervalSearch` | Segment metadata is loaded into memory by the Historical services for serving the segments. This setting enables the use of an index based on Interval trees to store this metadata in memory for faster identification and retrieval. Set it to true to speed up loading and searching of segments. | false |
+| Property                  | Description                                                                                                                                                                                                                                                                        | Default |
+|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
+| `druid.segment.timeline.fastIntervalSearch` | Segment metadata is loaded into memory by the Historical services to serve segments. This setting enables an index based on interval trees to store that metadata in memory for faster identification and retrieval. Set it to true to speed up loading and searching of segments. | false |
 
 #### Historical query configs
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1570,6 +1570,12 @@ In `druid.segmentCache.locationSelector.strategy`, one of `leastBytesUsed`, `rou
 
 Note that if `druid.segmentCache.numLoadingThreads` > 1, multiple threads can download different segments at the same time. In this case, with the `leastBytesUsed` strategy or `mostAvailableSize` strategy, Historicals may select a sub-optimal storage location because each decision is based on a snapshot of the storage location status of when a segment is requested to download.
 
+#### Loading segments
+
+| Property                  | Description                                                                                                                                                                                                                                                                                                 | Default |
+|---------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
+| `druid.segment.timeline.fastIntervalSearch` | Segment metadata is loaded into memory by the Historical services for serving the segments. This setting enables the use of an index based on Interval trees to store this metadata in memory for faster identification and retrieval. Set it to true to speed up loading and searching of segments. | false |
+
 #### Historical query configs
 
 ##### Concurrent requests

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -1572,9 +1572,9 @@ Note that if `druid.segmentCache.numLoadingThreads` > 1, multiple threads can do
 
 #### Loading segments
 
-| Property                  | Description                                                                                                                                                                                                                                                                        | Default |
-|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|
-| `druid.segment.timeline.fastIntervalSearch` | Segment metadata is loaded into memory by the Historical services to serve segments. This setting enables an index based on interval trees to store that metadata in memory for faster identification and retrieval. Set it to true to speed up loading and searching of segments. | false |
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.segment.timeline.fastIntervalSearch`|(Experimental) Boolean flag to enable faster searches of segments in the timeline stored in memory. The setting when enabled uses an index based on [Interval tree](https://en.wikipedia.org/wiki/Interval_tree) to organize the timeline in-memory, for faster loading and searching of segments.|false|
 
 #### Historical query configs
 


### PR DESCRIPTION
This is a documentation PR for the fastIntervalSearch feature merged in [19138](https://github.com/apache/druid/pull/19138)

This PR has:

- [] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.