### PR TITLE
docs: require JUnit 5 for new tests in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ Real-time analytics database. Java, Maven, multi-module project.
 
 ## Running Tests
 
+Use JUnit 5 (`org.junit.jupiter`) for new test cases; do not add new tests using JUnit 4 (`org.junit`).
+
 Use these flags for faster tests: `-Pskip-static-checks -Dweb.console.skip=true -T1C`
 
 **Single test method:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Real-time analytics database. Java, Maven, multi-module project.
 
 ## Running Tests
 
-Use JUnit 5 (`org.junit.jupiter`) for new test cases; do not add new tests using JUnit 4 (`org.junit`).
+Use JUnit 5 (`org.junit.jupiter`) for new test classes and for new test methods added to existing JUnit 5 classes. Before adding a JUnit 5 method to an existing JUnit 4 (`org.junit`) class, migrate the class and its module to JUnit 5; otherwise, keep the new method in JUnit 4 until that migration is complete.
 
 Use these flags for faster tests: `-Pskip-static-checks -Dweb.console.skip=true -T1C`
 


### PR DESCRIPTION
### Description

Update `AGENTS.md` to require JUnit 5 (`org.junit.jupiter`) for new test cases and tell coding agents not to add new tests using JUnit 4 (`org.junit`).

### Motivation

This follows [review feedback on PR #19826](https://github.com/apache/druid/pull/19826#discussion_r3710745864) asking that new tests use JUnit 5 and the [follow-up discussion](https://github.com/apache/druid/pull/19826#discussion_r3712424322) proposing that the rule be documented in `AGENTS.md`.

The repository-wide migration is tracked by [#13948: JUnit4 to JUnit5 migration](https://github.com/apache/druid/issues/13948), which proposes migrating incrementally while retaining JUnit Vintage for backward compatibility. Completing that migration may take time because legacy JUnit 4 tests remain across many modules. In the meantime, this guidance prevents new tests from adding to the remaining migration work. It does not affect Druid runtime behavior.

### Verification

- Confirmed that JUnit 5 is configured across Druid modules.
- Self-reviewed the complete diff against the target branch.
- Ran `git diff --check`.
- No runtime tests were run because this change only updates agent guidance.

This PR has:

- [x] been self-reviewed.
- [x] added documentation for a repository testing requirement.
