### PR TITLE
test: migrate extension-core format and lookup tests to JUnit 5

### DIFF
--- a/extensions-core/avro-extensions/pom.xml
+++ b/extensions-core/avro-extensions/pom.xml
@@ -218,8 +218,23 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputFormatTest.java
@@ -60,9 +60,9 @@ import org.apache.druid.segment.transform.ExpressionTransform;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.transform.TransformingInputEntityReader;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.schemarepo.InMemoryRepository;
 import org.schemarepo.Repository;
 import org.schemarepo.SchemaValidationException;
@@ -209,7 +209,7 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
     return someAvroDatumFile;
   }
 
-  @Before
+  @BeforeEach
   public void before()
   {
     timestampSpec = new TimestampSpec("nested", "millis", null);
@@ -245,7 +245,7 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
         NestedInputFormat.class
     );
 
-    Assert.assertEquals(inputFormat, inputFormat2);
+    Assertions.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -263,7 +263,7 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
         NestedInputFormat.class
     );
 
-    Assert.assertEquals(inputFormat, inputFormat2);
+    Assertions.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -279,21 +279,21 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
         jsonMapper.writeValueAsString(inputFormat),
         NestedInputFormat.class
     );
-    Assert.assertEquals(inputFormat, inputFormat2);
+    Assertions.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
   public void testMissingAvroBytesDecoderRaisesIAE()
   {
-    Assert.assertThrows(
-        "avroBytesDecoder is required to decode Avro records",
+    Assertions.assertThrows(
         IAE.class,
         () -> new AvroStreamInputFormat(
             flattenSpec,
             null,
             true,
             true
-        )
+        ),
+        "avroBytesDecoder is required to decode Avro records"
     );
   }
 
@@ -440,33 +440,33 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
     );
     InputRow inputRow = transformingReader.read().next();
 
-    Assert.assertEquals(1543698L, inputRow.getTimestampFromEpoch());
-    Assert.assertEquals(
+    Assertions.assertEquals(1543698L, inputRow.getTimestampFromEpoch());
+    Assertions.assertEquals(
         SOME_INT_VALUE_MAP_VALUE,
         StructuredData.unwrap(inputRow.getRaw("someIntValueMap"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SOME_STRING_VALUE_MAP_VALUE,
         StructuredData.unwrap(inputRow.getRaw("someStringValueMap"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of("subInt", 4892, "subLong", 1543698L),
         StructuredData.unwrap(inputRow.getRaw("someRecord"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(ImmutableMap.of("nestedString", "string in record")),
         StructuredData.unwrap(inputRow.getRaw("someRecordArray"))
     );
 
-    Assert.assertEquals(8L, inputRow.getRaw("tSomeIntValueMap8"));
-    Assert.assertEquals(8L, inputRow.getRaw("tSomeIntValueMap8_2"));
-    Assert.assertEquals("8", inputRow.getRaw("tSomeStringValueMap8"));
-    Assert.assertEquals(1543698L, inputRow.getRaw("tSomeRecordSubLong"));
-    Assert.assertEquals(
+    Assertions.assertEquals(8L, inputRow.getRaw("tSomeIntValueMap8"));
+    Assertions.assertEquals(8L, inputRow.getRaw("tSomeIntValueMap8_2"));
+    Assertions.assertEquals("8", inputRow.getRaw("tSomeStringValueMap8"));
+    Assertions.assertEquals(1543698L, inputRow.getRaw("tSomeRecordSubLong"));
+    Assertions.assertEquals(
         ImmutableMap.of("nestedString", "string in record"),
         StructuredData.unwrap(inputRow.getRaw("tSomeRecordArray0"))
     );
-    Assert.assertEquals("string in record", inputRow.getRaw("tSomeRecordArray0nestedString"));
+    Assertions.assertEquals("string in record", inputRow.getRaw("tSomeRecordArray0nestedString"));
   }
 
   @Test
@@ -516,87 +516,87 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
 
   static void assertInputRowCorrect(InputRow inputRow, List<String> expectedDimensions, boolean isFromPigAvro)
   {
-    Assert.assertEquals(expectedDimensions, inputRow.getDimensions());
-    Assert.assertEquals(1543698L, inputRow.getTimestampFromEpoch());
+    Assertions.assertEquals(expectedDimensions, inputRow.getDimensions());
+    Assertions.assertEquals(1543698L, inputRow.getTimestampFromEpoch());
 
     // test dimensions
-    Assert.assertEquals(Collections.singletonList(EVENT_TYPE_VALUE), inputRow.getDimension(EVENT_TYPE));
-    Assert.assertEquals(Collections.singletonList(String.valueOf(ID_VALUE)), inputRow.getDimension(ID));
-    Assert.assertEquals(
+    Assertions.assertEquals(Collections.singletonList(EVENT_TYPE_VALUE), inputRow.getDimension(EVENT_TYPE));
+    Assertions.assertEquals(Collections.singletonList(String.valueOf(ID_VALUE)), inputRow.getDimension(ID));
+    Assertions.assertEquals(
         Collections.singletonList(String.valueOf(SOME_OTHER_ID_VALUE)),
         inputRow.getDimension(SOME_OTHER_ID)
     );
-    Assert.assertEquals(Collections.singletonList(String.valueOf(true)), inputRow.getDimension(IS_VALID));
+    Assertions.assertEquals(Collections.singletonList(String.valueOf(true)), inputRow.getDimension(IS_VALID));
 
     // someRecordArray represents a record generated from Pig using AvroStorage
     // as it implicitly converts array elements to a record
     if (isFromPigAvro) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Collections.singletonList(SOME_RECORD_ARRAY_VALUE.get(0).getNestedString()),
           inputRow.getDimension("someRecordArray")
       );
     } else {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Lists.transform(SOME_INT_ARRAY_VALUE, String::valueOf),
           inputRow.getDimension("someIntArray")
       );
       // For string array, nulls are preserved so use ArrayList (ImmutableList doesn't support nulls)
-      Assert.assertEquals(
+      Assertions.assertEquals(
           SOME_STRING_ARRAY_VALUE.stream().map(Evals::asString).collect(Collectors.toList()),
           inputRow.getDimension("someStringArray")
       );
 
       final Object someRecordArrayObj = inputRow.getRaw("someRecordArray");
-      Assert.assertNotNull(someRecordArrayObj);
-      Assert.assertTrue(someRecordArrayObj instanceof List);
-      Assert.assertEquals(1, ((List) someRecordArrayObj).size());
+      Assertions.assertNotNull(someRecordArrayObj);
+      Assertions.assertTrue(someRecordArrayObj instanceof List);
+      Assertions.assertEquals(1, ((List) someRecordArrayObj).size());
       final Object recordArrayElementObj = ((List) someRecordArrayObj).get(0);
-      Assert.assertNotNull(recordArrayElementObj);
-      Assert.assertTrue(recordArrayElementObj instanceof LinkedHashMap);
+      Assertions.assertNotNull(recordArrayElementObj);
+      Assertions.assertTrue(recordArrayElementObj instanceof LinkedHashMap);
       LinkedHashMap recordArrayElement = (LinkedHashMap) recordArrayElementObj;
-      Assert.assertEquals("string in record", recordArrayElement.get("nestedString"));
+      Assertions.assertEquals("string in record", recordArrayElement.get("nestedString"));
     }
 
     final Object someIntValueMapObj = inputRow.getRaw("someIntValueMap");
-    Assert.assertNotNull(someIntValueMapObj);
-    Assert.assertTrue(someIntValueMapObj instanceof LinkedHashMap);
+    Assertions.assertNotNull(someIntValueMapObj);
+    Assertions.assertTrue(someIntValueMapObj instanceof LinkedHashMap);
     LinkedHashMap someIntValueMap = (LinkedHashMap) someIntValueMapObj;
-    Assert.assertEquals(4, someIntValueMap.size());
-    Assert.assertEquals(1, someIntValueMap.get("1"));
-    Assert.assertEquals(2, someIntValueMap.get("2"));
-    Assert.assertEquals(4, someIntValueMap.get("4"));
-    Assert.assertEquals(8, someIntValueMap.get("8"));
+    Assertions.assertEquals(4, someIntValueMap.size());
+    Assertions.assertEquals(1, someIntValueMap.get("1"));
+    Assertions.assertEquals(2, someIntValueMap.get("2"));
+    Assertions.assertEquals(4, someIntValueMap.get("4"));
+    Assertions.assertEquals(8, someIntValueMap.get("8"));
 
 
     final Object someStringValueMapObj = inputRow.getRaw("someStringValueMap");
-    Assert.assertNotNull(someStringValueMapObj);
-    Assert.assertTrue(someStringValueMapObj instanceof LinkedHashMap);
+    Assertions.assertNotNull(someStringValueMapObj);
+    Assertions.assertTrue(someStringValueMapObj instanceof LinkedHashMap);
     LinkedHashMap someStringValueMap = (LinkedHashMap) someStringValueMapObj;
-    Assert.assertEquals(4, someStringValueMap.size());
-    Assert.assertEquals("1", someStringValueMap.get("1"));
-    Assert.assertEquals("2", someStringValueMap.get("2"));
-    Assert.assertEquals("4", someStringValueMap.get("4"));
-    Assert.assertEquals("8", someStringValueMap.get("8"));
+    Assertions.assertEquals(4, someStringValueMap.size());
+    Assertions.assertEquals("1", someStringValueMap.get("1"));
+    Assertions.assertEquals("2", someStringValueMap.get("2"));
+    Assertions.assertEquals("4", someStringValueMap.get("4"));
+    Assertions.assertEquals("8", someStringValueMap.get("8"));
 
 
     final Object someRecordObj = inputRow.getRaw("someRecord");
-    Assert.assertNotNull(someRecordObj);
-    Assert.assertTrue(someRecordObj instanceof LinkedHashMap);
+    Assertions.assertNotNull(someRecordObj);
+    Assertions.assertTrue(someRecordObj instanceof LinkedHashMap);
     LinkedHashMap someRecord = (LinkedHashMap) someRecordObj;
-    Assert.assertEquals(4892, someRecord.get("subInt"));
-    Assert.assertEquals(1543698L, someRecord.get("subLong"));
+    Assertions.assertEquals(4892, someRecord.get("subInt"));
+    Assertions.assertEquals(1543698L, someRecord.get("subLong"));
 
     final Object someList = inputRow.getDimension("nestedArrayVal");
-    Assert.assertNotNull(someList);
-    Assert.assertTrue(someList instanceof List);
+    Assertions.assertNotNull(someList);
+    Assertions.assertTrue(someList instanceof List);
     List someRecordObj3List = (List) someList;
-    Assert.assertEquals(1, someRecordObj3List.size());
-    Assert.assertEquals("string in record", someRecordObj3List.get(0));
+    Assertions.assertEquals(1, someRecordObj3List.size());
+    Assertions.assertEquals("string in record", someRecordObj3List.get(0));
 
 
     // towards Map avro field as druid dimension, need to convert its toString() back to HashMap to check equality
-    Assert.assertEquals(1, inputRow.getDimension("someIntValueMap").size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, inputRow.getDimension("someIntValueMap").size());
+    Assertions.assertEquals(
         SOME_INT_VALUE_MAP_VALUE,
         new HashMap<CharSequence, Integer>(
             Maps.transformValues(
@@ -616,7 +616,7 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SOME_STRING_VALUE_MAP_VALUE,
         new HashMap<CharSequence, CharSequence>(
             Splitter
@@ -625,26 +625,26 @@ public class AvroStreamInputFormatTest extends InitializedNullHandlingTest
                 .split(BRACES_AND_SPACE.matcher(inputRow.getDimension("someIntValueMap").get(0)).replaceAll(""))
         )
     );
-    Assert.assertEquals(Collections.singletonList(SOME_UNION_VALUE), inputRow.getDimension("someUnion"));
-    Assert.assertEquals(Collections.emptyList(), inputRow.getDimension("someNull"));
-    Assert.assertEquals(
+    Assertions.assertEquals(Collections.singletonList(SOME_UNION_VALUE), inputRow.getDimension("someUnion"));
+    Assertions.assertEquals(Collections.emptyList(), inputRow.getDimension("someNull"));
+    Assertions.assertEquals(
         Arrays.toString(SOME_FIXED_VALUE.bytes()),
         Arrays.toString((byte[]) (inputRow.getRaw("someFixed")))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.toString(SOME_BYTES_VALUE.array()),
         Arrays.toString((byte[]) (inputRow.getRaw("someBytes")))
     );
-    Assert.assertEquals(Collections.singletonList(String.valueOf(MyEnum.ENUM1)), inputRow.getDimension("someEnum"));
-    Assert.assertEquals(
+    Assertions.assertEquals(Collections.singletonList(String.valueOf(MyEnum.ENUM1)), inputRow.getDimension("someEnum"));
+    Assertions.assertEquals(
         Collections.singletonList(ImmutableMap.of("subInt", 4892, "subLong", 1543698L).toString()),
         inputRow.getDimension("someRecord")
     );
 
     // test metrics
-    Assert.assertEquals(SOME_FLOAT_VALUE, inputRow.getMetric("someFloat").floatValue(), 0);
-    Assert.assertEquals(SOME_LONG_VALUE, inputRow.getMetric("someLong"));
-    Assert.assertEquals(SOME_INT_VALUE, inputRow.getMetric("someInt"));
+    Assertions.assertEquals(SOME_FLOAT_VALUE, inputRow.getMetric("someFloat").floatValue(), 0);
+    Assertions.assertEquals(SOME_LONG_VALUE, inputRow.getMetric("someLong"));
+    Assertions.assertEquals(SOME_INT_VALUE, inputRow.getMetric("someInt"));
   }
 
   public static SomeAvroDatum buildSomeAvroDatum()

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroFlattenerMakerTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.data.input.SomeAvroDatum;
 import org.apache.druid.data.input.UnionSubEnum;
 import org.apache.druid.data.input.UnionSubFixed;
 import org.apache.druid.data.input.UnionSubRecord;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -38,6 +38,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class AvroFlattenerMakerTest
 {
@@ -77,7 +79,7 @@ public class AvroFlattenerMakerTest
   public void makeJsonPathExtractor_flattenerWithExtractUnionsByType()
   {
     makeJsonPathExtractor_common(RECORD, FLATTENER_WITH_EXTRACT_UNION_BY_TYPE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RECORD.getSomeMultiMemberUnion(),
         FLATTENER_WITH_EXTRACT_UNION_BY_TYPE.makeJsonPathExtractor("$.someMultiMemberUnion.int").apply(RECORD)
     );
@@ -91,31 +93,31 @@ public class AvroFlattenerMakerTest
     // Unmamed types are accessed by type
 
     // int
-    Assert.assertEquals(1, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.int").apply(
+    Assertions.assertEquals(1, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.int").apply(
         buildSomeAvroDatumWithUnionValue(1)));
 
     // long
-    Assert.assertEquals(1L, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.long").apply(
+    Assertions.assertEquals(1L, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.long").apply(
         buildSomeAvroDatumWithUnionValue(1L)));
 
     // float
-    Assert.assertEquals((float) 1.0, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.float").apply(
+    Assertions.assertEquals((float) 1.0, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.float").apply(
         buildSomeAvroDatumWithUnionValue((float) 1.0)));
 
     // double
-    Assert.assertEquals(1.0, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.double").apply(
+    Assertions.assertEquals(1.0, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.double").apply(
         buildSomeAvroDatumWithUnionValue(1.0)));
 
     // string
-    Assert.assertEquals("string", flattener.makeJsonPathExtractor("$.someMultiMemberUnion.string").apply(
+    Assertions.assertEquals("string", flattener.makeJsonPathExtractor("$.someMultiMemberUnion.string").apply(
         buildSomeAvroDatumWithUnionValue(new Utf8("string"))));
 
     // bytes
-    Assert.assertArrayEquals(new byte[] {1}, (byte[]) flattener.makeJsonPathExtractor("$.someMultiMemberUnion.bytes").apply(
+    Assertions.assertArrayEquals(new byte[] {1}, (byte[]) flattener.makeJsonPathExtractor("$.someMultiMemberUnion.bytes").apply(
         buildSomeAvroDatumWithUnionValue(ByteBuffer.wrap(new byte[] {1}))));
 
     // map
-    Assert.assertEquals(2, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.map.two").apply(
+    Assertions.assertEquals(2, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.map.two").apply(
         buildSomeAvroDatumWithUnionValue(
             ImmutableMap.<String, Integer>builder()
                         .put("one", 1)
@@ -125,13 +127,13 @@ public class AvroFlattenerMakerTest
         )));
 
     // array
-    Assert.assertEquals(3, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.array[2]").apply(
+    Assertions.assertEquals(3, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.array[2]").apply(
         buildSomeAvroDatumWithUnionValue(Arrays.asList(1, 2, 3))));
 
     // Named types are accessed by name
 
     // record
-    Assert.assertEquals("subRecordString", flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubRecord.subString").apply(
+    Assertions.assertEquals("subRecordString", flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubRecord.subString").apply(
         buildSomeAvroDatumWithUnionValue(
             UnionSubRecord.newBuilder()
                           .setSubString("subRecordString")
@@ -139,30 +141,32 @@ public class AvroFlattenerMakerTest
 
     // fixed
     final byte[] fixedBytes = new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-    Assert.assertEquals(fixedBytes, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubFixed").apply(
+    Assertions.assertEquals(fixedBytes, flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubFixed").apply(
         buildSomeAvroDatumWithUnionValue(new UnionSubFixed(fixedBytes))));
 
     // enum
-    Assert.assertEquals(String.valueOf(UnionSubEnum.ENUM1), flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubEnum").apply(
+    Assertions.assertEquals(String.valueOf(UnionSubEnum.ENUM1), flattener.makeJsonPathExtractor("$.someMultiMemberUnion.UnionSubEnum").apply(
         buildSomeAvroDatumWithUnionValue(UnionSubEnum.ENUM1)));
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void makeJsonQueryExtractor_flattenerWithoutExtractUnionsByType()
   {
-    Assert.assertEquals(
-        RECORD.getTimestamp(),
-        FLATTENER_WITHOUT_EXTRACT_UNION_BY_TYPE.makeJsonQueryExtractor("$.timestamp").apply(RECORD)
-    );
+    assertThrows(UnsupportedOperationException.class, () ->
+      Assertions.assertEquals(
+          RECORD.getTimestamp(),
+          FLATTENER_WITHOUT_EXTRACT_UNION_BY_TYPE.makeJsonQueryExtractor("$.timestamp").apply(RECORD)
+      ));
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void makeJsonQueryExtractor_flattenerWithExtractUnionsByType()
   {
-    Assert.assertEquals(
-        RECORD.getTimestamp(),
-        FLATTENER_WITH_EXTRACT_UNION_BY_TYPE.makeJsonQueryExtractor("$.timestamp").apply(RECORD)
-    );
+    assertThrows(UnsupportedOperationException.class, () ->
+      Assertions.assertEquals(
+          RECORD.getTimestamp(),
+          FLATTENER_WITH_EXTRACT_UNION_BY_TYPE.makeJsonQueryExtractor("$.timestamp").apply(RECORD)
+      ));
   }
 
   @Test
@@ -175,7 +179,7 @@ public class AvroFlattenerMakerTest
     // isFieldPrimitive on someStringArray is false
     // as it contains items as nulls and strings
     // so flattenerNested should only be able to discover it
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             "someOtherId",
             "someIntArray",
@@ -192,7 +196,7 @@ public class AvroFlattenerMakerTest
         ),
         ImmutableSet.copyOf(flattener.discoverRootFields(input))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             "someStringValueMap",
             "someOtherId",
@@ -227,7 +231,7 @@ public class AvroFlattenerMakerTest
 
     SomeAvroDatum input = AvroStreamInputFormatTest.buildSomeAvroDatum();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             "someStringValueMap",
             "someOtherId",
@@ -255,70 +259,70 @@ public class AvroFlattenerMakerTest
 
     ArrayList<Object> results = (ArrayList<Object>) flattenerNested.getRootField(input, "someStringArray");
     // 4 strings a 1 null for a total of 5
-    Assert.assertEquals("8", results.get(0).toString());
-    Assert.assertEquals("4", results.get(1).toString());
-    Assert.assertEquals("2", results.get(2).toString());
-    Assert.assertEquals("1", results.get(3).toString());
-    Assert.assertEquals(null, results.get(4));
+    Assertions.assertEquals("8", results.get(0).toString());
+    Assertions.assertEquals("4", results.get(1).toString());
+    Assertions.assertEquals("2", results.get(2).toString());
+    Assertions.assertEquals("1", results.get(3).toString());
+    Assertions.assertEquals(null, results.get(4));
   }
 
   private void getRootField_common(final SomeAvroDatum record, final AvroFlattenerMaker flattener)
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getTimestamp(),
         flattener.getRootField(record, "timestamp")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getEventType(),
         flattener.getRootField(record, "eventType")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getId(),
         flattener.getRootField(record, "id")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeOtherId(),
         flattener.getRootField(record, "someOtherId")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getIsValid(),
         flattener.getRootField(record, "isValid")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeIntArray(),
         flattener.getRootField(record, "someIntArray")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeStringArray(),
         flattener.getRootField(record, "someStringArray")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeIntValueMap(),
         flattener.getRootField(record, "someIntValueMap")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeStringValueMap(),
         flattener.getRootField(record, "someStringValueMap")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeUnion(),
         flattener.getRootField(record, "someUnion")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeNull(),
         flattener.getRootField(record, "someNull")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Casted to an array by transformValue
         record.getSomeFixed().bytes(),
         flattener.getRootField(record, "someFixed")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Casted to an array by transformValue
         record.getSomeBytes().array(),
         flattener.getRootField(record, "someBytes")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Casted to a string by transformValue
         record.getSomeEnum().toString(),
         flattener.getRootField(record, "someEnum")
@@ -328,19 +332,19 @@ public class AvroFlattenerMakerTest
           .getSchema()
           .getFields()
           .forEach(field -> map.put(field.name(), record.getSomeRecord().get(field.name())));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         map,
         flattener.getRootField(record, "someRecord")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeLong(),
         flattener.getRootField(record, "someLong")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeInt(),
         flattener.getRootField(record, "someInt")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeFloat(),
         flattener.getRootField(record, "someFloat")
     );
@@ -353,11 +357,11 @@ public class AvroFlattenerMakerTest
           .forEach(field -> map1.put(field.name(), genericRecord.get(field.name())));
       list.add(map1);
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         list,
         flattener.getRootField(record, "someRecordArray")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         null,
         flattener.getRootField(record, "invalidField")
     );
@@ -365,92 +369,92 @@ public class AvroFlattenerMakerTest
 
   private void makeJsonPathExtractor_common(final SomeAvroDatum record, final AvroFlattenerMaker flattener)
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getTimestamp(),
         flattener.makeJsonPathExtractor("$.timestamp").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getEventType(),
         flattener.makeJsonPathExtractor("$.eventType").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getId(),
         flattener.makeJsonPathExtractor("$.id").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeOtherId(),
         flattener.makeJsonPathExtractor("$.someOtherId").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getIsValid(),
         flattener.makeJsonPathExtractor("$.isValid").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeIntArray(),
         flattener.makeJsonPathExtractor("$.someIntArray").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         (double) record.getSomeIntArray().stream().mapToInt(Integer::intValue).min().getAsInt(),
 
         //return type of min is double
         flattener.makeJsonPathExtractor("$.someIntArray.min()").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         (double) record.getSomeIntArray().stream().mapToInt(Integer::intValue).max().getAsInt(),
 
         //return type of max is double
         flattener.makeJsonPathExtractor("$.someIntArray.max()").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeIntArray().stream().mapToInt(Integer::intValue).average().getAsDouble(),
         flattener.makeJsonPathExtractor("$.someIntArray.avg()").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeIntArray().size(),
         flattener.makeJsonPathExtractor("$.someIntArray.length()").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         (double) record.getSomeIntArray().stream().mapToInt(Integer::intValue).sum(),
 
         //return type of sum is double
         flattener.makeJsonPathExtractor("$.someIntArray.sum()").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2.681,
         (double) flattener.makeJsonPathExtractor("$.someIntArray.stddev()").apply(record),
         0.0001
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeStringArray(),
         flattener.makeJsonPathExtractor("$.someStringArray").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeIntValueMap(),
         flattener.makeJsonPathExtractor("$.someIntValueMap").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeStringValueMap(),
         flattener.makeJsonPathExtractor("$.someStringValueMap").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeUnion(),
         flattener.makeJsonPathExtractor("$.someUnion").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeNull(),
         flattener.makeJsonPathExtractor("$.someNull").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Casted to an array by transformValue
         record.getSomeFixed().bytes(),
         flattener.makeJsonPathExtractor("$.someFixed").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Casted to an array by transformValue
         record.getSomeBytes().array(),
         flattener.makeJsonPathExtractor("$.someBytes").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         // Casted to a string by transformValue
         record.getSomeEnum().toString(),
         flattener.makeJsonPathExtractor("$.someEnum").apply(record)
@@ -460,19 +464,19 @@ public class AvroFlattenerMakerTest
           .getSchema()
           .getFields()
           .forEach(field -> map.put(field.name(), record.getSomeRecord().get(field.name())));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         map,
         flattener.makeJsonPathExtractor("$.someRecord").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeLong(),
         flattener.makeJsonPathExtractor("$.someLong").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeInt(),
         flattener.makeJsonPathExtractor("$.someInt").apply(record)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeFloat(),
         flattener.makeJsonPathExtractor("$.someFloat").apply(record)
     );
@@ -487,23 +491,23 @@ public class AvroFlattenerMakerTest
       list.add(map1);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         list,
         flattener.makeJsonPathExtractor("$.someRecordArray").apply(record)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         record.getSomeRecordArray().get(0).getNestedString(),
         flattener.makeJsonPathExtractor("$.someRecordArray[0].nestedString").apply(record)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         list,
         flattener.makeJsonPathExtractor("$.someRecordArray[?(@.nestedString)]").apply(record)
     );
 
     List<String> nestedStringArray = Collections.singletonList(record.getSomeRecordArray().get(0).getNestedString().toString());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nestedStringArray,
         flattener.makeJsonPathExtractor("$.someRecordArray[?(@.nestedString=='string in record')].nestedString").apply(record)
     );

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFInputFormatTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFInputFormatTest.java
@@ -29,9 +29,9 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -40,7 +40,7 @@ public class AvroOCFInputFormatTest
   private final ObjectMapper jsonMapper = new DefaultObjectMapper();
   private JSONPathSpec flattenSpec;
 
-  @Before
+  @BeforeEach
   public void before()
   {
     flattenSpec = new JSONPathSpec(
@@ -70,7 +70,7 @@ public class AvroOCFInputFormatTest
         NestedInputFormat.class
     );
 
-    Assert.assertEquals(inputFormat, inputFormat2);
+    Assertions.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -101,7 +101,7 @@ public class AvroOCFInputFormatTest
         NestedInputFormat.class
     );
 
-    Assert.assertEquals(inputFormat, inputFormat2);
+    Assertions.assertEquals(inputFormat, inputFormat2);
   }
 
   @Test
@@ -115,7 +115,7 @@ public class AvroOCFInputFormatTest
         false
     );
     long unweightedSize = 100L;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         unweightedSize * AvroOCFInputFormat.SCALE_FACTOR,
         format.getWeightedSize("file.avro", unweightedSize)
     );

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
@@ -37,10 +37,9 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,8 +48,8 @@ import java.util.Map;
 
 public class AvroOCFReaderTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void testParse() throws Exception
@@ -117,11 +116,11 @@ public class AvroOCFReaderTest
     final InputEntityReader reader = createReader(mapper, readerSchema);
 
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
       // eventType is aliased to eventClass in the reader schema and should be transformed at read time
-      Assert.assertEquals("type-a", Iterables.getOnlyElement(row.getDimension("eventClass")));
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertEquals("type-a", Iterables.getOnlyElement(row.getDimension("eventClass")));
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -134,14 +133,14 @@ public class AvroOCFReaderTest
     );
     final InputEntityReader reader = createReader(mapper, null);
     try (CloseableIterator<InputRowListPlusRawValues> iterator = reader.sample()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRowListPlusRawValues row = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(iterator.hasNext());
       final Map<String, Object> rawColumns = row.getRawValues();
-      Assert.assertNotNull(rawColumns);
-      Assert.assertEquals(20, rawColumns.size());
+      Assertions.assertNotNull(rawColumns);
+      Assertions.assertEquals(20, rawColumns.size());
       final List<InputRow> inputRows = row.getInputRows();
-      Assert.assertNotNull(inputRows);
+      Assertions.assertNotNull(inputRows);
       final InputRow inputRow = Iterables.getOnlyElement(inputRows);
       assertInputRow(inputRow);
     }
@@ -156,11 +155,11 @@ public class AvroOCFReaderTest
     );
     final InputEntityReader reader = createReader(mapper, null);
     try (CloseableIterator<InputRowListPlusRawValues> iterator = reader.sample()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRowListPlusRawValues row = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(iterator.hasNext());
       final List<InputRow> inputRows = row.getInputRows();
-      Assert.assertNotNull(inputRows);
+      Assertions.assertNotNull(inputRows);
       final InputRow inputRow = Iterables.getOnlyElement(inputRows);
       assertInputRow(inputRow);
       // Ensure the raw values can be serialised into JSON
@@ -171,18 +170,18 @@ public class AvroOCFReaderTest
   private void assertRow(InputEntityReader reader) throws IOException
   {
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       final InputRow row = iterator.next();
       assertInputRow(row);
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
   private void assertInputRow(InputRow row)
   {
-    Assert.assertEquals(DateTimes.of("2015-10-25T19:30:00.000Z"), row.getTimestamp());
-    Assert.assertEquals("type-a", Iterables.getOnlyElement(row.getDimension("eventType")));
-    Assert.assertEquals(679865987569912369L, row.getMetric("someLong"));
+    Assertions.assertEquals(DateTimes.of("2015-10-25T19:30:00.000Z"), row.getTimestamp());
+    Assertions.assertEquals("type-a", Iterables.getOnlyElement(row.getDimension("eventType")));
+    Assertions.assertEquals(679865987569912369L, row.getMetric("someLong"));
   }
 
   private InputEntityReader createReader(
@@ -198,6 +197,15 @@ public class AvroOCFReaderTest
     final AvroOCFInputFormat inputFormat = new AvroOCFInputFormat(mapper, null, readerSchema, null, null);
     final InputRowSchema schema = new InputRowSchema(TimestampSpec.DEFAULT, dimensionsSpec, ColumnsFilter.all());
     final FileEntity entity = new FileEntity(someAvroFile);
-    return inputFormat.createReader(schema, entity, temporaryFolder.newFolder());
+    return inputFormat.createReader(schema, entity, newFolder(temporaryFolder, "junit"));
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
@@ -201,7 +201,8 @@ public class AvroOCFReaderTest
     return inputFormat.createReader(schema, entity, newFolder(temporaryFolder, "junit"));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
@@ -201,11 +201,8 @@ public class AvroOCFReaderTest
     return inputFormat.createReader(schema, entity, newFolder(temporaryFolder, "junit"));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/AvroOCFReaderTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.data.input.impl.FileEntity;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -203,9 +204,7 @@ public class AvroOCFReaderTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemaAvroBytesDecoderTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.data.input.AvroStreamInputFormatTest;
 import org.apache.druid.data.input.SomeAvroDatum;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -73,7 +73,7 @@ public class InlineSchemaAvroBytesDecoderTest
         AvroBytesDecoder.class
     );
 
-    Assert.assertEquals(actual.getSchema().get("name"), "SomeData");
+    Assertions.assertEquals(actual.getSchema().get("name"), "SomeData");
   }
 
   @Test
@@ -88,7 +88,7 @@ public class InlineSchemaAvroBytesDecoderTest
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
     GenericRecord actual = new InlineSchemaAvroBytesDecoder(schema).parse(ByteBuffer.wrap(out.toByteArray()));
-    Assert.assertEquals(someAvroDatum.get("id"), actual.get("id"));
+    Assertions.assertEquals(someAvroDatum.get("id"), actual.get("id"));
   }
 
   @Test
@@ -107,13 +107,13 @@ public class InlineSchemaAvroBytesDecoderTest
     DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
-    ParseException parseException = Assert.assertThrows(
+    ParseException parseException = Assertions.assertThrows(
         ParseException.class,
         () -> new InlineSchemaAvroBytesDecoder(schema).parse(ByteBuffer.wrap(out.toByteArray()))
     );
 
-    Assert.assertTrue(parseException.getMessage().contains("Failed to read Avro message"));
-    Assert.assertTrue(parseException.getCause() instanceof IOException);
+    Assertions.assertTrue(parseException.getMessage().contains("Failed to read Avro message"));
+    Assertions.assertTrue(parseException.getCause() instanceof IOException);
   }
 
   @Test
@@ -129,11 +129,11 @@ public class InlineSchemaAvroBytesDecoderTest
     DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
-    ParseException parseException = Assert.assertThrows(
+    ParseException parseException = Assertions.assertThrows(
         ParseException.class,
         () -> new InlineSchemaAvroBytesDecoder(schema).parse(ByteBuffer.wrap(out.toByteArray()))
     );
-    Assert.assertTrue(parseException.getMessage().contains("Failed to read Avro message"));
-    Assert.assertTrue(parseException.getCause() instanceof AvroRuntimeException);
+    Assertions.assertTrue(parseException.getMessage().contains("Failed to read Avro message"));
+    Assertions.assertTrue(parseException.getCause() instanceof AvroRuntimeException);
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/InlineSchemasAvroBytesDecoderTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.data.input.AvroStreamInputFormatTest;
 import org.apache.druid.data.input.SomeAvroDatum;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -82,8 +82,8 @@ public class InlineSchemasAvroBytesDecoderTest
         AvroBytesDecoder.class
     );
 
-    Assert.assertEquals(actual.getSchemas().get("5").get("name"), "name5");
-    Assert.assertEquals(actual.getSchemas().get("8").get("name"), "name8");
+    Assertions.assertEquals(actual.getSchemas().get("5").get("name"), "name5");
+    Assertions.assertEquals(actual.getSchemas().get("8").get("name"), "name8");
   }
 
   @Test
@@ -105,7 +105,7 @@ public class InlineSchemasAvroBytesDecoderTest
             schema
         )
     ).parse(ByteBuffer.wrap(out.toByteArray()));
-    Assert.assertEquals(someAvroDatum.get("id"), actual.get("id"));
+    Assertions.assertEquals(someAvroDatum.get("id"), actual.get("id"));
   }
 
   @Test
@@ -119,7 +119,7 @@ public class InlineSchemasAvroBytesDecoderTest
     DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
-    ParseException parseException = Assert.assertThrows(
+    ParseException parseException = Assertions.assertThrows(
         ParseException.class,
         () -> new InlineSchemasAvroBytesDecoder(
             ImmutableMap.of(
@@ -128,7 +128,7 @@ public class InlineSchemasAvroBytesDecoderTest
             )
         ).parse(ByteBuffer.wrap(out.toByteArray()))
     );
-    Assert.assertTrue(parseException.getMessage().contains("Found record of arbitrary version"));
+    Assertions.assertTrue(parseException.getMessage().contains("Found record of arbitrary version"));
   }
 
   @Test
@@ -143,7 +143,7 @@ public class InlineSchemasAvroBytesDecoderTest
     DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
-    ParseException parseException = Assert.assertThrows(
+    ParseException parseException = Assertions.assertThrows(
         ParseException.class,
         () -> new InlineSchemasAvroBytesDecoder(
             ImmutableMap.of(
@@ -152,7 +152,7 @@ public class InlineSchemasAvroBytesDecoderTest
             )
         ).parse(ByteBuffer.wrap(out.toByteArray()))
     );
-    Assert.assertTrue(parseException.getMessage().contains("Failed to find schema for id"));
+    Assertions.assertTrue(parseException.getMessage().contains("Failed to find schema for id"));
   }
 
   @Test
@@ -169,7 +169,7 @@ public class InlineSchemasAvroBytesDecoderTest
     DatumWriter<GenericRecord> writer = new SpecificDatumWriter<>(schema);
     writer.write(someAvroDatum, EncoderFactory.get().directBinaryEncoder(out, null));
 
-    ParseException parseException = Assert.assertThrows(
+    ParseException parseException = Assertions.assertThrows(
         ParseException.class,
         () -> new InlineSchemasAvroBytesDecoder(
             ImmutableMap.of(
@@ -178,6 +178,6 @@ public class InlineSchemasAvroBytesDecoderTest
             )
         ).parse(ByteBuffer.wrap(out.toByteArray()))
     );
-    Assert.assertTrue(parseException.getMessage().contains("Failed to read Avro message with schema id[10]"));
+    Assertions.assertTrue(parseException.getMessage().contains("Failed to read Avro message with schema id[10]"));
   }
 }

--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/avro/SchemaRegistryBasedAvroBytesDecoderTest.java
@@ -37,10 +37,9 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.parsers.ParseException;
 import org.apache.druid.utils.DynamicConfigProviderUtils;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -49,11 +48,13 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class SchemaRegistryBasedAvroBytesDecoderTest
 {
   private SchemaRegistryClient registry;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     registry = Mockito.mock(SchemaRegistryClient.class);
@@ -73,7 +74,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
     // Then
-    Assert.assertNotEquals(decoder.hashCode(), 0);
+    Assertions.assertNotEquals(decoder.hashCode(), 0);
   }
 
   @Test
@@ -90,7 +91,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
     // Then
-    Assert.assertNotEquals(decoder.hashCode(), 0);
+    Assertions.assertNotEquals(decoder.hashCode(), 0);
   }
 
   @Test
@@ -107,7 +108,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     SchemaRegistryBasedAvroBytesDecoder decoder = mapper.readerFor(AvroBytesDecoder.class).readValue(json);
 
     // Then
-    Assert.assertNotEquals(decoder.hashCode(), 0);
+    Assertions.assertNotEquals(decoder.hashCode(), 0);
   }
 
   @Test
@@ -126,7 +127,7 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     GenericRecord parse = new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb);
 
     // Then
-    Assert.assertEquals(schema, parse.getSchema());
+    Assertions.assertEquals(schema, parse.getSchema());
   }
 
   @Test
@@ -137,11 +138,11 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     bb.rewind();
 
     // When / Then
-    final ParseException e = Assert.assertThrows(
+    final ParseException e = Assertions.assertThrows(
         ParseException.class,
         () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
     );
-    MatcherAssert.assertThat(
+    assertThat(
         e.getMessage(),
         CoreMatchers.containsString("Failed to decode avro message, not enough bytes to decode (2)")
     );
@@ -160,12 +161,12 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     bb.rewind();
 
     // When / Then
-    final ParseException e = Assert.assertThrows(
+    final ParseException e = Assertions.assertThrows(
         ParseException.class,
         () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
     );
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
-    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("Failed to decode Avro message for schema id[1234]"));
+    assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
+    assertThat(e.getMessage(), CoreMatchers.containsString("Failed to decode Avro message for schema id[1234]"));
   }
 
   @Test
@@ -177,11 +178,11 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     bb.rewind();
 
     // When / Then
-    final ParseException e = Assert.assertThrows(
+    final ParseException e = Assertions.assertThrows(
         ParseException.class,
         () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
     );
-    MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("No Avro schema id[1234] in registry"));
+    assertThat(e.getMessage(), CoreMatchers.containsString("No Avro schema id[1234] in registry"));
   }
 
   @Test
@@ -193,12 +194,12 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     bb.rewind();
 
     // When / Then
-    final ParseException e = Assert.assertThrows(
+    final ParseException e = Assertions.assertThrows(
         ParseException.class,
         () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
     );
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
-    MatcherAssert.assertThat(e.getCause().getMessage(), CoreMatchers.containsString("no pasaran"));
+    assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
+    assertThat(e.getCause().getMessage(), CoreMatchers.containsString("no pasaran"));
   }
 
   private byte[] getAvroDatum(Schema schema, GenericRecord someAvroDatum) throws IOException
@@ -228,10 +229,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     );
 
     // Then
-    Assert.assertEquals(3, header.size());
-    Assert.assertEquals("value.1", header.get("registry.header.prop.1"));
-    Assert.assertEquals("value.2", header.get("registry.header.prop.2"));
-    Assert.assertEquals("value.3", header.get("registry.header.prop.3"));
+    Assertions.assertEquals(3, header.size());
+    Assertions.assertEquals("value.1", header.get("registry.header.prop.1"));
+    Assertions.assertEquals("value.2", header.get("registry.header.prop.2"));
+    Assertions.assertEquals("value.3", header.get("registry.header.prop.3"));
   }
 
   @Test
@@ -253,10 +254,10 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     );
 
     // Then
-    Assert.assertEquals(3, config.size());
-    Assert.assertEquals("value.1", config.get("registry.config.prop.1"));
-    Assert.assertEquals("value.2", config.get("registry.config.prop.2"));
-    Assert.assertEquals("value.3", config.get("registry.config.prop.3"));
+    Assertions.assertEquals(3, config.size());
+    Assertions.assertEquals("value.1", config.get("registry.config.prop.1"));
+    Assertions.assertEquals("value.2", config.get("registry.config.prop.2"));
+    Assertions.assertEquals("value.3", config.get("registry.config.prop.3"));
   }
 
   @Test
@@ -272,13 +273,13 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     bb.rewind();
 
     // When / Then
-    final ParseException e = Assert.assertThrows(
+    final ParseException e = Assertions.assertThrows(
         ParseException.class,
         () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
     );
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RestClientException.class));
-    MatcherAssert.assertThat(e.getCause().getMessage(), CoreMatchers.containsString("unauthenticated"));
-    MatcherAssert.assertThat(
+    assertThat(e.getCause(), CoreMatchers.instanceOf(RestClientException.class));
+    assertThat(e.getCause().getMessage(), CoreMatchers.containsString("unauthenticated"));
+    assertThat(
         e.getMessage(),
         CoreMatchers.containsString(
             "Failed to authenticate to schema registry for Avro schema id[1234]. Please check your credentials"
@@ -299,13 +300,13 @@ public class SchemaRegistryBasedAvroBytesDecoderTest
     bb.rewind();
 
     // When / Then
-    final ParseException e = Assert.assertThrows(
+    final ParseException e = Assertions.assertThrows(
         ParseException.class,
         () -> new SchemaRegistryBasedAvroBytesDecoder(registry).parse(bb)
     );
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RestClientException.class));
-    MatcherAssert.assertThat(e.getCause().getMessage(), CoreMatchers.containsString("resource doesn't exist"));
-    MatcherAssert.assertThat(
+    assertThat(e.getCause(), CoreMatchers.instanceOf(RestClientException.class));
+    assertThat(e.getCause().getMessage(), CoreMatchers.containsString("resource doesn't exist"));
+    assertThat(
         e.getMessage(),
         CoreMatchers.containsString(
             "Failed to fetch Avro schema id[1234] from registry."

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -106,9 +106,24 @@
         </dependency>
 
         <!-- Tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-core/hdfs-storage/pom.xml
+++ b/extensions-core/hdfs-storage/pom.xml
@@ -106,8 +106,8 @@
         </dependency>
 
         <!-- Tests -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -29,10 +29,9 @@ import org.apache.druid.tasklogs.TaskLogs;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,13 +40,13 @@ import java.util.Map;
 
 public class HdfsTaskLogsTest
 {
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   @Test
   public void testStream() throws Exception
   {
-    final File tmpDir = tempFolder.newFolder();
+    final File tmpDir = newFolder(tempFolder, "junit");
     final File logDir = new File(tmpDir, "logs");
     final File logFile = new File(tmpDir, "log");
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
@@ -57,31 +56,31 @@ public class HdfsTaskLogsTest
     final Map<Long, String> expected = ImmutableMap.of(0L, "blah", 1L, "lah", -2L, "ah", -5L, "blah");
     for (Map.Entry<Long, String> entry : expected.entrySet()) {
       final String string = readLog(taskLogs, "foo", entry.getKey());
-      Assert.assertEquals(StringUtils.format("Read with offset %,d", entry.getKey()), string, entry.getValue());
+      Assertions.assertEquals(string, entry.getValue(), StringUtils.format("Read with offset %,d", entry.getKey()));
     }
   }
 
   @Test
   public void testOverwrite() throws Exception
   {
-    final File tmpDir = tempFolder.newFolder();
+    final File tmpDir = newFolder(tempFolder, "junit");
     final File logDir = new File(tmpDir, "logs");
     final File logFile = new File(tmpDir, "log");
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
 
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
     taskLogs.pushTaskLog("foo", logFile);
-    Assert.assertEquals("blah", readLog(taskLogs, "foo", 0));
+    Assertions.assertEquals("blah", readLog(taskLogs, "foo", 0));
 
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah blah");
     taskLogs.pushTaskLog("foo", logFile);
-    Assert.assertEquals("blah blah", readLog(taskLogs, "foo", 0));
+    Assertions.assertEquals("blah blah", readLog(taskLogs, "foo", 0));
   }
 
   @Test
   public void test_taskStatus() throws Exception
   {
-    final File tmpDir = tempFolder.newFolder();
+    final File tmpDir = newFolder(tempFolder, "junit");
     final File logDir = new File(tmpDir, "logs");
     final File statusFile = new File(tmpDir, "status.json");
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
@@ -89,7 +88,7 @@ public class HdfsTaskLogsTest
 
     Files.asCharSink(statusFile, StandardCharsets.UTF_8).write("{}");
     taskLogs.pushTaskStatus("id", statusFile);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{}",
         StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskStatus("id").get()))
     );
@@ -98,20 +97,20 @@ public class HdfsTaskLogsTest
   @Test
   public void test_taskPayload() throws Exception
   {
-    final File tmpDir = tempFolder.newFolder();
+    final File tmpDir = newFolder(tempFolder, "junit");
     final File logDir = new File(tmpDir, "logs");
     final File payload = new File(tmpDir, "payload.json");
     final TaskLogs taskLogs = new HdfsTaskLogs(new HdfsTaskLogsConfig(logDir.toString()), new Configuration());
 
     Files.asCharSink(payload, StandardCharsets.UTF_8).write("{}");
     taskLogs.pushTaskPayload("id", payload);
-    Assert.assertEquals("{}", StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskPayload("id").get())));
+    Assertions.assertEquals("{}", StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskPayload("id").get())));
   }
 
   @Test
   public void testKill() throws Exception
   {
-    final File tmpDir = tempFolder.newFolder();
+    final File tmpDir = newFolder(tempFolder, "junit");
     final File logDir = new File(tmpDir, "logs");
     final File logFile = new File(tmpDir, "log");
 
@@ -122,29 +121,38 @@ public class HdfsTaskLogsTest
 
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log1content");
     taskLogs.pushTaskLog("log1", logFile);
-    Assert.assertEquals("log1content", readLog(taskLogs, "log1", 0));
+    Assertions.assertEquals("log1content", readLog(taskLogs, "log1", 0));
 
     //File modification timestamp is only maintained to seconds resolution, so artificial delay
     //is necessary to separate 2 file creations by a timestamp that would result in only one
     //of them getting deleted
     Thread.sleep(1500);
     long time = (System.currentTimeMillis() / 1000) * 1000;
-    Assert.assertTrue(fs.getFileStatus(new Path(logDirPath, "log1")).getModificationTime() < time);
+    Assertions.assertTrue(fs.getFileStatus(new Path(logDirPath, "log1")).getModificationTime() < time);
 
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log2content");
     taskLogs.pushTaskLog("log2", logFile);
-    Assert.assertEquals("log2content", readLog(taskLogs, "log2", 0));
-    Assert.assertTrue(fs.getFileStatus(new Path(logDirPath, "log2")).getModificationTime() >= time);
+    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+    Assertions.assertTrue(fs.getFileStatus(new Path(logDirPath, "log2")).getModificationTime() >= time);
 
     taskLogs.killOlderThan(time);
 
-    Assert.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
-    Assert.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+    Assertions.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
+    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
 
   }
 
   private String readLog(TaskLogs taskLogs, String logFile, long offset) throws IOException
   {
     return StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskLog(logFile, offset).get()));
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -148,11 +148,8 @@ public class HdfsTaskLogsTest
     return StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskLog(logFile, offset).get()));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -148,7 +148,8 @@ public class HdfsTaskLogsTest
     return StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskLog(logFile, offset).get()));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/indexing/common/tasklogs/HdfsTaskLogsTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexing.common.tasklogs;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.storage.hdfs.tasklog.HdfsTaskLogs;
 import org.apache.druid.storage.hdfs.tasklog.HdfsTaskLogsConfig;
@@ -150,9 +151,7 @@ public class HdfsTaskLogsTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceAdapterTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceAdapterTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.inputsource.hdfs;
 
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -33,6 +33,6 @@ public class HdfsInputSourceAdapterTest
     Configuration conf = new Configuration();
     HdfsInputSourceConfig inputSourceConfig = new HdfsInputSourceConfig(null);
     HdfsInputSourceFactory hdfsInputSourceAdapter = new HdfsInputSourceFactory(conf, inputSourceConfig);
-    Assert.assertTrue(hdfsInputSourceAdapter.create(Arrays.asList("hdfs://localhost:7020/bar/def.parquet", "hdfs://localhost:7020/bar/abc.parquet")) instanceof HdfsInputSource);
+    Assertions.assertTrue(hdfsInputSourceAdapter.create(Arrays.asList("hdfs://localhost:7020/bar/def.parquet", "hdfs://localhost:7020/bar/abc.parquet")) instanceof HdfsInputSource);
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceConfigTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceConfigTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.inputsource.hdfs;
 
 import com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HdfsInputSourceConfigTest
 {
@@ -29,20 +29,20 @@ public class HdfsInputSourceConfigTest
   public void testNullAllowedProtocolsUseDefault()
   {
     HdfsInputSourceConfig config = new HdfsInputSourceConfig(null);
-    Assert.assertEquals(HdfsInputSourceConfig.DEFAULT_ALLOWED_PROTOCOLS, config.getAllowedProtocols());
+    Assertions.assertEquals(HdfsInputSourceConfig.DEFAULT_ALLOWED_PROTOCOLS, config.getAllowedProtocols());
   }
 
   @Test
   public void testEmptyAllowedProtocolsUseDefault()
   {
     HdfsInputSourceConfig config = new HdfsInputSourceConfig(ImmutableSet.of());
-    Assert.assertEquals(HdfsInputSourceConfig.DEFAULT_ALLOWED_PROTOCOLS, config.getAllowedProtocols());
+    Assertions.assertEquals(HdfsInputSourceConfig.DEFAULT_ALLOWED_PROTOCOLS, config.getAllowedProtocols());
   }
 
   @Test
   public void testCustomAllowedProtocols()
   {
     HdfsInputSourceConfig config = new HdfsInputSourceConfig(ImmutableSet.of("druid"));
-    Assert.assertEquals(ImmutableSet.of("druid"), config.getAllowedProtocols());
+    Assertions.assertEquals(ImmutableSet.of("druid"), config.getAllowedProtocols());
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
@@ -48,13 +48,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -74,6 +73,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HdfsInputSourceTest extends InitializedNullHandlingTest
 {
@@ -95,47 +97,46 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
       null
   );
 
-  public static class ConstructorTest
+  @Nested
+  public class ConstructorTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testConstructorAllowsOnlyDefaultProtocol()
     {
-      HdfsInputSource.builder()
-                     .paths(PATH + "*")
-                     .configuration(CONFIGURATION)
-                     .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
-                     .build();
-
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Only [hdfs] protocols are allowed");
-      HdfsInputSource.builder()
-                     .paths("file:/foo/bar*")
-                     .configuration(CONFIGURATION)
-                     .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
-                     .build();
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        HdfsInputSource.builder()
+            .paths(PATH + "*")
+            .configuration(CONFIGURATION)
+            .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
+            .build();
+        HdfsInputSource.builder()
+            .paths("file:/foo/bar*")
+            .configuration(CONFIGURATION)
+            .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
+            .build();
+      });
+      assertTrue(exception.getMessage().contains("Only [hdfs] protocols are allowed"));
     }
 
     @Test
     public void testConstructorAllowsOnlyCustomProtocol()
     {
-      final Configuration conf = new Configuration();
-      conf.set("fs.ftp.impl", "org.apache.hadoop.fs.ftp.FTPFileSystem");
-      HdfsInputSource.builder()
-                     .paths("ftp://localhost:21/foo/bar")
-                     .configuration(CONFIGURATION)
-                     .inputSourceConfig(new HdfsInputSourceConfig(ImmutableSet.of("ftp")))
-                     .build();
-
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Only [druid] protocols are allowed");
-      HdfsInputSource.builder()
-                     .paths(PATH + "*")
-                     .configuration(CONFIGURATION)
-                     .inputSourceConfig(new HdfsInputSourceConfig(ImmutableSet.of("druid")))
-                     .build();
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        final Configuration conf = new Configuration();
+        conf.set("fs.ftp.impl", "org.apache.hadoop.fs.ftp.FTPFileSystem");
+        HdfsInputSource.builder()
+            .paths("ftp://localhost:21/foo/bar")
+            .configuration(CONFIGURATION)
+            .inputSourceConfig(new HdfsInputSourceConfig(ImmutableSet.of("ftp")))
+            .build();
+        HdfsInputSource.builder()
+            .paths(PATH + "*")
+            .configuration(CONFIGURATION)
+            .inputSourceConfig(new HdfsInputSourceConfig(ImmutableSet.of("druid")))
+            .build();
+      });
+      assertTrue(exception.getMessage().contains("Only [druid] protocols are allowed"));
     }
 
     @Test
@@ -180,20 +181,18 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
                          .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
                          .build();
 
-      Assert.assertEquals(Collections.singleton(HdfsInputSource.TYPE_KEY), inputSource.getTypes());
+      Assertions.assertEquals(Collections.singleton(HdfsInputSource.TYPE_KEY), inputSource.getTypes());
     }
   }
 
-  public static class SerializeDeserializeTest
+  @Nested
+  public class SerializeDeserializeTest
   {
     private static final ObjectMapper OBJECT_MAPPER = createObjectMapper();
 
     private HdfsInputSource.Builder hdfsInputSourceBuilder;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
+    @BeforeEach
     public void setup()
     {
       hdfsInputSourceBuilder = HdfsInputSource.builder()
@@ -205,10 +204,10 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     @Test
     public void requiresPathsAsStringOrArrayOfStrings()
     {
-      exception.expect(IllegalArgumentException.class);
-      exception.expectMessage("'paths' must be a string or an array of strings");
+      Throwable exception = assertThrows(IllegalArgumentException.class, () ->
 
-      hdfsInputSourceBuilder.paths(Arrays.asList("a", 1)).build();
+        hdfsInputSourceBuilder.paths(Arrays.asList("a", 1)).build());
+      assertTrue(exception.getMessage().contains("'paths' must be a string or an array of strings"));
     }
 
     @Test
@@ -237,7 +236,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
       try {
         String serialized = OBJECT_MAPPER.writeValueAsString(hdfsInputSourceWrapper);
         Wrapper deserialized = OBJECT_MAPPER.readValue(serialized, Wrapper.class);
-        Assert.assertEquals(serialized, OBJECT_MAPPER.writeValueAsString(deserialized));
+        Assertions.assertEquals(serialized, OBJECT_MAPPER.writeValueAsString(deserialized));
       }
       catch (IOException e) {
         throw new UncheckedIOException(e);
@@ -274,15 +273,16 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     }
   }
 
-  public static class ReaderTest
+  @Nested
+  public class ReaderTest
   {
     private static final String PATH = "test";
     private static final int NUM_FILE = 3;
     private static final String KEY_VALUE_SEPARATOR = ",";
     private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     private FileSystem fileSystem;
     private HdfsInputSource target;
@@ -290,13 +290,13 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     private Map<Long, String> timestampToValue;
     private List<String> fileContents;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException
     {
       timestampToValue = new HashMap<>();
       fileContents = new ArrayList<>();
 
-      File dir = temporaryFolder.getRoot();
+      File dir = temporaryFolder;
       Configuration configuration = new Configuration(true);
       fileSystem = new LocalFileSystem();
       fileSystem.initialize(dir.toURI(), configuration);
@@ -322,7 +322,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
                               .build();
     }
 
-    @After
+    @AfterEach
     public void teardown() throws IOException
     {
       temporaryFolder.delete();
@@ -359,10 +359,10 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
         }
       }
 
-      Assert.assertEquals(timestampToValue, actualTimestampToValue);
+      Assertions.assertEquals(timestampToValue, actualTimestampToValue);
 
       long totalFileSize = fileContents.stream().mapToLong(String::length).sum();
-      Assert.assertEquals(totalFileSize, inputStats.getProcessedBytes());
+      Assertions.assertEquals(totalFileSize, inputStats.getProcessedBytes());
     }
 
     @Test
@@ -371,11 +371,11 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
       // Set maxSplitSize to 1 so that each inputSplit has only one object
       List<InputSplit<List<Path>>> splits = target.createSplits(null, new MaxSizeSplitHintSpec(1L, null))
                                                   .collect(Collectors.toList());
-      splits.forEach(split -> Assert.assertEquals(1, split.get().size()));
+      splits.forEach(split -> Assertions.assertEquals(1, split.get().size()));
       Set<Path> actualPaths = splits.stream()
                                     .flatMap(split -> split.get().stream())
                                     .collect(Collectors.toSet());
-      Assert.assertEquals(paths, actualPaths);
+      Assertions.assertEquals(paths, actualPaths);
     }
 
     @Test
@@ -383,9 +383,9 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     {
       List<InputSplit<List<Path>>> splits = target.createSplits(null, new MaxSizeSplitHintSpec(7L, null))
                                                   .collect(Collectors.toList());
-      Assert.assertEquals(2, splits.size());
-      Assert.assertEquals(2, splits.get(0).get().size());
-      Assert.assertEquals(1, splits.get(1).get().size());
+      Assertions.assertEquals(2, splits.size());
+      Assertions.assertEquals(2, splits.get(0).get().size());
+      Assertions.assertEquals(1, splits.get(1).get().size());
     }
 
     @Test
@@ -393,7 +393,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     {
       // Set maxSplitSize to 1 so that each inputSplit has only one object
       int numSplits = target.estimateNumSplits(null, new MaxSizeSplitHintSpec(1L, null));
-      Assert.assertEquals(NUM_FILE, numSplits);
+      Assertions.assertEquals(NUM_FILE, numSplits);
     }
 
     @Test
@@ -406,16 +406,17 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
         String expectedPath = Iterables.getOnlyElement(split.get()).toString();
         HdfsInputSource inputSource = (HdfsInputSource) target.withSplit(split);
         String actualPath = Iterables.getOnlyElement(inputSource.getInputPaths());
-        Assert.assertEquals(expectedPath, actualPath);
+        Assertions.assertEquals(expectedPath, actualPath);
       }
     }
   }
 
-  public static class EmptyPathsTest
+  @Nested
+  public class EmptyPathsTest
   {
     private HdfsInputSource target;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
       target = HdfsInputSource.builder()
@@ -432,9 +433,9 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
       final InputStats inputStats = new InputStatsImpl();
 
       try (CloseableIterator<InputRow> iterator = reader.read(inputStats)) {
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertFalse(iterator.hasNext());
       }
-      Assert.assertEquals(0, inputStats.getProcessedBytes());
+      Assertions.assertEquals(0, inputStats.getProcessedBytes());
     }
 
     @Test
@@ -442,18 +443,19 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     {
       List<InputSplit<List<Path>>> splits = target.createSplits(null, null)
                                                   .collect(Collectors.toList());
-      Assert.assertTrue(String.valueOf(splits), splits.isEmpty());
+      Assertions.assertTrue(splits.isEmpty(), String.valueOf(splits));
     }
 
     @Test
     public void hasCorrectNumberOfSplits() throws IOException
     {
       int numSplits = target.estimateNumSplits(null, null);
-      Assert.assertEquals(0, numSplits);
+      Assertions.assertEquals(0, numSplits);
     }
   }
 
-  public static class SystemFieldsTest
+  @Nested
+  public class SystemFieldsTest
   {
     @Test
     public void testSystemFields()
@@ -466,50 +468,51 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           new HdfsInputSourceConfig(null)
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           EnumSet.of(SystemField.URI, SystemField.PATH),
           inputSource.getConfiguredSystemFields()
       );
 
       final HdfsInputEntity entity = new HdfsInputEntity(configuration, new Path("hdfs://127.0.0.1/bar"));
-      Assert.assertEquals("hdfs://127.0.0.1/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
-      Assert.assertEquals("/bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
+      Assertions.assertEquals("hdfs://127.0.0.1/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
+      Assertions.assertEquals("/bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
 
       final HdfsInputEntity entity2 = new HdfsInputEntity(configuration, new Path("/127.0.0.1/bar"));
-      Assert.assertEquals("file:///127.0.0.1/bar", inputSource.getSystemFieldValue(entity2, SystemField.URI));
-      Assert.assertEquals("/127.0.0.1/bar", inputSource.getSystemFieldValue(entity2, SystemField.PATH));
+      Assertions.assertEquals("file:///127.0.0.1/bar", inputSource.getSystemFieldValue(entity2, SystemField.URI));
+      Assertions.assertEquals("/127.0.0.1/bar", inputSource.getSystemFieldValue(entity2, SystemField.PATH));
 
       final HdfsInputEntity entity3 = new HdfsInputEntity(configuration, new Path("bar"));
-      Assert.assertEquals(
+      Assertions.assertEquals(
           StringUtils.format("file:%s/bar", System.getProperty("user.dir")),
           inputSource.getSystemFieldValue(entity3, SystemField.URI)
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           StringUtils.format("%s/bar", System.getProperty("user.dir")),
           inputSource.getSystemFieldValue(entity3, SystemField.PATH)
       );
     }
   }
 
-  public static class GetPathsTest
+  @Nested
+  public class GetPathsTest
   {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    public File temporaryFolder;
 
     private FileSystem fileSystem;
     private Configuration configuration;
 
-    @Before
+    @BeforeEach
     public void setup() throws IOException
     {
-      final File dir = temporaryFolder.getRoot();
+      final File dir = temporaryFolder;
       configuration = new Configuration(true);
       fileSystem = new LocalFileSystem();
       fileSystem.initialize(dir.toURI(), configuration);
       fileSystem.setWorkingDirectory(new Path(dir.getAbsolutePath()));
     }
 
-    @After
+    @AfterEach
     public void teardown() throws IOException
     {
       fileSystem.close();
@@ -522,7 +525,7 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           Collections.singletonList(fileSystem.getWorkingDirectory() + "/nonexistent*"),
           configuration
       );
-      Assert.assertTrue(paths.isEmpty());
+      Assertions.assertTrue(paths.isEmpty());
     }
 
     @Test
@@ -545,8 +548,8 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           configuration
       );
 
-      Assert.assertEquals(1, paths.size());
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(nonEmptyFile)));
+      Assertions.assertEquals(1, paths.size());
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(nonEmptyFile)));
     }
 
     @Test
@@ -574,9 +577,9 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           configuration
       );
 
-      Assert.assertEquals(2, paths.size());
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(fileA)));
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(fileB)));
+      Assertions.assertEquals(2, paths.size());
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(fileA)));
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(fileB)));
     }
 
     @Test
@@ -603,9 +606,9 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           configuration
       );
 
-      Assert.assertEquals(2, paths.size());
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(fileA)));
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(fileB)));
+      Assertions.assertEquals(2, paths.size());
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(fileA)));
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(fileB)));
     }
 
     @Test
@@ -637,10 +640,10 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           configuration
       );
 
-      Assert.assertEquals(1, paths.size());
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(visibleFile)));
-      Assert.assertFalse(paths.contains(fileSystem.makeQualified(dotFile)));
-      Assert.assertFalse(paths.contains(fileSystem.makeQualified(underscoreFile)));
+      Assertions.assertEquals(1, paths.size());
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(visibleFile)));
+      Assertions.assertFalse(paths.contains(fileSystem.makeQualified(dotFile)));
+      Assertions.assertFalse(paths.contains(fileSystem.makeQualified(underscoreFile)));
     }
 
     @Test
@@ -680,8 +683,8 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           configuration
       );
 
-      Assert.assertEquals(1, paths.size());
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(fileInDir)));
+      Assertions.assertEquals(1, paths.size());
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(fileInDir)));
     }
 
     @Test
@@ -712,13 +715,14 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
           configuration
       );
 
-      Assert.assertEquals(1, paths.size());
-      Assert.assertTrue(paths.contains(fileSystem.makeQualified(visibleFile)));
-      Assert.assertFalse(paths.contains(fileSystem.makeQualified(hiddenFile)));
+      Assertions.assertEquals(1, paths.size());
+      Assertions.assertTrue(paths.contains(fileSystem.makeQualified(visibleFile)));
+      Assertions.assertFalse(paths.contains(fileSystem.makeQualified(hiddenFile)));
     }
   }
 
-  public static class EqualsTest
+  @Nested
+  public class EqualsTest
   {
     @Test
     public void testEquals()

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/inputsource/hdfs/HdfsInputSourceTest.java
@@ -104,18 +104,19 @@ public class HdfsInputSourceTest extends InitializedNullHandlingTest
     @Test
     public void testConstructorAllowsOnlyDefaultProtocol()
     {
-      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
-        HdfsInputSource.builder()
-            .paths(PATH + "*")
-            .configuration(CONFIGURATION)
-            .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
-            .build();
+      HdfsInputSource.builder()
+          .paths(PATH + "*")
+          .configuration(CONFIGURATION)
+          .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
+          .build();
+
+      Throwable exception = assertThrows(IllegalArgumentException.class, () ->
         HdfsInputSource.builder()
             .paths("file:/foo/bar*")
             .configuration(CONFIGURATION)
             .inputSourceConfig(DEFAULT_INPUT_SOURCE_CONFIG)
-            .build();
-      });
+            .build()
+      );
       assertTrue(exception.getMessage().contains("Only [hdfs] protocols are allowed"));
     }
 

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/segment/loading/HdfsFileTimestampVersionFinderTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/segment/loading/HdfsFileTimestampVersionFinderTest.java
@@ -28,12 +28,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -54,7 +54,7 @@ public class HdfsFileTimestampVersionFinderTest
   private static byte[] pathByteContents = StringUtils.toUtf8(pathContents);
   private static Configuration conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupStatic() throws IOException
   {
     hdfsTmpDir = File.createTempFile("hdfsHandlerTest", "dir");
@@ -79,7 +79,7 @@ public class HdfsFileTimestampVersionFinderTest
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownStatic() throws IOException
   {
     FileUtils.deleteDirectory(hdfsTmpDir);
@@ -89,13 +89,13 @@ public class HdfsFileTimestampVersionFinderTest
 
   private HdfsFileTimestampVersionFinder finder;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     finder = new HdfsFileTimestampVersionFinder(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     fileSystem.delete(perTestPath, true);
@@ -106,7 +106,7 @@ public class HdfsFileTimestampVersionFinderTest
   public void testSimpleLatestVersion() throws IOException, InterruptedException
   {
     final Path oldPath = new Path(perTestPath, "555test.txt");
-    Assert.assertFalse(fileSystem.exists(oldPath));
+    Assertions.assertFalse(fileSystem.exists(oldPath));
     try (final OutputStream outputStream = fileSystem.create(oldPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
@@ -115,13 +115,13 @@ public class HdfsFileTimestampVersionFinderTest
     Thread.sleep(10);
 
     final Path newPath = new Path(perTestPath, "666test.txt");
-    Assert.assertFalse(fileSystem.exists(newPath));
+    Assertions.assertFalse(fileSystem.exists(newPath));
     try (final OutputStream outputStream = fileSystem.create(newPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         fileSystem.makeQualified(newPath).toUri(),
         finder.getLatestVersion(fileSystem.makeQualified(oldPath).toUri(), Pattern.compile(".*")));
   }
@@ -130,7 +130,7 @@ public class HdfsFileTimestampVersionFinderTest
   public void testAlreadyLatestVersion() throws IOException, InterruptedException
   {
     final Path oldPath = new Path(perTestPath, "555test.txt");
-    Assert.assertFalse(fileSystem.exists(oldPath));
+    Assertions.assertFalse(fileSystem.exists(oldPath));
     try (final OutputStream outputStream = fileSystem.create(oldPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
@@ -139,13 +139,13 @@ public class HdfsFileTimestampVersionFinderTest
     Thread.sleep(10);
 
     final Path newPath = new Path(perTestPath, "666test.txt");
-    Assert.assertFalse(fileSystem.exists(newPath));
+    Assertions.assertFalse(fileSystem.exists(newPath));
     try (final OutputStream outputStream = fileSystem.create(newPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         fileSystem.makeQualified(newPath).toUri(),
         finder.getLatestVersion(fileSystem.makeQualified(newPath).toUri(), Pattern.compile(".*")));
   }
@@ -154,15 +154,15 @@ public class HdfsFileTimestampVersionFinderTest
   public void testNoLatestVersion() throws IOException
   {
     final Path oldPath = new Path(perTestPath, "555test.txt");
-    Assert.assertFalse(fileSystem.exists(oldPath));
-    Assert.assertNull(finder.getLatestVersion(fileSystem.makeQualified(oldPath).toUri(), Pattern.compile(".*")));
+    Assertions.assertFalse(fileSystem.exists(oldPath));
+    Assertions.assertNull(finder.getLatestVersion(fileSystem.makeQualified(oldPath).toUri(), Pattern.compile(".*")));
   }
 
   @Test
   public void testSimpleLatestVersionInDir() throws IOException, InterruptedException
   {
     final Path oldPath = new Path(perTestPath, "555test.txt");
-    Assert.assertFalse(fileSystem.exists(oldPath));
+    Assertions.assertFalse(fileSystem.exists(oldPath));
     try (final OutputStream outputStream = fileSystem.create(oldPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
@@ -171,13 +171,13 @@ public class HdfsFileTimestampVersionFinderTest
     Thread.sleep(10);
 
     final Path newPath = new Path(perTestPath, "666test.txt");
-    Assert.assertFalse(fileSystem.exists(newPath));
+    Assertions.assertFalse(fileSystem.exists(newPath));
     try (final OutputStream outputStream = fileSystem.create(newPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         fileSystem.makeQualified(newPath).toUri(),
         finder.getLatestVersion(fileSystem.makeQualified(perTestPath).toUri(), Pattern.compile(".*test\\.txt")));
   }
@@ -186,7 +186,7 @@ public class HdfsFileTimestampVersionFinderTest
   public void testSkipMismatch() throws IOException, InterruptedException
   {
     final Path oldPath = new Path(perTestPath, "555test.txt");
-    Assert.assertFalse(fileSystem.exists(oldPath));
+    Assertions.assertFalse(fileSystem.exists(oldPath));
     try (final OutputStream outputStream = fileSystem.create(oldPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
@@ -195,13 +195,13 @@ public class HdfsFileTimestampVersionFinderTest
     Thread.sleep(10);
 
     final Path newPath = new Path(perTestPath, "666test.txt2");
-    Assert.assertFalse(fileSystem.exists(newPath));
+    Assertions.assertFalse(fileSystem.exists(newPath));
     try (final OutputStream outputStream = fileSystem.create(newPath);
          final InputStream inputStream = new ByteArrayInputStream(pathByteContents)) {
       ByteStreams.copy(inputStream, outputStream);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         fileSystem.makeQualified(oldPath).toUri(),
         finder.getLatestVersion(fileSystem.makeQualified(perTestPath).toUri(), Pattern.compile(".*test\\.txt")));
   }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
@@ -30,19 +30,18 @@ import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class HdfsDataSegmentKillerTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testKill() throws Exception
@@ -91,26 +90,26 @@ public class HdfsDataSegmentKillerTest
 
     killer.kill(getSegmentWithPath(new Path(partition011Dir, "index.zip").toString()));
 
-    Assert.assertFalse(fs.exists(partition011Dir));
-    Assert.assertTrue(fs.exists(partition111Dir));
-    Assert.assertTrue(fs.exists(partition021Dir));
-    Assert.assertTrue(fs.exists(partition012Dir));
+    Assertions.assertFalse(fs.exists(partition011Dir));
+    Assertions.assertTrue(fs.exists(partition111Dir));
+    Assertions.assertTrue(fs.exists(partition021Dir));
+    Assertions.assertTrue(fs.exists(partition012Dir));
 
     killer.kill(getSegmentWithPath(new Path(partition111Dir, "index.zip").toString()));
 
-    Assert.assertFalse(fs.exists(version11Dir));
-    Assert.assertTrue(fs.exists(partition021Dir));
-    Assert.assertTrue(fs.exists(partition012Dir));
+    Assertions.assertFalse(fs.exists(version11Dir));
+    Assertions.assertTrue(fs.exists(partition021Dir));
+    Assertions.assertTrue(fs.exists(partition012Dir));
 
     killer.kill(getSegmentWithPath(new Path(partition021Dir, "index.zip").toString()));
 
-    Assert.assertFalse(fs.exists(interval1Dir));
-    Assert.assertTrue(fs.exists(partition012Dir));
+    Assertions.assertFalse(fs.exists(interval1Dir));
+    Assertions.assertTrue(fs.exists(partition012Dir));
 
     killer.kill(getSegmentWithPath(new Path(partition012Dir, "index.zip").toString()));
 
-    Assert.assertTrue(fs.exists(dataSourceDir));
-    Assert.assertTrue(fs.delete(dataSourceDir, false));
+    Assertions.assertTrue(fs.exists(dataSourceDir));
+    Assertions.assertTrue(fs.delete(dataSourceDir, false));
   }
 
   @Test
@@ -135,17 +134,17 @@ public class HdfsDataSegmentKillerTest
     Path interval1Dir = new Path(dataSourceDir, "intervalNew");
     Path version11Dir = new Path(interval1Dir, "v1");
 
-    Assert.assertTrue(fs.mkdirs(version11Dir));
+    Assertions.assertTrue(fs.mkdirs(version11Dir));
     fs.createNewFile(new Path(version11Dir, StringUtils.format("%s_index.zip", 3)));
 
     killer.kill(getSegmentWithPath(new Path(version11Dir, "3_index.zip").toString()));
 
-    Assert.assertFalse(fs.exists(version11Dir));
-    Assert.assertFalse(fs.exists(interval1Dir));
-    Assert.assertTrue(fs.exists(dataSourceDir));
-    Assert.assertTrue(fs.exists(new Path("/tmp")));
-    Assert.assertTrue(fs.exists(dataSourceDir));
-    Assert.assertTrue(fs.delete(dataSourceDir, false));
+    Assertions.assertFalse(fs.exists(version11Dir));
+    Assertions.assertFalse(fs.exists(interval1Dir));
+    Assertions.assertTrue(fs.exists(dataSourceDir));
+    Assertions.assertTrue(fs.exists(new Path("/tmp")));
+    Assertions.assertTrue(fs.exists(dataSourceDir));
+    Assertions.assertTrue(fs.delete(dataSourceDir, false));
   }
 
   @Test
@@ -171,17 +170,17 @@ public class HdfsDataSegmentKillerTest
     Path version11Dir = new Path(interval1Dir, "v1");
     String uuid = UUID.randomUUID().toString().substring(0, 5);
 
-    Assert.assertTrue(fs.mkdirs(version11Dir));
+    Assertions.assertTrue(fs.mkdirs(version11Dir));
     fs.createNewFile(new Path(version11Dir, StringUtils.format("%s_%s_index.zip", 3, uuid)));
 
     killer.kill(getSegmentWithPath(new Path(version11Dir, StringUtils.format("%s_%s_index.zip", 3, uuid)).toString()));
 
-    Assert.assertFalse(fs.exists(version11Dir));
-    Assert.assertFalse(fs.exists(interval1Dir));
-    Assert.assertTrue(fs.exists(dataSourceDir));
-    Assert.assertTrue(fs.exists(new Path("/tmp")));
-    Assert.assertTrue(fs.exists(dataSourceDir));
-    Assert.assertTrue(fs.delete(dataSourceDir, false));
+    Assertions.assertFalse(fs.exists(version11Dir));
+    Assertions.assertFalse(fs.exists(interval1Dir));
+    Assertions.assertTrue(fs.exists(dataSourceDir));
+    Assertions.assertTrue(fs.exists(new Path("/tmp")));
+    Assertions.assertTrue(fs.exists(dataSourceDir));
+    Assertions.assertTrue(fs.delete(dataSourceDir, false));
   }
 
   @Test
@@ -225,11 +224,11 @@ public class HdfsDataSegmentKillerTest
 
       final Path workspaceRoot = new Path(testRoot.getAbsolutePath(), "workspace");
       final Path nested = new Path(workspaceRoot, "evil");
-      Assert.assertTrue(fs.mkdirs(nested));
+      Assertions.assertTrue(fs.mkdirs(nested));
       fs.createNewFile(new Path(nested, "probe"));
 
       final Path stagingRun = new Path(new Path(testRoot.getAbsolutePath(), "staging"), "some_run_id");
-      Assert.assertTrue(fs.mkdirs(stagingRun));
+      Assertions.assertTrue(fs.mkdirs(stagingRun));
 
       killerWithStorage.killRecursively(null);
       killerWithStorage.killRecursively("");
@@ -241,8 +240,8 @@ public class HdfsDataSegmentKillerTest
       killerWithStorage.killRecursively("workspace//evil");
       killerWithStorage.killRecursively("workspace/evil/");
 
-      Assert.assertTrue("workspace/evil should survive null constructHdfsDeletePath cases", fs.exists(nested));
-      Assert.assertTrue(fs.exists(stagingRun));
+      Assertions.assertTrue(fs.exists(nested), "workspace/evil should survive null constructHdfsDeletePath cases");
+      Assertions.assertTrue(fs.exists(stagingRun));
 
       final HdfsDataSegmentKiller killerNoStorage = new HdfsDataSegmentKiller(
           config,
@@ -256,7 +255,7 @@ public class HdfsDataSegmentKillerTest
           }
       );
       killerNoStorage.killRecursively("staging/some_run_id");
-      Assert.assertTrue("paths must not be deleted when storage directory is unset", fs.exists(stagingRun));
+      Assertions.assertTrue(fs.exists(stagingRun), "paths must not be deleted when storage directory is unset");
     }
     finally {
       fs.delete(new Path(testRoot.getAbsolutePath()), true);
@@ -310,14 +309,14 @@ public class HdfsDataSegmentKillerTest
     try {
       Path parentDir = new Path(testRoot.getAbsolutePath(), "export");
       Path taskDir = new Path(new Path(parentDir, "run_a"), "leaf");
-      Assert.assertTrue(fs.mkdirs(taskDir.getParent()));
+      Assertions.assertTrue(fs.mkdirs(taskDir.getParent()));
       fs.createNewFile(taskDir);
 
       killer.killRecursively("export/run_a");
 
-      Assert.assertFalse(fs.exists(new Path(parentDir, "run_a")));
-      Assert.assertTrue(fs.exists(parentDir));
-      Assert.assertTrue(fs.delete(parentDir, true));
+      Assertions.assertFalse(fs.exists(new Path(parentDir, "run_a")));
+      Assertions.assertTrue(fs.exists(parentDir));
+      Assertions.assertTrue(fs.delete(parentDir, true));
     }
     finally {
       fs.delete(new Path(testRoot.getAbsolutePath()), true);
@@ -354,14 +353,14 @@ public class HdfsDataSegmentKillerTest
       Path taskDir = new Path(
           testRoot.getAbsolutePath() + Path.SEPARATOR + onDiskRelativePath + Path.SEPARATOR + "leaf"
       );
-      Assert.assertTrue(fs.mkdirs(taskDir.getParent()));
+      Assertions.assertTrue(fs.mkdirs(taskDir.getParent()));
       fs.createNewFile(taskDir);
 
       killer.killRecursively(relativePathWithColons);
 
-      Assert.assertFalse(fs.exists(new Path(testRoot.getAbsolutePath() + Path.SEPARATOR + onDiskRelativePath)));
-      Assert.assertTrue(fs.exists(batchRoot));
-      Assert.assertTrue(fs.delete(batchRoot, true));
+      Assertions.assertFalse(fs.exists(new Path(testRoot.getAbsolutePath() + Path.SEPARATOR + onDiskRelativePath)));
+      Assertions.assertTrue(fs.exists(batchRoot));
+      Assertions.assertTrue(fs.delete(batchRoot, true));
     }
     finally {
       fs.delete(new Path(testRoot.getAbsolutePath()), true);
@@ -369,72 +368,69 @@ public class HdfsDataSegmentKillerTest
   }
 
   @Test
-  public void testKillNonZipSegment() throws Exception
-  {
-    Configuration config = new Configuration();
-    HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
-        config,
-        new HdfsDataSegmentPusherConfig()
-        {
-          @Override
-          public String getStorageDirectory()
+  public void testKillNonZipSegment() {
+    Throwable exception = assertThrows(SegmentLoadingException.class, () -> {
+      Configuration config = new Configuration();
+      HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
+          config,
+          new HdfsDataSegmentPusherConfig()
           {
-            return "/tmp";
+            @Override
+            public String getStorageDirectory()
+            {
+              return "/tmp";
+            }
           }
-        }
-    );
-
-    expectedException.expect(SegmentLoadingException.class);
-    expectedException.expectMessage("Unknown file type");
-    killer.kill(getSegmentWithPath(new Path("/xxx/", "index.beep").toString()));
+      );
+      killer.kill(getSegmentWithPath(new Path("/xxx/", "index.beep").toString()));
+    });
+    assertTrue(exception.getMessage().contains("Unknown file type"));
   }
 
   @Test
-  public void testNoStorageDirectory() throws Exception
-  {
-    Configuration config = new Configuration();
-    HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
-        config,
-        new HdfsDataSegmentPusherConfig()
-        {
-          @Override
-          public String getStorageDirectory()
+  public void testNoStorageDirectory() {
+    Throwable exception = assertThrows(IllegalStateException.class, () -> {
+      Configuration config = new Configuration();
+      HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
+          config,
+          new HdfsDataSegmentPusherConfig()
           {
-            return "";
+            @Override
+            public String getStorageDirectory()
+            {
+              return "";
+            }
           }
-        }
-    );
+      );
 
-    FileSystem fs = FileSystem.get(config);
-    Path dataSourceDir = new Path("/tmp/dataSourceNew");
+      FileSystem fs = FileSystem.get(config);
+      Path dataSourceDir = new Path("/tmp/dataSourceNew");
 
-    Path interval1Dir = new Path(dataSourceDir, "intervalNew");
-    Path version11Dir = new Path(interval1Dir, "v1");
+      Path interval1Dir = new Path(dataSourceDir, "intervalNew");
+      Path version11Dir = new Path(interval1Dir, "v1");
 
-    Assert.assertTrue(fs.mkdirs(version11Dir));
-    fs.createNewFile(new Path(version11Dir, StringUtils.format("%s_index.zip", 3)));
+      Assertions.assertTrue(fs.mkdirs(version11Dir));
+      fs.createNewFile(new Path(version11Dir, StringUtils.format("%s_index.zip", 3)));
 
-    // 'kill' should work even if storageDirectory is not set.
-    killer.kill(getSegmentWithPath(new Path(version11Dir, "3_index.zip").toString()));
+      // 'kill' should work even if storageDirectory is not set.
+      killer.kill(getSegmentWithPath(new Path(version11Dir, "3_index.zip").toString()));
 
-    // Verify the segment no longer exists, but that its datasource directory does.
-    // Then delete its datasource directory.
-    Assert.assertFalse(fs.exists(version11Dir));
-    Assert.assertFalse(fs.exists(interval1Dir));
-    Assert.assertTrue(fs.exists(dataSourceDir));
-    Assert.assertTrue(fs.exists(new Path("/tmp")));
-    Assert.assertTrue(fs.exists(dataSourceDir));
-    Assert.assertTrue(fs.delete(dataSourceDir, false));
-
-    // killAll should *not* work when storageDirectory is not set.
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("Cannot delete all segment files since druid.storage.storageDirectory is not set");
-    killer.killAll();
+      // Verify the segment no longer exists, but that its datasource directory does.
+      // Then delete its datasource directory.
+      Assertions.assertFalse(fs.exists(version11Dir));
+      Assertions.assertFalse(fs.exists(interval1Dir));
+      Assertions.assertTrue(fs.exists(dataSourceDir));
+      Assertions.assertTrue(fs.exists(new Path("/tmp")));
+      Assertions.assertTrue(fs.exists(dataSourceDir));
+      Assertions.assertTrue(fs.delete(dataSourceDir, false));
+      killer.killAll();
+    });
+    assertTrue(exception.getMessage().contains("Cannot delete all segment files since druid.storage.storageDirectory is not set"));
   }
 
   private void makePartitionDirWithIndex(FileSystem fs, Path path) throws IOException
   {
-    Assert.assertTrue(fs.mkdirs(path));
+    Assertions.assertTrue(fs.mkdirs(path));
     fs.createNewFile(new Path(path, "index.zip"));
   }
 

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
@@ -368,7 +368,8 @@ public class HdfsDataSegmentKillerTest
   }
 
   @Test
-  public void testKillNonZipSegment() {
+  public void testKillNonZipSegment()
+  {
     Throwable exception = assertThrows(SegmentLoadingException.class, () -> {
       Configuration config = new Configuration();
       HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
@@ -388,7 +389,8 @@ public class HdfsDataSegmentKillerTest
   }
 
   @Test
-  public void testNoStorageDirectory() {
+  public void testNoStorageDirectory()
+  {
     Throwable exception = assertThrows(IllegalStateException.class, () -> {
       Configuration config = new Configuration();
       HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
@@ -389,44 +389,43 @@ public class HdfsDataSegmentKillerTest
   }
 
   @Test
-  public void testNoStorageDirectory()
+  public void testNoStorageDirectory() throws Exception
   {
-    Throwable exception = assertThrows(IllegalStateException.class, () -> {
-      Configuration config = new Configuration();
-      HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
-          config,
-          new HdfsDataSegmentPusherConfig()
+    Configuration config = new Configuration();
+    HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
+        config,
+        new HdfsDataSegmentPusherConfig()
+        {
+          @Override
+          public String getStorageDirectory()
           {
-            @Override
-            public String getStorageDirectory()
-            {
-              return "";
-            }
+            return "";
           }
-      );
+        }
+    );
 
-      FileSystem fs = FileSystem.get(config);
-      Path dataSourceDir = new Path("/tmp/dataSourceNew");
+    FileSystem fs = FileSystem.get(config);
+    Path dataSourceDir = new Path("/tmp/dataSourceNew");
 
-      Path interval1Dir = new Path(dataSourceDir, "intervalNew");
-      Path version11Dir = new Path(interval1Dir, "v1");
+    Path interval1Dir = new Path(dataSourceDir, "intervalNew");
+    Path version11Dir = new Path(interval1Dir, "v1");
 
-      Assertions.assertTrue(fs.mkdirs(version11Dir));
-      fs.createNewFile(new Path(version11Dir, StringUtils.format("%s_index.zip", 3)));
+    Assertions.assertTrue(fs.mkdirs(version11Dir));
+    fs.createNewFile(new Path(version11Dir, StringUtils.format("%s_index.zip", 3)));
 
-      // 'kill' should work even if storageDirectory is not set.
-      killer.kill(getSegmentWithPath(new Path(version11Dir, "3_index.zip").toString()));
+    // 'kill' should work even if storageDirectory is not set.
+    killer.kill(getSegmentWithPath(new Path(version11Dir, "3_index.zip").toString()));
 
-      // Verify the segment no longer exists, but that its datasource directory does.
-      // Then delete its datasource directory.
-      Assertions.assertFalse(fs.exists(version11Dir));
-      Assertions.assertFalse(fs.exists(interval1Dir));
-      Assertions.assertTrue(fs.exists(dataSourceDir));
-      Assertions.assertTrue(fs.exists(new Path("/tmp")));
-      Assertions.assertTrue(fs.exists(dataSourceDir));
-      Assertions.assertTrue(fs.delete(dataSourceDir, false));
-      killer.killAll();
-    });
+    // Verify the segment no longer exists, but that its datasource directory does.
+    // Then delete its datasource directory.
+    Assertions.assertFalse(fs.exists(version11Dir));
+    Assertions.assertFalse(fs.exists(interval1Dir));
+    Assertions.assertTrue(fs.exists(dataSourceDir));
+    Assertions.assertTrue(fs.exists(new Path("/tmp")));
+    Assertions.assertTrue(fs.exists(dataSourceDir));
+    Assertions.assertTrue(fs.delete(dataSourceDir, false));
+
+    Throwable exception = assertThrows(IllegalStateException.class, killer::killAll);
     assertTrue(exception.getMessage().contains("Cannot delete all segment files since druid.storage.storageDirectory is not set"));
   }
 

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPullerTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPullerTest.java
@@ -29,12 +29,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -58,7 +58,7 @@ public class HdfsDataSegmentPullerTest
   private static byte[] pathByteContents = StringUtils.toUtf8(pathContents);
   private static Configuration conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupStatic() throws IOException
   {
     hdfsTmpDir = File.createTempFile("hdfsHandlerTest", "dir");
@@ -83,7 +83,7 @@ public class HdfsDataSegmentPullerTest
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownStatic() throws IOException
   {
     FileUtils.deleteDirectory(hdfsTmpDir);
@@ -93,13 +93,13 @@ public class HdfsDataSegmentPullerTest
 
   private HdfsDataSegmentPuller puller;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     puller = new HdfsDataSegmentPuller(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     fileSystem.delete(perTestPath, true);
@@ -118,7 +118,7 @@ public class HdfsDataSegmentPullerTest
     try (final OutputStream stream = new FileOutputStream(tmpFile)) {
       ByteStreams.copy(new ByteArrayInputStream(pathByteContents), stream);
     }
-    Assert.assertTrue(tmpFile.exists());
+    Assertions.assertTrue(tmpFile.exists());
 
     final File outFile = new File(outTmpDir, tmpFile.getName());
     outFile.delete();
@@ -127,11 +127,11 @@ public class HdfsDataSegmentPullerTest
       CompressionUtils.zip(tmpDir, stream);
     }
     try {
-      Assert.assertFalse(outFile.exists());
+      Assertions.assertFalse(outFile.exists());
       puller.getSegmentFiles(fileSystem.makeQualified(zipPath), outTmpDir);
-      Assert.assertTrue(outFile.exists());
+      Assertions.assertTrue(outFile.exists());
 
-      Assert.assertArrayEquals(pathByteContents, Files.readAllBytes(outFile.toPath()));
+      Assertions.assertArrayEquals(pathByteContents, Files.readAllBytes(outFile.toPath()));
     }
     finally {
       if (tmpFile.exists()) {
@@ -164,11 +164,11 @@ public class HdfsDataSegmentPullerTest
       ByteStreams.copy(inputStream, gzStream);
     }
     try {
-      Assert.assertFalse(outFile.exists());
+      Assertions.assertFalse(outFile.exists());
       puller.getSegmentFiles(fileSystem.makeQualified(zipPath), outTmpDir);
-      Assert.assertTrue(outFile.exists());
+      Assertions.assertTrue(outFile.exists());
 
-      Assert.assertArrayEquals(pathByteContents, Files.readAllBytes(outFile.toPath()));
+      Assertions.assertArrayEquals(pathByteContents, Files.readAllBytes(outFile.toPath()));
     }
     finally {
       if (outFile.exists()) {
@@ -195,11 +195,11 @@ public class HdfsDataSegmentPullerTest
       ByteStreams.copy(inputStream, outputStream);
     }
     try {
-      Assert.assertFalse(outFile.exists());
+      Assertions.assertFalse(outFile.exists());
       puller.getSegmentFiles(fileSystem.makeQualified(perTestPath), outTmpDir);
-      Assert.assertTrue(outFile.exists());
+      Assertions.assertTrue(outFile.exists());
 
-      Assert.assertArrayEquals(pathByteContents, Files.readAllBytes(outFile.toPath()));
+      Assertions.assertArrayEquals(pathByteContents, Files.readAllBytes(outFile.toPath()));
     }
     finally {
       if (outFile.exists()) {

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
@@ -44,12 +44,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,6 +55,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  */
@@ -72,15 +73,12 @@ public class HdfsDataSegmentPusherTest
     objectMapper.setInjectableValues(injectableValues);
   }
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
+  @TempDir
+  public File tempFolder;
 
   private HdfsDataSegmentPusher hdfsDataSegmentPusher;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     HdfsDataSegmentPusherConfig hdfsDataSegmentPusherConf = new HdfsDataSegmentPusherConfig();
@@ -95,14 +93,14 @@ public class HdfsDataSegmentPusherTest
   }
 
   @Test
-  public void testPushWithBadScheme() throws Exception
-  {
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("No FileSystem for scheme");
-    testUsingScheme("xyzzy");
+  public void testPushWithBadScheme() {
+    Throwable exception = assertThrows(RuntimeException.class, () -> {
+      testUsingScheme("xyzzy");
 
-    // Not reached
-    Assert.assertTrue(false);
+      // Not reached
+      Assertions.assertTrue(false);
+    });
+    assertTrue(exception.getMessage().contains("No FileSystem for scheme"));
   }
 
   @Test
@@ -124,7 +122,7 @@ public class HdfsDataSegmentPusherTest
     Configuration conf = new Configuration(true);
 
     // Create a mock segment on disk
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = newFolder(tempFolder);
     File tmp = new File(segmentDir, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
@@ -132,7 +130,7 @@ public class HdfsDataSegmentPusherTest
     final long size = data.length;
 
     HdfsDataSegmentPusherConfig config = new HdfsDataSegmentPusherConfig();
-    final File storageDirectory = tempFolder.newFolder();
+    final File storageDirectory = newFolder(tempFolder);
 
     config.setStorageDirectory(StringUtils.format("file://%s", storageDirectory.getAbsolutePath()));
     HdfsDataSegmentPusher pusher = new HdfsDataSegmentPusher(config, conf);
@@ -153,9 +151,9 @@ public class HdfsDataSegmentPusherTest
 
     Pattern pattern =
         Pattern.compile(".*/foo/20150101T000000\\.000Z_20160101T000000\\.000Z/0/0_[A-Za-z0-9-]{36}_index\\.zip");
-    Assert.assertTrue(
-        segment.getLoadSpec().get("path").toString(),
-        pattern.matcher(segment.getLoadSpec().get("path").toString()).matches()
+    Assertions.assertTrue(
+        pattern.matcher(segment.getLoadSpec().get("path").toString()).matches(),
+        segment.getLoadSpec().get("path").toString()
     );
   }
 
@@ -165,7 +163,7 @@ public class HdfsDataSegmentPusherTest
     Configuration conf = new Configuration(true);
 
     // Create a mock segment on disk
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = newFolder(tempFolder);
     File tmp = new File(segmentDir, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
@@ -173,7 +171,7 @@ public class HdfsDataSegmentPusherTest
     final long size = data.length;
 
     HdfsDataSegmentPusherConfig config = new HdfsDataSegmentPusherConfig();
-    final File storageDirectory = tempFolder.newFolder();
+    final File storageDirectory = newFolder(tempFolder);
 
     config.setStorageDirectory(StringUtils.format("file://%s", storageDirectory.getAbsolutePath()));
     HdfsDataSegmentPusher pusher = new HdfsDataSegmentPusher(config, conf);
@@ -193,9 +191,9 @@ public class HdfsDataSegmentPusherTest
     final String storageDirSuffix = "shuffle-data/index_parallel_session_analysis_test_bkdhhedd_2023-09-08T03:18:21.121Z/2023-08-29T16:00:00.000Z/2023-08-29T17:00:00.000Z";
     DataSegment segment = pusher.pushToPath(segmentDir, segmentToPush, storageDirSuffix);
     
-    Assert.assertTrue(
-        segment.getLoadSpec().get("path").toString(),
-        segment.getLoadSpec().get("path").toString().endsWith(storageDirSuffix.replace(':', '_') + "/0_index.zip")
+    Assertions.assertTrue(
+        segment.getLoadSpec().get("path").toString().endsWith(storageDirSuffix.replace(':', '_') + "/0_index.zip"),
+        segment.getLoadSpec().get("path").toString()
     );
   }
 
@@ -205,7 +203,7 @@ public class HdfsDataSegmentPusherTest
     DataSegment[] segments = new DataSegment[numberOfSegments];
 
     // Create a mock segment on disk
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = newFolder(tempFolder);
     File tmp = new File(segmentDir, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
@@ -213,7 +211,7 @@ public class HdfsDataSegmentPusherTest
     final long size = data.length;
 
     HdfsDataSegmentPusherConfig config = new HdfsDataSegmentPusherConfig();
-    final File storageDirectory = tempFolder.newFolder();
+    final File storageDirectory = newFolder(tempFolder);
 
     config.setCompressionFormat(format);
     config.setStorageDirectory(
@@ -249,9 +247,9 @@ public class HdfsDataSegmentPusherTest
           format.getExtension()
       );
 
-      Assert.assertEquals(segments[i].getSize(), pushedSegment.getSize());
-      Assert.assertEquals(segments[i], pushedSegment);
-      Assert.assertEquals(ImmutableMap.of(
+      Assertions.assertEquals(segments[i].getSize(), pushedSegment.getSize());
+      Assertions.assertEquals(segments[i], pushedSegment);
+      Assertions.assertEquals(ImmutableMap.of(
           "type",
           "hdfs",
           "path",
@@ -267,10 +265,10 @@ public class HdfsDataSegmentPusherTest
           pushedSegment.getShardSpec().getPartitionNum(),
           format.getExtension()
       ));
-      Assert.assertTrue(indexFile.exists());
+      Assertions.assertTrue(indexFile.exists());
 
-      Assert.assertEquals(segments[i].getSize(), pushedSegment.getSize());
-      Assert.assertEquals(segments[i], pushedSegment);
+      Assertions.assertEquals(segments[i].getSize(), pushedSegment.getSize());
+      Assertions.assertEquals(segments[i], pushedSegment);
 
       indexFile = new File(StringUtils.format(
           "%s/%s/%d_index.%s",
@@ -279,7 +277,7 @@ public class HdfsDataSegmentPusherTest
           pushedSegment.getShardSpec().getPartitionNum(),
           format.getExtension()
       ));
-      Assert.assertTrue(indexFile.exists());
+      Assertions.assertTrue(indexFile.exists());
 
 
       // push twice will fail and temp dir cleaned
@@ -289,7 +287,7 @@ public class HdfsDataSegmentPusherTest
         pusher.push(segmentDir, segments[i], false);
       }
       catch (IOException e) {
-        Assert.fail("should not throw exception");
+        Assertions.fail("should not throw exception");
       }
     }
   }
@@ -299,7 +297,7 @@ public class HdfsDataSegmentPusherTest
     Configuration conf = new Configuration(true);
 
     // Create a mock segment on disk
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = newFolder(tempFolder);
     File tmp = new File(segmentDir, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
@@ -307,7 +305,7 @@ public class HdfsDataSegmentPusherTest
     final long size = data.length;
 
     HdfsDataSegmentPusherConfig config = new HdfsDataSegmentPusherConfig();
-    final File storageDirectory = tempFolder.newFolder();
+    final File storageDirectory = newFolder(tempFolder);
 
     config.setStorageDirectory(
         scheme != null
@@ -338,9 +336,9 @@ public class HdfsDataSegmentPusherTest
         segmentToPush.getShardSpec().getPartitionNum()
     );
 
-    Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
-    Assert.assertEquals(segmentToPush, segment);
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals(segmentToPush.getSize(), segment.getSize());
+    Assertions.assertEquals(segmentToPush, segment);
+    Assertions.assertEquals(ImmutableMap.of(
         "type",
         "hdfs",
         "path",
@@ -355,7 +353,7 @@ public class HdfsDataSegmentPusherTest
         segmentPath,
         segment.getShardSpec().getPartitionNum()
     ));
-    Assert.assertTrue(indexFile.exists());
+    Assertions.assertTrue(indexFile.exists());
 
     // push twice will fail and temp dir cleaned
     File outDir = new File(StringUtils.format("%s/%s", config.getStorageDirectory(), segmentPath));
@@ -364,7 +362,7 @@ public class HdfsDataSegmentPusherTest
       pusher.push(segmentDir, segmentToPush, false);
     }
     catch (IOException e) {
-      Assert.fail("should not throw exception");
+      Assertions.fail("should not throw exception");
     }
   }
 
@@ -402,6 +400,7 @@ public class HdfsDataSegmentPusherTest
             }
         );
       }
+
     }
   }
 
@@ -425,7 +424,12 @@ public class HdfsDataSegmentPusherTest
     );
 
     String storageDir = hdfsDataSegmentPusher.getStorageDir(segment, false);
-    Assert.assertEquals("something/20111001T000000.000Z_20111002T000000.000Z/brand_new_version", storageDir);
+    Assertions.assertEquals("something/20111001T000000.000Z_20111002T000000.000Z/brand_new_version", storageDir);
 
+  }
+
+  private static File newFolder(File root) throws IOException {
+    java.nio.file.Path path = java.nio.file.Files.createTempDirectory(root.toPath(), "junit");
+    return path.toFile();
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import org.apache.druid.jackson.GranularityModule;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.timeline.DataSegment;
@@ -429,7 +430,6 @@ public class HdfsDataSegmentPusherTest
   }
 
   private static File newFolder(File root) throws IOException {
-    java.nio.file.Path path = java.nio.file.Files.createTempDirectory(root.toPath(), "junit");
-    return path.toFile();
+    return FileUtils.createTempDirInLocation(root.toPath(), "junit");
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
@@ -94,7 +94,8 @@ public class HdfsDataSegmentPusherTest
   }
 
   @Test
-  public void testPushWithBadScheme() {
+  public void testPushWithBadScheme()
+  {
     Throwable exception = assertThrows(RuntimeException.class, () -> {
       testUsingScheme("xyzzy");
 
@@ -429,7 +430,8 @@ public class HdfsDataSegmentPusherTest
 
   }
 
-  private static File newFolder(File root) throws IOException {
+  private static File newFolder(File root) throws IOException
+  {
     return FileUtils.createTempDirInLocation(root.toPath(), "junit");
   }
 }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentPusherTest.java
@@ -430,7 +430,7 @@ public class HdfsDataSegmentPusherTest
 
   }
 
-  private static File newFolder(File root) throws IOException
+  private static File newFolder(File root)
   {
     return FileUtils.createTempDirInLocation(root.toPath(), "junit");
   }

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsKerberosConfigTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsKerberosConfigTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.storage.hdfs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -33,7 +33,7 @@ public class HdfsKerberosConfigTest
   public void testSerDesr() throws IOException
   {
     HdfsKerberosConfig hdfsKerberosConfig = new HdfsKerberosConfig("principal", "keytab");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         hdfsKerberosConfig,
         mapper.readerFor(HdfsKerberosConfig.class).readValue(mapper.writeValueAsString(hdfsKerberosConfig))
     );

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModuleTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsStorageDruidModuleTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.inputsource.hdfs.HdfsInputSourceConfig;
 import org.apache.druid.java.util.emitter.core.NoopEmitter;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.segment.loading.OmniDataSegmentKiller;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.Validation;
 import javax.validation.Validator;
@@ -46,7 +46,7 @@ public class HdfsStorageDruidModuleTest
     Properties props = new Properties();
     Injector injector = makeInjectorWithProperties(props);
     HdfsInputSourceConfig instance = injector.getInstance(HdfsInputSourceConfig.class);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("hdfs"),
         instance.getAllowedProtocols()
     );
@@ -59,7 +59,7 @@ public class HdfsStorageDruidModuleTest
     props.setProperty("druid.ingestion.hdfs.allowedProtocols", "[\"webhdfs\"]");
     Injector injector = makeInjectorWithProperties(props);
     HdfsInputSourceConfig instance = injector.getInstance(HdfsInputSourceConfig.class);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("webhdfs"),
         instance.getAllowedProtocols()
     );
@@ -70,8 +70,8 @@ public class HdfsStorageDruidModuleTest
   {
     Injector injector = makeInjectorWithProperties(new Properties());
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
-    Assert.assertTrue(killer.getKillers().containsKey(HdfsStorageDruidModule.SCHEME));
-    Assert.assertSame(
+    Assertions.assertTrue(killer.getKillers().containsKey(HdfsStorageDruidModule.SCHEME));
+    Assertions.assertSame(
         killer.getKillers().get(HdfsStorageDruidModule.SCHEME).get(),
         killer.getKillers().get(HdfsStorageDruidModule.SCHEME).get()
     );

--- a/extensions-core/kinesis-indexing-service/pom.xml
+++ b/extensions-core/kinesis-indexing-service/pom.xml
@@ -158,6 +158,7 @@
         </dependency>
 
         <!-- Tests -->
+        <!-- SeekableStreamIndexTaskTestBase still uses JUnit 4 rules. -->
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
@@ -166,6 +167,26 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -192,11 +213,6 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/data/input/kinesis/KinesisInputFormatTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/data/input/kinesis/KinesisInputFormatTest.java
@@ -43,9 +43,9 @@ import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.io.IOException;
@@ -76,7 +76,7 @@ public class KinesisInputFormatTest
 
   private KinesisInputFormat format;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     format = new KinesisInputFormat(
@@ -129,11 +129,11 @@ public class KinesisInputFormatTest
         "kinesis.newts.partitionKey",
         "kinesis.newts.timestamp"
     );
-    Assert.assertEquals(format, kif);
+    Assertions.assertEquals(format, kif);
 
     final byte[] formatBytes = mapper.writeValueAsBytes(format);
     final byte[] kifBytes = mapper.writeValueAsBytes(kif);
-    Assert.assertArrayEquals(formatBytes, kifBytes);
+    Assertions.assertArrayEquals(formatBytes, kifBytes);
   }
 
   @Test
@@ -168,27 +168,27 @@ public class KinesisInputFormatTest
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE), row.getTimestamp());
-        Assert.assertEquals(
+        Assertions.assertEquals(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE), row.getTimestamp());
+        Assertions.assertEquals(
             String.valueOf(KINESIS_APPROXOIMATE_TIMESTAMP_MILLIS),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -220,33 +220,33 @@ public class KinesisInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRowListPlusRawValues rawValues = iterator.next();
-        Assert.assertEquals(1, rawValues.getInputRows().size());
+        Assertions.assertEquals(1, rawValues.getInputRows().size());
         InputRow row = rawValues.getInputRows().get(0);
         // Payload verifications
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(
+        Assertions.assertEquals(
             String.valueOf(KINESIS_APPROXOIMATE_TIMESTAMP_MILLIS),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -278,34 +278,34 @@ public class KinesisInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRowListPlusRawValues rawValues = iterator.next();
-        Assert.assertEquals(1, rawValues.getInputRows().size());
+        Assertions.assertEquals(1, rawValues.getInputRows().size());
         InputRow row = rawValues.getInputRows().get(0);
         // Payload verifications
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(DateTimes.of(String.valueOf(KINESIS_APPROXOIMATE_TIMESTAMP_MILLIS)), row.getTimestamp());
-        Assert.assertEquals(
+        Assertions.assertEquals(DateTimes.of(String.valueOf(KINESIS_APPROXOIMATE_TIMESTAMP_MILLIS)), row.getTimestamp());
+        Assertions.assertEquals(
             String.valueOf(KINESIS_APPROXOIMATE_TIMESTAMP_MILLIS),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -362,28 +362,28 @@ public class KinesisInputFormatTest
           // Payload verification
           // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
           // but test reading them anyway since it isn't technically illegal
-          Assert.assertEquals(DateTimes.of("2024-07-1" + i), row.getTimestamp());
-          Assert.assertEquals(
+          Assertions.assertEquals(DateTimes.of("2024-07-1" + i), row.getTimestamp());
+          Assertions.assertEquals(
               String.valueOf(DateTimes.of("2024-07-1" + i).getMillis()),
               Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
           );
-          Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-          Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-          Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-          Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-          Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-          Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-          Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
-          Assert.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("index")));
+          Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+          Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+          Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+          Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+          Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+          Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+          Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+          Assertions.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("index")));
 
-          Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-          Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-          Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+          Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+          Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+          Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
           numActualIterations++;
         }
 
-        Assert.assertEquals(numExpectedIterations, numActualIterations);
+        Assertions.assertEquals(numExpectedIterations, numActualIterations);
       }
     }
   }
@@ -420,27 +420,27 @@ public class KinesisInputFormatTest
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(DateTimes.of(DATA_TIMSTAMP_DATE), row.getTimestamp());
-        Assert.assertEquals(
+        Assertions.assertEquals(DateTimes.of(DATA_TIMSTAMP_DATE), row.getTimestamp());
+        Assertions.assertEquals(
             String.valueOf(KINESIS_APPROXOIMATE_TIMESTAMP_MILLIS),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -497,28 +497,28 @@ public class KinesisInputFormatTest
           // Payload verification
           // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
           // but test reading them anyway since it isn't technically illegal
-          Assert.assertEquals(DateTimes.of("2024-07-2" + i), row.getTimestamp());
-          Assert.assertEquals(
+          Assertions.assertEquals(DateTimes.of("2024-07-2" + i), row.getTimestamp());
+          Assertions.assertEquals(
               String.valueOf(DateTimes.of("2024-07-29").getMillis()),
               Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
           );
-          Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-          Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-          Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-          Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-          Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-          Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-          Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
-          Assert.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("index")));
+          Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+          Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+          Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+          Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+          Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+          Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+          Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+          Assertions.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("index")));
 
-          Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-          Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-          Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+          Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+          Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+          Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
           numActualIterations++;
         }
 
-        Assert.assertEquals(numExpectedIterations, numActualIterations);
+        Assertions.assertEquals(numExpectedIterations, numActualIterations);
       }
     }
   }
@@ -549,8 +549,8 @@ public class KinesisInputFormatTest
 
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       while (iterator.hasNext()) {
-        Throwable t = Assert.assertThrows(ParseException.class, iterator::next);
-        Assert.assertTrue(
+        Throwable t = Assertions.assertThrows(ParseException.class, iterator::next);
+        Assertions.assertTrue(
             t.getMessage().startsWith("Timestamp[null] is unparseable! Event: {")
         );
       }
@@ -597,33 +597,33 @@ public class KinesisInputFormatTest
         );
         Collections.sort(expectedDimensions);
         Collections.sort(row.getDimensions());
-        Assert.assertEquals(
+        Assertions.assertEquals(
             expectedDimensions,
             row.getDimensions()
         );
 
         // Payload verifications
-        Assert.assertEquals(DateTimes.of(DATA_TIMSTAMP_DATE), row.getTimestamp());
-        Assert.assertEquals(
+        Assertions.assertEquals(DateTimes.of(DATA_TIMSTAMP_DATE), row.getTimestamp());
+        Assertions.assertEquals(
             String.valueOf(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE).getMillis()),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -667,33 +667,33 @@ public class KinesisInputFormatTest
         );
         Collections.sort(expectedDimensions);
         Collections.sort(row.getDimensions());
-        Assert.assertEquals(
+        Assertions.assertEquals(
             expectedDimensions,
             row.getDimensions()
         );
 
         // Payload verifications
-        Assert.assertEquals(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE), row.getTimestamp());
-        Assert.assertEquals(
+        Assertions.assertEquals(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE), row.getTimestamp());
+        Assertions.assertEquals(
             String.valueOf(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE).getMillis()),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -742,7 +742,7 @@ public class KinesisInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRow row = iterator.next();
-        Assert.assertEquals(
+        Assertions.assertEquals(
             Arrays.asList(
                 "bar",
                 "foo",
@@ -755,20 +755,20 @@ public class KinesisInputFormatTest
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(DateTimes.of("2024-07-30"), row.getTimestamp());
-        Assert.assertEquals(
+        Assertions.assertEquals(DateTimes.of("2024-07-30"), row.getTimestamp());
+        Assertions.assertEquals(
             String.valueOf(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE).getMillis()),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertTrue(row.getDimension("bar").isEmpty());
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertTrue(row.getDimension("bar").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -813,33 +813,33 @@ public class KinesisInputFormatTest
         );
         Collections.sort(expectedDimensions);
         Collections.sort(row.getDimensions());
-        Assert.assertEquals(
+        Assertions.assertEquals(
             expectedDimensions,
             row.getDimensions()
         );
 
         // Payload verifications
-        Assert.assertEquals(DateTimes.of(DATA_TIMSTAMP_DATE), row.getTimestamp());
-        Assert.assertEquals(
+        Assertions.assertEquals(DateTimes.of(DATA_TIMSTAMP_DATE), row.getTimestamp());
+        Assertions.assertEquals(
             String.valueOf(DateTimes.of(KINESIS_APPROXIMATE_TIME_DATE).getMillis()),
             Iterables.getOnlyElement(row.getDimension("kinesis.newts.timestamp"))
         );
-        Assert.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(PARTITION_KEY, Iterables.getOnlyElement(row.getDimension("kinesis.newts.partitionKey")));
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -883,10 +883,10 @@ public class KinesisInputFormatTest
   public void testInvalidInputFormatConstruction()
   {
     // null value format is invalid
-    Assert.assertThrows(
-        "valueFormat must not be null",
+    Assertions.assertThrows(
         NullPointerException.class,
-        () -> new KinesisInputFormat(null, null, null)
+        () -> new KinesisInputFormat(null, null, null),
+        "valueFormat must not be null"
     );
 
     InputFormat valueFormat = new JsonInputFormat(
@@ -908,10 +908,10 @@ public class KinesisInputFormatTest
     );
 
     // partitionKeyColumnName == timestampColumnName is invalid
-    Assert.assertThrows(
-        "timestampColumnName and partitionKeyColumnName must be different",
+    Assertions.assertThrows(
         IllegalStateException.class,
-        () -> new KinesisInputFormat(valueFormat, "kinesis.timestamp", "kinesis.timestamp")
+        () -> new KinesisInputFormat(valueFormat, "kinesis.timestamp", "kinesis.timestamp"),
+        "timestampColumnName and partitionKeyColumnName must be different"
     );
   }
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisDataSourceMetadataTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisDataSourceMetadataTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers
 import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers;
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.initialization.DruidModule;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Set;
@@ -61,116 +61,116 @@ public class KinesisDataSourceMetadataTest
   @Test
   public void testMatches()
   {
-    Assert.assertTrue(START0.matches(START0));
-    Assert.assertTrue(START0.matches(START1));
-    Assert.assertTrue(START0.matches(START2));
-    Assert.assertTrue(START0.matches(START3));
-    Assert.assertTrue(START0.matches(START4));
-    Assert.assertTrue(START0.matches(START5));
+    Assertions.assertTrue(START0.matches(START0));
+    Assertions.assertTrue(START0.matches(START1));
+    Assertions.assertTrue(START0.matches(START2));
+    Assertions.assertTrue(START0.matches(START3));
+    Assertions.assertTrue(START0.matches(START4));
+    Assertions.assertTrue(START0.matches(START5));
 
-    Assert.assertTrue(START1.matches(START0));
-    Assert.assertTrue(START1.matches(START1));
-    Assert.assertFalse(START1.matches(START2));
-    Assert.assertTrue(START1.matches(START3));
-    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START1.matches(START5));
+    Assertions.assertTrue(START1.matches(START0));
+    Assertions.assertTrue(START1.matches(START1));
+    Assertions.assertFalse(START1.matches(START2));
+    Assertions.assertTrue(START1.matches(START3));
+    Assertions.assertFalse(START1.matches(START4));
+    Assertions.assertFalse(START1.matches(START5));
 
-    Assert.assertTrue(START2.matches(START0));
-    Assert.assertFalse(START2.matches(START1));
-    Assert.assertTrue(START2.matches(START2));
-    Assert.assertTrue(START2.matches(START3));
-    Assert.assertFalse(START2.matches(START4));
-    Assert.assertFalse(START2.matches(START5));
+    Assertions.assertTrue(START2.matches(START0));
+    Assertions.assertFalse(START2.matches(START1));
+    Assertions.assertTrue(START2.matches(START2));
+    Assertions.assertTrue(START2.matches(START3));
+    Assertions.assertFalse(START2.matches(START4));
+    Assertions.assertFalse(START2.matches(START5));
 
-    Assert.assertTrue(START3.matches(START0));
-    Assert.assertTrue(START3.matches(START1));
-    Assert.assertTrue(START3.matches(START2));
-    Assert.assertTrue(START3.matches(START3));
-    Assert.assertFalse(START3.matches(START4));
-    Assert.assertFalse(START3.matches(START5));
+    Assertions.assertTrue(START3.matches(START0));
+    Assertions.assertTrue(START3.matches(START1));
+    Assertions.assertTrue(START3.matches(START2));
+    Assertions.assertTrue(START3.matches(START3));
+    Assertions.assertFalse(START3.matches(START4));
+    Assertions.assertFalse(START3.matches(START5));
 
-    Assert.assertTrue(START4.matches(START0));
-    Assert.assertFalse(START4.matches(START1));
-    Assert.assertFalse(START4.matches(START2));
-    Assert.assertFalse(START4.matches(START3));
-    Assert.assertTrue(START4.matches(START4));
-    Assert.assertFalse(START4.matches(START5));
+    Assertions.assertTrue(START4.matches(START0));
+    Assertions.assertFalse(START4.matches(START1));
+    Assertions.assertFalse(START4.matches(START2));
+    Assertions.assertFalse(START4.matches(START3));
+    Assertions.assertTrue(START4.matches(START4));
+    Assertions.assertFalse(START4.matches(START5));
 
-    Assert.assertTrue(START5.matches(START0));
-    Assert.assertFalse(START5.matches(START1));
-    Assert.assertFalse(START5.matches(START2));
-    Assert.assertFalse(START5.matches(START3));
-    Assert.assertFalse(START5.matches(START4));
-    Assert.assertTrue(START5.matches(START5));
+    Assertions.assertTrue(START5.matches(START0));
+    Assertions.assertFalse(START5.matches(START1));
+    Assertions.assertFalse(START5.matches(START2));
+    Assertions.assertFalse(START5.matches(START3));
+    Assertions.assertFalse(START5.matches(START4));
+    Assertions.assertTrue(START5.matches(START5));
 
-    Assert.assertTrue(END0.matches(END0));
-    Assert.assertTrue(END0.matches(END1));
-    Assert.assertTrue(END0.matches(END2));
+    Assertions.assertTrue(END0.matches(END0));
+    Assertions.assertTrue(END0.matches(END1));
+    Assertions.assertTrue(END0.matches(END2));
 
-    Assert.assertTrue(END1.matches(END0));
-    Assert.assertTrue(END1.matches(END1));
-    Assert.assertTrue(END1.matches(END2));
+    Assertions.assertTrue(END1.matches(END0));
+    Assertions.assertTrue(END1.matches(END1));
+    Assertions.assertTrue(END1.matches(END2));
 
-    Assert.assertTrue(END2.matches(END0));
-    Assert.assertTrue(END2.matches(END1));
-    Assert.assertTrue(END2.matches(END2));
+    Assertions.assertTrue(END2.matches(END0));
+    Assertions.assertTrue(END2.matches(END1));
+    Assertions.assertTrue(END2.matches(END2));
   }
 
   @Test
   public void testIsValidStart()
   {
-    Assert.assertTrue(START0.isValidStart());
-    Assert.assertTrue(START1.isValidStart());
-    Assert.assertTrue(START2.isValidStart());
-    Assert.assertTrue(START3.isValidStart());
-    Assert.assertTrue(START4.isValidStart());
-    Assert.assertTrue(START5.isValidStart());
+    Assertions.assertTrue(START0.isValidStart());
+    Assertions.assertTrue(START1.isValidStart());
+    Assertions.assertTrue(START2.isValidStart());
+    Assertions.assertTrue(START3.isValidStart());
+    Assertions.assertTrue(START4.isValidStart());
+    Assertions.assertTrue(START5.isValidStart());
   }
 
   @Test
   public void testPlus()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of("0", "2L", "1", "3L", "2", "5L")),
         START1.plus(START3)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of("0", "2L", "1", "4L", "2", "5L")),
         START0.plus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of("0", "2L", "1", "4L", "2", "5L")),
         START1.plus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of("0", "2L", "1", "3L", "2", "5L")),
         START2.plus(START1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of("0", "2L", "1", "4L", "2", "5L")),
         START2.plus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of("0", "2L", "1", "4L", "2", "5L"), ImmutableSet.of("1")),
         START2.plus(START4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of("0", "2L", "1", "4L", "2", "5L"), ImmutableSet.of("0", "1")),
         START2.plus(START5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of("0", "2L", "2", "5L")),
         END0.plus(END1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of("0", "2L", "1", "4L", "2", "5L")),
         END1.plus(END2)
     );
@@ -179,47 +179,47 @@ public class KinesisDataSourceMetadataTest
   @Test
   public void testMinus()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of("1", "3L")),
         START1.minus(START3)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of()),
         START0.minus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of()),
         START1.minus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of("2", "5L")),
         START2.minus(START1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         simpleStartMetadata(ImmutableMap.of()),
         START2.minus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(), ImmutableSet.of()),
         START4.minus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of("1", "4L"), ImmutableSet.of("1")),
         START5.minus(START4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of("1", "4L")),
         END2.minus(END1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of("2", "5L")),
         END1.minus(END2)
     );
@@ -233,12 +233,12 @@ public class KinesisDataSourceMetadataTest
     KinesisDataSourceMetadata kdm1 = startMetadata(ImmutableMap.of(), ImmutableSet.of());
     String kdmStr1 = jsonMapper.writeValueAsString(kdm1);
     DataSourceMetadata dsMeta1 = jsonMapper.readValue(kdmStr1, DataSourceMetadata.class);
-    Assert.assertEquals(kdm1, dsMeta1);
+    Assertions.assertEquals(kdm1, dsMeta1);
 
     KinesisDataSourceMetadata kdm2 = startMetadata(ImmutableMap.of("1", "3"), ImmutableSet.of());
     String kdmStr2 = jsonMapper.writeValueAsString(kdm2);
     DataSourceMetadata dsMeta2 = jsonMapper.readValue(kdmStr2, DataSourceMetadata.class);
-    Assert.assertEquals(kdm2, dsMeta2);
+    Assertions.assertEquals(kdm2, dsMeta2);
   }
 
   @Test
@@ -248,12 +248,12 @@ public class KinesisDataSourceMetadataTest
     KinesisDataSourceMetadata expectedKdm1 = endMetadata(ImmutableMap.of("1", "5"));
     String kdmStr1 = "{\"type\":\"kinesis\",\"partitions\":{\"type\":\"end\",\"stream\":\"foo\",\"topic\":\"foo\",\"partitionSequenceNumberMap\":{\"1\":5},\"partitionOffsetMap\":{\"1\":5},\"exclusivePartitions\":[]}}\n";
     DataSourceMetadata dsMeta1 = jsonMapper.readValue(kdmStr1, DataSourceMetadata.class);
-    Assert.assertEquals(dsMeta1, expectedKdm1);
+    Assertions.assertEquals(dsMeta1, expectedKdm1);
 
     KinesisDataSourceMetadata expectedKdm2 = endMetadata(ImmutableMap.of("1", "10", "2", "19"));
     String kdmStr2 = "{\"type\":\"kinesis\",\"partitions\":{\"type\":\"end\",\"stream\":\"foo\",\"topic\":\"food\",\"partitionSequenceNumberMap\":{\"1\":10, \"2\":19},\"partitionOffsetMap\":{\"1\":10, \"2\":19},\"exclusivePartitions\":[]}}\n";
     DataSourceMetadata dsMeta2 = jsonMapper.readValue(kdmStr2, DataSourceMetadata.class);
-    Assert.assertEquals(dsMeta2, expectedKdm2);
+    Assertions.assertEquals(dsMeta2, expectedKdm2);
   }
 
   private static KinesisDataSourceMetadata simpleStartMetadata(Map<String, String> sequences)

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIOConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIOConfigTest.java
@@ -31,13 +31,10 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbe
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.segment.indexing.IOConfig;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -53,9 +50,6 @@ public class KinesisIOConfigTest
     mapper = new DefaultObjectMapper();
     mapper.registerModules(new KinesisIndexingServiceModule().getJacksonModules());
   }
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testSerdeWithDefaults() throws Exception
@@ -77,25 +71,25 @@ public class KinesisIOConfigTest
         ), IOConfig.class
     );
 
-    Assert.assertNull(config.getTaskGroupId());
-    Assert.assertEquals("my-sequence-name", config.getBaseSequenceName());
-    Assert.assertEquals("mystream", config.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertNull(config.getTaskGroupId());
+    Assertions.assertEquals("my-sequence-name", config.getBaseSequenceName());
+    Assertions.assertEquals("mystream", config.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         ImmutableMap.of("0", "1", "1", "10"),
         config.getStartSequenceNumbers().getPartitionSequenceNumberMap()
     );
-    Assert.assertEquals("mystream", config.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals("mystream", config.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         ImmutableMap.of("0", "15", "1", "200"),
         config.getEndSequenceNumbers().getPartitionSequenceNumberMap()
     );
-    Assert.assertTrue(config.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", config.getMinimumMessageTime());
-    Assert.assertEquals(config.getEndpoint(), "kinesis.us-east-1.amazonaws.com");
-    Assert.assertEquals(config.getFetchDelayMillis(), 0);
-    Assert.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
-    Assert.assertNull(config.getAwsAssumedRoleArn());
-    Assert.assertNull(config.getAwsExternalId());
+    Assertions.assertTrue(config.isUseTransaction());
+    Assertions.assertNull(config.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertEquals(config.getEndpoint(), "kinesis.us-east-1.amazonaws.com");
+    Assertions.assertEquals(config.getFetchDelayMillis(), 0);
+    Assertions.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
+    Assertions.assertNull(config.getAwsAssumedRoleArn());
+    Assertions.assertNull(config.getAwsExternalId());
   }
 
   @Test
@@ -125,26 +119,26 @@ public class KinesisIOConfigTest
         ), IOConfig.class
     );
 
-    Assert.assertEquals((Integer) 0, config.getTaskGroupId());
-    Assert.assertEquals("my-sequence-name", config.getBaseSequenceName());
-    Assert.assertEquals("mystream", config.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals((Integer) 0, config.getTaskGroupId());
+    Assertions.assertEquals("my-sequence-name", config.getBaseSequenceName());
+    Assertions.assertEquals("mystream", config.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         ImmutableMap.of("0", "1", "1", "10"),
         config.getStartSequenceNumbers().getPartitionSequenceNumberMap()
     );
-    Assert.assertEquals("mystream", config.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals("mystream", config.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         ImmutableMap.of("0", "15", "1", "200"),
         config.getEndSequenceNumbers().getPartitionSequenceNumberMap()
     );
-    Assert.assertFalse(config.isUseTransaction());
-    Assert.assertEquals(DateTimes.of("2016-05-31T12:00Z"), config.getMinimumMessageTime());
-    Assert.assertEquals(DateTimes.of("2016-05-31T14:00Z"), config.getMaximumMessageTime());
-    Assert.assertEquals(config.getEndpoint(), "kinesis.us-east-2.amazonaws.com");
-    Assert.assertEquals(config.getStartSequenceNumbers().getExclusivePartitions(), ImmutableSet.of("0"));
-    Assert.assertEquals(1000, config.getFetchDelayMillis());
-    Assert.assertEquals("role", config.getAwsAssumedRoleArn());
-    Assert.assertEquals("awsexternalid", config.getAwsExternalId());
+    Assertions.assertFalse(config.isUseTransaction());
+    Assertions.assertEquals(DateTimes.of("2016-05-31T12:00Z"), config.getMinimumMessageTime());
+    Assertions.assertEquals(DateTimes.of("2016-05-31T14:00Z"), config.getMaximumMessageTime());
+    Assertions.assertEquals(config.getEndpoint(), "kinesis.us-east-2.amazonaws.com");
+    Assertions.assertEquals(config.getStartSequenceNumbers().getExclusivePartitions(), ImmutableSet.of("0"));
+    Assertions.assertEquals(1000, config.getFetchDelayMillis());
+    Assertions.assertEquals("role", config.getAwsAssumedRoleArn());
+    Assertions.assertEquals("awsexternalid", config.getAwsExternalId());
   }
 
   @Test
@@ -157,10 +151,12 @@ public class KinesisIOConfigTest
                      + "  \"endSequenceNumbers\": {\"type\":\"end\", \"stream\":\"mystream\", \"partitionSequenceNumberMap\" : {\"0\":\"15\", \"1\":\"200\"}}\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("baseSequenceName"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("baseSequenceName"));
   }
 
   @Test
@@ -173,10 +169,12 @@ public class KinesisIOConfigTest
                      + "  \"endSequenceNumbers\": {\"type\":\"end\", \"stream\":\"mystream\", \"partitionSequenceNumberMap\" : {\"0\":\"15\", \"1\":\"200\"}}\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("startSequenceNumbers"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("startSequenceNumbers"));
   }
 
   @Test
@@ -189,10 +187,12 @@ public class KinesisIOConfigTest
                      + "  \"startSequenceNumbers\": {\"type\":\"start\", \"stream\":\"mystream\", \"partitionSequenceNumberMap\" : {\"0\":\"1\", \"1\":\"10\"}}\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("endSequenceNumbers"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("endSequenceNumbers"));
   }
 
   @Test
@@ -206,10 +206,12 @@ public class KinesisIOConfigTest
                      + "  \"endSequenceNumbers\": {\"type\":\"end\", \"stream\":\"notmystream\", \"partitionSequenceNumberMap\" : {\"0\":\"15\", \"1\":\"200\"}}\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
-    exception.expectMessage(CoreMatchers.containsString("must match"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
+    Assertions.assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("must match"));
   }
 
   @Test
@@ -223,10 +225,14 @@ public class KinesisIOConfigTest
                      + "  \"endSequenceNumbers\": {\"type\":\"end\", \"stream\":\"mystream\", \"partitionSequenceNumberMap\" : {\"0\":\"15\", \"2\":\"200\"}}\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
-    exception.expectMessage(CoreMatchers.containsString("start partition set and end partition set must match"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
+    Assertions.assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    Assertions.assertTrue(
+        exception.getMessage().contains("start partition set and end partition set must match")
+    );
   }
 
   @Test
@@ -239,10 +245,12 @@ public class KinesisIOConfigTest
                      + "  \"endSequenceNumbers\": {\"type\":\"end\", \"stream\":\"mystream\", \"partitionSequenceNumberMap\" : {\"0\":\"15\", \"1\":\"200\"}}\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("endpoint"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("endpoint"));
   }
 
   @Test
@@ -277,23 +285,23 @@ public class KinesisIOConfigTest
         IOConfig.class
     );
 
-    Assert.assertEquals(currentConfig.getBaseSequenceName(), oldConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertEquals(currentConfig.getBaseSequenceName(), oldConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         currentConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap(),
         oldConfig.getStartPartitions().getPartitionSequenceNumberMap()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         currentConfig.getStartSequenceNumbers().getExclusivePartitions(),
         oldConfig.getExclusiveStartSequenceNumberPartitions()
     );
-    Assert.assertEquals(currentConfig.getEndSequenceNumbers(), oldConfig.getEndPartitions());
-    Assert.assertEquals(currentConfig.isUseTransaction(), oldConfig.isUseTransaction());
-    Assert.assertEquals(currentConfig.getMinimumMessageTime(), oldConfig.getMinimumMessageTime());
-    Assert.assertEquals(currentConfig.getMaximumMessageTime(), oldConfig.getMaximumMessageTime());
-    Assert.assertEquals(currentConfig.getEndpoint(), oldConfig.getEndpoint());
-    Assert.assertEquals(currentConfig.getFetchDelayMillis(), oldConfig.getFetchDelayMillis());
-    Assert.assertEquals(currentConfig.getAwsAssumedRoleArn(), oldConfig.getAwsAssumedRoleArn());
-    Assert.assertEquals(currentConfig.getAwsExternalId(), oldConfig.getAwsExternalId());
+    Assertions.assertEquals(currentConfig.getEndSequenceNumbers(), oldConfig.getEndPartitions());
+    Assertions.assertEquals(currentConfig.isUseTransaction(), oldConfig.isUseTransaction());
+    Assertions.assertEquals(currentConfig.getMinimumMessageTime(), oldConfig.getMinimumMessageTime());
+    Assertions.assertEquals(currentConfig.getMaximumMessageTime(), oldConfig.getMaximumMessageTime());
+    Assertions.assertEquals(currentConfig.getEndpoint(), oldConfig.getEndpoint());
+    Assertions.assertEquals(currentConfig.getFetchDelayMillis(), oldConfig.getFetchDelayMillis());
+    Assertions.assertEquals(currentConfig.getAwsAssumedRoleArn(), oldConfig.getAwsAssumedRoleArn());
+    Assertions.assertEquals(currentConfig.getAwsExternalId(), oldConfig.getAwsExternalId());
   }
 
   @Test
@@ -319,24 +327,24 @@ public class KinesisIOConfigTest
     final byte[] json = oldMapper.writeValueAsBytes(oldConfig);
     final KinesisIndexTaskIOConfig currentConfig = (KinesisIndexTaskIOConfig) mapper.readValue(json, IOConfig.class);
 
-    Assert.assertNull(currentConfig.getTaskGroupId());
-    Assert.assertEquals(oldConfig.getBaseSequenceName(), currentConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertNull(currentConfig.getTaskGroupId());
+    Assertions.assertEquals(oldConfig.getBaseSequenceName(), currentConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         oldConfig.getStartPartitions().getPartitionSequenceNumberMap(),
         currentConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         oldConfig.getExclusiveStartSequenceNumberPartitions(),
         currentConfig.getStartSequenceNumbers().getExclusivePartitions()
     );
-    Assert.assertEquals(oldConfig.getEndPartitions(), currentConfig.getEndSequenceNumbers());
-    Assert.assertEquals(oldConfig.isUseTransaction(), currentConfig.isUseTransaction());
-    Assert.assertEquals(oldConfig.getMinimumMessageTime(), currentConfig.getMinimumMessageTime());
-    Assert.assertEquals(oldConfig.getMaximumMessageTime(), currentConfig.getMaximumMessageTime());
-    Assert.assertEquals(oldConfig.getEndpoint(), currentConfig.getEndpoint());
-    Assert.assertEquals(oldConfig.getFetchDelayMillis(), currentConfig.getFetchDelayMillis());
-    Assert.assertEquals(oldConfig.getAwsAssumedRoleArn(), currentConfig.getAwsAssumedRoleArn());
-    Assert.assertEquals(oldConfig.getAwsExternalId(), currentConfig.getAwsExternalId());
+    Assertions.assertEquals(oldConfig.getEndPartitions(), currentConfig.getEndSequenceNumbers());
+    Assertions.assertEquals(oldConfig.isUseTransaction(), currentConfig.isUseTransaction());
+    Assertions.assertEquals(oldConfig.getMinimumMessageTime(), currentConfig.getMinimumMessageTime());
+    Assertions.assertEquals(oldConfig.getMaximumMessageTime(), currentConfig.getMaximumMessageTime());
+    Assertions.assertEquals(oldConfig.getEndpoint(), currentConfig.getEndpoint());
+    Assertions.assertEquals(oldConfig.getFetchDelayMillis(), currentConfig.getFetchDelayMillis());
+    Assertions.assertEquals(oldConfig.getAwsAssumedRoleArn(), currentConfig.getAwsAssumedRoleArn());
+    Assertions.assertEquals(oldConfig.getAwsExternalId(), currentConfig.getAwsExternalId());
   }
 
   private static class OldKinesisIndexTaskIoConfig implements IOConfig

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskSerdeTest.java
@@ -41,13 +41,15 @@ import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 public class KinesisIndexTaskSerdeTest
 {
@@ -102,17 +104,36 @@ public class KinesisIndexTaskSerdeTest
   private static final String SECRET_KEY = "test-secret-key";
   private static final String FILE_SESSION_CREDENTIALS = "test-file-session-credentials";
 
-  @Rule
-  public ProvideSystemProperty properties = new ProvideSystemProperty(
-      KinesisIndexingServiceModule.PROPERTY_BASE + ".accessKey",
-      ACCESS_KEY
-  ).and(
-      KinesisIndexingServiceModule.PROPERTY_BASE + ".secretKey",
-      SECRET_KEY
-  ).and(
-      KinesisIndexingServiceModule.PROPERTY_BASE + ".fileSessionCredentials",
-      FILE_SESSION_CREDENTIALS
-  );
+  private final Map<String, String> previousSystemProperties = new HashMap<>();
+
+  @BeforeEach
+  public void setUpSystemProperties()
+  {
+    setSystemProperty(KinesisIndexingServiceModule.PROPERTY_BASE + ".accessKey", ACCESS_KEY);
+    setSystemProperty(KinesisIndexingServiceModule.PROPERTY_BASE + ".secretKey", SECRET_KEY);
+    setSystemProperty(
+        KinesisIndexingServiceModule.PROPERTY_BASE + ".fileSessionCredentials",
+        FILE_SESSION_CREDENTIALS
+    );
+  }
+
+  @AfterEach
+  public void restoreSystemProperties()
+  {
+    previousSystemProperties.forEach((key, value) -> {
+      if (value == null) {
+        System.clearProperty(key);
+      } else {
+        System.setProperty(key, value);
+      }
+    });
+  }
+
+  private void setSystemProperty(String key, String value)
+  {
+    previousSystemProperties.put(key, System.getProperty(key));
+    System.setProperty(key, value);
+  }
 
   @Test
   public void injectsProperAwsCredentialsConfig() throws Exception
@@ -134,11 +155,11 @@ public class KinesisIndexTaskSerdeTest
     KinesisIndexTask deserialized = objectMapper.readValue(serialized, KinesisIndexTask.class);
 
     AWSCredentialsConfig awsCredentialsConfig = deserialized.getAwsCredentialsConfig();
-    Assert.assertEquals(ACCESS_KEY, awsCredentialsConfig.getAccessKey().getPassword());
-    Assert.assertEquals(SECRET_KEY, awsCredentialsConfig.getSecretKey().getPassword());
-    Assert.assertEquals(FILE_SESSION_CREDENTIALS, awsCredentialsConfig.getFileSessionCredentials());
-    Assert.assertNotNull(target.getPeonProcessingModuleConfig());
-    Assert.assertEquals(
+    Assertions.assertEquals(ACCESS_KEY, awsCredentialsConfig.getAccessKey().getPassword());
+    Assertions.assertEquals(SECRET_KEY, awsCredentialsConfig.getSecretKey().getPassword());
+    Assertions.assertEquals(FILE_SESSION_CREDENTIALS, awsCredentialsConfig.getFileSessionCredentials());
+    Assertions.assertNotNull(target.getPeonProcessingModuleConfig());
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 KinesisIndexingServiceModule.SCHEME,

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -67,6 +67,7 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.math.expr.ExprMacroTable;
+import org.apache.druid.math.expr.ExpressionProcessing;
 import org.apache.druid.query.DefaultQueryRunnerFactoryConglomerate;
 import org.apache.druid.query.DruidProcessingConfigTest;
 import org.apache.druid.query.QueryRunnerFactoryConglomerate;
@@ -88,14 +89,16 @@ import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import javax.annotation.Nonnull;
@@ -120,10 +123,14 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 @SuppressWarnings("unchecked")
-@RunWith(Parameterized.class)
 public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 {
+  @TempDir
+  private File tempFolder;
+
   private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
   private static final String STREAM = "stream";
   private static final String SHARD_ID1 = "1";
@@ -167,7 +174,6 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
   private static KinesisRecordSupplier recordSupplier;
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -188,7 +194,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   private int maxRecordsPerPoll;
   private int maxBytesPerPoll;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     taskExec = MoreExecutors.listeningDecorator(
@@ -203,9 +209,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     super(lockGranularity);
   }
 
-  @Before
+  @BeforeEach
   public void setupTest() throws IOException, InterruptedException
   {
+    ExpressionProcessing.initializeForTests();
+    super.tempFolder.create();
+    derby.before();
+    super.setupBase();
     handoffConditionTimeout = 0;
     reportParseExceptions = false;
     logParseExceptions = true;
@@ -223,7 +233,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     makeToolboxFactory();
   }
 
-  @After
+  @AfterEach
   public void tearDownTest()
   {
     synchronized (runningTasks) {
@@ -235,9 +245,12 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
     reportsFile.delete();
     destroyToolboxFactory();
+    super.tearDownBase();
+    derby.after();
+    super.tempFolder.delete();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass() throws Exception
   {
     taskExec.shutdown();
@@ -295,7 +308,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     return new KinesisRecord(STREAM, partitionId, sequenceNumber, Collections.singletonList(entity));
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunAfterDataInserted() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -323,7 +337,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -338,7 +352,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))
         ),
@@ -346,14 +360,15 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
-    Assert.assertEquals(2, observedSegmentGenerationMetrics.numPersists());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertEquals(2, observedSegmentGenerationMetrics.numPersists());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testIngestNullColumnAfterDataInserted() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -390,19 +405,20 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
     final Collection<DataSegment> segments = publishedSegments();
     for (DataSegment segment : segments) {
       for (int i = 0; i < dimensionsSpec.getDimensions().size(); i++) {
-        Assert.assertEquals(dimensionsSpec.getDimensionNames().get(i), segment.getDimensions().get(i));
+        Assertions.assertEquals(dimensionsSpec.getDimensionNames().get(i), segment.getDimensions().get(i));
       }
     }
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testIngestNullColumnAfterDataInserted_storeEmptyColumnsOff_shouldNotStoreEmptyColumns() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -441,13 +457,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
     final Collection<DataSegment> segments = publishedSegments();
     for (DataSegment segment : segments) {
-      Assert.assertFalse(segment.getDimensions().contains("unknownDim"));
+      Assertions.assertFalse(segment.getDimensions().contains("unknownDim"));
     }
   }
 
@@ -456,9 +472,11 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     return metadataStorageCoordinator.retrieveDataSourceMetadata(DATA_SCHEMA.getDataSource());
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunBeforeDataInserted() throws Exception
   {
+
 
     recordSupplier.assign(EasyMock.anyObject());
     EasyMock.expectLastCall().anyTimes();
@@ -486,7 +504,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSize(RECORDS, 13, 15))
@@ -500,7 +518,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID0, "1"))
         ),
@@ -508,7 +526,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOff() throws Exception
   {
     // as soon as any segment has more than one record, incremental publishing should happen
@@ -557,15 +576,15 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(task, this::isTaskPaused);
 
     final Map<String, String> currentOffsets = ImmutableMap.copyOf(task.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpoint1.getPartitionSequenceNumberMap(), currentOffsets);
+    Assertions.assertEquals(checkpoint1.getPartitionSequenceNumberMap(), currentOffsets);
     task.getRunner().setEndOffsets(currentOffsets, false);
 
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
-    Assert.assertEquals(1, checkpointRequestsHash.size());
-    Assert.assertTrue(
+    Assertions.assertEquals(1, checkpointRequestsHash.size());
+    Assertions.assertTrue(
         checkpointRequestsHash.contains(
             Objects.hash(
                 DATA_SCHEMA.getDataSource(),
@@ -591,7 +610,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(
                 STREAM,
@@ -602,7 +621,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOffMaxTotalRows() throws Exception
   {
     // incremental publish should happen every 3 records
@@ -641,23 +661,23 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     final Map<String, String> currentOffsets = ImmutableMap.copyOf(task.getRunner().getCurrentOffsets());
 
-    Assert.assertEquals(checkpointOffsets1, currentOffsets);
+    Assertions.assertEquals(checkpointOffsets1, currentOffsets);
     task.getRunner().setEndOffsets(currentOffsets, false);
 
     waitUntil(task, this::isTaskPaused);
 
     final Map<String, String> nextOffsets = ImmutableMap.copyOf(task.getRunner().getCurrentOffsets());
 
-    Assert.assertEquals(checkpointOffsets2, nextOffsets);
+    Assertions.assertEquals(checkpointOffsets2, nextOffsets);
 
     task.getRunner().setEndOffsets(nextOffsets, false);
 
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
-    Assert.assertEquals(2, checkpointRequestsHash.size());
-    Assert.assertTrue(
+    Assertions.assertEquals(2, checkpointRequestsHash.size());
+    Assertions.assertTrue(
         checkpointRequestsHash.contains(
             Objects.hash(
                 DATA_SCHEMA.getDataSource(),
@@ -668,7 +688,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             )
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         checkpointRequestsHash.contains(
             Objects.hash(
                 DATA_SCHEMA.getDataSource(),
@@ -694,21 +714,22 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(STREAM, endOffsets)),
         newDataSchemaMetadata()
     );
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(7, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(6, observedSegmentGenerationMetrics.handOffCount());
-    Assert.assertEquals(5, observedSegmentGenerationMetrics.numPersists());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(7, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(6, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertEquals(5, observedSegmentGenerationMetrics.numPersists());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithMinimumMessageTime() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -749,7 +770,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(task, this::isTaskPublishing);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -764,14 +785,15 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))),
         newDataSchemaMetadata()
     );
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithMaximumMessageTime() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -812,7 +834,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(task, this::isTaskPublishing);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -828,7 +850,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))),
         newDataSchemaMetadata()
@@ -836,7 +858,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithTransformSpec() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -871,7 +894,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(task, this::isTaskPublishing);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -880,7 +903,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     // Check published metadata
     assertEqualsExceptVersion(ImmutableList.of(sdd("2009/P1D", 0)), publishedDescriptors());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))),
         newDataSchemaMetadata()
@@ -888,12 +911,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     // Check segments in deep storage
     final List<SegmentDescriptor> publishedDescriptors = publishedDescriptors();
-    Assert.assertEquals(ImmutableList.of("b"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
-    Assert.assertEquals(ImmutableList.of("bb"), readSegmentColumn("dim1t", publishedDescriptors.get(0)));
+    Assertions.assertEquals(ImmutableList.of("b"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
+    Assertions.assertEquals(ImmutableList.of("bb"), readSegmentColumn("dim1t", publishedDescriptors.get(0)));
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunOnSingletonRange() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -922,7 +946,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -934,7 +958,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   }
 
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testHandoffConditionTimeoutWhenHandoffOccurs() throws Exception
   {
     handoffConditionTimeout = 5_000;
@@ -963,7 +988,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -978,22 +1003,23 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))
         ),
         newDataSchemaMetadata()
     );
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
-    Assert.assertEquals(2, observedSegmentGenerationMetrics.numPersists());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertEquals(2, observedSegmentGenerationMetrics.numPersists());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testHandoffConditionTimeoutWhenHandoffDoesNotOccur() throws Exception
   {
     doHandoff = false;
@@ -1023,7 +1049,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -1038,7 +1064,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))
         ),
@@ -1047,7 +1073,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testReportParseExceptions() throws Exception
   {
     reportParseExceptions = true;
@@ -1080,7 +1107,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.FAILED, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, future.get().getStatusCode());
 
     verifyAll();
 
@@ -1088,12 +1115,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
                                      .unparseable(1).totalProcessed(3));
 
     // Check published metadata
-    Assert.assertEquals(ImmutableList.of(), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertEquals(ImmutableList.of(), publishedDescriptors());
+    Assertions.assertNull(newDataSchemaMetadata());
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleParseExceptionsSuccess() throws Exception
   {
     reportParseExceptions = false;
@@ -1126,11 +1154,11 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     TaskStatus status = future.get();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, status.getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, status.getStatusCode());
 
     verifyAll();
 
-    Assert.assertNull(status.getErrorMsg());
+    Assertions.assertNull(status.getErrorMsg());
 
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSize(RECORDS, 2, 13))
                                      .errors(3).unparseable(4).totalProcessed(4));
@@ -1140,7 +1168,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ImmutableList.of(sdd("2010/P1D", 0), sdd("2011/P1D", 0), sdd("2013/P1D", 0), sdd("2049/P1D", 0)),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "12"))
         ),
@@ -1150,8 +1178,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     // Verify ingestion state and error message
-    Assert.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
-    Assert.assertNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
+    Assertions.assertNull(reportData.getErrorMsg());
 
     // Jackson will serde numerics ≤ 32bits as Integers, rather than Longs
     Map<String, Integer> expectedThrownAwayByReason = Map.of();
@@ -1166,7 +1194,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             RowIngestionMeters.THROWN_AWAY_BY_REASON, expectedThrownAwayByReason
         )
     );
-    Assert.assertEquals(expectedMetrics, reportData.getRowStats());
+    Assertions.assertEquals(expectedMetrics, reportData.getRowStats());
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
@@ -1180,7 +1208,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         "Unable to parse row [unparseable] (Record: 1)",
         "Encountered row with timestamp[246140482-04-24T15:36:27.903Z] that cannot be represented as a long: [{timestamp=246140482-04-24T15:36:27.903Z, dim1=x, dim2=z, dimLong=10, dimFloat=20.0, met1=1.0}] (Record: 1)"
     );
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = Arrays.asList(
         "{timestamp=2049, dim1=f, dim2=y, dimLong=10, dimFloat=20.0, met1=notanumber}",
@@ -1191,11 +1219,12 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         "unparseable",
         "{timestamp=246140482-04-24T15:36:27.903Z, dim1=x, dim2=z, dimLong=10, dimFloat=20.0, met1=1.0}"
     );
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleParseExceptionsFailure() throws Exception
   {
     reportParseExceptions = false;
@@ -1229,7 +1258,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     TaskStatus status = future.get();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.FAILED, status.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, status.getStatusCode());
     verifyAll();
     IndexTaskTest.checkTaskStatusErrorMsgForParseExceptionsExceeded(status);
 
@@ -1237,14 +1266,14 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyTaskMetrics(task, RowMeters.with().bytes(totalBytes).unparseable(3).totalProcessed(3));
 
     // Check published metadata
-    Assert.assertEquals(ImmutableList.of(), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertEquals(ImmutableList.of(), publishedDescriptors());
+    Assertions.assertNull(newDataSchemaMetadata());
 
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     // Verify ingestion state and error message
-    Assert.assertEquals(IngestionState.BUILD_SEGMENTS, reportData.getIngestionState());
-    Assert.assertNotNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.BUILD_SEGMENTS, reportData.getIngestionState());
+    Assertions.assertNotNull(reportData.getErrorMsg());
 
     // Jackson will serde numerics ≤ 32bits as Integers, rather than Longs
     Map<String, Integer> expectedThrownAwayByReason = Map.of();
@@ -1259,7 +1288,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
             RowIngestionMeters.THROWN_AWAY_BY_REASON, expectedThrownAwayByReason
         )
     );
-    Assert.assertEquals(expectedMetrics, reportData.getRowStats());
+    Assertions.assertEquals(expectedMetrics, reportData.getRowStats());
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
@@ -1268,12 +1297,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         "Unable to parse [] as the intermediateRow resulted in empty input row (Record: 1)",
         "Unable to parse row [unparseable] (Record: 1)"
     );
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
-    Assert.assertEquals(Arrays.asList("", "unparseable"), parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(Arrays.asList("", "unparseable"), parseExceptionReport.getInputs());
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunReplicas() throws Exception
   {
     // Insert data
@@ -1309,8 +1339,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
 
     // Wait for tasks to exit
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyAll();
 
@@ -1327,7 +1357,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))
         ),
@@ -1336,7 +1366,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunConflicting() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -1370,11 +1401,11 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     // Run first task
     final ListenableFuture<TaskStatus> future1 = runTask(task1);
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     // Run second task
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
-    Assert.assertEquals(TaskState.FAILED, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, future2.get().getStatusCode());
 
     verifyAll();
     verifyTaskMetrics(task1, RowMeters.with().bytes(getTotalSize(RECORDS, 2, 5))
@@ -1390,14 +1421,15 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))),
         newDataSchemaMetadata()
     );
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunConflictingWithoutTransactions() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -1437,17 +1469,17 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     // Run first task
     final ListenableFuture<TaskStatus> future1 = runTask(task1);
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     // Check published segments & metadata
     SegmentDescriptorAndExpectedDim1Values desc1 = sdd("2010/P1D", 0, ImmutableList.of("c"));
     SegmentDescriptorAndExpectedDim1Values desc2 = sdd("2011/P1D", 0, ImmutableList.of("d", "e"));
     assertEqualsExceptVersion(ImmutableList.of(desc1, desc2), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertNull(newDataSchemaMetadata());
 
     // Run second task
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyAll();
 
@@ -1460,11 +1492,12 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     SegmentDescriptorAndExpectedDim1Values desc3 = sdd("2011/P1D", 1, ImmutableList.of("d", "e"));
     SegmentDescriptorAndExpectedDim1Values desc4 = sdd("2013/P1D", 0, ImmutableList.of("f"));
     assertEqualsExceptVersion(ImmutableList.of(desc1, desc2, desc3, desc4), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertNull(newDataSchemaMetadata());
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunOneTaskTwoPartitions() throws Exception
   {
     // Insert data
@@ -1495,7 +1528,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(task, t -> countEvents(task) >= 5);
 
     // Wait for tasks to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -1511,7 +1544,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4", SHARD_ID0, "1"))
         ),
@@ -1520,7 +1553,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunTwoTasksTwoPartitions() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -1552,10 +1586,10 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
 
     final ListenableFuture<TaskStatus> future1 = runTask(task1);
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyAll();
 
@@ -1573,7 +1607,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4", SHARD_ID0, "1"))
         ),
@@ -1582,7 +1616,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   }
 
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRestore() throws Exception
   {
     final StreamPartition<String> streamPartition = StreamPartition.of(STREAM, SHARD_ID1);
@@ -1609,13 +1644,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future1 = runTask(task1);
 
     waitUntil(task1, t -> countEvents(t) == 2);
-    Assert.assertEquals(2, countEvents(task1));
+    Assertions.assertEquals(2, countEvents(task1));
 
     // Stop without publishing segment
     task1.stopGracefully(toolboxFactory.build(task1).getConfig());
     unlockAppenderatorBasePersistDirForTask(task1);
 
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     verifyAll();
     EasyMock.reset(recordSupplier);
@@ -1643,10 +1678,10 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
     waitUntil(task2, t -> countEvents(t) >= 3);
-    Assert.assertEquals(3, countEvents(task2));
+    Assertions.assertEquals(3, countEvents(task2));
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyAll();
 
@@ -1663,14 +1698,15 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "5"))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRestoreAfterPersistingSequences() throws Exception
   {
     maxRowsPerSegment = 2;
@@ -1717,14 +1753,14 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(task1, this::isTaskPaused);
 
     final Map<String, String> currentOffsets = ImmutableMap.copyOf(task1.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpointOffsets1, currentOffsets);
+    Assertions.assertEquals(checkpointOffsets1, currentOffsets);
     task1.getRunner().setEndOffsets(currentOffsets, false);
 
     // Stop without publishing segment
     task1.stopGracefully(toolboxFactory.build(task1).getConfig());
     unlockAppenderatorBasePersistDirForTask(task1);
 
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     verifyAll();
     EasyMock.reset(recordSupplier);
@@ -1756,7 +1792,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyAll();
 
@@ -1777,7 +1813,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "6"))
         ),
@@ -1785,7 +1821,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithPauseAndResume() throws Exception
   {
     final StreamPartition<String> streamPartition = StreamPartition.of(STREAM, SHARD_ID1);
@@ -1808,13 +1845,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     final ListenableFuture<TaskStatus> future = runTask(task);
     waitUntil(task, t -> countEvents(t) == 3);
-    Assert.assertEquals(3, countEvents(task));
-    Assert.assertTrue(isTaskReading(task));
+    Assertions.assertEquals(3, countEvents(task));
+    Assertions.assertTrue(isTaskReading(task));
 
     task.getRunner().pause();
 
     waitUntil(task, this::isTaskPaused);
-    Assert.assertTrue(isTaskPaused(task));
+    Assertions.assertTrue(isTaskPaused(task));
 
     verifyAll();
 
@@ -1822,13 +1859,13 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     try {
       future.get(10, TimeUnit.SECONDS);
-      Assert.fail("Task completed when it should have been paused");
+      Assertions.fail("Task completed when it should have been paused");
     }
     catch (TimeoutException e) {
       // carry on..
     }
 
-    Assert.assertEquals(currentOffsets, task.getRunner().getCurrentOffsets());
+    Assertions.assertEquals(currentOffsets, task.getRunner().getCurrentOffsets());
 
     EasyMock.reset(recordSupplier);
 
@@ -1841,10 +1878,10 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     task.getRunner().setEndOffsets(currentOffsets, true);
 
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
-    Assert.assertEquals(task.getRunner().getEndOffsets(), task.getRunner().getCurrentOffsets());
+    Assertions.assertEquals(task.getRunner().getEndOffsets(), task.getRunner().getCurrentOffsets());
 
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSize(RECORDS, 2, 5))
                                      .totalProcessed(3));
@@ -1857,7 +1894,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(
             STREAM,
             ImmutableMap.of(SHARD_ID1, currentOffsets.get(SHARD_ID1))
@@ -1866,7 +1903,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunContextSequenceAheadOfStartingOffsets() throws Exception
   {
     // This tests the case when a replacement task is created in place of a failed test
@@ -1922,7 +1960,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSize(RECORDS, 2, 5))
                                      .totalProcessed(3));
 
@@ -1934,13 +1972,14 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "4"))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOffReadsThroughEndOffsets() throws Exception
   {
     // as soon as any segment has more than one record, incremental publishing should happen
@@ -1996,7 +2035,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(staleReplica, this::isTaskPaused);
 
     Map<String, String> currentOffsets = ImmutableMap.copyOf(normalReplica.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpointOffsets1, currentOffsets);
+    Assertions.assertEquals(checkpointOffsets1, currentOffsets);
 
     normalReplica.getRunner().setEndOffsets(currentOffsets, false);
     staleReplica.getRunner().setEndOffsets(currentOffsets, false);
@@ -2005,19 +2044,19 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     waitUntil(staleReplica, this::isTaskPaused);
 
     currentOffsets = ImmutableMap.copyOf(normalReplica.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpointOffsets2, currentOffsets);
+    Assertions.assertEquals(checkpointOffsets2, currentOffsets);
     currentOffsets = ImmutableMap.copyOf(staleReplica.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpointOffsets2, currentOffsets);
+    Assertions.assertEquals(checkpointOffsets2, currentOffsets);
 
     normalReplica.getRunner().setEndOffsets(currentOffsets, true);
     staleReplica.getRunner().setEndOffsets(currentOffsets, true);
 
-    Assert.assertEquals(TaskState.SUCCESS, normalReplicaFuture.get().getStatusCode());
-    Assert.assertEquals(TaskState.SUCCESS, staleReplicaFuture.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, normalReplicaFuture.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, staleReplicaFuture.get().getStatusCode());
 
     verifyAll();
 
-    Assert.assertEquals(2, checkpointRequestsHash.size());
+    Assertions.assertEquals(2, checkpointRequestsHash.size());
 
     long totalRecordBytes = getTotalSize(SINGLE_PARTITION_RECORDS, 0, 10);
     verifyTaskMetrics(normalReplica, RowMeters.with().bytes(totalRecordBytes).totalProcessed(10));
@@ -2037,7 +2076,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(STREAM, ImmutableMap.of(SHARD_ID1, "9"))
         ),
@@ -2087,38 +2126,39 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     task.getRunner().initializeSequences();
     final List<SequenceMetadata<String, String>> sequences = task.getRunner().getSequences();
 
-    Assert.assertEquals(3, sequences.size());
+    Assertions.assertEquals(3, sequences.size());
 
     SequenceMetadata<String, String> sequenceMetadata = sequences.get(0);
-    Assert.assertEquals(checkpoints.get(0), sequenceMetadata.getStartOffsets());
-    Assert.assertEquals(checkpoints.get(1), sequenceMetadata.getEndOffsets());
-    Assert.assertEquals(
+    Assertions.assertEquals(checkpoints.get(0), sequenceMetadata.getStartOffsets());
+    Assertions.assertEquals(checkpoints.get(1), sequenceMetadata.getEndOffsets());
+    Assertions.assertEquals(
         task.getIOConfig().getStartSequenceNumbers().getExclusivePartitions(),
         sequenceMetadata.getExclusiveStartPartitions()
     );
-    Assert.assertTrue(sequenceMetadata.isCheckpointed());
+    Assertions.assertTrue(sequenceMetadata.isCheckpointed());
 
     sequenceMetadata = sequences.get(1);
-    Assert.assertEquals(checkpoints.get(1), sequenceMetadata.getStartOffsets());
-    Assert.assertEquals(checkpoints.get(2), sequenceMetadata.getEndOffsets());
-    Assert.assertEquals(checkpoints.get(1).keySet(), sequenceMetadata.getExclusiveStartPartitions());
-    Assert.assertTrue(sequenceMetadata.isCheckpointed());
+    Assertions.assertEquals(checkpoints.get(1), sequenceMetadata.getStartOffsets());
+    Assertions.assertEquals(checkpoints.get(2), sequenceMetadata.getEndOffsets());
+    Assertions.assertEquals(checkpoints.get(1).keySet(), sequenceMetadata.getExclusiveStartPartitions());
+    Assertions.assertTrue(sequenceMetadata.isCheckpointed());
 
     sequenceMetadata = sequences.get(2);
-    Assert.assertEquals(checkpoints.get(2), sequenceMetadata.getStartOffsets());
-    Assert.assertEquals(
+    Assertions.assertEquals(checkpoints.get(2), sequenceMetadata.getStartOffsets());
+    Assertions.assertEquals(
         task.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap(),
         sequenceMetadata.getEndOffsets()
     );
-    Assert.assertEquals(checkpoints.get(2).keySet(), sequenceMetadata.getExclusiveStartPartitions());
-    Assert.assertFalse(sequenceMetadata.isCheckpointed());
+    Assertions.assertEquals(checkpoints.get(2).keySet(), sequenceMetadata.getExclusiveStartPartitions());
+    Assertions.assertFalse(sequenceMetadata.isCheckpointed());
   }
 
   /**
    * Tests handling of a closed shard. The task is initially given an unlimited end sequence number and
    * eventually gets an EOS marker which causes it to stop reading.
    */
-  @Test(timeout = 120_000L)
+  @Test
+  @Timeout(value = 120_000L, unit = TimeUnit.MILLISECONDS)
   public void testEndOfShard() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -2151,7 +2191,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
 
@@ -2166,7 +2206,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KinesisDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(
                 STREAM,
@@ -2177,7 +2217,8 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithoutDataInserted() throws Exception
   {
     recordSupplier.assign(EasyMock.anyObject());
@@ -2207,20 +2248,20 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     Thread.sleep(1000);
 
-    Assert.assertEquals(0, countEvents(task));
-    Assert.assertEquals(SeekableStreamIndexTaskRunner.Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(0, countEvents(task));
+    Assertions.assertEquals(SeekableStreamIndexTaskRunner.Status.READING, task.getRunner().getStatus());
 
     task.getRunner().stopGracefully();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     verifyAll();
     verifyTaskMetrics(task, RowMeters.with().totalProcessed(0));
 
     // Check published metadata and segments in deep storage
     assertEqualsExceptVersion(Collections.emptyList(), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertNull(newDataSchemaMetadata());
   }
 
   @Test
@@ -2229,18 +2270,18 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final DruidProcessingConfigTest.MockRuntimeInfo runtimeInfo =
         new DruidProcessingConfigTest.MockRuntimeInfo(3, 1000, 10_000_000_000L);
 
-    Assert.assertEquals(6, KinesisIndexTask.computeFetchThreads(runtimeInfo, null));
-    Assert.assertEquals(2, KinesisIndexTask.computeFetchThreads(runtimeInfo, 2));
+    Assertions.assertEquals(6, KinesisIndexTask.computeFetchThreads(runtimeInfo, null));
+    Assertions.assertEquals(2, KinesisIndexTask.computeFetchThreads(runtimeInfo, 2));
 
     final DruidProcessingConfigTest.MockRuntimeInfo runtimeInfo2 =
         new DruidProcessingConfigTest.MockRuntimeInfo(3, 1000, 1_000_000_000);
-    Assert.assertEquals(5, KinesisIndexTask.computeFetchThreads(runtimeInfo2, null));
-    Assert.assertEquals(5, KinesisIndexTask.computeFetchThreads(runtimeInfo2, 6));
-    Assert.assertThrows(
+    Assertions.assertEquals(5, KinesisIndexTask.computeFetchThreads(runtimeInfo2, null));
+    Assertions.assertEquals(5, KinesisIndexTask.computeFetchThreads(runtimeInfo2, 6));
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> KinesisIndexTask.computeFetchThreads(runtimeInfo, 0)
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> KinesisIndexTask.computeFetchThreads(runtimeInfo, -1)
     );
@@ -2404,7 +2445,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
   private void makeToolboxFactory() throws IOException
   {
-    directory = tempFolder.newFolder();
+    directory = newFolder(tempFolder, "junit");
     final TestUtils testUtils = new TestUtils();
     final ObjectMapper objectMapper = testUtils.getTestObjectMapper();
     objectMapper.setInjectableValues(((InjectableValues.Std) objectMapper.getInjectableValues()).addValue(
@@ -2500,6 +2541,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     {
       return localSupplier == null ? recordSupplier : localSupplier;
     }
+
   }
 
   /**
@@ -2526,6 +2568,17 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     {
       return data;
     }
+
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 
 }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -2572,12 +2572,9 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 
 }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -64,6 +64,7 @@ import org.apache.druid.indexing.seekablestream.common.OrderedPartitionableRecor
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -2575,9 +2576,7 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTuningConfigTest.java
@@ -29,12 +29,9 @@ import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.indexing.TuningConfig;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,9 +46,6 @@ public class KinesisIndexTaskTuningConfigTest
     mapper = new DefaultObjectMapper();
     mapper.registerModules(new KinesisIndexingServiceModule().getJacksonModules());
   }
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testSerdeWithDefaults() throws Exception
@@ -68,24 +62,24 @@ public class KinesisIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(150000, config.getMaxRowsInMemory());
-    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(0, config.getMaxPendingPersists());
-    Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
-    Assert.assertFalse(config.isReportParseExceptions());
-    Assert.assertEquals(Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
-    Assert.assertNull(config.getRecordBufferSizeBytesConfigured());
-    Assert.assertEquals(100_000_000, config.getRecordBufferSizeBytesOrDefault(2_000_000_000));
-    Assert.assertEquals(100_000_000, config.getRecordBufferSizeBytesOrDefault(1_000_000_000));
-    Assert.assertEquals(10_000_000, config.getRecordBufferSizeBytesOrDefault(100_000_000));
-    Assert.assertEquals(5000, config.getRecordBufferOfferTimeout());
-    Assert.assertEquals(5000, config.getRecordBufferFullWait());
-    Assert.assertNull(config.getFetchThreads());
-    Assert.assertFalse(config.isSkipSequenceNumberAvailabilityCheck());
-    Assert.assertFalse(config.isResetOffsetAutomatically());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(150000, config.getMaxRowsInMemory());
+    Assertions.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(0, config.getMaxPendingPersists());
+    Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
+    Assertions.assertFalse(config.isReportParseExceptions());
+    Assertions.assertEquals(Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+    Assertions.assertNull(config.getRecordBufferSizeBytesConfigured());
+    Assertions.assertEquals(100_000_000, config.getRecordBufferSizeBytesOrDefault(2_000_000_000));
+    Assertions.assertEquals(100_000_000, config.getRecordBufferSizeBytesOrDefault(1_000_000_000));
+    Assertions.assertEquals(10_000_000, config.getRecordBufferSizeBytesOrDefault(100_000_000));
+    Assertions.assertEquals(5000, config.getRecordBufferOfferTimeout());
+    Assertions.assertEquals(5000, config.getRecordBufferFullWait());
+    Assertions.assertNull(config.getFetchThreads());
+    Assertions.assertFalse(config.isSkipSequenceNumberAvailabilityCheck());
+    Assertions.assertFalse(config.isResetOffsetAutomatically());
   }
 
   @Test
@@ -119,22 +113,22 @@ public class KinesisIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(100, config.getMaxRowsInMemory());
-    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(100, config.getMaxPendingPersists());
-    Assert.assertTrue(config.isReportParseExceptions());
-    Assert.assertEquals(100, config.getHandoffConditionTimeout());
-    Assert.assertEquals(1000, (int) config.getRecordBufferSizeBytesConfigured());
-    Assert.assertEquals(1000, config.getRecordBufferSizeBytesOrDefault(1_000_000_000));
-    Assert.assertEquals(500, config.getRecordBufferOfferTimeout());
-    Assert.assertEquals(500, config.getRecordBufferFullWait());
-    Assert.assertEquals(2, (int) config.getFetchThreads());
-    Assert.assertTrue(config.isSkipSequenceNumberAvailabilityCheck());
-    Assert.assertFalse(config.isResetOffsetAutomatically());
-    Assert.assertEquals(-1, config.getMaxColumnsToMerge());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(100, config.getMaxRowsInMemory());
+    Assertions.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(100, config.getMaxPendingPersists());
+    Assertions.assertTrue(config.isReportParseExceptions());
+    Assertions.assertEquals(100, config.getHandoffConditionTimeout());
+    Assertions.assertEquals(1000, (int) config.getRecordBufferSizeBytesConfigured());
+    Assertions.assertEquals(1000, config.getRecordBufferSizeBytesOrDefault(1_000_000_000));
+    Assertions.assertEquals(500, config.getRecordBufferOfferTimeout());
+    Assertions.assertEquals(500, config.getRecordBufferFullWait());
+    Assertions.assertEquals(2, (int) config.getFetchThreads());
+    Assertions.assertTrue(config.isSkipSequenceNumberAvailabilityCheck());
+    Assertions.assertFalse(config.isResetOffsetAutomatically());
+    Assertions.assertEquals(-1, config.getMaxColumnsToMerge());
 
   }
 
@@ -176,31 +170,31 @@ public class KinesisIndexTaskTuningConfigTest
     TestModifiedKinesisIndexTaskTuningConfig deserialized =
         mapper.readValue(serialized, TestModifiedKinesisIndexTaskTuningConfig.class);
 
-    Assert.assertEquals(null, deserialized.getExtra());
-    Assert.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
-    Assert.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
-    Assert.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
-    Assert.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
-    Assert.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
-    Assert.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
-    Assert.assertNull(deserialized.getBasePersistDirectory());
-    Assert.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
-    Assert.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
-    Assert.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
-    Assert.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
-    Assert.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
-    Assert.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
-    Assert.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
-    Assert.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
-    Assert.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
-    Assert.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
-    Assert.assertEquals(base.getRecordBufferFullWait(), deserialized.getRecordBufferFullWait());
-    Assert.assertEquals(base.getRecordBufferOfferTimeout(), deserialized.getRecordBufferOfferTimeout());
-    Assert.assertEquals(base.getRecordBufferSizeConfigured(), deserialized.getRecordBufferSizeConfigured());
-    Assert.assertEquals(base.getRecordBufferSizeBytesConfigured(), deserialized.getRecordBufferSizeBytesConfigured());
-    Assert.assertEquals(base.getMaxRecordsPerPollConfigured(), deserialized.getMaxRecordsPerPollConfigured());
-    Assert.assertEquals(base.getMaxBytesPerPollConfigured(), deserialized.getMaxBytesPerPollConfigured());
-    Assert.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
+    Assertions.assertEquals(null, deserialized.getExtra());
+    Assertions.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
+    Assertions.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
+    Assertions.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
+    Assertions.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
+    Assertions.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
+    Assertions.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
+    Assertions.assertNull(deserialized.getBasePersistDirectory());
+    Assertions.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
+    Assertions.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
+    Assertions.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
+    Assertions.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
+    Assertions.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
+    Assertions.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
+    Assertions.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
+    Assertions.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
+    Assertions.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
+    Assertions.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
+    Assertions.assertEquals(base.getRecordBufferFullWait(), deserialized.getRecordBufferFullWait());
+    Assertions.assertEquals(base.getRecordBufferOfferTimeout(), deserialized.getRecordBufferOfferTimeout());
+    Assertions.assertEquals(base.getRecordBufferSizeConfigured(), deserialized.getRecordBufferSizeConfigured());
+    Assertions.assertEquals(base.getRecordBufferSizeBytesConfigured(), deserialized.getRecordBufferSizeBytesConfigured());
+    Assertions.assertEquals(base.getMaxRecordsPerPollConfigured(), deserialized.getMaxRecordsPerPollConfigured());
+    Assertions.assertEquals(base.getMaxBytesPerPollConfigured(), deserialized.getMaxBytesPerPollConfigured());
+    Assertions.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
   }
 
   @Test
@@ -241,28 +235,28 @@ public class KinesisIndexTaskTuningConfigTest
     KinesisIndexTaskTuningConfig deserialized =
         mapper.readValue(serialized, KinesisIndexTaskTuningConfig.class);
 
-    Assert.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
-    Assert.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
-    Assert.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
-    Assert.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
-    Assert.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
-    Assert.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
-    Assert.assertNull(deserialized.getBasePersistDirectory());
-    Assert.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
-    Assert.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
-    Assert.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
-    Assert.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
-    Assert.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
-    Assert.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
-    Assert.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
-    Assert.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
-    Assert.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
-    Assert.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
-    Assert.assertEquals(base.getRecordBufferFullWait(), deserialized.getRecordBufferFullWait());
-    Assert.assertEquals(base.getRecordBufferOfferTimeout(), deserialized.getRecordBufferOfferTimeout());
-    Assert.assertEquals(base.getRecordBufferSizeBytesConfigured(), deserialized.getRecordBufferSizeBytesConfigured());
-    Assert.assertEquals(base.getMaxRecordsPerPollConfigured(), deserialized.getMaxRecordsPerPollConfigured());
-    Assert.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
+    Assertions.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
+    Assertions.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
+    Assertions.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
+    Assertions.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
+    Assertions.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
+    Assertions.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
+    Assertions.assertNull(deserialized.getBasePersistDirectory());
+    Assertions.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
+    Assertions.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
+    Assertions.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
+    Assertions.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
+    Assertions.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
+    Assertions.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
+    Assertions.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
+    Assertions.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
+    Assertions.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
+    Assertions.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
+    Assertions.assertEquals(base.getRecordBufferFullWait(), deserialized.getRecordBufferFullWait());
+    Assertions.assertEquals(base.getRecordBufferOfferTimeout(), deserialized.getRecordBufferOfferTimeout());
+    Assertions.assertEquals(base.getRecordBufferSizeBytesConfigured(), deserialized.getRecordBufferSizeBytesConfigured());
+    Assertions.assertEquals(base.getMaxRecordsPerPollConfigured(), deserialized.getMaxRecordsPerPollConfigured());
+    Assertions.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
   }
 
   @Test
@@ -285,11 +279,16 @@ public class KinesisIndexTaskTuningConfigTest
                      + "  \"fetchThreads\": 2\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
-    exception.expectMessage(CoreMatchers.containsString(
-        "resetOffsetAutomatically cannot be used if skipSequenceNumberAvailabilityCheck=true"));
-    mapper.readValue(jsonStr, TuningConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, TuningConfig.class)
+    );
+    Assertions.assertInstanceOf(IllegalArgumentException.class, exception.getCause());
+    Assertions.assertTrue(
+        exception.getMessage().contains(
+            "resetOffsetAutomatically cannot be used if skipSequenceNumberAvailabilityCheck=true"
+        )
+    );
   }
 
   @Test
@@ -333,26 +332,26 @@ public class KinesisIndexTaskTuningConfigTest
     );
     KinesisIndexTaskTuningConfig copy = original.convertToTaskTuningConfig();
 
-    Assert.assertEquals(original.getAppendableIndexSpec(), copy.getAppendableIndexSpec());
-    Assert.assertEquals(1, copy.getMaxRowsInMemory());
-    Assert.assertEquals(3, copy.getMaxBytesInMemory());
-    Assert.assertEquals(2, copy.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(100L, (long) copy.getMaxTotalRows());
-    Assert.assertEquals(new Period("PT3S"), copy.getIntermediatePersistPeriod());
-    Assert.assertNull(copy.getBasePersistDirectory());
-    Assert.assertEquals(4, copy.getMaxPendingPersists());
-    Assert.assertEquals(IndexSpec.getDefault(), copy.getIndexSpec());
-    Assert.assertTrue(copy.isReportParseExceptions());
-    Assert.assertEquals(5L, copy.getHandoffConditionTimeout());
-    Assert.assertEquals(1000, (int) copy.getRecordBufferSizeBytesConfigured());
-    Assert.assertEquals(500, copy.getRecordBufferOfferTimeout());
-    Assert.assertEquals(500, copy.getRecordBufferFullWait());
-    Assert.assertEquals(2, (int) copy.getFetchThreads());
-    Assert.assertFalse(copy.isSkipSequenceNumberAvailabilityCheck());
-    Assert.assertTrue(copy.isResetOffsetAutomatically());
-    Assert.assertEquals(10, (int) copy.getMaxRecordsPerPollConfigured());
-    Assert.assertEquals(new Period().withDays(Integer.MAX_VALUE), copy.getIntermediateHandoffPeriod());
-    Assert.assertEquals(-1, copy.getMaxColumnsToMerge());
+    Assertions.assertEquals(original.getAppendableIndexSpec(), copy.getAppendableIndexSpec());
+    Assertions.assertEquals(1, copy.getMaxRowsInMemory());
+    Assertions.assertEquals(3, copy.getMaxBytesInMemory());
+    Assertions.assertEquals(2, copy.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(100L, (long) copy.getMaxTotalRows());
+    Assertions.assertEquals(new Period("PT3S"), copy.getIntermediatePersistPeriod());
+    Assertions.assertNull(copy.getBasePersistDirectory());
+    Assertions.assertEquals(4, copy.getMaxPendingPersists());
+    Assertions.assertEquals(IndexSpec.getDefault(), copy.getIndexSpec());
+    Assertions.assertTrue(copy.isReportParseExceptions());
+    Assertions.assertEquals(5L, copy.getHandoffConditionTimeout());
+    Assertions.assertEquals(1000, (int) copy.getRecordBufferSizeBytesConfigured());
+    Assertions.assertEquals(500, copy.getRecordBufferOfferTimeout());
+    Assertions.assertEquals(500, copy.getRecordBufferFullWait());
+    Assertions.assertEquals(2, (int) copy.getFetchThreads());
+    Assertions.assertFalse(copy.isSkipSequenceNumberAvailabilityCheck());
+    Assertions.assertTrue(copy.isResetOffsetAutomatically());
+    Assertions.assertEquals(10, (int) copy.getMaxRecordsPerPollConfigured());
+    Assertions.assertEquals(new Period().withDays(Integer.MAX_VALUE), copy.getIntermediateHandoffPeriod());
+    Assertions.assertEquals(-1, copy.getMaxColumnsToMerge());
   }
 
   @Test

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRecordSupplierTest.java
@@ -31,10 +31,10 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.druid.indexing.kinesis.KinesisSequenceNumber.END_OF_SHARD_MARKER;
 import static org.apache.druid.indexing.kinesis.KinesisSequenceNumber.UNREAD_TRIM_HORIZON;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KinesisRecordSupplierTest extends EasyMockSupport
 {
@@ -162,13 +163,13 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   private KinesisClient kinesis;
   private KinesisRecordSupplier recordSupplier;
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     kinesis = EasyMock.createMock(KinesisClient.class);
   }
 
-  @After
+  @AfterEach
   public void tearDownTest()
   {
     if (null != recordSupplier) {
@@ -224,26 +225,26 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
         false
     );
 
-    Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
+    Assertions.assertTrue(recordSupplier.getAssignment().isEmpty());
 
     recordSupplier.assign(partitions);
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertEquals(ImmutableSet.of(SHARD_ID0, SHARD_ID1), recordSupplier.getPartitionIds(STREAM));
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(ImmutableSet.of(SHARD_ID0, SHARD_ID1), recordSupplier.getPartitionIds(STREAM));
 
     // calling poll would start background fetch if seek was called, but will instead be skipped and the results
     // empty
-    Assert.assertEquals(Collections.emptyList(), recordSupplier.poll(100));
+    Assertions.assertEquals(Collections.emptyList(), recordSupplier.poll(100));
 
     EasyMock.verify(kinesis);
 
     // Check first request
-    Assert.assertEquals(STREAM, capturedRequest0.getValue().streamName());
-    Assert.assertNull(capturedRequest0.getValue().exclusiveStartShardId());
+    Assertions.assertEquals(STREAM, capturedRequest0.getValue().streamName());
+    Assertions.assertNull(capturedRequest0.getValue().exclusiveStartShardId());
 
     // Check second request has exclusive start shard id
-    Assert.assertEquals(STREAM, capturedRequest1.getValue().streamName());
-    Assert.assertEquals(SHARD_ID1, capturedRequest1.getValue().exclusiveStartShardId());
+    Assertions.assertEquals(STREAM, capturedRequest1.getValue().streamName());
+    Assertions.assertEquals(SHARD_ID1, capturedRequest1.getValue().exclusiveStartShardId());
   }
 
   @Test
@@ -289,24 +290,24 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
         true
     );
 
-    Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
+    Assertions.assertTrue(recordSupplier.getAssignment().isEmpty());
 
     recordSupplier.assign(partitions);
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertEquals(ImmutableSet.of(SHARD_ID1, SHARD_ID0), recordSupplier.getPartitionIds(STREAM));
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(ImmutableSet.of(SHARD_ID1, SHARD_ID0), recordSupplier.getPartitionIds(STREAM));
 
     // calling poll would start background fetch if seek was called, but will instead be skipped and the results
     // empty
-    Assert.assertEquals(Collections.emptyList(), recordSupplier.poll(100));
+    Assertions.assertEquals(Collections.emptyList(), recordSupplier.poll(100));
 
     EasyMock.verify(kinesis);
 
-    Assert.assertEquals(STREAM, capturedRequest0.getValue().streamName());
-    Assert.assertNull(capturedRequest0.getValue().nextToken());
+    Assertions.assertEquals(STREAM, capturedRequest0.getValue().streamName());
+    Assertions.assertNull(capturedRequest0.getValue().nextToken());
 
-    Assert.assertNull(capturedRequest1.getValue().streamName());
-    Assert.assertEquals(nextToken, capturedRequest1.getValue().nextToken());
+    Assertions.assertNull(capturedRequest1.getValue().streamName());
+    Assertions.assertEquals(nextToken, capturedRequest1.getValue().nextToken());
   }
 
   // filter out EOS markers
@@ -396,8 +397,8 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
 
     EasyMock.verify(kinesis);
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertTrue(polledRecords.containsAll(ALL_RECORDS));
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertTrue(polledRecords.containsAll(ALL_RECORDS));
   }
 
   @Test
@@ -477,7 +478,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
         POLL_TIMEOUT_MILLIS));
 
     EasyMock.verify(kinesis);
-    Assert.assertEquals(9, polledRecords.size());
+    Assertions.assertEquals(9, polledRecords.size());
   }
 
   @Test
@@ -529,34 +530,36 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
     for (int i = 0; i < 10 && recordSupplier.bufferSize() < 2; i++) {
       Thread.sleep(100);
     }
-    Assert.assertEquals(Collections.emptyList(), cleanRecords(recordSupplier.poll(POLL_TIMEOUT_MILLIS)));
+    Assertions.assertEquals(Collections.emptyList(), cleanRecords(recordSupplier.poll(POLL_TIMEOUT_MILLIS)));
 
     EasyMock.verify(kinesis);
   }
 
-  @Test(expected = ISE.class)
-  public void testSeekUnassigned() throws InterruptedException
+  @Test
+  public void testSeekUnassigned()
   {
-    StreamPartition<String> shard0 = StreamPartition.of(STREAM, SHARD_ID0);
-    StreamPartition<String> shard1 = StreamPartition.of(STREAM, SHARD_ID1);
-    Set<StreamPartition<String>> partitions = ImmutableSet.of(
-        shard1
-    );
+    assertThrows(ISE.class, () -> {
+      StreamPartition<String> shard0 = StreamPartition.of(STREAM, SHARD_ID0);
+      StreamPartition<String> shard1 = StreamPartition.of(STREAM, SHARD_ID1);
+      Set<StreamPartition<String>> partitions = ImmutableSet.of(
+          shard1
+      );
 
-    recordSupplier = new KinesisRecordSupplier(
-        kinesis,
-        0,
-        2,
-        100,
-        5000,
-        5000,
-        1_000_000,
-        true,
-        false
-    );
+      recordSupplier = new KinesisRecordSupplier(
+          kinesis,
+          0,
+          2,
+          100,
+          5000,
+          5000,
+          1_000_000,
+          true,
+          false
+      );
 
-    recordSupplier.assign(partitions);
-    recordSupplier.seekToEarliest(Collections.singleton(shard0));
+      recordSupplier.assign(partitions);
+      recordSupplier.seekToEarliest(Collections.singleton(shard0));
+    });
   }
 
   @Test
@@ -634,8 +637,8 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
 
     EasyMock.verify(kinesis);
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertTrue(polledRecords.containsAll(ALL_RECORDS));
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertTrue(polledRecords.containsAll(ALL_RECORDS));
   }
 
   @Test
@@ -672,7 +675,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
         false
     );
 
-    Assert.assertEquals(KinesisSequenceNumber.UNREAD_LATEST,
+    Assertions.assertEquals(KinesisSequenceNumber.UNREAD_LATEST,
                         recordSupplier.getLatestSequenceNumber(StreamPartition.of(STREAM, SHARD_ID0)));
     EasyMock.verify(kinesis);
   }
@@ -711,7 +714,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
         false
     );
 
-    Assert.assertEquals(KinesisSequenceNumber.UNREAD_TRIM_HORIZON,
+    Assertions.assertEquals(KinesisSequenceNumber.UNREAD_TRIM_HORIZON,
                         recordSupplier.getEarliestSequenceNumber(StreamPartition.of(STREAM, SHARD_ID0)));
     EasyMock.verify(kinesis);
   }
@@ -754,7 +757,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
         false
     );
 
-    Assert.assertEquals("0", recordSupplier.getLatestSequenceNumber(StreamPartition.of(STREAM, SHARD_ID0)));
+    Assertions.assertEquals("0", recordSupplier.getLatestSequenceNumber(StreamPartition.of(STREAM, SHARD_ID0)));
   }
 
   @Test
@@ -830,11 +833,11 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
 
     EasyMock.replay(mockKinesis);
 
-    Assert.assertTrue(target.isOffsetAvailable(partition, KinesisSequenceNumber.of(UNREAD_TRIM_HORIZON)));
-    Assert.assertFalse(target.isOffsetAvailable(partition, KinesisSequenceNumber.of(END_OF_SHARD_MARKER)));
-    Assert.assertFalse(target.isOffsetAvailable(partition, KinesisSequenceNumber.of("-1")));
-    Assert.assertFalse(target.isOffsetAvailable(partition, KinesisSequenceNumber.of("0")));
-    Assert.assertTrue(target.isOffsetAvailable(partition, KinesisSequenceNumber.of("10")));
+    Assertions.assertTrue(target.isOffsetAvailable(partition, KinesisSequenceNumber.of(UNREAD_TRIM_HORIZON)));
+    Assertions.assertFalse(target.isOffsetAvailable(partition, KinesisSequenceNumber.of(END_OF_SHARD_MARKER)));
+    Assertions.assertFalse(target.isOffsetAvailable(partition, KinesisSequenceNumber.of("-1")));
+    Assertions.assertFalse(target.isOffsetAvailable(partition, KinesisSequenceNumber.of("0")));
+    Assertions.assertTrue(target.isOffsetAvailable(partition, KinesisSequenceNumber.of("10")));
 
     target.close();
   }
@@ -842,7 +845,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   @Test
   public void testParseRegionFromEndpoint_standardEndpoint()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Region.US_EAST_1,
         KinesisRecordSupplier.parseRegionFromEndpoint("https://kinesis.us-east-1.amazonaws.com")
     );
@@ -851,7 +854,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   @Test
   public void testParseRegionFromEndpoint_withoutScheme()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Region.EU_WEST_1,
         KinesisRecordSupplier.parseRegionFromEndpoint("kinesis.eu-west-1.amazonaws.com")
     );
@@ -860,7 +863,7 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   @Test
   public void testParseRegionFromEndpoint_cnRegion()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Region.of("cn-north-1"),
         KinesisRecordSupplier.parseRegionFromEndpoint("https://kinesis.cn-north-1.amazonaws.com")
     );
@@ -869,19 +872,19 @@ public class KinesisRecordSupplierTest extends EasyMockSupport
   @Test
   public void testParseRegionFromEndpoint_null()
   {
-    Assert.assertNull(KinesisRecordSupplier.parseRegionFromEndpoint(null));
+    Assertions.assertNull(KinesisRecordSupplier.parseRegionFromEndpoint(null));
   }
 
   @Test
   public void testParseRegionFromEndpoint_nonAwsEndpoint()
   {
-    Assert.assertNull(KinesisRecordSupplier.parseRegionFromEndpoint("https://localhost:4566"));
+    Assertions.assertNull(KinesisRecordSupplier.parseRegionFromEndpoint("https://localhost:4566"));
   }
 
   @Test
   public void testParseRegionFromEndpoint_noKinesisPrefix()
   {
-    Assert.assertNull(
+    Assertions.assertNull(
         KinesisRecordSupplier.parseRegionFromEndpoint("https://custom.us-east-1.amazonaws.com")
     );
   }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRegionTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisRegionTest.java
@@ -22,17 +22,19 @@ package org.apache.druid.indexing.kinesis;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KinesisRegionTest
 {
   private ObjectMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     mapper = new DefaultObjectMapper();
@@ -44,8 +46,8 @@ public class KinesisRegionTest
     KinesisRegion kinesisRegionUs1 = KinesisRegion.US_EAST_1;
     KinesisRegion kinesisRegionAp1 = KinesisRegion.AP_NORTHEAST_1;
 
-    Assert.assertEquals("\"us-east-1\"", mapper.writeValueAsString(kinesisRegionUs1));
-    Assert.assertEquals("\"ap-northeast-1\"", mapper.writeValueAsString(kinesisRegionAp1));
+    Assertions.assertEquals("\"us-east-1\"", mapper.writeValueAsString(kinesisRegionUs1));
+    Assertions.assertEquals("\"ap-northeast-1\"", mapper.writeValueAsString(kinesisRegionAp1));
 
     KinesisRegion kinesisRegion = mapper.readValue(
         mapper.writeValueAsString(
@@ -57,23 +59,24 @@ public class KinesisRegionTest
         KinesisRegion.class
     );
 
-    Assert.assertEquals(kinesisRegion, KinesisRegion.US_EAST_1);
+    Assertions.assertEquals(kinesisRegion, KinesisRegion.US_EAST_1);
   }
 
   @Test
   public void testGetEndpoint()
   {
-    Assert.assertEquals("kinesis.cn-north-1.amazonaws.com.cn", KinesisRegion.CN_NORTH_1.getEndpoint());
-    Assert.assertEquals("kinesis.us-east-1.amazonaws.com", KinesisRegion.US_EAST_1.getEndpoint());
+    Assertions.assertEquals("kinesis.cn-north-1.amazonaws.com.cn", KinesisRegion.CN_NORTH_1.getEndpoint());
+    Assertions.assertEquals("kinesis.us-east-1.amazonaws.com", KinesisRegion.US_EAST_1.getEndpoint());
   }
 
-  @Test(expected = JsonMappingException.class)
-  public void testBadSerde() throws IOException
+  @Test
+  public void testBadSerde()
   {
-    mapper.readValue(
-        "\"us-east-10\"",
-        KinesisRegion.class
-    );
+    assertThrows(JsonMappingException.class, () ->
+      mapper.readValue(
+          "\"us-east-10\"",
+          KinesisRegion.class
+      ));
   }
 
 }

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisSamplerSpecTest.java
@@ -53,8 +53,9 @@ import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
 
 import java.nio.ByteBuffer;
@@ -63,6 +64,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public class KinesisSamplerSpecTest extends EasyMockSupport
 {
@@ -112,7 +114,8 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
     );
   }
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(value = 10_000L, unit = TimeUnit.MILLISECONDS)
   public void testSample() throws InterruptedException
   {
     KinesisSupervisorSpec supervisorSpec = new KinesisSupervisorSpec(
@@ -183,7 +186,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 KinesisIndexingServiceModule.SCHEME,
@@ -214,13 +217,13 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertEquals(5, response.getNumRowsRead());
-    Assert.assertEquals(3, response.getNumRowsIndexed());
-    Assert.assertEquals(5, response.getData().size());
+    Assertions.assertEquals(5, response.getNumRowsRead());
+    Assertions.assertEquals(3, response.getNumRowsIndexed());
+    Assertions.assertEquals(5, response.getData().size());
 
     Iterator<SamplerResponse.SamplerResponseRow> it = response.getData().iterator();
 
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "2008")
             .put("dim1", "a")
@@ -242,7 +245,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "2009")
             .put("dim1", "b")
@@ -264,7 +267,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "2010")
             .put("dim1", "c")
@@ -286,7 +289,7 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "246140482-04-24T15:36:27.903Z")
             .put("dim1", "x")
@@ -299,14 +302,14 @@ public class KinesisSamplerSpecTest extends EasyMockSupport
         true,
         "Encountered row with timestamp[246140482-04-24T15:36:27.903Z] that cannot be represented as a long: [{timestamp=246140482-04-24T15:36:27.903Z, dim1=x, dim2=z, dimLong=10, dimFloat=20.0, met1=1.0}]"
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         null,
         null,
         true,
         "Unable to parse row [unparseable]" + (useInputFormat ? " into JSON" : "")
     ), it.next());
 
-    Assert.assertFalse(it.hasNext());
+    Assertions.assertFalse(it.hasNext());
   }
 
   private static List<KinesisRecordEntity> jb(String ts, String dim1, String dim2, String dimLong, String dimFloat, String met1)

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorIOConfigTest.java
@@ -30,13 +30,10 @@ import org.apache.druid.indexing.kinesis.KinesisRegion;
 import org.apache.druid.indexing.seekablestream.supervisor.LagAggregator;
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.easymock.EasyMock.createMock;
 
@@ -49,9 +46,6 @@ public class KinesisSupervisorIOConfigTest
     mapper = new DefaultObjectMapper();
     mapper.registerModules(new KinesisIndexingServiceModule().getJacksonModules());
   }
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testSerdeWithDefaults() throws Exception
@@ -66,23 +60,23 @@ public class KinesisSupervisorIOConfigTest
         KinesisSupervisorIOConfig.class
     );
 
-    Assert.assertEquals("my-stream", config.getStream());
-    Assert.assertEquals(KinesisRegion.US_EAST_1.getEndpoint(), config.getEndpoint());
-    Assert.assertEquals(1, (int) config.getReplicas());
-    Assert.assertEquals(1, (int) config.getTaskCount());
-    Assert.assertNull(config.getStopTaskCount());
-    Assert.assertEquals((int) config.getTaskCount(), config.getMaxAllowedStops());
-    Assert.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
-    Assert.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());
-    Assert.assertFalse(config.isUseEarliestSequenceNumber());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
-    Assert.assertFalse("lateMessageRejectionPeriod", config.getLateMessageRejectionPeriod().isPresent());
-    Assert.assertFalse("earlyMessageRejectionPeriod", config.getEarlyMessageRejectionPeriod().isPresent());
-    Assert.assertFalse("lateMessageRejectionStartDateTime", config.getLateMessageRejectionStartDateTime().isPresent());
-    Assert.assertEquals(0, config.getFetchDelayMillis());
-    Assert.assertNull(config.getAwsAssumedRoleArn());
-    Assert.assertNull(config.getAwsExternalId());
+    Assertions.assertEquals("my-stream", config.getStream());
+    Assertions.assertEquals(KinesisRegion.US_EAST_1.getEndpoint(), config.getEndpoint());
+    Assertions.assertEquals(1, (int) config.getReplicas());
+    Assertions.assertEquals(1, (int) config.getTaskCount());
+    Assertions.assertNull(config.getStopTaskCount());
+    Assertions.assertEquals((int) config.getTaskCount(), config.getMaxAllowedStops());
+    Assertions.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
+    Assertions.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(30), config.getPeriod());
+    Assertions.assertFalse(config.isUseEarliestSequenceNumber());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
+    Assertions.assertFalse(config.getLateMessageRejectionPeriod().isPresent(), "lateMessageRejectionPeriod");
+    Assertions.assertFalse(config.getEarlyMessageRejectionPeriod().isPresent(), "earlyMessageRejectionPeriod");
+    Assertions.assertFalse(config.getLateMessageRejectionStartDateTime().isPresent(), "lateMessageRejectionStartDateTime");
+    Assertions.assertEquals(0, config.getFetchDelayMillis());
+    Assertions.assertNull(config.getAwsAssumedRoleArn());
+    Assertions.assertNull(config.getAwsExternalId());
   }
 
   @Test
@@ -112,20 +106,20 @@ public class KinesisSupervisorIOConfigTest
         KinesisSupervisorIOConfig.class
     );
 
-    Assert.assertEquals("my-stream", config.getStream());
-    Assert.assertEquals(config.getEndpoint(), "kinesis.us-east-2.amazonaws.com");
-    Assert.assertEquals(3, (int) config.getReplicas());
-    Assert.assertEquals(9, (int) config.getTaskCount());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
-    Assert.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(10), config.getPeriod());
-    Assert.assertTrue(config.isUseEarliestSequenceNumber());
-    Assert.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
-    Assert.assertEquals(Duration.standardHours(1), config.getLateMessageRejectionPeriod().get());
-    Assert.assertEquals(Duration.standardHours(1), config.getEarlyMessageRejectionPeriod().get());
-    Assert.assertEquals(1000, config.getFetchDelayMillis());
-    Assert.assertEquals("role", config.getAwsAssumedRoleArn());
-    Assert.assertEquals("awsexternalid", config.getAwsExternalId());
+    Assertions.assertEquals("my-stream", config.getStream());
+    Assertions.assertEquals(config.getEndpoint(), "kinesis.us-east-2.amazonaws.com");
+    Assertions.assertEquals(3, (int) config.getReplicas());
+    Assertions.assertEquals(9, (int) config.getTaskCount());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
+    Assertions.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(10), config.getPeriod());
+    Assertions.assertTrue(config.isUseEarliestSequenceNumber());
+    Assertions.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
+    Assertions.assertEquals(Duration.standardHours(1), config.getLateMessageRejectionPeriod().get());
+    Assertions.assertEquals(Duration.standardHours(1), config.getEarlyMessageRejectionPeriod().get());
+    Assertions.assertEquals(1000, config.getFetchDelayMillis());
+    Assertions.assertEquals("role", config.getAwsAssumedRoleArn());
+    Assertions.assertEquals("awsexternalid", config.getAwsExternalId());
   }
 
   @Test
@@ -135,10 +129,12 @@ public class KinesisSupervisorIOConfigTest
                      + "  \"type\": \"kinesis\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("stream"));
-    mapper.readValue(jsonStr, KinesisSupervisorIOConfig.class);
+    JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, KinesisSupervisorIOConfig.class)
+    );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("stream"));
   }
 
   @Test
@@ -155,10 +151,10 @@ public class KinesisSupervisorIOConfigTest
 
     KinesisSupervisorIOConfig config = mapper.readValue(jsonStr, KinesisSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
   }
 
   @Test
@@ -175,10 +171,10 @@ public class KinesisSupervisorIOConfigTest
 
     KinesisSupervisorIOConfig config = mapper.readValue(jsonStr, KinesisSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
   }
 
   @Test
@@ -195,8 +191,8 @@ public class KinesisSupervisorIOConfigTest
 
     KinesisSupervisorIOConfig config = mapper.readValue(jsonStr, KinesisSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
   }
 
   @Test
@@ -209,8 +205,8 @@ public class KinesisSupervisorIOConfigTest
 
     KinesisSupervisorIOConfig config = mapper.readValue(jsonStr, KinesisSupervisorIOConfig.class);
 
-    Assert.assertFalse(config.isBounded());
-    Assert.assertNull(config.getBoundedStreamConfig());
+    Assertions.assertFalse(config.isBounded());
+    Assertions.assertNull(config.getBoundedStreamConfig());
   }
 
   private static KinesisIOConfigBuilder ioConfigBuilder()
@@ -227,25 +223,25 @@ public class KinesisSupervisorIOConfigTest
   public void testEqualsAndHashCode()
   {
     final KinesisSupervisorIOConfig config = ioConfigBuilder().build();
-    Assert.assertEquals(config, ioConfigBuilder().build());
-    Assert.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
-    Assert.assertNotEquals(config, null);
-    Assert.assertNotEquals(config, "not an io config");
-    Assert.assertNotEquals(config, ioConfigBuilder().withEndpoint("other").build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withFetchDelayMillis(999).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withDeaggregate(true).build());
+    Assertions.assertEquals(config, ioConfigBuilder().build());
+    Assertions.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
+    Assertions.assertNotEquals(config, null);
+    Assertions.assertNotEquals(config, "not an io config");
+    Assertions.assertNotEquals(config, ioConfigBuilder().withEndpoint("other").build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withFetchDelayMillis(999).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withDeaggregate(true).build());
   }
 
   @Test
   public void testTuningConfigEqualsAndHashCode()
   {
     final KinesisSupervisorTuningConfig config = KinesisSupervisorTuningConfig.defaultConfig();
-    Assert.assertEquals(config, KinesisSupervisorTuningConfig.defaultConfig());
-    Assert.assertEquals(config.hashCode(), KinesisSupervisorTuningConfig.defaultConfig().hashCode());
-    Assert.assertNotEquals(config, null);
-    Assert.assertNotEquals(config, "not a tuning config");
+    Assertions.assertEquals(config, KinesisSupervisorTuningConfig.defaultConfig());
+    Assertions.assertEquals(config.hashCode(), KinesisSupervisorTuningConfig.defaultConfig().hashCode());
+    Assertions.assertNotEquals(config, null);
+    Assertions.assertNotEquals(config, "not a tuning config");
   }
 
   /**

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTest.java
@@ -97,11 +97,12 @@ import org.easymock.IAnswer;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -116,8 +117,11 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KinesisSupervisorTest extends EasyMockSupport
 {
@@ -161,13 +165,13 @@ public class KinesisSupervisorTest extends EasyMockSupport
     this.numThreads = 1;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     dataSchema = getDataSchema(DATASOURCE);
   }
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     taskStorage = createMock(TaskStorage.class);
@@ -221,7 +225,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisorConfig = new SupervisorStateManagerConfig();
   }
 
-  @After
+  @AfterEach
   public void tearDownTest()
   {
     supervisor = null;
@@ -264,31 +268,31 @@ public class KinesisSupervisorTest extends EasyMockSupport
     verifyAll();
 
     KinesisIndexTask task = captured.getValue();
-    Assert.assertEquals(dataSchema, task.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
+    Assertions.assertEquals(dataSchema, task.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
 
     KinesisIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", taskConfig.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", taskConfig.getMinimumMessageTime());
-    Assert.assertNull("maximumMessageTime", taskConfig.getMaximumMessageTime());
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertTrue(taskConfig.isUseTransaction(), "isUseTransaction");
+    Assertions.assertNull(taskConfig.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertNull(taskConfig.getMaximumMessageTime(), "maximumMessageTime");
 
-    Assert.assertEquals(STREAM, taskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(STREAM, taskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         "0",
         taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "0",
         taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
 
-    Assert.assertEquals(STREAM, taskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(STREAM, taskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         taskConfig.getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         taskConfig.getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
@@ -357,14 +361,14 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     int taskCountBeforeScale = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountBeforeScale);
+    Assertions.assertEquals(1, taskCountBeforeScale);
     autoscaler.start();
 
     supervisor.runInternal();
     verifyAll();
     Thread.sleep(1 * 1000);
     int taskCountAfterScale = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(2, taskCountAfterScale);
+    Assertions.assertEquals(2, taskCountAfterScale);
     autoscaler.stop();
   }
 
@@ -429,19 +433,19 @@ public class KinesisSupervisorTest extends EasyMockSupport
     replayAll();
 
     int taskCountInit = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(2, taskCountInit);
+    Assertions.assertEquals(2, taskCountInit);
     supervisor.getIoConfig().setTaskCount(2);
 
     supervisor.start();
     int taskCountBeforeScale = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(2, taskCountBeforeScale);
+    Assertions.assertEquals(2, taskCountBeforeScale);
     autoscaler.start();
 
     supervisor.runInternal();
     verifyAll();
     Thread.sleep(1 * 1000);
     int taskCountAfterScale = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountAfterScale);
+    Assertions.assertEquals(1, taskCountAfterScale);
     autoscaler.stop();
   }
 
@@ -493,12 +497,12 @@ public class KinesisSupervisorTest extends EasyMockSupport
     );
 
     KinesisRecordSupplier supplier = (KinesisRecordSupplier) supervisor.setupRecordSupplier();
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(0, supplier.bufferSize());
-    Assert.assertEquals(Collections.emptySet(), supplier.getAssignment());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(0, supplier.bufferSize());
+    Assertions.assertEquals(Collections.emptySet(), supplier.getAssignment());
     // background fetch should not be enabled for supervisor supplier
     supplier.start();
-    Assert.assertFalse(supplier.isBackgroundFetchRunning());
+    Assertions.assertFalse(supplier.isBackgroundFetchRunning());
   }
 
   @Test
@@ -521,7 +525,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         .build();
 
     AutoScalerConfig autoscalerConfigNull = kinesisSupervisorIOConfigWithNullAutoScalerConfig.getAutoScalerConfig();
-    Assert.assertNull(autoscalerConfigNull);
+    Assertions.assertNull(autoscalerConfigNull);
 
     // create KinesisSupervisorIOConfig with autoScalerConfig Empty
     KinesisSupervisorIOConfig kinesisSupervisorIOConfigWithEmptyAutoScalerConfig = new KinesisIOConfigBuilder()
@@ -541,10 +545,10 @@ public class KinesisSupervisorTest extends EasyMockSupport
         .build();
 
     AutoScalerConfig autoscalerConfig = kinesisSupervisorIOConfigWithEmptyAutoScalerConfig.getAutoScalerConfig();
-    Assert.assertNotNull(autoscalerConfig);
-    Assert.assertTrue(autoscalerConfig instanceof LagBasedAutoScalerConfig);
-    Assert.assertFalse(autoscalerConfig.getEnableTaskAutoScaler());
-    Assert.assertTrue(autoscalerConfig.toString().contains("autoScalerConfig"));
+    Assertions.assertNotNull(autoscalerConfig);
+    Assertions.assertTrue(autoscalerConfig instanceof LagBasedAutoScalerConfig);
+    Assertions.assertFalse(autoscalerConfig.getEnableTaskAutoScaler());
+    Assertions.assertTrue(autoscalerConfig.toString().contains("autoScalerConfig"));
   }
 
   @Test
@@ -584,25 +588,25 @@ public class KinesisSupervisorTest extends EasyMockSupport
     List<KinesisIndexTask> tasks = captured.getValues();
     tasks.sort(Comparator.comparing(KinesisIndexTask::getId));
     KinesisIndexTask task1 = tasks.get(0);
-    Assert.assertEquals(1, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(1, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(1, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         "0",
         task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
 
     KinesisIndexTask task2 = tasks.get(1);
-    Assert.assertEquals(1, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(1, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(1, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         "0",
         task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
@@ -644,41 +648,41 @@ public class KinesisSupervisorTest extends EasyMockSupport
     verifyAll();
 
     KinesisIndexTask task1 = captured.getValues().get(0);
-    Assert.assertEquals(2, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(2, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(2, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         "0",
         task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "0",
         task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
 
     KinesisIndexTask task2 = captured.getValues().get(1);
-    Assert.assertEquals(2, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(2, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(2, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         "0",
         task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "0",
         task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
@@ -723,15 +727,15 @@ public class KinesisSupervisorTest extends EasyMockSupport
     KinesisIndexTask task1 = captured.getValues().get(0);
     KinesisIndexTask task2 = captured.getValues().get(1);
 
-    Assert.assertTrue(
-        "minimumMessageTime",
-        task1.getIOConfig().getMinimumMessageTime().plusMinutes(59).isBeforeNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMinimumMessageTime().plusMinutes(59).isBeforeNow(),
+        "minimumMessageTime"
     );
-    Assert.assertTrue(
-        "minimumMessageTime",
-        task1.getIOConfig().getMinimumMessageTime().plusMinutes(61).isAfterNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMinimumMessageTime().plusMinutes(61).isAfterNow(),
+        "minimumMessageTime"
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         task1.getIOConfig().getMinimumMessageTime(),
         task2.getIOConfig().getMinimumMessageTime()
     );
@@ -775,15 +779,15 @@ public class KinesisSupervisorTest extends EasyMockSupport
     KinesisIndexTask task1 = captured.getValues().get(0);
     KinesisIndexTask task2 = captured.getValues().get(1);
 
-    Assert.assertTrue(
-        "maximumMessageTime",
-        task1.getIOConfig().getMaximumMessageTime().minusMinutes(59 + 60).isAfterNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMaximumMessageTime().minusMinutes(59 + 60).isAfterNow(),
+        "maximumMessageTime"
     );
-    Assert.assertTrue(
-        "maximumMessageTime",
-        task1.getIOConfig().getMaximumMessageTime().minusMinutes(61 + 60).isBeforeNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMaximumMessageTime().minusMinutes(61 + 60).isBeforeNow(),
+        "maximumMessageTime"
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         task1.getIOConfig().getMaximumMessageTime(),
         task2.getIOConfig().getMaximumMessageTime()
     );
@@ -841,12 +845,12 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     KinesisIndexTask task = captured.getValue();
     KinesisIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         "2",
         taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "1",
         taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
@@ -899,13 +903,13 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisor.start();
     supervisor.runInternal();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "org.apache.druid.java.util.common.ISE",
         supervisor.getStateManager().getExceptionEvents().get(0).getExceptionClass()
     );
 
     AlertEvent alert = serviceEmitter.getAlerts().get(0);
-    Assert.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
+    Assertions.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
   }
 
   @Test
@@ -1191,8 +1195,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    Assert.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
-    Assert.assertEquals(
+    Assertions.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
+    Assertions.assertEquals(
         iHaveFailed.getIOConfig().getBaseSequenceName(),
         ((KinesisIndexTask) aNewTaskCapture.getValue()).getIOConfig().getBaseSequenceName()
     );
@@ -1279,7 +1283,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     verifyAll();
 
     // check that replica tasks are created with the same minimumMessageTime as tasks inherited from another supervisor
-    Assert.assertEquals(now, ((KinesisIndexTask) captured.getValue()).getIOConfig().getMinimumMessageTime());
+    Assertions.assertEquals(now, ((KinesisIndexTask) captured.getValue()).getIOConfig().getMinimumMessageTime());
 
     // test that a task failing causes a new task to be re-queued with the same parameters
     String runningTaskId = captured.getValue().getId();
@@ -1319,19 +1323,19 @@ public class KinesisSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    Assert.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
-    Assert.assertEquals(
+    Assertions.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
+    Assertions.assertEquals(
         iHaveFailed.getIOConfig().getBaseSequenceName(),
         ((KinesisIndexTask) aNewTaskCapture.getValue()).getIOConfig().getBaseSequenceName()
     );
 
     // check that failed tasks are recreated with the same minimumMessageTime as the task it replaced, even if that
     // task came from another supervisor
-    Assert.assertEquals(
+    Assertions.assertEquals(
         now,
         ((KinesisIndexTask) aNewTaskCapture.getValue()).getIOConfig().getMinimumMessageTime()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         maxi,
         ((KinesisIndexTask) aNewTaskCapture.getValue()).getIOConfig().getMaximumMessageTime()
     );
@@ -1458,7 +1462,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     verifyAll();
 
     // make sure we killed the right task (sequenceName for replicas are the same)
-    Assert.assertTrue(shutdownTaskIdCapture.getValue().contains(iAmSuccess.getIOConfig().getBaseSequenceName()));
+    Assertions.assertTrue(shutdownTaskIdCapture.getValue().contains(iAmSuccess.getIOConfig().getBaseSequenceName()));
   }
 
   @Test
@@ -1572,20 +1576,20 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     for (Task task : secondTasks.getValues()) {
       KinesisIndexTask kinesisIndexTask = (KinesisIndexTask) task;
-      Assert.assertEquals(dataSchema, kinesisIndexTask.getDataSchema());
-      Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), kinesisIndexTask.getTuningConfig());
+      Assertions.assertEquals(dataSchema, kinesisIndexTask.getDataSchema());
+      Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), kinesisIndexTask.getTuningConfig());
 
       KinesisIndexTaskIOConfig taskConfig = kinesisIndexTask.getIOConfig();
-      Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-      Assert.assertTrue("isUseTransaction", taskConfig.isUseTransaction());
+      Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+      Assertions.assertTrue(taskConfig.isUseTransaction(), "isUseTransaction");
 
-      Assert.assertEquals(STREAM, taskConfig.getStartSequenceNumbers().getStream());
-      Assert.assertEquals(
+      Assertions.assertEquals(STREAM, taskConfig.getStartSequenceNumbers().getStream());
+      Assertions.assertEquals(
           "3",
           taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
       );
       // start sequenceNumbers should be exclusive for the second batch of tasks
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableSet.of(SHARD_ID1),
           ((KinesisIndexTask) task).getIOConfig().getStartSequenceNumbers().getExclusivePartitions()
       );
@@ -1694,30 +1698,30 @@ public class KinesisSupervisorTest extends EasyMockSupport
     SupervisorReport<KinesisSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, report.getId());
+    Assertions.assertEquals(DATASOURCE, report.getId());
 
     KinesisSupervisorReportPayload payload = report.getPayload();
 
-    Assert.assertEquals(DATASOURCE, payload.getDataSource());
-    Assert.assertEquals(3600L, payload.getDurationSeconds());
-    Assert.assertEquals(2, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(STREAM, payload.getStream());
-    Assert.assertEquals(0, payload.getActiveTasks().size());
-    Assert.assertEquals(1, payload.getPublishingTasks().size());
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
-    Assert.assertEquals(0, payload.getRecentErrors().size());
+    Assertions.assertEquals(DATASOURCE, payload.getDataSource());
+    Assertions.assertEquals(3600L, payload.getDurationSeconds());
+    Assertions.assertEquals(2, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(STREAM, payload.getStream());
+    Assertions.assertEquals(0, payload.getActiveTasks().size());
+    Assertions.assertEquals(1, payload.getPublishingTasks().size());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
+    Assertions.assertEquals(0, payload.getRecentErrors().size());
 
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
-    Assert.assertEquals("id1", publishingReport.getId());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals("id1", publishingReport.getId());
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "0",
         SHARD_ID0,
         "0"
     ), publishingReport.getStartingOffsets());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "2",
         SHARD_ID0,
@@ -1725,31 +1729,31 @@ public class KinesisSupervisorTest extends EasyMockSupport
     ), publishingReport.getCurrentOffsets());
 
     KinesisIndexTask capturedTask = captured.getValue();
-    Assert.assertEquals(dataSchema, capturedTask.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
+    Assertions.assertEquals(dataSchema, capturedTask.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
 
     KinesisIndexTaskIOConfig capturedTaskConfig = capturedTask.getIOConfig();
-    Assert.assertEquals("awsEndpoint", capturedTaskConfig.getEndpoint());
-    Assert.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", capturedTaskConfig.isUseTransaction());
+    Assertions.assertEquals("awsEndpoint", capturedTaskConfig.getEndpoint());
+    Assertions.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
+    Assertions.assertTrue(capturedTaskConfig.isUseTransaction(), "isUseTransaction");
 
     // check that the new task was created with starting sequences matching where the publishing task finished
-    Assert.assertEquals(STREAM, capturedTaskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(STREAM, capturedTaskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         "2",
         capturedTaskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "1",
         capturedTaskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
 
-    Assert.assertEquals(STREAM, capturedTaskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(STREAM, capturedTaskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         capturedTaskConfig.getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         capturedTaskConfig.getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
@@ -1844,30 +1848,30 @@ public class KinesisSupervisorTest extends EasyMockSupport
     SupervisorReport<KinesisSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, report.getId());
+    Assertions.assertEquals(DATASOURCE, report.getId());
 
     KinesisSupervisorReportPayload payload = report.getPayload();
 
-    Assert.assertEquals(DATASOURCE, payload.getDataSource());
-    Assert.assertEquals(3600L, payload.getDurationSeconds());
-    Assert.assertEquals(2, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(STREAM, payload.getStream());
-    Assert.assertEquals(0, payload.getActiveTasks().size());
-    Assert.assertEquals(1, payload.getPublishingTasks().size());
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
-    Assert.assertEquals(0, payload.getRecentErrors().size());
+    Assertions.assertEquals(DATASOURCE, payload.getDataSource());
+    Assertions.assertEquals(3600L, payload.getDurationSeconds());
+    Assertions.assertEquals(2, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(STREAM, payload.getStream());
+    Assertions.assertEquals(0, payload.getActiveTasks().size());
+    Assertions.assertEquals(1, payload.getPublishingTasks().size());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
+    Assertions.assertEquals(0, payload.getRecentErrors().size());
 
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
-    Assert.assertEquals("id1", publishingReport.getId());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals("id1", publishingReport.getId());
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "0",
         SHARD_ID0,
         "0"
     ), publishingReport.getStartingOffsets());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "2",
         SHARD_ID0,
@@ -1875,31 +1879,31 @@ public class KinesisSupervisorTest extends EasyMockSupport
     ), publishingReport.getCurrentOffsets());
 
     KinesisIndexTask capturedTask = captured.getValue();
-    Assert.assertEquals(dataSchema, capturedTask.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
+    Assertions.assertEquals(dataSchema, capturedTask.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
 
     KinesisIndexTaskIOConfig capturedTaskConfig = capturedTask.getIOConfig();
-    Assert.assertEquals("awsEndpoint", capturedTaskConfig.getEndpoint());
-    Assert.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", capturedTaskConfig.isUseTransaction());
+    Assertions.assertEquals("awsEndpoint", capturedTaskConfig.getEndpoint());
+    Assertions.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
+    Assertions.assertTrue(capturedTaskConfig.isUseTransaction(), "isUseTransaction");
 
     // check that the new task was created with starting sequences matching where the publishing task finished
-    Assert.assertEquals(STREAM, capturedTaskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(STREAM, capturedTaskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         "2",
         capturedTaskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "1",
         capturedTaskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
 
-    Assert.assertEquals(STREAM, capturedTaskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(STREAM, capturedTaskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         capturedTaskConfig.getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KinesisSequenceNumber.NO_END_SEQUENCE_NUMBER,
         capturedTaskConfig.getEndSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
     );
@@ -2041,47 +2045,47 @@ public class KinesisSupervisorTest extends EasyMockSupport
     SupervisorReport<KinesisSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, report.getId());
+    Assertions.assertEquals(DATASOURCE, report.getId());
 
     KinesisSupervisorReportPayload payload = report.getPayload();
 
-    Assert.assertEquals(DATASOURCE, payload.getDataSource());
-    Assert.assertEquals(3600L, payload.getDurationSeconds());
-    Assert.assertEquals(2, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(STREAM, payload.getStream());
-    Assert.assertEquals(1, payload.getActiveTasks().size());
-    Assert.assertEquals(1, payload.getPublishingTasks().size());
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
-    Assert.assertEquals(0, payload.getRecentErrors().size());
+    Assertions.assertEquals(DATASOURCE, payload.getDataSource());
+    Assertions.assertEquals(3600L, payload.getDurationSeconds());
+    Assertions.assertEquals(2, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(STREAM, payload.getStream());
+    Assertions.assertEquals(1, payload.getActiveTasks().size());
+    Assertions.assertEquals(1, payload.getPublishingTasks().size());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
+    Assertions.assertEquals(0, payload.getRecentErrors().size());
 
     TaskReportData activeReport = payload.getActiveTasks().get(0);
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
-    Assert.assertEquals("id2", activeReport.getId());
-    Assert.assertEquals(startTime, activeReport.getStartTime());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals("id2", activeReport.getId());
+    Assertions.assertEquals(startTime, activeReport.getStartTime());
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "2",
         SHARD_ID0,
         "1"
     ), activeReport.getStartingOffsets());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "12",
         SHARD_ID0,
         "1"
     ), activeReport.getCurrentOffsets());
-    Assert.assertEquals(timeLag, activeReport.getLagMillis());
+    Assertions.assertEquals(timeLag, activeReport.getLagMillis());
 
-    Assert.assertEquals("id1", publishingReport.getId());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals("id1", publishingReport.getId());
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "0",
         SHARD_ID0,
         "0"
     ), publishingReport.getStartingOffsets());
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals(ImmutableMap.of(
         SHARD_ID1,
         "2",
         SHARD_ID0,
@@ -2269,11 +2273,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     for (Task task : captured.getValues()) {
       KinesisIndexTaskIOConfig taskConfig = ((KinesisIndexTask) task).getIOConfig();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "0",
           taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
       );
-      Assert.assertNull(
+      Assertions.assertNull(
           taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID0)
       );
     }
@@ -2395,18 +2399,20 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     for (Task task : captured.getValues()) {
       KinesisIndexTaskIOConfig taskConfig = ((KinesisIndexTask) task).getIOConfig();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           "0",
           taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().get(SHARD_ID1)
       );
     }
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testStopNotStarted()
   {
-    supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
-    supervisor.stop(false);
+    assertThrows(IllegalStateException.class, () -> {
+      supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
+      supervisor.stop(false);
+    });
   }
 
   @Test
@@ -2712,12 +2718,12 @@ public class KinesisSupervisorTest extends EasyMockSupport
     catch (NullPointerException npe) {
       // Expected as there will be an attempt to EasyMock.reset partitionGroups sequences to NOT_SET
       // however there would be no entries in the map as we have not put nay data in kafka
-      Assert.assertNull(npe.getCause());
+      Assertions.assertNull(npe.getCause());
     }
     verifyAll();
 
-    Assert.assertEquals(captureDataSource.getValue(), DATASOURCE);
-    Assert.assertEquals(captureDataSourceMetadata.getValue(), expectedMetadata);
+    Assertions.assertEquals(captureDataSource.getValue(), DATASOURCE);
+    Assertions.assertEquals(captureDataSourceMetadata.getValue(), expectedMetadata);
   }
 
   @Test
@@ -2851,7 +2857,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     verifyAll();
 
     AlertEvent alert = serviceEmitter.getAlerts().get(0);
-    Assert.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
+    Assertions.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
   }
 
   @Test
@@ -3173,7 +3179,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
   }
 
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCheckpointForInactiveTaskGroup() throws InterruptedException
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1S", null, null, false);
@@ -3327,10 +3334,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertTrue(serviceEmitter.getAlerts().isEmpty());
+    Assertions.assertTrue(serviceEmitter.getAlerts().isEmpty());
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCheckpointForUnknownTaskGroup()
       throws InterruptedException
   {
@@ -3457,11 +3465,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
     }
 
     final AlertEvent alert = serviceEmitter.getAlerts().get(0);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Supervisor[testDS] for datasource[testDS] failed to handle notice",
         alert.getDescription()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot find taskGroup [0] among all activelyReadingTaskGroups [{}]",
         alert.getDataMap().get(AlertBuilder.EXCEPTION_MESSAGE_KEY)
     );
@@ -3485,7 +3493,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     ).anyTimes();
     // this asserts that taskQueue.add does not in fact get called because supervisor should be suspended
     EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andAnswer((IAnswer) () -> {
-      Assert.fail();
+      Assertions.fail();
       return null;
     }).anyTimes();
     taskRunner.registerListener(EasyMock.anyObject(TaskRunnerListener.class), EasyMock.anyObject(Executor.class));
@@ -3740,10 +3748,10 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertEquals(2, stats.size());
-    Assert.assertEquals(ImmutableSet.of("0", "1"), stats.keySet());
-    Assert.assertEquals(ImmutableMap.of("task1", ImmutableMap.of("prop1", "val1")), stats.get("0"));
-    Assert.assertEquals(ImmutableMap.of("task2", ImmutableMap.of("prop2", "val2")), stats.get("1"));
+    Assertions.assertEquals(2, stats.size());
+    Assertions.assertEquals(ImmutableSet.of("0", "1"), stats.keySet());
+    Assertions.assertEquals(ImmutableMap.of("task1", ImmutableMap.of("prop1", "val1")), stats.get("0"));
+    Assertions.assertEquals(ImmutableMap.of("task2", ImmutableMap.of("prop2", "val2")), stats.get("1"));
   }
 
   @Test
@@ -4072,10 +4080,10 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     replayAll();
 
-    Assert.assertTrue(supervisor.isTaskCurrent(42, "id1", taskMap));
-    Assert.assertFalse(supervisor.isTaskCurrent(42, "id2", taskMap));
-    Assert.assertFalse(supervisor.isTaskCurrent(42, "id3", taskMap));
-    Assert.assertFalse(supervisor.isTaskCurrent(42, "id4", taskMap));
+    Assertions.assertTrue(supervisor.isTaskCurrent(42, "id1", taskMap));
+    Assertions.assertFalse(supervisor.isTaskCurrent(42, "id2", taskMap));
+    Assertions.assertFalse(supervisor.isTaskCurrent(42, "id3", taskMap));
+    Assertions.assertFalse(supervisor.isTaskCurrent(42, "id4", taskMap));
     verifyAll();
   }
 
@@ -4132,7 +4140,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         task1.getDataSchema(),
         task1.getTuningConfig()
     );
-    Assert.assertNotNull(sequenceTask1);
+    Assertions.assertNotNull(sequenceTask1);
 
     final String sequenceTask2 = supervisor.generateSequenceName(
         task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap(),
@@ -4141,10 +4149,10 @@ public class KinesisSupervisorTest extends EasyMockSupport
         task2.getDataSchema(),
         task2.getTuningConfig()
     );
-    Assert.assertNotNull(sequenceTask2);
+    Assertions.assertNotNull(sequenceTask2);
 
-    Assert.assertNotEquals(task1.getId(), task2.getId());
-    Assert.assertEquals(sequenceTask1, sequenceTask2);
+    Assertions.assertNotEquals(task1.getId(), task2.getId());
+    Assertions.assertEquals(sequenceTask1, sequenceTask2);
 
     verifyAll();
   }
@@ -4188,7 +4196,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(
                 new Resource(KinesisSupervisorSpec.SUPERVISOR_TYPE, ResourceType.EXTERNAL),
@@ -4431,15 +4439,15 @@ public class KinesisSupervisorTest extends EasyMockSupport
             )
         );
 
-    Assert.assertEquals(2, postSplitTasks.size());
+    Assertions.assertEquals(2, postSplitTasks.size());
     KinesisIndexTaskIOConfig group0Config = ((KinesisIndexTask) postSplitTasks.get(0)).getIOConfig();
     KinesisIndexTaskIOConfig group1Config = ((KinesisIndexTask) postSplitTasks.get(1)).getIOConfig();
-    Assert.assertEquals((Integer) 0, group0Config.getTaskGroupId());
-    Assert.assertEquals((Integer) 1, group1Config.getTaskGroupId());
-    Assert.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
-    Assert.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
-    Assert.assertEquals(group1ExpectedStartSequenceNumbers, group1Config.getStartSequenceNumbers());
-    Assert.assertEquals(group1ExpectedEndSequenceNumbers, group1Config.getEndSequenceNumbers());
+    Assertions.assertEquals((Integer) 0, group0Config.getTaskGroupId());
+    Assertions.assertEquals((Integer) 1, group1Config.getTaskGroupId());
+    Assertions.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
+    Assertions.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
+    Assertions.assertEquals(group1ExpectedStartSequenceNumbers, group1Config.getStartSequenceNumbers());
+    Assertions.assertEquals(group1ExpectedEndSequenceNumbers, group1Config.getEndSequenceNumbers());
 
     return postSplitTasks;
   }
@@ -4620,21 +4628,21 @@ public class KinesisSupervisorTest extends EasyMockSupport
             )
         );
 
-    Assert.assertEquals(2, postSplitTasks.size());
+    Assertions.assertEquals(2, postSplitTasks.size());
     KinesisIndexTaskIOConfig group0Config = ((KinesisIndexTask) postSplitTasks.get(0)).getIOConfig();
     KinesisIndexTaskIOConfig group1Config = ((KinesisIndexTask) postSplitTasks.get(1)).getIOConfig();
-    Assert.assertEquals((Integer) 0, group0Config.getTaskGroupId());
-    Assert.assertEquals((Integer) 1, group1Config.getTaskGroupId());
-    Assert.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
-    Assert.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
-    Assert.assertEquals(group1ExpectedStartSequenceNumbers, group1Config.getStartSequenceNumbers());
-    Assert.assertEquals(group1ExpectedEndSequenceNumbers, group1Config.getEndSequenceNumbers());
+    Assertions.assertEquals((Integer) 0, group0Config.getTaskGroupId());
+    Assertions.assertEquals((Integer) 1, group1Config.getTaskGroupId());
+    Assertions.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
+    Assertions.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
+    Assertions.assertEquals(group1ExpectedStartSequenceNumbers, group1Config.getStartSequenceNumbers());
+    Assertions.assertEquals(group1ExpectedEndSequenceNumbers, group1Config.getEndSequenceNumbers());
 
     Map<Integer, Set<String>> expectedPartitionGroups = ImmutableMap.of(
         0, ImmutableSet.of(SHARD_ID1),
         1, ImmutableSet.of(SHARD_ID2)
     );
-    Assert.assertEquals(expectedPartitionGroups, supervisor.getPartitionGroups());
+    Assertions.assertEquals(expectedPartitionGroups, supervisor.getPartitionGroups());
 
     ConcurrentHashMap<String, String> expectedPartitionOffsets = new ConcurrentHashMap<>(
         ImmutableMap.of(
@@ -4643,7 +4651,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
             SHARD_ID0, "-1"
         )
     );
-    Assert.assertEquals(expectedPartitionOffsets, supervisor.getPartitionOffsets());
+    Assertions.assertEquals(expectedPartitionOffsets, supervisor.getPartitionOffsets());
 
   }
 
@@ -4666,19 +4674,19 @@ public class KinesisSupervisorTest extends EasyMockSupport
     EasyMock.expect(kinesisTaskMatch.getSupervisorId()).andReturn("supervisorId");
     EasyMock.replay(kinesisTaskMatch);
 
-    Assert.assertTrue(supervisor.doesTaskMatchSupervisor(kinesisTaskMatch));
+    Assertions.assertTrue(supervisor.doesTaskMatchSupervisor(kinesisTaskMatch));
 
     KinesisIndexTask kinesisTaskNoMatch = createMock(KinesisIndexTask.class);
     EasyMock.expect(kinesisTaskNoMatch.getSupervisorId()).andReturn(dataSchema.getDataSource());
     EasyMock.replay(kinesisTaskNoMatch);
 
-    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(kinesisTaskNoMatch));
+    Assertions.assertFalse(supervisor.doesTaskMatchSupervisor(kinesisTaskNoMatch));
 
     SeekableStreamIndexTask differentTaskType = createMock(SeekableStreamIndexTask.class);
     EasyMock.expect(differentTaskType.getSupervisorId()).andReturn("supervisorId");
     EasyMock.replay(differentTaskType);
 
-    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(differentTaskType));
+    Assertions.assertFalse(supervisor.doesTaskMatchSupervisor(differentTaskType));
   }
 
   @Test
@@ -4705,7 +4713,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
         .withBoundedStreamConfig(new BoundedStreamConfig(startOffsets, endOffsets))
         .build();
 
-    Assert.assertTrue(kinesisSupervisorIOConfig.isBounded());
+    Assertions.assertTrue(kinesisSupervisorIOConfig.isBounded());
 
     final KinesisIndexTaskClientFactory taskClientFactory = new KinesisIndexTaskClientFactory(null, null);
     final KinesisSupervisorSpec spec = new KinesisSupervisorSpec(
@@ -4740,23 +4748,23 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     // Test type conversion methods
     String shardId = supervisor.createPartitionIdFromString("shardId-000000000000");
-    Assert.assertEquals("shardId-000000000000", shardId);
+    Assertions.assertEquals("shardId-000000000000", shardId);
 
     String offset = supervisor.createSequenceOffsetFromObject("49590338271490256608559692538361571095921575989136588898");
-    Assert.assertEquals("49590338271490256608559692538361571095921575989136588898", offset);
+    Assertions.assertEquals("49590338271490256608559692538361571095921575989136588898", offset);
 
     offset = supervisor.createSequenceOffsetFromObject(100);
-    Assert.assertEquals("100", offset);
+    Assertions.assertEquals("100", offset);
 
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(
         "49590338271512257353759162668991891722121171891717232706",
         "49590338271490256608559692538361571095921575989136588898"
     ));
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(
         "49590338271490256608559692538361571095921575989136588898",
         "49590338271490256608559692538361571095921575989136588898"
     ));
-    Assert.assertFalse(supervisor.isOffsetAtOrBeyond(
+    Assertions.assertFalse(supervisor.isOffsetAtOrBeyond(
         "49590338271490256608559692538361571095921575989136588898",
         "49590338271512257353759162668991891722121171891717232706"
     ));
@@ -4769,7 +4777,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
 
     // Special markers like EOS are treated as max sequence numbers by KinesisSequenceNumber,
     // so they are considered at or beyond any numeric offset.
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(KinesisSequenceNumber.END_OF_SHARD_MARKER, "12345"));
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(KinesisSequenceNumber.END_OF_SHARD_MARKER, "12345"));
   }
 
   @Test
@@ -4825,7 +4833,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     );
 
     // Kinesis uses inclusive end offsets
-    Assert.assertFalse("Kinesis should have inclusive end offsets", supervisor.isEndOffsetExclusive());
+    Assertions.assertFalse(supervisor.isEndOffsetExclusive(), "Kinesis should have inclusive end offsets");
 
     // Verify that start == end is treated correctly based on offset semantics
     // For inclusive offsets: start == end means ONE record (not empty)
@@ -4834,7 +4842,7 @@ public class KinesisSupervisorTest extends EasyMockSupport
     String end = singleOffset;
 
     // start >= end is true (they're equal)
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(start, end));
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(start, end));
 
     // But for Kinesis (inclusive), this is NOT an empty range
     // The empty range check should be: isOffsetAtOrBeyond(start, end) && !start.equals(end)
@@ -4843,9 +4851,9 @@ public class KinesisSupervisorTest extends EasyMockSupport
     boolean isEqual = start.equals(end);
     boolean shouldBeEmpty = isAtOrBeyond && !isEqual;
 
-    Assert.assertFalse(
-        "For Kinesis with inclusive end offsets, start == end should NOT be considered an empty range",
-        shouldBeEmpty
+    Assertions.assertFalse(
+        shouldBeEmpty,
+        "For Kinesis with inclusive end offsets, start == end should NOT be considered an empty range"
     );
   }
 
@@ -5074,11 +5082,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
             )
         );
 
-    Assert.assertEquals(1, postMergeTasks.size());
+    Assertions.assertEquals(1, postMergeTasks.size());
     KinesisIndexTaskIOConfig group0Config = ((KinesisIndexTask) postMergeTasks.get(0)).getIOConfig();
-    Assert.assertEquals((Integer) 0, group0Config.getTaskGroupId());
-    Assert.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
-    Assert.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
+    Assertions.assertEquals((Integer) 0, group0Config.getTaskGroupId());
+    Assertions.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
+    Assertions.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
 
     return postMergeTasks;
   }
@@ -5228,11 +5236,11 @@ public class KinesisSupervisorTest extends EasyMockSupport
             )
         );
 
-    Assert.assertEquals(1, postSplitTasks.size());
+    Assertions.assertEquals(1, postSplitTasks.size());
     KinesisIndexTaskIOConfig group0Config = ((KinesisIndexTask) postSplitTasks.get(0)).getIOConfig();
-    Assert.assertEquals((Integer) 0, group0Config.getTaskGroupId());
-    Assert.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
-    Assert.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
+    Assertions.assertEquals((Integer) 0, group0Config.getTaskGroupId());
+    Assertions.assertEquals(group0ExpectedStartSequenceNumbers, group0Config.getStartSequenceNumbers());
+    Assertions.assertEquals(group0ExpectedEndSequenceNumbers, group0Config.getEndSequenceNumbers());
 
     Map<Integer, Set<String>> expectedPartitionGroups = ImmutableMap.of(
         0, ImmutableSet.of(SHARD_ID2),
@@ -5245,8 +5253,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
             SHARD_ID0, "-1"
         )
     );
-    Assert.assertEquals(expectedPartitionGroups, supervisor.getPartitionGroups());
-    Assert.assertEquals(expectedPartitionOffsets, supervisor.getPartitionOffsets());
+    Assertions.assertEquals(expectedPartitionGroups, supervisor.getPartitionGroups());
+    Assertions.assertEquals(expectedPartitionOffsets, supervisor.getPartitionOffsets());
   }
 
   private TestableKinesisSupervisor getTestableSupervisor(
@@ -5312,8 +5320,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -5448,8 +5456,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -5527,8 +5535,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -5608,8 +5616,8 @@ public class KinesisSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfigTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/supervisor/KinesisSupervisorTuningConfigTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.indexing.TuningConfig;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class KinesisSupervisorTuningConfigTest
 {
@@ -55,20 +55,20 @@ public class KinesisSupervisorTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(150000, config.getMaxRowsInMemory());
-    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(0, config.getMaxPendingPersists());
-    Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
-    Assert.assertEquals(false, config.isReportParseExceptions());
-    Assert.assertEquals(java.time.Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
-    Assert.assertNull(config.getWorkerThreads());
-    Assert.assertEquals(8L, (long) config.getChatRetries());
-    Assert.assertEquals(Duration.standardSeconds(10), config.getHttpTimeout());
-    Assert.assertEquals(Duration.standardSeconds(80), config.getShutdownTimeout());
-    Assert.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(150000, config.getMaxRowsInMemory());
+    Assertions.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(0, config.getMaxPendingPersists());
+    Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
+    Assertions.assertEquals(false, config.isReportParseExceptions());
+    Assertions.assertEquals(java.time.Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+    Assertions.assertNull(config.getWorkerThreads());
+    Assertions.assertEquals(8L, (long) config.getChatRetries());
+    Assertions.assertEquals(Duration.standardSeconds(10), config.getHttpTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(80), config.getShutdownTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
   }
 
   @Test
@@ -101,18 +101,18 @@ public class KinesisSupervisorTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(100, config.getMaxRowsInMemory());
-    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(100, config.getMaxPendingPersists());
-    Assert.assertEquals(true, config.isReportParseExceptions());
-    Assert.assertEquals(100, config.getHandoffConditionTimeout());
-    Assert.assertEquals(12, (int) config.getWorkerThreads());
-    Assert.assertEquals(14L, (long) config.getChatRetries());
-    Assert.assertEquals(Duration.standardSeconds(15), config.getHttpTimeout());
-    Assert.assertEquals(Duration.standardSeconds(95), config.getShutdownTimeout());
-    Assert.assertEquals(Duration.standardSeconds(500), config.getRepartitionTransitionDuration());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(100, config.getMaxRowsInMemory());
+    Assertions.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(100, config.getMaxPendingPersists());
+    Assertions.assertEquals(true, config.isReportParseExceptions());
+    Assertions.assertEquals(100, config.getHandoffConditionTimeout());
+    Assertions.assertEquals(12, (int) config.getWorkerThreads());
+    Assertions.assertEquals(14L, (long) config.getChatRetries());
+    Assertions.assertEquals(Duration.standardSeconds(15), config.getHttpTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(95), config.getShutdownTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(500), config.getRepartitionTransitionDuration());
   }
 }

--- a/extensions-core/lookups-cached-single/pom.xml
+++ b/extensions-core/lookups-cached-single/pom.xml
@@ -92,9 +92,30 @@
     </dependency>
 
     <!-- Tests -->
+    <!-- TestDerbyConnector uses JUnit 4 assertions during cleanup. -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/CacheRefKeeperTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/CacheRefKeeperTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.server.lookup;
 
 import org.apache.druid.server.lookup.cache.polling.PollingCache;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CacheRefKeeperTest
 {
@@ -32,7 +32,7 @@ public class CacheRefKeeperTest
   {
     PollingCache mockPollingCache = EasyMock.createStrictMock(PollingCache.class);
     PollingLookup.CacheRefKeeper cacheRefKeeper = new PollingLookup.CacheRefKeeper(mockPollingCache);
-    Assert.assertEquals(mockPollingCache, cacheRefKeeper.getAndIncrementRef());
+    Assertions.assertEquals(mockPollingCache, cacheRefKeeper.getAndIncrementRef());
   }
 
   @Test
@@ -57,8 +57,8 @@ public class CacheRefKeeperTest
     EasyMock.replay(mockPollingCache);
     cacheRefKeeper.doneWithIt();
     EasyMock.verify(mockPollingCache);
-    Assert.assertEquals(null, cacheRefKeeper.getAndIncrementRef());
-    Assert.assertEquals(null, cacheRefKeeper.getAndIncrementRef());
+    Assertions.assertEquals(null, cacheRefKeeper.getAndIncrementRef());
+    Assertions.assertEquals(null, cacheRefKeeper.getAndIncrementRef());
   }
 
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupFactoryTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupFactoryTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.server.lookup.cache.loading.LoadingCache;
 import org.apache.druid.server.lookup.cache.loading.OffHeapLoadingCache;
 import org.apache.druid.server.lookup.cache.loading.OnHeapLoadingCache;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -56,10 +56,10 @@ public class LoadingLookupFactoryTest
     loadingLookup.close();
     EasyMock.expectLastCall().once();
     EasyMock.replay(loadingLookup);
-    Assert.assertTrue(loadingLookupFactory.start());
+    Assertions.assertTrue(loadingLookupFactory.start());
     loadingLookupFactory.awaitInitialization();
-    Assert.assertTrue(loadingLookupFactory.isInitialized());
-    Assert.assertTrue(loadingLookupFactory.close());
+    Assertions.assertTrue(loadingLookupFactory.isInitialized());
+    Assertions.assertTrue(loadingLookupFactory.close());
     EasyMock.verify(loadingLookup);
 
   }
@@ -67,29 +67,29 @@ public class LoadingLookupFactoryTest
   @Test
   public void testReplacesWithNull()
   {
-    Assert.assertTrue(loadingLookupFactory.replaces(null));
+    Assertions.assertTrue(loadingLookupFactory.replaces(null));
   }
 
   @Test
   public void testReplacesWithSame()
   {
-    Assert.assertFalse(loadingLookupFactory.replaces(loadingLookupFactory));
+    Assertions.assertFalse(loadingLookupFactory.replaces(loadingLookupFactory));
   }
 
   @Test
   public void testReplacesWithDifferent()
   {
-    Assert.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
+    Assertions.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
         EasyMock.createMock(DataFetcher.class),
         lookupCache,
         reverseLookupCache
     )));
-    Assert.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
+    Assertions.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
         dataFetcher,
         EasyMock.createMock(LoadingCache.class),
         reverseLookupCache
     )));
-    Assert.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
+    Assertions.assertTrue(loadingLookupFactory.replaces(new LoadingLookupFactory(
         dataFetcher,
         lookupCache,
         EasyMock.createMock(LoadingCache.class)
@@ -100,7 +100,7 @@ public class LoadingLookupFactoryTest
   @Test
   public void testGet()
   {
-    Assert.assertEquals(loadingLookup, loadingLookupFactory.get());
+    Assertions.assertEquals(loadingLookup, loadingLookupFactory.get());
   }
 
   @Test
@@ -126,7 +126,7 @@ public class LoadingLookupFactoryTest
 
     mapper.registerSubtypes(MockDataFetcher.class);
     mapper.registerSubtypes(LoadingLookupFactory.class);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         loadingLookupFactory,
         mapper.readerFor(LookupExtractorFactory.class)
               .readValue(mapper.writeValueAsString(loadingLookupFactory))

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/LoadingLookupTest.java
@@ -25,10 +25,8 @@ import com.google.common.collect.Lists;
 import org.apache.druid.server.lookup.cache.loading.LoadingCache;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,24 +42,21 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
   LoadingCache reverseLookupCache = EasyMock.createStrictMock(LoadingCache.class);
   LoadingLookup loadingLookup = new LoadingLookup(dataFetcher, lookupCache, reverseLookupCache);
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testApplyEmptyOrNull()
   {
     EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("")))
             .andReturn("empty").atLeastOnce();
     EasyMock.replay(lookupCache);
-    Assert.assertEquals("empty", loadingLookup.apply(""));
-    Assert.assertNull(loadingLookup.apply(null));
+    Assertions.assertEquals("empty", loadingLookup.apply(""));
+    Assertions.assertNull(loadingLookup.apply(null));
     EasyMock.verify(lookupCache);
   }
 
   @Test
   public void testUnapplyNull()
   {
-    Assert.assertEquals(Collections.emptyList(), loadingLookup.unapply(null));
+    Assertions.assertEquals(Collections.emptyList(), loadingLookup.unapply(null));
   }
 
   @Test
@@ -69,7 +64,7 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
   {
     EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("key"))).andReturn("value").once();
     EasyMock.replay(lookupCache);
-    Assert.assertEquals(ImmutableMap.of("key", "value"), loadingLookup.applyAll(ImmutableSet.of("key")));
+    Assertions.assertEquals(ImmutableMap.of("key", "value"), loadingLookup.applyAll(ImmutableSet.of("key")));
     EasyMock.verify(lookupCache);
   }
 
@@ -79,7 +74,7 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
     EasyMock.expect(lookupCache.getIfPresent(EasyMock.eq("key"))).andReturn(null).once();
     EasyMock.expect(dataFetcher.fetch("key")).andReturn(null).once();
     EasyMock.replay(lookupCache, dataFetcher);
-    Assert.assertNull(loadingLookup.apply("key"));
+    Assertions.assertNull(loadingLookup.apply("key"));
     EasyMock.verify(lookupCache, dataFetcher);
   }
 
@@ -94,8 +89,8 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
     EasyMock.expectLastCall().andVoid();
     EasyMock.expect(lookupCache.getIfPresent("key")).andReturn("value").once();
     EasyMock.replay(lookupCache, dataFetcher);
-    Assert.assertEquals(loadingLookup.apply("key"), "value");
-    Assert.assertEquals(loadingLookup.apply("key"), "value");
+    Assertions.assertEquals(loadingLookup.apply("key"), "value");
+    Assertions.assertEquals(loadingLookup.apply("key"), "value");
     EasyMock.verify(lookupCache, dataFetcher);
   }
 
@@ -106,7 +101,7 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
             .andReturn(Collections.singletonList("key"))
             .once();
     EasyMock.replay(reverseLookupCache);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList("key"),
         Lists.newArrayList(loadingLookup.unapplyAll(ImmutableSet.of("value")))
     );
@@ -130,20 +125,20 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
             .andThrow(new ExecutionException(null))
             .once();
     EasyMock.replay(reverseLookupCache);
-    Assert.assertEquals(Collections.emptyList(), loadingLookup.unapply("value"));
+    Assertions.assertEquals(Collections.emptyList(), loadingLookup.unapply("value"));
     EasyMock.verify(reverseLookupCache);
   }
 
   @Test
   public void testGetCacheKey()
   {
-    Assert.assertFalse(Arrays.equals(loadingLookup.getCacheKey(), loadingLookup.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(loadingLookup.getCacheKey(), loadingLookup.getCacheKey()));
   }
 
   @Test
   public void testSupportsAsMap()
   {
-    Assert.assertTrue(loadingLookup.supportsAsMap());
+    Assertions.assertTrue(loadingLookup.supportsAsMap());
   }
 
   @Test
@@ -155,7 +150,7 @@ public class LoadingLookupTest extends InitializedNullHandlingTest
     fetchedData.put(null, "value");
     EasyMock.expect(dataFetcher.fetchAll()).andReturn(fetchedData.entrySet());
     EasyMock.replay(dataFetcher);
-    Assert.assertEquals(loadingLookup.asMap(), fetchedData);
+    Assertions.assertEquals(loadingLookup.asMap(), fetchedData);
     EasyMock.verify(dataFetcher);
   }
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupFactoryTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupFactoryTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.server.lookup;
 
 import org.easymock.EasyMock;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PollingLookupFactoryTest
 {
@@ -35,28 +35,28 @@ public class PollingLookupFactoryTest
   {
     EasyMock.expect(pollingLookup.isOpen()).andReturn(true).once();
     EasyMock.replay(pollingLookup);
-    Assert.assertTrue(pollingLookupFactory.start());
+    Assertions.assertTrue(pollingLookupFactory.start());
     pollingLookupFactory.awaitInitialization();
-    Assert.assertTrue(pollingLookupFactory.isInitialized());
+    Assertions.assertTrue(pollingLookupFactory.isInitialized());
     EasyMock.verify(pollingLookup);
   }
 
   @Test
   public void testClose()
   {
-    Assert.assertTrue(pollingLookupFactory.close());
+    Assertions.assertTrue(pollingLookupFactory.close());
   }
 
   @Test
   public void testReplacesWithNull()
   {
-    Assert.assertTrue(pollingLookupFactory.replaces(null));
+    Assertions.assertTrue(pollingLookupFactory.replaces(null));
   }
 
   @Test
   public void testReplaces()
   {
-    Assert.assertTrue(pollingLookupFactory.replaces(new PollingLookupFactory(
+    Assertions.assertTrue(pollingLookupFactory.replaces(new PollingLookupFactory(
         Period.millis(1),
         null,
         null,
@@ -67,7 +67,7 @@ public class PollingLookupFactoryTest
   @Test
   public void testGet()
   {
-    Assert.assertEquals(pollingLookup, pollingLookupFactory.get());
+    Assertions.assertEquals(pollingLookup, pollingLookupFactory.get());
   }
 
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupSerDeserTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupSerDeserTest.java
@@ -28,10 +28,9 @@ import org.apache.druid.server.lookup.cache.polling.OffHeapPollingCache;
 import org.apache.druid.server.lookup.cache.polling.OnHeapPollingCache;
 import org.apache.druid.server.lookup.cache.polling.PollingCacheFactory;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,10 +40,8 @@ import java.util.List;
 import java.util.Map;
 
 
-@RunWith(Parameterized.class)
 public class PollingLookupSerDeserTest
 {
-  @Parameterized.Parameters
   public static Collection<Object[]> inputData()
   {
     return Arrays.asList(new Object[][]{
@@ -52,29 +49,31 @@ public class PollingLookupSerDeserTest
     });
   }
 
-  private final PollingCacheFactory cacheFactory;
+  private PollingCacheFactory cacheFactory;
   private final DataFetcher dataFetcher = new MockDataFetcher();
 
-  public PollingLookupSerDeserTest(PollingCacheFactory cacheFactory)
+  public void initPollingLookupSerDeserTest(PollingCacheFactory cacheFactory)
   {
     this.cacheFactory = cacheFactory;
   }
 
-  @Test
-  public void testSerDeser() throws IOException
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testSerDeser(PollingCacheFactory cacheFactory) throws IOException
   {
+    initPollingLookupSerDeserTest(cacheFactory);
     ObjectMapper mapper = new DefaultObjectMapper();
     PollingLookupFactory pollingLookupFactory = new PollingLookupFactory(Period.ZERO, dataFetcher, cacheFactory);
     mapper.registerSubtypes(MockDataFetcher.class);
     mapper.registerSubtypes(PollingLookupFactory.class);
-    Assert.assertEquals(pollingLookupFactory, mapper.readerFor(LookupExtractorFactory.class).readValue(mapper.writeValueAsString(pollingLookupFactory)));
+    Assertions.assertEquals(pollingLookupFactory, mapper.readerFor(LookupExtractorFactory.class).readValue(mapper.writeValueAsString(pollingLookupFactory)));
   }
 
   @JsonTypeName("mock")
   private static class MockDataFetcher implements DataFetcher
   {
     @JsonCreator
-    public MockDataFetcher()
+    public void initPollingLookupSerDeserTest()
     {
     }
 

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupSerDeserTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupSerDeserTest.java
@@ -73,7 +73,7 @@ public class PollingLookupSerDeserTest
   private static class MockDataFetcher implements DataFetcher
   {
     @JsonCreator
-    public void initPollingLookupSerDeserTest()
+    public MockDataFetcher()
     {
     }
 

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/PollingLookupTest.java
@@ -28,14 +28,11 @@ import org.apache.druid.server.lookup.cache.polling.OffHeapPollingCache;
 import org.apache.druid.server.lookup.cache.polling.OnHeapPollingCache;
 import org.apache.druid.server.lookup.cache.polling.PollingCacheFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -43,8 +40,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class PollingLookupTest extends InitializedNullHandlingTest
 {
   private static final Map<String, String> FIRST_LOOKUP_MAP = ImmutableMap.of(
@@ -60,9 +59,6 @@ public class PollingLookupTest extends InitializedNullHandlingTest
   );
 
   private static final long POLL_PERIOD = 1000L;
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @JsonTypeName("mock")
   private static class MockDataFetcher implements DataFetcher
@@ -111,7 +107,6 @@ public class PollingLookupTest extends InitializedNullHandlingTest
     }
   }
 
-  @Parameterized.Parameters
   public static Collection<Object[]> inputData()
   {
     return Arrays.asList(new Object[][]{
@@ -120,22 +115,17 @@ public class PollingLookupTest extends InitializedNullHandlingTest
     });
   }
 
-  private final PollingCacheFactory pollingCacheFactory;
+  private PollingCacheFactory pollingCacheFactory;
   private final DataFetcher dataFetcher = new MockDataFetcher();
   private PollingLookup pollingLookup;
 
-  public PollingLookupTest(PollingCacheFactory pollingCacheFactory)
+  private void initPollingLookupTest(PollingCacheFactory pollingCacheFactory)
   {
     this.pollingCacheFactory = pollingCacheFactory;
-  }
-
-  @Before
-  public void setUp()
-  {
     pollingLookup = new PollingLookup(POLL_PERIOD, dataFetcher, pollingCacheFactory);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (pollingLookup != null) {
@@ -144,83 +134,105 @@ public class PollingLookupTest extends InitializedNullHandlingTest
     pollingLookup = null;
   }
 
-  @Test(expected = ISE.class)
-  public void testClose()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testClose(PollingCacheFactory pollingCacheFactory)
   {
-    pollingLookup.close();
-    pollingLookup.apply("key");
+    initPollingLookupTest(pollingCacheFactory);
+    assertThrows(ISE.class, () -> {
+      pollingLookup.close();
+      pollingLookup.apply("key");
+    });
   }
 
-  @Test
-  public void testApply()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testApply(PollingCacheFactory pollingCacheFactory)
   {
+    initPollingLookupTest(pollingCacheFactory);
     assertMapLookup(FIRST_LOOKUP_MAP, pollingLookup);
   }
 
-  @Test(timeout = POLL_PERIOD * 3)
-  public void testApplyAfterDataChange() throws InterruptedException
+  @MethodSource("inputData")
+  @ParameterizedTest
+  @Timeout(value = POLL_PERIOD * 3, unit = TimeUnit.MILLISECONDS)
+  public void testApplyAfterDataChange(PollingCacheFactory pollingCacheFactory) throws InterruptedException
   {
+    initPollingLookupTest(pollingCacheFactory);
     assertMapLookup(FIRST_LOOKUP_MAP, pollingLookup);
     Thread.sleep(POLL_PERIOD * 2);
     assertMapLookup(SECOND_LOOKUP_MAP, pollingLookup);
   }
 
-  @Test
-  public void testUnapply()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testUnapply(PollingCacheFactory pollingCacheFactory)
   {
-    Assert.assertEquals(
-        "reverse lookup should match",
+    initPollingLookupTest(pollingCacheFactory);
+    Assertions.assertEquals(
         Sets.newHashSet("foo", "bad"),
-        Sets.newHashSet(pollingLookup.unapply("bar"))
+        Sets.newHashSet(pollingLookup.unapply("bar")),
+        "reverse lookup should match"
     );
-    Assert.assertEquals(
-        "reverse lookup should match",
+    Assertions.assertEquals(
         Sets.newHashSet("how about that"),
-        Sets.newHashSet(pollingLookup.unapply("foo"))
+        Sets.newHashSet(pollingLookup.unapply("foo")),
+        "reverse lookup should match"
     );
-    Assert.assertEquals(
-        "reverse lookup should match",
+    Assertions.assertEquals(
         Sets.newHashSet("empty string"),
-        Sets.newHashSet(pollingLookup.unapply(""))
+        Sets.newHashSet(pollingLookup.unapply("")),
+        "reverse lookup should match"
     );
-    Assert.assertEquals(
-        "reverse lookup of none existing value should be empty list",
+    Assertions.assertEquals(
         Collections.emptyList(),
-        pollingLookup.unapply("does't exist")
+        pollingLookup.unapply("does't exist"),
+        "reverse lookup of none existing value should be empty list"
     );
   }
 
-  @Test
-  public void testBulkApply()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testBulkApply(PollingCacheFactory pollingCacheFactory)
   {
+    initPollingLookupTest(pollingCacheFactory);
     Map<String, String> map = pollingLookup.applyAll(FIRST_LOOKUP_MAP.keySet());
-    Assert.assertEquals(FIRST_LOOKUP_MAP, map);
+    Assertions.assertEquals(FIRST_LOOKUP_MAP, map);
   }
 
-  @Test
-  public void testGetCacheKey()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testGetCacheKey(PollingCacheFactory pollingCacheFactory)
   {
+    initPollingLookupTest(pollingCacheFactory);
     PollingLookup pollingLookup2 = new PollingLookup(1L, dataFetcher, pollingCacheFactory);
-    Assert.assertFalse(Arrays.equals(pollingLookup2.getCacheKey(), pollingLookup.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(pollingLookup2.getCacheKey(), pollingLookup.getCacheKey()));
   }
 
-  @Test
-  public void testSupportsAsMap()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testSupportsAsMap(PollingCacheFactory pollingCacheFactory)
   {
-    Assert.assertFalse(pollingLookup.supportsAsMap());
+    initPollingLookupTest(pollingCacheFactory);
+    Assertions.assertFalse(pollingLookup.supportsAsMap());
   }
 
-  @Test
-  public void testAsMap()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testAsMap(PollingCacheFactory pollingCacheFactory)
   {
-    expectedException.expect(UnsupportedOperationException.class);
-    pollingLookup.asMap();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      initPollingLookupTest(pollingCacheFactory);
+      pollingLookup.asMap();
+    });
   }
 
-  @Test
-  public void testEstimateHeapFootprint()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testEstimateHeapFootprint(PollingCacheFactory pollingCacheFactory)
   {
-    Assert.assertEquals(
+    initPollingLookupTest(pollingCacheFactory);
+    Assertions.assertEquals(
         pollingCacheFactory instanceof OffHeapPollingCache.OffHeapPollingCacheProvider ? 0L : 402L,
         pollingLookup.estimateHeapFootprint()
     );
@@ -231,7 +243,7 @@ public class PollingLookupTest extends InitializedNullHandlingTest
     for (Map.Entry<String, String> entry : map.entrySet()) {
       String key = entry.getKey();
       String val = entry.getValue();
-      Assert.assertEquals("non-null check", val, lookup.apply(key));
+      Assertions.assertEquals(val, lookup.apply(key), "non-null check");
     }
   }
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/LoadingCacheTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/LoadingCacheTest.java
@@ -22,12 +22,10 @@ package org.apache.druid.server.lookup.cache.loading;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -36,12 +34,10 @@ import java.util.Collections;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-@RunWith(Parameterized.class)
 public class LoadingCacheTest
 {
   private static final ImmutableMap IMMUTABLE_MAP = ImmutableMap.of("key", "value");
 
-  @Parameterized.Parameters
   public static Collection<Object[]> inputData()
   {
     return Arrays.asList(new Object[][]{
@@ -50,42 +46,43 @@ public class LoadingCacheTest
     });
   }
 
-  private final LoadingCache loadingCache;
+  private LoadingCache loadingCache;
 
-  public LoadingCacheTest(LoadingCache loadingCache)
+  private void initLoadingCacheTest(LoadingCache loadingCache)
   {
     this.loadingCache = loadingCache;
-  }
-
-  @Before
-  public void setUp()
-  {
-    Assert.assertFalse(loadingCache.isClosed());
+    Assertions.assertFalse(loadingCache.isClosed());
     loadingCache.putAll(IMMUTABLE_MAP);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     loadingCache.invalidateAll();
   }
 
-  @Test
-  public void testGetIfPresent()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testGetIfPresent(LoadingCache loadingCache)
   {
-    Assert.assertNull(loadingCache.getIfPresent("not there"));
-    Assert.assertEquals(IMMUTABLE_MAP.get("key"), loadingCache.getIfPresent("key"));
+    initLoadingCacheTest(loadingCache);
+    Assertions.assertNull(loadingCache.getIfPresent("not there"));
+    Assertions.assertEquals(IMMUTABLE_MAP.get("key"), loadingCache.getIfPresent("key"));
   }
 
-  @Test
-  public void testGetAllPresent()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testGetAllPresent(LoadingCache loadingCache)
   {
-    Assert.assertEquals(IMMUTABLE_MAP, loadingCache.getAllPresent(IMMUTABLE_MAP.keySet()));
+    initLoadingCacheTest(loadingCache);
+    Assertions.assertEquals(IMMUTABLE_MAP, loadingCache.getAllPresent(IMMUTABLE_MAP.keySet()));
   }
 
-  @Test
-  public void testPut() throws ExecutionException
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testPut(LoadingCache loadingCache) throws ExecutionException
   {
+    initLoadingCacheTest(loadingCache);
     loadingCache.get("key2", new Callable()
     {
       @Override
@@ -94,12 +91,14 @@ public class LoadingCacheTest
         return "value2";
       }
     });
-    Assert.assertEquals("value2", loadingCache.getIfPresent("key2"));
+    Assertions.assertEquals("value2", loadingCache.getIfPresent("key2"));
   }
 
-  @Test
-  public void testInvalidate() throws ExecutionException
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testInvalidate(LoadingCache loadingCache) throws ExecutionException
   {
+    initLoadingCacheTest(loadingCache);
     loadingCache.get("key2", new Callable()
     {
       @Override
@@ -108,14 +107,16 @@ public class LoadingCacheTest
         return "value2";
       }
     });
-    Assert.assertEquals("value2", loadingCache.getIfPresent("key2"));
+    Assertions.assertEquals("value2", loadingCache.getIfPresent("key2"));
     loadingCache.invalidate("key2");
-    Assert.assertEquals(null, loadingCache.getIfPresent("key2"));
+    Assertions.assertEquals(null, loadingCache.getIfPresent("key2"));
   }
 
-  @Test
-  public void testInvalidateAll() throws ExecutionException
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testInvalidateAll(LoadingCache loadingCache) throws ExecutionException
   {
+    initLoadingCacheTest(loadingCache);
     loadingCache.get("key2", new Callable()
     {
       @Override
@@ -124,14 +125,16 @@ public class LoadingCacheTest
         return "value2";
       }
     });
-    Assert.assertEquals("value2", loadingCache.getIfPresent("key2"));
+    Assertions.assertEquals("value2", loadingCache.getIfPresent("key2"));
     loadingCache.invalidateAll(Collections.singletonList("key2"));
-    Assert.assertEquals(null, loadingCache.getIfPresent("key2"));
+    Assertions.assertEquals(null, loadingCache.getIfPresent("key2"));
   }
 
-  @Test
-  public void testInvalidateAll1() throws ExecutionException
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testInvalidateAll1(LoadingCache loadingCache) throws ExecutionException
   {
+    initLoadingCacheTest(loadingCache);
     loadingCache.invalidateAll();
     loadingCache.get("key2", new Callable()
     {
@@ -141,27 +144,33 @@ public class LoadingCacheTest
         return "value2";
       }
     });
-    Assert.assertEquals(loadingCache.getAllPresent(IMMUTABLE_MAP.keySet()), Collections.emptyMap());
+    Assertions.assertEquals(loadingCache.getAllPresent(IMMUTABLE_MAP.keySet()), Collections.emptyMap());
   }
 
-  @Test
-  public void testGetStats()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testGetStats(LoadingCache loadingCache)
   {
-    Assert.assertTrue(loadingCache.getStats() != null && loadingCache.getStats() instanceof LookupCacheStats);
+    initLoadingCacheTest(loadingCache);
+    Assertions.assertTrue(loadingCache.getStats() != null && loadingCache.getStats() instanceof LookupCacheStats);
   }
 
-  @Test
-  public void testIsClosed()
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testIsClosed(LoadingCache loadingCache)
   {
-    Assert.assertFalse(loadingCache.isClosed());
+    initLoadingCacheTest(loadingCache);
+    Assertions.assertFalse(loadingCache.isClosed());
   }
 
-  @Test
-  public void testSerDeser() throws IOException
+  @MethodSource("inputData")
+  @ParameterizedTest
+  public void testSerDeser(LoadingCache loadingCache) throws IOException
   {
+    initLoadingCacheTest(loadingCache);
     ObjectMapper mapper = new DefaultObjectMapper();
-    Assert.assertEquals(loadingCache, mapper.readerFor(LoadingCache.class).readValue(mapper.writeValueAsString(loadingCache)));
-    Assert.assertEquals(loadingCache.hashCode(), mapper.readerFor(LoadingCache.class).readValue(mapper.writeValueAsString(loadingCache)).hashCode());
+    Assertions.assertEquals(loadingCache, mapper.readerFor(LoadingCache.class).readValue(mapper.writeValueAsString(loadingCache)));
+    Assertions.assertEquals(loadingCache.hashCode(), mapper.readerFor(LoadingCache.class).readValue(mapper.writeValueAsString(loadingCache)).hashCode());
   }
 
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/LoadingCacheTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/LoadingCacheTest.java
@@ -59,6 +59,7 @@ public class LoadingCacheTest
   public void tearDown()
   {
     loadingCache.invalidateAll();
+    loadingCache.close();
   }
 
   @MethodSource("inputData")

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/OffHeapLoadingCacheTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/OffHeapLoadingCacheTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.server.lookup.cache.loading;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class OffHeapLoadingCacheTest
 {
@@ -29,7 +29,7 @@ public class OffHeapLoadingCacheTest
   {
     LoadingCache loadingCache = new OffHeapLoadingCache<>(1000L, 1000L, 0L, 0L);
     loadingCache.close();
-    Assert.assertTrue(loadingCache.isClosed());
+    Assertions.assertTrue(loadingCache.isClosed());
   }
 
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/OnHeapLoadingCacheTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/cache/loading/OnHeapLoadingCacheTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.server.lookup.cache.loading;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class OnHeapLoadingCacheTest
 {
@@ -29,6 +29,6 @@ public class OnHeapLoadingCacheTest
   {
     OnHeapLoadingCache onHeapLookupLoadingCache = new OnHeapLoadingCache(4, 15, 100L, 10L, 10L);
     onHeapLookupLoadingCache.close();
-    Assert.assertTrue(onHeapLookupLoadingCache.isClosed());
+    Assertions.assertTrue(onHeapLookupLoadingCache.isClosed());
   }
 }

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/jdbc/JdbcDataFetcherTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/jdbc/JdbcDataFetcherTest.java
@@ -30,12 +30,11 @@ import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
 import org.apache.druid.server.lookup.DataFetcher;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.skife.jdbi.v2.Handle;
 
 import java.io.IOException;
@@ -43,16 +42,20 @@ import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class JdbcDataFetcherTest extends InitializedNullHandlingTest
 {
   private static final String TABLE_NAME = "tableName";
   private static final String KEY_COLUMN = "keyColumn";
   private static final String VALUE_COLUMN = "valueColumn";
 
-  public static class FetchTest
+  @Nested
+  public class FetchTest
   {
-    @Rule
-    public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+    private TestDerbyConnector derbyConnector;
+    private MetadataStorageConnectorConfig derbyConnectorConfig;
 
     private Handle handle;
 
@@ -65,11 +68,21 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
         "empty string", ""
     );
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
+      derbyConnector = new TestDerbyConnector();
+      derbyConnector.createDatabase();
+      derbyConnectorConfig = new MetadataStorageConnectorConfig()
+      {
+        @Override
+        public String getConnectURI()
+        {
+          return derbyConnector.getJdbcUri();
+        }
+      };
       jdbcDataFetcher = new JdbcDataFetcher(
-          derbyConnectorRule.getMetadataConnectorConfig(),
+          derbyConnectorConfig,
           "tableName",
           "keyColumn",
           "valueColumn",
@@ -77,8 +90,8 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
           new JdbcAccessSecurityConfig()
       );
 
-      handle = derbyConnectorRule.getConnector().getDBI().open();
-      Assert.assertEquals(
+      handle = derbyConnector.getDBI().open();
+      Assertions.assertEquals(
           0,
           handle.createStatement(
               StringUtils.format(
@@ -97,17 +110,18 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
       handle.commit();
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
       handle.createStatement("DROP TABLE " + TABLE_NAME).setQueryTimeout(1).execute();
       handle.close();
+      derbyConnector.tearDown();
     }
 
     @Test
     public void testFetch()
     {
-      Assert.assertEquals("null check", null, jdbcDataFetcher.fetch("baz"));
+      Assertions.assertEquals(null, jdbcDataFetcher.fetch("baz"), "null check");
       assertMapLookup(LOOKUP_MAP, jdbcDataFetcher);
     }
 
@@ -116,7 +130,7 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
     {
       ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
       jdbcDataFetcher.fetchAll().forEach(mapBuilder::put);
-      Assert.assertEquals("maps should match", LOOKUP_MAP, mapBuilder.build());
+      Assertions.assertEquals(LOOKUP_MAP, mapBuilder.build(), "maps should match");
     }
 
     @Test
@@ -124,31 +138,31 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
     {
       ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.builder();
       jdbcDataFetcher.fetch(LOOKUP_MAP.keySet()).forEach(mapBuilder::put);
-      Assert.assertEquals(LOOKUP_MAP, mapBuilder.build());
+      Assertions.assertEquals(LOOKUP_MAP, mapBuilder.build());
     }
 
     @Test
     public void testReverseFetch()
     {
-      Assert.assertEquals(
-          "reverse lookup should match",
+      Assertions.assertEquals(
           Sets.newHashSet("foo", "bad"),
-          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys("bar"))
+          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys("bar")),
+          "reverse lookup should match"
       );
-      Assert.assertEquals(
-          "reverse lookup should match",
+      Assertions.assertEquals(
           Sets.newHashSet("how about that"),
-          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys("foo"))
+          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys("foo")),
+          "reverse lookup should match"
       );
-      Assert.assertEquals(
-          "reverse lookup should match",
+      Assertions.assertEquals(
           Sets.newHashSet("empty string"),
-          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys(""))
+          Sets.newHashSet(jdbcDataFetcher.reverseFetchKeys("")),
+          "reverse lookup should match"
       );
-      Assert.assertEquals(
-          "reverse lookup of none existing value should be empty list",
+      Assertions.assertEquals(
           Collections.emptyList(),
-          jdbcDataFetcher.reverseFetchKeys("does't exist")
+          jdbcDataFetcher.reverseFetchKeys("does't exist"),
+          "reverse lookup of none existing value should be empty list"
       );
     }
 
@@ -167,7 +181,7 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
       DefaultObjectMapper mapper = new DefaultObjectMapper();
       mapper.setInjectableValues(new Std().addValue(JdbcAccessSecurityConfig.class, securityConfig));
       String jdbcDataFetcherSer = mapper.writeValueAsString(jdbcDataFetcher);
-      Assert.assertEquals(jdbcDataFetcher, mapper.readerFor(DataFetcher.class).readValue(jdbcDataFetcherSer));
+      Assertions.assertEquals(jdbcDataFetcher, mapper.readerFor(DataFetcher.class).readValue(jdbcDataFetcherSer));
     }
 
     @SuppressWarnings("SameParameterValue")
@@ -176,7 +190,7 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
       for (Map.Entry<String, String> entry : map.entrySet()) {
         String key = entry.getKey();
         String val = entry.getValue();
-        Assert.assertEquals("non-null check", val, dataFetcher.fetch(key));
+        Assertions.assertEquals(val, dataFetcher.fetch(key), "non-null check");
       }
     }
 
@@ -192,12 +206,13 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
           KEY_COLUMN, VALUE_COLUMN,
           key, val
       );
-      Assert.assertEquals(1, handle.createStatement(query).setQueryTimeout(1).execute());
+      Assertions.assertEquals(1, handle.createStatement(query).setQueryTimeout(1).execute());
       handle.commit();
     }
   }
 
-  public static class MissingJdbcJarTest
+  @Nested
+  public class MissingJdbcJarTest
   {
     private static final MetadataStorageConnectorConfig MISSING_METADATA_STORAGE_CONNECTOR_CONFIG =
         createMissingMetadataStorageConnectorConfig();
@@ -205,10 +220,7 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
 
     private JdbcDataFetcher target;
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Before
+    @BeforeEach
     public void setUp()
     {
       target = new JdbcDataFetcher(
@@ -247,10 +259,10 @@ public class JdbcDataFetcherTest extends InitializedNullHandlingTest
 
     private void test(Runnable runnable)
     {
-      exception.expect(IllegalStateException.class);
-      exception.expectMessage("JDBC driver JAR files missing in the classpath");
+      Throwable exception = assertThrows(IllegalStateException.class, () ->
 
-      runnable.run();
+        runnable.run());
+      assertTrue(exception.getMessage().contains("JDBC driver JAR files missing in the classpath"));
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/jdbc/JdbcDataFetcherUrlCheckTest.java
+++ b/extensions-core/lookups-cached-single/src/test/java/org/apache/druid/server/lookup/jdbc/JdbcDataFetcherUrlCheckTest.java
@@ -22,11 +22,13 @@ package org.apache.druid.server.lookup.jdbc;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JdbcDataFetcherUrlCheckTest
 {
@@ -34,10 +36,9 @@ public class JdbcDataFetcherUrlCheckTest
   private static final String KEY_COLUMN = "keyColumn";
   private static final String VALUE_COLUMN = "valueColumn";
 
-  public static class MySqlTest
+  @Nested
+  public class MySqlTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
@@ -75,36 +76,37 @@ public class JdbcDataFetcherUrlCheckTest
     @Test
     public void testThrowWhenUrlHasDisallowedPropertiesWhenEnforcingAllowedProperties()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
-      new JdbcDataFetcher(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcDataFetcher(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
-            }
-          },
-          TABLE_NAME,
-          KEY_COLUMN,
-          VALUE_COLUMN,
-          100,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+              }
+            },
+            TABLE_NAME,
+            KEY_COLUMN,
+            VALUE_COLUMN,
+            100,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]"));
     }
 
     @Test
@@ -141,10 +143,9 @@ public class JdbcDataFetcherUrlCheckTest
     }
   }
 
-  public static class PostgreSqlTest
+  @Nested
+  public class PostgreSqlTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
@@ -182,36 +183,37 @@ public class JdbcDataFetcherUrlCheckTest
     @Test
     public void testThrowWhenUrlHasDisallowedPropertiesWhenEnforcingAllowedProperties()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
-      new JdbcDataFetcher(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcDataFetcher(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
-            }
-          },
-          TABLE_NAME,
-          KEY_COLUMN,
-          VALUE_COLUMN,
-          100,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+              }
+            },
+            TABLE_NAME,
+            KEY_COLUMN,
+            VALUE_COLUMN,
+            100,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]"));
     }
 
     @Test
@@ -250,83 +252,84 @@ public class JdbcDataFetcherUrlCheckTest
     @Test
     public void testWhenInvalidUrlFormat()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Invalid URL format for PostgreSQL: [jdbc:postgresql://invalid-url::3006]");
-      new JdbcDataFetcher(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcDataFetcher(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:postgresql://invalid-url::3006";
-            }
-          },
-          TABLE_NAME,
-          KEY_COLUMN,
-          VALUE_COLUMN,
-          100,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:postgresql://invalid-url::3006";
+              }
+            },
+            TABLE_NAME,
+            KEY_COLUMN,
+            VALUE_COLUMN,
+            100,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("Invalid URL format for PostgreSQL: [jdbc:postgresql://invalid-url::3006]"));
     }
   }
 
-  public static class UnknownSchemeTest
+  @Nested
+  public class UnknownSchemeTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testThrowWhenUnknownFormatIsNotAllowed()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Unknown JDBC connection scheme: mydb");
-      new JdbcDataFetcher(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcDataFetcher(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
-            }
-          },
-          TABLE_NAME,
-          KEY_COLUMN,
-          VALUE_COLUMN,
-          100,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+              }
+            },
+            TABLE_NAME,
+            KEY_COLUMN,
+            VALUE_COLUMN,
+            100,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isAllowUnknownJdbcUrlFormat()
-            {
-              return false;
-            }
+              @Override
+              public boolean isAllowUnknownJdbcUrlFormat()
+              {
+                return false;
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("Unknown JDBC connection scheme: mydb"));
     }
 
     @Test

--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -128,9 +128,24 @@
       <artifactId>airline</artifactId>
       <scope>provided</scope>
     </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/parquet-extensions/pom.xml
+++ b/extensions-core/parquet-extensions/pom.xml
@@ -128,8 +128,8 @@
       <artifactId>airline</artifactId>
       <scope>provided</scope>
     </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/CompatParquetReaderTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -65,13 +65,13 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     List<InputRow> rows = readAllRows(reader);
     List<InputRow> rowsAsBinary = readAllRows(readerNotAsString);
 
-    Assert.assertEquals("hey this is &é(-è_çà)=^$ù*! Ω^^", rows.get(0).getDimension("field").get(0));
-    Assert.assertEquals(1471800234, rows.get(0).getTimestampFromEpoch());
-    Assert.assertEquals(
+    Assertions.assertEquals("hey this is &é(-è_çà)=^$ù*! Ω^^", rows.get(0).getDimension("field").get(0));
+    Assertions.assertEquals(1471800234, rows.get(0).getTimestampFromEpoch());
+    Assertions.assertEquals(
         "aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==",
         rowsAsBinary.get(0).getDimension("field").get(0)
     );
-    Assert.assertEquals(1471800234, rowsAsBinary.get(0).getTimestampFromEpoch());
+    Assertions.assertEquals(1471800234, rowsAsBinary.get(0).getTimestampFromEpoch());
 
     reader = createReader(
         file,
@@ -91,13 +91,13 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"field\" : \"hey this is &é(-è_çà)=^$ù*! Ω^^\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
 
     final String expectedJsonBinary = "{\n"
                                 + "  \"field\" : \"aGV5IHRoaXMgaXMgJsOpKC3DqF/Dp8OgKT1eJMO5KiEgzqleXg==\",\n"
                                 + "  \"ts\" : 1471800234\n"
                                 + "}";
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedJsonBinary,
         DEFAULT_JSON_WRITER.writeValueAsString(sampledAsBinary.get(0).getRawValues())
     );
@@ -126,10 +126,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
 
     List<InputRow> rows = readAllRows(reader);
 
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("-1", rows.get(0).getDimension("col").get(0));
-    Assert.assertEquals(-1, rows.get(0).getMetric("metric1"));
-    Assert.assertTrue(rows.get(4).getDimension("col").isEmpty());
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("-1", rows.get(0).getDimension("col").get(0));
+    Assertions.assertEquals(-1, rows.get(0).getMetric("metric1"));
+    Assertions.assertTrue(rows.get(4).getDimension("col").isEmpty());
 
     reader = createReader(
         file,
@@ -140,7 +140,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"col\" : -1\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -212,30 +212,30 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
 
     List<InputRow> rows = readAllRows(reader);
 
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("true", rows.get(0).getDimension("boolColumn").get(0));
-    Assert.assertEquals("0", rows.get(0).getDimension("byteColumn").get(0));
-    Assert.assertEquals("1", rows.get(0).getDimension("shortColumn").get(0));
-    Assert.assertEquals("2", rows.get(0).getDimension("intColumn").get(0));
-    Assert.assertEquals("0", rows.get(0).getDimension("longColumn").get(0));
-    Assert.assertEquals("0.2", rows.get(0).getDimension("doubleColumn").get(0));
-    Assert.assertEquals("val_0", rows.get(0).getDimension("binaryColumn").get(0));
-    Assert.assertEquals("val_0", rows.get(0).getDimension("stringColumn").get(0));
-    Assert.assertEquals("SPADES", rows.get(0).getDimension("enumColumn").get(0));
-    Assert.assertTrue(rows.get(0).getDimension("maybeBoolColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeByteColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeShortColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeIntColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeLongColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeDoubleColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeBinaryColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeStringColumn").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("maybeEnumColumn").isEmpty());
-    Assert.assertEquals("arr_0", rows.get(0).getDimension("stringsColumn").get(0));
-    Assert.assertEquals("arr_1", rows.get(0).getDimension("stringsColumn").get(1));
-    Assert.assertEquals("0", rows.get(0).getDimension("intSetColumn").get(0));
-    Assert.assertEquals("val_1", rows.get(0).getDimension("extractByLogicalMap").get(0));
-    Assert.assertEquals("1", rows.get(0).getDimension("extractByComplexLogicalMap").get(0));
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("true", rows.get(0).getDimension("boolColumn").get(0));
+    Assertions.assertEquals("0", rows.get(0).getDimension("byteColumn").get(0));
+    Assertions.assertEquals("1", rows.get(0).getDimension("shortColumn").get(0));
+    Assertions.assertEquals("2", rows.get(0).getDimension("intColumn").get(0));
+    Assertions.assertEquals("0", rows.get(0).getDimension("longColumn").get(0));
+    Assertions.assertEquals("0.2", rows.get(0).getDimension("doubleColumn").get(0));
+    Assertions.assertEquals("val_0", rows.get(0).getDimension("binaryColumn").get(0));
+    Assertions.assertEquals("val_0", rows.get(0).getDimension("stringColumn").get(0));
+    Assertions.assertEquals("SPADES", rows.get(0).getDimension("enumColumn").get(0));
+    Assertions.assertTrue(rows.get(0).getDimension("maybeBoolColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeByteColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeShortColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeIntColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeLongColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeDoubleColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeBinaryColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeStringColumn").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("maybeEnumColumn").isEmpty());
+    Assertions.assertEquals("arr_0", rows.get(0).getDimension("stringsColumn").get(0));
+    Assertions.assertEquals("arr_1", rows.get(0).getDimension("stringsColumn").get(1));
+    Assertions.assertEquals("0", rows.get(0).getDimension("intSetColumn").get(0));
+    Assertions.assertEquals("val_1", rows.get(0).getDimension("extractByLogicalMap").get(0));
+    Assertions.assertEquals("1", rows.get(0).getDimension("extractByComplexLogicalMap").get(0));
 
     reader = createReader(
         file,
@@ -302,7 +302,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    } ]\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -325,10 +325,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("1", rows.get(0).getDimension("repeatedInt").get(0));
-    Assert.assertEquals("2", rows.get(0).getDimension("repeatedInt").get(1));
-    Assert.assertEquals("3", rows.get(0).getDimension("repeatedInt").get(2));
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("1", rows.get(0).getDimension("repeatedInt").get(0));
+    Assertions.assertEquals("2", rows.get(0).getDimension("repeatedInt").get(1));
+    Assertions.assertEquals("3", rows.get(0).getDimension("repeatedInt").get(2));
 
     reader = createReader(
         file,
@@ -339,7 +339,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"repeatedInt\" : [ 1, 2, 3 ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
 
@@ -364,10 +364,10 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
-    Assert.assertEquals("5", rows.get(1).getDimension("primitive").get(0));
-    Assert.assertEquals("4", rows.get(1).getDimension("extracted1").get(0));
-    Assert.assertEquals("6", rows.get(1).getDimension("extracted2").get(0));
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
+    Assertions.assertEquals("5", rows.get(1).getDimension("primitive").get(0));
+    Assertions.assertEquals("4", rows.get(1).getDimension("extracted1").get(0));
+    Assertions.assertEquals("6", rows.get(1).getDimension("extracted2").get(0));
 
     reader = createReader(
         file,
@@ -382,7 +382,7 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"repeatedMessage\" : [ 3 ]\n"
                                 + "  } ]\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -407,14 +407,14 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("10", rows.get(0).getDimension("optionalPrimitive").get(0));
-    Assert.assertEquals("9", rows.get(0).getDimension("requiredPrimitive").get(0));
-    Assert.assertTrue(rows.get(0).getDimension("repeatedPrimitive").isEmpty());
-    Assert.assertTrue(rows.get(0).getDimension("extractedOptional").isEmpty());
-    Assert.assertEquals("9", rows.get(0).getDimension("extractedRequired").get(0));
-    Assert.assertEquals("9", rows.get(0).getDimension("extractedRepeated").get(0));
-    Assert.assertEquals("10", rows.get(0).getDimension("extractedRepeated").get(1));
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("10", rows.get(0).getDimension("optionalPrimitive").get(0));
+    Assertions.assertEquals("9", rows.get(0).getDimension("requiredPrimitive").get(0));
+    Assertions.assertTrue(rows.get(0).getDimension("repeatedPrimitive").isEmpty());
+    Assertions.assertTrue(rows.get(0).getDimension("extractedOptional").isEmpty());
+    Assertions.assertEquals("9", rows.get(0).getDimension("extractedRequired").get(0));
+    Assertions.assertEquals("9", rows.get(0).getDimension("extractedRepeated").get(0));
+    Assertions.assertEquals("10", rows.get(0).getDimension("extractedRepeated").get(1));
 
     reader = createReader(
         file,
@@ -432,6 +432,6 @@ public class CompatParquetReaderTest extends BaseParquetReaderTest
                                 + "    \"someId\" : 9\n"
                                 + "  }\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/DecimalParquetReaderTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -91,9 +91,9 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
      */
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
-    Assert.assertEquals("1.0", rows.get(1).getDimension("fixed_len_dec").get(0));
-    Assert.assertEquals(new BigDecimal("1.0"), rows.get(1).getMetric("metric1"));
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
+    Assertions.assertEquals("1.0", rows.get(1).getDimension("fixed_len_dec").get(0));
+    Assertions.assertEquals(new BigDecimal("1.0"), rows.get(1).getMetric("metric1"));
 
     reader = createReader(
         file,
@@ -104,7 +104,7 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"fixed_len_dec\" : 1.0\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
   }
 
   @Test
@@ -158,9 +158,9 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
      */
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
-    Assert.assertEquals("1.00", rows.get(1).getDimension("i32_dec").get(0));
-    Assert.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(1).getMetric("metric1"));
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
+    Assertions.assertEquals("1.00", rows.get(1).getDimension("i32_dec").get(0));
+    Assertions.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(1).getMetric("metric1"));
 
     reader = createReader(
         file,
@@ -171,7 +171,7 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"i32_dec\" : 1.00\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
   }
 
   @Test
@@ -225,9 +225,9 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
      */
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
-    Assert.assertEquals("1.00", rows.get(1).getDimension("i64_dec").get(0));
-    Assert.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(1).getMetric("metric1"));
+    Assertions.assertEquals("2018-09-01T00:00:00.000Z", rows.get(1).getTimestamp().toString());
+    Assertions.assertEquals("1.00", rows.get(1).getDimension("i64_dec").get(0));
+    Assertions.assertEquals(BigDecimal.valueOf(100L, 2), rows.get(1).getMetric("metric1"));
 
     reader = createReader(
         file,
@@ -238,6 +238,6 @@ public class DecimalParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"i64_dec\" : 1.00\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(1).getRawValues()));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/FlattenSpecParquetReaderTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathFieldType;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -77,13 +77,13 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
-    Assert.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
-    Assert.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
-    Assert.assertEquals("listDim1v1", rows.get(0).getDimension("listDim").get(0));
-    Assert.assertEquals("listDim1v2", rows.get(0).getDimension("listDim").get(1));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
+    Assertions.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
+    Assertions.assertEquals("listDim1v1", rows.get(0).getDimension("listDim").get(0));
+    Assertions.assertEquals("listDim1v2", rows.get(0).getDimension("listDim").get(1));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
 
     reader = createReader(
         file,
@@ -91,7 +91,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -110,13 +110,13 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
-    Assert.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
-    Assert.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
-    Assert.assertEquals("listDim1v1", rows.get(0).getDimension("listDim").get(0));
-    Assert.assertEquals("listDim1v2", rows.get(0).getDimension("listDim").get(1));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
+    Assertions.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
+    Assertions.assertEquals("listDim1v1", rows.get(0).getDimension("listDim").get(0));
+    Assertions.assertEquals("listDim1v2", rows.get(0).getDimension("listDim").get(1));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
 
     reader = createReader(
         file,
@@ -124,7 +124,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -151,13 +151,13 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
-    Assert.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
-    Assert.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
-    Assert.assertEquals("listDim1v1", rows.get(0).getDimension("list").get(0));
-    Assert.assertEquals("listDim1v2", rows.get(0).getDimension("list").get(1));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
+    Assertions.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
+    Assertions.assertEquals("listDim1v1", rows.get(0).getDimension("list").get(0));
+    Assertions.assertEquals("listDim1v2", rows.get(0).getDimension("list").get(1));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
 
     reader = createReader(
         file,
@@ -165,7 +165,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -191,11 +191,11 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
-    Assert.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
-    Assert.assertEquals("listDim1v2", rows.get(0).getDimension("listExtracted").get(0));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
+    Assertions.assertEquals("listDim1v2", rows.get(0).getDimension("listExtracted").get(0));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
 
     reader = createReader(
         file,
@@ -204,7 +204,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
 
-    Assert.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(FLAT_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
 
@@ -225,15 +225,15 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
     List<String> dims = rows.get(0).getDimensions();
-    Assert.assertEquals(1, dims.size());
-    Assert.assertFalse(dims.contains("dim2"));
-    Assert.assertFalse(dims.contains("dim3"));
-    Assert.assertFalse(dims.contains("listDim"));
-    Assert.assertFalse(dims.contains("nestedData"));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertEquals(1, dims.size());
+    Assertions.assertFalse(dims.contains("dim2"));
+    Assertions.assertFalse(dims.contains("dim3"));
+    Assertions.assertFalse(dims.contains("listDim"));
+    Assertions.assertFalse(dims.contains("nestedData"));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
 
     reader = createReader(
         file,
@@ -241,7 +241,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -260,13 +260,13 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
     List<String> dims = rows.get(0).getDimensions();
-    Assert.assertFalse(dims.contains("dim2"));
-    Assert.assertFalse(dims.contains("dim3"));
-    Assert.assertFalse(dims.contains("listDim"));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertFalse(dims.contains("dim2"));
+    Assertions.assertFalse(dims.contains("dim3"));
+    Assertions.assertFalse(dims.contains("listDim"));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
 
     reader = createReader(
         file,
@@ -274,7 +274,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         JSONPathSpec.DEFAULT
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -302,14 +302,14 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
-    Assert.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
-    Assert.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
-    Assert.assertEquals("listDim1v1", rows.get(0).getDimension("listDim").get(0));
-    Assert.assertEquals("listDim1v2", rows.get(0).getDimension("listDim").get(1));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
-    Assert.assertEquals(2, rows.get(0).getMetric("metric2").longValue());
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
+    Assertions.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
+    Assertions.assertEquals("listDim1v1", rows.get(0).getDimension("listDim").get(0));
+    Assertions.assertEquals("listDim1v2", rows.get(0).getDimension("listDim").get(1));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertEquals(2, rows.get(0).getMetric("metric2").longValue());
 
     reader = createReader(
         file,
@@ -317,7 +317,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -345,12 +345,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
 
     List<InputRow> rows = readAllRows(reader);
 
-    Assert.assertEquals(TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
-    Assert.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
-    Assert.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
-    Assert.assertEquals("listDim1v2", rows.get(0).getDimension("listextracted").get(0));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
+    Assertions.assertEquals(TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("d1v1", rows.get(0).getDimension("dim1").get(0));
+    Assertions.assertEquals("d2v1", rows.get(0).getDimension("dim2").get(0));
+    Assertions.assertEquals("1", rows.get(0).getDimension("dim3").get(0));
+    Assertions.assertEquals("listDim1v2", rows.get(0).getDimension("listextracted").get(0));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1").longValue());
 
     reader = createReader(
         file,
@@ -358,7 +358,7 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
         flattenSpec
     );
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
-    Assert.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(NESTED_JSON, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -389,12 +389,12 @@ public class FlattenSpecParquetReaderTest extends BaseParquetReaderTest
     );
     List<InputRow> rows = readAllRows(reader);
 
-    Assert.assertEquals("2022-02-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals(1L, rows.get(0).getRaw("a1_b1_c1"));
-    Assert.assertEquals(2L, rows.get(0).getRaw("a1_b1_c2"));
-    Assert.assertEquals(1L, rows.get(0).getRaw("a2_0_b1"));
-    Assert.assertEquals(2L, rows.get(0).getRaw("a2_0_b2"));
-    Assert.assertEquals(1L, rows.get(0).getRaw("a2_1_b1"));
-    Assert.assertEquals(2L, rows.get(0).getRaw("a2_1_b2"));
+    Assertions.assertEquals("2022-02-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals(1L, rows.get(0).getRaw("a1_b1_c1"));
+    Assertions.assertEquals(2L, rows.get(0).getRaw("a1_b1_c2"));
+    Assertions.assertEquals(1L, rows.get(0).getRaw("a2_0_b1"));
+    Assertions.assertEquals(2L, rows.get(0).getRaw("a2_0_b2"));
+    Assertions.assertEquals(1L, rows.get(0).getRaw("a2_1_b1"));
+    Assertions.assertEquals(2L, rows.get(0).getRaw("a2_1_b2"));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
@@ -35,8 +35,8 @@ import org.apache.druid.segment.AutoTypeColumnSchema;
 import org.apache.druid.segment.transform.ExpressionTransform;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.transform.TransformingInputEntityReader;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -87,14 +87,14 @@ public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(transformingReader);
-    Assert.assertEquals(FlattenSpecParquetReaderTest.TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals(1L, rows.get(0).getRaw("t_nestedData_dim3"));
-    Assert.assertEquals("d2v1", rows.get(0).getRaw("t_nestedData_dim2"));
-    Assert.assertEquals(ImmutableList.of("listDim1v1", "listDim1v2"), rows.get(0).getRaw("t_nestedData_listDim"));
-    Assert.assertEquals(ImmutableList.of("listDim1v1", "listDim1v2"), rows.get(0).getDimension("t_nestedData_listDim_string"));
-    Assert.assertEquals("listDim1v1", rows.get(0).getRaw("t_nestedData_listDim_1"));
-    Assert.assertEquals("listDim1v2", rows.get(0).getRaw("t_nestedData_listDim_2"));
-    Assert.assertEquals(2L, rows.get(0).getRaw("t_nestedData_metric2"));
+    Assertions.assertEquals(FlattenSpecParquetReaderTest.TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals(1L, rows.get(0).getRaw("t_nestedData_dim3"));
+    Assertions.assertEquals("d2v1", rows.get(0).getRaw("t_nestedData_dim2"));
+    Assertions.assertEquals(ImmutableList.of("listDim1v1", "listDim1v2"), rows.get(0).getRaw("t_nestedData_listDim"));
+    Assertions.assertEquals(ImmutableList.of("listDim1v1", "listDim1v2"), rows.get(0).getDimension("t_nestedData_listDim_string"));
+    Assertions.assertEquals("listDim1v1", rows.get(0).getRaw("t_nestedData_listDim_1"));
+    Assertions.assertEquals("listDim1v2", rows.get(0).getRaw("t_nestedData_listDim_2"));
+    Assertions.assertEquals(2L, rows.get(0).getRaw("t_nestedData_metric2"));
   }
 
   @Test
@@ -141,26 +141,26 @@ public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
 
     List<InputRow> rows = readAllRows(transformingReader);
 
-    Assert.assertEquals("2022-02-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
-    Assert.assertEquals(
+    Assertions.assertEquals("2022-02-01T00:00:00.000Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableMap.of("b1", 1L, "b2", 2L), ImmutableMap.of("b1", 1L, "b2", 2L)
         ),
         rows.get(0).getRaw("a2")
     );
     // expression turns List into Object[]
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             ImmutableMap.of("b1", 1L, "b2", 2L), ImmutableMap.of("b1", 1L, "b2", 2L)
         },
         (Object[]) rows.get(0).getRaw("t_a2")
     );
-    Assert.assertEquals(ImmutableMap.of("c1", 1L, "c2", 2L), rows.get(0).getRaw("t_a1_b1"));
-    Assert.assertEquals(ImmutableMap.of("b1", 1L, "b2", 2L), rows.get(0).getRaw("t_a2_0"));
-    Assert.assertEquals(1L, rows.get(0).getRaw("t_a1_b1_c1"));
-    Assert.assertEquals(1L, rows.get(0).getRaw("t_a2_0_b1"));
-    Assert.assertEquals(1L, rows.get(0).getRaw("t_a2_1_b1"));
-    Assert.assertEquals(1L, rows.get(0).getRaw("tt_a2_0_b1"));
+    Assertions.assertEquals(ImmutableMap.of("c1", 1L, "c2", 2L), rows.get(0).getRaw("t_a1_b1"));
+    Assertions.assertEquals(ImmutableMap.of("b1", 1L, "b2", 2L), rows.get(0).getRaw("t_a2_0"));
+    Assertions.assertEquals(1L, rows.get(0).getRaw("t_a1_b1_c1"));
+    Assertions.assertEquals(1L, rows.get(0).getRaw("t_a2_0_b1"));
+    Assertions.assertEquals(1L, rows.get(0).getRaw("t_a2_1_b1"));
+    Assertions.assertEquals(1L, rows.get(0).getRaw("tt_a2_0_b1"));
   }
 
   @Test
@@ -181,15 +181,15 @@ public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(ImmutableList.of("dim1", "metric1"), rows.get(0).getDimensions());
-    Assert.assertEquals(FlattenSpecParquetReaderTest.TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals(ImmutableList.of("d1v1"), rows.get(0).getDimension("dim1"));
-    Assert.assertEquals("d1v1", rows.get(0).getRaw("dim1"));
-    Assert.assertEquals(ImmutableList.of("1"), rows.get(0).getDimension("metric1"));
-    Assert.assertEquals(1, rows.get(0).getRaw("metric1"));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1"));
+    Assertions.assertEquals(ImmutableList.of("dim1", "metric1"), rows.get(0).getDimensions());
+    Assertions.assertEquals(FlattenSpecParquetReaderTest.TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals(ImmutableList.of("d1v1"), rows.get(0).getDimension("dim1"));
+    Assertions.assertEquals("d1v1", rows.get(0).getRaw("dim1"));
+    Assertions.assertEquals(ImmutableList.of("1"), rows.get(0).getDimension("metric1"));
+    Assertions.assertEquals(1, rows.get(0).getRaw("metric1"));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1"));
     // can still read even if it doesn't get reported as a dimension
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             "listDim", ImmutableList.of("listDim1v1", "listDim1v2"),
             "dim3", 1,
@@ -218,14 +218,14 @@ public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(ImmutableList.of("nestedData", "dim1", "metric1"), rows.get(0).getDimensions());
-    Assert.assertEquals(FlattenSpecParquetReaderTest.TS1, rows.get(0).getTimestamp().toString());
-    Assert.assertEquals(ImmutableList.of("d1v1"), rows.get(0).getDimension("dim1"));
-    Assert.assertEquals("d1v1", rows.get(0).getRaw("dim1"));
-    Assert.assertEquals(ImmutableList.of("1"), rows.get(0).getDimension("metric1"));
-    Assert.assertEquals(1, rows.get(0).getRaw("metric1"));
-    Assert.assertEquals(1, rows.get(0).getMetric("metric1"));
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableList.of("nestedData", "dim1", "metric1"), rows.get(0).getDimensions());
+    Assertions.assertEquals(FlattenSpecParquetReaderTest.TS1, rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals(ImmutableList.of("d1v1"), rows.get(0).getDimension("dim1"));
+    Assertions.assertEquals("d1v1", rows.get(0).getRaw("dim1"));
+    Assertions.assertEquals(ImmutableList.of("1"), rows.get(0).getDimension("metric1"));
+    Assertions.assertEquals(1, rows.get(0).getRaw("metric1"));
+    Assertions.assertEquals(1, rows.get(0).getMetric("metric1"));
+    Assertions.assertEquals(
         ImmutableMap.of(
             "listDim", ImmutableList.of("listDim1v1", "listDim1v2"),
             "dim3", 1,

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetInputFormatTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetInputFormatTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.data.input.parquet;
 
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ParquetInputFormatTest
 {
@@ -31,7 +31,7 @@ public class ParquetInputFormatTest
   {
     final ParquetInputFormat format = new ParquetInputFormat(JSONPathSpec.DEFAULT, false, new Configuration());
     long unweightedSize = 100L;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         unweightedSize * ParquetInputFormat.SCALE_FACTOR,
         format.getWeightedSize("file.parquet", unweightedSize)
     );

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
@@ -32,10 +32,9 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,8 +42,8 @@ import java.util.Objects;
 
 public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void testFetchOnReadCleanupAfterExhaustingIterator() throws IOException
@@ -58,16 +57,16 @@ public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
     );
     FetchingFileEntity entity = new FetchingFileEntity(new File("example/wiki/wiki.parquet"));
     ParquetInputFormat parquet = new ParquetInputFormat(JSONPathSpec.DEFAULT, false, new Configuration());
-    File tempDir = temporaryFolder.newFolder();
+    File tempDir = newFolder(temporaryFolder, "junit");
     InputEntityReader reader = parquet.createReader(schema, entity, tempDir);
-    Assert.assertEquals(0, Objects.requireNonNull(tempDir.list()).length);
+    Assertions.assertEquals(0, Objects.requireNonNull(tempDir.list()).length);
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(Objects.requireNonNull(tempDir.list()).length > 0);
+      Assertions.assertTrue(Objects.requireNonNull(tempDir.list()).length > 0);
       while (iterator.hasNext()) {
         iterator.next();
       }
     }
-    Assert.assertEquals(0, Objects.requireNonNull(tempDir.list()).length);
+    Assertions.assertEquals(0, Objects.requireNonNull(tempDir.list()).length);
   }
 
   private static class FetchingFileEntity extends FileEntity
@@ -113,5 +112,23 @@ public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
         throw new RuntimeException(e);
       }
     }
+
+    private static File newFolder(File root, String... subDirs) throws IOException {
+      String subFolder = String.join("/", subDirs);
+      File result = new File(root, subFolder);
+      if (!result.mkdirs()) {
+        throw new IOException("Couldn't create folders " + root);
+      }
+      return result;
+    }
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
@@ -113,20 +113,10 @@ public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
       }
     }
 
-    private static File newFolder(File root, String... subDirs) throws IOException
-    {
-      String subFolder = String.join("/", subDirs);
-      File result = new File(root, subFolder);
-      FileUtils.mkdirp(result);
-      return result;
-    }
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
@@ -113,7 +113,8 @@ public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
       }
     }
 
-    private static File newFolder(File root, String... subDirs) throws IOException {
+    private static File newFolder(File root, String... subDirs) throws IOException
+    {
       String subFolder = String.join("/", subDirs);
       File result = new File(root, subFolder);
       FileUtils.mkdirp(result);
@@ -121,7 +122,8 @@ public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
     }
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetReaderResourceLeakTest.java
@@ -116,9 +116,7 @@ public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
     private static File newFolder(File root, String... subDirs) throws IOException {
       String subFolder = String.join("/", subDirs);
       File result = new File(root, subFolder);
-      if (!result.mkdirs()) {
-        throw new IOException("Couldn't create folders " + root);
-      }
+      FileUtils.mkdirp(result);
       return result;
     }
   }
@@ -126,9 +124,7 @@ public class ParquetReaderResourceLeakTest extends BaseParquetReaderTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
@@ -22,30 +22,30 @@ package org.apache.druid.data.input.parquet;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("ALL")
 public class ParquetToJsonTest
 {
-  @ClassRule
-  public static TemporaryFolder tmp = new TemporaryFolder();
+  @TempDir
+  public static File tmp;
 
   @Test
   public void testSanity() throws Exception
   {
-    final File tmpDir = tmp.newFolder();
+    final File tmpDir = newFolder(tmp, "junit");
     try (InputStream in = new BufferedInputStream(ClassLoader.getSystemResourceAsStream("smlTbl.parquet"))) {
       Files.copy(in, tmpDir.toPath().resolve("smlTbl.parquet"));
     }
@@ -55,8 +55,8 @@ public class ParquetToJsonTest
     DefaultObjectMapper mapper = DefaultObjectMapper.INSTANCE;
     List<Object> objs = mapper.readerFor(Object.class).readValues(new File(tmpDir, "smlTbl.parquet.json")).readAll();
 
-    Assert.assertEquals(56, objs.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(56, objs.size());
+    Assertions.assertEquals(
         ImmutableMap
             .builder()
             .put("col_int", 8122)
@@ -76,7 +76,7 @@ public class ParquetToJsonTest
   @Test
   public void testConvertedDates() throws Exception
   {
-    final File tmpDir = tmp.newFolder();
+    final File tmpDir = newFolder(tmp, "junit");
     try (InputStream in = new BufferedInputStream(ClassLoader.getSystemResourceAsStream("smlTbl.parquet"))) {
       Files.copy(in, tmpDir.toPath().resolve("smlTbl.parquet"));
     }
@@ -86,8 +86,8 @@ public class ParquetToJsonTest
     DefaultObjectMapper mapper = DefaultObjectMapper.INSTANCE;
     List<Object> objs = mapper.readerFor(Object.class).readValues(new File(tmpDir, "smlTbl.parquet.json")).readAll();
 
-    Assert.assertEquals(56, objs.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(56, objs.size());
+    Assertions.assertEquals(
         ImmutableMap
             .builder()
             .put("col_int", 8122)
@@ -108,30 +108,34 @@ public class ParquetToJsonTest
   @Test
   public void testInputValidation()
   {
-    Assert.assertThrows(IAE.class, () -> ParquetToJson.main(new String[]{}));
-    Assert.assertThrows(IAE.class, () -> ParquetToJson.main(new String[]{"a", "b"}));
+    Assertions.assertThrows(IAE.class, () -> ParquetToJson.main(new String[]{}));
+    Assertions.assertThrows(IAE.class, () -> ParquetToJson.main(new String[]{"a", "b"}));
   }
 
   @Test
   public void testEmptyDir() throws Exception
   {
-    final File tmpDir = tmp.newFolder();
-    Assert.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {tmpDir.getAbsolutePath()}));
+    final File tmpDir = newFolder(tmp, "junit");
+    Assertions.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {tmpDir.getAbsolutePath()}));
   }
 
   @Test
   public void testSomeFile() throws Exception
   {
-    final File file = tmp.newFile();
+    final File file = File.createTempFile("junit", null, tmp);
     assertTrue(file.exists());
-    Assert.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {file.getAbsolutePath()}));
+    Assertions.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {file.getAbsolutePath()}));
   }
 
   @Test
   public void testNonExistentFile() throws Exception
   {
-    final File file = new File(tmp.getRoot(), "nonExistent");
+    final File file = new File(tmp, "nonExistent");
     assertFalse(file.exists());
-    Assert.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {file.getAbsolutePath()}));
+    Assertions.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {file.getAbsolutePath()}));
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    return Files.createTempDirectory(root.toPath(), String.join("-", subDirs)).toFile();
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
@@ -136,7 +136,8 @@ public class ParquetToJsonTest
     Assertions.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {file.getAbsolutePath()}));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.List;
@@ -136,7 +135,7 @@ public class ParquetToJsonTest
     Assertions.assertThrows(IAE.class, () -> ParquetToJson.main(new String[] {file.getAbsolutePath()}));
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
     return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/ParquetToJsonTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input.parquet;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -136,6 +137,6 @@ public class ParquetToJsonTest
   }
 
   private static File newFolder(File root, String... subDirs) throws IOException {
-    return Files.createTempDirectory(root.toPath(), String.join("-", subDirs)).toFile();
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/TimestampsParquetReaderTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -63,10 +63,10 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
 
     List<InputRow> rowsWithString = readAllRows(readerAsString);
     List<InputRow> rowsWithDate = readAllRows(readerAsDate);
-    Assert.assertEquals(rowsWithDate.size(), rowsWithString.size());
+    Assertions.assertEquals(rowsWithDate.size(), rowsWithString.size());
 
     for (int i = 0; i < rowsWithDate.size(); i++) {
-      Assert.assertEquals(rowsWithString.get(i).getTimestamp(), rowsWithDate.get(i).getTimestamp());
+      Assertions.assertEquals(rowsWithString.get(i).getTimestamp(), rowsWithDate.get(i).getTimestamp());
     }
 
     readerAsString = createReader(
@@ -88,8 +88,8 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
                                       + "  \"idx\" : 1,\n"
                                       + "  \"date_as_date\" : 1497744000000\n"
                                       + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsString.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampledAsDate.get(0).getRawValues()));
   }
 
   @Test
@@ -106,7 +106,7 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
     InputEntityReader reader = createReader(file, schema, JSONPathSpec.DEFAULT);
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("2001-01-01T01:01:01.000Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("2001-01-01T01:01:01.000Z", rows.get(0).getTimestamp().toString());
 
     reader = createReader(
         file,
@@ -117,7 +117,7 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"ts\" : 978310861000\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -136,7 +136,7 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("1970-01-01T00:00:00.010Z", rows.get(0).getTimestamp().toString());
+    Assertions.assertEquals("1970-01-01T00:00:00.010Z", rows.get(0).getTimestamp().toString());
 
     reader = createReader(
         file,
@@ -147,6 +147,6 @@ public class TimestampsParquetReaderTest extends BaseParquetReaderTest
     final String expectedJson = "{\n"
                                 + "  \"time\" : 10\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,11 +47,11 @@ public class WikiParquetReaderTest extends BaseParquetReaderTest
     InputEntityReader reader = createReader("example/wiki/wiki.parquet", schema, JSONPathSpec.DEFAULT);
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals("Gypsy Danger", rows.get(0).getDimension("page").get(0));
+    Assertions.assertEquals("Gypsy Danger", rows.get(0).getDimension("page").get(0));
     String s1 = rows.get(0).getDimension("language").get(0);
     String s2 = rows.get(0).getDimension("language").get(1);
-    Assert.assertEquals("en", s1);
-    Assert.assertEquals("zh", s2);
+    Assertions.assertEquals("en", s1);
+    Assertions.assertEquals("zh", s2);
 
     reader = createReader("example/wiki/wiki.parquet", schema, JSONPathSpec.DEFAULT);
     List<InputRowListPlusRawValues> sampled = sampleAllRows(reader);
@@ -74,7 +74,7 @@ public class WikiParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"user\" : \"nuclear\",\n"
                                 + "  \"timestamp\" : \"2013-08-31T01:02:33Z\"\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 
   @Test
@@ -93,6 +93,6 @@ public class WikiParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"foo\" : \"baz\",\n"
                                 + "  \"time\" : 1678853101621\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    Assertions.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
   }
 }


### PR DESCRIPTION
Part of #13948.

Builds on [PR #19875](https://github.com/apache/druid/pull/19875).

### Description

This PR migrates the JUnit 4 tests in the second extension-core batch to JUnit 5:

- avro-extensions
- parquet-extensions
- hdfs-storage
- lookups-cached-single
- kinesis-indexing-service

The tests now use Jupiter assertions, lifecycle annotations, parameterized tests, nested tests, and temporary-directory support. Transitional JUnit 4 test dependencies remain only where migrated tests inherit shared JUnit 4 fixtures from indexing-service or use the shared TestDerbyConnector utility; those dependencies can be removed after the shared fixtures are migrated.

### Validation

Ran the complete changed-test set for all five modules with Maven. The reactor completed successfully with no failures, errors, or flakes.

### Related migration PR

- Previous batch: #19875
