### PR TITLE
test: migrate extensions-core and processing tests to JUnit 5

### DIFF
--- a/extensions-core/druid-aws-rds-extensions/pom.xml
+++ b/extensions-core/druid-aws-rds-extensions/pom.xml
@@ -78,8 +78,13 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-core/druid-aws-rds-extensions/src/test/java/org/apache/druid/aws/rds/AWSRDSTokenPasswordProviderTest.java
+++ b/extensions-core/druid-aws-rds-extensions/src/test/java/org/apache/druid/aws/rds/AWSRDSTokenPasswordProviderTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.metadata.PasswordProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 
@@ -68,9 +68,9 @@ public class AWSRDSTokenPasswordProviderTest
     );
 
     AWSRDSTokenPasswordProvider awsPwdProvider = (AWSRDSTokenPasswordProvider) pp;
-    Assert.assertEquals("testuser", awsPwdProvider.getUser());
-    Assert.assertEquals("testhost", awsPwdProvider.getHost());
-    Assert.assertEquals(5273, awsPwdProvider.getPort());
-    Assert.assertEquals("testregion", awsPwdProvider.getRegion());
+    Assertions.assertEquals("testuser", awsPwdProvider.getUser());
+    Assertions.assertEquals("testhost", awsPwdProvider.getHost());
+    Assertions.assertEquals(5273, awsPwdProvider.getPort());
+    Assertions.assertEquals("testregion", awsPwdProvider.getRegion());
   }
 }

--- a/extensions-core/druid-bloom-filter/pom.xml
+++ b/extensions-core/druid-bloom-filter/pom.xml
@@ -126,22 +126,22 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/druid-bloom-filter/pom.xml
+++ b/extensions-core/druid-bloom-filter/pom.xml
@@ -134,14 +134,10 @@
       <artifactId>reflections</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Required because the processing and SQL test JARs expose Hamcrest types in shared fixture APIs. -->
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactoryTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorFactoryTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BloomFilterAggregatorFactoryTest
 {
@@ -55,7 +55,7 @@ public class BloomFilterAggregatorFactoryTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)
@@ -78,8 +78,8 @@ public class BloomFilterAggregatorFactoryTest
         DefaultDimensionSpec.of("col"),
         1024
     );
-    Assert.assertEquals(factory, factory.withName("bloom"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("bloom"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 
 
@@ -87,7 +87,7 @@ public class BloomFilterAggregatorFactoryTest
   public void testWithNameBloomFilterMergeAggFactory()
   {
     BloomFilterMergeAggregatorFactory factory = new BloomFilterMergeAggregatorFactory("bloomMerge", "bloom", 1024);
-    Assert.assertEquals(factory, factory.withName("bloomMerge"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("bloomMerge"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 }

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterAggregatorTest.java
@@ -44,8 +44,8 @@ import org.apache.druid.segment.DoubleColumnSelector;
 import org.apache.druid.segment.FloatColumnSelector;
 import org.apache.druid.segment.LongColumnSelector;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -250,7 +250,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get())
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedFilter1, serialized);
+    Assertions.assertEquals(serializedFilter1, serialized);
   }
 
   @Test
@@ -267,7 +267,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get())
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedLongFilter, serialized);
+    Assertions.assertEquals(serializedLongFilter, serialized);
   }
 
   @Test
@@ -284,7 +284,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get())
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedFloatFilter, serialized);
+    Assertions.assertEquals(serializedFloatFilter, serialized);
   }
 
   @Test
@@ -301,7 +301,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get())
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedDoubleFilter, serialized);
+    Assertions.assertEquals(serializedDoubleFilter, serialized);
   }
 
   @Test
@@ -324,7 +324,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos))
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedFilter2, serialized);
+    Assertions.assertEquals(serializedFilter2, serialized);
   }
 
   @Test
@@ -346,7 +346,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos))
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedLongFilter, serialized);
+    Assertions.assertEquals(serializedLongFilter, serialized);
   }
 
   @Test
@@ -368,7 +368,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos))
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedFloatFilter, serialized);
+    Assertions.assertEquals(serializedFloatFilter, serialized);
   }
 
   @Test
@@ -390,7 +390,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.finalizeComputation(agg.get(buf, pos))
     );
     String serialized = filterToString(bloomKFilter);
-    Assert.assertEquals(serializedDoubleFilter, serialized);
+    Assertions.assertEquals(serializedDoubleFilter, serialized);
   }
 
   @Test
@@ -419,7 +419,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
     );
 
     String serialized = filterToString(combined);
-    Assert.assertEquals(serializedCombinedFilter, serialized);
+    Assertions.assertEquals(serializedCombinedFilter, serialized);
   }
 
   @Test
@@ -445,7 +445,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.getCombiningFactory().finalizeComputation(mergeAggregator.get())
     );
     String serialized = filterToString(merged);
-    Assert.assertEquals(serializedCombinedFilter, serialized);
+    Assertions.assertEquals(serializedCombinedFilter, serialized);
   }
 
   @Test
@@ -471,7 +471,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         (ByteBuffer) valueAggregatorFactory.getCombiningFactory().finalizeComputation(mergeAggregator.get())
     );
     String serialized = filterToString(merged);
-    Assert.assertEquals(serializedCombinedFilter, serialized);
+    Assertions.assertEquals(serializedCombinedFilter, serialized);
   }
 
   @Test
@@ -503,7 +503,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
     );
     String serialized = filterToString(merged);
 
-    Assert.assertEquals(serializedCombinedFilter, serialized);
+    Assertions.assertEquals(serializedCombinedFilter, serialized);
   }
 
   @Test
@@ -516,7 +516,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
     );
     ObjectMapper objectMapper = new DefaultObjectMapper();
     new BloomFilterExtensionModule().getJacksonModules().forEach(objectMapper::registerModule);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         factory,
         objectMapper.readValue(objectMapper.writeValueAsString(factory), AggregatorFactory.class)
     );
@@ -527,7 +527,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
                             + "\"field\":\"b\","
                             + "\"maxNumEntries\":15"
                             + "}";
-    Assert.assertEquals(
+    Assertions.assertEquals(
         factory,
         objectMapper.readValue(fieldNamesOnly, AggregatorFactory.class)
     );
@@ -538,7 +538,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         MAX_NUM_VALUES
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         factory2,
         objectMapper.readValue(objectMapper.writeValueAsString(factory2), AggregatorFactory.class)
     );
@@ -548,7 +548,7 @@ public class BloomFilterAggregatorTest extends InitializedNullHandlingTest
         new RegexFilteredDimensionSpec(new DefaultDimensionSpec("a", "a"), ".*"),
         MAX_NUM_VALUES
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         factory3,
         objectMapper.readValue(objectMapper.writeValueAsString(factory3), AggregatorFactory.class)
     );

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterGroupByQueryTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterGroupByQueryTest.java
@@ -46,21 +46,19 @@ import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-@RunWith(Parameterized.class)
 public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
 {
   private static final BloomFilterExtensionModule MODULE = new BloomFilterExtensionModule();
@@ -75,19 +73,18 @@ public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
 
   private AggregationTestHelper helper;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private File tempFolder;
 
-  public BloomFilterGroupByQueryTest(final GroupByQueryConfig config)
+  public void initBloomFilterGroupByQueryTest(final GroupByQueryConfig config)
   {
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         Lists.newArrayList(MODULE.getJacksonModules()),
         config,
         tempFolder
     );
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -97,15 +94,17 @@ public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
-  @Test
-  public void testQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testQuery(final GroupByQueryConfig config) throws Exception
   {
+    initBloomFilterGroupByQueryTest(config);
     GroupByQuery query = GroupByQuery.builder()
                                      .setDataSource("test_datasource")
                                      .setGranularity(Granularities.ALL)
@@ -119,14 +118,16 @@ public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
     MapBasedRow row = ingestAndQuery(query);
 
     BloomKFilter filter = BloomKFilter.deserialize((ByteBuffer) row.getRaw("blooming_quality"));
-    Assert.assertTrue(filter.testString("mezzanine"));
-    Assert.assertTrue(filter.testString("premium"));
-    Assert.assertFalse(filter.testString("entertainment"));
+    Assertions.assertTrue(filter.testString("mezzanine"));
+    Assertions.assertTrue(filter.testString("premium"));
+    Assertions.assertFalse(filter.testString("entertainment"));
   }
 
-  @Test
-  public void testNestedQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testNestedQuery(final GroupByQueryConfig config) throws Exception
   {
+    initBloomFilterGroupByQueryTest(config);
     GroupByQuery innerQuery = GroupByQuery.builder()
                                           .setDataSource("test_datasource")
                                           .setGranularity(Granularities.ALL)
@@ -146,13 +147,15 @@ public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
     MapBasedRow row = ingestAndQuery(query);
 
     BloomKFilter filter = BloomKFilter.deserialize((ByteBuffer) row.getRaw("bloom"));
-    Assert.assertTrue(filter.testLong(13L));
-    Assert.assertFalse(filter.testLong(5L));
+    Assertions.assertTrue(filter.testLong(13L));
+    Assertions.assertFalse(filter.testLong(5L));
   }
 
-  @Test
-  public void testNestedQueryComplex() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testNestedQueryComplex(final GroupByQueryConfig config) throws Exception
   {
+    initBloomFilterGroupByQueryTest(config);
     GroupByQuery innerQuery = GroupByQuery.builder()
                                           .setDataSource("test_datasource")
                                           .setGranularity(Granularities.ALL)
@@ -175,14 +178,16 @@ public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
     MapBasedRow row = ingestAndQuery(query);
 
     BloomKFilter filter = BloomKFilter.deserialize((ByteBuffer) row.getRaw("innerBloom"));
-    Assert.assertTrue(filter.testString("mezzanine"));
-    Assert.assertTrue(filter.testString("premium"));
-    Assert.assertFalse(filter.testString("entertainment"));
+    Assertions.assertTrue(filter.testString("mezzanine"));
+    Assertions.assertTrue(filter.testString("premium"));
+    Assertions.assertFalse(filter.testString("entertainment"));
   }
 
-  @Test
-  public void testQueryFakeDimension() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testQueryFakeDimension(final GroupByQueryConfig config) throws Exception
   {
+    initBloomFilterGroupByQueryTest(config);
     GroupByQuery query = GroupByQuery.builder()
                                      .setDataSource("test_datasource")
                                      .setGranularity(Granularities.ALL)
@@ -203,7 +208,7 @@ public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
     String serialized = BloomFilterAggregatorTest.filterToString(BloomKFilter.deserialize((ByteBuffer) val));
     String empty = BloomFilterAggregatorTest.filterToString(filter);
 
-    Assert.assertEquals(empty, serialized);
+    Assertions.assertEquals(empty, serialized);
   }
 
   private MapBasedRow ingestAndQuery(GroupByQuery query) throws Exception

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterGroupByQueryTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/aggregation/bloom/BloomFilterGroupByQueryTest.java
@@ -97,7 +97,9 @@ public class BloomFilterGroupByQueryTest extends InitializedNullHandlingTest
   @AfterEach
   public void teardown() throws IOException
   {
-    helper.close();
+    if (helper != null) {
+      helper.close();
+    }
   }
 
   @MethodSource("constructorFeeder")

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/expressions/BloomFilterExpressionsTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/expressions/BloomFilterExpressionsTest.java
@@ -30,10 +30,11 @@ import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.query.filter.BloomKFilter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public class BloomFilterExpressionsTest extends InitializedNullHandlingTest
@@ -62,18 +63,15 @@ public class BloomFilterExpressionsTest extends InitializedNullHandlingTest
           .build()
   );
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testCreate()
   {
     Expr expr = Parser.parse("bloom_filter(100)", macroTable);
     ExprEval eval = expr.eval(inputBindings);
 
-    Assert.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
-    Assert.assertTrue(eval.value() instanceof BloomKFilter);
-    Assert.assertEquals(1024, ((BloomKFilter) eval.value()).getBitSize());
+    Assertions.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
+    Assertions.assertTrue(eval.value() instanceof BloomKFilter);
+    Assertions.assertEquals(1024, ((BloomKFilter) eval.value()).getBitSize());
   }
 
   @Test
@@ -82,16 +80,16 @@ public class BloomFilterExpressionsTest extends InitializedNullHandlingTest
     Expr expr = Parser.parse("bloom_filter_add('foo', bloomy)", macroTable);
     ExprEval eval = expr.eval(inputBindings);
 
-    Assert.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
-    Assert.assertTrue(eval.value() instanceof BloomKFilter);
-    Assert.assertTrue(((BloomKFilter) eval.value()).testString(SOME_STRING));
+    Assertions.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
+    Assertions.assertTrue(eval.value() instanceof BloomKFilter);
+    Assertions.assertTrue(((BloomKFilter) eval.value()).testString(SOME_STRING));
 
     expr = Parser.parse("bloom_filter_add(string, bloomy)", macroTable);
     eval = expr.eval(inputBindings);
 
-    Assert.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
-    Assert.assertTrue(eval.value() instanceof BloomKFilter);
-    Assert.assertTrue(((BloomKFilter) eval.value()).testString(SOME_STRING));
+    Assertions.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
+    Assertions.assertTrue(eval.value() instanceof BloomKFilter);
+    Assertions.assertTrue(((BloomKFilter) eval.value()).testString(SOME_STRING));
   }
 
   @Test
@@ -100,16 +98,16 @@ public class BloomFilterExpressionsTest extends InitializedNullHandlingTest
     Expr expr = Parser.parse("bloom_filter_add(1234, bloomy)", macroTable);
     ExprEval eval = expr.eval(inputBindings);
 
-    Assert.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
-    Assert.assertTrue(eval.value() instanceof BloomKFilter);
-    Assert.assertTrue(((BloomKFilter) eval.value()).testLong(SOME_LONG));
+    Assertions.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
+    Assertions.assertTrue(eval.value() instanceof BloomKFilter);
+    Assertions.assertTrue(((BloomKFilter) eval.value()).testLong(SOME_LONG));
 
     expr = Parser.parse("bloom_filter_add(long, bloomy)", macroTable);
     eval = expr.eval(inputBindings);
 
-    Assert.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
-    Assert.assertTrue(eval.value() instanceof BloomKFilter);
-    Assert.assertTrue(((BloomKFilter) eval.value()).testLong(SOME_LONG));
+    Assertions.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
+    Assertions.assertTrue(eval.value() instanceof BloomKFilter);
+    Assertions.assertTrue(((BloomKFilter) eval.value()).testLong(SOME_LONG));
   }
 
   @Test
@@ -118,16 +116,16 @@ public class BloomFilterExpressionsTest extends InitializedNullHandlingTest
     Expr expr = Parser.parse("bloom_filter_add(1.234, bloomy)", macroTable);
     ExprEval eval = expr.eval(inputBindings);
 
-    Assert.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
-    Assert.assertTrue(eval.value() instanceof BloomKFilter);
-    Assert.assertTrue(((BloomKFilter) eval.value()).testDouble(SOME_DOUBLE));
+    Assertions.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
+    Assertions.assertTrue(eval.value() instanceof BloomKFilter);
+    Assertions.assertTrue(((BloomKFilter) eval.value()).testDouble(SOME_DOUBLE));
 
     expr = Parser.parse("bloom_filter_add(double, bloomy)", macroTable);
     eval = expr.eval(inputBindings);
 
-    Assert.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
-    Assert.assertTrue(eval.value() instanceof BloomKFilter);
-    Assert.assertTrue(((BloomKFilter) eval.value()).testDouble(SOME_DOUBLE));
+    Assertions.assertEquals(BloomFilterExpressions.BLOOM_FILTER_TYPE, eval.type());
+    Assertions.assertTrue(eval.value() instanceof BloomKFilter);
+    Assertions.assertTrue(((BloomKFilter) eval.value()).testDouble(SOME_DOUBLE));
   }
 
   @Test
@@ -135,90 +133,91 @@ public class BloomFilterExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("bloom_filter_test(1.234, bloom_filter_add(1.234, bloomy))", macroTable);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertTrue(eval.asBoolean());
 
     expr = Parser.parse("bloom_filter_test(1234, bloom_filter_add(1234, bloomy))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertTrue(eval.asBoolean());
 
     expr = Parser.parse("bloom_filter_test('foo', bloom_filter_add('foo', bloomy))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertTrue(eval.asBoolean());
 
     expr = Parser.parse("bloom_filter_test('bar', bloom_filter_add('foo', bloomy))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.asBoolean());
 
     expr = Parser.parse("bloom_filter_test(1234, bloom_filter_add('foo', bloomy))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.asBoolean());
 
     expr = Parser.parse("bloom_filter_test(1.23, bloom_filter_add('foo', bloomy))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.asBoolean());
 
 
     expr = Parser.parse("bloom_filter_test(1234, bloom_filter_add(1234, bloom_filter(100)))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertTrue(eval.asBoolean());
 
     expr = Parser.parse("bloom_filter_test(4321, bloom_filter_add(1234, bloom_filter(100)))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.asBoolean());
 
     expr = Parser.parse("bloom_filter_test(4321, bloom_filter_add(bloom_filter_add(1234, bloom_filter(100)), bloom_filter_add(4321, bloom_filter(100))))", macroTable);
     eval = expr.eval(inputBindings);
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertTrue(eval.asBoolean());
   }
 
 
   @Test
   public void testCreateWrongArgsCount()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Function[bloom_filter] requires 1 argument");
-    Parser.parse("bloom_filter()", macroTable);
+    Throwable exception = assertThrows(IAE.class, () ->
+      Parser.parse("bloom_filter()", macroTable));
+    assertTrue(exception.getMessage().contains("Function[bloom_filter] requires 1 argument"));
   }
 
   @Test
   public void testAddWrongArgsCount()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Function[bloom_filter_add] requires 2 arguments");
-    Parser.parse("bloom_filter_add(1)", macroTable);
+    Throwable exception = assertThrows(IAE.class, () ->
+      Parser.parse("bloom_filter_add(1)", macroTable));
+    assertTrue(exception.getMessage().contains("Function[bloom_filter_add] requires 2 arguments"));
   }
 
   @Test
   public void testAddWrongArgType()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Function[bloom_filter_add] must take a bloom filter as the second argument");
-    Parser.parse("bloom_filter_add(1, 2)", macroTable);
+    Throwable exception = assertThrows(IAE.class, () ->
+      Parser.parse("bloom_filter_add(1, 2)", macroTable));
+    assertTrue(exception.getMessage().contains("Function[bloom_filter_add] must take a bloom filter as the second argument"));
   }
 
   @Test
   public void testAddWrongArgType2()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Function[bloom_filter_add] cannot add [ARRAY<LONG>] to a bloom filter");
-    Expr expr = Parser.parse("bloom_filter_add(ARRAY<LONG>[], bloomy)", macroTable);
-    expr.eval(inputBindings);
+    Throwable exception = assertThrows(IAE.class, () -> {
+      Expr expr = Parser.parse("bloom_filter_add(ARRAY<LONG>[], bloomy)", macroTable);
+      expr.eval(inputBindings);
+    });
+    assertTrue(exception.getMessage().contains("Function[bloom_filter_add] cannot add [ARRAY<LONG>] to a bloom filter"));
   }
 
   @Test
   public void testTestWrongArgsCount()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Function[bloom_filter_test] requires 2 arguments");
-    Parser.parse("bloom_filter_test(1)", macroTable);
+    Throwable exception = assertThrows(IAE.class, () ->
+      Parser.parse("bloom_filter_test(1)", macroTable));
+    assertTrue(exception.getMessage().contains("Function[bloom_filter_test] requires 2 arguments"));
   }
 
   @Test
   public void testTestWrongArgsType()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Function[bloom_filter_test] must take a bloom filter as the second argument");
-    Parser.parse("bloom_filter_test(1, 2)", macroTable);
+    Throwable exception = assertThrows(IAE.class, () ->
+      Parser.parse("bloom_filter_test(1, 2)", macroTable));
+    assertTrue(exception.getMessage().contains("Function[bloom_filter_test] must take a bloom filter as the second argument"));
   }
 }

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomDimFilterTest.java
@@ -88,7 +88,7 @@ public class BloomDimFilterTest extends BaseFilterTest
       BaseFilterTest.makeSchemaRow(SCHEMA, ROW_SIGNATURE, "5", "abc")
   );
 
-  private static DefaultObjectMapper mapper = new DefaultObjectMapper();
+  private static final DefaultObjectMapper MAPPER = new DefaultObjectMapper();
 
   public BloomDimFilterTest(
       String testName,
@@ -114,7 +114,7 @@ public class BloomDimFilterTest extends BaseFilterTest
   @BeforeAll
   public static void beforeClass()
   {
-    mapper.registerModule(new BloomFilterSerializersModule());
+    MAPPER.registerModule(new BloomFilterSerializersModule());
   }
 
   @AfterAll
@@ -134,7 +134,7 @@ public class BloomDimFilterTest extends BaseFilterTest
         holder,
         new TimeDimExtractionFn("yyyy-MM-dd", "yyyy-MM", true)
     );
-    DimFilter filter = mapper.readValue(mapper.writeValueAsBytes(bloomDimFilter), DimFilter.class);
+    DimFilter filter = MAPPER.readValue(MAPPER.writeValueAsBytes(bloomDimFilter), DimFilter.class);
     Assertions.assertTrue(filter instanceof BloomDimFilter);
     BloomDimFilter serde = (BloomDimFilter) filter;
     Assertions.assertEquals(bloomDimFilter.getDimension(), serde.getDimension());

--- a/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomKFilterTest.java
+++ b/extensions-core/druid-bloom-filter/src/test/java/org/apache/druid/query/filter/BloomKFilterTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.query.filter;
 
 import org.apache.druid.io.ByteBufferInputStream;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -54,31 +54,31 @@ public class BloomKFilterTest
     BloomKFilter.add(buffer, val);
     BloomKFilter rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.test(val));
-    Assert.assertFalse(rehydrated.test(val1));
-    Assert.assertFalse(rehydrated.test(val2));
-    Assert.assertFalse(rehydrated.test(val3));
+    Assertions.assertTrue(rehydrated.test(val));
+    Assertions.assertFalse(rehydrated.test(val1));
+    Assertions.assertFalse(rehydrated.test(val2));
+    Assertions.assertFalse(rehydrated.test(val3));
     BloomKFilter.add(buffer, val1);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.test(val));
-    Assert.assertTrue(rehydrated.test(val1));
-    Assert.assertFalse(rehydrated.test(val2));
-    Assert.assertFalse(rehydrated.test(val3));
+    Assertions.assertTrue(rehydrated.test(val));
+    Assertions.assertTrue(rehydrated.test(val1));
+    Assertions.assertFalse(rehydrated.test(val2));
+    Assertions.assertFalse(rehydrated.test(val3));
     BloomKFilter.add(buffer, val2);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.test(val));
-    Assert.assertTrue(rehydrated.test(val1));
-    Assert.assertTrue(rehydrated.test(val2));
-    Assert.assertFalse(rehydrated.test(val3));
+    Assertions.assertTrue(rehydrated.test(val));
+    Assertions.assertTrue(rehydrated.test(val1));
+    Assertions.assertTrue(rehydrated.test(val2));
+    Assertions.assertFalse(rehydrated.test(val3));
     BloomKFilter.add(buffer, val3);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.test(val));
-    Assert.assertTrue(rehydrated.test(val1));
-    Assert.assertTrue(rehydrated.test(val2));
-    Assert.assertTrue(rehydrated.test(val3));
+    Assertions.assertTrue(rehydrated.test(val));
+    Assertions.assertTrue(rehydrated.test(val1));
+    Assertions.assertTrue(rehydrated.test(val2));
+    Assertions.assertTrue(rehydrated.test(val3));
 
     byte[] randVal = new byte[COUNT];
     for (int i = 0; i < COUNT; i++) {
@@ -87,16 +87,16 @@ public class BloomKFilterTest
     }
     // last value should be present
     rehydrated = deserializeBloomFilter(buffer);
-    Assert.assertTrue(rehydrated.test(randVal));
+    Assertions.assertTrue(rehydrated.test(randVal));
     // most likely this value should not exist
     randVal[0] = 0;
     randVal[1] = 0;
     randVal[2] = 0;
     randVal[3] = 0;
     randVal[4] = 0;
-    Assert.assertFalse(rehydrated.test(randVal));
+    Assertions.assertFalse(rehydrated.test(randVal));
 
-    Assert.assertEquals(7808, rehydrated.sizeInBytes());
+    Assertions.assertEquals(7808, rehydrated.sizeInBytes());
   }
 
   @Test
@@ -116,31 +116,31 @@ public class BloomKFilterTest
     BloomKFilter.addLong(buffer, val);
     BloomKFilter rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertFalse(rehydrated.testLong(val1));
-    Assert.assertFalse(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertFalse(rehydrated.testLong(val1));
+    Assertions.assertFalse(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val1);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertFalse(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertFalse(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val2);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertTrue(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertTrue(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val3);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertTrue(rehydrated.testLong(val2));
-    Assert.assertTrue(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertTrue(rehydrated.testLong(val2));
+    Assertions.assertTrue(rehydrated.testLong(val3));
 
     byte randVal = 0;
     for (int i = 0; i < COUNT; i++) {
@@ -151,11 +151,11 @@ public class BloomKFilterTest
     rehydrated = deserializeBloomFilter(buffer);
 
     // last value should be present
-    Assert.assertTrue(rehydrated.testLong(randVal));
+    Assertions.assertTrue(rehydrated.testLong(randVal));
     // most likely this value should not exist
-    Assert.assertFalse(rehydrated.testLong((byte) -120));
+    Assertions.assertFalse(rehydrated.testLong((byte) -120));
 
-    Assert.assertEquals(7808, rehydrated.sizeInBytes());
+    Assertions.assertEquals(7808, rehydrated.sizeInBytes());
   }
 
   @Test
@@ -175,31 +175,31 @@ public class BloomKFilterTest
     BloomKFilter.addLong(buffer, val);
     BloomKFilter rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertFalse(rehydrated.testLong(val1));
-    Assert.assertFalse(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertFalse(rehydrated.testLong(val1));
+    Assertions.assertFalse(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val1);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertFalse(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertFalse(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val2);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertTrue(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertTrue(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val3);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertTrue(rehydrated.testLong(val2));
-    Assert.assertTrue(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertTrue(rehydrated.testLong(val2));
+    Assertions.assertTrue(rehydrated.testLong(val3));
 
     int randVal = 0;
     for (int i = 0; i < COUNT; i++) {
@@ -208,11 +208,11 @@ public class BloomKFilterTest
     }
     rehydrated = deserializeBloomFilter(buffer);
     // last value should be present
-    Assert.assertTrue(rehydrated.testLong(randVal));
+    Assertions.assertTrue(rehydrated.testLong(randVal));
     // most likely this value should not exist
-    Assert.assertFalse(rehydrated.testLong(-120));
+    Assertions.assertFalse(rehydrated.testLong(-120));
 
-    Assert.assertEquals(7808, rehydrated.sizeInBytes());
+    Assertions.assertEquals(7808, rehydrated.sizeInBytes());
   }
 
   @Test
@@ -232,31 +232,31 @@ public class BloomKFilterTest
     BloomKFilter.addLong(buffer, val);
     BloomKFilter rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertFalse(rehydrated.testLong(val1));
-    Assert.assertFalse(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertFalse(rehydrated.testLong(val1));
+    Assertions.assertFalse(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val1);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertFalse(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertFalse(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val2);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertTrue(rehydrated.testLong(val2));
-    Assert.assertFalse(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertTrue(rehydrated.testLong(val2));
+    Assertions.assertFalse(rehydrated.testLong(val3));
     BloomKFilter.addLong(buffer, val3);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testLong(val));
-    Assert.assertTrue(rehydrated.testLong(val1));
-    Assert.assertTrue(rehydrated.testLong(val2));
-    Assert.assertTrue(rehydrated.testLong(val3));
+    Assertions.assertTrue(rehydrated.testLong(val));
+    Assertions.assertTrue(rehydrated.testLong(val1));
+    Assertions.assertTrue(rehydrated.testLong(val2));
+    Assertions.assertTrue(rehydrated.testLong(val3));
 
     int randVal = 0;
     for (int i = 0; i < COUNT; i++) {
@@ -265,11 +265,11 @@ public class BloomKFilterTest
     }
     rehydrated = deserializeBloomFilter(buffer);
     // last value should be present
-    Assert.assertTrue(rehydrated.testLong(randVal));
+    Assertions.assertTrue(rehydrated.testLong(randVal));
     // most likely this value should not exist
-    Assert.assertFalse(rehydrated.testLong(-120));
+    Assertions.assertFalse(rehydrated.testLong(-120));
 
-    Assert.assertEquals(7808, rehydrated.sizeInBytes());
+    Assertions.assertEquals(7808, rehydrated.sizeInBytes());
   }
 
   @Test
@@ -289,31 +289,31 @@ public class BloomKFilterTest
     BloomKFilter.addFloat(buffer, val);
     BloomKFilter rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testFloat(val));
-    Assert.assertFalse(rehydrated.testFloat(val1));
-    Assert.assertFalse(rehydrated.testFloat(val2));
-    Assert.assertFalse(rehydrated.testFloat(val3));
+    Assertions.assertTrue(rehydrated.testFloat(val));
+    Assertions.assertFalse(rehydrated.testFloat(val1));
+    Assertions.assertFalse(rehydrated.testFloat(val2));
+    Assertions.assertFalse(rehydrated.testFloat(val3));
     BloomKFilter.addFloat(buffer, val1);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testFloat(val));
-    Assert.assertTrue(rehydrated.testFloat(val1));
-    Assert.assertFalse(rehydrated.testFloat(val2));
-    Assert.assertFalse(rehydrated.testFloat(val3));
+    Assertions.assertTrue(rehydrated.testFloat(val));
+    Assertions.assertTrue(rehydrated.testFloat(val1));
+    Assertions.assertFalse(rehydrated.testFloat(val2));
+    Assertions.assertFalse(rehydrated.testFloat(val3));
     BloomKFilter.addFloat(buffer, val2);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testFloat(val));
-    Assert.assertTrue(rehydrated.testFloat(val1));
-    Assert.assertTrue(rehydrated.testFloat(val2));
-    Assert.assertFalse(rehydrated.testFloat(val3));
+    Assertions.assertTrue(rehydrated.testFloat(val));
+    Assertions.assertTrue(rehydrated.testFloat(val1));
+    Assertions.assertTrue(rehydrated.testFloat(val2));
+    Assertions.assertFalse(rehydrated.testFloat(val3));
     BloomKFilter.addFloat(buffer, val3);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testFloat(val));
-    Assert.assertTrue(rehydrated.testFloat(val1));
-    Assert.assertTrue(rehydrated.testFloat(val2));
-    Assert.assertTrue(rehydrated.testFloat(val3));
+    Assertions.assertTrue(rehydrated.testFloat(val));
+    Assertions.assertTrue(rehydrated.testFloat(val1));
+    Assertions.assertTrue(rehydrated.testFloat(val2));
+    Assertions.assertTrue(rehydrated.testFloat(val3));
 
     float randVal = 0;
     for (int i = 0; i < COUNT; i++) {
@@ -323,11 +323,11 @@ public class BloomKFilterTest
     rehydrated = deserializeBloomFilter(buffer);
 
     // last value should be present
-    Assert.assertTrue(rehydrated.testFloat(randVal));
+    Assertions.assertTrue(rehydrated.testFloat(randVal));
     // most likely this value should not exist
-    Assert.assertFalse(rehydrated.testFloat(-120.2f));
+    Assertions.assertFalse(rehydrated.testFloat(-120.2f));
 
-    Assert.assertEquals(7808, rehydrated.sizeInBytes());
+    Assertions.assertEquals(7808, rehydrated.sizeInBytes());
   }
 
   @Test
@@ -347,31 +347,31 @@ public class BloomKFilterTest
     BloomKFilter.addDouble(buffer, val);
     BloomKFilter rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testDouble(val));
-    Assert.assertFalse(rehydrated.testDouble(val1));
-    Assert.assertFalse(rehydrated.testDouble(val2));
-    Assert.assertFalse(rehydrated.testDouble(val3));
+    Assertions.assertTrue(rehydrated.testDouble(val));
+    Assertions.assertFalse(rehydrated.testDouble(val1));
+    Assertions.assertFalse(rehydrated.testDouble(val2));
+    Assertions.assertFalse(rehydrated.testDouble(val3));
     BloomKFilter.addDouble(buffer, val1);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testDouble(val));
-    Assert.assertTrue(rehydrated.testDouble(val1));
-    Assert.assertFalse(rehydrated.testDouble(val2));
-    Assert.assertFalse(rehydrated.testDouble(val3));
+    Assertions.assertTrue(rehydrated.testDouble(val));
+    Assertions.assertTrue(rehydrated.testDouble(val1));
+    Assertions.assertFalse(rehydrated.testDouble(val2));
+    Assertions.assertFalse(rehydrated.testDouble(val3));
     BloomKFilter.addDouble(buffer, val2);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testDouble(val));
-    Assert.assertTrue(rehydrated.testDouble(val1));
-    Assert.assertTrue(rehydrated.testDouble(val2));
-    Assert.assertFalse(rehydrated.testDouble(val3));
+    Assertions.assertTrue(rehydrated.testDouble(val));
+    Assertions.assertTrue(rehydrated.testDouble(val1));
+    Assertions.assertTrue(rehydrated.testDouble(val2));
+    Assertions.assertFalse(rehydrated.testDouble(val3));
     BloomKFilter.addDouble(buffer, val3);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testDouble(val));
-    Assert.assertTrue(rehydrated.testDouble(val1));
-    Assert.assertTrue(rehydrated.testDouble(val2));
-    Assert.assertTrue(rehydrated.testDouble(val3));
+    Assertions.assertTrue(rehydrated.testDouble(val));
+    Assertions.assertTrue(rehydrated.testDouble(val1));
+    Assertions.assertTrue(rehydrated.testDouble(val2));
+    Assertions.assertTrue(rehydrated.testDouble(val3));
 
     double randVal = 0;
     for (int i = 0; i < COUNT; i++) {
@@ -381,11 +381,11 @@ public class BloomKFilterTest
     rehydrated = deserializeBloomFilter(buffer);
 
     // last value should be present
-    Assert.assertTrue(rehydrated.testDouble(randVal));
+    Assertions.assertTrue(rehydrated.testDouble(randVal));
     // most likely this value should not exist
-    Assert.assertFalse(rehydrated.testDouble(-120.2d));
+    Assertions.assertFalse(rehydrated.testDouble(-120.2d));
 
-    Assert.assertEquals(7808, rehydrated.sizeInBytes());
+    Assertions.assertEquals(7808, rehydrated.sizeInBytes());
   }
 
   @Test
@@ -405,31 +405,31 @@ public class BloomKFilterTest
     BloomKFilter.addString(buffer, val);
     BloomKFilter rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testString(val));
-    Assert.assertFalse(rehydrated.testString(val1));
-    Assert.assertFalse(rehydrated.testString(val2));
-    Assert.assertFalse(rehydrated.testString(val3));
+    Assertions.assertTrue(rehydrated.testString(val));
+    Assertions.assertFalse(rehydrated.testString(val1));
+    Assertions.assertFalse(rehydrated.testString(val2));
+    Assertions.assertFalse(rehydrated.testString(val3));
     BloomKFilter.addString(buffer, val1);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testString(val));
-    Assert.assertTrue(rehydrated.testString(val1));
-    Assert.assertFalse(rehydrated.testString(val2));
-    Assert.assertFalse(rehydrated.testString(val3));
+    Assertions.assertTrue(rehydrated.testString(val));
+    Assertions.assertTrue(rehydrated.testString(val1));
+    Assertions.assertFalse(rehydrated.testString(val2));
+    Assertions.assertFalse(rehydrated.testString(val3));
     BloomKFilter.addString(buffer, val2);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testString(val));
-    Assert.assertTrue(rehydrated.testString(val1));
-    Assert.assertTrue(rehydrated.testString(val2));
-    Assert.assertFalse(rehydrated.testString(val3));
+    Assertions.assertTrue(rehydrated.testString(val));
+    Assertions.assertTrue(rehydrated.testString(val1));
+    Assertions.assertTrue(rehydrated.testString(val2));
+    Assertions.assertFalse(rehydrated.testString(val3));
     BloomKFilter.addString(buffer, val3);
     rehydrated = deserializeBloomFilter(buffer);
     buffer.position(0);
-    Assert.assertTrue(rehydrated.testString(val));
-    Assert.assertTrue(rehydrated.testString(val1));
-    Assert.assertTrue(rehydrated.testString(val2));
-    Assert.assertTrue(rehydrated.testString(val3));
+    Assertions.assertTrue(rehydrated.testString(val));
+    Assertions.assertTrue(rehydrated.testString(val1));
+    Assertions.assertTrue(rehydrated.testString(val2));
+    Assertions.assertTrue(rehydrated.testString(val3));
 
     long randVal = 0;
     for (int i = 0; i < COUNT; i++) {
@@ -438,11 +438,11 @@ public class BloomKFilterTest
     }
     rehydrated = deserializeBloomFilter(buffer);
     // last value should be present
-    Assert.assertTrue(rehydrated.testString(Long.toString(randVal)));
+    Assertions.assertTrue(rehydrated.testString(Long.toString(randVal)));
     // most likely this value should not exist
-    Assert.assertFalse(rehydrated.testString(Long.toString(-120)));
+    Assertions.assertFalse(rehydrated.testString(Long.toString(-120)));
 
-    Assert.assertEquals(77952, rehydrated.sizeInBytes());
+    Assertions.assertEquals(77952, rehydrated.sizeInBytes());
   }
 
   @Test
@@ -498,10 +498,10 @@ public class BloomKFilterTest
     BloomKFilter bfMerged = BloomKFilter.deserialize(bytesIn);
     // All values should pass test
     for (String val : inputs1) {
-      Assert.assertTrue(bfMerged.testString(val));
+      Assertions.assertTrue(bfMerged.testString(val));
     }
     for (String val : inputs2) {
-      Assert.assertTrue(bfMerged.testString(val));
+      Assertions.assertTrue(bfMerged.testString(val));
     }
   }
 
@@ -529,10 +529,10 @@ public class BloomKFilterTest
     ByteBuffer bufWithNull = ByteBuffer.wrap(bytesOut.toByteArray());
 
 
-    Assert.assertTrue(BloomKFilter.getNumSetBits(bufWithValues, 0) > 0);
-    Assert.assertFalse(BloomKFilter.getNumSetBits(bufEmpty, 0) > 0);
-    Assert.assertTrue(BloomKFilter.getNumSetBits(bufWithNull, 0) > 0);
-    Assert.assertTrue(
+    Assertions.assertTrue(BloomKFilter.getNumSetBits(bufWithValues, 0) > 0);
+    Assertions.assertFalse(BloomKFilter.getNumSetBits(bufEmpty, 0) > 0);
+    Assertions.assertTrue(BloomKFilter.getNumSetBits(bufWithNull, 0) > 0);
+    Assertions.assertTrue(
         BloomKFilter.getNumSetBits(bufWithValues, 0) > BloomKFilter.getNumSetBits(bufWithNull, 0)
     );
   }

--- a/extensions-core/druid-kerberos/pom.xml
+++ b/extensions-core/druid-kerberos/pom.xml
@@ -382,8 +382,13 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
+++ b/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosAuthenticatorTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.security.kerberos;
 
 import org.apache.druid.error.DruidException;
 import org.apache.druid.server.DruidNode;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class KerberosAuthenticatorTest
 {
@@ -44,7 +44,7 @@ public class KerberosAuthenticatorTest
   {
     DruidNode node = createTestNode();
 
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> new KerberosAuthenticator(
             TEST_SERVER_PRINCIPAL,
@@ -57,15 +57,15 @@ public class KerberosAuthenticatorTest
         )
     );
 
-    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
-    Assert.assertTrue(
-        "Exception message should mention cookieSignatureSecret",
-        exception.getMessage().contains("cookieSignatureSecret")
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertTrue(
+        exception.getMessage().contains("cookieSignatureSecret"),
+        "Exception message should mention cookieSignatureSecret"
     );
-    Assert.assertTrue(
-        "Exception message should mention 'is not set'",
-        exception.getMessage().contains("is not set")
+    Assertions.assertTrue(
+        exception.getMessage().contains("is not set"),
+        "Exception message should mention 'is not set'"
     );
   }
 
@@ -74,7 +74,7 @@ public class KerberosAuthenticatorTest
   {
     DruidNode node = createTestNode();
 
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> new KerberosAuthenticator(
             TEST_SERVER_PRINCIPAL,
@@ -87,15 +87,15 @@ public class KerberosAuthenticatorTest
         )
     );
 
-    Assert.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
-    Assert.assertTrue(
-        "Exception message should mention cookieSignatureSecret",
-        exception.getMessage().contains("cookieSignatureSecret")
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertTrue(
+        exception.getMessage().contains("cookieSignatureSecret"),
+        "Exception message should mention cookieSignatureSecret"
     );
-    Assert.assertTrue(
-        "Exception message should mention 'is not set'",
-        exception.getMessage().contains("is not set")
+    Assertions.assertTrue(
+        exception.getMessage().contains("is not set"),
+        "Exception message should mention 'is not set'"
     );
   }
 }

--- a/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosUtilTest.java
+++ b/extensions-core/druid-kerberos/src/test/java/org/apache/druid/security/kerberos/KerberosUtilTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.security.kerberos;
 
 import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.CookieManager;
 import java.net.CookieStore;
@@ -42,12 +42,12 @@ public class KerberosUtilTest
     cookieStore.add(new URI("http://test1.druid.apache.com/abc/def"), cookie1);
 
     // mismatch domain name
-    Assert.assertNull(DruidKerberosUtil.getAuthCookie(cookieStore, new URI("https://test2.druid.apache.com/def")));
+    Assertions.assertNull(DruidKerberosUtil.getAuthCookie(cookieStore, new URI("https://test2.druid.apache.com/def")));
 
     // cookie is secure and the url is unsecure
-    Assert.assertNull(DruidKerberosUtil.getAuthCookie(cookieStore, new URI("http://test1.druid.apache.com/def")));
+    Assertions.assertNull(DruidKerberosUtil.getAuthCookie(cookieStore, new URI("http://test1.druid.apache.com/def")));
 
-    Assert.assertEquals(cookie1, DruidKerberosUtil.getAuthCookie(cookieStore, new URI("https://test1.druid.apache.com/def")));
+    Assertions.assertEquals(cookie1, DruidKerberosUtil.getAuthCookie(cookieStore, new URI("https://test1.druid.apache.com/def")));
 
 
   }

--- a/extensions-core/druid-pac4j/pom.xml
+++ b/extensions-core/druid-pac4j/pom.xml
@@ -143,8 +143,13 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -155,6 +160,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/JwtAuthenticatorTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/JwtAuthenticatorTest.java
@@ -28,8 +28,8 @@ import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import org.apache.druid.server.security.AuthConfig;
 import org.apache.druid.server.security.AuthenticationResult;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.pac4j.oidc.profile.creator.TokenValidator;
 
 import javax.servlet.FilterChain;
@@ -70,9 +70,9 @@ public class JwtAuthenticatorTest
     authFilter.doFilter(req, resp, filterChain);
 
     EasyMock.verify(req, resp, filterChain);
-    Assert.assertEquals(jwtAuthenticator.getFilterClass(), JwtAuthFilter.class);
-    Assert.assertNull(jwtAuthenticator.getInitParameters());
-    Assert.assertNull(jwtAuthenticator.authenticateJDBCContext(ImmutableMap.of()));
+    Assertions.assertEquals(jwtAuthenticator.getFilterClass(), JwtAuthFilter.class);
+    Assertions.assertNull(jwtAuthenticator.getInitParameters());
+    Assertions.assertNull(jwtAuthenticator.authenticateJDBCContext(ImmutableMap.of()));
   }
 
   @Test
@@ -137,9 +137,9 @@ public class JwtAuthenticatorTest
     authFilter.doFilter(req, resp, filterChain);
 
     EasyMock.verify(req, resp, filterChain);
-    Assert.assertEquals(jwtAuthenticator.getFilterClass(), JwtAuthFilter.class);
-    Assert.assertNull(jwtAuthenticator.getInitParameters());
-    Assert.assertNull(jwtAuthenticator.authenticateJDBCContext(ImmutableMap.of()));
+    Assertions.assertEquals(jwtAuthenticator.getFilterClass(), JwtAuthFilter.class);
+    Assertions.assertNull(jwtAuthenticator.getInitParameters());
+    Assertions.assertNull(jwtAuthenticator.authenticateJDBCContext(ImmutableMap.of()));
   }
 
   @Test
@@ -179,8 +179,8 @@ public class JwtAuthenticatorTest
     authFilter.doFilter(req, resp, filterChain);
 
     EasyMock.verify(req, resp, filterChain);
-    Assert.assertEquals(jwtAuthenticator.getFilterClass(), JwtAuthFilter.class);
-    Assert.assertNull(jwtAuthenticator.getInitParameters());
-    Assert.assertNull(jwtAuthenticator.authenticateJDBCContext(ImmutableMap.of()));
+    Assertions.assertEquals(jwtAuthenticator.getFilterClass(), JwtAuthFilter.class);
+    Assertions.assertNull(jwtAuthenticator.getInitParameters());
+    Assertions.assertNull(jwtAuthenticator.authenticateJDBCContext(ImmutableMap.of()));
   }
 }

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/OIDCConfigTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/OIDCConfigTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.security.pac4j;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class OIDCConfigTest
 {
@@ -41,12 +41,12 @@ public class OIDCConfigTest
         jsonMapper.writeValueAsString(jsonMapper.readValue(jsonStr, OIDCConfig.class)),
         OIDCConfig.class
     );
-    Assert.assertEquals("testid", conf.getClientID());
-    Assert.assertEquals("testsecret", conf.getClientSecret().getPassword());
-    Assert.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
-    Assert.assertEquals("name", conf.getOidcClaim());
-    Assert.assertEquals("testscope", conf.getScope());
-    Assert.assertNull(conf.getClientAuthenticationMethod());
+    Assertions.assertEquals("testid", conf.getClientID());
+    Assertions.assertEquals("testsecret", conf.getClientSecret().getPassword());
+    Assertions.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
+    Assertions.assertEquals("name", conf.getOidcClaim());
+    Assertions.assertEquals("testscope", conf.getScope());
+    Assertions.assertNull(conf.getClientAuthenticationMethod());
   }
 
   @Test
@@ -67,11 +67,11 @@ public class OIDCConfigTest
         OIDCConfig.class
     );
 
-    Assert.assertEquals("testid", conf.getClientID());
-    Assert.assertEquals("testsecret", conf.getClientSecret().getPassword());
-    Assert.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
-    Assert.assertEquals("email", conf.getOidcClaim());
-    Assert.assertEquals("testscope", conf.getScope());
+    Assertions.assertEquals("testid", conf.getClientID());
+    Assertions.assertEquals("testsecret", conf.getClientSecret().getPassword());
+    Assertions.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
+    Assertions.assertEquals("email", conf.getOidcClaim());
+    Assertions.assertEquals("testscope", conf.getScope());
   }
 
   @Test
@@ -93,11 +93,11 @@ public class OIDCConfigTest
         OIDCConfig.class
     );
 
-    Assert.assertEquals("testid", conf.getClientID());
-    Assert.assertEquals("testsecret", conf.getClientSecret().getPassword());
-    Assert.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
-    Assert.assertEquals("email", conf.getOidcClaim());
-    Assert.assertEquals("testscope", conf.getScope());
-    Assert.assertEquals("client_secret_post", conf.getClientAuthenticationMethod());
+    Assertions.assertEquals("testid", conf.getClientID());
+    Assertions.assertEquals("testsecret", conf.getClientSecret().getPassword());
+    Assertions.assertEquals("testdiscoveryuri", conf.getDiscoveryURI());
+    Assertions.assertEquals("email", conf.getOidcClaim());
+    Assertions.assertEquals("testscope", conf.getScope());
+    Assertions.assertEquals("client_secret_post", conf.getClientAuthenticationMethod());
   }
 }

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jCommonConfigTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jCommonConfigTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.security.pac4j;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class Pac4jCommonConfigTest
 {
@@ -42,8 +42,8 @@ public class Pac4jCommonConfigTest
         Pac4jCommonConfig.class
     );
 
-    Assert.assertEquals("testpass", conf.getCookiePassphrase().getPassword());
-    Assert.assertEquals(10_000L, conf.getReadTimeout().getMillis());
-    Assert.assertTrue(conf.isEnableCustomSslContext());
+    Assertions.assertEquals("testpass", conf.getCookiePassphrase().getPassword());
+    Assertions.assertEquals(10_000L, conf.getReadTimeout().getMillis());
+    Assertions.assertTrue(conf.isEnableCustomSslContext());
   }
 }

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jFilterTest.java
@@ -19,13 +19,13 @@
 
 package org.apache.druid.security.pac4j;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.pac4j.core.config.Config;
 import org.pac4j.core.exception.http.ForbiddenAction;
 import org.pac4j.core.exception.http.FoundAction;
@@ -43,8 +43,9 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class Pac4jFilterTest
 {
   private static final String DRUID_AUTHENTICATION_RESULT = "Druid-Authentication-Result";
@@ -65,11 +66,11 @@ public class Pac4jFilterTest
   private JEEContext context;
   private Pac4jFilter pac4jFilter;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     // Mock the PrintWriter for the response
-    Mockito.when(response.getWriter()).thenReturn(printWriter);
+    lenient().when(response.getWriter()).thenReturn(printWriter);
     context = new JEEContext(request, response);
     pac4jFilter = new Pac4jFilter("test", "testAuthorizer", pac4jConfig, "/callback", "testPassphrase");
   }
@@ -175,8 +176,8 @@ public class Pac4jFilterTest
     Mockito.doReturn(httpAction.getCode()).when(response).getStatus();
     Mockito.doReturn(((WithLocationAction) httpAction).getLocation()).when(response).getHeader(any());
     JEEHttpActionAdapter.INSTANCE.adapt(httpAction, context);
-    Assert.assertEquals(response.getStatus(), 302);
-    Assert.assertEquals(response.getHeader("Location"), "testUrl");
+    Assertions.assertEquals(response.getStatus(), 302);
+    Assertions.assertEquals(response.getHeader("Location"), "testUrl");
   }
 
   @Test
@@ -185,7 +186,7 @@ public class Pac4jFilterTest
     HttpAction httpAction = ForbiddenAction.INSTANCE;
     Mockito.doReturn(httpAction.getCode()).when(response).getStatus();
     JEEHttpActionAdapter.INSTANCE.adapt(httpAction, context);
-    Assert.assertEquals(response.getStatus(), HttpServletResponse.SC_FORBIDDEN);
+    Assertions.assertEquals(response.getStatus(), HttpServletResponse.SC_FORBIDDEN);
   }
 
   @Test
@@ -193,7 +194,6 @@ public class Pac4jFilterTest
   {
     // Test that filter can be created without exceptions
     Pac4jFilter filter = new Pac4jFilter("testName", "testAuthorizer", pac4jConfig, "/test-callback", "testPassphrase");
-    Assert.assertNotNull(filter);
+    Assertions.assertNotNull(filter);
   }
 }
-

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jSessionStoreTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jSessionStoreTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.security.pac4j;
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.pac4j.core.context.Cookie;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.profile.CommonProfile;
@@ -53,9 +53,9 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext1, "key", "value");
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure());
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(900, cookie.getMaxAge());
+    Assertions.assertTrue(cookie.isSecure());
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(900, cookie.getMaxAge());
 
     // For the get test, we need to mock the context to return the cookie
     WebContext webContext2 = EasyMock.mock(WebContext.class);
@@ -63,7 +63,7 @@ public class Pac4jSessionStoreTest
     EasyMock.expect(webContext2.getRequestCookies()).andReturn(Collections.singletonList(cookie));
     EasyMock.replay(webContext2);
 
-    Assert.assertEquals("value", Objects.requireNonNull(sessionStore.get(webContext2, "key")).orElse(null));
+    Assertions.assertEquals("value", Objects.requireNonNull(sessionStore.get(webContext2, "key")).orElse(null));
     EasyMock.verify(webContext2);
   }
 
@@ -82,9 +82,9 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext1, "key", "value");
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure()); // Should still be secure due to our fix
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(900, cookie.getMaxAge());
+    Assertions.assertTrue(cookie.isSecure()); // Should still be secure due to our fix
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(900, cookie.getMaxAge());
 
     EasyMock.verify(webContext1);
   }
@@ -104,10 +104,10 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext, "key", null);
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure());
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(0, cookie.getMaxAge()); // Should be 0 for null values
-    Assert.assertEquals("", cookie.getValue());
+    Assertions.assertTrue(cookie.isSecure());
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(0, cookie.getMaxAge()); // Should be 0 for null values
+    Assertions.assertEquals("", cookie.getValue());
 
     EasyMock.verify(webContext);
   }
@@ -127,10 +127,10 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext, "key", "");
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure());
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(0, cookie.getMaxAge()); // Should be 0 for empty string
-    Assert.assertEquals("", cookie.getValue());
+    Assertions.assertTrue(cookie.isSecure());
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(0, cookie.getMaxAge()); // Should be 0 for empty string
+    Assertions.assertEquals("", cookie.getValue());
 
     EasyMock.verify(webContext);
   }
@@ -150,10 +150,10 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext, "key", Collections.emptyMap());
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure());
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(0, cookie.getMaxAge()); // Should be 0 for empty map
-    Assert.assertEquals("", cookie.getValue());
+    Assertions.assertTrue(cookie.isSecure());
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(0, cookie.getMaxAge()); // Should be 0 for empty map
+    Assertions.assertEquals("", cookie.getValue());
 
     EasyMock.verify(webContext);
   }
@@ -168,7 +168,7 @@ public class Pac4jSessionStoreTest
     EasyMock.replay(webContext);
 
     Optional<Object> result = sessionStore.get(webContext, "key");
-    Assert.assertFalse(result.isPresent());
+    Assertions.assertFalse(result.isPresent());
 
     EasyMock.verify(webContext);
   }
@@ -183,7 +183,7 @@ public class Pac4jSessionStoreTest
     EasyMock.replay(webContext);
 
     Optional<Object> result = sessionStore.get(webContext, "key");
-    Assert.assertFalse(result.isPresent());
+    Assertions.assertFalse(result.isPresent());
 
     EasyMock.verify(webContext);
   }
@@ -213,24 +213,24 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext1, Pac4jConstants.USER_PROFILES, profile);
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure());
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(900, cookie.getMaxAge());
+    Assertions.assertTrue(cookie.isSecure());
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(900, cookie.getMaxAge());
 
     WebContext webContext2 = EasyMock.mock(WebContext.class);
     EasyMock.expect(webContext2.getRequestCookies()).andReturn(Collections.singletonList(cookie));
     EasyMock.replay(webContext2);
 
     Optional<Object> value = sessionStore.get(webContext2, Pac4jConstants.USER_PROFILES);
-    Assert.assertTrue(Objects.requireNonNull(value).isPresent());
+    Assertions.assertTrue(Objects.requireNonNull(value).isPresent());
     CommonProfile retrievedProfile = (CommonProfile) value.get();
-    Assert.assertEquals("name", retrievedProfile.getAttribute("display_name"));
+    Assertions.assertEquals("name", retrievedProfile.getAttribute("display_name"));
     
     // Verify sensitive data was removed
-    Assert.assertNull(retrievedProfile.getAttribute("access_token"));
-    Assert.assertNull(retrievedProfile.getAttribute("refresh_token"));
-    Assert.assertNull(retrievedProfile.getAttribute("id_token"));
-    Assert.assertNull(retrievedProfile.getAttribute("credentials"));
+    Assertions.assertNull(retrievedProfile.getAttribute("access_token"));
+    Assertions.assertNull(retrievedProfile.getAttribute("refresh_token"));
+    Assertions.assertNull(retrievedProfile.getAttribute("id_token"));
+    Assertions.assertNull(retrievedProfile.getAttribute("credentials"));
     
     EasyMock.verify(webContext2);
   }
@@ -264,23 +264,23 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext1, Pac4jConstants.USER_PROFILES, profiles);
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure());
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(900, cookie.getMaxAge());
+    Assertions.assertTrue(cookie.isSecure());
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(900, cookie.getMaxAge());
 
     WebContext webContext2 = EasyMock.mock(WebContext.class);
     EasyMock.expect(webContext2.getRequestCookies()).andReturn(Collections.singletonList(cookie));
     EasyMock.replay(webContext2);
 
     Optional<Object> value = sessionStore.get(webContext2, Pac4jConstants.USER_PROFILES);
-    Assert.assertTrue(Objects.requireNonNull(value).isPresent());
+    Assertions.assertTrue(Objects.requireNonNull(value).isPresent());
     @SuppressWarnings("unchecked")
     Map<String, CommonProfile> retrievedProfiles = (Map<String, CommonProfile>) value.get();
-    Assert.assertEquals(2, retrievedProfiles.size());
+    Assertions.assertEquals(2, retrievedProfiles.size());
     
     // Verify sensitive data was removed from both profiles
-    Assert.assertNull(retrievedProfiles.get("profile1").getAttribute("access_token"));
-    Assert.assertNull(retrievedProfiles.get("profile2").getAttribute("refresh_token"));
+    Assertions.assertNull(retrievedProfiles.get("profile1").getAttribute("access_token"));
+    Assertions.assertNull(retrievedProfiles.get("profile2").getAttribute("refresh_token"));
     
     EasyMock.verify(webContext2);
   }
@@ -293,11 +293,11 @@ public class Pac4jSessionStoreTest
     EasyMock.replay(webContext);
 
     // Test methods that return empty/false for non-JEE contexts
-    Assert.assertFalse(sessionStore.getSessionId(webContext, true).isPresent());
-    Assert.assertFalse(sessionStore.destroySession(webContext));
-    Assert.assertFalse(sessionStore.getTrackableSession(webContext).isPresent());
-    Assert.assertFalse(sessionStore.buildFromTrackableSession(webContext, "test").isPresent());
-    Assert.assertFalse(sessionStore.renewSession(webContext));
+    Assertions.assertFalse(sessionStore.getSessionId(webContext, true).isPresent());
+    Assertions.assertFalse(sessionStore.destroySession(webContext));
+    Assertions.assertFalse(sessionStore.getTrackableSession(webContext).isPresent());
+    Assertions.assertFalse(sessionStore.buildFromTrackableSession(webContext, "test").isPresent());
+    Assertions.assertFalse(sessionStore.renewSession(webContext));
 
     EasyMock.verify(webContext);
   }
@@ -329,12 +329,12 @@ public class Pac4jSessionStoreTest
 
     // Verify that trying to decrypt the invalid cookie throws an exception
     final Pac4jSessionStore sessionStore = new Pac4jSessionStore(COOKIE_PASSPHRASE);
-    RuntimeException exception = Assert.assertThrows(
+    RuntimeException exception = Assertions.assertThrows(
         RuntimeException.class,
         () -> sessionStore.get(getContext, "key")
     );
-    Assert.assertTrue(exception.getMessage().contains("Decryption failed"));
-    Assert.assertNotNull(exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("Decryption failed"));
+    Assertions.assertNotNull(exception.getCause());
 
     EasyMock.verify(getContext);
   }
@@ -360,9 +360,9 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext, "key", largeData.toString());
 
     Cookie cookie = cookieCapture.getValue();
-    Assert.assertTrue(cookie.isSecure());
-    Assert.assertTrue(cookie.isHttpOnly());
-    Assert.assertEquals(900, cookie.getMaxAge());
+    Assertions.assertTrue(cookie.isSecure());
+    Assertions.assertTrue(cookie.isHttpOnly());
+    Assertions.assertEquals(900, cookie.getMaxAge());
 
     EasyMock.verify(webContext);
   }

--- a/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jSessionStoreTest.java
+++ b/extensions-core/druid-pac4j/src/test/java/org/apache/druid/security/pac4j/Pac4jSessionStoreTest.java
@@ -82,7 +82,7 @@ public class Pac4jSessionStoreTest
     sessionStore.set(webContext1, "key", "value");
 
     Cookie cookie = cookieCapture.getValue();
-    Assertions.assertTrue(cookie.isSecure()); // Should still be secure due to our fix
+    Assertions.assertTrue(cookie.isSecure());
     Assertions.assertTrue(cookie.isHttpOnly());
     Assertions.assertEquals(900, cookie.getMaxAge());
 
@@ -106,7 +106,7 @@ public class Pac4jSessionStoreTest
     Cookie cookie = cookieCapture.getValue();
     Assertions.assertTrue(cookie.isSecure());
     Assertions.assertTrue(cookie.isHttpOnly());
-    Assertions.assertEquals(0, cookie.getMaxAge()); // Should be 0 for null values
+    Assertions.assertEquals(0, cookie.getMaxAge());
     Assertions.assertEquals("", cookie.getValue());
 
     EasyMock.verify(webContext);
@@ -129,7 +129,7 @@ public class Pac4jSessionStoreTest
     Cookie cookie = cookieCapture.getValue();
     Assertions.assertTrue(cookie.isSecure());
     Assertions.assertTrue(cookie.isHttpOnly());
-    Assertions.assertEquals(0, cookie.getMaxAge()); // Should be 0 for empty string
+    Assertions.assertEquals(0, cookie.getMaxAge());
     Assertions.assertEquals("", cookie.getValue());
 
     EasyMock.verify(webContext);
@@ -152,7 +152,7 @@ public class Pac4jSessionStoreTest
     Cookie cookie = cookieCapture.getValue();
     Assertions.assertTrue(cookie.isSecure());
     Assertions.assertTrue(cookie.isHttpOnly());
-    Assertions.assertEquals(0, cookie.getMaxAge()); // Should be 0 for empty map
+    Assertions.assertEquals(0, cookie.getMaxAge());
     Assertions.assertEquals("", cookie.getValue());
 
     EasyMock.verify(webContext);
@@ -367,4 +367,3 @@ public class Pac4jSessionStoreTest
     EasyMock.verify(webContext);
   }
 }
-

--- a/extensions-core/ec2-extensions/pom.xml
+++ b/extensions-core/ec2-extensions/pom.xml
@@ -86,8 +86,13 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerSerdeTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerSerdeTest.java
@@ -27,8 +27,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexing.overlord.autoscaling.AutoScaler;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -60,22 +60,22 @@ public class EC2AutoScalerSerdeTest
 
   private static void verifyAutoScaler(final EC2AutoScaler autoScaler)
   {
-    Assert.assertEquals(3, autoScaler.getMaxNumWorkers());
-    Assert.assertEquals(2, autoScaler.getMinNumWorkers());
-    Assert.assertEquals("westeros-east-1a", autoScaler.getEnvConfig().getAvailabilityZone());
+    Assertions.assertEquals(3, autoScaler.getMaxNumWorkers());
+    Assertions.assertEquals(2, autoScaler.getMinNumWorkers());
+    Assertions.assertEquals("westeros-east-1a", autoScaler.getEnvConfig().getAvailabilityZone());
 
     // nodeData
-    Assert.assertEquals("ami-abc", autoScaler.getEnvConfig().getNodeData().getAmiId());
-    Assert.assertEquals("t1.micro", autoScaler.getEnvConfig().getNodeData().getInstanceType());
-    Assert.assertEquals("iron", autoScaler.getEnvConfig().getNodeData().getKeyName());
-    Assert.assertEquals(1, autoScaler.getEnvConfig().getNodeData().getMaxInstances());
-    Assert.assertEquals(1, autoScaler.getEnvConfig().getNodeData().getMinInstances());
-    Assert.assertEquals(
+    Assertions.assertEquals("ami-abc", autoScaler.getEnvConfig().getNodeData().getAmiId());
+    Assertions.assertEquals("t1.micro", autoScaler.getEnvConfig().getNodeData().getInstanceType());
+    Assertions.assertEquals("iron", autoScaler.getEnvConfig().getNodeData().getKeyName());
+    Assertions.assertEquals(1, autoScaler.getEnvConfig().getNodeData().getMaxInstances());
+    Assertions.assertEquals(1, autoScaler.getEnvConfig().getNodeData().getMinInstances());
+    Assertions.assertEquals(
         Collections.singletonList("kingsguard"),
         autoScaler.getEnvConfig().getNodeData().getSecurityGroupIds()
     );
-    Assert.assertEquals("redkeep", autoScaler.getEnvConfig().getNodeData().getSubnetId());
-    Assert.assertEquals(
+    Assertions.assertEquals("redkeep", autoScaler.getEnvConfig().getNodeData().getSubnetId());
+    Assertions.assertEquals(
         "foo",
         autoScaler.getEnvConfig()
                   .getNodeData()
@@ -83,7 +83,7 @@ public class EC2AutoScalerSerdeTest
                   .toIamInstanceProfileSpecification()
                   .name()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "bar",
         autoScaler.getEnvConfig()
                   .getNodeData()
@@ -93,7 +93,7 @@ public class EC2AutoScalerSerdeTest
     );
 
     // userData
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "VERSION=1234\n",
         StringUtils.fromUtf8(
             StringUtils
@@ -132,6 +132,6 @@ public class EC2AutoScalerSerdeTest
     );
     verifyAutoScaler(roundTripAutoScaler);
 
-    Assert.assertEquals("Round trip equals", autoScaler, roundTripAutoScaler);
+    Assertions.assertEquals(autoScaler, roundTripAutoScaler, "Round trip equals");
   }
 }

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
@@ -28,10 +28,10 @@ import org.apache.druid.indexing.overlord.autoscaling.AutoScalingData;
 import org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
@@ -65,7 +65,7 @@ public class EC2AutoScalerTest
   private Instance instance;
   private SimpleWorkerProvisioningConfig managementConfig;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     amazonEC2Client = EasyMock.createMock(Ec2Client.class);
@@ -80,7 +80,7 @@ public class EC2AutoScalerTest
     managementConfig = new SimpleWorkerProvisioningConfig().setWorkerPort(8080).setWorkerVersion("");
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(amazonEC2Client);
@@ -119,13 +119,13 @@ public class EC2AutoScalerTest
 
     AutoScalingData created = autoScaler.provision();
 
-    Assert.assertEquals(created.getNodeIds().size(), 1);
-    Assert.assertEquals("theInstance", created.getNodeIds().get(0));
+    Assertions.assertEquals(created.getNodeIds().size(), 1);
+    Assertions.assertEquals("theInstance", created.getNodeIds().get(0));
 
     AutoScalingData deleted = autoScaler.terminate(Collections.singletonList("dummyIP"));
 
-    Assert.assertEquals(deleted.getNodeIds().size(), 1);
-    Assert.assertEquals(INSTANCE_ID, deleted.getNodeIds().get(0));
+    Assertions.assertEquals(deleted.getNodeIds().size(), 1);
+    Assertions.assertEquals(INSTANCE_ID, deleted.getNodeIds().get(0));
   }
 
   @Test
@@ -140,7 +140,7 @@ public class EC2AutoScalerTest
     );
 
     final int n = 150;
-    Assert.assertTrue(n <= 2 * EC2AutoScaler.MAX_AWS_FILTER_VALUES);
+    Assertions.assertTrue(n <= 2 * EC2AutoScaler.MAX_AWS_FILTER_VALUES);
 
     List<String> ips = Lists.transform(
         ContiguousSet.create(Range.closedOpen(0, n), DiscreteDomain.integers()).asList(),
@@ -178,7 +178,7 @@ public class EC2AutoScalerTest
 
     List<String> ids = autoScaler.ipToIdLookup(ips);
 
-    Assert.assertEquals(n, ids.size());
+    Assertions.assertEquals(n, ids.size());
   }
 
   @Test
@@ -193,7 +193,7 @@ public class EC2AutoScalerTest
     );
 
     final int n = 150;
-    Assert.assertTrue(n <= 2 * EC2AutoScaler.MAX_AWS_FILTER_VALUES);
+    Assertions.assertTrue(n <= 2 * EC2AutoScaler.MAX_AWS_FILTER_VALUES);
 
     List<String> ids = Lists.transform(
         ContiguousSet.create(Range.closedOpen(0, n), DiscreteDomain.integers()).asList(),
@@ -231,6 +231,6 @@ public class EC2AutoScalerTest
 
     List<String> resultIps = autoScaler.idToIpLookup(ids);
 
-    Assert.assertEquals(n, resultIps.size());
+    Assertions.assertEquals(n, resultIps.size());
   }
 }

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
@@ -28,10 +28,10 @@ import org.apache.druid.indexing.overlord.autoscaling.AutoScalingData;
 import org.apache.druid.indexing.overlord.autoscaling.SimpleWorkerProvisioningConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesRequest;
 import software.amazon.awssdk.services.ec2.model.DescribeInstancesResponse;
@@ -65,7 +65,7 @@ public class EC2AutoScalerTest
   private Instance instance;
   private SimpleWorkerProvisioningConfig managementConfig;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     amazonEC2Client = EasyMock.createMock(Ec2Client.class);
@@ -80,7 +80,7 @@ public class EC2AutoScalerTest
     managementConfig = new SimpleWorkerProvisioningConfig().setWorkerPort(8080).setWorkerVersion("");
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     EasyMock.verify(amazonEC2Client);
@@ -119,13 +119,13 @@ public class EC2AutoScalerTest
 
     AutoScalingData created = autoScaler.provision();
 
-    Assert.assertEquals(created.getNodeIds().size(), 1);
-    Assert.assertEquals("theInstance", created.getNodeIds().get(0));
+    Assertions.assertEquals(created.getNodeIds().size(), 1);
+    Assertions.assertEquals("theInstance", created.getNodeIds().get(0));
 
     AutoScalingData deleted = autoScaler.terminate(Collections.singletonList("dummyIP"));
 
-    Assert.assertEquals(deleted.getNodeIds().size(), 1);
-    Assert.assertEquals(INSTANCE_ID, deleted.getNodeIds().get(0));
+    Assertions.assertEquals(deleted.getNodeIds().size(), 1);
+    Assertions.assertEquals(INSTANCE_ID, deleted.getNodeIds().get(0));
   }
 
   @Test
@@ -177,7 +177,7 @@ public class EC2AutoScalerTest
 
     List<String> ids = autoScaler.ipToIdLookup(ips);
 
-    Assert.assertEquals(n, ids.size());
+    Assertions.assertEquals(n, ids.size());
   }
 
   @Test
@@ -229,6 +229,6 @@ public class EC2AutoScalerTest
 
     List<String> resultIps = autoScaler.idToIpLookup(ids);
 
-    Assert.assertEquals(n, resultIps.size());
+    Assertions.assertEquals(n, resultIps.size());
   }
 }

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2AutoScalerTest.java
@@ -119,12 +119,12 @@ public class EC2AutoScalerTest
 
     AutoScalingData created = autoScaler.provision();
 
-    Assertions.assertEquals(created.getNodeIds().size(), 1);
+    Assertions.assertEquals(1, created.getNodeIds().size());
     Assertions.assertEquals("theInstance", created.getNodeIds().get(0));
 
     AutoScalingData deleted = autoScaler.terminate(Collections.singletonList("dummyIP"));
 
-    Assertions.assertEquals(deleted.getNodeIds().size(), 1);
+    Assertions.assertEquals(1, deleted.getNodeIds().size());
     Assertions.assertEquals(INSTANCE_ID, deleted.getNodeIds().get(0));
   }
 

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2NodeDataTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/ec2/EC2NodeDataTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.overlord.autoscaling.ec2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -37,23 +37,23 @@ public class EC2NodeDataTest
                         + " \"associatePublicIpAddress\" : true, \"iamProfile\" : { \"name\" : \"john\", \"arn\" : \"xxx:abc:1234/xyz\" } }";
     EC2NodeData nodeData = objectMapper.readValue(json, EC2NodeData.class);
 
-    Assert.assertEquals("abc123", nodeData.getAmiId());
-    Assert.assertEquals("k2.9xsmall", nodeData.getInstanceType());
-    Assert.assertEquals(2, nodeData.getMaxInstances());
-    Assert.assertEquals(1, nodeData.getMinInstances());
-    Assert.assertEquals(Collections.singletonList("sg-abc321"), nodeData.getSecurityGroupIds());
-    Assert.assertEquals("opensesame", nodeData.getKeyName());
-    Assert.assertEquals("darknet2", nodeData.getSubnetId());
-    Assert.assertEquals("john", nodeData.getIamProfile().getName());
-    Assert.assertEquals("xxx:abc:1234/xyz", nodeData.getIamProfile().getArn());
-    Assert.assertEquals(true, nodeData.getAssociatePublicIpAddress());
+    Assertions.assertEquals("abc123", nodeData.getAmiId());
+    Assertions.assertEquals("k2.9xsmall", nodeData.getInstanceType());
+    Assertions.assertEquals(2, nodeData.getMaxInstances());
+    Assertions.assertEquals(1, nodeData.getMinInstances());
+    Assertions.assertEquals(Collections.singletonList("sg-abc321"), nodeData.getSecurityGroupIds());
+    Assertions.assertEquals("opensesame", nodeData.getKeyName());
+    Assertions.assertEquals("darknet2", nodeData.getSubnetId());
+    Assertions.assertEquals("john", nodeData.getIamProfile().getName());
+    Assertions.assertEquals("xxx:abc:1234/xyz", nodeData.getIamProfile().getArn());
+    Assertions.assertEquals(true, nodeData.getAssociatePublicIpAddress());
 
     EC2NodeData nodeData2 = objectMapper.readValue("{}", EC2NodeData.class);
     // default is not always false, null has to be a valid value
-    Assert.assertNull(nodeData2.getAssociatePublicIpAddress());
+    Assertions.assertNull(nodeData2.getAssociatePublicIpAddress());
 
     // round trip
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nodeData,
         objectMapper.readValue(
             objectMapper.writeValueAsBytes(nodeData),

--- a/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
+++ b/extensions-core/ec2-extensions/src/test/java/org/apache/druid/indexing/overlord/setup/WorkerBehaviorConfigTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.indexing.overlord.autoscaling.ec2.EC2EnvironmentConfig;
 import org.apache.druid.indexing.overlord.autoscaling.ec2.EC2NodeData;
 import org.apache.druid.indexing.overlord.autoscaling.ec2.StringEC2UserData;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -92,6 +92,6 @@ public class WorkerBehaviorConfigTest
           }
         }
     );
-    Assert.assertEquals(config, mapper.readValue(mapper.writeValueAsBytes(config), DefaultWorkerBehaviorConfig.class));
+    Assertions.assertEquals(config, mapper.readValue(mapper.writeValueAsBytes(config), DefaultWorkerBehaviorConfig.class));
   }
 }

--- a/extensions-core/kafka-extraction-namespace/pom.xml
+++ b/extensions-core/kafka-extraction-namespace/pom.xml
@@ -110,8 +110,13 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/KafkaLookupExtractorFactoryTest.java
@@ -34,9 +34,9 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -53,7 +53,7 @@ public class KafkaLookupExtractorFactoryTest
   private final ObjectMapper mapper = new DefaultObjectMapper();
   private final NamespaceExtractionCacheManager cacheManager = MockNamespaceExtractionCacheManager.createMockNamespaceExtractionCacheManager();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(new InjectableValues()
@@ -84,12 +84,12 @@ public class KafkaLookupExtractorFactoryTest
         KafkaLookupExtractorFactory.class
     );
     result.awaitInitialization();
-    Assert.assertEquals(expected.getKafkaTopic(), result.getKafkaTopic());
-    Assert.assertEquals(expected.getKafkaProperties(), result.getKafkaProperties());
-    Assert.assertEquals(cacheManager, result.getCacheManager());
-    Assert.assertEquals(0, expected.getCompletedEventCount());
-    Assert.assertEquals(0, result.getCompletedEventCount());
-    Assert.assertTrue(result.isInitialized());
+    Assertions.assertEquals(expected.getKafkaTopic(), result.getKafkaTopic());
+    Assertions.assertEquals(expected.getKafkaProperties(), result.getKafkaProperties());
+    Assertions.assertEquals(cacheManager, result.getCacheManager());
+    Assertions.assertEquals(0, expected.getCompletedEventCount());
+    Assertions.assertEquals(0, result.getCompletedEventCount());
+    Assertions.assertTrue(result.isInitialized());
   }
 
   @Test
@@ -109,11 +109,11 @@ public class KafkaLookupExtractorFactoryTest
     final Set<List<Byte>> byteArrays = Sets.newHashSetWithExpectedSize(n);
     for (int i = 0; i < n; ++i) {
       final List<Byte> myKey = Bytes.asList(extractor.getCacheKey());
-      Assert.assertFalse(byteArrays.contains(myKey));
+      Assertions.assertFalse(byteArrays.contains(myKey));
       byteArrays.add(myKey);
       events.incrementAndGet();
     }
-    Assert.assertEquals(n, byteArrays.size());
+    Assertions.assertEquals(n, byteArrays.size());
   }
 
   @Test
@@ -132,11 +132,11 @@ public class KafkaLookupExtractorFactoryTest
     for (int i = 0; i < n; ++i) {
       final LookupExtractor extractor = factory.get();
       final List<Byte> myKey = Bytes.asList(extractor.getCacheKey());
-      Assert.assertFalse(byteArrays.contains(myKey));
+      Assertions.assertFalse(byteArrays.contains(myKey));
       byteArrays.add(myKey);
       events.incrementAndGet();
     }
-    Assert.assertEquals(n, byteArrays.size());
+    Assertions.assertEquals(n, byteArrays.size());
   }
 
   @Test
@@ -154,7 +154,7 @@ public class KafkaLookupExtractorFactoryTest
 
     final byte[] baseKey = extractor.getCacheKey();
     for (int i = 0; i < n; ++i) {
-      Assert.assertArrayEquals(baseKey, factory.get().getCacheKey());
+      Assertions.assertArrayEquals(baseKey, factory.get().getCacheKey());
     }
   }
 
@@ -175,7 +175,7 @@ public class KafkaLookupExtractorFactoryTest
     );
     factory2.getMapRef().set(ImmutableMap.of());
 
-    Assert.assertFalse(Arrays.equals(factory1.get().getCacheKey(), factory2.get().getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(factory1.get().getCacheKey(), factory2.get().getCacheKey()));
   }
 
   @Test
@@ -187,36 +187,36 @@ public class KafkaLookupExtractorFactoryTest
         DEFAULT_PROPERTIES
     );
 
-    Assert.assertTrue(factory.replaces(null));
+    Assertions.assertTrue(factory.replaces(null));
 
-    Assert.assertTrue(factory.replaces(new MapLookupExtractorFactory(ImmutableMap.of(), false)));
-    Assert.assertFalse(factory.replaces(factory));
-    Assert.assertFalse(factory.replaces(new KafkaLookupExtractorFactory(
+    Assertions.assertTrue(factory.replaces(new MapLookupExtractorFactory(ImmutableMap.of(), false)));
+    Assertions.assertFalse(factory.replaces(factory));
+    Assertions.assertFalse(factory.replaces(new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
         DEFAULT_PROPERTIES
     )));
 
     //noinspection StringConcatenationMissingWhitespace
-    Assert.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
+    Assertions.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC + "b",
         DEFAULT_PROPERTIES
     )));
 
-    Assert.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
+    Assertions.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
         ImmutableMap.of("some.property", "some.other.value")
     )));
 
-    Assert.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
+    Assertions.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
         ImmutableMap.of("some.other.property", "some.value")
     )));
 
-    Assert.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
+    Assertions.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
         DEFAULT_PROPERTIES,
@@ -224,7 +224,7 @@ public class KafkaLookupExtractorFactoryTest
         false
     )));
 
-    Assert.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
+    Assertions.assertTrue(factory.replaces(new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
         DEFAULT_PROPERTIES,
@@ -241,7 +241,7 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         DEFAULT_PROPERTIES
     );
-    Assert.assertTrue(factory.close());
+    Assertions.assertTrue(factory.close());
   }
 
   @Test
@@ -265,9 +265,9 @@ public class KafkaLookupExtractorFactoryTest
       }
     };
 
-    Assert.assertTrue(factory.start());
-    Assert.assertTrue(factory.close());
-    Assert.assertTrue(factory.getFuture().isDone());
+    Assertions.assertTrue(factory.start());
+    Assertions.assertTrue(factory.close());
+    Assertions.assertTrue(factory.getFuture().isDone());
     EasyMock.verify(cacheManager);
   }
 
@@ -297,9 +297,9 @@ public class KafkaLookupExtractorFactoryTest
         throw new RuntimeException("shouldn't make it here");
       }
     };
-    Assert.assertFalse(factory.start());
-    Assert.assertTrue(factory.getFuture().isDone());
-    Assert.assertTrue(factory.getFuture().isCancelled());
+    Assertions.assertFalse(factory.start());
+    Assertions.assertTrue(factory.getFuture().isDone());
+    Assertions.assertTrue(factory.getFuture().isCancelled());
     EasyMock.verify(cacheManager);
   }
 
@@ -320,9 +320,9 @@ public class KafkaLookupExtractorFactoryTest
         return kafkaConsumer;
       }
     };
-    Assert.assertTrue(factory.start());
-    Assert.assertTrue(factory.close());
-    Assert.assertFalse(factory.start());
+    Assertions.assertTrue(factory.start());
+    Assertions.assertTrue(factory.close());
+    Assertions.assertFalse(factory.start());
     EasyMock.verify(cacheManager);
   }
 
@@ -345,10 +345,10 @@ public class KafkaLookupExtractorFactoryTest
         return kafkaConsumer;
       }
     };
-    Assert.assertTrue(factory.start());
-    Assert.assertTrue(factory.start());
-    Assert.assertTrue(factory.close());
-    Assert.assertTrue(factory.close());
+    Assertions.assertTrue(factory.start());
+    Assertions.assertTrue(factory.start());
+    Assertions.assertTrue(factory.close());
+    Assertions.assertTrue(factory.close());
     EasyMock.verify(cacheManager);
   }
 
@@ -360,12 +360,12 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         ImmutableMap.of()
     );
-    Assert.assertThrows(
-        "bootstrap.servers required property",
+    Assertions.assertThrows(
         NullPointerException.class,
-        () -> factory.start()
+        () -> factory.start(),
+        "bootstrap.servers required property"
     );
-    Assert.assertTrue(factory.close());
+    Assertions.assertTrue(factory.close());
   }
 
   @Test
@@ -376,12 +376,12 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         ImmutableMap.of("group.id", "make me fail")
     );
-    Assert.assertThrows(
-        "Cannot set kafka property [group.id]. Property is randomly generated for you. Found",
+    Assertions.assertThrows(
         IAE.class,
-        () -> factory.start()
+        () -> factory.start(),
+        "Cannot set kafka property [group.id]. Property is randomly generated for you. Found"
     );
-    Assert.assertTrue(factory.close());
+    Assertions.assertTrue(factory.close());
   }
 
   @Test
@@ -392,12 +392,12 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         ImmutableMap.of("auto.offset.reset", "make me fail")
     );
-    Assert.assertThrows(
-        "Cannot set kafka property [auto.offset.reset]. Property will be forced to [smallest]. Found ",
+    Assertions.assertThrows(
         IAE.class,
-        () -> factory.start()
+        () -> factory.start(),
+        "Cannot set kafka property [auto.offset.reset]. Property will be forced to [smallest]. Found "
     );
-    Assert.assertTrue(factory.close());
+    Assertions.assertTrue(factory.close());
   }
 
   @Test
@@ -408,22 +408,22 @@ public class KafkaLookupExtractorFactoryTest
         TOPIC,
         ImmutableMap.of("enable.auto.commit", "true")
     );
-    Assert.assertThrows(
-        "Cannot set kafka property [enable.auto.commit]. Property will be forced to [false]. Found [true]",
+    Assertions.assertThrows(
         IAE.class,
-        () -> factory.start()
+        () -> factory.start(),
+        "Cannot set kafka property [enable.auto.commit]. Property will be forced to [false]. Found [true]"
     );
-    Assert.assertTrue(factory.close());
+    Assertions.assertTrue(factory.close());
   }
 
   @Test
   public void testFailsGetNotStarted()
   {
-    Assert.assertThrows("Not started", NullPointerException.class, () -> new KafkaLookupExtractorFactory(
+    Assertions.assertThrows(NullPointerException.class, () -> new KafkaLookupExtractorFactory(
         cacheManager,
         TOPIC,
         DEFAULT_PROPERTIES
-    ).get());
+    ).get(), "Not started");
   }
 
   @Test
@@ -445,9 +445,9 @@ public class KafkaLookupExtractorFactoryTest
         mapper.writeValueAsString(factory),
         KafkaLookupExtractorFactory.class
     );
-    Assert.assertEquals(kafkaTopic, otherFactory.getKafkaTopic());
-    Assert.assertEquals(kafkaProperties, otherFactory.getKafkaProperties());
-    Assert.assertEquals(connectTimeout, otherFactory.getConnectTimeout());
-    Assert.assertEquals(injective, otherFactory.isInjective());
+    Assertions.assertEquals(kafkaTopic, otherFactory.getKafkaTopic());
+    Assertions.assertEquals(kafkaProperties, otherFactory.getKafkaProperties());
+    Assertions.assertEquals(connectTimeout, otherFactory.getConnectTimeout());
+    Assertions.assertEquals(injective, otherFactory.isInjective());
   }
 }

--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -40,23 +40,26 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.kafka.KafkaContainer;
 
 import javax.annotation.Nonnull;
+
+import java.io.File;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
@@ -67,8 +70,8 @@ public class TestKafkaExtractionCluster
   private static final String TOPIC_NAME = "testTopic";
   private static final Map<String, String> KAFKA_PROPERTIES = new HashMap<>();
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private final Closer closer = Closer.create();
 
@@ -88,7 +91,7 @@ public class TestKafkaExtractionCluster
                     StringUtils.toUtf8("abcdefg")));
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     kafkaServer = new KafkaContainer(KAFKA_IMAGE);
@@ -134,8 +137,8 @@ public class TestKafkaExtractionCluster
         mapper.writeValueAsString(kafkaLookupExtractorFactory),
         LookupExtractorFactory.class
     );
-    Assert.assertEquals(kafkaLookupExtractorFactory.getKafkaTopic(), factory.getKafkaTopic());
-    Assert.assertEquals(kafkaLookupExtractorFactory.getKafkaProperties(), factory.getKafkaProperties());
+    Assertions.assertEquals(kafkaLookupExtractorFactory.getKafkaTopic(), factory.getKafkaTopic());
+    Assertions.assertEquals(kafkaLookupExtractorFactory.getKafkaProperties(), factory.getKafkaProperties());
     factory.start();
     closer.register(() -> factory.close());
     log.info("--------------------------- started rename manager ---------------------------");
@@ -158,7 +161,7 @@ public class TestKafkaExtractionCluster
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     closer.close();
@@ -201,7 +204,7 @@ public class TestKafkaExtractionCluster
         TOPIC_NAME,
         properties
     );
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(KafkaException.class, factory::getConsumer),
         CoreMatchers.instanceOf(KafkaException.class)
     );
@@ -213,13 +216,14 @@ public class TestKafkaExtractionCluster
         TOPIC_NAME,
         properties
     );
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(KafkaException.class, factory::getConsumer),
         CoreMatchers.instanceOf(KafkaException.class)
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testSimpleLookup() throws Exception
   {
     try (final Producer<byte[], byte[]> producer = new KafkaProducer(makeProducerProperties())) {
@@ -259,15 +263,16 @@ public class TestKafkaExtractionCluster
       }
 
       log.info("-------------------------     Checking baz bat     -------------------------------");
-      Assert.assertEquals("bat", factory.get().apply("baz"));
-      Assert.assertEquals(
+      Assertions.assertEquals("bat", factory.get().apply("baz"));
+      Assertions.assertEquals(
           Collections.singletonList("baz"),
           Lists.newArrayList(factory.get().unapplyAll(Collections.singleton("bat")))
       );
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testLookupWithTombstone() throws Exception
   {
     try (final Producer<byte[], byte[]> producer = new KafkaProducer(makeProducerProperties())) {
@@ -311,7 +316,8 @@ public class TestKafkaExtractionCluster
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testLookupWithInitTombstone() throws Exception
   {
     try (final Producer<byte[], byte[]> producer = new KafkaProducer(makeProducerProperties())) {
@@ -356,7 +362,7 @@ public class TestKafkaExtractionCluster
       }
     }
 
-    Assert.assertEquals("update check", expected, extractor.apply(key));
+    Assertions.assertEquals(expected, extractor.apply(key), "update check");
   }
 
   private void assertReverseUpdated(
@@ -371,6 +377,6 @@ public class TestKafkaExtractionCluster
       Thread.sleep(100);
     }
 
-    Assert.assertEquals("update check", expected, Lists.newArrayList(extractor.unapplyAll(Collections.singleton(key))));
+    Assertions.assertEquals(expected, Lists.newArrayList(extractor.unapplyAll(Collections.singleton(key))), "update check");
   }
 }

--- a/extensions-core/mysql-metadata-storage/pom.xml
+++ b/extensions-core/mysql-metadata-storage/pom.xml
@@ -101,8 +101,18 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,6 +129,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
@@ -29,20 +29,21 @@ import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.storage.mysql.MySQLConnectorDriverConfig;
 import org.apache.druid.metadata.storage.mysql.MySQLMetadataStorageModule;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
 public class MySQLInputSourceDatabaseConnectorTest
 {
   private static final JdbcAccessSecurityConfig INJECTED_CONF = newSecurityConfigEnforcingAllowList(ImmutableSet.of());
@@ -50,14 +51,11 @@ public class MySQLInputSourceDatabaseConnectorTest
   @Mock
   private MySQLConnectorDriverConfig mySQLConnectorDriverConfig;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
-    Mockito.doReturn("com.mysql.jdbc.Driver").when(mySQLConnectorDriverConfig).getDriverClassName();
+    lenient().doReturn("com.mysql.jdbc.Driver").when(mySQLConnectorDriverConfig).getDriverClassName();
   }
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -87,7 +85,7 @@ public class MySQLInputSourceDatabaseConnectorTest
         mapper.writeValueAsString(connector),
         MySQLInputSourceDatabaseConnector.class
     );
-    Assert.assertEquals(connector, andBack);
+    Assertions.assertEquals(connector, andBack);
 
     // test again with classname
     connector = new MySQLInputSourceDatabaseConnector(
@@ -97,7 +95,7 @@ public class MySQLInputSourceDatabaseConnectorTest
         mySQLConnectorDriverConfig
     );
     andBack = mapper.readValue(mapper.writeValueAsString(connector), MySQLInputSourceDatabaseConnector.class);
-    Assert.assertEquals(connector, andBack);
+    Assertions.assertEquals(connector, andBack);
   }
 
   @Test
@@ -168,19 +166,18 @@ public class MySQLInputSourceDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
 
-    expectedException.expectMessage(
-        CoreMatchers.anyOf(
-            CoreMatchers.containsString("The property [password] is not in the allowed list"),
-            CoreMatchers.containsString("The property [user] is not in the allowed list")
+    Throwable exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new MySQLInputSourceDatabaseConnector(
+            connectorConfig,
+            null,
+            securityConfig,
+            mySQLConnectorDriverConfig
         )
     );
-    expectedException.expect(IllegalArgumentException.class);
-
-    new MySQLInputSourceDatabaseConnector(
-        connectorConfig,
-        null,
-        securityConfig,
-        mySQLConnectorDriverConfig
+    assertTrue(
+        exception.getMessage().contains("The property [password] is not in the allowed list")
+            || exception.getMessage().contains("The property [user] is not in the allowed list")
     );
   }
 
@@ -247,45 +244,44 @@ public class MySQLInputSourceDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
 
-    expectedException.expectMessage(
-        CoreMatchers.anyOf(
-            CoreMatchers.containsString("The property [password] is not in the allowed list"),
-            CoreMatchers.containsString("The property [user] is not in the allowed list")
+    Throwable exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new MySQLInputSourceDatabaseConnector(
+            connectorConfig,
+            null,
+            securityConfig,
+            mySQLConnectorDriverConfig
         )
     );
-    expectedException.expect(IllegalArgumentException.class);
-
-    new MySQLInputSourceDatabaseConnector(
-        connectorConfig,
-        null,
-        securityConfig,
-        mySQLConnectorDriverConfig
+    assertTrue(
+        exception.getMessage().contains("The property [password] is not in the allowed list")
+            || exception.getMessage().contains("The property [user] is not in the allowed list")
     );
   }
 
   @Test
   public void testFailValidAndInvalidProperty()
   {
-    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
-    {
-      @Override
-      public String getConnectURI()
+    Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+      MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
       {
-        return "jdbc:mysql://localhost:3306/test?user=maytas&password=secret&keyonly";
-      }
-    };
+        @Override
+        public String getConnectURI()
+        {
+          return "jdbc:mysql://localhost:3306/test?user=maytas&password=secret&keyonly";
+        }
+      };
 
-    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
+      JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
 
-    expectedException.expectMessage("The property [password] is not in the allowed list");
-    expectedException.expect(IllegalArgumentException.class);
-
-    new MySQLInputSourceDatabaseConnector(
-        connectorConfig,
-        null,
-        securityConfig,
-        mySQLConnectorDriverConfig
-    );
+      new MySQLInputSourceDatabaseConnector(
+          connectorConfig,
+          null,
+          securityConfig,
+          mySQLConnectorDriverConfig
+      );
+    });
+    assertTrue(exception.getMessage().contains("The property [password] is not in the allowed list"));
   }
 
   @Test
@@ -302,19 +298,18 @@ public class MySQLInputSourceDatabaseConnectorTest
 
     JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
 
-    expectedException.expectMessage(
-        CoreMatchers.anyOf(
-            CoreMatchers.containsString("The property [password] is not in the allowed list"),
-            CoreMatchers.containsString("The property [keyonly] is not in the allowed list")
+    Throwable exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> new MySQLInputSourceDatabaseConnector(
+            connectorConfig,
+            null,
+            securityConfig,
+            mySQLConnectorDriverConfig
         )
     );
-    expectedException.expect(IllegalArgumentException.class);
-
-    new MySQLInputSourceDatabaseConnector(
-        connectorConfig,
-        null,
-        securityConfig,
-        mySQLConnectorDriverConfig
+    assertTrue(
+        exception.getMessage().contains("The property [password] is not in the allowed list")
+            || exception.getMessage().contains("The property [keyonly] is not in the allowed list")
     );
   }
 

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/input/MySQLInputSourceDatabaseConnectorTest.java
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Set;

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorDriverConfigTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorDriverConfigTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.metadata.storage.mysql;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class MySQLConnectorDriverConfigTest
 {

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLConnectorTest.java
@@ -23,16 +23,14 @@ import com.google.common.base.Supplier;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
 import java.sql.SQLTransientException;
 
-@RunWith(Parameterized.class)
 public class MySQLConnectorTest
 {
   private static final MySQLConnectorDriverConfig MYSQL_DRIVER_CONFIG = new MySQLConnectorDriverConfig();
@@ -51,12 +49,11 @@ public class MySQLConnectorTest
 
   private CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig;
 
-  public MySQLConnectorTest(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
+  public void initMySQLConnectorTest(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
     this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Object[][] constructorFeeder()
   {
     return new Object[][]{
@@ -65,9 +62,11 @@ public class MySQLConnectorTest
     };
   }
 
-  @Test
-  public void testIsExceptionTransientMySql()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIsExceptionTransientMySql(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initMySQLConnectorTest(centralizedDatasourceSchemaConfig);
     MySQLConnector connector = new MySQLConnector(
         CONNECTOR_CONFIG_SUPPLIER,
         TABLES_CONFIG_SUPPLIER,
@@ -75,20 +74,22 @@ public class MySQLConnectorTest
         MYSQL_DRIVER_CONFIG,
         centralizedDatasourceSchemaConfig
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         connector.connectorIsTransientException(new SQLException("some transient failure", "s0", 1317))
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         connector.connectorIsTransientException(new SQLException("totally realistic test data", "s0", 1337))
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         connector.connectorIsTransientException(new SQLTransientConnectionException("transient"))
     );
   }
 
-  @Test
-  public void testIsExceptionTransientNoMySqlClazz()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIsExceptionTransientNoMySqlClazz(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initMySQLConnectorTest(centralizedDatasourceSchemaConfig);
     MySQLConnector connector = new MySQLConnector(
         CONNECTOR_CONFIG_SUPPLIER,
         TABLES_CONFIG_SUPPLIER,
@@ -97,21 +98,23 @@ public class MySQLConnectorTest
         centralizedDatasourceSchemaConfig
     );
     // no vendor specific for MariaDb, so should always be false
-    Assert.assertFalse(connector.connectorIsTransientException(new SQLTransientException()));
-    Assert.assertFalse(
+    Assertions.assertFalse(connector.connectorIsTransientException(new SQLTransientException()));
+    Assertions.assertFalse(
         connector.connectorIsTransientException(new SQLException("some transient failure", "s0", 1317))
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         connector.connectorIsTransientException(new SQLException("totally realistic test data", "s0", 1337))
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         connector.connectorIsTransientException(new SQLTransientConnectionException("transient"))
     );
   }
 
-  @Test
-  public void testIsRootCausePacketTooBigException()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIsRootCausePacketTooBigException(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initMySQLConnectorTest(centralizedDatasourceSchemaConfig);
     MySQLConnector connector = new MySQLConnector(
         CONNECTOR_CONFIG_SUPPLIER,
         TABLES_CONFIG_SUPPLIER,
@@ -126,20 +129,22 @@ public class MySQLConnectorTest
     // and has only a private constructor. It would be overkill to try to mock it.
 
     // Verify some of the false cases
-    Assert.assertFalse(
+    Assertions.assertFalse(
         connector.isRootCausePacketTooBigException(new SQLException())
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         connector.isRootCausePacketTooBigException(new SQLTransientException())
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         connector.isRootCausePacketTooBigException(new SQLTransientException())
     );
   }
 
-  @Test
-  public void testIsUniqueConstraintViolation()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIsUniqueConstraintViolation(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initMySQLConnectorTest(centralizedDatasourceSchemaConfig);
     MySQLConnector connector = new MySQLConnector(
         CONNECTOR_CONFIG_SUPPLIER,
         TABLES_CONFIG_SUPPLIER,
@@ -149,27 +154,29 @@ public class MySQLConnectorTest
     );
 
     // MySQL integrity_constraint_violation SQL state (23000)
-    Assert.assertTrue(connector.isUniqueConstraintViolation(
+    Assertions.assertTrue(connector.isUniqueConstraintViolation(
         new SQLException("Duplicate entry 'value' for key 'PRIMARY'", "23000")
     ));
 
     // Different SQL state should return false
-    Assert.assertFalse(connector.isUniqueConstraintViolation(
+    Assertions.assertFalse(connector.isUniqueConstraintViolation(
         new SQLException("some other error", "42S02")
     ));
 
     // SQLException wrapped in another exception (tests cause chain traversal)
-    Assert.assertTrue(connector.isUniqueConstraintViolation(
+    Assertions.assertTrue(connector.isUniqueConstraintViolation(
         new RuntimeException(new SQLException("Duplicate entry", "23000"))
     ));
 
     // Non-SQLException exception
-    Assert.assertFalse(connector.isUniqueConstraintViolation(new Exception("not a SQLException")));
+    Assertions.assertFalse(connector.isUniqueConstraintViolation(new Exception("not a SQLException")));
   }
 
-  @Test
-  public void testLimitClause()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testLimitClause(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initMySQLConnectorTest(centralizedDatasourceSchemaConfig);
     MySQLConnector connector = new MySQLConnector(
         CONNECTOR_CONFIG_SUPPLIER,
         TABLES_CONFIG_SUPPLIER,
@@ -177,6 +184,6 @@ public class MySQLConnectorTest
         MYSQL_DRIVER_CONFIG,
         centralizedDatasourceSchemaConfig
     );
-    Assert.assertEquals("LIMIT 100", connector.limitClause(100));
+    Assertions.assertEquals("LIMIT 100", connector.limitClause(100));
   }
 }

--- a/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLMetadataStorageModuleTest.java
+++ b/extensions-core/mysql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/mysql/MySQLMetadataStorageModuleTest.java
@@ -40,8 +40,8 @@ import org.apache.druid.guice.security.EscalatorModule;
 import org.apache.druid.java.util.common.concurrent.ScheduledExecutorFactory;
 import org.apache.druid.java.util.emitter.core.NoopEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 import java.util.Set;
@@ -70,16 +70,16 @@ public class MySQLMetadataStorageModuleTest
     properties.setProperty(propertyPrefix + ".verifyServerCertificate", "true");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final MySQLConnectorSslConfig config = provider.get();
-    Assert.assertTrue(config.isUseSSL());
-    Assert.assertEquals("url", config.getTrustCertificateKeyStoreUrl());
-    Assert.assertEquals("type", config.getTrustCertificateKeyStoreType());
-    Assert.assertEquals("secret", config.getTrustCertificateKeyStorePassword());
-    Assert.assertEquals("url", config.getClientCertificateKeyStoreUrl());
-    Assert.assertEquals("type", config.getClientCertificateKeyStoreType());
-    Assert.assertEquals("secret", config.getClientCertificateKeyStorePassword());
-    Assert.assertEquals(ImmutableList.of("some", "ciphers"), config.getEnabledSSLCipherSuites());
-    Assert.assertEquals(ImmutableList.of("some", "protocols"), config.getEnabledTLSProtocols());
-    Assert.assertTrue(config.isVerifyServerCertificate());
+    Assertions.assertTrue(config.isUseSSL());
+    Assertions.assertEquals("url", config.getTrustCertificateKeyStoreUrl());
+    Assertions.assertEquals("type", config.getTrustCertificateKeyStoreType());
+    Assertions.assertEquals("secret", config.getTrustCertificateKeyStorePassword());
+    Assertions.assertEquals("url", config.getClientCertificateKeyStoreUrl());
+    Assertions.assertEquals("type", config.getClientCertificateKeyStoreType());
+    Assertions.assertEquals("secret", config.getClientCertificateKeyStorePassword());
+    Assertions.assertEquals(ImmutableList.of("some", "ciphers"), config.getEnabledSSLCipherSuites());
+    Assertions.assertEquals(ImmutableList.of("some", "protocols"), config.getEnabledTLSProtocols());
+    Assertions.assertTrue(config.isVerifyServerCertificate());
   }
 
   @Test
@@ -94,7 +94,7 @@ public class MySQLMetadataStorageModuleTest
     final Properties properties = new Properties();
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final MySQLConnectorDriverConfig config = provider.get();
-    Assert.assertEquals(new MySQLConnectorDriverConfig().getDriverClassName(), config.getDriverClassName());
+    Assertions.assertEquals(new MySQLConnectorDriverConfig().getDriverClassName(), config.getDriverClassName());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class MySQLMetadataStorageModuleTest
     properties.setProperty(propertyPrefix + ".driverClassName", "some.driver.classname");
     provider.inject(properties, injector.getInstance(JsonConfigurator.class));
     final MySQLConnectorDriverConfig config = provider.get();
-    Assert.assertEquals("some.driver.classname", config.getDriverClassName());
+    Assertions.assertEquals("some.driver.classname", config.getDriverClassName());
   }
 
   private Injector createInjector()

--- a/extensions-core/orc-extensions/pom.xml
+++ b/extensions-core/orc-extensions/pom.xml
@@ -212,8 +212,13 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcInputFormatTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcInputFormatTest.java
@@ -26,9 +26,9 @@ import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.segment.TestHelper;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -37,7 +37,7 @@ public class OrcInputFormatTest
   private ObjectMapper mapper;
 
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper =
@@ -51,7 +51,7 @@ public class OrcInputFormatTest
   {
     final OrcInputFormat config = new OrcInputFormat(null, null, null);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         config,
         mapper.readValue(mapper.writeValueAsString(config), InputFormat.class)
     );
@@ -62,7 +62,7 @@ public class OrcInputFormatTest
   {
     final OrcInputFormat config = new OrcInputFormat(new JSONPathSpec(true, Collections.emptyList()), true, null);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         config,
         mapper.readValue(mapper.writeValueAsString(config), InputFormat.class)
     );
@@ -83,7 +83,7 @@ public class OrcInputFormatTest
   {
     final OrcInputFormat format = new OrcInputFormat(null, null, null);
     long unweightedSize = 100L;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         unweightedSize * OrcInputFormat.SCALE_FACTOR,
         format.getWeightedSize("file.orc", unweightedSize)
     );

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
@@ -43,10 +43,9 @@ import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.transform.TransformingInputEntityReader;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,8 +54,8 @@ import java.util.List;
 
 public class OrcReaderTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void testTest1() throws IOException
@@ -68,13 +67,13 @@ public class OrcReaderTest extends InitializedNullHandlingTest
         "example/test_1.orc"
     );
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
-      Assert.assertEquals(DateTimes.of("2016-01-01T00:00:00.000Z"), row.getTimestamp());
-      Assert.assertEquals("bar", Iterables.getOnlyElement(row.getDimension("col1")));
-      Assert.assertEquals(ImmutableList.of("dat1", "dat2", "dat3"), row.getDimension("col2"));
-      Assert.assertEquals(1.1, row.getMetric("val1").doubleValue(), 0.001);
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertEquals(DateTimes.of("2016-01-01T00:00:00.000Z"), row.getTimestamp());
+      Assertions.assertEquals("bar", Iterables.getOnlyElement(row.getDimension("col1")));
+      Assertions.assertEquals(ImmutableList.of("dat1", "dat2", "dat3"), row.getDimension("col2"));
+      Assertions.assertEquals(1.1, row.getMetric("val1").doubleValue(), 0.001);
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -96,16 +95,16 @@ public class OrcReaderTest extends InitializedNullHandlingTest
         "example/test_2.orc"
     );
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
-      Assert.assertEquals(DateTimes.of("2016-01-01T00:00:00.000Z"), row.getTimestamp());
-      Assert.assertEquals("bar", Iterables.getOnlyElement(row.getDimension("col1")));
-      Assert.assertEquals(ImmutableList.of("dat1", "dat2", "dat3"), row.getDimension("col2"));
-      Assert.assertEquals("1.1", Iterables.getOnlyElement(row.getDimension("col3")));
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("col4")));
-      Assert.assertEquals("3.5", Iterables.getOnlyElement(row.getDimension("col5")));
-      Assert.assertTrue(row.getDimension("col6").isEmpty());
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertEquals(DateTimes.of("2016-01-01T00:00:00.000Z"), row.getTimestamp());
+      Assertions.assertEquals("bar", Iterables.getOnlyElement(row.getDimension("col1")));
+      Assertions.assertEquals(ImmutableList.of("dat1", "dat2", "dat3"), row.getDimension("col2"));
+      Assertions.assertEquals("1.1", Iterables.getOnlyElement(row.getDimension("col3")));
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("col4")));
+      Assertions.assertEquals("3.5", Iterables.getOnlyElement(row.getDimension("col5")));
+      Assertions.assertTrue(row.getDimension("col6").isEmpty());
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -140,25 +139,25 @@ public class OrcReaderTest extends InitializedNullHandlingTest
       int actualRowCount = 0;
 
       // Check the first row
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       InputRow row = iterator.next();
       actualRowCount++;
-      Assert.assertEquals("false", Iterables.getOnlyElement(row.getDimension("boolean1")));
-      Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("byte1")));
-      Assert.assertEquals("1024", Iterables.getOnlyElement(row.getDimension("short1")));
-      Assert.assertEquals("65536", Iterables.getOnlyElement(row.getDimension("int1")));
-      Assert.assertEquals("9223372036854775807", Iterables.getOnlyElement(row.getDimension("long1")));
-      Assert.assertEquals("1.0", Iterables.getOnlyElement(row.getDimension("float1")));
-      Assert.assertEquals("-15.0", Iterables.getOnlyElement(row.getDimension("double1")));
-      Assert.assertEquals("AAECAwQAAA==", Iterables.getOnlyElement(row.getDimension("bytes1")));
-      Assert.assertEquals("hi", Iterables.getOnlyElement(row.getDimension("string1")));
-      Assert.assertEquals("1.23456786547456E7", Iterables.getOnlyElement(row.getDimension("decimal1")));
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_int")));
-      Assert.assertEquals(ImmutableList.of("1", "2"), row.getDimension("struct_list_struct_intlist"));
-      Assert.assertEquals("good", Iterables.getOnlyElement(row.getDimension("list_struct_string")));
+      Assertions.assertEquals("false", Iterables.getOnlyElement(row.getDimension("boolean1")));
+      Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("byte1")));
+      Assertions.assertEquals("1024", Iterables.getOnlyElement(row.getDimension("short1")));
+      Assertions.assertEquals("65536", Iterables.getOnlyElement(row.getDimension("int1")));
+      Assertions.assertEquals("9223372036854775807", Iterables.getOnlyElement(row.getDimension("long1")));
+      Assertions.assertEquals("1.0", Iterables.getOnlyElement(row.getDimension("float1")));
+      Assertions.assertEquals("-15.0", Iterables.getOnlyElement(row.getDimension("double1")));
+      Assertions.assertEquals("AAECAwQAAA==", Iterables.getOnlyElement(row.getDimension("bytes1")));
+      Assertions.assertEquals("hi", Iterables.getOnlyElement(row.getDimension("string1")));
+      Assertions.assertEquals("1.23456786547456E7", Iterables.getOnlyElement(row.getDimension("decimal1")));
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_int")));
+      Assertions.assertEquals(ImmutableList.of("1", "2"), row.getDimension("struct_list_struct_intlist"));
+      Assertions.assertEquals("good", Iterables.getOnlyElement(row.getDimension("list_struct_string")));
 
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_middleListLength")));
-      Assert.assertEquals(DateTimes.of("2000-03-12T15:00:00.0Z"), row.getTimestamp());
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_middleListLength")));
+      Assertions.assertEquals(DateTimes.of("2000-03-12T15:00:00.0Z"), row.getTimestamp());
 
       while (iterator.hasNext()) {
         actualRowCount++;
@@ -166,23 +165,23 @@ public class OrcReaderTest extends InitializedNullHandlingTest
       }
 
       // Check the last row
-      Assert.assertEquals("true", Iterables.getOnlyElement(row.getDimension("boolean1")));
-      Assert.assertEquals("100", Iterables.getOnlyElement(row.getDimension("byte1")));
-      Assert.assertEquals("2048", Iterables.getOnlyElement(row.getDimension("short1")));
-      Assert.assertEquals("65536", Iterables.getOnlyElement(row.getDimension("int1")));
-      Assert.assertEquals("9223372036854775807", Iterables.getOnlyElement(row.getDimension("long1")));
-      Assert.assertEquals("2.0", Iterables.getOnlyElement(row.getDimension("float1")));
-      Assert.assertEquals("-5.0", Iterables.getOnlyElement(row.getDimension("double1")));
-      Assert.assertEquals("", Iterables.getOnlyElement(row.getDimension("bytes1")));
-      Assert.assertEquals("bye", Iterables.getOnlyElement(row.getDimension("string1")));
-      Assert.assertEquals("1.23456786547457E7", Iterables.getOnlyElement(row.getDimension("decimal1")));
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_int")));
-      Assert.assertEquals(ImmutableList.of("1", "2"), row.getDimension("struct_list_struct_intlist"));
-      Assert.assertEquals("cat", Iterables.getOnlyElement(row.getDimension("list_struct_string")));
-      Assert.assertEquals("5", Iterables.getOnlyElement(row.getDimension("map_struct_int")));
-      Assert.assertEquals(DateTimes.of("2000-03-12T15:00:01.000Z"), row.getTimestamp());
+      Assertions.assertEquals("true", Iterables.getOnlyElement(row.getDimension("boolean1")));
+      Assertions.assertEquals("100", Iterables.getOnlyElement(row.getDimension("byte1")));
+      Assertions.assertEquals("2048", Iterables.getOnlyElement(row.getDimension("short1")));
+      Assertions.assertEquals("65536", Iterables.getOnlyElement(row.getDimension("int1")));
+      Assertions.assertEquals("9223372036854775807", Iterables.getOnlyElement(row.getDimension("long1")));
+      Assertions.assertEquals("2.0", Iterables.getOnlyElement(row.getDimension("float1")));
+      Assertions.assertEquals("-5.0", Iterables.getOnlyElement(row.getDimension("double1")));
+      Assertions.assertEquals("", Iterables.getOnlyElement(row.getDimension("bytes1")));
+      Assertions.assertEquals("bye", Iterables.getOnlyElement(row.getDimension("string1")));
+      Assertions.assertEquals("1.23456786547457E7", Iterables.getOnlyElement(row.getDimension("decimal1")));
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_int")));
+      Assertions.assertEquals(ImmutableList.of("1", "2"), row.getDimension("struct_list_struct_intlist"));
+      Assertions.assertEquals("cat", Iterables.getOnlyElement(row.getDimension("list_struct_string")));
+      Assertions.assertEquals("5", Iterables.getOnlyElement(row.getDimension("map_struct_int")));
+      Assertions.assertEquals(DateTimes.of("2000-03-12T15:00:01.000Z"), row.getTimestamp());
 
-      Assert.assertEquals(7500, actualRowCount);
+      Assertions.assertEquals(7500, actualRowCount);
     }
   }
 
@@ -197,19 +196,19 @@ public class OrcReaderTest extends InitializedNullHandlingTest
     );
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       int actualRowCount = 0;
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
       actualRowCount++;
-      Assert.assertEquals(DateTimes.of("1969-12-31T16:00:00.0Z"), row.getTimestamp());
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("userid")));
-      Assert.assertEquals("foo", Iterables.getOnlyElement(row.getDimension("string1")));
-      Assert.assertEquals("0.8", Iterables.getOnlyElement(row.getDimension("subtype")));
-      Assert.assertEquals("1.2", Iterables.getOnlyElement(row.getDimension("decimal1")));
+      Assertions.assertEquals(DateTimes.of("1969-12-31T16:00:00.0Z"), row.getTimestamp());
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("userid")));
+      Assertions.assertEquals("foo", Iterables.getOnlyElement(row.getDimension("string1")));
+      Assertions.assertEquals("0.8", Iterables.getOnlyElement(row.getDimension("subtype")));
+      Assertions.assertEquals("1.2", Iterables.getOnlyElement(row.getDimension("decimal1")));
       while (iterator.hasNext()) {
         actualRowCount++;
         iterator.next();
       }
-      Assert.assertEquals(25000, actualRowCount);
+      Assertions.assertEquals(25000, actualRowCount);
     }
   }
 
@@ -224,17 +223,17 @@ public class OrcReaderTest extends InitializedNullHandlingTest
     );
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       int actualRowCount = 0;
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
       actualRowCount++;
-      Assert.assertEquals(1, row.getDimensions().size());
-      Assert.assertEquals(DateTimes.of("1900-05-05T12:34:56.1Z"), row.getTimestamp());
-      Assert.assertEquals("1900-12-25T00:00:00.000Z", Iterables.getOnlyElement(row.getDimension("date")));
+      Assertions.assertEquals(1, row.getDimensions().size());
+      Assertions.assertEquals(DateTimes.of("1900-05-05T12:34:56.1Z"), row.getTimestamp());
+      Assertions.assertEquals("1900-12-25T00:00:00.000Z", Iterables.getOnlyElement(row.getDimension("date")));
       while (iterator.hasNext()) {
         actualRowCount++;
         iterator.next();
       }
-      Assert.assertEquals(70000, actualRowCount);
+      Assertions.assertEquals(70000, actualRowCount);
     }
   }
 
@@ -249,17 +248,17 @@ public class OrcReaderTest extends InitializedNullHandlingTest
     );
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       int actualRowCount = 0;
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
       actualRowCount++;
-      Assert.assertEquals(1, row.getDimensions().size());
-      Assert.assertEquals(DateTimes.of("2038-05-05T12:34:56.1Z"), row.getTimestamp());
-      Assert.assertEquals("2038-12-25T00:00:00.000Z", Iterables.getOnlyElement(row.getDimension("date")));
+      Assertions.assertEquals(1, row.getDimensions().size());
+      Assertions.assertEquals(DateTimes.of("2038-05-05T12:34:56.1Z"), row.getTimestamp());
+      Assertions.assertEquals("2038-12-25T00:00:00.000Z", Iterables.getOnlyElement(row.getDimension("date")));
       while (iterator.hasNext()) {
         actualRowCount++;
         iterator.next();
       }
-      Assert.assertEquals(212000, actualRowCount);
+      Assertions.assertEquals(212000, actualRowCount);
     }
   }
 
@@ -299,22 +298,21 @@ public class OrcReaderTest extends InitializedNullHandlingTest
         final InputRow row = iterator.next();
         actualRowCount++;
 
-        Assert.assertEquals("7.0", Iterables.getOnlyElement(row.getDimension("min")));
-        Assert.assertEquals("8.0", Iterables.getOnlyElement(row.getDimension("avg")));
-        Assert.assertEquals("9.0", Iterables.getOnlyElement(row.getDimension("max")));
-        Assert.assertEquals("24.0", Iterables.getOnlyElement(row.getDimension("sum")));
-        Assert.assertEquals("3", Iterables.getOnlyElement(row.getDimension("len")));
+        Assertions.assertEquals("7.0", Iterables.getOnlyElement(row.getDimension("min")));
+        Assertions.assertEquals("8.0", Iterables.getOnlyElement(row.getDimension("avg")));
+        Assertions.assertEquals("9.0", Iterables.getOnlyElement(row.getDimension("max")));
+        Assertions.assertEquals("24.0", Iterables.getOnlyElement(row.getDimension("sum")));
+        Assertions.assertEquals("3", Iterables.getOnlyElement(row.getDimension("len")));
 
         //deviation of [7,8,9] is 1/3, stddev is sqrt(1/3), approximately 0.8165
-        Assert.assertEquals(0.8165, Double.parseDouble(Iterables.getOnlyElement(row.getDimension("stddev"))), 0.0001);
+        Assertions.assertEquals(0.8165, Double.parseDouble(Iterables.getOnlyElement(row.getDimension("stddev"))), 0.0001);
 
         // we do not support json-path append function for ORC format (see https://github.com/apache/druid/pull/11722)
-        Exception exception = Assert.assertThrows(UnsupportedOperationException.class, () -> {
-          row.getDimension("append");
-        });
-        Assert.assertEquals("Unused", exception.getMessage());
+        Exception exception = Assertions.assertThrows(UnsupportedOperationException.class, () ->
+          row.getDimension("append"));
+        Assertions.assertEquals("Unused", exception.getMessage());
       }
-      Assert.assertEquals(1, actualRowCount);
+      Assertions.assertEquals(1, actualRowCount);
     }
   }
 
@@ -353,10 +351,10 @@ public class OrcReaderTest extends InitializedNullHandlingTest
       int actualRowCount = 0;
 
       // Check the first row
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       InputRow row = iterator.next();
       actualRowCount++;
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(
               "list",
               ImmutableList.of(
@@ -366,19 +364,19 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           ),
           row.getRaw("middle")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableMap.of("int1", 3, "string1", "good"),
               ImmutableMap.of("int1", 4, "string1", "bad")
           ),
           row.getRaw("list")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(),
           row.getRaw("map")
       );
-      Assert.assertEquals(2L, row.getRaw("struct_list_struct_int"));
-      Assert.assertEquals(DateTimes.of("2000-03-12T15:00:00.0Z"), row.getTimestamp());
+      Assertions.assertEquals(2L, row.getRaw("struct_list_struct_int"));
+      Assertions.assertEquals(DateTimes.of("2000-03-12T15:00:00.0Z"), row.getTimestamp());
 
       while (iterator.hasNext()) {
         actualRowCount++;
@@ -386,7 +384,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
       }
 
       // Check the last row
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(
               "list",
               ImmutableList.of(
@@ -396,7 +394,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           ),
           row.getRaw("middle")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableMap.of("int1", 100000000, "string1", "cat"),
               ImmutableMap.of("int1", -100000, "string1", "in"),
@@ -404,17 +402,17 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           ),
           row.getRaw("list")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(
               "chani", ImmutableMap.of("int1", 5, "string1", "chani"),
               "mauddib", ImmutableMap.of("int1", 1, "string1", "mauddib")
           ),
           row.getRaw("map")
       );
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_int")));
-      Assert.assertEquals("5", Iterables.getOnlyElement(row.getDimension("map_struct_int")));
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("struct_list_struct_int")));
+      Assertions.assertEquals("5", Iterables.getOnlyElement(row.getDimension("map_struct_int")));
 
-      Assert.assertEquals(7500, actualRowCount);
+      Assertions.assertEquals(7500, actualRowCount);
     }
   }
 
@@ -434,7 +432,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
     );
     final FileEntity entity = new FileEntity(new File("example/orc-file-11-format.orc"));
 
-    final InputEntityReader reader = inputFormat.createReader(schema, entity, temporaryFolder.newFolder());
+    final InputEntityReader reader = inputFormat.createReader(schema, entity, newFolder(temporaryFolder, "junit"));
 
     List<String> dims = ImmutableList.of(
         "boolean1",
@@ -455,12 +453,12 @@ public class OrcReaderTest extends InitializedNullHandlingTest
       int actualRowCount = 0;
 
       // Check the first row
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       InputRow row = iterator.next();
 
-      Assert.assertEquals(dims, row.getDimensions());
+      Assertions.assertEquals(dims, row.getDimensions());
       actualRowCount++;
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(
               "list",
               ImmutableList.of(
@@ -470,27 +468,27 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           ),
           row.getRaw("middle")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableMap.of("int1", 3, "string1", "good"),
               ImmutableMap.of("int1", 4, "string1", "bad")
           ),
           row.getRaw("list")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(),
           row.getRaw("map")
       );
-      Assert.assertEquals(DateTimes.of("2000-03-12T15:00:00.0Z"), row.getTimestamp());
+      Assertions.assertEquals(DateTimes.of("2000-03-12T15:00:00.0Z"), row.getTimestamp());
 
       while (iterator.hasNext()) {
         actualRowCount++;
         row = iterator.next();
-        Assert.assertEquals(dims, row.getDimensions());
+        Assertions.assertEquals(dims, row.getDimensions());
       }
 
       // Check the last row
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(
               "list",
               ImmutableList.of(
@@ -500,7 +498,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           ),
           row.getRaw("middle")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableMap.of("int1", 100000000, "string1", "cat"),
               ImmutableMap.of("int1", -100000, "string1", "in"),
@@ -508,7 +506,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           ),
           row.getRaw("list")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.of(
               "chani", ImmutableMap.of("int1", 5, "string1", "chani"),
               "mauddib", ImmutableMap.of("int1", 1, "string1", "mauddib")
@@ -516,7 +514,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           row.getRaw("map")
       );
 
-      Assert.assertEquals(7500, actualRowCount);
+      Assertions.assertEquals(7500, actualRowCount);
     }
   }
 
@@ -558,7 +556,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
         transformSpec.toTransformer()
     );
     try (CloseableIterator<InputRow> iterator = transformingReader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
       /*
         {
@@ -567,21 +565,21 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           "b": [{"id0": "str0", "id1": "str1"}, {"id0": "str2", "id1": "str3"}]
         }
      */
-      Assert.assertEquals(DateTimes.of("2022-01-01T00:00:00.000Z"), row.getTimestamp());
-      Assert.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("a_id0")));
-      Assert.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("t_a_id0")));
-      Assert.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("b0_id0")));
-      Assert.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("t_b0_id0")));
-      Assert.assertEquals(ImmutableList.of("{id0=str0, id1=str1}", "{id0=str2, id1=str3}"), row.getDimension("b_raw_str"));
-      Assert.assertEquals(ImmutableMap.of("id0", "str0", "id1", "str1"), row.getRaw("a"));
-      Assert.assertEquals(
+      Assertions.assertEquals(DateTimes.of("2022-01-01T00:00:00.000Z"), row.getTimestamp());
+      Assertions.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("a_id0")));
+      Assertions.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("t_a_id0")));
+      Assertions.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("b0_id0")));
+      Assertions.assertEquals("str0", Iterables.getOnlyElement(row.getDimension("t_b0_id0")));
+      Assertions.assertEquals(ImmutableList.of("{id0=str0, id1=str1}", "{id0=str2, id1=str3}"), row.getDimension("b_raw_str"));
+      Assertions.assertEquals(ImmutableMap.of("id0", "str0", "id1", "str1"), row.getRaw("a"));
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableMap.of("id0", "str0", "id1", "str1"),
               ImmutableMap.of("id0", "str2", "id1", "str3")
           ),
           row.getRaw("b")
       );
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -630,7 +628,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
         transformSpec.toTransformer()
     );
     try (CloseableIterator<InputRow> iterator = transformingReader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
       /*
         {
@@ -641,27 +639,27 @@ public class OrcReaderTest extends InitializedNullHandlingTest
           "d": [[1, 2], [3, 4]]
         }
        */
-      Assert.assertEquals(DateTimes.of("2022-01-01T00:00:00.000Z"), row.getTimestamp());
-      Assert.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("a_0")));
-      Assert.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("t_a_0")));
-      Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("b_0")));
-      Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("t_b_0")));
-      Assert.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("c_0_0")));
-      Assert.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("t_c_0_0")));
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("d_0_1")));
-      Assert.assertEquals("2", Iterables.getOnlyElement(row.getDimension("t_d_0_1")));
-      Assert.assertEquals(ImmutableList.of("str1", "str2"), row.getRaw("a"));
-      Assert.assertEquals(ImmutableList.of(1, 2), row.getRaw("b"));
-      Assert.assertEquals(
+      Assertions.assertEquals(DateTimes.of("2022-01-01T00:00:00.000Z"), row.getTimestamp());
+      Assertions.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("a_0")));
+      Assertions.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("t_a_0")));
+      Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("b_0")));
+      Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("t_b_0")));
+      Assertions.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("c_0_0")));
+      Assertions.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("t_c_0_0")));
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("d_0_1")));
+      Assertions.assertEquals("2", Iterables.getOnlyElement(row.getDimension("t_d_0_1")));
+      Assertions.assertEquals(ImmutableList.of("str1", "str2"), row.getRaw("a"));
+      Assertions.assertEquals(ImmutableList.of(1, 2), row.getRaw("b"));
+      Assertions.assertEquals(
           ImmutableList.of(ImmutableList.of("str1", "str2"), ImmutableList.of("str3", "str4")),
           row.getRaw("c")
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3, 4)),
           row.getRaw("d")
       );
-      Assert.assertArrayEquals(new Object[]{1L, 2L}, (Object[]) row.getRaw("t_d_0"));
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertArrayEquals(new Object[]{1L, 2L}, (Object[]) row.getRaw("t_d_0"));
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -688,18 +686,18 @@ public class OrcReaderTest extends InitializedNullHandlingTest
         "example/test_simple.orc"
     );
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       InputRow row = iterator.next();
 
-      Assert.assertEquals(DateTimes.of("2022-01-01T00:00:00.000Z"), row.getTimestamp());
-      Assert.assertEquals("true", Iterables.getOnlyElement(row.getDimension("c1")));
-      Assert.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("c2")));
+      Assertions.assertEquals(DateTimes.of("2022-01-01T00:00:00.000Z"), row.getTimestamp());
+      Assertions.assertEquals("true", Iterables.getOnlyElement(row.getDimension("c1")));
+      Assertions.assertEquals("str1", Iterables.getOnlyElement(row.getDimension("c2")));
 
       row = iterator.next();
-      Assert.assertEquals(DateTimes.of("2022-01-02T00:00:00.000Z"), row.getTimestamp());
-      Assert.assertEquals(ImmutableList.of(), row.getDimension("c1"));
-      Assert.assertEquals(ImmutableList.of(), row.getDimension("c2"));
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertEquals(DateTimes.of("2022-01-02T00:00:00.000Z"), row.getTimestamp());
+      Assertions.assertEquals(ImmutableList.of(), row.getDimension("c1"));
+      Assertions.assertEquals(ImmutableList.of(), row.getDimension("c2"));
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -712,6 +710,15 @@ public class OrcReaderTest extends InitializedNullHandlingTest
   {
     final InputRowSchema schema = new InputRowSchema(timestampSpec, dimensionsSpec, ColumnsFilter.all());
     final FileEntity entity = new FileEntity(new File(dataFile));
-    return inputFormat.createReader(schema, entity, temporaryFolder.newFolder());
+    return inputFormat.createReader(schema, entity, newFolder(temporaryFolder, "junit"));
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
@@ -714,11 +714,8 @@ public class OrcReaderTest extends InitializedNullHandlingTest
     return inputFormat.createReader(schema, entity, newFolder(temporaryFolder, "junit"));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
@@ -707,7 +707,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
       DimensionsSpec dimensionsSpec,
       InputFormat inputFormat,
       String dataFile
-  ) throws IOException
+  )
   {
     final InputRowSchema schema = new InputRowSchema(timestampSpec, dimensionsSpec, ColumnsFilter.all());
     final FileEntity entity = new FileEntity(new File(dataFile));

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
@@ -714,7 +714,8 @@ public class OrcReaderTest extends InitializedNullHandlingTest
     return inputFormat.createReader(schema, entity, newFolder(temporaryFolder, "junit"));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcReaderTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.data.input.impl.FileEntity;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
@@ -716,9 +717,7 @@ public class OrcReaderTest extends InitializedNullHandlingTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcStructConverterTest.java
+++ b/extensions-core/orc-extensions/src/test/java/org/apache/druid/data/input/orc/OrcStructConverterTest.java
@@ -38,8 +38,8 @@ import org.apache.orc.mapred.OrcList;
 import org.apache.orc.mapred.OrcMap;
 import org.apache.orc.mapred.OrcStruct;
 import org.apache.orc.mapred.OrcTimestamp;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.sql.Date;
@@ -454,23 +454,23 @@ public class OrcStructConverterTest
   )
   {
     final Object field = converter.convertRootField(orcStruct, fieldName);
-    Assert.assertNotNull(field);
-    Assert.assertEquals(expectedValue, field);
+    Assertions.assertNotNull(field);
+    Assertions.assertEquals(expectedValue, field);
 
 
     final int fieldIndex = orcStruct.getSchema().getFieldNames().indexOf(fieldName);
     TypeDescription fieldDescription = orcStruct.getSchema().getChildren().get(fieldIndex);
     if (fieldDescription.getCategory().isPrimitive()) {
       final Object simple = converter.tryConvertPrimitive(orcStruct.getFieldValue(fieldIndex));
-      Assert.assertNotNull(simple);
-      Assert.assertEquals(expectedValue, simple);
+      Assertions.assertNotNull(simple);
+      Assertions.assertEquals(expectedValue, simple);
     }
   }
 
   private static void assertNullValue(OrcStructConverter converter, OrcStruct orcStruct, String fieldName)
   {
     final Object field = converter.convertRootField(orcStruct, fieldName);
-    Assert.assertNull(field);
+    Assertions.assertNull(field);
   }
 
 }

--- a/extensions-core/postgresql-metadata-storage/pom.xml
+++ b/extensions-core/postgresql-metadata-storage/pom.xml
@@ -100,8 +100,18 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/input/PostgresqlInputSourceDatabaseConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/input/PostgresqlInputSourceDatabaseConnectorTest.java
@@ -28,12 +28,13 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.storage.postgresql.PostgreSQLMetadataStorageModule;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PostgresqlInputSourceDatabaseConnectorTest
 {
@@ -44,9 +45,6 @@ public class PostgresqlInputSourceDatabaseConnectorTest
     MAPPER.registerModules(new PostgreSQLMetadataStorageModule().getJacksonModules());
     MAPPER.setInjectableValues(new InjectableValues.Std().addValue(JdbcAccessSecurityConfig.class, INJECTED_CONF));
   }
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
 
   @Test
@@ -68,7 +66,7 @@ public class PostgresqlInputSourceDatabaseConnectorTest
         MAPPER.writeValueAsString(connector),
         PostgresqlInputSourceDatabaseConnector.class
     );
-    Assert.assertEquals(connector, andBack);
+    Assertions.assertEquals(connector, andBack);
   }
 
   @Test
@@ -124,24 +122,24 @@ public class PostgresqlInputSourceDatabaseConnectorTest
   @Test
   public void testFailWhenNoAllowlistAndHaveProperty()
   {
-    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
-    {
-      @Override
-      public String getConnectURI()
+    Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+      MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
       {
-        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
-      }
-    };
+        @Override
+        public String getConnectURI()
+        {
+          return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+        }
+      };
 
-    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
+      JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of(""));
 
-    expectedException.expectMessage("is not in the allowed list");
-    expectedException.expect(IllegalArgumentException.class);
-
-    new PostgresqlInputSourceDatabaseConnector(
-        connectorConfig,
-        securityConfig
-    );
+      new PostgresqlInputSourceDatabaseConnector(
+          connectorConfig,
+          securityConfig
+      );
+    });
+    assertTrue(exception.getMessage().contains("is not in the allowed list"));
   }
 
   @Test
@@ -169,47 +167,47 @@ public class PostgresqlInputSourceDatabaseConnectorTest
   @Test
   public void testFailOnlyInvalidProperty()
   {
-    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
-    {
-      @Override
-      public String getConnectURI()
+    Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+      MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
       {
-        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
-      }
-    };
+        @Override
+        public String getConnectURI()
+        {
+          return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+        }
+      };
 
-    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
+      JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("none", "nonenone"));
 
-    expectedException.expectMessage("is not in the allowed list");
-    expectedException.expect(IllegalArgumentException.class);
-
-    new PostgresqlInputSourceDatabaseConnector(
-        connectorConfig,
-        securityConfig
-    );
+      new PostgresqlInputSourceDatabaseConnector(
+          connectorConfig,
+          securityConfig
+      );
+    });
+    assertTrue(exception.getMessage().contains("is not in the allowed list"));
   }
 
   @Test
   public void testFailValidAndInvalidProperty()
   {
-    MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
-    {
-      @Override
-      public String getConnectURI()
+    Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+      MetadataStorageConnectorConfig connectorConfig = new MetadataStorageConnectorConfig()
       {
-        return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
-      }
-    };
+        @Override
+        public String getConnectURI()
+        {
+          return "jdbc:postgresql://localhost:3306/test?user=maytas&password=secret&keyonly";
+        }
+      };
 
-    JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
+      JdbcAccessSecurityConfig securityConfig = newSecurityConfigEnforcingAllowList(ImmutableSet.of("user", "nonenone"));
 
-    expectedException.expectMessage("is not in the allowed list");
-    expectedException.expect(IllegalArgumentException.class);
-
-    new PostgresqlInputSourceDatabaseConnector(
-        connectorConfig,
-        securityConfig
-    );
+      new PostgresqlInputSourceDatabaseConnector(
+          connectorConfig,
+          securityConfig
+      );
+    });
+    assertTrue(exception.getMessage().contains("is not in the allowed list"));
   }
 
   @Test

--- a/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
+++ b/extensions-core/postgresql-metadata-storage/src/test/java/org/apache/druid/metadata/storage/postgresql/PostgreSQLConnectorTest.java
@@ -23,24 +23,21 @@ import com.google.common.base.Suppliers;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.sql.SQLException;
 
-@RunWith(Parameterized.class)
 public class PostgreSQLConnectorTest
 {
   private CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig;
 
-  public PostgreSQLConnectorTest(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
+  public void initPostgreSQLConnectorTest(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
     this.centralizedDatasourceSchemaConfig = centralizedDatasourceSchemaConfig;
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Object[][] constructorFeeder()
   {
     return new Object[][]{
@@ -49,9 +46,11 @@ public class PostgreSQLConnectorTest
     };
   }
 
-  @Test
-  public void testIsTransientException()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIsTransientException(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initPostgreSQLConnectorTest(centralizedDatasourceSchemaConfig);
     PostgreSQLConnector connector = new PostgreSQLConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(MetadataStorageTablesConfig.fromBase(null)),
@@ -60,18 +59,20 @@ public class PostgreSQLConnectorTest
         centralizedDatasourceSchemaConfig
     );
 
-    Assert.assertTrue(connector.isTransientException(new SQLException("bummer, connection problem", "08DIE")));
-    Assert.assertTrue(connector.isTransientException(new SQLException("bummer, too many things going on", "53RES")));
-    Assert.assertFalse(connector.isTransientException(new SQLException("oh god, no!", "58000")));
-    Assert.assertFalse(connector.isTransientException(new SQLException("help!")));
-    Assert.assertFalse(connector.isTransientException(new SQLException()));
-    Assert.assertFalse(connector.isTransientException(new Exception("I'm not happy")));
-    Assert.assertFalse(connector.isTransientException(new Throwable("I give up")));
+    Assertions.assertTrue(connector.isTransientException(new SQLException("bummer, connection problem", "08DIE")));
+    Assertions.assertTrue(connector.isTransientException(new SQLException("bummer, too many things going on", "53RES")));
+    Assertions.assertFalse(connector.isTransientException(new SQLException("oh god, no!", "58000")));
+    Assertions.assertFalse(connector.isTransientException(new SQLException("help!")));
+    Assertions.assertFalse(connector.isTransientException(new SQLException()));
+    Assertions.assertFalse(connector.isTransientException(new Exception("I'm not happy")));
+    Assertions.assertFalse(connector.isTransientException(new Throwable("I give up")));
   }
 
-  @Test
-  public void testIsUniqueConstraintViolation()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIsUniqueConstraintViolation(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initPostgreSQLConnectorTest(centralizedDatasourceSchemaConfig);
     PostgreSQLConnector connector = new PostgreSQLConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(MetadataStorageTablesConfig.fromBase(null)),
@@ -81,27 +82,29 @@ public class PostgreSQLConnectorTest
     );
 
     // PostgreSQL unique_violation SQL state (23505)
-    Assert.assertTrue(connector.isUniqueConstraintViolation(
+    Assertions.assertTrue(connector.isUniqueConstraintViolation(
         new SQLException("duplicate key value violates unique constraint", "23505")
     ));
 
     // Different SQL state should return false
-    Assert.assertFalse(connector.isUniqueConstraintViolation(
+    Assertions.assertFalse(connector.isUniqueConstraintViolation(
         new SQLException("some other error", "42P01")
     ));
 
     // SQLException wrapped in another exception (tests cause chain traversal)
-    Assert.assertTrue(connector.isUniqueConstraintViolation(
+    Assertions.assertTrue(connector.isUniqueConstraintViolation(
         new RuntimeException(new SQLException("duplicate key", "23505"))
     ));
 
     // Non-SQLException exception
-    Assert.assertFalse(connector.isUniqueConstraintViolation(new Exception("not a SQLException")));
+    Assertions.assertFalse(connector.isUniqueConstraintViolation(new Exception("not a SQLException")));
   }
 
-  @Test
-  public void testLimitClause()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testLimitClause(CentralizedDatasourceSchemaConfig centralizedDatasourceSchemaConfig)
   {
+    initPostgreSQLConnectorTest(centralizedDatasourceSchemaConfig);
     PostgreSQLConnector connector = new PostgreSQLConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(MetadataStorageTablesConfig.fromBase(null)),
@@ -109,6 +112,6 @@ public class PostgreSQLConnectorTest
         new PostgreSQLTablesConfig(),
         centralizedDatasourceSchemaConfig
     );
-    Assert.assertEquals("LIMIT 100", connector.limitClause(100));
+    Assertions.assertEquals("LIMIT 100", connector.limitClause(100));
   }
 }

--- a/extensions-core/testing-tools/pom.xml
+++ b/extensions-core/testing-tools/pom.xml
@@ -168,11 +168,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -195,11 +190,6 @@
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/testing-tools/src/test/java/org/apache/druid/guice/ClusterTestingModuleTest.java
+++ b/extensions-core/testing-tools/src/test/java/org/apache/druid/guice/ClusterTestingModuleTest.java
@@ -57,10 +57,9 @@ import org.apache.druid.testing.cluster.task.FaultyCoordinatorClient;
 import org.apache.druid.testing.cluster.task.FaultyOverlordClient;
 import org.apache.druid.testing.cluster.task.FaultyRemoteTaskActionClientFactory;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -76,8 +75,8 @@ public class ClusterTestingModuleTest
       .registerModules(new IndexingServiceTuningConfigModule().getJacksonModules())
       .registerModules(new IndexingServiceInputSourceModule().getJacksonModules());
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void test_peonRunnable_isNotModified_ifTestingIsDisabled() throws IOException
@@ -87,7 +86,7 @@ public class ClusterTestingModuleTest
       System.setProperty("druid.unsafe.cluster.testing", "false");
 
       // Write out the task payload in a temporary json file
-      File file = temporaryFolder.newFile("task.json");
+      File file = File.createTempFile("task.json", null, temporaryFolder);
       FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 
@@ -97,13 +96,13 @@ public class ClusterTestingModuleTest
       final Injector peonInjector = peon.makeInjector(Set.of(NodeRole.PEON));
 
       CoordinatorClient coordinatorClient = peonInjector.getInstance(CoordinatorClient.class);
-      Assert.assertTrue(coordinatorClient instanceof CoordinatorClientImpl);
+      Assertions.assertTrue(coordinatorClient instanceof CoordinatorClientImpl);
 
       OverlordClient overlordClient = peonInjector.getInstance(OverlordClient.class);
-      Assert.assertTrue(overlordClient instanceof OverlordClientImpl);
+      Assertions.assertTrue(overlordClient instanceof OverlordClientImpl);
 
       TaskActionClientFactory taskActionClientFactory = peonInjector.getInstance(TaskActionClientFactory.class);
-      Assert.assertTrue(taskActionClientFactory instanceof RemoteTaskActionClientFactory);
+      Assertions.assertTrue(taskActionClientFactory instanceof RemoteTaskActionClientFactory);
     }
     finally {
       System.clearProperty("druid.unsafe.cluster.testing");
@@ -118,7 +117,7 @@ public class ClusterTestingModuleTest
       System.setProperty("druid.unsafe.cluster.testing", "true");
 
       // Write out the task payload in a temporary json file
-      File file = temporaryFolder.newFile("task.json");
+      File file = File.createTempFile("task.json", null, temporaryFolder);
       FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 
@@ -128,10 +127,10 @@ public class ClusterTestingModuleTest
       final Injector peonInjector = peon.makeInjector(Set.of(NodeRole.PEON));
 
       CoordinatorClient coordinatorClient = peonInjector.getInstance(CoordinatorClient.class);
-      Assert.assertTrue(coordinatorClient instanceof FaultyCoordinatorClient);
+      Assertions.assertTrue(coordinatorClient instanceof FaultyCoordinatorClient);
 
       TaskActionClientFactory taskActionClientFactory = peonInjector.getInstance(TaskActionClientFactory.class);
-      Assert.assertTrue(taskActionClientFactory instanceof FaultyRemoteTaskActionClientFactory);
+      Assertions.assertTrue(taskActionClientFactory instanceof FaultyRemoteTaskActionClientFactory);
     }
     finally {
       System.clearProperty("druid.unsafe.cluster.testing");
@@ -156,7 +155,7 @@ public class ClusterTestingModuleTest
 
       // Write out the task payload in a temporary json file
       final String taskJson = MAPPER.writeValueAsString(task);
-      File file = temporaryFolder.newFile("task.json");
+      File file = File.createTempFile("task.json", null, temporaryFolder);
       FileUtils.write(file, taskJson, StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 
@@ -214,7 +213,7 @@ public class ClusterTestingModuleTest
 
       // Write out the task payload in a temporary json file
       final String taskJson = MAPPER.writeValueAsString(task);
-      File file = temporaryFolder.newFile("task.json");
+      File file = File.createTempFile("task.json", null, temporaryFolder);
       FileUtils.write(file, taskJson, StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 
@@ -244,7 +243,7 @@ public class ClusterTestingModuleTest
       final Injector overlordInjector = overlord.makeInjector(Set.of(NodeRole.OVERLORD));
 
       GlobalTaskLockbox taskLockbox = overlordInjector.getInstance(GlobalTaskLockbox.class);
-      Assert.assertTrue(taskLockbox instanceof FaultyTaskLockbox);
+      Assertions.assertTrue(taskLockbox instanceof FaultyTaskLockbox);
     }
     finally {
       System.clearProperty("druid.unsafe.cluster.testing");
@@ -264,7 +263,7 @@ public class ClusterTestingModuleTest
       final Injector indexerInjector = indexer.makeInjector(Set.of(NodeRole.INDEXER));
 
       OverlordClient overlordClient = indexerInjector.getInstance(OverlordClient.class);
-      Assert.assertTrue(overlordClient instanceof FaultyOverlordClient);
+      Assertions.assertTrue(overlordClient instanceof FaultyOverlordClient);
     }
     finally {
       System.clearProperty("druid.unsafe.cluster.testing");
@@ -273,25 +272,25 @@ public class ClusterTestingModuleTest
 
   private static void verifyTestingConfig(ClusterTestingTaskConfig taskConfig)
   {
-    Assert.assertNotNull(taskConfig);
-    Assert.assertNotNull(taskConfig.getCoordinatorClientConfig());
-    Assert.assertNotNull(taskConfig.getOverlordClientConfig());
-    Assert.assertNotNull(taskConfig.getTaskActionClientConfig());
-    Assert.assertNotNull(taskConfig.getMetadataConfig());
+    Assertions.assertNotNull(taskConfig);
+    Assertions.assertNotNull(taskConfig.getCoordinatorClientConfig());
+    Assertions.assertNotNull(taskConfig.getOverlordClientConfig());
+    Assertions.assertNotNull(taskConfig.getTaskActionClientConfig());
+    Assertions.assertNotNull(taskConfig.getMetadataConfig());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Duration.standardSeconds(10),
         taskConfig.getTaskActionClientConfig().getSegmentPublishDelay()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Duration.standardSeconds(5),
         taskConfig.getTaskActionClientConfig().getSegmentAllocateDelay()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Duration.standardSeconds(30),
         taskConfig.getCoordinatorClientConfig().getMinSegmentHandoffDelay()
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         taskConfig.getMetadataConfig().isCleanupPendingSegments()
     );
   }

--- a/extensions-core/testing-tools/src/test/java/org/apache/druid/guice/ClusterTestingModuleTest.java
+++ b/extensions-core/testing-tools/src/test/java/org/apache/druid/guice/ClusterTestingModuleTest.java
@@ -86,7 +86,7 @@ public class ClusterTestingModuleTest
       System.setProperty("druid.unsafe.cluster.testing", "false");
 
       // Write out the task payload in a temporary json file
-      File file = File.createTempFile("task.json", null, temporaryFolder);
+      File file = new File(temporaryFolder, "task.json");
       FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 
@@ -117,7 +117,7 @@ public class ClusterTestingModuleTest
       System.setProperty("druid.unsafe.cluster.testing", "true");
 
       // Write out the task payload in a temporary json file
-      File file = File.createTempFile("task.json", null, temporaryFolder);
+      File file = new File(temporaryFolder, "task.json");
       FileUtils.write(file, "{\"type\":\"noop\"}", StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 
@@ -155,7 +155,7 @@ public class ClusterTestingModuleTest
 
       // Write out the task payload in a temporary json file
       final String taskJson = MAPPER.writeValueAsString(task);
-      File file = File.createTempFile("task.json", null, temporaryFolder);
+      File file = new File(temporaryFolder, "task.json");
       FileUtils.write(file, taskJson, StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 
@@ -213,7 +213,7 @@ public class ClusterTestingModuleTest
 
       // Write out the task payload in a temporary json file
       final String taskJson = MAPPER.writeValueAsString(task);
-      File file = File.createTempFile("task.json", null, temporaryFolder);
+      File file = new File(temporaryFolder, "task.json");
       FileUtils.write(file, taskJson, StandardCharsets.UTF_8);
       peon.taskAndStatusFile = List.of(file.getParent(), "1");
 

--- a/extensions-core/testing-tools/src/test/java/org/apache/druid/query/expressions/SleepExprTest.java
+++ b/extensions-core/testing-tools/src/test/java/org/apache/druid/query/expressions/SleepExprTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.math.expr.FunctionTest;
 import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -59,10 +59,10 @@ public class SleepExprTest extends InitializedNullHandlingTest
     expr.eval(InputBindings.nilBindings()).value();
     final long after = System.currentTimeMillis();
     final long elapsed = after - before;
-    Assert.assertTrue(
-        StringUtils.format("Expected [%s], but actual elapsed was [%s]", expectedTimeElapsedMs, elapsed),
+    Assertions.assertTrue(
         elapsed >= expectedTimeElapsedMs
-        && elapsed < expectedTimeElapsedMs + detla
+        && elapsed < expectedTimeElapsedMs + detla,
+        StringUtils.format("Expected [%s], but actual elapsed was [%s]", expectedTimeElapsedMs, elapsed)
     );
   }
 

--- a/extensions-core/testing-tools/src/test/java/org/apache/druid/query/expressions/SleepExprTest.java
+++ b/extensions-core/testing-tools/src/test/java/org/apache/druid/query/expressions/SleepExprTest.java
@@ -53,7 +53,7 @@ public class SleepExprTest extends InitializedNullHandlingTest
 
   private void assertTimeElapsed(String expression, long expectedTimeElapsedMs)
   {
-    final long detla = 50;
+    final long deltaMs = 50;
     final long before = System.currentTimeMillis();
     final Expr expr = Parser.parse(expression, exprMacroTable);
     expr.eval(InputBindings.nilBindings()).value();
@@ -61,7 +61,7 @@ public class SleepExprTest extends InitializedNullHandlingTest
     final long elapsed = after - before;
     Assertions.assertTrue(
         elapsed >= expectedTimeElapsedMs
-        && elapsed < expectedTimeElapsedMs + detla,
+        && elapsed < expectedTimeElapsedMs + deltaMs,
         StringUtils.format("Expected [%s], but actual elapsed was [%s]", expectedTimeElapsedMs, elapsed)
     );
   }

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -96,6 +96,7 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -111,13 +112,19 @@ import java.util.stream.Collectors;
  */
 public class AggregationTestHelper implements Closeable
 {
+  @FunctionalInterface
+  private interface TempFolderProvider
+  {
+    File newFolder() throws IOException;
+  }
+
   private final ObjectMapper mapper;
   private final IndexMerger indexMerger;
   private final IndexIO indexIO;
   private final QueryToolChest toolChest;
   private final QueryRunnerFactory factory;
 
-  private final TemporaryFolder tempFolder;
+  private final TempFolderProvider tempFolderProvider;
   private final Closer resourceCloser;
 
   private final Map<String, Object> queryContext;
@@ -128,7 +135,7 @@ public class AggregationTestHelper implements Closeable
       IndexIO indexIO,
       QueryToolChest toolchest,
       QueryRunnerFactory factory,
-      TemporaryFolder tempFolder,
+      TempFolderProvider tempFolderProvider,
       List<? extends Module> jsonModulesToRegister,
       Closer resourceCloser,
       Map<String, Object> queryContext
@@ -139,7 +146,7 @@ public class AggregationTestHelper implements Closeable
     this.indexIO = indexIO;
     this.toolChest = toolchest;
     this.factory = factory;
-    this.tempFolder = tempFolder;
+    this.tempFolderProvider = tempFolderProvider;
     this.resourceCloser = resourceCloser;
     this.queryContext = queryContext;
 
@@ -152,6 +159,32 @@ public class AggregationTestHelper implements Closeable
       List<? extends Module> jsonModulesToRegister,
       GroupByQueryConfig config,
       TemporaryFolder tempFolder
+  )
+  {
+    return createGroupByQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        config,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createGroupByQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      GroupByQueryConfig config,
+      File tempFolder
+  )
+  {
+    return createGroupByQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        config,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createGroupByQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      GroupByQueryConfig config,
+      TempFolderProvider tempFolderProvider
   )
   {
     final Closer closer = Closer.create();
@@ -179,7 +212,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         factory.getToolchest(),
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         closer,
         Collections.emptyMap()
@@ -189,6 +222,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createTimeseriesQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createTimeseriesQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createTimeseriesQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -214,7 +269,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         Closer.create(),
         Collections.emptyMap()
@@ -224,6 +279,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createTopNQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createTopNQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createTopNQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createTopNQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createTopNQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -261,7 +338,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         resourceCloser,
         Collections.emptyMap()
@@ -271,6 +348,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createScanQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createScanQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createScanQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createScanQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createScanQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -299,11 +398,21 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         resourceCloser,
         Collections.emptyMap()
     );
+  }
+
+  private static TempFolderProvider tempFolderProvider(final TemporaryFolder tempFolder)
+  {
+    return tempFolder::newFolder;
+  }
+
+  private static TempFolderProvider tempFolderProvider(final File tempFolder)
+  {
+    return () -> Files.createTempDirectory(tempFolder.toPath(), "druid-").toFile();
   }
 
   public AggregationTestHelper withQueryContext(final Map<String, Object> queryContext)
@@ -316,7 +425,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolChest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         Collections.emptyList(),
         resourceCloser,
         newContext
@@ -334,7 +443,7 @@ public class AggregationTestHelper implements Closeable
       Query<T> query
   ) throws Exception
   {
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = tempFolderProvider.newFolder();
     createIndex(inputDataFile, inputSchema, inputFormat, aggregators, segmentDir, minTimestamp, gran, maxRowCount);
     return runQueryOnSegments(Collections.singletonList(segmentDir), query);
   }
@@ -350,7 +459,7 @@ public class AggregationTestHelper implements Closeable
       Query<T> query
   ) throws Exception
   {
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = tempFolderProvider.newFolder();
     createIndex(inputDataStream, inputSchema, inputFormat, aggregators, segmentDir, minTimestamp, gran, maxRowCount, true);
     return runQueryOnSegments(Collections.singletonList(segmentDir), query);
   }
@@ -439,7 +548,7 @@ public class AggregationTestHelper implements Closeable
           return inputDataStream;
         }
       };
-      InputEntityReader reader = inputFormat.createReader(inputSchema, streamEntity, tempFolder.newFolder());
+      InputEntityReader reader = inputFormat.createReader(inputSchema, streamEntity, tempFolderProvider.newFolder());
       AggregatorFactory[] metrics = aggregators.toArray(new AggregatorFactory[0]);
       index = new OnheapIncrementalIndex.Builder()
           .setIndexSchema(
@@ -458,7 +567,7 @@ public class AggregationTestHelper implements Closeable
         while (iter.hasNext()) {
           InputRow row = iter.next();
           if (!index.canAppendRow()) {
-            File tmp = tempFolder.newFolder();
+            File tmp = tempFolderProvider.newFolder();
             toMerge.add(tmp);
             indexMerger.persist(index, tmp, IndexSpec.getDefault(), null);
             index.close();
@@ -480,7 +589,7 @@ public class AggregationTestHelper implements Closeable
       }
 
       if (toMerge.size() > 0) {
-        File tmp = tempFolder.newFolder();
+        File tmp = tempFolderProvider.newFolder();
         toMerge.add(tmp);
         indexMerger.persist(index, tmp, IndexSpec.getDefault(), null);
 
@@ -510,7 +619,7 @@ public class AggregationTestHelper implements Closeable
   ) throws Exception
   {
     if (outDir == null) {
-      outDir = tempFolder.newFolder();
+      outDir = tempFolderProvider.newFolder();
     }
     indexMerger.persist(index, outDir, IndexSpec.getDefault(), null);
 

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -97,7 +97,6 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -97,6 +97,7 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
## Summary

Migrate the selected tests in these ten `extensions-core` modules to JUnit 5:

- `druid-aws-rds-extensions`
- `druid-bloom-filter`
- `druid-kerberos`
- `druid-pac4j`
- `ec2-extensions`
- `kafka-extraction-namespace`
- `mysql-metadata-storage`
- `orc-extensions`
- `postgresql-metadata-storage`
- `testing-tools`

The changes replace JUnit 4 annotations, assertions, parameterized runners, and temporary-folder usage with Jupiter APIs and the approved temporary-directory helpers. The module test POMs are updated with the Jupiter and Mockito-Jupiter dependencies required by the migrated tests, and direct JUnit 4/Vintage dependencies are removed where this batch no longer needs them.

The following compatibility dependencies or usages remain intentionally in this PR:

- `druid-bloom-filter` retains `junit:junit` and `org.hamcrest:hamcrest` because shared processing/SQL test-jar fixture APIs expose those types.
- `kafka-extraction-namespace` still uses Hamcrest in `TestKafkaExtractionCluster`.
- `testing-tools` retains `junit-jupiter-migrationsupport`.
- `mysql-metadata-storage` retains its existing Hamcrest test dependency.

This PR contains no processing, SQL, server, benchmark, or extensions-contrib fixture migration.

## Validation

- All current GitHub Actions checks passed, including strict compilation, packaging, web checks, OpenRewrite, Maven static checks, unit/integration tests, coverage, Docker tests, and CodeQL.
- The Bloom filter test suite passed locally with 80 tests and only existing skips.
- `Pac4jSessionStoreTest` passed locally with 12 tests and no failures or errors.
- Checkstyle, PMD, Enforcer, forbidden-API checks, and `git diff --check` passed.

## Release note

Test-only change; there is no user-facing behavior change.

## Tracking

Part of #13948.
