### PR TITLE
test: migrate extension-core google kafka and lookup tests to JUnit 5

### DIFF
--- a/extensions-core/google-extensions/pom.xml
+++ b/extensions-core/google-extensions/pom.xml
@@ -133,8 +133,23 @@
             <type>test-jar</type>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/data/input/google/GoogleCloudStorageInputSourceFactoryTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/data/input/google/GoogleCloudStorageInputSourceFactoryTest.java
@@ -28,13 +28,15 @@ import org.apache.druid.storage.google.GoogleInputDataConfig;
 import org.apache.druid.storage.google.GoogleStorage;
 import org.apache.druid.storage.google.GoogleStorageDruidModule;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GoogleCloudStorageInputSourceFactoryTest
 {
@@ -66,7 +68,7 @@ public class GoogleCloudStorageInputSourceFactoryTest
     );
 
     final SplittableInputSource inputSource = factory.create(paths);
-    Assert.assertTrue(inputSource instanceof GoogleCloudStorageInputSource);
+    Assertions.assertTrue(inputSource instanceof GoogleCloudStorageInputSource);
   }
 
   @Test
@@ -83,11 +85,11 @@ public class GoogleCloudStorageInputSourceFactoryTest
     );
 
     final GoogleCloudStorageInputSource inputSource = (GoogleCloudStorageInputSource) factory.create(paths);
-    Assert.assertNotNull(inputSource.getUris());
-    Assert.assertEquals(3, inputSource.getUris().size());
-    Assert.assertEquals(URI.create("gs://foo/bar/file.csv"), inputSource.getUris().get(0));
-    Assert.assertEquals(URI.create("gs://bar/foo/file2.csv"), inputSource.getUris().get(1));
-    Assert.assertEquals(URI.create("gs://baz/qux/file3.txt"), inputSource.getUris().get(2));
+    Assertions.assertNotNull(inputSource.getUris());
+    Assertions.assertEquals(3, inputSource.getUris().size());
+    Assertions.assertEquals(URI.create("gs://foo/bar/file.csv"), inputSource.getUris().get(0));
+    Assertions.assertEquals(URI.create("gs://bar/foo/file2.csv"), inputSource.getUris().get(1));
+    Assertions.assertEquals(URI.create("gs://baz/qux/file3.txt"), inputSource.getUris().get(2));
   }
 
   @Test
@@ -101,19 +103,21 @@ public class GoogleCloudStorageInputSourceFactoryTest
 
     final GoogleCloudStorageInputSource inputSource = (GoogleCloudStorageInputSource) factory.create(paths);
     final URI uri = inputSource.getUris().get(0);
-    Assert.assertEquals("gs", uri.getScheme());
-    Assert.assertEquals("bucket", uri.getHost());
-    Assert.assertEquals("/path/to/file.csv", uri.getPath());
+    Assertions.assertEquals("gs", uri.getScheme());
+    Assertions.assertEquals("bucket", uri.getHost());
+    Assertions.assertEquals("/path/to/file.csv", uri.getPath());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testCreateWithEmptyListThrows()
   {
-    final GoogleCloudStorageInputSourceFactory factory = new GoogleCloudStorageInputSourceFactory(
-        STORAGE,
-        INPUT_DATA_CONFIG
-    );
-    factory.create(Collections.emptyList());
+    assertThrows(IllegalArgumentException.class, () -> {
+      final GoogleCloudStorageInputSourceFactory factory = new GoogleCloudStorageInputSourceFactory(
+          STORAGE,
+          INPUT_DATA_CONFIG
+      );
+      factory.create(Collections.emptyList());
+    });
   }
 
   @Test
@@ -127,7 +131,7 @@ public class GoogleCloudStorageInputSourceFactoryTest
 
     final GoogleCloudStorageInputSource inputSource = (GoogleCloudStorageInputSource) factory.create(paths);
     final URI uri = inputSource.getUris().get(0);
-    Assert.assertEquals("gs://bucket/path%20with%20spaces/file.csv", uri.toString());
+    Assertions.assertEquals("gs://bucket/path%20with%20spaces/file.csv", uri.toString());
   }
 
   @Test
@@ -137,7 +141,7 @@ public class GoogleCloudStorageInputSourceFactoryTest
 
     final String json = "{\"type\": \"google\"}";
     final InputSourceFactory factory = mapper.readValue(json, InputSourceFactory.class);
-    Assert.assertTrue(factory instanceof GoogleCloudStorageInputSourceFactory);
+    Assertions.assertTrue(factory instanceof GoogleCloudStorageInputSourceFactory);
   }
 
   @Test
@@ -151,12 +155,12 @@ public class GoogleCloudStorageInputSourceFactoryTest
     );
 
     final String json = mapper.writeValueAsString(original);
-    Assert.assertTrue(json.contains("\"type\":\"google\""));
+    Assertions.assertTrue(json.contains("\"type\":\"google\""));
 
     final GoogleCloudStorageInputSourceFactory deserialized = mapper.readValue(
         json,
         GoogleCloudStorageInputSourceFactory.class
     );
-    Assert.assertNotNull(deserialized);
+    Assertions.assertNotNull(deserialized);
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/data/input/google/GoogleCloudStorageInputSourceTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/data/input/google/GoogleCloudStorageInputSourceTest.java
@@ -59,10 +59,8 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.utils.CompressionUtils;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -75,6 +73,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTest
 {
@@ -116,9 +116,6 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
   private static final String OBJECT_NAME = "TEST_NAME";
   private static final Long UPDATE_TIME = 111L;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testSerde() throws Exception
   {
@@ -135,7 +132,7 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         );
     final GoogleCloudStorageInputSource serdeWithUris =
         mapper.readValue(mapper.writeValueAsString(withUris), GoogleCloudStorageInputSource.class);
-    Assert.assertEquals(withUris, serdeWithUris);
+    Assertions.assertEquals(withUris, serdeWithUris);
   }
 
   @Test
@@ -146,7 +143,7 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         new GoogleCloudStorageInputSource(STORAGE, INPUT_DATA_CONFIG, ImmutableList.of(), PREFIXES, null, null, null);
     final GoogleCloudStorageInputSource serdeWithPrefixes =
         mapper.readValue(mapper.writeValueAsString(withPrefixes), GoogleCloudStorageInputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
   }
 
   @Test
@@ -165,8 +162,8 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         );
     final GoogleCloudStorageInputSource serdeWithObjects =
         mapper.readValue(mapper.writeValueAsString(withObjects), GoogleCloudStorageInputSource.class);
-    Assert.assertEquals(withObjects, serdeWithObjects);
-    Assert.assertEquals(Collections.emptySet(), serdeWithObjects.getConfiguredSystemFields());
+    Assertions.assertEquals(withObjects, serdeWithObjects);
+    Assertions.assertEquals(Collections.emptySet(), serdeWithObjects.getConfiguredSystemFields());
   }
 
   @Test
@@ -185,8 +182,8 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         );
     final GoogleCloudStorageInputSource serdeWithObjects =
         mapper.readValue(mapper.writeValueAsString(withObjects), GoogleCloudStorageInputSource.class);
-    Assert.assertEquals(withObjects, serdeWithObjects);
-    Assert.assertEquals(
+    Assertions.assertEquals(withObjects, serdeWithObjects);
+    Assertions.assertEquals(
         EnumSet.of(SystemField.URI, SystemField.BUCKET, SystemField.PATH),
         serdeWithObjects.getConfiguredSystemFields()
     );
@@ -205,7 +202,7 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
             null,
             null
         );
-    Assert.assertEquals(Collections.singleton(GoogleCloudStorageInputSource.TYPE_KEY), inputSource.getTypes());
+    Assertions.assertEquals(Collections.singleton(GoogleCloudStorageInputSource.TYPE_KEY), inputSource.getTypes());
   }
 
   @Test
@@ -250,7 +247,7 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         null,
         new MaxSizeSplitHintSpec(10, null)
     );
-    Assert.assertEquals(EXPECTED_OBJECTS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_OBJECTS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(STORAGE);
   }
 
@@ -292,40 +289,42 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         null,
         new MaxSizeSplitHintSpec(10, null)
     );
-    Assert.assertEquals(EXPECTED_OBJECTS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_OBJECTS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(STORAGE);
   }
 
   @Test
   public void testIllegalObjectsAndPrefixes()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new GoogleCloudStorageInputSource(
-        STORAGE,
-        INPUT_DATA_CONFIG,
-        null,
-        PREFIXES,
-        EXPECTED_OBJECTS.get(0),
-        "**.csv",
-        null
-    );
+    assertThrows(IllegalArgumentException.class, () -> {
+      // constructor will explode
+      new GoogleCloudStorageInputSource(
+          STORAGE,
+          INPUT_DATA_CONFIG,
+          null,
+          PREFIXES,
+          EXPECTED_OBJECTS.get(0),
+          "**.csv",
+          null
+      );
+    });
   }
 
   @Test
   public void testIllegalUrisAndPrefixes()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new GoogleCloudStorageInputSource(
-        STORAGE,
-        INPUT_DATA_CONFIG,
-        URIS_BEFORE_GLOB,
-        PREFIXES,
-        null,
-        "**.csv",
-        null
-    );
+    assertThrows(IllegalArgumentException.class, () -> {
+      // constructor will explode
+      new GoogleCloudStorageInputSource(
+          STORAGE,
+          INPUT_DATA_CONFIG,
+          URIS_BEFORE_GLOB,
+          PREFIXES,
+          null,
+          "**.csv",
+          null
+      );
+    });
   }
 
   @Test
@@ -347,7 +346,7 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         new MaxSizeSplitHintSpec(null, 1)
     );
 
-    Assert.assertEquals(EXPECTED_OBJECTS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_OBJECTS, splits.map(InputSplit::get).collect(Collectors.toList()));
   }
 
   @Test
@@ -369,7 +368,7 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         new MaxSizeSplitHintSpec(new HumanReadableBytes(CONTENT.length * 3L), null)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(EXPECTED_URIS.stream().map(CloudObjectLocation::new).collect(Collectors.toList())),
         splits.map(InputSplit::get).collect(Collectors.toList())
     );
@@ -415,11 +414,11 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
 
     while (iterator.hasNext()) {
       InputRow nextRow = iterator.next();
-      Assert.assertEquals(NOW, nextRow.getTimestamp());
-      Assert.assertEquals("hello", nextRow.getDimension("dim1").get(0));
-      Assert.assertEquals("world", nextRow.getDimension("dim2").get(0));
+      Assertions.assertEquals(NOW, nextRow.getTimestamp());
+      Assertions.assertEquals("hello", nextRow.getDimension("dim1").get(0));
+      Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
-    Assert.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
+    Assertions.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -462,11 +461,11 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
 
     while (iterator.hasNext()) {
       InputRow nextRow = iterator.next();
-      Assert.assertEquals(NOW, nextRow.getTimestamp());
-      Assert.assertEquals("hello", nextRow.getDimension("dim1").get(0));
-      Assert.assertEquals("world", nextRow.getDimension("dim2").get(0));
+      Assertions.assertEquals(NOW, nextRow.getTimestamp());
+      Assertions.assertEquals("hello", nextRow.getDimension("dim1").get(0));
+      Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
-    Assert.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
+    Assertions.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -482,16 +481,16 @@ public class GoogleCloudStorageInputSourceTest extends InitializedNullHandlingTe
         new SystemFields(EnumSet.of(SystemField.URI, SystemField.BUCKET, SystemField.PATH))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         EnumSet.of(SystemField.URI, SystemField.BUCKET, SystemField.PATH),
         inputSource.getConfiguredSystemFields()
     );
 
     final GoogleCloudStorageEntity entity = new GoogleCloudStorageEntity(null, new CloudObjectLocation("foo", "bar"));
 
-    Assert.assertEquals("gs://foo/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
-    Assert.assertEquals("foo", inputSource.getSystemFieldValue(entity, SystemField.BUCKET));
-    Assert.assertEquals("bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
+    Assertions.assertEquals("gs://foo/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
+    Assertions.assertEquals("foo", inputSource.getSystemFieldValue(entity, SystemField.BUCKET));
+    Assertions.assertEquals("bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
   }
 
   @Test

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleByteSourceTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleByteSourceTest.java
@@ -21,10 +21,12 @@ package org.apache.druid.storage.google;
 
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GoogleByteSourceTest extends EasyMockSupport
 {
@@ -47,21 +49,23 @@ public class GoogleByteSourceTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test(expected = IOException.class)
-  public void openStreamWithRecoverableErrorTest() throws IOException
+  @Test
+  public void openStreamWithRecoverableErrorTest()
   {
-    final String bucket = "bucket";
-    final String path = "/path/to/file";
-    GoogleStorage storage = createMock(GoogleStorage.class);
+    assertThrows(IOException.class, () -> {
+      final String bucket = "bucket";
+      final String path = "/path/to/file";
+      GoogleStorage storage = createMock(GoogleStorage.class);
 
-    EasyMock.expect(storage.getInputStream(bucket, path)).andThrow(new IOException(""));
+      EasyMock.expect(storage.getInputStream(bucket, path)).andThrow(new IOException(""));
 
-    replayAll();
+      replayAll();
 
-    GoogleByteSource byteSource = new GoogleByteSource(storage, bucket, path);
+      GoogleByteSource byteSource = new GoogleByteSource(storage, bucket, path);
 
-    byteSource.openStream();
+      byteSource.openStream();
 
-    verifyAll();
+      verifyAll();
+    });
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentKillerTest.java
@@ -31,9 +31,9 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URI;
@@ -70,7 +70,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   private GoogleAccountConfig accountConfig;
   private GoogleInputDataConfig inputDataConfig;
 
-  @Before
+  @BeforeEach
   public void before()
   {
     accountConfig = createMock(GoogleAccountConfig.class);
@@ -98,7 +98,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
   @Test
   public void killWithErrorTest()
   {
-    Assert.assertThrows(SegmentLoadingException.class, () -> {
+    Assertions.assertThrows(SegmentLoadingException.class, () -> {
       storage.delete(EasyMock.eq(BUCKET), EasyMock.eq(INDEX_PATH));
       EasyMock.expectLastCall().andThrow(NON_RECOVERABLE_EXCEPTION);
 
@@ -138,7 +138,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
     GoogleDataSegmentKiller killer = new GoogleDataSegmentKiller(storage, accountConfig, inputDataConfig);
     EasyMock.replay(storage, inputDataConfig, accountConfig);
 
-    Assert.assertThrows(ISE.class, killer::killAll);
+    Assertions.assertThrows(ISE.class, killer::killAll);
 
     EasyMock.verify(accountConfig, inputDataConfig, storage);
   }
@@ -216,7 +216,7 @@ public class GoogleDataSegmentKillerTest extends EasyMockSupport
 
     GoogleDataSegmentKiller killer = new GoogleDataSegmentKiller(storage, accountConfig, inputDataConfig);
 
-    Assert.assertThrows(IOException.class, killer::killAll);
+    Assertions.assertThrows(IOException.class, killer::killAll);
 
     EasyMock.verify(accountConfig, inputDataConfig, storage);
   }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentPullerTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentPullerTest.java
@@ -27,45 +27,48 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class GoogleDataSegmentPullerTest extends EasyMockSupport
 {
   private static final String BUCKET = "bucket";
   private static final String PATH = "/path/to/storage/index.zip";
 
-  @Test(expected = SegmentLoadingException.class)
+  @Test
   public void testDeleteOutputDirectoryWhenErrorIsRaisedPullingSegmentFiles()
-      throws IOException, SegmentLoadingException
   {
-    final File outDir = FileUtils.createTempDir();
-    try {
-      GoogleStorage storage = createMock(GoogleStorage.class);
-      final GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting.newMock(
-          JacksonFactory.getDefaultInstance(),
-          300,
-          "test"
-      );
-      EasyMock.expect(storage.getInputStream(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(exception);
+    assertThrows(SegmentLoadingException.class, () -> {
+      final File outDir = FileUtils.createTempDir();
+      try {
+        GoogleStorage storage = createMock(GoogleStorage.class);
+        final GoogleJsonResponseException exception = GoogleJsonResponseExceptionFactoryTesting.newMock(
+            JacksonFactory.getDefaultInstance(),
+            300,
+            "test"
+        );
+        EasyMock.expect(storage.getInputStream(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(exception);
 
-      replayAll();
+        replayAll();
 
-      GoogleDataSegmentPuller puller = new GoogleDataSegmentPuller(storage);
-      puller.getSegmentFiles(BUCKET, PATH, outDir);
+        GoogleDataSegmentPuller puller = new GoogleDataSegmentPuller(storage);
+        puller.getSegmentFiles(BUCKET, PATH, outDir);
 
-      Assert.assertFalse(outDir.exists());
+        Assertions.assertFalse(outDir.exists());
 
-      verifyAll();
-    }
-    finally {
-      FileUtils.deleteDirectory(outDir);
-    }
+        verifyAll();
+      }
+      finally {
+        FileUtils.deleteDirectory(outDir);
+      }
+    });
   }
 
   @Test
@@ -82,7 +85,7 @@ public class GoogleDataSegmentPullerTest extends EasyMockSupport
     GoogleDataSegmentPuller puller = new GoogleDataSegmentPuller(storage);
 
     String actual = puller.getVersion(URI.create(StringUtils.format("gs://%s/%s", bucket, prefix)));
-    Assert.assertEquals(version, actual);
+    Assertions.assertEquals(version, actual);
     EasyMock.verify(storage);
   }
 

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentPusherTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleDataSegmentPusherTest.java
@@ -26,11 +26,10 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -38,8 +37,8 @@ import java.util.HashMap;
 
 public class GoogleDataSegmentPusherTest extends EasyMockSupport
 {
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   private static final String BUCKET = "bucket";
   private static final String PREFIX = "prefix";
@@ -47,7 +46,7 @@ public class GoogleDataSegmentPusherTest extends EasyMockSupport
   private GoogleStorage storage;
   private GoogleAccountConfig googleAccountConfig;
 
-  @Before
+  @BeforeEach
   public void before()
   {
     storage = createMock(GoogleStorage.class);
@@ -60,7 +59,7 @@ public class GoogleDataSegmentPusherTest extends EasyMockSupport
   public void testPush() throws Exception
   {
     // Create a mock segment on disk
-    File tmp = tempFolder.newFile("version.bin");
+    File tmp = new File(tempFolder, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
     Files.write(data, tmp);
@@ -95,11 +94,11 @@ public class GoogleDataSegmentPusherTest extends EasyMockSupport
 
     replayAll();
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, false);
+    DataSegment segment = pusher.push(tempFolder, segmentToPush, false);
 
-    Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
-    Assert.assertEquals(segmentToPush, segment);
-    Assert.assertEquals(ImmutableMap.of(
+    Assertions.assertEquals(segmentToPush.getSize(), segment.getSize());
+    Assertions.assertEquals(segmentToPush, segment);
+    Assertions.assertEquals(ImmutableMap.of(
         "type", GoogleStorageDruidModule.SCHEME,
         "bucket", BUCKET,
         "path", indexPath
@@ -116,9 +115,9 @@ public class GoogleDataSegmentPusherTest extends EasyMockSupport
     sb.setLength(0);
     config.setPrefix(sb.toString()); // avoid cached empty string
     GoogleDataSegmentPusher pusher = new GoogleDataSegmentPusher(storage, config);
-    Assert.assertEquals("/path", pusher.buildPath("/path"));
+    Assertions.assertEquals("/path", pusher.buildPath("/path"));
     config.setPrefix(null);
-    Assert.assertEquals("/path", pusher.buildPath("/path"));
+    Assertions.assertEquals("/path", pusher.buildPath("/path"));
   }
 
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageDruidModuleTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageDruidModuleTest.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Injector;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.segment.loading.OmniDataSegmentKiller;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class GoogleStorageDruidModuleTest
 {
@@ -39,14 +39,14 @@ public class GoogleStorageDruidModuleTest
     // 2. That the same object is returned.
     Injector injector = GuiceInjectors.makeStartupInjectorWithModules(ImmutableList.of(new GoogleStorageDruidModule()));
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
-    Assert.assertTrue(killer.getKillers().containsKey(GoogleStorageDruidModule.SCHEME));
-    Assert.assertSame(
+    Assertions.assertTrue(killer.getKillers().containsKey(GoogleStorageDruidModule.SCHEME));
+    Assertions.assertSame(
         killer.getKillers().get(GoogleStorageDruidModule.SCHEME).get(),
         killer.getKillers().get(GoogleStorageDruidModule.SCHEME).get()
     );
 
     final Storage storage = injector.getInstance(Storage.class);
-    Assert.assertSame(storage, injector.getInstance(Storage.class));
+    Assertions.assertSame(storage, injector.getInstance(Storage.class));
   }
 
   @Test
@@ -59,6 +59,6 @@ public class GoogleStorageDruidModuleTest
     // 2. That the same object is returned.
     Injector injector = GuiceInjectors.makeStartupInjectorWithModules(ImmutableList.of(new GoogleStorageDruidModule()));
     final GoogleStorage instance = injector.getInstance(GoogleStorage.class);
-    Assert.assertSame(instance, injector.getInstance(GoogleStorage.class));
+    Assertions.assertSame(instance, injector.getInstance(GoogleStorage.class));
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleStorageTest.java
@@ -29,9 +29,9 @@ import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -41,9 +41,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GoogleStorageTest
 {
@@ -59,7 +59,7 @@ public class GoogleStorageTest
   private static final Exception STORAGE_EXCEPTION = new StorageException(404, "Runtime Storage Exception");
 
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mockStorage = EasyMock.mock(Storage.class);
@@ -130,7 +130,7 @@ public class GoogleStorageTest
   {
     EasyMock.expect(mockStorage.delete(EasyMock.eq(BUCKET), EasyMock.eq(PATH))).andThrow(STORAGE_EXCEPTION);
     EasyMock.replay(mockStorage);
-    Assert.assertThrows(StorageException.class, () -> googleStorage.delete(BUCKET, PATH));
+    Assertions.assertThrows(StorageException.class, () -> googleStorage.delete(BUCKET, PATH));
     EasyMock.verify(mockStorage);
   }
 
@@ -184,7 +184,7 @@ public class GoogleStorageTest
     EasyMock.expect(mockStorage.delete((Iterable<BlobId>) EasyMock.anyObject()))
             .andThrow(STORAGE_EXCEPTION);
     EasyMock.replay(mockStorage);
-    Assert.assertThrows(StorageException.class, () -> googleStorage.batchDelete(BUCKET, paths));
+    Assertions.assertThrows(StorageException.class, () -> googleStorage.batchDelete(BUCKET, paths));
     EasyMock.verify(mockStorage);
   }
 

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTaskLogsTest.java
@@ -30,9 +30,9 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -66,7 +66,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
   private GoogleInputDataConfig inputDataConfig;
   private CurrentTimeMillisSupplier timeSupplier;
 
-  @Before
+  @BeforeEach
   public void before()
   {
     storage = createMock(GoogleStorage.class);
@@ -153,7 +153,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
 
     final StringWriter writer = new StringWriter();
     IOUtils.copy(stream.get(), writer, "UTF-8");
-    Assert.assertEquals(writer.toString(), testLog);
+    Assertions.assertEquals(writer.toString(), testLog);
 
     verifyAll();
   }
@@ -176,7 +176,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
 
     final StringWriter writer = new StringWriter();
     IOUtils.copy(stream.get(), writer, "UTF-8");
-    Assert.assertEquals(writer.toString(), expectedLog);
+    Assertions.assertEquals(writer.toString(), expectedLog);
 
     verifyAll();
   }
@@ -200,7 +200,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
 
     final StringWriter writer = new StringWriter();
     IOUtils.copy(stream.get(), writer, "UTF-8");
-    Assert.assertEquals(writer.toString(), expectedLog);
+    Assertions.assertEquals(writer.toString(), expectedLog);
 
     verifyAll();
   }
@@ -221,7 +221,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
 
     final StringWriter writer = new StringWriter();
     IOUtils.copy(stream.get(), writer, "UTF-8");
-    Assert.assertEquals(writer.toString(), taskStatus);
+    Assertions.assertEquals(writer.toString(), taskStatus);
 
     verifyAll();
   }
@@ -301,7 +301,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
 
     EasyMock.verify(inputDataConfig, storage, timeSupplier);
   }
@@ -374,7 +374,7 @@ public class GoogleTaskLogsTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
 
     EasyMock.verify(inputDataConfig, storage);
   }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTimestampVersionedDataFinderTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleTimestampVersionedDataFinderTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.storage.google;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.regex.Pattern;
@@ -50,7 +50,7 @@ public class GoogleTimestampVersionedDataFinderTest
     Pattern pattern = Pattern.compile("v.*");
     URI latest = finder.getLatestVersion(URI.create(StringUtils.format("gs://%s/%s", bucket, keyPrefix)), pattern);
     URI expected = URI.create(StringUtils.format("gs://%s/%s", bucket, storageObject3.getName()));
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 
   @Test
@@ -74,6 +74,6 @@ public class GoogleTimestampVersionedDataFinderTest
     Pattern pattern = Pattern.compile("v.*");
     URI latest = finder.getLatestVersion(URI.create(StringUtils.format("gs://%s/%s", bucket, keyPrefix)), pattern);
     URI expected = URI.create(StringUtils.format("gs://%s/%s", bucket, storageObject3.getName()));
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/GoogleUtilsTest.java
@@ -23,8 +23,8 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import com.google.cloud.storage.StorageException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -33,7 +33,7 @@ public class GoogleUtilsTest
   @Test
   public void test429()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(429, "ignored", new HttpHeaders()),
@@ -41,27 +41,27 @@ public class GoogleUtilsTest
             )
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new HttpResponseException.Builder(429, "ignored", new HttpHeaders()).build()
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new HttpResponseException.Builder(500, "ignored", new HttpHeaders()).build()
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new HttpResponseException.Builder(503, "ignored", new HttpHeaders()).build()
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new HttpResponseException.Builder(599, "ignored", new HttpHeaders()).build()
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         GoogleUtils.isRetryable(
             new GoogleJsonResponseException(
                 new HttpResponseException.Builder(404, "ignored", new HttpHeaders()),
@@ -69,37 +69,37 @@ public class GoogleUtilsTest
             )
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         GoogleUtils.isRetryable(
             new HttpResponseException.Builder(404, "ignored", new HttpHeaders()).build()
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new IOException("generic io exception")
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         GoogleUtils.isRetryable(
             new StorageException(404, "ignored")
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new StorageException(429, "ignored")
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new StorageException(500, "ignored")
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         GoogleUtils.isRetryable(
             new StorageException(503, "ignored")
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         GoogleUtils.isRetryable(
             new StorageException(599, "ignored")
         )

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/ObjectStorageIteratorTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/ObjectStorageIteratorTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.storage.google;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -175,10 +175,10 @@ public class ObjectStorageIteratorTest
         )
     );
 
-    Assert.assertEquals(
-        prefixes.toString(),
+    Assertions.assertEquals(
         expectedObjects.stream().map(GoogleUtils::objectToUri).collect(Collectors.toList()),
-        actualObjects.stream().map(GoogleUtils::objectToUri).collect(Collectors.toList())
+        actualObjects.stream().map(GoogleUtils::objectToUri).collect(Collectors.toList()),
+        prefixes.toString()
     );
   }
 

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleExportStorageProviderTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleExportStorageProviderTest.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.storage.StorageConnector;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.List;
@@ -44,10 +44,10 @@ public class GoogleExportStorageProviderTest
     GoogleExportStorageProvider googleExportStorageProvider = new GoogleExportStorageProvider("bucket-name", "validPath1");
     googleExportStorageProvider.googleExportConfig = new GoogleExportConfig("tempLocalDir", null, null, validPrefixes);
     StorageConnector storageConnector = googleExportStorageProvider.createStorageConnector(tempDir);
-    Assert.assertNotNull(storageConnector);
-    Assert.assertTrue(storageConnector instanceof GoogleStorageConnector);
+    Assertions.assertNotNull(storageConnector);
+    Assertions.assertTrue(storageConnector instanceof GoogleStorageConnector);
 
-    Assert.assertEquals("gs://bucket-name/validPath1", googleExportStorageProvider.getBasePath());
+    Assertions.assertEquals("gs://bucket-name/validPath1", googleExportStorageProvider.getBasePath());
   }
 
   @Test
@@ -61,15 +61,15 @@ public class GoogleExportStorageProviderTest
     GoogleExportStorageProvider.validatePrefix(ImmutableList.of("gs://bucket-name"), "bucket-name", "validPath");
     GoogleExportStorageProvider.validatePrefix(validPrefixes, "bucket-name", "validPath1/../validPath2/");
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> GoogleExportStorageProvider.validatePrefix(validPrefixes, "incorrect-bucket", "validPath1/")
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> GoogleExportStorageProvider.validatePrefix(validPrefixes, "bucket-name", "invalidPath1")
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> GoogleExportStorageProvider.validatePrefix(validPrefixes, "bucket-name", "validPath123")
     );

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleInputRangeTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleInputRangeTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.storage.google.output;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GoogleInputRangeTest
 {

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
@@ -22,16 +22,18 @@ package org.apache.druid.storage.google.output;
 
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.HumanReadableBytes;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
 
 public class GoogleOutputConfigTest
 {
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private static final String BUCKET = "bucket";
   private static final String PREFIX = "prefix";
@@ -41,9 +43,18 @@ public class GoogleOutputConfigTest
   public void testTooLargeChunkSize()
   {
     HumanReadableBytes chunkSize = new HumanReadableBytes("17MiB");
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
-        () -> new GoogleOutputConfig(BUCKET, PREFIX, temporaryFolder.newFolder(), chunkSize, MAX_RETRY_COUNT)
+        () -> new GoogleOutputConfig(BUCKET, PREFIX, newFolder(temporaryFolder, "junit"), chunkSize, MAX_RETRY_COUNT)
     );
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 
 public class GoogleOutputConfigTest
 {
@@ -50,11 +49,8 @@ public class GoogleOutputConfigTest
     );
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
@@ -50,7 +50,8 @@ public class GoogleOutputConfigTest
     );
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleOutputConfigTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.storage.google.output;
 
 
 import org.apache.druid.error.DruidException;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -52,9 +53,7 @@ public class GoogleOutputConfigTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorProviderTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorProviderTest.java
@@ -34,8 +34,8 @@ import org.apache.druid.storage.google.GoogleInputDataConfig;
 import org.apache.druid.storage.google.GoogleStorage;
 import org.apache.druid.storage.google.GoogleStorageDruidModule;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Properties;
@@ -56,11 +56,11 @@ public class GoogleStorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".tempDir", "/tmp");
     StorageConnectorProvider googleStorageConnectorProvider = getStorageConnectorProvider(properties);
 
-    Assert.assertTrue(googleStorageConnectorProvider instanceof GoogleStorageConnectorProvider);
-    Assert.assertTrue(googleStorageConnectorProvider.createStorageConnector(tempDir) instanceof GoogleStorageConnector);
-    Assert.assertEquals("bucket", ((GoogleStorageConnectorProvider) googleStorageConnectorProvider).getBucket());
-    Assert.assertEquals("prefix", ((GoogleStorageConnectorProvider) googleStorageConnectorProvider).getPrefix());
-    Assert.assertEquals(new File("/tmp"), ((GoogleStorageConnectorProvider) googleStorageConnectorProvider).getTempDir());
+    Assertions.assertTrue(googleStorageConnectorProvider instanceof GoogleStorageConnectorProvider);
+    Assertions.assertTrue(googleStorageConnectorProvider.createStorageConnector(tempDir) instanceof GoogleStorageConnector);
+    Assertions.assertEquals("bucket", ((GoogleStorageConnectorProvider) googleStorageConnectorProvider).getBucket());
+    Assertions.assertEquals("prefix", ((GoogleStorageConnectorProvider) googleStorageConnectorProvider).getPrefix());
+    Assertions.assertEquals(new File("/tmp"), ((GoogleStorageConnectorProvider) googleStorageConnectorProvider).getTempDir());
 
   }
 
@@ -72,10 +72,10 @@ public class GoogleStorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".type", "bucket");
     properties.setProperty(CUSTOM_NAMESPACE + ".bucket", "bucket");
     properties.setProperty(CUSTOM_NAMESPACE + ".tempDir", "/tmp");
-    Assert.assertThrows(
-        "Missing required creator property 'prefix'",
+    Assertions.assertThrows(
         ProvisionException.class,
-        () -> getStorageConnectorProvider(properties)
+        () -> getStorageConnectorProvider(properties),
+        "Missing required creator property 'prefix'"
     );
   }
 
@@ -88,10 +88,10 @@ public class GoogleStorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".type", "Google");
     properties.setProperty(CUSTOM_NAMESPACE + ".prefix", "prefix");
     properties.setProperty(CUSTOM_NAMESPACE + ".tempDir", "/tmp");
-    Assert.assertThrows(
-        "Missing required creator property 'bucket'",
+    Assertions.assertThrows(
         ProvisionException.class,
-        () -> getStorageConnectorProvider(properties)
+        () -> getStorageConnectorProvider(properties),
+        "Missing required creator property 'bucket'"
     );
   }
 
@@ -104,10 +104,10 @@ public class GoogleStorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".bucket", "bucket");
     properties.setProperty(CUSTOM_NAMESPACE + ".prefix", "prefix");
 
-    Assert.assertThrows(
-        "Missing required creator property 'tempDir'",
+    Assertions.assertThrows(
         ProvisionException.class,
-        () -> getStorageConnectorProvider(properties)
+        () -> getStorageConnectorProvider(properties),
+        "Missing required creator property 'tempDir'"
     );
   }
 
@@ -117,14 +117,13 @@ public class GoogleStorageConnectorProviderTest
         new GoogleStorageDruidModule(),
         new StorageConnectorModule(),
         new GoogleStorageConnectorModule(),
-        binder -> {
+        binder ->
           JsonConfigProvider.bind(
               binder,
               CUSTOM_NAMESPACE,
               StorageConnectorProvider.class,
               Names.named(CUSTOM_NAMESPACE)
-          );
-        }
+          )
     ).withProperties(properties);
 
     Injector injector = startupInjectorBuilder.build();

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.StorageException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.commons.io.IOUtils;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.storage.google.GoogleInputDataConfig;
 import org.apache.druid.storage.google.GoogleStorage;
@@ -432,9 +433,7 @@ public class GoogleStorageConnectorTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
@@ -30,12 +30,12 @@ import org.apache.druid.storage.google.GoogleStorageObjectMetadata;
 import org.apache.druid.storage.google.GoogleStorageObjectPage;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -46,8 +46,8 @@ public class GoogleStorageConnectorTest
   private static final String BUCKET = "BUCKET";
   private static final String PREFIX = "PREFIX";
   private static final String TEST_FILE = "TEST_FILE";
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private static final int MAX_LISTING_LEN = 10;
 
@@ -58,10 +58,10 @@ public class GoogleStorageConnectorTest
   private static final Exception RECOVERABLE_EXCEPTION = new StorageException(429, "recoverable");
   private static final Exception NON_RECOVERABLE_EXCEPTION = new StorageException(404, "non-recoverable");
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
-    GoogleOutputConfig config = new GoogleOutputConfig(BUCKET, PREFIX, temporaryFolder.newFolder(), CHUNK_SIZE, null);
+    GoogleOutputConfig config = new GoogleOutputConfig(BUCKET, PREFIX, newFolder(temporaryFolder, "junit"), CHUNK_SIZE, null);
     GoogleInputDataConfig inputDataConfig = new GoogleInputDataConfig();
     inputDataConfig.setMaxListingLength(MAX_LISTING_LEN);
     googleStorageConnector = new GoogleStorageConnector(config, googleStorage, inputDataConfig);
@@ -74,9 +74,9 @@ public class GoogleStorageConnectorTest
     final Capture<String> path = Capture.newInstance();
     EasyMock.expect(googleStorage.exists(EasyMock.capture(bucket), EasyMock.capture(path))).andReturn(true);
     EasyMock.replay(googleStorage);
-    Assert.assertTrue(googleStorageConnector.pathExists(TEST_FILE));
-    Assert.assertEquals(BUCKET, bucket.getValue());
-    Assert.assertEquals(PREFIX + "/" + TEST_FILE, path.getValue());
+    Assertions.assertTrue(googleStorageConnector.pathExists(TEST_FILE));
+    Assertions.assertEquals(BUCKET, bucket.getValue());
+    Assertions.assertEquals(PREFIX + "/" + TEST_FILE, path.getValue());
     EasyMock.verify(googleStorage);
   }
 
@@ -87,9 +87,9 @@ public class GoogleStorageConnectorTest
     final Capture<String> path = Capture.newInstance();
     EasyMock.expect(googleStorage.exists(EasyMock.capture(bucket), EasyMock.capture(path))).andReturn(false);
     EasyMock.replay(googleStorage);
-    Assert.assertFalse(googleStorageConnector.pathExists(TEST_FILE));
-    Assert.assertEquals(BUCKET, bucket.getValue());
-    Assert.assertEquals(PREFIX + "/" + TEST_FILE, path.getValue());
+    Assertions.assertFalse(googleStorageConnector.pathExists(TEST_FILE));
+    Assertions.assertEquals(BUCKET, bucket.getValue());
+    Assertions.assertEquals(PREFIX + "/" + TEST_FILE, path.getValue());
     EasyMock.verify(googleStorage);
   }
 
@@ -105,8 +105,8 @@ public class GoogleStorageConnectorTest
 
     EasyMock.replay(googleStorage);
     googleStorageConnector.deleteFile(TEST_FILE);
-    Assert.assertEquals(BUCKET, bucketCapture.getValue());
-    Assert.assertEquals(PREFIX + "/" + TEST_FILE, pathCapture.getValue());
+    Assertions.assertEquals(BUCKET, bucketCapture.getValue());
+    Assertions.assertEquals(PREFIX + "/" + TEST_FILE, pathCapture.getValue());
   }
 
   @Test
@@ -122,8 +122,8 @@ public class GoogleStorageConnectorTest
 
     EasyMock.replay(googleStorage);
     googleStorageConnector.deleteFile(TEST_FILE);
-    Assert.assertEquals(BUCKET, bucketCapture.getValue());
-    Assert.assertEquals(PREFIX + "/" + TEST_FILE, pathCapture.getValue());
+    Assertions.assertEquals(BUCKET, bucketCapture.getValue());
+    Assertions.assertEquals(PREFIX + "/" + TEST_FILE, pathCapture.getValue());
   }
 
   @Test
@@ -137,9 +137,9 @@ public class GoogleStorageConnectorTest
     );
     EasyMock.expectLastCall().andThrow(NON_RECOVERABLE_EXCEPTION).once().andVoid().once();
     EasyMock.replay(googleStorage);
-    Assert.assertThrows(IOException.class, () -> googleStorageConnector.deleteFile(TEST_FILE));
-    Assert.assertEquals(BUCKET, bucketCapture.getValue());
-    Assert.assertEquals(PREFIX + "/" + TEST_FILE, pathCapture.getValue());
+    Assertions.assertThrows(IOException.class, () -> googleStorageConnector.deleteFile(TEST_FILE));
+    Assertions.assertEquals(BUCKET, bucketCapture.getValue());
+    Assertions.assertEquals(PREFIX + "/" + TEST_FILE, pathCapture.getValue());
   }
 
   @Test
@@ -150,8 +150,8 @@ public class GoogleStorageConnectorTest
     googleStorage.batchDelete(EasyMock.capture(containerCapture), EasyMock.capture(pathsCapture));
     EasyMock.replay(googleStorage);
     googleStorageConnector.deleteFiles(ImmutableList.of(TEST_FILE + "_1.part", TEST_FILE + "_2.json"));
-    Assert.assertEquals(BUCKET, containerCapture.getValue());
-    Assert.assertEquals(
+    Assertions.assertEquals(BUCKET, containerCapture.getValue());
+    Assertions.assertEquals(
         ImmutableList.of(
             PREFIX + "/" + TEST_FILE + "_1.part",
             PREFIX + "/" + TEST_FILE + "_2.json"
@@ -171,8 +171,8 @@ public class GoogleStorageConnectorTest
 
     EasyMock.replay(googleStorage);
     googleStorageConnector.deleteFiles(ImmutableList.of(TEST_FILE + "_1.part", TEST_FILE + "_2.json"));
-    Assert.assertEquals(BUCKET, containerCapture.getValue());
-    Assert.assertEquals(
+    Assertions.assertEquals(BUCKET, containerCapture.getValue());
+    Assertions.assertEquals(
         ImmutableList.of(
             PREFIX + "/" + TEST_FILE + "_1.part",
             PREFIX + "/" + TEST_FILE + "_2.json"
@@ -191,15 +191,15 @@ public class GoogleStorageConnectorTest
     EasyMock.expectLastCall().andThrow(NON_RECOVERABLE_EXCEPTION).once().andVoid().once();
 
     EasyMock.replay(googleStorage);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IOException.class,
         () -> googleStorageConnector.deleteFiles(ImmutableList.of(
             TEST_FILE + "_1.part",
             TEST_FILE + "_2.json"
         ))
     );
-    Assert.assertEquals(BUCKET, containerCapture.getValue());
-    Assert.assertEquals(
+    Assertions.assertEquals(BUCKET, containerCapture.getValue());
+    Assertions.assertEquals(
         ImmutableList.of(
             PREFIX + "/" + TEST_FILE + "_1.part",
             PREFIX + "/" + TEST_FILE + "_2.json"
@@ -245,8 +245,8 @@ public class GoogleStorageConnectorTest
 
     EasyMock.replay(googleStorage);
     googleStorageConnector.deleteRecursively("");
-    Assert.assertEquals(BUCKET, containerCapture.getValue());
-    Assert.assertEquals(
+    Assertions.assertEquals(BUCKET, containerCapture.getValue());
+    Assertions.assertEquals(
         ImmutableList.of(
             PREFIX + "/x/y/" + TEST_FILE,
             PREFIX + "/p/q/r/" + TEST_FILE
@@ -291,8 +291,8 @@ public class GoogleStorageConnectorTest
 
     EasyMock.replay(googleStorage);
     googleStorageConnector.deleteRecursively("");
-    Assert.assertEquals(BUCKET, containerCapture.getValue());
-    Assert.assertEquals(
+    Assertions.assertEquals(BUCKET, containerCapture.getValue());
+    Assertions.assertEquals(
         ImmutableList.of(
             PREFIX + "/x/y/" + TEST_FILE,
             PREFIX + "/p/q/r/" + TEST_FILE
@@ -335,9 +335,9 @@ public class GoogleStorageConnectorTest
     EasyMock.expectLastCall().andThrow(NON_RECOVERABLE_EXCEPTION).once().andVoid().once();
 
     EasyMock.replay(googleStorage);
-    Assert.assertThrows(IOException.class, () -> googleStorageConnector.deleteRecursively(""));
-    Assert.assertEquals(BUCKET, containerCapture.getValue());
-    Assert.assertEquals(
+    Assertions.assertThrows(IOException.class, () -> googleStorageConnector.deleteRecursively(""));
+    Assertions.assertEquals(BUCKET, containerCapture.getValue());
+    Assertions.assertEquals(
         ImmutableList.of(
             PREFIX + "/x/y/" + TEST_FILE,
             PREFIX + "/p/q/r/" + TEST_FILE
@@ -372,9 +372,9 @@ public class GoogleStorageConnectorTest
             .andReturn(new GoogleStorageObjectPage(ImmutableList.of(objectMetadata1, objectMetadata2), null));
     EasyMock.replay(googleStorage);
     List<String> ret = Lists.newArrayList(googleStorageConnector.listDir(""));
-    Assert.assertEquals(ImmutableList.of("x/y" + TEST_FILE, "p/q/r/" + TEST_FILE), ret);
-    Assert.assertEquals(MAX_LISTING_LEN, maxListingCapture.getValue().intValue());
-    Assert.assertEquals(null, pageTokenCapture.getValue());
+    Assertions.assertEquals(ImmutableList.of("x/y" + TEST_FILE, "p/q/r/" + TEST_FILE), ret);
+    Assertions.assertEquals(MAX_LISTING_LEN, maxListingCapture.getValue().intValue());
+    Assertions.assertEquals(null, pageTokenCapture.getValue());
 
   }
 
@@ -396,9 +396,9 @@ public class GoogleStorageConnectorTest
     EasyMock.replay(googleStorage);
     InputStream is = googleStorageConnector.read(TEST_FILE);
     byte[] dataBytes = new byte[data.length()];
-    Assert.assertEquals(data.length(), is.read(dataBytes));
-    Assert.assertEquals(-1, is.read());
-    Assert.assertEquals(data, new String(dataBytes, StandardCharsets.UTF_8));
+    Assertions.assertEquals(data.length(), is.read(dataBytes));
+    Assertions.assertEquals(-1, is.read());
+    Assertions.assertEquals(data, new String(dataBytes, StandardCharsets.UTF_8));
   }
 
   @Test
@@ -420,12 +420,21 @@ public class GoogleStorageConnectorTest
 
         InputStream is = googleStorageConnector.readRange(TEST_FILE, start, length);
         byte[] dataBytes = new byte[((Long) length).intValue()];
-        Assert.assertEquals(length, is.read(dataBytes));
-        Assert.assertEquals(-1, is.read());
-        Assert.assertEquals(dataQueried, new String(dataBytes, StandardCharsets.UTF_8));
+        Assertions.assertEquals(length, is.read(dataBytes));
+        Assertions.assertEquals(-1, is.read());
+        Assertions.assertEquals(dataQueried, new String(dataBytes, StandardCharsets.UTF_8));
         EasyMock.reset(googleStorage);
       }
     }
 
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
@@ -430,11 +430,8 @@ public class GoogleStorageConnectorTest
 
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
+++ b/extensions-core/google-extensions/src/test/java/org/apache/druid/storage/google/output/GoogleStorageConnectorTest.java
@@ -430,7 +430,8 @@ public class GoogleStorageConnectorTest
 
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -136,6 +136,11 @@
 
     <!-- Tests -->
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -136,8 +136,8 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -221,8 +221,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafka/KafkaTopicPartitionTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafka/KafkaTopicPartitionTest.java
@@ -22,15 +22,15 @@ package org.apache.druid.data.input.kafka;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class KafkaTopicPartitionTest
 {
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     objectMapper = new ObjectMapper();
@@ -53,13 +53,13 @@ public class KafkaTopicPartitionTest
     KafkaTopicPartition partition7 = new KafkaTopicPartition(true, "topic", 0);
     KafkaTopicPartition partition8 = new KafkaTopicPartition(true, "topic2", 0);
 
-    Assert.assertEquals(partition1, partition2);
-    Assert.assertNotEquals(partition1, partition3);
-    Assert.assertEquals(partition1, partition4);
-    Assert.assertEquals(partition5, partition6);
-    Assert.assertEquals(partition1, partition5);
-    Assert.assertNotEquals(partition1, partition7);
-    Assert.assertNotEquals(partition7, partition8);
+    Assertions.assertEquals(partition1, partition2);
+    Assertions.assertNotEquals(partition1, partition3);
+    Assertions.assertEquals(partition1, partition4);
+    Assertions.assertEquals(partition5, partition6);
+    Assertions.assertEquals(partition1, partition5);
+    Assertions.assertNotEquals(partition1, partition7);
+    Assertions.assertNotEquals(partition7, partition8);
   }
 
   @Test
@@ -74,31 +74,31 @@ public class KafkaTopicPartitionTest
     KafkaTopicPartition partition7 = new KafkaTopicPartition(true, "topic", 0);
     KafkaTopicPartition partition8 = new KafkaTopicPartition(true, "topic2", 0);
 
-    Assert.assertEquals(partition1.hashCode(), partition2.hashCode());
-    Assert.assertNotEquals(partition1.hashCode(), partition3.hashCode());
-    Assert.assertEquals(partition1.hashCode(), partition4.hashCode());
-    Assert.assertEquals(partition5.hashCode(), partition6.hashCode());
-    Assert.assertEquals(partition1.hashCode(), partition5.hashCode());
-    Assert.assertNotEquals(partition1.hashCode(), partition7.hashCode());
-    Assert.assertNotEquals(partition7.hashCode(), partition8.hashCode());
+    Assertions.assertEquals(partition1.hashCode(), partition2.hashCode());
+    Assertions.assertNotEquals(partition1.hashCode(), partition3.hashCode());
+    Assertions.assertEquals(partition1.hashCode(), partition4.hashCode());
+    Assertions.assertEquals(partition5.hashCode(), partition6.hashCode());
+    Assertions.assertEquals(partition1.hashCode(), partition5.hashCode());
+    Assertions.assertNotEquals(partition1.hashCode(), partition7.hashCode());
+    Assertions.assertNotEquals(partition7.hashCode(), partition8.hashCode());
   }
 
   @Test
   public void testMultiTopicDeserialization() throws JsonProcessingException
   {
     KafkaTopicPartition partition = objectMapper.readerFor(KafkaTopicPartition.class).readValue("\"topic:0\"");
-    Assert.assertEquals(0, partition.partition());
-    Assert.assertEquals("topic", partition.topic().orElse(null));
-    Assert.assertTrue(partition.isMultiTopicPartition());
+    Assertions.assertEquals(0, partition.partition());
+    Assertions.assertEquals("topic", partition.topic().orElse(null));
+    Assertions.assertTrue(partition.isMultiTopicPartition());
   }
 
   @Test
   public void testSingleTopicDeserialization() throws JsonProcessingException
   {
     KafkaTopicPartition partition = objectMapper.readerFor(KafkaTopicPartition.class).readValue("0");
-    Assert.assertEquals(0, partition.partition());
-    Assert.assertNull(partition.topic().orElse(null));
-    Assert.assertFalse(partition.isMultiTopicPartition());
+    Assertions.assertEquals(0, partition.partition());
+    Assertions.assertNull(partition.topic().orElse(null));
+    Assertions.assertFalse(partition.isMultiTopicPartition());
   }
 
   @Test
@@ -106,7 +106,7 @@ public class KafkaTopicPartitionTest
   {
     KafkaTopicPartition partition = new KafkaTopicPartition(true, "topic", 0);
     KafkaTopicPartition reincarnated = objectMapper.readerFor(KafkaTopicPartition.class).readValue(objectMapper.writeValueAsString(partition));
-    Assert.assertEquals(partition, reincarnated);
+    Assertions.assertEquals(partition, reincarnated);
   }
 
   @Test
@@ -114,6 +114,6 @@ public class KafkaTopicPartitionTest
   {
     KafkaTopicPartition partition = new KafkaTopicPartition(false, null, 0);
     KafkaTopicPartition reincarnated = objectMapper.readerFor(KafkaTopicPartition.class).readValue(objectMapper.writeValueAsString(partition));
-    Assert.assertEquals(partition, reincarnated);
+    Assertions.assertEquals(partition, reincarnated);
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaInputFormatTest.java
@@ -47,9 +47,9 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -110,7 +110,7 @@ public class KafkaInputFormatTest
   );
   private KafkaInputFormat format;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     format = new KafkaInputFormat(
@@ -189,11 +189,11 @@ public class KafkaInputFormatTest
         "kafka.new.partition",
         "kafka.new.offset"
     );
-    Assert.assertEquals(format, kif);
+    Assertions.assertEquals(format, kif);
 
     final byte[] formatBytes = mapper.writeValueAsBytes(format);
     final byte[] kifBytes = mapper.writeValueAsBytes(kif);
-    Assert.assertArrayEquals(formatBytes, kifBytes);
+    Assertions.assertArrayEquals(formatBytes, kifBytes);
   }
 
   @Test
@@ -230,7 +230,7 @@ public class KafkaInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRow row = iterator.next();
-        Assert.assertEquals(
+        Assertions.assertEquals(
             Arrays.asList(
                 "bar",
                 "foo",
@@ -245,27 +245,27 @@ public class KafkaInputFormatTest
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
         
-        Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
         verifyHeader(row);
 
         // Key verification
-        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+        Assertions.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -305,11 +305,11 @@ public class KafkaInputFormatTest
         final InputRow row = iterator.next();
 
         // Key verification
-        Assert.assertTrue(row.getDimension("kafka.newkey.key").isEmpty());
+        Assertions.assertTrue(row.getDimension("kafka.newkey.key").isEmpty());
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
 
   }
@@ -371,27 +371,27 @@ public class KafkaInputFormatTest
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(DateTimes.of("2021-06-24"), row.getTimestamp());
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(DateTimes.of("2021-06-24"), row.getTimestamp());
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
         verifyHeader(row);
 
         // Key verification
-        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+        Assertions.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -456,17 +456,17 @@ public class KafkaInputFormatTest
         // Key verification
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
-        Assert.assertTrue(row.getDimension("kafka.newkey.key").isEmpty());
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertTrue(row.getDimension("kafka.newkey.key").isEmpty());
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
 
   }
@@ -541,47 +541,47 @@ public class KafkaInputFormatTest
           // Payload verification
           // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
           // but test reading them anyway since it isn't technically illegal
-          Assert.assertEquals(DateTimes.of("2021-06-2" + i), row.getTimestamp());
-          Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-          Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-          Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-          Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-          Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-          Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
-          Assert.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("index")));
+          Assertions.assertEquals(DateTimes.of("2021-06-2" + i), row.getTimestamp());
+          Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+          Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+          Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+          Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+          Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+          Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+          Assertions.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("index")));
 
           // Header verification
-          Assert.assertEquals(
+          Assertions.assertEquals(
               "application/json",
               Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding"))
           );
-          Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
-          Assert.assertEquals(
+          Assertions.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
+          Assertions.assertEquals(
               String.valueOf(DateTimes.of("2021-06-24").getMillis()),
               Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
           );
-          Assert.assertEquals(
+          Assertions.assertEquals(
               TOPIC,
               Iterables.getOnlyElement(row.getDimension("kafka.newtopic.topic"))
           );
-          Assert.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("kafka.newheader.indexH")));
+          Assertions.assertEquals(String.valueOf(i), Iterables.getOnlyElement(row.getDimension("kafka.newheader.indexH")));
 
 
           // Key verification
           if (i == 2) {
-            Assert.assertEquals(Collections.emptyList(), row.getDimension("kafka.newkey.key"));
+            Assertions.assertEquals(Collections.emptyList(), row.getDimension("kafka.newkey.key"));
           } else {
-            Assert.assertEquals("sampleKey-" + i, Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+            Assertions.assertEquals("sampleKey-" + i, Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
           }
 
-          Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-          Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-          Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+          Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+          Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+          Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
           numActualIterations++;
         }
 
-        Assert.assertEquals(numExpectedIterations, numActualIterations);
+        Assertions.assertEquals(numExpectedIterations, numActualIterations);
       }
     }
   }
@@ -616,8 +616,8 @@ public class KafkaInputFormatTest
 
     try (CloseableIterator<InputRow> iterator = reader.read()) {
       while (iterator.hasNext()) {
-        Throwable t = Assert.assertThrows(ParseException.class, iterator::next);
-        Assert.assertTrue(
+        Throwable t = Assertions.assertThrows(ParseException.class, iterator::next);
+        Assertions.assertTrue(
             t.getMessage().startsWith("Timestamp[null] is unparseable! Event: {")
         );
       }
@@ -647,7 +647,7 @@ public class KafkaInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRow row = iterator.next();
-        Assert.assertEquals(
+        Assertions.assertEquals(
             Arrays.asList(
                 "kafka.newtopic.topic",
                 "foo",
@@ -671,27 +671,27 @@ public class KafkaInputFormatTest
         );
 
         // Payload verifications
-        Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
         verifyHeader(row);
 
         // Key verification
-        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+        Assertions.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -763,7 +763,7 @@ public class KafkaInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRow row = iterator.next();
-        Assert.assertEquals(
+        Assertions.assertEquals(
             Arrays.asList(
                 "bar",
                 "foo",
@@ -779,20 +779,20 @@ public class KafkaInputFormatTest
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertTrue(row.getDimension("bar").isEmpty());
+        Assertions.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertTrue(row.getDimension("bar").isEmpty());
 
         verifyHeader(row);
 
         // Key verification
-        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+        Assertions.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -857,7 +857,7 @@ public class KafkaInputFormatTest
       while (iterator.hasNext()) {
 
         final InputRow row = iterator.next();
-        Assert.assertEquals(
+        Assertions.assertEquals(
             Arrays.asList(
                 "bar",
                 "foo",
@@ -872,20 +872,20 @@ public class KafkaInputFormatTest
         // this isn't super realistic, since most of these columns are not actually defined in the dimensionSpec
         // but test reading them anyway since it isn't technically illegal
 
-        Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertTrue(row.getDimension("bar").isEmpty());
+        Assertions.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertTrue(row.getDimension("bar").isEmpty());
 
         verifyHeader(row);
 
         // Key verification
-        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+        Assertions.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -916,7 +916,7 @@ public class KafkaInputFormatTest
 
         final InputRow row = iterator.next();
 
-        Assert.assertEquals(
+        Assertions.assertEquals(
             Arrays.asList(
                 "bar",
                 "kafka.newheader.kafkapkc",
@@ -940,27 +940,27 @@ public class KafkaInputFormatTest
         );
 
         // Payload verifications
-        Assert.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
-        Assert.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
-        Assert.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
-        Assert.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
-        Assert.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
+        Assertions.assertEquals(DateTimes.of("2021-06-25"), row.getTimestamp());
+        Assertions.assertEquals("x", Iterables.getOnlyElement(row.getDimension("foo")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("baz")));
+        Assertions.assertEquals("4", Iterables.getOnlyElement(row.getDimension("root_baz")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("path_omg")));
+        Assertions.assertEquals("1", Iterables.getOnlyElement(row.getDimension("jq_omg")));
+        Assertions.assertEquals(ImmutableMap.of("mg", 1L), row.getRaw("o"));
 
         verifyHeader(row);
 
         // Key verification
-        Assert.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
+        Assertions.assertEquals("sampleKey", Iterables.getOnlyElement(row.getDimension("kafka.newkey.key")));
 
-        Assert.assertTrue(row.getDimension("root_baz2").isEmpty());
-        Assert.assertTrue(row.getDimension("path_omg2").isEmpty());
-        Assert.assertTrue(row.getDimension("jq_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("root_baz2").isEmpty());
+        Assertions.assertTrue(row.getDimension("path_omg2").isEmpty());
+        Assertions.assertTrue(row.getDimension("jq_omg2").isEmpty());
 
         numActualIterations++;
       }
 
-      Assert.assertEquals(numExpectedIterations, numActualIterations);
+      Assertions.assertEquals(numExpectedIterations, numActualIterations);
     }
   }
 
@@ -985,17 +985,17 @@ public class KafkaInputFormatTest
 
   private void verifyHeader(InputRow row)
   {
-    Assert.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
-    Assert.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
-    Assert.assertEquals(
+    Assertions.assertEquals("application/json", Iterables.getOnlyElement(row.getDimension("kafka.newheader.encoding")));
+    Assertions.assertEquals("pkc-bar", Iterables.getOnlyElement(row.getDimension("kafka.newheader.kafkapkc")));
+    Assertions.assertEquals(
         String.valueOf(DateTimes.of("2021-06-24").getMillis()),
         Iterables.getOnlyElement(row.getDimension("kafka.newts.timestamp"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TOPIC,
         Iterables.getOnlyElement(row.getDimension("kafka.newtopic.topic"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "2021-06-25",
         Iterables.getOnlyElement(row.getDimension("timestamp"))
     );

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/data/input/kafkainput/KafkaStringHeaderFormatTest.java
@@ -30,8 +30,8 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -79,12 +79,12 @@ public class KafkaStringHeaderFormatTest
   @Test
   public void testSerde() throws JsonProcessingException
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KAFKAHEADERNOENCODE,
         MAPPER.readValue(MAPPER.writeValueAsString(KAFKAHEADERNOENCODE), KafkaStringHeaderFormat.class)
     );
     final KafkaStringHeaderFormat kafkaAsciiHeader = new KafkaStringHeaderFormat("US-ASCII");
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         KAFKAHEADERNOENCODE,
         kafkaAsciiHeader
     );
@@ -113,7 +113,7 @@ public class KafkaStringHeaderFormatTest
 
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat(null);
     KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
-    Assert.assertEquals(expectedResults, headerParser.read());
+    Assertions.assertEquals(expectedResults, headerParser.read());
   }
 
   @Test
@@ -165,7 +165,7 @@ public class KafkaStringHeaderFormatTest
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
     KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
     List<Pair<String, Object>> rows = headerParser.read();
-    Assert.assertEquals(expectedResults, rows);
+    Assertions.assertEquals(expectedResults, rows);
   }
 
   @Test
@@ -217,7 +217,7 @@ public class KafkaStringHeaderFormatTest
     KafkaHeaderFormat headerInput = new KafkaStringHeaderFormat("US-ASCII");
     KafkaHeaderReader headerParser = headerInput.createReader(inputEntity.getRecord().headers(), headerLabelPrefix);
     List<Pair<String, Object>> rows = headerParser.read();
-    Assert.assertEquals(expectedResults, rows);
+    Assertions.assertEquals(expectedResults, rows);
   }
 }
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaCheckpointDataSourceMetadataSerdeTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaCheckpointDataSourceMetadataSerdeTest.java
@@ -27,9 +27,9 @@ import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.indexing.common.actions.CheckPointDataSourceMetadataAction;
 import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -37,7 +37,7 @@ public class KafkaCheckpointDataSourceMetadataSerdeTest
 {
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     objectMapper = new DefaultObjectMapper();
@@ -75,7 +75,7 @@ public class KafkaCheckpointDataSourceMetadataSerdeTest
         serialized,
         CheckPointDataSourceMetadataAction.class
     );
-    Assert.assertEquals(checkpointAction, deserialized);
+    Assertions.assertEquals(checkpointAction, deserialized);
   }
 
   @Test
@@ -104,7 +104,7 @@ public class KafkaCheckpointDataSourceMetadataSerdeTest
         serialized,
         CheckPointDataSourceMetadataAction.class
     );
-    Assert.assertEquals(checkpointAction, deserialized);
+    Assertions.assertEquals(checkpointAction, deserialized);
   }
 
   @Test
@@ -196,6 +196,6 @@ public class KafkaCheckpointDataSourceMetadataSerdeTest
         kafkaDataSourceMetadata,
         kafkaDataSourceMetadata
     );
-    Assert.assertEquals(checkpointAction, actual);
+    Assertions.assertEquals(checkpointAction, actual);
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaDataSourceMetadataTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaDataSourceMetadataTest.java
@@ -35,8 +35,8 @@ import org.apache.druid.indexing.seekablestream.supervisor.BoundedStreamConfig;
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.utils.CollectionUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -70,551 +70,551 @@ public class KafkaDataSourceMetadataTest
   @Test
   public void testMatches()
   {
-    Assert.assertTrue(START0.matches(START0));
-    Assert.assertTrue(START0.matches(START1));
-    Assert.assertTrue(START0.matches(START2));
-    Assert.assertTrue(START0.matches(START3));
+    Assertions.assertTrue(START0.matches(START0));
+    Assertions.assertTrue(START0.matches(START1));
+    Assertions.assertTrue(START0.matches(START2));
+    Assertions.assertTrue(START0.matches(START3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior
-    Assert.assertFalse(START0.matches(START4));
-    Assert.assertTrue(START0.matches(START5));
+    Assertions.assertFalse(START0.matches(START4));
+    Assertions.assertTrue(START0.matches(START5));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(START0.matches(START6));
+    Assertions.assertFalse(START0.matches(START6));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(START0.matches(START7));
+    Assertions.assertFalse(START0.matches(START7));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(START0.matches(START8));
+    Assertions.assertFalse(START0.matches(START8));
     // when merging, we lose the sequence numbers for topics foo2, and foo22 here when merging, so false
-    Assert.assertFalse(START0.matches(START9));
+    Assertions.assertFalse(START0.matches(START9));
 
-    Assert.assertTrue(START1.matches(START0));
-    Assert.assertTrue(START1.matches(START1));
+    Assertions.assertTrue(START1.matches(START0));
+    Assertions.assertTrue(START1.matches(START1));
     // sequence numbers for topic foo partition 1 are inconsistent, so false
-    Assert.assertFalse(START1.matches(START2));
-    Assert.assertTrue(START1.matches(START3));
+    Assertions.assertFalse(START1.matches(START2));
+    Assertions.assertTrue(START1.matches(START3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertTrue(START1.matches(START5));
+    Assertions.assertTrue(START1.matches(START5));
     // when merging, we lose the sequence numbers for topic foo2, and sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(START1.matches(START6));
+    Assertions.assertFalse(START1.matches(START6));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(START1.matches(START7));
+    Assertions.assertFalse(START1.matches(START7));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(START1.matches(START8));
+    Assertions.assertFalse(START1.matches(START8));
     // when merging, we lose the sequence numbers for topics foo2 and foo22, so false
-    Assert.assertFalse(START1.matches(START9));
+    Assertions.assertFalse(START1.matches(START9));
 
-    Assert.assertTrue(START2.matches(START0));
-    Assert.assertFalse(START2.matches(START1));
-    Assert.assertTrue(START2.matches(START2));
-    Assert.assertTrue(START2.matches(START3));
+    Assertions.assertTrue(START2.matches(START0));
+    Assertions.assertFalse(START2.matches(START1));
+    Assertions.assertTrue(START2.matches(START2));
+    Assertions.assertTrue(START2.matches(START3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START2.matches(START4));
+    Assertions.assertFalse(START2.matches(START4));
     // when merging, sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(START2.matches(START5));
+    Assertions.assertFalse(START2.matches(START5));
     // when merging, we lose the sequence numbers for topic foo2, and sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(START2.matches(START6));
+    Assertions.assertFalse(START2.matches(START6));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(START2.matches(START7));
+    Assertions.assertFalse(START2.matches(START7));
 
-    Assert.assertTrue(START3.matches(START0));
-    Assert.assertTrue(START3.matches(START1));
-    Assert.assertTrue(START3.matches(START2));
-    Assert.assertTrue(START3.matches(START3));
+    Assertions.assertTrue(START3.matches(START0));
+    Assertions.assertTrue(START3.matches(START1));
+    Assertions.assertTrue(START3.matches(START2));
+    Assertions.assertTrue(START3.matches(START3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START3.matches(START4));
-    Assert.assertTrue(START3.matches(START5));
+    Assertions.assertFalse(START3.matches(START4));
+    Assertions.assertTrue(START3.matches(START5));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(START3.matches(START6));
+    Assertions.assertFalse(START3.matches(START6));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(START3.matches(START7));
+    Assertions.assertFalse(START3.matches(START7));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(START3.matches(START8));
+    Assertions.assertFalse(START3.matches(START8));
     // when merging, we lose the sequence numbers for topics foo2 and foo22, so false
-    Assert.assertFalse(START3.matches(START9));
+    Assertions.assertFalse(START3.matches(START9));
 
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START0));
+    Assertions.assertFalse(START4.matches(START0));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START1));
+    Assertions.assertFalse(START4.matches(START1));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START2));
+    Assertions.assertFalse(START4.matches(START2));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START3));
-    Assert.assertTrue(START4.matches(START4));
+    Assertions.assertFalse(START4.matches(START3));
+    Assertions.assertTrue(START4.matches(START4));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START5));
+    Assertions.assertFalse(START4.matches(START5));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START6));
+    Assertions.assertFalse(START4.matches(START6));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START7));
+    Assertions.assertFalse(START4.matches(START7));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START8));
+    Assertions.assertFalse(START4.matches(START8));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(START4.matches(START9));
+    Assertions.assertFalse(START4.matches(START9));
 
-    Assert.assertTrue(START5.matches(START0));
-    Assert.assertTrue(START5.matches(START1));
+    Assertions.assertTrue(START5.matches(START0));
+    Assertions.assertTrue(START5.matches(START1));
     // when merging, the sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(START5.matches(START2));
-    Assert.assertTrue(START5.matches(START3));
-    Assert.assertTrue(START5.matches(START4));
-    Assert.assertTrue(START5.matches(START5));
-    Assert.assertTrue(START5.matches(START6));
-    Assert.assertTrue(START5.matches(START7));
-    Assert.assertTrue(START5.matches(START8));
-    Assert.assertTrue(START5.matches(START9));
+    Assertions.assertFalse(START5.matches(START2));
+    Assertions.assertTrue(START5.matches(START3));
+    Assertions.assertTrue(START5.matches(START4));
+    Assertions.assertTrue(START5.matches(START5));
+    Assertions.assertTrue(START5.matches(START6));
+    Assertions.assertTrue(START5.matches(START7));
+    Assertions.assertTrue(START5.matches(START8));
+    Assertions.assertTrue(START5.matches(START9));
 
-    Assert.assertTrue(START6.matches(START0));
-    Assert.assertTrue(START6.matches(START1));
+    Assertions.assertTrue(START6.matches(START0));
+    Assertions.assertTrue(START6.matches(START1));
     // when merging, the sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(START6.matches(START2));
-    Assert.assertTrue(START6.matches(START3));
-    Assert.assertTrue(START6.matches(START4));
-    Assert.assertTrue(START6.matches(START5));
-    Assert.assertTrue(START6.matches(START6));
-    Assert.assertTrue(START6.matches(START7));
-    Assert.assertTrue(START6.matches(START8));
-    Assert.assertTrue(START6.matches(START9));
+    Assertions.assertFalse(START6.matches(START2));
+    Assertions.assertTrue(START6.matches(START3));
+    Assertions.assertTrue(START6.matches(START4));
+    Assertions.assertTrue(START6.matches(START5));
+    Assertions.assertTrue(START6.matches(START6));
+    Assertions.assertTrue(START6.matches(START7));
+    Assertions.assertTrue(START6.matches(START8));
+    Assertions.assertTrue(START6.matches(START9));
 
-    Assert.assertTrue(START7.matches(START0));
-    Assert.assertTrue(START7.matches(START1));
-    Assert.assertTrue(START7.matches(START2));
-    Assert.assertTrue(START7.matches(START3));
-    Assert.assertTrue(START7.matches(START4));
-    Assert.assertTrue(START7.matches(START5));
-    Assert.assertTrue(START7.matches(START6));
-    Assert.assertTrue(START7.matches(START7));
-    Assert.assertTrue(START7.matches(START8));
-    Assert.assertTrue(START7.matches(START9));
+    Assertions.assertTrue(START7.matches(START0));
+    Assertions.assertTrue(START7.matches(START1));
+    Assertions.assertTrue(START7.matches(START2));
+    Assertions.assertTrue(START7.matches(START3));
+    Assertions.assertTrue(START7.matches(START4));
+    Assertions.assertTrue(START7.matches(START5));
+    Assertions.assertTrue(START7.matches(START6));
+    Assertions.assertTrue(START7.matches(START7));
+    Assertions.assertTrue(START7.matches(START8));
+    Assertions.assertTrue(START7.matches(START9));
 
-    Assert.assertTrue(START8.matches(START0));
+    Assertions.assertTrue(START8.matches(START0));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START8.matches(START1));
+    Assertions.assertFalse(START8.matches(START1));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START8.matches(START2));
+    Assertions.assertFalse(START8.matches(START2));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START8.matches(START3));
-    Assert.assertTrue(START8.matches(START4));
+    Assertions.assertFalse(START8.matches(START3));
+    Assertions.assertTrue(START8.matches(START4));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START8.matches(START5));
+    Assertions.assertFalse(START8.matches(START5));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START8.matches(START6));
+    Assertions.assertFalse(START8.matches(START6));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START8.matches(START7));
-    Assert.assertTrue(START8.matches(START8));
-    Assert.assertTrue(START8.matches(START9));
+    Assertions.assertFalse(START8.matches(START7));
+    Assertions.assertTrue(START8.matches(START8));
+    Assertions.assertTrue(START8.matches(START9));
 
-    Assert.assertTrue(START9.matches(START0));
+    Assertions.assertTrue(START9.matches(START0));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START9.matches(START1));
+    Assertions.assertFalse(START9.matches(START1));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START9.matches(START2));
+    Assertions.assertFalse(START9.matches(START2));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START9.matches(START3));
-    Assert.assertTrue(START9.matches(START4));
+    Assertions.assertFalse(START9.matches(START3));
+    Assertions.assertTrue(START9.matches(START4));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START9.matches(START5));
+    Assertions.assertFalse(START9.matches(START5));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START9.matches(START6));
+    Assertions.assertFalse(START9.matches(START6));
     // when merging, we lose the sequence numbers for topic foo, so false
-    Assert.assertFalse(START9.matches(START7));
-    Assert.assertTrue(START9.matches(START8));
-    Assert.assertTrue(START9.matches(START9));
+    Assertions.assertFalse(START9.matches(START7));
+    Assertions.assertTrue(START9.matches(START8));
+    Assertions.assertTrue(START9.matches(START9));
 
-    Assert.assertTrue(END0.matches(END0));
-    Assert.assertTrue(END0.matches(END1));
-    Assert.assertTrue(END0.matches(END2));
-    Assert.assertTrue(END0.matches(END3));
+    Assertions.assertTrue(END0.matches(END0));
+    Assertions.assertTrue(END0.matches(END1));
+    Assertions.assertTrue(END0.matches(END2));
+    Assertions.assertTrue(END0.matches(END3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END0.matches(END4));
-    Assert.assertTrue(END0.matches(END5));
-    Assert.assertTrue(END0.matches(END6));
+    Assertions.assertFalse(END0.matches(END4));
+    Assertions.assertTrue(END0.matches(END5));
+    Assertions.assertTrue(END0.matches(END6));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(END0.matches(END7));
+    Assertions.assertFalse(END0.matches(END7));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(END0.matches(END8));
+    Assertions.assertFalse(END0.matches(END8));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(END0.matches(END9));
+    Assertions.assertFalse(END0.matches(END9));
     // when merging, we lose the sequence numbers for topic foo2, so false
-    Assert.assertFalse(END0.matches(END10));
+    Assertions.assertFalse(END0.matches(END10));
 
-    Assert.assertTrue(END1.matches(END0));
-    Assert.assertTrue(END1.matches(END1));
-    Assert.assertTrue(END1.matches(END2));
-    Assert.assertTrue(END1.matches(END3));
+    Assertions.assertTrue(END1.matches(END0));
+    Assertions.assertTrue(END1.matches(END1));
+    Assertions.assertTrue(END1.matches(END2));
+    Assertions.assertTrue(END1.matches(END3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END1.matches(END4));
-    Assert.assertTrue(END1.matches(END5));
-    Assert.assertTrue(END1.matches(END6));
+    Assertions.assertFalse(END1.matches(END4));
+    Assertions.assertTrue(END1.matches(END5));
+    Assertions.assertTrue(END1.matches(END6));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END1.matches(END7));
+    Assertions.assertFalse(END1.matches(END7));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END1.matches(END8));
+    Assertions.assertFalse(END1.matches(END8));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END1.matches(END9));
+    Assertions.assertFalse(END1.matches(END9));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END1.matches(END10));
+    Assertions.assertFalse(END1.matches(END10));
 
-    Assert.assertTrue(END2.matches(END0));
-    Assert.assertTrue(END2.matches(END1));
-    Assert.assertTrue(END2.matches(END2));
+    Assertions.assertTrue(END2.matches(END0));
+    Assertions.assertTrue(END2.matches(END1));
+    Assertions.assertTrue(END2.matches(END2));
     // when merging, the sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(END2.matches(END3));
+    Assertions.assertFalse(END2.matches(END3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END2.matches(END4));
-    Assert.assertTrue(END2.matches(END5));
-    Assert.assertTrue(END2.matches(END6));
+    Assertions.assertFalse(END2.matches(END4));
+    Assertions.assertTrue(END2.matches(END5));
+    Assertions.assertTrue(END2.matches(END6));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END2.matches(END7));
+    Assertions.assertFalse(END2.matches(END7));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END2.matches(END8));
+    Assertions.assertFalse(END2.matches(END8));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END2.matches(END9));
+    Assertions.assertFalse(END2.matches(END9));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END2.matches(END10));
+    Assertions.assertFalse(END2.matches(END10));
 
-    Assert.assertTrue(END3.matches(END0));
-    Assert.assertTrue(END3.matches(END1));
+    Assertions.assertTrue(END3.matches(END0));
+    Assertions.assertTrue(END3.matches(END1));
     // when merging, the sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(END3.matches(END2));
-    Assert.assertTrue(END3.matches(END3));
+    Assertions.assertFalse(END3.matches(END2));
+    Assertions.assertTrue(END3.matches(END3));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END3.matches(END4));
-    Assert.assertTrue(END3.matches(END5));
+    Assertions.assertFalse(END3.matches(END4));
+    Assertions.assertTrue(END3.matches(END5));
     // when merging, the sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(END3.matches(END6));
+    Assertions.assertFalse(END3.matches(END6));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END3.matches(END7));
+    Assertions.assertFalse(END3.matches(END7));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END3.matches(END8));
+    Assertions.assertFalse(END3.matches(END8));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END3.matches(END9));
+    Assertions.assertFalse(END3.matches(END9));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END3.matches(END10));
+    Assertions.assertFalse(END3.matches(END10));
 
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END0));
+    Assertions.assertFalse(END4.matches(END0));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END1));
+    Assertions.assertFalse(END4.matches(END1));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END2));
+    Assertions.assertFalse(END4.matches(END2));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END3));
-    Assert.assertTrue(END4.matches(END4));
+    Assertions.assertFalse(END4.matches(END3));
+    Assertions.assertTrue(END4.matches(END4));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END5));
+    Assertions.assertFalse(END4.matches(END5));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END6));
+    Assertions.assertFalse(END4.matches(END6));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END7));
+    Assertions.assertFalse(END4.matches(END7));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END8));
+    Assertions.assertFalse(END4.matches(END8));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END9));
+    Assertions.assertFalse(END4.matches(END9));
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertFalse(END4.matches(END10));
+    Assertions.assertFalse(END4.matches(END10));
 
-    Assert.assertTrue(END5.matches(END0));
-    Assert.assertTrue(END5.matches(END1));
-    Assert.assertTrue(END5.matches(END2));
-    Assert.assertTrue(END5.matches(END3));
-    Assert.assertTrue(END5.matches(END4));
-    Assert.assertTrue(END5.matches(END5));
-    Assert.assertTrue(END5.matches(END6));
-    Assert.assertTrue(END5.matches(END7));
-    Assert.assertTrue(END5.matches(END8));
-    Assert.assertTrue(END5.matches(END9));
-    Assert.assertTrue(END5.matches(END10));
+    Assertions.assertTrue(END5.matches(END0));
+    Assertions.assertTrue(END5.matches(END1));
+    Assertions.assertTrue(END5.matches(END2));
+    Assertions.assertTrue(END5.matches(END3));
+    Assertions.assertTrue(END5.matches(END4));
+    Assertions.assertTrue(END5.matches(END5));
+    Assertions.assertTrue(END5.matches(END6));
+    Assertions.assertTrue(END5.matches(END7));
+    Assertions.assertTrue(END5.matches(END8));
+    Assertions.assertTrue(END5.matches(END9));
+    Assertions.assertTrue(END5.matches(END10));
 
-    Assert.assertTrue(END6.matches(END0));
-    Assert.assertTrue(END6.matches(END1));
-    Assert.assertTrue(END6.matches(END2));
+    Assertions.assertTrue(END6.matches(END0));
+    Assertions.assertTrue(END6.matches(END1));
+    Assertions.assertTrue(END6.matches(END2));
     // when merging, the sequence numbers for topic foo-1 are inconsistent, so false
-    Assert.assertFalse(END6.matches(END3));
-    Assert.assertTrue(END6.matches(END4));
-    Assert.assertTrue(END6.matches(END5));
-    Assert.assertTrue(END6.matches(END6));
-    Assert.assertTrue(END6.matches(END7));
-    Assert.assertTrue(END6.matches(END8));
-    Assert.assertTrue(END6.matches(END9));
-    Assert.assertTrue(END6.matches(END10));
+    Assertions.assertFalse(END6.matches(END3));
+    Assertions.assertTrue(END6.matches(END4));
+    Assertions.assertTrue(END6.matches(END5));
+    Assertions.assertTrue(END6.matches(END6));
+    Assertions.assertTrue(END6.matches(END7));
+    Assertions.assertTrue(END6.matches(END8));
+    Assertions.assertTrue(END6.matches(END9));
+    Assertions.assertTrue(END6.matches(END10));
 
-    Assert.assertTrue(END7.matches(END0));
-    Assert.assertTrue(END7.matches(END1));
-    Assert.assertTrue(END7.matches(END2));
-    Assert.assertTrue(END7.matches(END3));
-    Assert.assertTrue(END7.matches(END4));
-    Assert.assertTrue(END7.matches(END5));
-    Assert.assertTrue(END7.matches(END6));
-    Assert.assertTrue(END7.matches(END7));
-    Assert.assertTrue(END7.matches(END8));
-    Assert.assertTrue(END7.matches(END9));
-    Assert.assertTrue(END7.matches(END10));
+    Assertions.assertTrue(END7.matches(END0));
+    Assertions.assertTrue(END7.matches(END1));
+    Assertions.assertTrue(END7.matches(END2));
+    Assertions.assertTrue(END7.matches(END3));
+    Assertions.assertTrue(END7.matches(END4));
+    Assertions.assertTrue(END7.matches(END5));
+    Assertions.assertTrue(END7.matches(END6));
+    Assertions.assertTrue(END7.matches(END7));
+    Assertions.assertTrue(END7.matches(END8));
+    Assertions.assertTrue(END7.matches(END9));
+    Assertions.assertTrue(END7.matches(END10));
 
-    Assert.assertTrue(END8.matches(END0));
-    Assert.assertTrue(END8.matches(END1));
-    Assert.assertTrue(END8.matches(END2));
+    Assertions.assertTrue(END8.matches(END0));
+    Assertions.assertTrue(END8.matches(END1));
+    Assertions.assertTrue(END8.matches(END2));
     // when merging, the sequence numbers for topic foo-1, and foo-2 are inconsistent, so false
-    Assert.assertFalse(END8.matches(END3));
-    Assert.assertTrue(END8.matches(END4));
-    Assert.assertTrue(END8.matches(END5));
-    Assert.assertTrue(END8.matches(END6));
-    Assert.assertTrue(END8.matches(END7));
-    Assert.assertTrue(END8.matches(END8));
-    Assert.assertTrue(END8.matches(END9));
-    Assert.assertTrue(END8.matches(END10));
+    Assertions.assertFalse(END8.matches(END3));
+    Assertions.assertTrue(END8.matches(END4));
+    Assertions.assertTrue(END8.matches(END5));
+    Assertions.assertTrue(END8.matches(END6));
+    Assertions.assertTrue(END8.matches(END7));
+    Assertions.assertTrue(END8.matches(END8));
+    Assertions.assertTrue(END8.matches(END9));
+    Assertions.assertTrue(END8.matches(END10));
 
-    Assert.assertTrue(END9.matches(END0));
+    Assertions.assertTrue(END9.matches(END0));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END9.matches(END1));
+    Assertions.assertFalse(END9.matches(END1));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END9.matches(END2));
+    Assertions.assertFalse(END9.matches(END2));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END9.matches(END3));
-    Assert.assertTrue(END9.matches(END4));
+    Assertions.assertFalse(END9.matches(END3));
+    Assertions.assertTrue(END9.matches(END4));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END9.matches(END5));
+    Assertions.assertFalse(END9.matches(END5));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END9.matches(END6));
+    Assertions.assertFalse(END9.matches(END6));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END9.matches(END7));
+    Assertions.assertFalse(END9.matches(END7));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END9.matches(END8));
-    Assert.assertTrue(END9.matches(END9));
-    Assert.assertTrue(END9.matches(END10));
+    Assertions.assertFalse(END9.matches(END8));
+    Assertions.assertTrue(END9.matches(END9));
+    Assertions.assertTrue(END9.matches(END10));
 
-    Assert.assertTrue(END10.matches(END0));
+    Assertions.assertTrue(END10.matches(END0));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END10.matches(END1));
+    Assertions.assertFalse(END10.matches(END1));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END10.matches(END2));
+    Assertions.assertFalse(END10.matches(END2));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END10.matches(END3));
-    Assert.assertTrue(END10.matches(END4));
+    Assertions.assertFalse(END10.matches(END3));
+    Assertions.assertTrue(END10.matches(END4));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END10.matches(END5));
+    Assertions.assertFalse(END10.matches(END5));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END10.matches(END6));
+    Assertions.assertFalse(END10.matches(END6));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END10.matches(END7));
+    Assertions.assertFalse(END10.matches(END7));
     // when merging, we lose the sequence numbers for topic foo2 here when merging, so false
-    Assert.assertFalse(END10.matches(END8));
-    Assert.assertTrue(END10.matches(END9));
-    Assert.assertTrue(END10.matches(END10));
+    Assertions.assertFalse(END10.matches(END8));
+    Assertions.assertTrue(END10.matches(END9));
+    Assertions.assertTrue(END10.matches(END10));
   }
 
   @Test
   public void testIsValidStart()
   {
-    Assert.assertTrue(START0.isValidStart());
-    Assert.assertTrue(START1.isValidStart());
-    Assert.assertTrue(START2.isValidStart());
-    Assert.assertTrue(START3.isValidStart());
-    Assert.assertTrue(START4.isValidStart());
-    Assert.assertTrue(START5.isValidStart());
-    Assert.assertTrue(START6.isValidStart());
-    Assert.assertTrue(START7.isValidStart());
-    Assert.assertTrue(START8.isValidStart());
-    Assert.assertTrue(START9.isValidStart());
+    Assertions.assertTrue(START0.isValidStart());
+    Assertions.assertTrue(START1.isValidStart());
+    Assertions.assertTrue(START2.isValidStart());
+    Assertions.assertTrue(START3.isValidStart());
+    Assertions.assertTrue(START4.isValidStart());
+    Assertions.assertTrue(START5.isValidStart());
+    Assertions.assertTrue(START6.isValidStart());
+    Assertions.assertTrue(START7.isValidStart());
+    Assertions.assertTrue(START8.isValidStart());
+    Assertions.assertTrue(START9.isValidStart());
   }
 
   @Test
   public void testPlus()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 3L, 2, 5L)),
         START1.plus(START3)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 4L, 2, 5L)),
         START0.plus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 4L, 2, 5L)),
         START1.plus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 3L, 2, 5L)),
         START2.plus(START1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 4L, 2, 5L)),
         START2.plus(START2)
     );
 
     // add comment on this
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START4,
         START1.plus(START4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 3L)),
         START1.plus(START5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 3L)),
         START1.plus(START6)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 3L, 2, 5L)),
         START1.plus(START7)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(0, 2L, 1, 3L, 2, 5L)),
         START2.plus(START6)
     );
 
     // add comment on this
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START0,
         START4.plus(START0)
     );
 
     // add comment on this
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START1,
         START4.plus(START1)
     );
 
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START4,
         START4.plus(START5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START5,
         START5.plus(START4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2"), ImmutableMap.of(0, 2L, 1, 3L)),
         START5.plus(START6)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2"), ImmutableMap.of(0, 2L, 2, 5L)),
         START7.plus(START8)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2", "foo22"), ImmutableMap.of(0, 2L, 2, 5L)),
         START7.plus(START9)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadataMultiTopic("foo2.*", ImmutableList.of("foo2"), ImmutableMap.of(0, 2L, 2, 5L)),
         START8.plus(START7)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadataMultiTopic("foo2.*", ImmutableList.of("foo2", "foo22"), ImmutableMap.of(0, 2L, 2, 5L)),
         START8.plus(START9)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadataMultiTopic("foo2.*", ImmutableList.of("foo2", "foo22"), ImmutableMap.of(0, 2L, 2, 5L)),
         START9.plus(START8)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of(0, 2L, 2, 5L)),
         END0.plus(END1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of(0, 2L, 1, 4L, 2, 5L)),
         END1.plus(END2)
     );
 
     // add comment on this
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END4,
         END0.plus(END4)
     );
 
     // add comment on this
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END4,
         END1.plus(END4)
     );
 
     // add comment on this
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END0,
         END4.plus(END0)
     );
 
     // add comment on this
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END1,
         END4.plus(END1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END3,
         END2.plus(END3)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END2,
         END3.plus(END2)
     );
 
     // when sequence map is empty, we don't know whether its multi-topic or not, so assume single topic to preserve existing behavior    Assert.assertFalse(START1.matches(START4));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END4,
         END4.plus(END5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END5,
         END5.plus(END4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2"), ImmutableMap.of(0, 2L, 2, 5L)),
         END5.plus(END9)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2", "foo22"), ImmutableMap.of(0, 2L, 2, 5L)),
         END5.plus(END10)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of(0, 2L, 1, 4L, 2, 5L)),
         END5.plus(END6)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2"), ImmutableMap.of(0, 2L, 2, 5L)),
         END5.plus(END7)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2"), ImmutableMap.of(0, 2L, 2, 5L)),
         END7.plus(END5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo2"), ImmutableMap.of(0, 2L, 2, 5L)),
         END9.plus(END5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo2", "foo22"), ImmutableMap.of(0, 2L, 2, 5L)),
         END9.plus(END10)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo2", "foo22"), ImmutableMap.of(0, 2L, 2, 5L)),
         END10.plus(END9)
     );
@@ -623,172 +623,172 @@ public class KafkaDataSourceMetadataTest
   @Test
   public void testMinus()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of()),
         START0.minus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START0,
         START0.minus(START4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of()),
         START1.minus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(1, 3L)),
         START1.minus(START3)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START1,
         START1.minus(START4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata("foo", ImmutableMap.of()),
         START1.minus(START5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata("foo", ImmutableMap.of()),
         START1.minus(START6)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata("foo", ImmutableMap.of(1, 3L)),
         START1.minus(START7)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of(2, 5L)),
         START2.minus(START1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadata(ImmutableMap.of()),
         START2.minus(START2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START4,
         START4.minus(START0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         START4,
         START4.minus(START1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         startMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of()),
         START5.minus(START1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of(1, 4L)),
         END2.minus(END1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadata(ImmutableMap.of(2, 5L)),
         END1.minus(END2)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END0,
         END0.minus(END4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END4,
         END4.minus(END0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END1,
         END1.minus(END4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END4,
         END4.minus(END1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of()),
         END5.minus(END1)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of(0, 2L, 2, 5L)),
         END5.minus(END4)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of(2, 5L)),
         END5.minus(END6)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of(1, 4L)),
         END6.minus(END5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of(1, 4L)),
         END6.minus(END7)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo2"), ImmutableMap.of(0, 2L, 2, 5L)),
         END7.minus(END5)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo", "foo2"), ImmutableMap.of(2, 5L)),
         END7.minus(END8)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of(0, 2L, 2, 5L)),
         END7.minus(END9)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo.*", ImmutableList.of("foo"), ImmutableMap.of(0, 2L, 2, 5L)),
         END7.minus(END10)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         END9,
         END9.minus(END6)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo2"), ImmutableMap.of()),
         END9.minus(END7)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo2"), ImmutableMap.of(2, 5L)),
         END9.minus(END8)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo2"), ImmutableMap.of()),
         END9.minus(END9)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo2"), ImmutableMap.of()),
         END9.minus(END10)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         endMetadataMultiTopic("foo2.*", ImmutableList.of("foo22"), ImmutableMap.of(0, 2L, 2, 5L)),
         END10.minus(END9)
     );
@@ -802,12 +802,12 @@ public class KafkaDataSourceMetadataTest
     KafkaDataSourceMetadata kdm1 = endMetadata(ImmutableMap.of());
     String kdmStr1 = jsonMapper.writeValueAsString(kdm1);
     DataSourceMetadata dsMeta1 = jsonMapper.readValue(kdmStr1, DataSourceMetadata.class);
-    Assert.assertEquals(kdm1, dsMeta1);
+    Assertions.assertEquals(kdm1, dsMeta1);
 
     KafkaDataSourceMetadata kdm2 = endMetadata(ImmutableMap.of(1, 3L));
     String kdmStr2 = jsonMapper.writeValueAsString(kdm2);
     DataSourceMetadata dsMeta2 = jsonMapper.readValue(kdmStr2, DataSourceMetadata.class);
-    Assert.assertEquals(kdm2, dsMeta2);
+    Assertions.assertEquals(kdm2, dsMeta2);
   }
 
   @Test
@@ -817,12 +817,12 @@ public class KafkaDataSourceMetadataTest
     KafkaDataSourceMetadata expectedKdm1 = endMetadata(ImmutableMap.of(1, 3L));
     String kdmStr1 = "{\"type\":\"kafka\",\"partitions\":{\"type\":\"end\",\"stream\":\"foo\",\"topic\":\"foo\",\"partitionSequenceNumberMap\":{\"1\":3},\"partitionOffsetMap\":{\"1\":3},\"exclusivePartitions\":[]}}\n";
     DataSourceMetadata dsMeta1 = jsonMapper.readValue(kdmStr1, DataSourceMetadata.class);
-    Assert.assertEquals(dsMeta1, expectedKdm1);
+    Assertions.assertEquals(dsMeta1, expectedKdm1);
 
     KafkaDataSourceMetadata expectedKdm2 = endMetadata(ImmutableMap.of(1, 3L, 2, 1900L));
     String kdmStr2 = "{\"type\":\"kafka\",\"partitions\":{\"type\":\"end\",\"stream\":\"foo\",\"topic\":\"food\",\"partitionSequenceNumberMap\":{\"1\":3, \"2\":1900},\"partitionOffsetMap\":{\"1\":3, \"2\":1900},\"exclusivePartitions\":[]}}\n";
     DataSourceMetadata dsMeta2 = jsonMapper.readValue(kdmStr2, DataSourceMetadata.class);
-    Assert.assertEquals(dsMeta2, expectedKdm2);
+    Assertions.assertEquals(dsMeta2, expectedKdm2);
   }
 
   private static KafkaDataSourceMetadata startMetadata(Map<Integer, Long> offsets)
@@ -852,9 +852,9 @@ public class KafkaDataSourceMetadataTest
       Map<Integer, Long> offsets
   )
   {
-    Assert.assertFalse(topics.isEmpty());
+    Assertions.assertFalse(topics.isEmpty());
     Pattern pattern = Pattern.compile(topicPattern);
-    Assert.assertTrue(topics.stream().allMatch(t -> pattern.matcher(t).matches()));
+    Assertions.assertTrue(topics.stream().allMatch(t -> pattern.matcher(t).matches()));
     Map<KafkaTopicPartition, Long> newOffsets = new HashMap<>();
     for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
       for (String topic : topics) {
@@ -897,9 +897,9 @@ public class KafkaDataSourceMetadataTest
       Map<Integer, Long> offsets
   )
   {
-    Assert.assertFalse(topics.isEmpty());
+    Assertions.assertFalse(topics.isEmpty());
     Pattern pattern = Pattern.compile(topicPattern);
-    Assert.assertTrue(topics.stream().allMatch(t -> pattern.matcher(t).matches()));
+    Assertions.assertTrue(topics.stream().allMatch(t -> pattern.matcher(t).matches()));
     Map<KafkaTopicPartition, Long> newOffsets = new HashMap<>();
     for (Map.Entry<Integer, Long> e : offsets.entrySet()) {
       for (String topic : topics) {
@@ -924,7 +924,7 @@ public class KafkaDataSourceMetadataTest
     KafkaDataSourceMetadata metadata1 = startMetadata("foo", ImmutableMap.of(0, 100L));
     KafkaDataSourceMetadata metadata2 = startMetadata("foo", ImmutableMap.of(0, 200L));
 
-    Assert.assertNotEquals(metadata1, metadata2);
+    Assertions.assertNotEquals(metadata1, metadata2);
   }
 
   @Test
@@ -945,7 +945,7 @@ public class KafkaDataSourceMetadataTest
     KafkaDataSourceMetadata metadata1 = new KafkaDataSourceMetadata(partitions, boundedConfig1);
     KafkaDataSourceMetadata metadata2 = new KafkaDataSourceMetadata(partitions, boundedConfig2);
 
-    Assert.assertNotEquals(metadata1, metadata2);
+    Assertions.assertNotEquals(metadata1, metadata2);
   }
 
   @Test
@@ -961,7 +961,7 @@ public class KafkaDataSourceMetadataTest
     KafkaDataSourceMetadata metadata1 = new KafkaDataSourceMetadata(partitions, boundedConfig);
     KafkaDataSourceMetadata metadata2 = new KafkaDataSourceMetadata(partitions, boundedConfig);
 
-    Assert.assertEquals(metadata1, metadata2);
+    Assertions.assertEquals(metadata1, metadata2);
   }
 
   @Test
@@ -984,7 +984,7 @@ public class KafkaDataSourceMetadataTest
         boundedConfig2
     );
 
-    Assert.assertNotEquals(metadata1, metadata2);
+    Assertions.assertNotEquals(metadata1, metadata2);
   }
 
   private static ObjectMapper createObjectMapper()

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIOConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIOConfigTest.java
@@ -26,11 +26,9 @@ import org.apache.druid.data.input.kafka.KafkaTopicPartition;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.segment.indexing.IOConfig;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.Collections;
 
@@ -43,9 +41,6 @@ public class KafkaIOConfigTest
     mapper = new DefaultObjectMapper();
     mapper.registerModules(new KafkaIndexTaskModule().getJacksonModules());
   }
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testSerdeWithDefaults() throws Exception
@@ -68,18 +63,18 @@ public class KafkaIOConfigTest
         ), IOConfig.class
     );
 
-    Assert.assertEquals("my-sequence-name", config.getBaseSequenceName());
-    Assert.assertEquals("mytopic", config.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 1L, new KafkaTopicPartition(false, null, 1), 10L),
+    Assertions.assertEquals("my-sequence-name", config.getBaseSequenceName());
+    Assertions.assertEquals("mytopic", config.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 1L, new KafkaTopicPartition(false, null, 1), 10L),
                         config.getStartSequenceNumbers().getPartitionSequenceNumberMap());
-    Assert.assertEquals("mytopic", config.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 15L, new KafkaTopicPartition(false, null, 1),
+    Assertions.assertEquals("mytopic", config.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 15L, new KafkaTopicPartition(false, null, 1),
                                         200L), config.getEndSequenceNumbers().getPartitionSequenceNumberMap());
-    Assert.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
-    Assert.assertTrue(config.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", config.getMinimumMessageTime());
-    Assert.assertNull("maximumMessageTime", config.getMaximumMessageTime());
-    Assert.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
+    Assertions.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
+    Assertions.assertTrue(config.isUseTransaction());
+    Assertions.assertNull(config.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertNull(config.getMaximumMessageTime(), "maximumMessageTime");
+    Assertions.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
   }
 
   @Test
@@ -103,18 +98,18 @@ public class KafkaIOConfigTest
         ), IOConfig.class
     );
 
-    Assert.assertEquals("my-sequence-name", config.getBaseSequenceName());
-    Assert.assertEquals("mytopic", config.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 1L, new KafkaTopicPartition(false, null, 1), 10L),
+    Assertions.assertEquals("my-sequence-name", config.getBaseSequenceName());
+    Assertions.assertEquals("mytopic", config.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 1L, new KafkaTopicPartition(false, null, 1), 10L),
                         config.getStartSequenceNumbers().getPartitionSequenceNumberMap());
-    Assert.assertEquals("mytopic", config.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 15L, new KafkaTopicPartition(false, null, 1),
+    Assertions.assertEquals("mytopic", config.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 15L, new KafkaTopicPartition(false, null, 1),
                                         200L), config.getEndSequenceNumbers().getPartitionSequenceNumberMap());
-    Assert.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
-    Assert.assertTrue(config.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", config.getMinimumMessageTime());
-    Assert.assertNull("maximumMessageTime", config.getMaximumMessageTime());
-    Assert.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
+    Assertions.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
+    Assertions.assertTrue(config.isUseTransaction());
+    Assertions.assertNull(config.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertNull(config.getMaximumMessageTime(), "maximumMessageTime");
+    Assertions.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
   }
 
   @Test
@@ -141,18 +136,18 @@ public class KafkaIOConfigTest
         ), IOConfig.class
     );
 
-    Assert.assertEquals("my-sequence-name", config.getBaseSequenceName());
-    Assert.assertEquals("mytopic", config.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 1L, new KafkaTopicPartition(false, null, 1), 10L),
+    Assertions.assertEquals("my-sequence-name", config.getBaseSequenceName());
+    Assertions.assertEquals("mytopic", config.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 1L, new KafkaTopicPartition(false, null, 1), 10L),
                         config.getStartSequenceNumbers().getPartitionSequenceNumberMap());
-    Assert.assertEquals("mytopic", config.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 15L, new KafkaTopicPartition(false, null, 1),
+    Assertions.assertEquals("mytopic", config.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(ImmutableMap.of(new KafkaTopicPartition(false, null, 0), 15L, new KafkaTopicPartition(false, null, 1),
                                         200L), config.getEndSequenceNumbers().getPartitionSequenceNumberMap());
-    Assert.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
-    Assert.assertFalse(config.isUseTransaction());
-    Assert.assertEquals(DateTimes.of("2016-05-31T12:00Z"), config.getMinimumMessageTime());
-    Assert.assertEquals(DateTimes.of("2016-05-31T14:00Z"), config.getMaximumMessageTime());
-    Assert.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
+    Assertions.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
+    Assertions.assertFalse(config.isUseTransaction());
+    Assertions.assertEquals(DateTimes.of("2016-05-31T12:00Z"), config.getMinimumMessageTime());
+    Assertions.assertEquals(DateTimes.of("2016-05-31T14:00Z"), config.getMaximumMessageTime());
+    Assertions.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
   }
 
   @Test
@@ -169,10 +164,11 @@ public class KafkaIOConfigTest
                      + "  \"maximumMessageTime\": \"2016-05-31T14:00Z\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("baseSequenceName"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    assertJsonMappingException(
+        NullPointerException.class,
+        "baseSequenceName",
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
   }
 
   @Test
@@ -189,10 +185,11 @@ public class KafkaIOConfigTest
                      + "  \"maximumMessageTime\": \"2016-05-31T14:00Z\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("startPartitions"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    assertJsonMappingException(
+        NullPointerException.class,
+        "startPartitions",
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
   }
 
   @Test
@@ -209,10 +206,11 @@ public class KafkaIOConfigTest
                      + "  \"maximumMessageTime\": \"2016-05-31T14:00Z\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("endSequenceNumbers"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    assertJsonMappingException(
+        NullPointerException.class,
+        "endSequenceNumbers",
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
   }
 
   @Test
@@ -229,10 +227,11 @@ public class KafkaIOConfigTest
                      + "  \"maximumMessageTime\": \"2016-05-31T14:00Z\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("consumerProperties"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    assertJsonMappingException(
+        NullPointerException.class,
+        "consumerProperties",
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
   }
 
   @Test
@@ -250,10 +249,11 @@ public class KafkaIOConfigTest
                      + "  \"maximumMessageTime\": \"2016-05-31T14:00Z\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
-    exception.expectMessage(CoreMatchers.containsString("start topic/stream and end topic/stream must match"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    assertJsonMappingException(
+        IllegalArgumentException.class,
+        "start topic/stream and end topic/stream must match",
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
   }
 
   @Test
@@ -271,10 +271,11 @@ public class KafkaIOConfigTest
                      + "  \"maximumMessageTime\": \"2016-05-31T14:00Z\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
-    exception.expectMessage(CoreMatchers.containsString("start partition set and end partition set must match"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    assertJsonMappingException(
+        IllegalArgumentException.class,
+        "start partition set and end partition set must match",
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
   }
 
   @Test
@@ -292,9 +293,21 @@ public class KafkaIOConfigTest
                      + "  \"maximumMessageTime\": \"2016-05-31T14:00Z\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
-    exception.expectMessage(CoreMatchers.containsString("end offset must be >= start offset"));
-    mapper.readValue(jsonStr, IOConfig.class);
+    assertJsonMappingException(
+        IllegalArgumentException.class,
+        "end offset must be >= start offset",
+        () -> mapper.readValue(jsonStr, IOConfig.class)
+    );
+  }
+
+  private static void assertJsonMappingException(
+      Class<? extends Throwable> causeType,
+      String expectedMessage,
+      Executable executable
+  )
+  {
+    final JsonMappingException exception = Assertions.assertThrows(JsonMappingException.class, executable);
+    Assertions.assertInstanceOf(causeType, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains(expectedMessage));
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -38,7 +38,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Injector;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.cli.CliPeon;
-import org.apache.druid.cli.CliPeonTest;
 import org.apache.druid.cli.PeonLoadSpecHolder;
 import org.apache.druid.cli.PeonTaskHolder;
 import org.apache.druid.data.input.InputEntity;
@@ -137,16 +136,15 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -169,11 +167,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
 @SuppressWarnings("unchecked")
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
 {
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private static final long POLL_RETRY_MS = 100;
   private static final Iterable<Header> SAMPLE_HEADERS = ImmutableList.of(new Header()
@@ -211,7 +210,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     ).forEach(OBJECT_MAPPER::registerModule);
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -285,7 +283,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     super(lockGranularity);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     kafkaServer = new EmbeddedKafkaBroker(ImmutableMap.of("KAFKA_NUM_PARTITIONS", "2"));
@@ -298,7 +296,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Before
+  @BeforeEach
   public void setupTest() throws IOException
   {
     handoffConditionTimeout = 0;
@@ -313,7 +311,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     makeToolboxFactory();
   }
 
-  @After
+  @AfterEach
   public void tearDownTest()
   {
     synchronized (runningTasks) {
@@ -327,7 +325,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     destroyToolboxFactory();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass() throws Exception
   {
     taskExec.shutdown();
@@ -337,7 +335,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     kafkaServer = null;
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunAfterDataInserted() throws Exception
   {
     // Insert data
@@ -364,7 +362,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
 
     // Check published metadata and segments in deep storage
@@ -375,19 +373,19 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIngestNullColumnAfterDataInserted() throws Exception
   {
     // Insert data
@@ -424,24 +422,24 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
 
     final Collection<DataSegment> segments = publishedSegments();
     for (DataSegment segment : segments) {
       for (int i = 0; i < dimensionsSpec.getDimensions().size(); i++) {
-        Assert.assertEquals(dimensionsSpec.getDimensionNames().get(i), segment.getDimensions().get(i));
+        Assertions.assertEquals(dimensionsSpec.getDimensionNames().get(i), segment.getDimensions().get(i));
       }
     }
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(3, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(2, observedSegmentGenerationMetrics.handOffCount());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIngestNullColumnAfterDataInserted_storeEmptyColumnsOff_shouldNotStoreEmptyColumns() throws Exception
   {
     // Insert data
@@ -480,15 +478,15 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
     final Collection<DataSegment> segments = publishedSegments();
     for (DataSegment segment : segments) {
-      Assert.assertFalse(segment.getDimensions().contains("unknownDim"));
+      Assertions.assertFalse(segment.getDimensions().contains("unknownDim"));
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunBeforeDataInserted() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -520,9 +518,9 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
-    Assert.assertTrue(task.getRunner().getSegmentGenerationMetrics().isProcessingDone());
+    Assertions.assertTrue(task.getRunner().getSegmentGenerationMetrics().isProcessingDone());
 
     // Check published metadata and segments in deep storage
     assertEqualsExceptVersion(
@@ -532,13 +530,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunAfterDataInsertedLiveReport() throws Exception
   {
     // Insert data
@@ -581,16 +579,16 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     runner.resume();
 
     // Check metrics
-    Assert.assertEquals(buildSegments, task.getRunner().getRowIngestionMeters().getTotals());
+    Assertions.assertEquals(buildSegments, task.getRunner().getRowIngestionMeters().getTotals());
 
-    Assert.assertEquals(avg_1min.get("processed"), 0.0);
-    Assert.assertEquals(avg_5min.get("processed"), 0.0);
-    Assert.assertEquals(avg_15min.get("processed"), 0.0);
+    Assertions.assertEquals(avg_1min.get("processed"), 0.0);
+    Assertions.assertEquals(avg_5min.get("processed"), 0.0);
+    Assertions.assertEquals(avg_15min.get("processed"), 0.0);
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOff() throws Exception
   {
     final String baseSequenceName = "sequence0";
@@ -643,14 +641,14 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(10);
     }
     final Map<KafkaTopicPartition, Long> currentOffsets = ImmutableMap.copyOf(task.getRunner().getCurrentOffsets());
-    Assert.assertTrue(checkpoint1.getPartitionSequenceNumberMap().equals(currentOffsets)
+    Assertions.assertTrue(checkpoint1.getPartitionSequenceNumberMap().equals(currentOffsets)
                       || checkpoint2.getPartitionSequenceNumberMap()
                                     .equals(currentOffsets));
     task.getRunner().setEndOffsets(currentOffsets, false);
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
-    Assert.assertEquals(1, checkpointRequestsHash.size());
-    Assert.assertTrue(
+    Assertions.assertEquals(1, checkpointRequestsHash.size());
+    Assertions.assertTrue(
         checkpointRequestsHash.contains(
             Objects.hash(
                 DATA_SCHEMA.getDataSource(),
@@ -676,7 +674,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 10L, new KafkaTopicPartition(false, topic, 1), 2L))
         ),
@@ -684,14 +682,14 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(8, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(7, observedSegmentGenerationMetrics.handOffCount());
-    Assert.assertEquals(4, observedSegmentGenerationMetrics.numPersists());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(8, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(7, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertEquals(4, observedSegmentGenerationMetrics.numPersists());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOffMaxTotalRows() throws Exception
   {
     final String baseSequenceName = "sequence0";
@@ -755,7 +753,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
     final Map<KafkaTopicPartition, Long> currentOffsets = ImmutableMap.copyOf(task.getRunner().getCurrentOffsets());
 
-    Assert.assertEquals(checkpoint1.getPartitionSequenceNumberMap(), currentOffsets);
+    Assertions.assertEquals(checkpoint1.getPartitionSequenceNumberMap(), currentOffsets);
     task.getRunner().setEndOffsets(currentOffsets, false);
 
     while (task.getRunner().getStatus() != Status.PAUSED) {
@@ -774,13 +772,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final Map<KafkaTopicPartition, Long> nextOffsets = ImmutableMap.copyOf(task.getRunner().getCurrentOffsets());
 
 
-    Assert.assertEquals(checkpoint2.getPartitionSequenceNumberMap(), nextOffsets);
+    Assertions.assertEquals(checkpoint2.getPartitionSequenceNumberMap(), nextOffsets);
     task.getRunner().setEndOffsets(nextOffsets, false);
 
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
-    Assert.assertEquals(2, checkpointRequestsHash.size());
-    Assert.assertTrue(
+    Assertions.assertEquals(2, checkpointRequestsHash.size());
+    Assertions.assertTrue(
         checkpointRequestsHash.contains(
             Objects.hash(
                 DATA_SCHEMA.getDataSource(),
@@ -789,7 +787,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
             )
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         checkpointRequestsHash.contains(
             Objects.hash(
                 DATA_SCHEMA.getDataSource(),
@@ -817,14 +815,14 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 10L, new KafkaTopicPartition(false, topic, 1), 2L))
         ),
         newDataSchemaMetadata()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 10L, new KafkaTopicPartition(false, topic, 1), 2L))
         ),
@@ -832,7 +830,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testTimeBasedIncrementalHandOff() throws Exception
   {
     final String baseSequenceName = "sequence0";
@@ -883,12 +881,12 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(10);
     }
     final Map<KafkaTopicPartition, Long> currentOffsets = ImmutableMap.copyOf(task.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpoint.getPartitionSequenceNumberMap(), currentOffsets);
+    Assertions.assertEquals(checkpoint.getPartitionSequenceNumberMap(), currentOffsets);
     task.getRunner().setEndOffsets(currentOffsets, false);
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
 
-    Assert.assertEquals(1, checkpointRequestsHash.size());
-    Assert.assertTrue(
+    Assertions.assertEquals(1, checkpointRequestsHash.size());
+    Assertions.assertTrue(
         checkpointRequestsHash.contains(
             Objects.hash(
                 DATA_SCHEMA.getDataSource(),
@@ -908,7 +906,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 2L, new KafkaTopicPartition(false, topic, 1), 0L))
         ),
@@ -916,7 +914,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCheckpointResetWithSameEndOffsets() throws Exception
   {
     final String baseSequenceName = "sequence0";
@@ -965,13 +963,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final Map<KafkaTopicPartition, Long> nextEndOffsets = task.getRunner().getLastSequenceMetadata().getStartOffsets();
     task.getRunner().setEndOffsets(nextEndOffsets, false);
     long newNextCheckpointTime = task.getRunner().getNextCheckpointTime();
-    Assert.assertTrue(
+    Assertions.assertTrue(
+        newNextCheckpointTime > currentNextCheckpointTime,
         StringUtils.format(
             "Old checkpoint time: [%d], new checkpoint time: [%d]",
             currentNextCheckpointTime,
-            newNextCheckpointTime),
-        newNextCheckpointTime > currentNextCheckpointTime);
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+            newNextCheckpointTime));
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
   }
 
   DataSourceMetadata newDataSchemaMetadata()
@@ -979,7 +977,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     return metadataStorageCoordinator.retrieveDataSourceMetadata(DATA_SCHEMA.getDataSource());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOffReadsThroughEndOffsets() throws Exception
   {
     records = generateSinglePartitionRecords(topic);
@@ -1056,7 +1054,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(10);
     }
     Map<KafkaTopicPartition, Long> currentOffsets = ImmutableMap.copyOf(normalReplica.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpoint1.getPartitionSequenceNumberMap(), currentOffsets);
+    Assertions.assertEquals(checkpoint1.getPartitionSequenceNumberMap(), currentOffsets);
 
     normalReplica.getRunner().setEndOffsets(currentOffsets, false);
     staleReplica.getRunner().setEndOffsets(currentOffsets, false);
@@ -1068,22 +1066,22 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(10);
     }
     currentOffsets = ImmutableMap.copyOf(normalReplica.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpoint2.getPartitionSequenceNumberMap(), currentOffsets);
+    Assertions.assertEquals(checkpoint2.getPartitionSequenceNumberMap(), currentOffsets);
     currentOffsets = ImmutableMap.copyOf(staleReplica.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpoint2.getPartitionSequenceNumberMap(), currentOffsets);
+    Assertions.assertEquals(checkpoint2.getPartitionSequenceNumberMap(), currentOffsets);
 
     normalReplica.getRunner().setEndOffsets(currentOffsets, true);
     staleReplica.getRunner().setEndOffsets(currentOffsets, true);
 
-    Assert.assertEquals(TaskState.SUCCESS, normalReplicaFuture.get().getStatusCode());
-    Assert.assertEquals(TaskState.SUCCESS, staleReplicaFuture.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, normalReplicaFuture.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, staleReplicaFuture.get().getStatusCode());
 
     long totalBytes = getTotalSizeOfRecords(0, 9);
     verifyTaskMetrics(normalReplica, RowMeters.with().bytes(totalBytes).totalProcessed(9));
     verifyTaskMetrics(staleReplica, RowMeters.with().bytes(totalBytes).totalProcessed(9));
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithMinimumMessageTime() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -1115,7 +1113,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 5)).thrownAwayByReason(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME, 2).totalProcessed(3));
 
     // Check published metadata and segments in deep storage
@@ -1126,13 +1124,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithMaximumMessageTime() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -1164,7 +1162,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 5)).thrownAwayByReason(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME, 2).totalProcessed(3));
 
     // Check published metadata and segments in deep storage
@@ -1176,13 +1174,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithTransformSpec() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -1222,23 +1220,23 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 5)).thrownAwayByReason(InputRowFilterResult.CUSTOM_FILTER, 4).totalProcessed(1));
 
     // Check published metadata
     final List<SegmentDescriptor> publishedDescriptors = publishedDescriptors();
     assertEqualsExceptVersion(ImmutableList.of(sdd("2009/P1D", 0)), publishedDescriptors);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
 
     // Check segments in deep storage
-    Assert.assertEquals(ImmutableList.of("b"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
-    Assert.assertEquals(ImmutableList.of("bb"), readSegmentColumn("dim1t", publishedDescriptors.get(0)));
+    Assertions.assertEquals(ImmutableList.of("b"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
+    Assertions.assertEquals(ImmutableList.of("bb"), readSegmentColumn("dim1t", publishedDescriptors.get(0)));
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testKafkaRecordEntityInputFormat() throws Exception
   {
     // Insert data
@@ -1289,30 +1287,30 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(25);
     }
 
-    Assert.assertEquals(Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
 
     final QuerySegmentSpec interval = OBJECT_MAPPER.readValue(
         "\"2008/2012\"", QuerySegmentSpec.class
     );
     List<Map<String, Object>> scanResultValues = scanData(task, interval);
     //verify that there are no records indexed in the rollbacked time period
-    Assert.assertEquals(3, Iterables.size(scanResultValues));
+    Assertions.assertEquals(3, Iterables.size(scanResultValues));
 
     int i = 0;
     for (Map<String, Object> event : scanResultValues) {
-      Assert.assertEquals((long) i++, event.get("kafka.offset"));
-      Assert.assertEquals(topic, event.get("kafka.topic"));
-      Assert.assertEquals("application/json", event.get("kafka.header.encoding"));
+      Assertions.assertEquals((long) i++, event.get("kafka.offset"));
+      Assertions.assertEquals(topic, event.get("kafka.topic"));
+      Assertions.assertEquals("application/json", event.get("kafka.header.encoding"));
     }
     // insert remaining data
     insertData(Iterables.skip(records, 3));
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 4)).totalProcessed(4));
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testKafkaInputFormat() throws Exception
   {
     // Insert data
@@ -1361,28 +1359,28 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(25);
     }
 
-    Assert.assertEquals(Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
 
     final QuerySegmentSpec interval = OBJECT_MAPPER.readValue(
         "\"2008/2012\"", QuerySegmentSpec.class
     );
     List<Map<String, Object>> scanResultValues = scanData(task, interval);
-    Assert.assertEquals(3, Iterables.size(scanResultValues));
+    Assertions.assertEquals(3, Iterables.size(scanResultValues));
 
     for (Map<String, Object> event : scanResultValues) {
-      Assert.assertEquals("application/json", event.get("kafka.testheader.encoding"));
-      Assert.assertEquals("y", event.get("dim2"));
+      Assertions.assertEquals("application/json", event.get("kafka.testheader.encoding"));
+      Assertions.assertEquals("y", event.get("dim2"));
     }
 
     // insert remaining data
     insertData(Iterables.skip(records, 3));
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 4)).totalProcessed(4));
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunOnNothing() throws Exception
   {
     // Insert data
@@ -1409,14 +1407,14 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().totalProcessed(0));
 
     // Check published metadata
-    Assert.assertEquals(ImmutableList.of(), publishedDescriptors());
+    Assertions.assertEquals(ImmutableList.of(), publishedDescriptors());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testHandoffConditionTimeoutWhenHandoffOccurs() throws Exception
   {
     handoffConditionTimeout = 5_000;
@@ -1445,7 +1443,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
 
     // Check published metadata and segments in deep storage
@@ -1456,13 +1454,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testHandoffConditionTimeoutWhenHandoffDoesNotOccur() throws Exception
   {
     doHandoff = false;
@@ -1492,7 +1490,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
 
     // Check published metadata and segments in deep storage
@@ -1503,7 +1501,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))
         ),
@@ -1511,7 +1509,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testReportParseExceptions() throws Exception
   {
     reportParseExceptions = true;
@@ -1544,15 +1542,15 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.FAILED, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 6)).unparseable(1).totalProcessed(3));
 
     // Check published metadata
-    Assert.assertEquals(ImmutableList.of(), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertEquals(ImmutableList.of(), publishedDescriptors());
+    Assertions.assertNull(newDataSchemaMetadata());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleParseExceptionsSuccess() throws Exception
   {
     reportParseExceptions = false;
@@ -1585,8 +1583,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     TaskStatus status = future.get();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, status.getStatusCode());
-    Assert.assertNull(status.getErrorMsg());
+    Assertions.assertEquals(TaskState.SUCCESS, status.getStatusCode());
+    Assertions.assertNull(status.getErrorMsg());
     final long totalRecordBytes = getTotalSizeOfRecords(2, 13);
     verifyTaskMetrics(task, RowMeters.with()
                                      .bytes(totalRecordBytes)
@@ -1598,7 +1596,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ImmutableList.of(sdd("2010/P1D", 0), sdd("2011/P1D", 0), sdd("2013/P1D", 0), sdd("2049/P1D", 0)),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 13L))),
         newDataSchemaMetadata()
     );
@@ -1606,8 +1604,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     // Verify ingestion state and error message
-    Assert.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
-    Assert.assertNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
+    Assertions.assertNull(reportData.getErrorMsg());
 
     // Jackson will serde numerics ≤ 32bits as Integers, rather than Longs
     Map<String, Integer> expectedThrownAwayByReason = Map.of(InputRowFilterResult.NULL_OR_EMPTY_RECORD.getReason(), 1);
@@ -1622,7 +1620,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
             RowIngestionMeters.THROWN_AWAY_BY_REASON, expectedThrownAwayByReason
         )
     );
-    Assert.assertEquals(expectedMetrics, reportData.getRowStats());
+    Assertions.assertEquals(expectedMetrics, reportData.getRowStats());
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
@@ -1635,7 +1633,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         "Unable to parse row [unparseable] (Record: 1)",
         "Encountered row with timestamp[246140482-04-24T15:36:27.903Z] that cannot be represented as a long: [{timestamp=246140482-04-24T15:36:27.903Z, dim1=x, dim2=z, dimLong=10, dimFloat=20.0, met1=1.0}] (Record: 1)"
     );
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = Arrays.asList(
         "{timestamp=2049, dim1=f, dim2=y, dimLong=10, dimFloat=20.0, met1=notanumber}",
@@ -1645,18 +1643,18 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         "unparseable",
         "{timestamp=246140482-04-24T15:36:27.903Z, dim1=x, dim2=z, dimLong=10, dimFloat=20.0, met1=1.0}"
     );
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
 
     emitter.verifyValue("ingest/segments/count", 4);
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(7, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(4, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(7, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(4, observedSegmentGenerationMetrics.handOffCount());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleParseExceptionsFailure() throws Exception
   {
     reportParseExceptions = false;
@@ -1689,21 +1687,21 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     TaskStatus status = future.get();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.FAILED, status.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, status.getStatusCode());
     IndexTaskTest.checkTaskStatusErrorMsgForParseExceptionsExceeded(status);
 
     final long totalBytes = getTotalSizeOfRecords(2, 8);
     verifyTaskMetrics(task, RowMeters.with().bytes(totalBytes).unparseable(3).totalProcessed(3));
 
     // Check published metadata
-    Assert.assertEquals(ImmutableList.of(), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertEquals(ImmutableList.of(), publishedDescriptors());
+    Assertions.assertNull(newDataSchemaMetadata());
 
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     // Verify ingestion state and error message
-    Assert.assertEquals(IngestionState.BUILD_SEGMENTS, reportData.getIngestionState());
-    Assert.assertNotNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.BUILD_SEGMENTS, reportData.getIngestionState());
+    Assertions.assertNotNull(reportData.getErrorMsg());
 
     // Jackson will serde numerics ≤ 32bits as Integers, rather than Longs
     Map<String, Integer> expectedThrownAwayByReason = Map.of();
@@ -1718,7 +1716,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
             RowIngestionMeters.THROWN_AWAY_BY_REASON, expectedThrownAwayByReason
         )
     );
-    Assert.assertEquals(expectedMetrics, reportData.getRowStats());
+    Assertions.assertEquals(expectedMetrics, reportData.getRowStats());
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
@@ -1727,21 +1725,21 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         "Unable to parse [] as the intermediateRow resulted in empty input row (Record: 1)",
         "Unable to parse row [unparseable] (Record: 1)"
     );
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = Arrays.asList("", "unparseable");
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
 
     emitter.verifyNotEmitted("ingest/segments/count");
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(0, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(0, observedSegmentGenerationMetrics.numPersists());
-    Assert.assertEquals(0, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(0, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(0, observedSegmentGenerationMetrics.numPersists());
+    Assertions.assertEquals(0, observedSegmentGenerationMetrics.handOffCount());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunReplicas() throws Exception
   {
     final KafkaIndexTask task1 = createTask(
@@ -1786,8 +1784,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData();
 
     // Wait for tasks to exit
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     final long totalBytes = getTotalSizeOfRecords(2, 5);
     verifyTaskMetrics(task1, RowMeters.with().bytes(totalBytes).totalProcessed(3));
@@ -1801,13 +1799,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunConflicting() throws Exception
   {
     final KafkaIndexTask task1 = createTask(
@@ -1850,11 +1848,11 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     // Run first task
     final ListenableFuture<TaskStatus> future1 = runTask(task1);
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     // Run second task
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
-    Assert.assertEquals(TaskState.FAILED, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, future2.get().getStatusCode());
 
     verifyTaskMetrics(task1, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
     verifyTaskMetrics(task2, RowMeters.with().bytes(getTotalSizeOfRecords(3, 10))
@@ -1869,13 +1867,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunConflictingWithoutTransactions() throws Exception
   {
     final KafkaIndexTask task1 = createTask(
@@ -1918,17 +1916,17 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     // Run first task
     final ListenableFuture<TaskStatus> future1 = runTask(task1);
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     // Check published segments & metadata
     SegmentDescriptorAndExpectedDim1Values desc1 = sdd("2010/P1D", 0, ImmutableList.of("c"));
     SegmentDescriptorAndExpectedDim1Values desc2 = sdd("2011/P1D", 0, ImmutableList.of("d", "e"));
     assertEqualsExceptVersion(ImmutableList.of(desc1, desc2), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertNull(newDataSchemaMetadata());
 
     // Run second task
     final ListenableFuture<TaskStatus> future2 = runTask(task2);
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyTaskMetrics(task1, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
     verifyTaskMetrics(task2, RowMeters.with().bytes(getTotalSizeOfRecords(3, 10))
@@ -1938,10 +1936,10 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     SegmentDescriptorAndExpectedDim1Values desc3 = sdd("2011/P1D", 1, ImmutableList.of("d", "e"));
     SegmentDescriptorAndExpectedDim1Values desc4 = sdd("2013/P1D", 0, ImmutableList.of("f"));
     assertEqualsExceptVersion(ImmutableList.of(desc1, desc2, desc3, desc4), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertNull(newDataSchemaMetadata());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunOneTaskTwoPartitions() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -1968,7 +1966,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData();
 
     // Wait for tasks to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     long totalBytes = getTotalSizeOfRecords(2, 5) + getTotalSizeOfRecords(13, 15);
     verifyTaskMetrics(task, RowMeters.with().bytes(totalBytes).totalProcessed(5));
 
@@ -1980,7 +1978,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     SegmentDescriptor desc3 = sd("2011/P1D", 1);
     SegmentDescriptorAndExpectedDim1Values desc4 = sdd("2012/P1D", 0, ImmutableList.of("g"));
     assertEqualsExceptVersion(ImmutableList.of(desc1, desc2, desc4), publishedDescriptors());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L, new KafkaTopicPartition(false, topic, 1), 2L))
         ),
@@ -1988,7 +1986,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunTwoTasksTwoPartitions() throws Exception
   {
     final KafkaIndexTask task1 = createTask(
@@ -2033,8 +2031,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData();
 
     // Wait for tasks to exit
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyTaskMetrics(task1, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
     verifyTaskMetrics(task2, RowMeters.with().bytes(getTotalSizeOfRecords(13, 14)).totalProcessed(1));
@@ -2048,7 +2046,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(
             new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L, new KafkaTopicPartition(false, topic, 1), 1L))
         ),
@@ -2056,7 +2054,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRestore() throws Exception
   {
     final KafkaIndexTask task1 = createTask(
@@ -2085,13 +2083,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     while (countEvents(task1) != 2) {
       Thread.sleep(25);
     }
-    Assert.assertEquals(2, countEvents(task1));
+    Assertions.assertEquals(2, countEvents(task1));
 
     // Stop without publishing segment
     task1.stopGracefully(toolboxFactory.build(task1).getConfig());
     unlockAppenderatorBasePersistDirForTask(task1);
 
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     // Start a new task
     final KafkaIndexTask task2 = createTask(
@@ -2118,7 +2116,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData(Iterables.skip(records, 4));
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyTaskMetrics(task1, RowMeters.with().bytes(getTotalSizeOfRecords(2, 4)).totalProcessed(2));
     verifyTaskMetrics(task2, RowMeters.with().bytes(getTotalSizeOfRecords(4, 5)).totalProcessed(1));
@@ -2131,13 +2129,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 6L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRestoreAfterPersistingSequences() throws Exception
   {
     records = generateSinglePartitionRecords(topic);
@@ -2178,7 +2176,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(10);
     }
     final Map<KafkaTopicPartition, Long> currentOffsets = ImmutableMap.copyOf(task1.getRunner().getCurrentOffsets());
-    Assert.assertEquals(checkpoint.getPartitionSequenceNumberMap(), currentOffsets);
+    Assertions.assertEquals(checkpoint.getPartitionSequenceNumberMap(), currentOffsets);
     // Set endOffsets to persist sequences
     task1.getRunner().setEndOffsets(ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L), false);
 
@@ -2186,7 +2184,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     task1.stopGracefully(toolboxFactory.build(task1).getConfig());
     unlockAppenderatorBasePersistDirForTask(task1);
 
-    Assert.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future1.get().getStatusCode());
 
     // Start a new task
     final KafkaIndexTask task2 = createTask(
@@ -2214,7 +2212,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData(Iterables.skip(records, 5));
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future2.get().getStatusCode());
 
     verifyTaskMetrics(task1, RowMeters.with().bytes(getTotalSizeOfRecords(0, 5)).totalProcessed(5));
     verifyTaskMetrics(task2, RowMeters.with().bytes(getTotalSizeOfRecords(6, 10)).totalProcessed(4));
@@ -2232,13 +2230,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 10L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithPauseAndResume() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -2259,7 +2257,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    Assert.assertEquals(Status.NOT_STARTED.toString(), task.getCurrentRunnerStatus());
+    Assertions.assertEquals(Status.NOT_STARTED.toString(), task.getCurrentRunnerStatus());
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
@@ -2269,35 +2267,35 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     while (countEvents(task) != 2) {
       Thread.sleep(25);
     }
-    Assert.assertEquals(2, countEvents(task));
-    Assert.assertEquals(Status.READING, task.getRunner().getStatus());
-    Assert.assertEquals(Status.READING.toString(), task.getCurrentRunnerStatus());
+    Assertions.assertEquals(2, countEvents(task));
+    Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(Status.READING.toString(), task.getCurrentRunnerStatus());
 
 
     Map<KafkaTopicPartition, Long> currentOffsets = OBJECT_MAPPER.readValue(
         task.getRunner().pause().getEntity().toString(),
         new TypeReference<>() {}
     );
-    Assert.assertEquals(Status.PAUSED, task.getRunner().getStatus());
-    Assert.assertEquals(Status.PAUSED.toString(), task.getCurrentRunnerStatus());
+    Assertions.assertEquals(Status.PAUSED, task.getRunner().getStatus());
+    Assertions.assertEquals(Status.PAUSED.toString(), task.getCurrentRunnerStatus());
     // Insert remaining data
     insertData(Iterables.skip(records, 4));
 
     try {
       future.get(10, TimeUnit.SECONDS);
-      Assert.fail("Task completed when it should have been paused");
+      Assertions.fail("Task completed when it should have been paused");
     }
     catch (TimeoutException e) {
       // carry on..
     }
 
-    Assert.assertEquals(currentOffsets, task.getRunner().getCurrentOffsets());
+    Assertions.assertEquals(currentOffsets, task.getRunner().getCurrentOffsets());
 
     task.getRunner().resume();
 
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
-    Assert.assertEquals(task.getRunner().getEndOffsets(), task.getRunner().getCurrentOffsets());
-    Assert.assertEquals(Status.PUBLISHING.toString(), task.getCurrentRunnerStatus());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(task.getRunner().getEndOffsets(), task.getRunner().getCurrentOffsets());
+    Assertions.assertEquals(Status.PUBLISHING.toString(), task.getCurrentRunnerStatus());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
 
     // Check published metadata and segments in deep storage
@@ -2308,13 +2306,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 6L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithOffsetOutOfRangeExceptionAndPause() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -2348,7 +2346,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithOffsetOutOfRangeExceptionAndNextOffsetGreaterThanLeastAvailable() throws Exception
   {
     resetOffsetAutomatically = true;
@@ -2380,13 +2378,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
 
     for (int i = 0; i < 5; i++) {
-      Assert.assertEquals(Status.READING, task.getRunner().getStatus());
+      Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
       // Offset should not be reset
-      Assert.assertEquals(200L, (long) task.getRunner().getCurrentOffsets().get(new KafkaTopicPartition(false, topic, 0)));
+      Assertions.assertEquals(200L, (long) task.getRunner().getCurrentOffsets().get(new KafkaTopicPartition(false, topic, 0)));
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunContextSequenceAheadOfStartingOffsets() throws Exception
   {
     // Insert data
@@ -2425,7 +2423,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(2, 5)).totalProcessed(3));
 
     // Check published metadata and segments in deep storage
@@ -2436,13 +2434,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithDuplicateRequest() throws Exception
   {
     // Insert data
@@ -2475,15 +2473,15 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     // first setEndOffsets request
     task.getRunner().pause();
     task.getRunner().setEndOffsets(ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 500L), true);
-    Assert.assertEquals(Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
 
     // duplicate setEndOffsets request
     task.getRunner().pause();
     task.getRunner().setEndOffsets(ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 500L), true);
-    Assert.assertEquals(Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunTransactionModeRollback() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -2512,13 +2510,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData(records.subList(0, 2));
 
     awaitConsumedOffsets(task, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 1L)); // Consume two real messages
-    Assert.assertEquals(2, countEvents(task));
-    Assert.assertEquals(Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(2, countEvents(task));
+    Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
 
     //verify the 2 indexed records
     final QuerySegmentSpec firstInterval = OBJECT_MAPPER.readValue("\"2008/2010\"", QuerySegmentSpec.class);
     Iterable<Map<String, Object>> scanResultValues = scanData(task, firstInterval);
-    Assert.assertEquals(2, Iterables.size(scanResultValues));
+    Assertions.assertEquals(2, Iterables.size(scanResultValues));
 
     // Insert 3 more records and rollback
     insertData(records.subList(2, 5), true);
@@ -2527,23 +2525,23 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     insertData(records.subList(5, 8));
 
     awaitConsumedOffsets(task, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 9L)); // Consume 8 real messages + 2 txn controls
-    Assert.assertEquals(2, countEvents(task));
+    Assertions.assertEquals(2, countEvents(task));
 
     final QuerySegmentSpec rollbackedInterval = OBJECT_MAPPER.readValue("\"2010/2012\"", QuerySegmentSpec.class);
     scanResultValues = scanData(task, rollbackedInterval);
     //verify that there are no records indexed in the rollbacked time period
-    Assert.assertEquals(0, Iterables.size(scanResultValues));
+    Assertions.assertEquals(0, Iterables.size(scanResultValues));
 
     final QuerySegmentSpec endInterval = OBJECT_MAPPER.readValue("\"2008/2049\"", QuerySegmentSpec.class);
     Iterable<Map<String, Object>> scanResultValues1 = scanData(task, endInterval);
-    Assert.assertEquals(2, Iterables.size(scanResultValues1));
+    Assertions.assertEquals(2, Iterables.size(scanResultValues1));
 
     // Insert all remaining messages. One will get picked up.
     insertData(Iterables.skip(records, 8));
 
     // Wait for task to exit and publish
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
-    Assert.assertEquals(task.getRunner().getEndOffsets(), task.getRunner().getCurrentOffsets());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(task.getRunner().getEndOffsets(), task.getRunner().getCurrentOffsets());
 
     long totalBytes = getTotalSizeOfRecords(0, 2) + getTotalSizeOfRecords(5, 11);
     verifyTaskMetrics(task, RowMeters.with().bytes(totalBytes)
@@ -2559,13 +2557,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 14L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunUnTransactionMode() throws Exception
   {
     Map<String, Object> configs = kafkaServer.consumerProperties();
@@ -2605,10 +2603,10 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       Thread.sleep(25);
     }
 
-    Assert.assertEquals(2, countEvents(task));
+    Assertions.assertEquals(2, countEvents(task));
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCanStartFromLaterThanEarliestOffset() throws Exception
   {
     final String baseSequenceName = "sequence0";
@@ -2649,10 +2647,10 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
     final ListenableFuture<TaskStatus> future = runTask(task);
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithoutDataInserted() throws Exception
   {
     final KafkaIndexTask task = createTask(
@@ -2677,21 +2675,20 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
     Thread.sleep(1000);
 
-    Assert.assertEquals(0, countEvents(task));
-    Assert.assertEquals(SeekableStreamIndexTaskRunner.Status.READING, task.getRunner().getStatus());
+    Assertions.assertEquals(0, countEvents(task));
+    Assertions.assertEquals(SeekableStreamIndexTaskRunner.Status.READING, task.getRunner().getStatus());
 
     task.getRunner().stopGracefully();
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().totalProcessed(0));
 
     // Check published metadata and segments in deep storage
     assertEqualsExceptVersion(Collections.emptyList(), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertNull(newDataSchemaMetadata());
   }
 
-  @Test
   public void testSerde() throws Exception
   {
     // This is both a serde test and a regression test for https://github.com/apache/druid/issues/7724.
@@ -2721,10 +2718,9 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
 
     final Task task1 = OBJECT_MAPPER.readValue(OBJECT_MAPPER.writeValueAsBytes(task), Task.class);
-    Assert.assertEquals(task, task1);
+    Assertions.assertEquals(task, task1);
   }
 
-  @Test
   public void testCorrectInputSources() throws Exception
   {
     // This is both a serde test and a regression test for https://github.com/apache/druid/issues/7724.
@@ -2753,7 +2749,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 KafkaIndexTaskModule.SCHEME,
@@ -2960,7 +2956,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
   private void makeToolboxFactory() throws IOException
   {
-    directory = tempFolder.newFolder();
+    directory = newFolder(temporaryFolder, "junit");
     final TestUtils testUtils = new TestUtils();
     final ObjectMapper objectMapper = testUtils.getTestObjectMapper();
 
@@ -2971,7 +2967,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     makeToolboxFactory(testUtils, emitter, doHandoff);
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleLinesJSONText() throws Exception
   {
     reportParseExceptions = false;
@@ -3021,7 +3017,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 4)).unparseable(1).totalProcessed(4));
 
     // Check published metadata
@@ -3032,13 +3028,13 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 4L))),
         newDataSchemaMetadata()
     );
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testParseExceptionsInIteratorConstructionSuccess() throws Exception
   {
     reportParseExceptions = false;
@@ -3083,7 +3079,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 4)).unparseable(2).totalProcessed(2));
 
     // Check published metadata
@@ -3094,7 +3090,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 4L))),
         newDataSchemaMetadata()
     );
@@ -3102,8 +3098,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     // Verify ingestion state and error message
-    Assert.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
-    Assert.assertNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
+    Assertions.assertNull(reportData.getErrorMsg());
 
     // Verify unparseable data
     ParseExceptionReport parseExceptionReport =
@@ -3113,10 +3109,10 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         "Unable to parse malformed data during iterator construction",
         "Unable to parse malformed data during iterator construction"
     );
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testNoParseExceptionsTaskSucceeds() throws Exception
   {
     reportParseExceptions = false;
@@ -3155,7 +3151,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 2)).unparseable(0).totalProcessed(2));
 
     // Check published metadata
@@ -3166,7 +3162,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         ),
         publishedDescriptors()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 2L))),
         newDataSchemaMetadata()
     );
@@ -3175,10 +3171,10 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(getTaskReportData(), RowIngestionMeters.BUILD_SEGMENTS);
 
-    Assert.assertEquals(ImmutableList.of(), parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(ImmutableList.of(), parseExceptionReport.getErrorMessages());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testParseExceptionsBeyondThresholdTaskFails() throws Exception
   {
     reportParseExceptions = false;
@@ -3229,26 +3225,26 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit. Should fail and trip up with the first two bad messages in the stream
-    Assert.assertEquals(TaskState.FAILED, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 3)).unparseable(2).totalProcessed(1));
 
     // Check there's no published metadata since the task failed
-    Assert.assertEquals(ImmutableList.of(), publishedDescriptors());
-    Assert.assertNull(newDataSchemaMetadata());
+    Assertions.assertEquals(ImmutableList.of(), publishedDescriptors());
+    Assertions.assertNull(newDataSchemaMetadata());
 
     // Verify ingestion state and error message
     final IngestionStatsAndErrors reportData = getTaskReportData();
-    Assert.assertEquals(IngestionState.BUILD_SEGMENTS, reportData.getIngestionState());
-    Assert.assertNotNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.BUILD_SEGMENTS, reportData.getIngestionState());
+    Assertions.assertNotNull(reportData.getErrorMsg());
 
     // Verify there is no unparseable data in the report since we've 0 saved parse exceptions
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
 
-    Assert.assertEquals(ImmutableList.of(), parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(ImmutableList.of(), parseExceptionReport.getErrorMessages());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCompletionReportPartitionStats() throws Exception
   {
     insertData();
@@ -3281,19 +3277,19 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
     TaskStatus status = future.get();
 
-    Assert.assertEquals(TaskState.SUCCESS, status.getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, status.getStatusCode());
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     // Verify ingestion state and error message
-    Assert.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
-    Assert.assertNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
+    Assertions.assertNull(reportData.getErrorMsg());
 
     // Verify report metrics
-    Assert.assertEquals(reportData.getRecordsProcessed().size(), 1);
-    Assert.assertEquals(reportData.getRecordsProcessed().values().iterator().next(), (Long) 6L);
+    Assertions.assertEquals(reportData.getRecordsProcessed().size(), 1);
+    Assertions.assertEquals(reportData.getRecordsProcessed().values().iterator().next(), (Long) 6L);
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCompletionReportMultiplePartitionStats() throws Exception
   {
     insertData();
@@ -3336,19 +3332,19 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
     TaskStatus status = future.get();
 
-    Assert.assertEquals(TaskState.SUCCESS, status.getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, status.getStatusCode());
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     // Verify ingestion state and error message
-    Assert.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
-    Assert.assertNull(reportData.getErrorMsg());
+    Assertions.assertEquals(IngestionState.COMPLETED, reportData.getIngestionState());
+    Assertions.assertNull(reportData.getErrorMsg());
 
     // Verify report metrics
-    Assert.assertEquals(reportData.getRecordsProcessed().size(), 2);
-    Assert.assertTrue(reportData.getRecordsProcessed().values().containsAll(ImmutableSet.of(6L, 2L)));
+    Assertions.assertEquals(reportData.getRecordsProcessed().size(), 2);
+    Assertions.assertTrue(reportData.getRecordsProcessed().values().containsAll(ImmutableSet.of(6L, 2L)));
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testTaskWithTransformSpecDoesNotCauseCliPeonCyclicDependency()
       throws IOException, ExecutionException, InterruptedException
   {
@@ -3380,7 +3376,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    File file = temporaryFolder.newFile("task.json");
+    File file = File.createTempFile("task.json", null, temporaryFolder);
 
     FileUtils.write(file, OBJECT_MAPPER.writeValueAsString(task), StandardCharsets.UTF_8);
 
@@ -3394,43 +3390,43 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final Injector peonInjector = peon.makeInjector(Set.of(NodeRole.PEON));
 
     final LoadSpecHolder loadSpecHolder = peonInjector.getInstance(LoadSpecHolder.class);
-    Assert.assertTrue(loadSpecHolder instanceof PeonLoadSpecHolder);
-    Assert.assertEquals(LookupLoadingSpec.ALL, loadSpecHolder.getLookupLoadingSpec());
-    Assert.assertEquals(BroadcastDatasourceLoadingSpec.ALL, loadSpecHolder.getBroadcastDatasourceLoadingSpec());
+    Assertions.assertTrue(loadSpecHolder instanceof PeonLoadSpecHolder);
+    Assertions.assertEquals(LookupLoadingSpec.ALL, loadSpecHolder.getLookupLoadingSpec());
+    Assertions.assertEquals(BroadcastDatasourceLoadingSpec.ALL, loadSpecHolder.getBroadcastDatasourceLoadingSpec());
 
     final TaskHolder taskHolder = peonInjector.getInstance(TaskHolder.class);
-    Assert.assertTrue(taskHolder instanceof PeonTaskHolder);
-    Assert.assertEquals("index_kafka_test_id1", taskHolder.getTaskId());
-    Assert.assertEquals("test_ds", taskHolder.getDataSource());
+    Assertions.assertTrue(taskHolder instanceof PeonTaskHolder);
+    Assertions.assertEquals("index_kafka_test_id1", taskHolder.getTaskId());
+    Assertions.assertEquals("test_ds", taskHolder.getDataSource());
 
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 5)).thrownAwayByReason(InputRowFilterResult.CUSTOM_FILTER, 4).totalProcessed(1));
 
     // Check published metadata
     final List<SegmentDescriptor> publishedDescriptors = publishedDescriptors();
     assertEqualsExceptVersion(ImmutableList.of(sdd("2009/P1D", 0)), publishedDescriptors);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
 
     // Check segments in deep storage
-    Assert.assertEquals(ImmutableList.of("b"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
-    Assert.assertEquals(ImmutableList.of("bb"), readSegmentColumn("dim1t", publishedDescriptors.get(0)));
+    Assertions.assertEquals(ImmutableList.of("b"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
+    Assertions.assertEquals(ImmutableList.of("bb"), readSegmentColumn("dim1t", publishedDescriptors.get(0)));
 
     emitter.verifyValue("ingest/segments/count", 1);
 
     final SegmentGenerationMetrics observedSegmentGenerationMetrics = task.getRunner().getSegmentGenerationMetrics();
-    Assert.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
-    Assert.assertEquals(1, observedSegmentGenerationMetrics.rowOutput());
-    Assert.assertEquals(1, observedSegmentGenerationMetrics.handOffCount());
+    Assertions.assertTrue(observedSegmentGenerationMetrics.isProcessingDone());
+    Assertions.assertEquals(1, observedSegmentGenerationMetrics.rowOutput());
+    Assertions.assertEquals(1, observedSegmentGenerationMetrics.handOffCount());
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testKafkaTaskContainsAllTaskDimensions()
       throws IOException, ExecutionException, InterruptedException
   {
@@ -3454,9 +3450,19 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    Injector peonInjector = CliPeonTest.makePeonInjectorWithStubEmitter(task, temporaryFolder, OBJECT_MAPPER);
+    final File taskFile = File.createTempFile("task.json", null, temporaryFolder);
+    FileUtils.write(taskFile, OBJECT_MAPPER.writeValueAsString(task), StandardCharsets.UTF_8);
+
+    final CliPeon peon = new CliPeon();
+    peon.taskAndStatusFile = ImmutableList.of(taskFile.getParent(), "1");
+
+    final Properties properties = new Properties();
+    peon.configure(properties);
+    final Injector baseInjector = GuiceInjectors.makeStartupInjector();
+    peon.configure(properties, baseInjector);
+    final Injector peonInjector = peon.makeInjector(Set.of(NodeRole.PEON));
     Emitter peonEmitter = peonInjector.getInstance(Emitter.class);
-    Assert.assertTrue(peonEmitter instanceof StubServiceEmitter);
+    Assertions.assertTrue(peonEmitter instanceof StubServiceEmitter);
     emitter = (StubServiceEmitter) peonEmitter;
     emitter.start();
     makeToolboxFactory();
@@ -3464,26 +3470,26 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     final ListenableFuture<TaskStatus> future = runTask(task);
 
     // Wait for task to exit
-    Assert.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
-    Assert.assertTrue(emitter.getNumEmittedEvents() > 0);
+    Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
+    Assertions.assertTrue(emitter.getNumEmittedEvents() > 0);
 
     // Check published metadata & segments in deep storage
     final List<SegmentDescriptor> publishedDescriptors = publishedDescriptors();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KafkaDataSourceMetadata(new SeekableStreamEndSequenceNumbers<>(topic, ImmutableMap.of(new KafkaTopicPartition(false, topic, 0), 5L))),
         newDataSchemaMetadata()
     );
-    Assert.assertEquals(ImmutableList.of("c"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
+    Assertions.assertEquals(ImmutableList.of("c"), readSegmentColumn("dim1", publishedDescriptors.get(0)));
 
-    Assert.assertTrue(emitter.getNumEmittedEvents() > 0);
+    Assertions.assertTrue(emitter.getNumEmittedEvents() > 0);
     for (Event event : emitter.getEvents()) {
       if (event instanceof ServiceMetricEvent) {
         EventMap observedEvent = event.toMap();
         // Do not verify emission of "id" dimension as that is deprecated in favor of "taskId"
-        Assert.assertEquals("test_ds", observedEvent.get("dataSource"));
-        Assert.assertEquals("index_kafka_test_id1", observedEvent.get("taskId"));
-        Assert.assertEquals("index_kafka", observedEvent.get("taskType"));
-        Assert.assertEquals("index_kafka_test_ds", observedEvent.get("groupId"));
+        Assertions.assertEquals("test_ds", observedEvent.get("dataSource"));
+        Assertions.assertEquals("index_kafka_test_id1", observedEvent.get("taskId"));
+        Assertions.assertEquals("index_kafka", observedEvent.get("taskType"));
+        Assertions.assertEquals("index_kafka_test_ds", observedEvent.get("groupId"));
       }
     }
   }
@@ -3547,6 +3553,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     {
       return baseInputFormat;
     }
+
   }
 
   /**
@@ -3620,5 +3627,15 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     {
       return baseInputFormat;
     }
+
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -3675,11 +3675,11 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    org.apache.druid.java.util.common.FileUtils.mkdirp(result);
-    return result;
+    return org.apache.druid.java.util.common.FileUtils.createTempDirInLocation(
+        root.toPath(),
+        String.join("-", subDirs)
+    );
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -38,6 +38,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.inject.Injector;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.cli.CliPeon;
+import org.apache.druid.cli.CliPeonTest;
 import org.apache.druid.cli.PeonLoadSpecHolder;
 import org.apache.druid.cli.PeonTaskHolder;
 import org.apache.druid.data.input.InputEntity;
@@ -141,6 +142,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedClass;
@@ -299,6 +301,9 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
   @BeforeEach
   public void setupTest() throws IOException
   {
+    super.tempFolder.create();
+    derby.before();
+    setupBase();
     handoffConditionTimeout = 0;
     reportParseExceptions = false;
     logParseExceptions = true;
@@ -323,6 +328,9 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
     reportsFile.delete();
     destroyToolboxFactory();
+    tearDownBase();
+    derby.after();
+    super.tempFolder.delete();
   }
 
   @AfterAll
@@ -335,6 +343,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     kafkaServer = null;
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunAfterDataInserted() throws Exception
   {
@@ -385,6 +394,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIngestNullColumnAfterDataInserted() throws Exception
   {
@@ -439,6 +449,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIngestNullColumnAfterDataInserted_storeEmptyColumnsOff_shouldNotStoreEmptyColumns() throws Exception
   {
@@ -486,6 +497,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunBeforeDataInserted() throws Exception
   {
@@ -536,6 +548,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunAfterDataInsertedLiveReport() throws Exception
   {
@@ -588,6 +601,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOff() throws Exception
   {
@@ -689,6 +703,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOffMaxTotalRows() throws Exception
   {
@@ -830,6 +845,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testTimeBasedIncrementalHandOff() throws Exception
   {
@@ -914,6 +930,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCheckpointResetWithSameEndOffsets() throws Exception
   {
@@ -977,6 +994,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     return metadataStorageCoordinator.retrieveDataSourceMetadata(DATA_SCHEMA.getDataSource());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testIncrementalHandOffReadsThroughEndOffsets() throws Exception
   {
@@ -1081,6 +1099,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyTaskMetrics(staleReplica, RowMeters.with().bytes(totalBytes).totalProcessed(9));
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithMinimumMessageTime() throws Exception
   {
@@ -1130,6 +1149,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithMaximumMessageTime() throws Exception
   {
@@ -1180,6 +1200,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithTransformSpec() throws Exception
   {
@@ -1236,6 +1257,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(ImmutableList.of("bb"), readSegmentColumn("dim1t", publishedDescriptors.get(0)));
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testKafkaRecordEntityInputFormat() throws Exception
   {
@@ -1310,6 +1332,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 4)).totalProcessed(4));
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testKafkaInputFormat() throws Exception
   {
@@ -1380,6 +1403,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyTaskMetrics(task, RowMeters.with().bytes(getTotalSizeOfRecords(0, 4)).totalProcessed(4));
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunOnNothing() throws Exception
   {
@@ -1414,6 +1438,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(ImmutableList.of(), publishedDescriptors());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testHandoffConditionTimeoutWhenHandoffOccurs() throws Exception
   {
@@ -1460,6 +1485,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testHandoffConditionTimeoutWhenHandoffDoesNotOccur() throws Exception
   {
@@ -1509,6 +1535,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testReportParseExceptions() throws Exception
   {
@@ -1550,6 +1577,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertNull(newDataSchemaMetadata());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleParseExceptionsSuccess() throws Exception
   {
@@ -1654,6 +1682,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleParseExceptionsFailure() throws Exception
   {
@@ -1739,6 +1768,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(0, observedSegmentGenerationMetrics.handOffCount());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunReplicas() throws Exception
   {
@@ -1805,6 +1835,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunConflicting() throws Exception
   {
@@ -1873,6 +1904,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunConflictingWithoutTransactions() throws Exception
   {
@@ -1939,6 +1971,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertNull(newDataSchemaMetadata());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunOneTaskTwoPartitions() throws Exception
   {
@@ -1986,6 +2019,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunTwoTasksTwoPartitions() throws Exception
   {
@@ -2054,6 +2088,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRestore() throws Exception
   {
@@ -2135,6 +2170,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRestoreAfterPersistingSequences() throws Exception
   {
@@ -2236,6 +2272,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithPauseAndResume() throws Exception
   {
@@ -2312,6 +2349,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithOffsetOutOfRangeExceptionAndPause() throws Exception
   {
@@ -2346,6 +2384,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithOffsetOutOfRangeExceptionAndNextOffsetGreaterThanLeastAvailable() throws Exception
   {
@@ -2384,6 +2423,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunContextSequenceAheadOfStartingOffsets() throws Exception
   {
@@ -2440,6 +2480,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithDuplicateRequest() throws Exception
   {
@@ -2481,6 +2522,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(Status.READING, task.getRunner().getStatus());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunTransactionModeRollback() throws Exception
   {
@@ -2563,6 +2605,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunUnTransactionMode() throws Exception
   {
@@ -2606,6 +2649,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(2, countEvents(task));
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCanStartFromLaterThanEarliestOffset() throws Exception
   {
@@ -2650,6 +2694,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(TaskState.SUCCESS, future.get().getStatusCode());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testRunWithoutDataInserted() throws Exception
   {
@@ -2689,6 +2734,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertNull(newDataSchemaMetadata());
   }
 
+  @Test
   public void testSerde() throws Exception
   {
     // This is both a serde test and a regression test for https://github.com/apache/druid/issues/7724.
@@ -2721,6 +2767,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(task, task1);
   }
 
+  @Test
   public void testCorrectInputSources() throws Exception
   {
     // This is both a serde test and a regression test for https://github.com/apache/druid/issues/7724.
@@ -2967,6 +3014,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     makeToolboxFactory(testUtils, emitter, doHandoff);
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testMultipleLinesJSONText() throws Exception
   {
@@ -3034,6 +3082,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     );
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testParseExceptionsInIteratorConstructionSuccess() throws Exception
   {
@@ -3112,6 +3161,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testNoParseExceptionsTaskSucceeds() throws Exception
   {
@@ -3174,6 +3224,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(ImmutableList.of(), parseExceptionReport.getErrorMessages());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testParseExceptionsBeyondThresholdTaskFails() throws Exception
   {
@@ -3244,6 +3295,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(ImmutableList.of(), parseExceptionReport.getErrorMessages());
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCompletionReportPartitionStats() throws Exception
   {
@@ -3289,6 +3341,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertEquals(reportData.getRecordsProcessed().values().iterator().next(), (Long) 6L);
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCompletionReportMultiplePartitionStats() throws Exception
   {
@@ -3344,6 +3397,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     Assertions.assertTrue(reportData.getRecordsProcessed().values().containsAll(ImmutableSet.of(6L, 2L)));
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testTaskWithTransformSpecDoesNotCauseCliPeonCyclicDependency()
       throws IOException, ExecutionException, InterruptedException
@@ -3426,6 +3480,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     verifyPersistAndMergeTimeMetricsArePositive(observedSegmentGenerationMetrics);
   }
 
+  @Test
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testKafkaTaskContainsAllTaskDimensions()
       throws IOException, ExecutionException, InterruptedException
@@ -3450,17 +3505,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    final File taskFile = File.createTempFile("task.json", null, temporaryFolder);
-    FileUtils.write(taskFile, OBJECT_MAPPER.writeValueAsString(task), StandardCharsets.UTF_8);
-
-    final CliPeon peon = new CliPeon();
-    peon.taskAndStatusFile = ImmutableList.of(taskFile.getParent(), "1");
-
-    final Properties properties = new Properties();
-    peon.configure(properties);
-    final Injector baseInjector = GuiceInjectors.makeStartupInjector();
-    peon.configure(properties, baseInjector);
-    final Injector peonInjector = peon.makeInjector(Set.of(NodeRole.PEON));
+    final Injector peonInjector = CliPeonTest.makePeonInjectorWithStubEmitter(task, super.tempFolder, OBJECT_MAPPER);
     Emitter peonEmitter = peonInjector.getInstance(Emitter.class);
     Assertions.assertTrue(peonEmitter instanceof StubServiceEmitter);
     emitter = (StubServiceEmitter) peonEmitter;

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -3630,7 +3630,8 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
 
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     org.apache.druid.java.util.common.FileUtils.mkdirp(result);

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -3430,7 +3430,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    File file = File.createTempFile("task.json", null, temporaryFolder);
+    final File file = new File(temporaryFolder, "task.json");
 
     FileUtils.write(file, OBJECT_MAPPER.writeValueAsString(task), StandardCharsets.UTF_8);
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -3633,9 +3633,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    org.apache.druid.java.util.common.FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTuningConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTuningConfigTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.indexing.TuningConfig;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -66,19 +66,19 @@ public class KafkaIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(150000, config.getMaxRowsInMemory());
-    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
-    Assert.assertNull(config.getMaxTotalRows());
-    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(0, config.getMaxPendingPersists());
-    Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
-    Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpecForIntermediatePersists());
-    Assert.assertFalse(config.isReportParseExceptions());
-    Assert.assertEquals(Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
-    Assert.assertEquals(1, config.getNumPersistThreads());
-    Assert.assertEquals(-1, config.getMaxColumnsToMerge());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(150000, config.getMaxRowsInMemory());
+    Assertions.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertNull(config.getMaxTotalRows());
+    Assertions.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(0, config.getMaxPendingPersists());
+    Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
+    Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpecForIntermediatePersists());
+    Assertions.assertFalse(config.isReportParseExceptions());
+    Assertions.assertEquals(Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+    Assertions.assertEquals(1, config.getNumPersistThreads());
+    Assertions.assertEquals(-1, config.getMaxColumnsToMerge());
   }
 
   @Test
@@ -110,26 +110,26 @@ public class KafkaIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(100, config.getMaxRowsInMemory());
-    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
-    Assert.assertNotEquals(null, config.getMaxTotalRows());
-    Assert.assertEquals(1000, config.getMaxTotalRows().longValue());
-    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(100, config.getMaxPendingPersists());
-    Assert.assertEquals(true, config.isReportParseExceptions());
-    Assert.assertEquals(100, config.getHandoffConditionTimeout());
-    Assert.assertEquals(
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(100, config.getMaxRowsInMemory());
+    Assertions.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertNotEquals(null, config.getMaxTotalRows());
+    Assertions.assertEquals(1000, config.getMaxTotalRows().longValue());
+    Assertions.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(100, config.getMaxPendingPersists());
+    Assertions.assertEquals(true, config.isReportParseExceptions());
+    Assertions.assertEquals(100, config.getHandoffConditionTimeout());
+    Assertions.assertEquals(
         IndexSpec.builder().withMetricCompression(CompressionStrategy.NONE).build(),
         config.getIndexSpec()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         IndexSpec.builder().withDimensionCompression(CompressionStrategy.UNCOMPRESSED).build(),
         config.getIndexSpecForIntermediatePersists()
     );
-    Assert.assertEquals(2, config.getNumPersistThreads());
-    Assert.assertEquals(-1, config.getMaxColumnsToMerge());
+    Assertions.assertEquals(2, config.getNumPersistThreads());
+    Assertions.assertEquals(-1, config.getMaxColumnsToMerge());
   }
 
   @Test
@@ -145,11 +145,11 @@ public class KafkaIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DimensionValueSetPartitionsSpec(List.of("tenant", "region")),
         config.getStreamingPartitionsSpec()
     );
-    Assert.assertEquals(List.of("tenant", "region"), partitionDimensionsOf(config));
+    Assertions.assertEquals(List.of("tenant", "region"), partitionDimensionsOf(config));
   }
 
   @Test
@@ -159,21 +159,21 @@ public class KafkaIndexTaskTuningConfigTest
         mapper.writeValueAsString(mapper.readValue("{\"type\": \"kafka\"}", TuningConfig.class)),
         TuningConfig.class
     );
-    Assert.assertNull(config.getStreamingPartitionsSpec());
+    Assertions.assertNull(config.getStreamingPartitionsSpec());
   }
 
   @Test
   public void testSerdeWithEmptyPartitionDimensions() throws Exception
   {
     final KafkaIndexTaskTuningConfig config = roundTripWithStreamingPartitionsSpec("[]");
-    Assert.assertEquals(Collections.emptyList(), partitionDimensionsOf(config));
+    Assertions.assertEquals(Collections.emptyList(), partitionDimensionsOf(config));
   }
 
   @Test
   public void testSerdeWithNullPartitionDimensionsCoalescesToEmpty() throws Exception
   {
     final KafkaIndexTaskTuningConfig config = roundTripWithStreamingPartitionsSpec("null");
-    Assert.assertEquals(Collections.emptyList(), partitionDimensionsOf(config));
+    Assertions.assertEquals(Collections.emptyList(), partitionDimensionsOf(config));
   }
 
   @Test
@@ -181,7 +181,7 @@ public class KafkaIndexTaskTuningConfigTest
   {
     // An empty-string dimension name is preserved verbatim (it simply never matches an ingested value).
     final KafkaIndexTaskTuningConfig config = roundTripWithStreamingPartitionsSpec("[\"\"]");
-    Assert.assertEquals(List.of(""), partitionDimensionsOf(config));
+    Assertions.assertEquals(List.of(""), partitionDimensionsOf(config));
   }
 
   @Test
@@ -189,14 +189,14 @@ public class KafkaIndexTaskTuningConfigTest
   {
     // Dimension names are plain strings; a numeric-looking name is just a string.
     final KafkaIndexTaskTuningConfig config = roundTripWithStreamingPartitionsSpec("[\"123\"]");
-    Assert.assertEquals(List.of("123"), partitionDimensionsOf(config));
+    Assertions.assertEquals(List.of("123"), partitionDimensionsOf(config));
   }
 
   @Test
   public void testSerdeWithNullElementInPartitionDimensions() throws Exception
   {
     final KafkaIndexTaskTuningConfig config = roundTripWithStreamingPartitionsSpec("[\"tenant\", null]");
-    Assert.assertEquals(Arrays.asList("tenant", null), partitionDimensionsOf(config));
+    Assertions.assertEquals(Arrays.asList("tenant", null), partitionDimensionsOf(config));
   }
 
   @Test
@@ -214,11 +214,11 @@ public class KafkaIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new DimensionValueSetPartitionsSpec(List.of("tenant", "region")),
         config.getStreamingPartitionsSpec()
     );
-    Assert.assertEquals(List.of("tenant", "region"), partitionDimensionsOf(config));
+    Assertions.assertEquals(List.of("tenant", "region"), partitionDimensionsOf(config));
   }
 
   @Test
@@ -232,13 +232,13 @@ public class KafkaIndexTaskTuningConfigTest
                            + "{\"type\": \"dim_value_sets\", \"partitionDimensions\": [\"tenant\"]}\n"
                            + "}";
 
-    final Exception e = Assert.assertThrows(
+    final Exception e = Assertions.assertThrows(
         Exception.class,
         () -> mapper.readValue(jsonStr, TuningConfig.class)
     );
-    Assert.assertTrue(
-        "Expected the unknown type id to be surfaced, got: " + e.getMessage(),
-        e.getMessage().contains("dim_value_sets")
+    Assertions.assertTrue(
+        e.getMessage().contains("dim_value_sets"),
+        "Expected the unknown type id to be surfaced, got: " + e.getMessage()
     );
   }
 
@@ -278,19 +278,19 @@ public class KafkaIndexTaskTuningConfigTest
         .build();
     KafkaIndexTaskTuningConfig copy = original.convertToTaskTuningConfig();
 
-    Assert.assertEquals(original.getAppendableIndexSpec(), copy.getAppendableIndexSpec());
-    Assert.assertEquals(1, copy.getMaxRowsInMemory());
-    Assert.assertEquals(2, copy.getMaxRowsPerSegment().intValue());
-    Assert.assertNotEquals(null, copy.getMaxTotalRows());
-    Assert.assertEquals(10L, copy.getMaxTotalRows().longValue());
-    Assert.assertEquals(new Period("PT3S"), copy.getIntermediatePersistPeriod());
-    Assert.assertNull(copy.getBasePersistDirectory());
-    Assert.assertEquals(4, copy.getMaxPendingPersists());
-    Assert.assertEquals(IndexSpec.getDefault(), copy.getIndexSpec());
-    Assert.assertTrue(copy.isReportParseExceptions());
-    Assert.assertEquals(5L, copy.getHandoffConditionTimeout());
-    Assert.assertEquals(2, copy.getNumPersistThreads());
-    Assert.assertEquals(5, copy.getMaxColumnsToMerge());
+    Assertions.assertEquals(original.getAppendableIndexSpec(), copy.getAppendableIndexSpec());
+    Assertions.assertEquals(1, copy.getMaxRowsInMemory());
+    Assertions.assertEquals(2, copy.getMaxRowsPerSegment().intValue());
+    Assertions.assertNotEquals(null, copy.getMaxTotalRows());
+    Assertions.assertEquals(10L, copy.getMaxTotalRows().longValue());
+    Assertions.assertEquals(new Period("PT3S"), copy.getIntermediatePersistPeriod());
+    Assertions.assertNull(copy.getBasePersistDirectory());
+    Assertions.assertEquals(4, copy.getMaxPendingPersists());
+    Assertions.assertEquals(IndexSpec.getDefault(), copy.getIndexSpec());
+    Assertions.assertTrue(copy.isReportParseExceptions());
+    Assertions.assertEquals(5L, copy.getHandoffConditionTimeout());
+    Assertions.assertEquals(2, copy.getNumPersistThreads());
+    Assertions.assertEquals(5, copy.getMaxColumnsToMerge());
   }
 
   @Test
@@ -326,26 +326,26 @@ public class KafkaIndexTaskTuningConfigTest
     TestModifiedKafkaIndexTaskTuningConfig deserialized =
         mapper.readValue(serialized, TestModifiedKafkaIndexTaskTuningConfig.class);
 
-    Assert.assertNull(deserialized.getExtra());
-    Assert.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
-    Assert.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
-    Assert.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
-    Assert.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
-    Assert.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
-    Assert.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
-    Assert.assertNull(deserialized.getBasePersistDirectory());
-    Assert.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
-    Assert.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
-    Assert.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
-    Assert.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
-    Assert.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
-    Assert.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
-    Assert.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
-    Assert.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
-    Assert.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
-    Assert.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
-    Assert.assertEquals(base.getNumPersistThreads(), deserialized.getNumPersistThreads());
-    Assert.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
+    Assertions.assertNull(deserialized.getExtra());
+    Assertions.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
+    Assertions.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
+    Assertions.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
+    Assertions.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
+    Assertions.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
+    Assertions.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
+    Assertions.assertNull(deserialized.getBasePersistDirectory());
+    Assertions.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
+    Assertions.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
+    Assertions.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
+    Assertions.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
+    Assertions.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
+    Assertions.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
+    Assertions.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
+    Assertions.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
+    Assertions.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
+    Assertions.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
+    Assertions.assertEquals(base.getNumPersistThreads(), deserialized.getNumPersistThreads());
+    Assertions.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
   }
 
   @Test
@@ -379,25 +379,25 @@ public class KafkaIndexTaskTuningConfigTest
     KafkaIndexTaskTuningConfig deserialized =
         mapper.readValue(serialized, KafkaIndexTaskTuningConfig.class);
 
-    Assert.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
-    Assert.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
-    Assert.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
-    Assert.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
-    Assert.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
-    Assert.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
-    Assert.assertEquals(base.getBasePersistDirectory(), deserialized.getBasePersistDirectory());
-    Assert.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
-    Assert.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
-    Assert.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
-    Assert.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
-    Assert.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
-    Assert.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
-    Assert.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
-    Assert.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
-    Assert.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
-    Assert.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
-    Assert.assertEquals(base.getNumPersistThreads(), deserialized.getNumPersistThreads());
-    Assert.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
+    Assertions.assertEquals(base.getAppendableIndexSpec(), deserialized.getAppendableIndexSpec());
+    Assertions.assertEquals(base.getMaxRowsInMemory(), deserialized.getMaxRowsInMemory());
+    Assertions.assertEquals(base.getMaxBytesInMemory(), deserialized.getMaxBytesInMemory());
+    Assertions.assertEquals(base.getMaxRowsPerSegment(), deserialized.getMaxRowsPerSegment());
+    Assertions.assertEquals(base.getMaxTotalRows(), deserialized.getMaxTotalRows());
+    Assertions.assertEquals(base.getIntermediatePersistPeriod(), deserialized.getIntermediatePersistPeriod());
+    Assertions.assertEquals(base.getBasePersistDirectory(), deserialized.getBasePersistDirectory());
+    Assertions.assertEquals(base.getMaxPendingPersists(), deserialized.getMaxPendingPersists());
+    Assertions.assertEquals(base.getIndexSpec(), deserialized.getIndexSpec());
+    Assertions.assertEquals(base.isReportParseExceptions(), deserialized.isReportParseExceptions());
+    Assertions.assertEquals(base.getHandoffConditionTimeout(), deserialized.getHandoffConditionTimeout());
+    Assertions.assertEquals(base.isResetOffsetAutomatically(), deserialized.isResetOffsetAutomatically());
+    Assertions.assertEquals(base.getSegmentWriteOutMediumFactory(), deserialized.getSegmentWriteOutMediumFactory());
+    Assertions.assertEquals(base.getIntermediateHandoffPeriod(), deserialized.getIntermediateHandoffPeriod());
+    Assertions.assertEquals(base.isLogParseExceptions(), deserialized.isLogParseExceptions());
+    Assertions.assertEquals(base.getMaxParseExceptions(), deserialized.getMaxParseExceptions());
+    Assertions.assertEquals(base.getMaxSavedParseExceptions(), deserialized.getMaxSavedParseExceptions());
+    Assertions.assertEquals(base.getNumPersistThreads(), deserialized.getNumPersistThreads());
+    Assertions.assertEquals(base.getMaxColumnsToMerge(), deserialized.getMaxColumnsToMerge());
   }
 
   @Test

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -47,12 +47,11 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -66,7 +65,8 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaRecordSupplierTest
 {
@@ -199,21 +199,21 @@ public class KafkaRecordSupplierTest
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     KAFKA_SERVER = new EmbeddedKafkaBroker(ImmutableMap.of("KAFKA_NUM_PARTITIONS", "2"));
     KAFKA_SERVER.start();
   }
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     TOPIC = nextTopicName();
     records = generateRecords(TOPIC);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass()
   {
     KAFKA_SERVER.close();
@@ -235,12 +235,12 @@ public class KafkaRecordSupplierTest
     KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
         KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false, null);
 
-    Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
+    Assertions.assertTrue(recordSupplier.getAssignment().isEmpty());
 
     recordSupplier.assign(partitions);
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertEquals(ImmutableSet.of(PARTITION_0, PARTITION_1),
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(ImmutableSet.of(PARTITION_0, PARTITION_1),
                         recordSupplier.getPartitionIds(TOPIC));
 
     recordSupplier.close();
@@ -265,14 +265,14 @@ public class KafkaRecordSupplierTest
 
     properties.put("sasl.oauthbearer.token.endpoint.url", "http://localhost:8080/token");
 
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(KafkaException.class, () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false, null)),
         CoreMatchers.instanceOf(KafkaException.class)
     );
 
     properties.remove("sasl.oauthbearer.token.endpoint.url");
     properties.put("sasl.oauthbearer.jwks.endpoint.url", "http://localhost:8080/jwks");
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(KafkaException.class, () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false, null)),
         CoreMatchers.instanceOf(KafkaException.class)
     );
@@ -303,7 +303,7 @@ public class KafkaRecordSupplierTest
         ),
         partitions
     );
-    Assert.assertEquals(diff.toString(), 0, diff.size());
+    Assertions.assertEquals(0, diff.size(), diff.toString());
   }
 
   @Test
@@ -330,12 +330,12 @@ public class KafkaRecordSupplierTest
         null
     );
 
-    Assert.assertTrue(recordSupplier.getAssignment().isEmpty());
+    Assertions.assertTrue(recordSupplier.getAssignment().isEmpty());
 
     recordSupplier.assign(partitions);
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertEquals(ImmutableSet.of(PARTITION_0, PARTITION_1),
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(ImmutableSet.of(PARTITION_0, PARTITION_1),
                         recordSupplier.getPartitionIds(TOPIC));
 
     recordSupplier.close();
@@ -359,28 +359,30 @@ public class KafkaRecordSupplierTest
             null
     );
 
-    Assert.assertTrue(recordSupplier.getAssignment().isEmpty()); //just test recordSupplier is initiated
+    Assertions.assertTrue(recordSupplier.getAssignment().isEmpty()); //just test recordSupplier is initiated
     recordSupplier.close();
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testSupplierSetupCustomDeserializerRequiresParameterButMissingIt()
   {
+    assertThrows(IllegalStateException.class, () -> {
 
-    Map<String, Object> properties = KAFKA_SERVER.consumerProperties();
-    properties.put("key.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializerRequiresParameter.class.getName());
-    properties.put("value.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializerRequiresParameter.class.getName());
+      Map<String, Object> properties = KAFKA_SERVER.consumerProperties();
+      properties.put("key.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializerRequiresParameter.class.getName());
+      properties.put("value.deserializer", KafkaRecordSupplierTest.TestKafkaDeserializerRequiresParameter.class.getName());
 
-    KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
-            properties,
-            OBJECT_MAPPER,
-            null,
-            false,
-            null
-    );
+      KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
+          properties,
+          OBJECT_MAPPER,
+          null,
+          false,
+          null
+      );
 
-    Assert.assertTrue(recordSupplier.getAssignment().isEmpty()); //just test recordSupplier is initiated
-    recordSupplier.close();
+      Assertions.assertTrue(recordSupplier.getAssignment().isEmpty()); //just test recordSupplier is initiated
+      recordSupplier.close();
+    });
   }
 
   @Test
@@ -419,9 +421,9 @@ public class KafkaRecordSupplierTest
       Thread.sleep(200);
     }
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertEquals(initialRecords.size(), polledRecords.size());
-    Assert.assertTrue(initialRecords.containsAll(polledRecords));
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(initialRecords.size(), polledRecords.size());
+    Assertions.assertTrue(initialRecords.containsAll(polledRecords));
 
     recordSupplier.close();
   }
@@ -461,13 +463,13 @@ public class KafkaRecordSupplierTest
       Thread.sleep(200);
     }
 
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
-    Assert.assertEquals(initialRecords.size(), polledRecords.size());
-    Assert.assertTrue(initialRecords.containsAll(polledRecords));
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(initialRecords.size(), polledRecords.size());
+    Assertions.assertTrue(initialRecords.containsAll(polledRecords));
 
     // Verify metrics
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
-    Assert.assertTrue(monitor.monitor(emitter));
+    Assertions.assertTrue(monitor.monitor(emitter));
     emitter.verifyEmitted("kafka/consumer/bytesConsumed", 1);
     emitter.verifyEmitted("kafka/consumer/recordsConsumed", 1);
     emitter.verifyEmitted("kafka/consumer/fetch", 1);
@@ -484,11 +486,11 @@ public class KafkaRecordSupplierTest
 
     // All emitted metrics carry the supervisorId dimension.
     for (final ServiceMetricEvent event : emitter.getMetricEvents("kafka/consumer/bytesConsumed")) {
-      Assert.assertEquals("supervisor-1", event.getUserDims().get(DruidMetrics.SUPERVISOR_ID));
+      Assertions.assertEquals("supervisor-1", event.getUserDims().get(DruidMetrics.SUPERVISOR_ID));
     }
 
     recordSupplier.close();
-    Assert.assertFalse(monitor.monitor(emitter));
+    Assertions.assertFalse(monitor.monitor(emitter));
   }
 
 
@@ -540,8 +542,8 @@ public class KafkaRecordSupplierTest
 
     List<OrderedPartitionableRecord<KafkaTopicPartition, Long, KafkaRecordEntity>> initialRecords = createOrderedPartitionableRecords();
 
-    Assert.assertEquals(records.size(), polledRecords.size());
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(records.size(), polledRecords.size());
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
 
     final int initialRecordsPartition0Size = initialRecords.stream()
                                                            .filter(r -> r.getPartitionId().partition() == 0)
@@ -561,8 +563,8 @@ public class KafkaRecordSupplierTest
                                                          .collect(Collectors.toSet())
                                                          .size();
 
-    Assert.assertEquals(initialRecordsPartition0Size, polledRecordsPartition0Size);
-    Assert.assertEquals(initialRecordsPartition1Size, polledRecordsPartition1Size);
+    Assertions.assertEquals(initialRecordsPartition0Size, polledRecordsPartition0Size);
+    Assertions.assertEquals(initialRecordsPartition1Size, polledRecordsPartition1Size);
 
     recordSupplier.close();
   }
@@ -587,8 +589,8 @@ public class KafkaRecordSupplierTest
     recordSupplier.assign(partitions);
     recordSupplier.seekToEarliest(partitions);
 
-    Assert.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition0));
-    Assert.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition1));
+    Assertions.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition0));
+    Assertions.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition1));
 
     recordSupplier.seek(partition0, 2L);
     recordSupplier.seek(partition1, 2L);
@@ -602,8 +604,8 @@ public class KafkaRecordSupplierTest
     }
 
 
-    Assert.assertEquals(11, polledRecords.size());
-    Assert.assertTrue(initialRecords.containsAll(polledRecords));
+    Assertions.assertEquals(11, polledRecords.size());
+    Assertions.assertTrue(initialRecords.containsAll(polledRecords));
 
 
     recordSupplier.close();
@@ -630,43 +632,45 @@ public class KafkaRecordSupplierTest
     recordSupplier.assign(partitions);
     recordSupplier.seekToEarliest(partitions);
 
-    Assert.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition0));
-    Assert.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition1));
+    Assertions.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition0));
+    Assertions.assertEquals(0L, (long) recordSupplier.getEarliestSequenceNumber(partition1));
 
     recordSupplier.seekToLatest(partitions);
     List<OrderedPartitionableRecord<KafkaTopicPartition, Long, KafkaRecordEntity>> polledRecords = recordSupplier.poll(POLL_TIMEOUT_MILLIS);
 
-    Assert.assertEquals(Collections.emptyList(), polledRecords);
+    Assertions.assertEquals(Collections.emptyList(), polledRecords);
     recordSupplier.close();
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void testSeekUnassigned() throws InterruptedException, ExecutionException
+  @Test
+  public void testSeekUnassigned()
   {
-    // Insert data
-    try (final KafkaProducer<byte[], byte[]> kafkaProducer = KAFKA_SERVER.newProducer()) {
-      for (ProducerRecord<byte[], byte[]> record : records) {
-        kafkaProducer.send(record).get();
+    assertThrows(IllegalStateException.class, () -> {
+      // Insert data
+      try (final KafkaProducer<byte[], byte[]> kafkaProducer = KAFKA_SERVER.newProducer()) {
+        for (ProducerRecord<byte[], byte[]> record : records) {
+          kafkaProducer.send(record).get();
+        }
       }
-    }
 
-    StreamPartition<KafkaTopicPartition> partition0 = StreamPartition.of(TOPIC, PARTITION_0);
-    StreamPartition<KafkaTopicPartition> partition1 = StreamPartition.of(TOPIC, PARTITION_1);
+      StreamPartition<KafkaTopicPartition> partition0 = StreamPartition.of(TOPIC, PARTITION_0);
+      StreamPartition<KafkaTopicPartition> partition1 = StreamPartition.of(TOPIC, PARTITION_1);
 
-    Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(
-        StreamPartition.of(TOPIC, PARTITION_0)
-    );
+      Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(
+          StreamPartition.of(TOPIC, PARTITION_0)
+      );
 
-    KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
-        KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false, null);
+      KafkaRecordSupplier recordSupplier = new KafkaRecordSupplier(
+          KAFKA_SERVER.consumerProperties(), OBJECT_MAPPER, null, false, null);
 
-    recordSupplier.assign(partitions);
+      recordSupplier.assign(partitions);
 
-    Assert.assertEquals(0, (long) recordSupplier.getEarliestSequenceNumber(partition0));
+      Assertions.assertEquals(0, (long) recordSupplier.getEarliestSequenceNumber(partition0));
 
-    recordSupplier.seekToEarliest(Collections.singleton(partition1));
+      recordSupplier.seekToEarliest(Collections.singleton(partition1));
 
-    recordSupplier.close();
+      recordSupplier.close();
+    });
   }
 
   @Test
@@ -689,27 +693,27 @@ public class KafkaRecordSupplierTest
     recordSupplier.assign(partitions);
     recordSupplier.seekToEarliest(partitions);
 
-    Assert.assertEquals(0L, (long) recordSupplier.getPosition(partition0));
-    Assert.assertEquals(0L, (long) recordSupplier.getPosition(partition1));
+    Assertions.assertEquals(0L, (long) recordSupplier.getPosition(partition0));
+    Assertions.assertEquals(0L, (long) recordSupplier.getPosition(partition1));
 
     recordSupplier.seek(partition0, 4L);
     recordSupplier.seek(partition1, 5L);
 
-    Assert.assertEquals(4L, (long) recordSupplier.getPosition(partition0));
-    Assert.assertEquals(5L, (long) recordSupplier.getPosition(partition1));
+    Assertions.assertEquals(4L, (long) recordSupplier.getPosition(partition0));
+    Assertions.assertEquals(5L, (long) recordSupplier.getPosition(partition1));
 
     recordSupplier.seekToEarliest(Collections.singleton(partition0));
-    Assert.assertEquals(0L, (long) recordSupplier.getPosition(partition0));
+    Assertions.assertEquals(0L, (long) recordSupplier.getPosition(partition0));
 
     recordSupplier.seekToLatest(Collections.singleton(partition0));
-    Assert.assertEquals(12L, (long) recordSupplier.getPosition(partition0));
+    Assertions.assertEquals(12L, (long) recordSupplier.getPosition(partition0));
 
     long prevPos = recordSupplier.getPosition(partition0);
     recordSupplier.getEarliestSequenceNumber(partition0);
-    Assert.assertEquals(prevPos, (long) recordSupplier.getPosition(partition0));
+    Assertions.assertEquals(prevPos, (long) recordSupplier.getPosition(partition0));
 
     recordSupplier.getLatestSequenceNumber(partition0);
-    Assert.assertEquals(prevPos, (long) recordSupplier.getPosition(partition0));
+    Assertions.assertEquals(prevPos, (long) recordSupplier.getPosition(partition0));
 
 
     recordSupplier.close();
@@ -724,7 +728,7 @@ public class KafkaRecordSupplierTest
     Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(streamPartition);
     recordSupplier.assign(partitions);
     recordSupplier.seekToEarliest(partitions);
-    Assert.assertEquals(Long.valueOf(0), recordSupplier.getLatestSequenceNumber(streamPartition));
+    Assertions.assertEquals(Long.valueOf(0), recordSupplier.getLatestSequenceNumber(streamPartition));
   }
 
   @Test
@@ -736,7 +740,7 @@ public class KafkaRecordSupplierTest
     Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(streamPartition);
     recordSupplier.assign(partitions);
     recordSupplier.seekToEarliest(partitions);
-    Assert.assertEquals(Long.valueOf(0), recordSupplier.getEarliestSequenceNumber(streamPartition));
+    Assertions.assertEquals(Long.valueOf(0), recordSupplier.getEarliestSequenceNumber(streamPartition));
   }
 
   @Test
@@ -748,7 +752,7 @@ public class KafkaRecordSupplierTest
     Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(streamPartition);
     recordSupplier.assign(partitions);
     recordSupplier.seekToLatest(partitions);
-    Assert.assertEquals(Long.valueOf(0), recordSupplier.getLatestSequenceNumber(streamPartition));
+    Assertions.assertEquals(Long.valueOf(0), recordSupplier.getLatestSequenceNumber(streamPartition));
   }
 
   @Test
@@ -760,7 +764,7 @@ public class KafkaRecordSupplierTest
     Set<StreamPartition<KafkaTopicPartition>> partitions = ImmutableSet.of(streamPartition);
     recordSupplier.assign(partitions);
     recordSupplier.seekToLatest(partitions);
-    Assert.assertEquals(Long.valueOf(0), recordSupplier.getEarliestSequenceNumber(streamPartition));
+    Assertions.assertEquals(Long.valueOf(0), recordSupplier.getEarliestSequenceNumber(streamPartition));
   }
 
   @Test
@@ -784,10 +788,10 @@ public class KafkaRecordSupplierTest
         consumerProperties
     );
 
-    Assert.assertEquals(3, properties.size());
-    Assert.assertEquals("value.1", properties.getProperty("kafka.prop.1"));
-    Assert.assertEquals("value.2", properties.getProperty("kafka.prop.2"));
-    Assert.assertEquals("pwd2", properties.getProperty(KafkaSupervisorIOConfig.TRUST_STORE_PASSWORD_KEY));
+    Assertions.assertEquals(3, properties.size());
+    Assertions.assertEquals("value.1", properties.getProperty("kafka.prop.1"));
+    Assertions.assertEquals("value.2", properties.getProperty("kafka.prop.2"));
+    Assertions.assertEquals("pwd2", properties.getProperty(KafkaSupervisorIOConfig.TRUST_STORE_PASSWORD_KEY));
   }
 
   @Test
@@ -806,7 +810,7 @@ public class KafkaRecordSupplierTest
     // We set a client ID via config override, it should appear in the metric name tags
     Map<MetricName, KafkaMetric> metrics = (Map<MetricName, KafkaMetric>) kafkaConsumer.metrics();
     for (MetricName metricName : metrics.keySet()) {
-      Assert.assertEquals("overrideConfigTest", metricName.tags().get("client-id"));
+      Assertions.assertEquals("overrideConfigTest", metricName.tags().get("client-id"));
       break;
     }
   }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSamplerSpecTest.java
@@ -50,12 +50,10 @@ import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -64,10 +62,11 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
   private static final String TOPIC = "sampling";
@@ -111,14 +110,14 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
     );
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     kafkaServer = new EmbeddedKafkaBroker(ImmutableMap.of("KAFKA_NUM_PARTITIONS", "2"));
     kafkaServer.start();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass()
   {
     kafkaServer.close();
@@ -198,11 +197,11 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     SamplerResponse response = samplerSpec.sample();
 
-    Assert.assertEquals(5, response.getNumRowsRead());
+    Assertions.assertEquals(5, response.getNumRowsRead());
     // we can parse an extra row compared to other generated data samples because we are using kafka timestamp
     // for timestamp
-    Assert.assertEquals(4, response.getNumRowsIndexed());
-    Assert.assertEquals(5, response.getData().size());
+    Assertions.assertEquals(4, response.getNumRowsIndexed());
+    Assertions.assertEquals(5, response.getData().size());
 
     Iterator<SamplerResponse.SamplerResponseRow> it = response.getData().iterator();
 
@@ -212,29 +211,29 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
 
     for (int i = 0; i < 4; i++) {
       nextRow = it.next();
-      Assert.assertNull(nextRow.isUnparseable());
+      Assertions.assertNull(nextRow.isUnparseable());
       rawInput = nextRow.getInput();
       parsedInput = nextRow.getParsed();
-      Assert.assertTrue(rawInput.containsKey("kafka.timestamp"));
-      Assert.assertEquals(rawInput.get("kafka.timestamp"), parsedInput.get("__time"));
+      Assertions.assertTrue(rawInput.containsKey("kafka.timestamp"));
+      Assertions.assertEquals(rawInput.get("kafka.timestamp"), parsedInput.get("__time"));
     }
     nextRow = it.next();
-    Assert.assertTrue(nextRow.isUnparseable());
+    Assertions.assertTrue(nextRow.isUnparseable());
 
-    Assert.assertFalse(it.hasNext());
+    Assertions.assertFalse(it.hasNext());
   }
 
   private static void runSamplerAndCompareResponse(SamplerSpec samplerSpec, boolean useInputFormat)
   {
     SamplerResponse response = samplerSpec.sample();
 
-    Assert.assertEquals(5, response.getNumRowsRead());
-    Assert.assertEquals(3, response.getNumRowsIndexed());
-    Assert.assertEquals(5, response.getData().size());
+    Assertions.assertEquals(5, response.getNumRowsRead());
+    Assertions.assertEquals(3, response.getNumRowsIndexed());
+    Assertions.assertEquals(5, response.getData().size());
 
     Iterator<SamplerResponse.SamplerResponseRow> it = response.getData().iterator();
 
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         new SamplerTestUtils.MapAllowingNullValuesBuilder<String, Object>()
             .put("timestamp", "2008")
             .put("dim1", "a")
@@ -256,7 +255,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         new SamplerTestUtils.MapAllowingNullValuesBuilder<String, Object>()
             .put("timestamp", "2009")
             .put("dim1", "b")
@@ -278,7 +277,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         new SamplerTestUtils.MapAllowingNullValuesBuilder<String, Object>()
             .put("timestamp", "2010")
             .put("dim1", "c")
@@ -300,7 +299,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         new SamplerTestUtils.MapAllowingNullValuesBuilder<String, Object>()
             .put("timestamp", "246140482-04-24T15:36:27.903Z")
             .put("dim1", "x")
@@ -313,14 +312,14 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
         true,
         "Encountered row with timestamp[246140482-04-24T15:36:27.903Z] that cannot be represented as a long: [{timestamp=246140482-04-24T15:36:27.903Z, dim1=x, dim2=z, dimLong=10, dimFloat=20.0, met1=1.0}]"
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         null,
         null,
         true,
         "Unable to parse row [unparseable]" + (useInputFormat ? " into JSON" : "")
     ), it.next());
 
-    Assert.assertFalse(it.hasNext());
+    Assertions.assertFalse(it.hasNext());
   }
 
   private static void insertData(List<ProducerRecord<byte[], byte[]>> data)
@@ -357,26 +356,26 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
   @Test
   public void testInvalidKafkaConfig()
   {
-    KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpecBuilder()
-        .withDataSchema(DATA_SCHEMA)
-        .withIoConfig(
-            ioConfig -> ioConfig
-                .withJsonInputFormat()
-                .withConsumerProperties(Map.of("bootstrap.servers", "invalid"))
-                .withUseEarliestSequenceNumber(true)
-        )
-        .build(DATASOURCE, TOPIC);
+    Throwable exception = assertThrows(SamplerException.class, () -> {
+      KafkaSupervisorSpec supervisorSpec = new KafkaSupervisorSpecBuilder()
+          .withDataSchema(DATA_SCHEMA)
+          .withIoConfig(
+              ioConfig -> ioConfig
+                  .withJsonInputFormat()
+                  .withConsumerProperties(Map.of("bootstrap.servers", "invalid"))
+                  .withUseEarliestSequenceNumber(true)
+          )
+          .build(DATASOURCE, TOPIC);
 
-    KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
-        supervisorSpec,
-        new SamplerConfig(5, null, null, null),
-        new InputSourceSampler(OBJECT_MAPPER),
-        OBJECT_MAPPER
-    );
-
-    expectedException.expect(SamplerException.class);
-    expectedException.expectMessage("Invalid url in bootstrap.servers");
-    samplerSpec.sample();
+      KafkaSamplerSpec samplerSpec = new KafkaSamplerSpec(
+          supervisorSpec,
+          new SamplerConfig(5, null, null, null),
+          new InputSourceSampler(OBJECT_MAPPER),
+          OBJECT_MAPPER
+      );
+      samplerSpec.sample();
+    });
+    assertTrue(exception.getMessage().contains("Invalid url in bootstrap.servers"));
   }
 
   @Test
@@ -399,7 +398,7 @@ public class KafkaSamplerSpecTest extends InitializedNullHandlingTest
         OBJECT_MAPPER
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 KafkaIndexTaskModule.SCHEME,

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSeekableStreamEndSequenceNumbersTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSeekableStreamEndSequenceNumbersTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamEndSequenceNumbers
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -64,14 +64,14 @@ public class KafkaSeekableStreamEndSequenceNumbersTest
         new TypeReference<>() {}
     );
 
-    Assert.assertEquals(
-        "Round trip",
+    Assertions.assertEquals(
         partitions,
         new KafkaSeekableStreamEndSequenceNumbers(partitions2.getStream(),
             partitions2.getTopic(),
             partitions2.getPartitionSequenceNumberMap(),
             partitions2.getPartitionOffsetMap()
-        )
+        ),
+        "Round trip"
     );
 
     // Check backwards compatibility.
@@ -80,15 +80,15 @@ public class KafkaSeekableStreamEndSequenceNumbersTest
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    Assert.assertEquals(stream, asMap.get("stream"));
-    Assert.assertEquals(stream, asMap.get("topic"));
+    Assertions.assertEquals(stream, asMap.get("stream"));
+    Assertions.assertEquals(stream, asMap.get("topic"));
 
     // Jackson will deserialize the maps as string -> int maps, not int -> long.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionSequenceNumberMap"), new TypeReference<Map<KafkaTopicPartition, Long>>() {})
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionOffsetMap"), new TypeReference<Map<KafkaTopicPartition, Long>>() {})
     );
@@ -106,7 +106,7 @@ public class KafkaSeekableStreamEndSequenceNumbersTest
       expectedExceptionThrown = true;
     }
 
-    Assert.assertTrue("KafkaSeekableStreamEndSequenceNumbers should not be registered type", expectedExceptionThrown);
+    Assertions.assertTrue(expectedExceptionThrown, "KafkaSeekableStreamEndSequenceNumbers should not be registered type");
   }
 
   private static ObjectMapper createObjectMapper()

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSeekableStreamStartSequenceNumbersTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaSeekableStreamStartSequenceNumbersTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbe
 import org.apache.druid.initialization.CoreInjectorBuilder;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Set;
@@ -69,8 +69,7 @@ public class KafkaSeekableStreamStartSequenceNumbersTest
         new TypeReference<>() {}
     );
 
-    Assert.assertEquals(
-        "Round trip",
+    Assertions.assertEquals(
         partitions,
         new KafkaSeekableStreamStartSequenceNumbers(
             partitions2.getStream(),
@@ -78,7 +77,8 @@ public class KafkaSeekableStreamStartSequenceNumbersTest
             partitions2.getPartitionSequenceNumberMap(),
             partitions2.getPartitionOffsetMap(),
             partitions2.getExclusivePartitions()
-        )
+        ),
+        "Round trip"
     );
 
     // Check backwards compatibility.
@@ -87,20 +87,20 @@ public class KafkaSeekableStreamStartSequenceNumbersTest
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    Assert.assertEquals(stream, asMap.get("stream"));
-    Assert.assertEquals(stream, asMap.get("topic"));
+    Assertions.assertEquals(stream, asMap.get("stream"));
+    Assertions.assertEquals(stream, asMap.get("topic"));
 
     // Jackson will deserialize the maps as string -> int maps, not int -> long.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionSequenceNumberMap"), new TypeReference<Map<KafkaTopicPartition, Long>>() {})
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionOffsetMap"), new TypeReference<Map<KafkaTopicPartition, Long>>() {})
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         exclusivePartitions,
         OBJECT_MAPPER.convertValue(asMap.get("exclusivePartitions"), new TypeReference<Set<KafkaTopicPartition>>() {})
     );
@@ -118,7 +118,7 @@ public class KafkaSeekableStreamStartSequenceNumbersTest
       expectedExceptionThrown = true;
     }
 
-    Assert.assertTrue("KafkaSeekableStreamStartSequenceNumbers should not be registered type", expectedExceptionThrown);
+    Assertions.assertTrue(expectedExceptionThrown, "KafkaSeekableStreamStartSequenceNumbers should not be registered type");
   }
 
   private static ObjectMapper createObjectMapper()

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
@@ -39,13 +39,11 @@ import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScaler
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.LagBasedAutoScalerConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -62,9 +60,6 @@ public class KafkaSupervisorIOConfigTest
     mapper = new DefaultObjectMapper();
     mapper.registerModules(new KafkaIndexTaskModule().getJacksonModules());
   }
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testSerdeWithDefaults() throws Exception
@@ -84,22 +79,22 @@ public class KafkaSupervisorIOConfigTest
         ), KafkaSupervisorIOConfig.class
     );
 
-    Assert.assertEquals("my-topic", config.getTopic());
-    Assert.assertNull(config.getTopicPattern());
-    Assert.assertEquals(1, (int) config.getReplicas());
-    Assert.assertEquals(1, (int) config.getTaskCount());
-    Assert.assertNull(config.getStopTaskCount());
-    Assert.assertEquals((int) config.getTaskCount(), config.getMaxAllowedStops());
-    Assert.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
-    Assert.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
-    Assert.assertEquals(100, config.getPollTimeout());
-    Assert.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());
-    Assert.assertFalse(config.isUseEarliestOffset());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
-    Assert.assertFalse("lateMessageRejectionPeriod", config.getLateMessageRejectionPeriod().isPresent());
-    Assert.assertFalse("earlyMessageRejectionPeriod", config.getEarlyMessageRejectionPeriod().isPresent());
-    Assert.assertFalse("lateMessageRejectionStartDateTime", config.getLateMessageRejectionStartDateTime().isPresent());
+    Assertions.assertEquals("my-topic", config.getTopic());
+    Assertions.assertNull(config.getTopicPattern());
+    Assertions.assertEquals(1, (int) config.getReplicas());
+    Assertions.assertEquals(1, (int) config.getTaskCount());
+    Assertions.assertNull(config.getStopTaskCount());
+    Assertions.assertEquals((int) config.getTaskCount(), config.getMaxAllowedStops());
+    Assertions.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
+    Assertions.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
+    Assertions.assertEquals(100, config.getPollTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(30), config.getPeriod());
+    Assertions.assertFalse(config.isUseEarliestOffset());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
+    Assertions.assertFalse(config.getLateMessageRejectionPeriod().isPresent(), "lateMessageRejectionPeriod");
+    Assertions.assertFalse(config.getEarlyMessageRejectionPeriod().isPresent(), "earlyMessageRejectionPeriod");
+    Assertions.assertFalse(config.getLateMessageRejectionStartDateTime().isPresent(), "lateMessageRejectionStartDateTime");
   }
 
   @Test
@@ -120,8 +115,8 @@ public class KafkaSupervisorIOConfigTest
         ), KafkaSupervisorIOConfig.class
     );
 
-    Assert.assertEquals("my-topic.*", config.getTopicPattern());
-    Assert.assertNull(config.getTopic());
+    Assertions.assertEquals("my-topic.*", config.getTopicPattern());
+    Assertions.assertNull(config.getTopic());
   }
 
   @Test
@@ -152,19 +147,19 @@ public class KafkaSupervisorIOConfigTest
             ), KafkaSupervisorIOConfig.class
         );
 
-    Assert.assertEquals("my-topic", config.getTopic());
-    Assert.assertNull(config.getTopicPattern());
-    Assert.assertEquals(3, (int) config.getReplicas());
-    Assert.assertEquals(9, (int) config.getTaskCount());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
-    Assert.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
-    Assert.assertEquals(1000, config.getPollTimeout());
-    Assert.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(10), config.getPeriod());
-    Assert.assertTrue(config.isUseEarliestOffset());
-    Assert.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
-    Assert.assertEquals(Duration.standardHours(1), config.getLateMessageRejectionPeriod().orNull());
-    Assert.assertEquals(Duration.standardHours(1), config.getEarlyMessageRejectionPeriod().orNull());
+    Assertions.assertEquals("my-topic", config.getTopic());
+    Assertions.assertNull(config.getTopicPattern());
+    Assertions.assertEquals(3, (int) config.getReplicas());
+    Assertions.assertEquals(9, (int) config.getTaskCount());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
+    Assertions.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
+    Assertions.assertEquals(1000, config.getPollTimeout());
+    Assertions.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(10), config.getPeriod());
+    Assertions.assertTrue(config.isUseEarliestOffset());
+    Assertions.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
+    Assertions.assertEquals(Duration.standardHours(1), config.getLateMessageRejectionPeriod().orNull());
+    Assertions.assertEquals(Duration.standardHours(1), config.getEarlyMessageRejectionPeriod().orNull());
   }
 
   @Test
@@ -195,18 +190,18 @@ public class KafkaSupervisorIOConfigTest
             ), KafkaSupervisorIOConfig.class
         );
 
-    Assert.assertEquals("my-topic", config.getTopic());
-    Assert.assertNull(config.getTopicPattern());
-    Assert.assertEquals(3, (int) config.getReplicas());
-    Assert.assertEquals(9, (int) config.getTaskCount());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
-    Assert.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
-    Assert.assertEquals(1000, config.getPollTimeout());
-    Assert.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(10), config.getPeriod());
-    Assert.assertTrue(config.isUseEarliestOffset());
-    Assert.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
-    Assert.assertEquals(DateTimes.of("2016-05-31T12:00Z"), config.getLateMessageRejectionStartDateTime().orNull());
+    Assertions.assertEquals("my-topic", config.getTopic());
+    Assertions.assertNull(config.getTopicPattern());
+    Assertions.assertEquals(3, (int) config.getReplicas());
+    Assertions.assertEquals(9, (int) config.getTaskCount());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
+    Assertions.assertEquals(ImmutableMap.of("bootstrap.servers", "localhost:9092"), config.getConsumerProperties());
+    Assertions.assertEquals(1000, config.getPollTimeout());
+    Assertions.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(10), config.getPeriod());
+    Assertions.assertTrue(config.isUseEarliestOffset());
+    Assertions.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
+    Assertions.assertEquals(DateTimes.of("2016-05-31T12:00Z"), config.getLateMessageRejectionStartDateTime().orNull());
   }
 
   @Test
@@ -225,12 +220,12 @@ public class KafkaSupervisorIOConfigTest
     Properties props = new Properties();
     KafkaRecordSupplier.addConsumerPropertiesFromConfig(props, mapper, config.getConsumerProperties());
 
-    Assert.assertEquals("my-topic", config.getTopic());
-    Assert.assertNull(config.getTopicPattern());
-    Assert.assertEquals("localhost:9092", props.getProperty("bootstrap.servers"));
-    Assert.assertEquals("mytruststorepassword", props.getProperty("ssl.truststore.password"));
-    Assert.assertEquals("mykeystorepassword", props.getProperty("ssl.keystore.password"));
-    Assert.assertEquals("mykeypassword", props.getProperty("ssl.key.password"));
+    Assertions.assertEquals("my-topic", config.getTopic());
+    Assertions.assertNull(config.getTopicPattern());
+    Assertions.assertEquals("localhost:9092", props.getProperty("bootstrap.servers"));
+    Assertions.assertEquals("mytruststorepassword", props.getProperty("ssl.truststore.password"));
+    Assertions.assertEquals("mykeystorepassword", props.getProperty("ssl.keystore.password"));
+    Assertions.assertEquals("mykeypassword", props.getProperty("ssl.key.password"));
   }
 
   @Test
@@ -241,10 +236,11 @@ public class KafkaSupervisorIOConfigTest
                      + "  \"consumerProperties\": {\"bootstrap.servers\":\"localhost:9092\"}\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(DruidException.class));
-    exception.expectMessage(CoreMatchers.containsString("Either topic or topicPattern must be specified"));
-    mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class);
+    assertJsonMappingException(
+        DruidException.class,
+        "Either topic or topicPattern must be specified",
+        () -> mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class)
+    );
   }
 
   @Test
@@ -255,10 +251,11 @@ public class KafkaSupervisorIOConfigTest
                      + "  \"topic\": \"my-topic\"\n"
                      + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("consumerProperties"));
-    mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class);
+    assertJsonMappingException(
+        NullPointerException.class,
+        "consumerProperties",
+        () -> mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class)
+    );
   }
 
   @Test
@@ -270,40 +267,41 @@ public class KafkaSupervisorIOConfigTest
         + "  \"consumerProperties\": {}\n"
         + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("bootstrap.servers"));
-    mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class);
+    assertJsonMappingException(
+        NullPointerException.class,
+        "bootstrap.servers",
+        () -> mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class)
+    );
   }
 
   @Test
-  public void testSerdeWithBothExclusiveProperties() throws Exception
-  {
-    String jsonStr = "{\n"
-        + "  \"type\": \"kafka\",\n"
-        + "  \"topic\": \"my-topic\",\n"
-        + "  \"replicas\": 3,\n"
-        + "  \"taskCount\": 9,\n"
-        + "  \"taskDuration\": \"PT30M\",\n"
-        + "  \"consumerProperties\": {\"bootstrap.servers\":\"localhost:9092\"},\n"
-        + "  \"pollTimeout\": 1000,\n"
-        + "  \"startDelay\": \"PT1M\",\n"
-        + "  \"period\": \"PT10S\",\n"
-        + "  \"useEarliestOffset\": true,\n"
-        + "  \"completionTimeout\": \"PT45M\",\n"
-        + "  \"lateMessageRejectionPeriod\": \"PT1H\",\n"
-        + "  \"earlyMessageRejectionPeriod\": \"PT1H\",\n"
-        + "  \"lateMessageRejectionStartDateTime\": \"2016-05-31T12:00Z\"\n"
-        + "}";
-    exception.expect(JsonMappingException.class);
-    mapper.readValue(
-        mapper.writeValueAsString(
-            mapper.readValue(
-                jsonStr,
-                KafkaSupervisorIOConfig.class
-            )
-        ), KafkaSupervisorIOConfig.class
-    );
+  public void testSerdeWithBothExclusiveProperties() {
+    Assertions.assertThrows(JsonMappingException.class, () -> {
+      String jsonStr = "{\n"
+          + "  \"type\": \"kafka\",\n"
+          + "  \"topic\": \"my-topic\",\n"
+          + "  \"replicas\": 3,\n"
+          + "  \"taskCount\": 9,\n"
+          + "  \"taskDuration\": \"PT30M\",\n"
+          + "  \"consumerProperties\": {\"bootstrap.servers\":\"localhost:9092\"},\n"
+          + "  \"pollTimeout\": 1000,\n"
+          + "  \"startDelay\": \"PT1M\",\n"
+          + "  \"period\": \"PT10S\",\n"
+          + "  \"useEarliestOffset\": true,\n"
+          + "  \"completionTimeout\": \"PT45M\",\n"
+          + "  \"lateMessageRejectionPeriod\": \"PT1H\",\n"
+          + "  \"earlyMessageRejectionPeriod\": \"PT1H\",\n"
+          + "  \"lateMessageRejectionStartDateTime\": \"2016-05-31T12:00Z\"\n"
+          + "}";
+      mapper.readValue(
+          mapper.writeValueAsString(
+              mapper.readValue(
+                  jsonStr,
+                  KafkaSupervisorIOConfig.class
+              )
+          ), KafkaSupervisorIOConfig.class
+      );
+    });
   }
 
   @Test
@@ -357,11 +355,11 @@ public class KafkaSupervisorIOConfigTest
     );
     String ioConfig = mapper.writeValueAsString(kafkaSupervisorIOConfig);
     KafkaSupervisorIOConfig kafkaSupervisorIOConfig1 = mapper.readValue(ioConfig, KafkaSupervisorIOConfig.class);
-    Assert.assertNotNull(kafkaSupervisorIOConfig1.getAutoScalerConfig());
-    Assert.assertTrue(kafkaSupervisorIOConfig1.getAutoScalerConfig().getEnableTaskAutoScaler());
-    Assert.assertEquals(1, kafkaSupervisorIOConfig1.getAutoScalerConfig().getTaskCountMin());
-    Assert.assertEquals(10, kafkaSupervisorIOConfig1.getAutoScalerConfig().getTaskCountMax());
-    Assert.assertEquals(
+    Assertions.assertNotNull(kafkaSupervisorIOConfig1.getAutoScalerConfig());
+    Assertions.assertTrue(kafkaSupervisorIOConfig1.getAutoScalerConfig().getEnableTaskAutoScaler());
+    Assertions.assertEquals(1, kafkaSupervisorIOConfig1.getAutoScalerConfig().getTaskCountMin());
+    Assertions.assertEquals(10, kafkaSupervisorIOConfig1.getAutoScalerConfig().getTaskCountMax());
+    Assertions.assertEquals(
         1200000,
         kafkaSupervisorIOConfig1.getAutoScalerConfig().getMinTriggerScaleActionFrequencyMillis()
     );
@@ -392,22 +390,20 @@ public class KafkaSupervisorIOConfigTest
         null,
         null
     );
-    Assert.assertEquals(1, kafkaSupervisorIOConfig.getTaskCount());
+    Assertions.assertEquals(1, kafkaSupervisorIOConfig.getTaskCount());
 
-    Assert.assertThrows(
-        "taskCountMin <= taskCountStart <= taskCountMax",
+    Assertions.assertThrows(
         RuntimeException.class, () -> {
           autoScalerConfig.put("taskCountStart", 11); // > max task count
           mapper.convertValue(autoScalerConfig, LagBasedAutoScalerConfig.class);
-        }
+        }, "taskCountMin <= taskCountStart <= taskCountMax"
     );
 
-    Assert.assertThrows(
-        "taskCountMin <= taskCountStart <= taskCountMax",
+    Assertions.assertThrows(
         RuntimeException.class, () -> {
           autoScalerConfig.put("taskCountStart", 0); // < min task count
           mapper.convertValue(autoScalerConfig, LagBasedAutoScalerConfig.class);
-        }
+        }, "taskCountMin <= taskCountStart <= taskCountMax"
     );
   }
 
@@ -421,11 +417,11 @@ public class KafkaSupervisorIOConfigTest
         "taskCountStart", 5
     );
 
-    Assert.assertEquals(7, makeIOConfig(7, autoScalerConfig).getTaskCount());
-    Assert.assertTrue(makeIOConfig(7, autoScalerConfig).isTaskCountExplicit());
+    Assertions.assertEquals(7, makeIOConfig(7, autoScalerConfig).getTaskCount());
+    Assertions.assertTrue(makeIOConfig(7, autoScalerConfig).isTaskCountExplicit());
 
-    Assert.assertEquals(5, makeIOConfig(null, autoScalerConfig).getTaskCount());
-    Assert.assertFalse(makeIOConfig(null, autoScalerConfig).isTaskCountExplicit());
+    Assertions.assertEquals(5, makeIOConfig(null, autoScalerConfig).getTaskCount());
+    Assertions.assertFalse(makeIOConfig(null, autoScalerConfig).isTaskCountExplicit());
   }
 
   private KafkaSupervisorIOConfig makeIOConfig(Integer taskCount, Map<String, Object> autoScalerConfig)
@@ -495,9 +491,9 @@ public class KafkaSupervisorIOConfigTest
     String ioConfig = mapper.writeValueAsString(kafkaSupervisorIOConfig);
     KafkaSupervisorIOConfig kafkaSupervisorIOConfig1 = mapper.readValue(ioConfig, KafkaSupervisorIOConfig.class);
 
-    Assert.assertNotNull(kafkaSupervisorIOConfig1.getIdleConfig());
-    Assert.assertTrue(kafkaSupervisorIOConfig1.getIdleConfig().isEnabled());
-    Assert.assertEquals(Long.valueOf(600000), kafkaSupervisorIOConfig1.getIdleConfig().getInactiveAfterMillis());
+    Assertions.assertNotNull(kafkaSupervisorIOConfig1.getIdleConfig());
+    Assertions.assertTrue(kafkaSupervisorIOConfig1.getIdleConfig().isEnabled());
+    Assertions.assertEquals(Long.valueOf(600000), kafkaSupervisorIOConfig1.getIdleConfig().getInactiveAfterMillis());
   }
 
   @Test
@@ -515,10 +511,10 @@ public class KafkaSupervisorIOConfigTest
 
     KafkaSupervisorIOConfig config = mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
   }
 
   @Test
@@ -536,10 +532,10 @@ public class KafkaSupervisorIOConfigTest
 
     KafkaSupervisorIOConfig config = mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
   }
 
   @Test
@@ -557,8 +553,8 @@ public class KafkaSupervisorIOConfigTest
 
     KafkaSupervisorIOConfig config = mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
   }
 
   @Test
@@ -572,8 +568,8 @@ public class KafkaSupervisorIOConfigTest
 
     KafkaSupervisorIOConfig config = mapper.readValue(jsonStr, KafkaSupervisorIOConfig.class);
 
-    Assert.assertFalse(config.isBounded());
-    Assert.assertNull(config.getBoundedStreamConfig());
+    Assertions.assertFalse(config.isBounded());
+    Assertions.assertNull(config.getBoundedStreamConfig());
   }
 
   @Test
@@ -621,10 +617,10 @@ public class KafkaSupervisorIOConfigTest
     String json = mapper.writeValueAsString(original);
     KafkaSupervisorIOConfig deserialized = mapper.readValue(json, KafkaSupervisorIOConfig.class);
 
-    Assert.assertTrue(deserialized.isBounded());
-    Assert.assertNotNull(deserialized.getBoundedStreamConfig());
-    Assert.assertEquals(2, deserialized.getBoundedStreamConfig().getStartSequenceNumbers().size());
-    Assert.assertEquals(2, deserialized.getBoundedStreamConfig().getEndSequenceNumbers().size());
+    Assertions.assertTrue(deserialized.isBounded());
+    Assertions.assertNotNull(deserialized.getBoundedStreamConfig());
+    Assertions.assertEquals(2, deserialized.getBoundedStreamConfig().getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, deserialized.getBoundedStreamConfig().getEndSequenceNumbers().size());
   }
 
   private static KafkaIOConfigBuilder ioConfigBuilder()
@@ -641,31 +637,31 @@ public class KafkaSupervisorIOConfigTest
   public void testEqualsAndHashCode()
   {
     final KafkaSupervisorIOConfig config = ioConfigBuilder().build();
-    Assert.assertEquals(config, ioConfigBuilder().build());
-    Assert.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
-    Assert.assertNotEquals(config, null);
-    Assert.assertNotEquals(config, "not an io config");
-    Assert.assertNotEquals(config, ioConfigBuilder().withTopic("other").build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
-    Assert.assertNotEquals(
+    Assertions.assertEquals(config, ioConfigBuilder().build());
+    Assertions.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
+    Assertions.assertNotEquals(config, null);
+    Assertions.assertNotEquals(config, "not an io config");
+    Assertions.assertNotEquals(config, ioConfigBuilder().withTopic("other").build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
+    Assertions.assertNotEquals(
         config,
         ioConfigBuilder().withConsumerProperties(Map.of("bootstrap.servers", "other:9092")).build()
     );
-    Assert.assertNotEquals(config, ioConfigBuilder().withEmitTimeLagMetrics(true).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withEmitTimeLagMetrics(true).build());
   }
 
   @Test
   public void testTuningConfigEqualsAndHashCode()
   {
     final KafkaSupervisorTuningConfig config = new KafkaTuningConfigBuilder().build();
-    Assert.assertEquals(config, new KafkaTuningConfigBuilder().build());
-    Assert.assertEquals(config.hashCode(), new KafkaTuningConfigBuilder().build().hashCode());
-    Assert.assertNotEquals(config, null);
-    Assert.assertNotEquals(config, "not a tuning config");
-    Assert.assertNotEquals(config, new KafkaTuningConfigBuilder().withWorkerThreads(99).build());
-    Assert.assertNotEquals(config, new KafkaTuningConfigBuilder().withShutdownTimeout(new Period("PT99M")).build());
-    Assert.assertNotEquals(config, new KafkaTuningConfigBuilder().withOffsetFetchPeriod(new Period("PT99S")).build());
+    Assertions.assertEquals(config, new KafkaTuningConfigBuilder().build());
+    Assertions.assertEquals(config.hashCode(), new KafkaTuningConfigBuilder().build().hashCode());
+    Assertions.assertNotEquals(config, null);
+    Assertions.assertNotEquals(config, "not a tuning config");
+    Assertions.assertNotEquals(config, new KafkaTuningConfigBuilder().withWorkerThreads(99).build());
+    Assertions.assertNotEquals(config, new KafkaTuningConfigBuilder().withShutdownTimeout(new Period("PT99M")).build());
+    Assertions.assertNotEquals(config, new KafkaTuningConfigBuilder().withOffsetFetchPeriod(new Period("PT99S")).build());
   }
 
   /**
@@ -700,5 +696,16 @@ public class KafkaSupervisorIOConfigTest
                   .withRedefinedSuperclass()
                   .suppress(Warning.NONFINAL_FIELDS)
                   .verify();
+  }
+
+  private static void assertJsonMappingException(
+      Class<? extends Throwable> causeType,
+      String expectedMessage,
+      Executable executable
+  )
+  {
+    final JsonMappingException exception = Assertions.assertThrows(JsonMappingException.class, executable);
+    Assertions.assertInstanceOf(causeType, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains(expectedMessage));
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorIOConfigTest.java
@@ -275,7 +275,8 @@ public class KafkaSupervisorIOConfigTest
   }
 
   @Test
-  public void testSerdeWithBothExclusiveProperties() {
+  public void testSerdeWithBothExclusiveProperties()
+  {
     Assertions.assertThrows(JsonMappingException.class, () -> {
       String jsonStr = "{\n"
           + "  \"type\": \"kafka\",\n"
@@ -393,17 +394,21 @@ public class KafkaSupervisorIOConfigTest
     Assertions.assertEquals(1, kafkaSupervisorIOConfig.getTaskCount());
 
     Assertions.assertThrows(
-        RuntimeException.class, () -> {
+        RuntimeException.class,
+        () -> {
           autoScalerConfig.put("taskCountStart", 11); // > max task count
           mapper.convertValue(autoScalerConfig, LagBasedAutoScalerConfig.class);
-        }, "taskCountMin <= taskCountStart <= taskCountMax"
+        },
+        "taskCountMin <= taskCountStart <= taskCountMax"
     );
 
     Assertions.assertThrows(
-        RuntimeException.class, () -> {
+        RuntimeException.class,
+        () -> {
           autoScalerConfig.put("taskCountStart", 0); // < min task count
           mapper.convertValue(autoScalerConfig, LagBasedAutoScalerConfig.class);
-        }, "taskCountMin <= taskCountStart <= taskCountMax"
+        },
+        "taskCountMin <= taskCountStart <= taskCountMax"
     );
   }
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpecTest.java
@@ -46,14 +46,14 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.expression.LookupEnabledTestExprMacroTable;
 import org.apache.druid.segment.incremental.RowIngestionMetersFactory;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
 
-import static org.junit.Assert.assertThrows;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaSupervisorSpecTest
 {
@@ -141,23 +141,23 @@ public class KafkaSupervisorSpecTest
                   + "}";
     KafkaSupervisorSpec spec = mapper.readValue(json, KafkaSupervisorSpec.class);
 
-    Assert.assertNotNull(spec);
-    Assert.assertNotNull(spec.getDataSchema());
-    Assert.assertEquals("metrics.*", spec.getIoConfig().getTopicPattern());
-    Assert.assertNull(spec.getIoConfig().getTopic());
-    Assert.assertNotNull(spec.getTuningConfig());
-    Assert.assertNull(spec.getContext());
+    Assertions.assertNotNull(spec);
+    Assertions.assertNotNull(spec.getDataSchema());
+    Assertions.assertEquals("metrics.*", spec.getIoConfig().getTopicPattern());
+    Assertions.assertNull(spec.getIoConfig().getTopic());
+    Assertions.assertNotNull(spec.getTuningConfig());
+    Assertions.assertNull(spec.getContext());
     String serialized = mapper.writeValueAsString(spec);
 
     // expect default values populated in reserialized string
-    Assert.assertTrue(serialized.contains("\"topicPattern\":\"metrics.*\""));
-    Assert.assertTrue(serialized, serialized.contains("\"topic\":null"));
+    Assertions.assertTrue(serialized.contains("\"topicPattern\":\"metrics.*\""));
+    Assertions.assertTrue(serialized.contains("\"topic\":null"), serialized);
 
     KafkaSupervisorSpec spec2 = mapper.readValue(serialized, KafkaSupervisorSpec.class);
 
     String stable = mapper.writeValueAsString(spec2);
 
-    Assert.assertEquals(serialized, stable);
+    Assertions.assertEquals(serialized, stable);
   }
   @Test
   public void testSerdeWithInputFormat() throws IOException
@@ -222,28 +222,28 @@ public class KafkaSupervisorSpecTest
                   + "}";
     KafkaSupervisorSpec spec = mapper.readValue(json, KafkaSupervisorSpec.class);
 
-    Assert.assertNotNull(spec);
-    Assert.assertNotNull(spec.getDataSchema());
-    Assert.assertEquals(4, spec.getDataSchema().getAggregators().length);
-    Assert.assertNotNull(spec.getIoConfig());
-    Assert.assertEquals("metrics", spec.getIoConfig().getTopic());
-    Assert.assertNull(spec.getIoConfig().getTopicPattern());
-    Assert.assertNotNull(spec.getTuningConfig());
-    Assert.assertNull(spec.getContext());
-    Assert.assertFalse(spec.isSuspended());
+    Assertions.assertNotNull(spec);
+    Assertions.assertNotNull(spec.getDataSchema());
+    Assertions.assertEquals(4, spec.getDataSchema().getAggregators().length);
+    Assertions.assertNotNull(spec.getIoConfig());
+    Assertions.assertEquals("metrics", spec.getIoConfig().getTopic());
+    Assertions.assertNull(spec.getIoConfig().getTopicPattern());
+    Assertions.assertNotNull(spec.getTuningConfig());
+    Assertions.assertNull(spec.getContext());
+    Assertions.assertFalse(spec.isSuspended());
     String serialized = mapper.writeValueAsString(spec);
 
     // expect default values populated in reserialized string
-    Assert.assertTrue(serialized.contains("\"tuningConfig\":{"));
-    Assert.assertTrue(serialized.contains("\"indexSpec\":{"));
-    Assert.assertTrue(serialized.contains("\"suspended\":false"));
-    Assert.assertTrue(serialized.contains("\"inputFormat\":{"));
+    Assertions.assertTrue(serialized.contains("\"tuningConfig\":{"));
+    Assertions.assertTrue(serialized.contains("\"indexSpec\":{"));
+    Assertions.assertTrue(serialized.contains("\"suspended\":false"));
+    Assertions.assertTrue(serialized.contains("\"inputFormat\":{"));
 
     KafkaSupervisorSpec spec2 = mapper.readValue(serialized, KafkaSupervisorSpec.class);
 
     String stable = mapper.writeValueAsString(spec2);
 
-    Assert.assertEquals(serialized, stable);
+    Assertions.assertEquals(serialized, stable);
   }
 
   @Test
@@ -311,28 +311,28 @@ public class KafkaSupervisorSpecTest
                   + "}";
     KafkaSupervisorSpec spec = mapper.readValue(json, KafkaSupervisorSpec.class);
 
-    Assert.assertNotNull(spec);
-    Assert.assertNotNull(spec.getDataSchema());
-    Assert.assertEquals(4, spec.getDataSchema().getAggregators().length);
-    Assert.assertNotNull(spec.getIoConfig());
-    Assert.assertEquals("metrics", spec.getIoConfig().getTopic());
-    Assert.assertNull(spec.getIoConfig().getTopicPattern());
-    Assert.assertNotNull(spec.getTuningConfig());
-    Assert.assertNull(spec.getContext());
-    Assert.assertFalse(spec.isSuspended());
+    Assertions.assertNotNull(spec);
+    Assertions.assertNotNull(spec.getDataSchema());
+    Assertions.assertEquals(4, spec.getDataSchema().getAggregators().length);
+    Assertions.assertNotNull(spec.getIoConfig());
+    Assertions.assertEquals("metrics", spec.getIoConfig().getTopic());
+    Assertions.assertNull(spec.getIoConfig().getTopicPattern());
+    Assertions.assertNotNull(spec.getTuningConfig());
+    Assertions.assertNull(spec.getContext());
+    Assertions.assertFalse(spec.isSuspended());
     String serialized = mapper.writeValueAsString(spec);
 
     // expect default values populated in reserialized string
-    Assert.assertTrue(serialized.contains("\"tuningConfig\":{"));
-    Assert.assertTrue(serialized.contains("\"indexSpec\":{"));
-    Assert.assertTrue(serialized.contains("\"suspended\":false"));
-    Assert.assertTrue(serialized.contains("\"inputFormat\":{"));
+    Assertions.assertTrue(serialized.contains("\"tuningConfig\":{"));
+    Assertions.assertTrue(serialized.contains("\"indexSpec\":{"));
+    Assertions.assertTrue(serialized.contains("\"suspended\":false"));
+    Assertions.assertTrue(serialized.contains("\"inputFormat\":{"));
 
     KafkaSupervisorSpec spec2 = mapper.readValue(serialized, KafkaSupervisorSpec.class);
 
     String stable = mapper.writeValueAsString(spec2);
 
-    Assert.assertEquals(serialized, stable);
+    Assertions.assertEquals(serialized, stable);
   }
 
   @Test
@@ -398,32 +398,32 @@ public class KafkaSupervisorSpecTest
                   + "}";
     KafkaSupervisorSpec spec = mapper.readValue(json, KafkaSupervisorSpec.class);
 
-    Assert.assertNotNull(spec);
-    Assert.assertNotNull(spec.getDataSchema());
-    Assert.assertEquals(4, spec.getDataSchema().getAggregators().length);
-    Assert.assertNotNull(spec.getIoConfig());
-    Assert.assertEquals("metrics", spec.getIoConfig().getTopic());
-    Assert.assertNull(spec.getIoConfig().getTopicPattern());
-    Assert.assertNotNull(spec.getTuningConfig());
-    Assert.assertNull(spec.getContext());
-    Assert.assertFalse(spec.isSuspended());
+    Assertions.assertNotNull(spec);
+    Assertions.assertNotNull(spec.getDataSchema());
+    Assertions.assertEquals(4, spec.getDataSchema().getAggregators().length);
+    Assertions.assertNotNull(spec.getIoConfig());
+    Assertions.assertEquals("metrics", spec.getIoConfig().getTopic());
+    Assertions.assertNull(spec.getIoConfig().getTopicPattern());
+    Assertions.assertNotNull(spec.getTuningConfig());
+    Assertions.assertNull(spec.getContext());
+    Assertions.assertFalse(spec.isSuspended());
 
     String suspendedSerialized = mapper.writeValueAsString(spec.createSuspendedSpec());
 
     // expect default values populated in reserialized string
-    Assert.assertTrue(suspendedSerialized.contains("\"tuningConfig\":{"));
-    Assert.assertTrue(suspendedSerialized.contains("\"indexSpec\":{"));
-    Assert.assertTrue(suspendedSerialized.contains("\"suspended\":true"));
+    Assertions.assertTrue(suspendedSerialized.contains("\"tuningConfig\":{"));
+    Assertions.assertTrue(suspendedSerialized.contains("\"indexSpec\":{"));
+    Assertions.assertTrue(suspendedSerialized.contains("\"suspended\":true"));
 
     KafkaSupervisorSpec suspendedSpec = mapper.readValue(suspendedSerialized, KafkaSupervisorSpec.class);
 
-    Assert.assertTrue(suspendedSpec.isSuspended());
+    Assertions.assertTrue(suspendedSpec.isSuspended());
 
     String runningSerialized = mapper.writeValueAsString(spec.createRunningSpec());
 
     KafkaSupervisorSpec runningSpec = mapper.readValue(runningSerialized, KafkaSupervisorSpec.class);
 
-    Assert.assertFalse(runningSpec.isSuspended());
+    Assertions.assertFalse(runningSpec.isSuspended());
   }
 
   @Test
@@ -462,8 +462,8 @@ public class KafkaSupervisorSpecTest
     final byte[] payload = mapper.writeValueAsBytes(spec);
     final KafkaSupervisorSpec roundTripped =
         (KafkaSupervisorSpec) mapper.readValue(payload, SupervisorSpec.class);
-    Assert.assertEquals(50, roundTripped.getIoConfig().getTaskCount());
-    Assert.assertTrue(roundTripped.getIoConfig().isTaskCountExplicit());
+    Assertions.assertEquals(50, roundTripped.getIoConfig().getTaskCount());
+    Assertions.assertTrue(roundTripped.getIoConfig().isTaskCountExplicit());
   }
 
   @Test
@@ -473,7 +473,7 @@ public class KafkaSupervisorSpecTest
 
     // Proposed spec being non-kafka is not allowed
     TestSupervisorSpec otherSpec = new TestSupervisorSpec("test", new Object());
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(otherSpec)),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,
@@ -485,7 +485,7 @@ public class KafkaSupervisorSpecTest
     );
 
     KafkaSupervisorSpec multiTopicProposedSpec = getSpec(null, "metrics-.*");
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(multiTopicProposedSpec)),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,
@@ -501,7 +501,7 @@ public class KafkaSupervisorSpecTest
     );
 
     KafkaSupervisorSpec singleTopicNewStreamProposedSpec = getSpec("metricsNew", null);
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(singleTopicNewStreamProposedSpec)),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,
@@ -517,7 +517,7 @@ public class KafkaSupervisorSpecTest
     );
 
     KafkaSupervisorSpec multiTopicMatchingSourceString = getSpec(null, "metrics");
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(multiTopicMatchingSourceString)),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,
@@ -533,7 +533,7 @@ public class KafkaSupervisorSpecTest
     );
 
     // test the inverse as well
-    MatcherAssert.assertThat(
+    assertThat(
         assertThrows(DruidException.class, () -> multiTopicMatchingSourceString.validateSpecUpdateTo(sourceSpec)),
         new DruidExceptionMatcher(
             DruidException.Persona.USER,
@@ -590,11 +590,11 @@ public class KafkaSupervisorSpecTest
 
     KafkaSupervisorSpec backfill = (KafkaSupervisorSpec) spec.createBackfillSpec("backfill-id", boundedStreamConfig, 2);
 
-    Assert.assertEquals("backfill-id", backfill.getId());
-    Assert.assertEquals("testDs", backfill.getSpec().getDataSchema().getDataSource());
-    Assert.assertEquals("metrics", backfill.getSpec().getIOConfig().getTopic());
-    Assert.assertEquals(2, backfill.getSpec().getIOConfig().getTaskCount());
-    Assert.assertEquals(boundedStreamConfig, backfill.getSpec().getIOConfig().getBoundedStreamConfig());
+    Assertions.assertEquals("backfill-id", backfill.getId());
+    Assertions.assertEquals("testDs", backfill.getSpec().getDataSchema().getDataSource());
+    Assertions.assertEquals("metrics", backfill.getSpec().getIOConfig().getTopic());
+    Assertions.assertEquals(2, backfill.getSpec().getIOConfig().getTaskCount());
+    Assertions.assertEquals(boundedStreamConfig, backfill.getSpec().getIOConfig().getBoundedStreamConfig());
   }
 
   private KafkaSupervisorSpec getSpec(String topic, String topicPattern)

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -112,14 +112,14 @@ import org.easymock.IAnswer;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
@@ -138,10 +138,14 @@ import java.util.TreeMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class KafkaSupervisorTest extends EasyMockSupport
 {
   private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
@@ -164,7 +168,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   private static DataSchema dataSchema;
   private static int topicPostfix;
 
-  private final int numThreads;
+  private int numThreads;
 
   private TestableKafkaSupervisor supervisor;
   private TaskStorage taskStorage;
@@ -193,7 +197,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     return TOPIC_PREFIX + topicPostfix + ".*";
   }
 
-  @Parameterized.Parameters(name = "numThreads = {0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(new Object[]{1}, new Object[]{8});
@@ -204,7 +207,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     this.numThreads = numThreads;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     kafkaServer = new EmbeddedKafkaBroker(
@@ -224,7 +227,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     dataSchema = getDataSchema(DATASOURCE);
   }
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     taskStorage = createMock(TaskStorage.class);
@@ -246,20 +249,19 @@ public class KafkaSupervisorTest extends EasyMockSupport
     ingestionSchema = EasyMock.createMock(KafkaSupervisorIngestionSpec.class);
   }
 
-  @After
+  @AfterEach
   public void tearDownTest()
   {
     supervisor = null;
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass()
   {
     kafkaServer.close();
     kafkaServer = null;
   }
 
-  @Test
   public void testNoInitialStateWithAutoscaler() throws Exception
   {
     final int taskCountMax = 2;
@@ -278,8 +280,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
           final ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -381,67 +383,67 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     supervisor.start();
     int taskCountBeforeScale = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountBeforeScale);
+    Assertions.assertEquals(1, taskCountBeforeScale);
     autoscaler.start();
     supervisor.runInternal();
     Thread.sleep(1000);
     verifyAll();
 
     int taskCountAfterScale = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(2, taskCountAfterScale);
+    Assertions.assertEquals(2, taskCountAfterScale);
 
     KafkaIndexTask task = captured.getValue();
-    Assert.assertEquals(KafkaSupervisorTest.dataSchema, task.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
+    Assertions.assertEquals(KafkaSupervisorTest.dataSchema, task.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
 
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals(kafkaHost, taskConfig.getConsumerProperties().get("bootstrap.servers"));
-    Assert.assertEquals("myCustomValue", taskConfig.getConsumerProperties().get("myCustomKey"));
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", taskConfig.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", taskConfig.getMinimumMessageTime());
-    Assert.assertNull("maximumMessageTime", taskConfig.getMaximumMessageTime());
+    Assertions.assertEquals(kafkaHost, taskConfig.getConsumerProperties().get("bootstrap.servers"));
+    Assertions.assertEquals("myCustomValue", taskConfig.getConsumerProperties().get("myCustomKey"));
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertTrue(taskConfig.isUseTransaction(), "isUseTransaction");
+    Assertions.assertNull(taskConfig.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertNull(taskConfig.getMaximumMessageTime(), "maximumMessageTime");
 
-    Assert.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         0L,
         (long) taskConfig.getStartSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 0))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         (long) taskConfig.getStartSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 1))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         (long) taskConfig.getStartSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 2))
     );
 
-    Assert.assertEquals(topic, taskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, taskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         (long) taskConfig.getEndSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 0))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         (long) taskConfig.getEndSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 1))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         (long) taskConfig.getEndSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 2))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(new ResourceAction(
             new Resource(KafkaSupervisorSpec.TASK_TYPE, ResourceType.EXTERNAL),
             Action.READ
@@ -453,7 +455,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     autoscaler.stop();
   }
 
-  @Test
   public void testGetTaskRunnerType() throws JsonProcessingException
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -480,11 +481,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
         null,
         null
     ).get(0);
-    Assert.assertTrue(indexTask.getRunner() instanceof KafkaIndexTaskRunner);
-    Assert.assertNull(indexTask.getServerPriority());
+    Assertions.assertTrue(indexTask.getRunner() instanceof KafkaIndexTaskRunner);
+    Assertions.assertNull(indexTask.getServerPriority());
   }
 
-  @Test
   public void testCreateIndexTasksWithServerPrioritiesToAssign() throws JsonProcessingException
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -512,13 +512,12 @@ public class KafkaSupervisorTest extends EasyMockSupport
             null,
             List.of(10, 20, 20)
         );
-    Assert.assertEquals(3, taskList.size());
-    Assert.assertEquals(Integer.valueOf(10), taskList.get(0).getServerPriority());
-    Assert.assertEquals(Integer.valueOf(20), taskList.get(1).getServerPriority());
-    Assert.assertEquals(Integer.valueOf(20), taskList.get(2).getServerPriority());
+    Assertions.assertEquals(3, taskList.size());
+    Assertions.assertEquals(Integer.valueOf(10), taskList.get(0).getServerPriority());
+    Assertions.assertEquals(Integer.valueOf(20), taskList.get(1).getServerPriority());
+    Assertions.assertEquals(Integer.valueOf(20), taskList.get(2).getServerPriority());
   }
 
-  @Test
   public void testNoInitialState() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -543,51 +542,51 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     KafkaIndexTask task = captured.getValue();
-    Assert.assertEquals(dataSchema, task.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
+    Assertions.assertEquals(dataSchema, task.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
 
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals(kafkaHost, taskConfig.getConsumerProperties().get("bootstrap.servers"));
-    Assert.assertEquals("myCustomValue", taskConfig.getConsumerProperties().get("myCustomKey"));
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", taskConfig.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", taskConfig.getMinimumMessageTime());
-    Assert.assertNull("maximumMessageTime", taskConfig.getMaximumMessageTime());
+    Assertions.assertEquals(kafkaHost, taskConfig.getConsumerProperties().get("bootstrap.servers"));
+    Assertions.assertEquals("myCustomValue", taskConfig.getConsumerProperties().get("myCustomKey"));
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertTrue(taskConfig.isUseTransaction(), "isUseTransaction");
+    Assertions.assertNull(taskConfig.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertNull(taskConfig.getMaximumMessageTime(), "maximumMessageTime");
 
-    Assert.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         0L,
         (long) taskConfig.getStartSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 0))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         (long) taskConfig.getStartSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 1))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         (long) taskConfig.getStartSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 2))
     );
 
-    Assert.assertEquals(topic, taskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, taskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         (long) taskConfig.getEndSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 0))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         (long) taskConfig.getEndSequenceNumbers()
                          .getPartitionSequenceNumberMap()
                          .get(new KafkaTopicPartition(false, topic, 1))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         (long) taskConfig.getEndSequenceNumbers()
                          .getPartitionSequenceNumberMap()
@@ -595,7 +594,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  @Test
   public void testSkipOffsetGaps() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -619,7 +617,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testMultiTask() throws Exception
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null);
@@ -644,9 +641,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     List<KafkaIndexTask> tasks = captured.getValues();
     tasks.sort(Comparator.comparing(KafkaIndexTask::getId));
     KafkaIndexTask task1 = tasks.get(0);
-    Assert.assertEquals(2, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(2, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(2, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         0L,
         task1.getIOConfig()
              .getStartSequenceNumbers()
@@ -654,7 +651,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 0))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         task1.getIOConfig()
              .getEndSequenceNumbers()
@@ -662,7 +659,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 0))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         task1.getIOConfig()
              .getStartSequenceNumbers()
@@ -670,7 +667,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 2))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         task1.getIOConfig()
              .getEndSequenceNumbers()
@@ -680,9 +677,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
 
     KafkaIndexTask task2 = tasks.get(1);
-    Assert.assertEquals(1, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(1, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(1, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         0L,
         task2.getIOConfig()
              .getStartSequenceNumbers()
@@ -690,7 +687,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 1))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         task2.getIOConfig()
              .getEndSequenceNumbers()
@@ -700,7 +697,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  @Test
   public void testReplicas() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, null);
@@ -723,9 +719,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     KafkaIndexTask task1 = captured.getValues().get(0);
-    Assert.assertEquals(3, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(3, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(3, task1.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(3, task1.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         0L,
         task1.getIOConfig()
              .getStartSequenceNumbers()
@@ -733,7 +729,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 0))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         task1.getIOConfig()
              .getStartSequenceNumbers()
@@ -741,7 +737,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 1))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         task1.getIOConfig()
              .getStartSequenceNumbers()
@@ -751,9 +747,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
 
     KafkaIndexTask task2 = captured.getValues().get(1);
-    Assert.assertEquals(3, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(3, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(3, task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(3, task2.getIOConfig().getEndSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(
         0L,
         task2.getIOConfig()
              .getStartSequenceNumbers()
@@ -761,7 +757,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 0))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         task2.getIOConfig()
              .getStartSequenceNumbers()
@@ -769,7 +765,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
              .get(new KafkaTopicPartition(false, topic, 1))
              .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         task2.getIOConfig()
              .getStartSequenceNumbers()
@@ -779,7 +775,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  @Test
   public void testLateMessageRejectionPeriod() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", new Period("PT1H"), null);
@@ -804,21 +799,20 @@ public class KafkaSupervisorTest extends EasyMockSupport
     KafkaIndexTask task1 = captured.getValues().get(0);
     KafkaIndexTask task2 = captured.getValues().get(1);
 
-    Assert.assertTrue(
-        "minimumMessageTime",
-        task1.getIOConfig().getMinimumMessageTime().plusMinutes(59).isBeforeNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMinimumMessageTime().plusMinutes(59).isBeforeNow(),
+        "minimumMessageTime"
     );
-    Assert.assertTrue(
-        "minimumMessageTime",
-        task1.getIOConfig().getMinimumMessageTime().plusMinutes(61).isAfterNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMinimumMessageTime().plusMinutes(61).isAfterNow(),
+        "minimumMessageTime"
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         task1.getIOConfig().getMinimumMessageTime(),
         task2.getIOConfig().getMinimumMessageTime()
     );
   }
 
-  @Test
   public void testEarlyMessageRejectionPeriod() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, new Period("PT1H"));
@@ -843,15 +837,15 @@ public class KafkaSupervisorTest extends EasyMockSupport
     KafkaIndexTask task1 = captured.getValues().get(0);
     KafkaIndexTask task2 = captured.getValues().get(1);
 
-    Assert.assertTrue(
-        "maximumMessageTime",
-        task1.getIOConfig().getMaximumMessageTime().minusMinutes(59 + 60).isAfterNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMaximumMessageTime().minusMinutes(59 + 60).isAfterNow(),
+        "maximumMessageTime"
     );
-    Assert.assertTrue(
-        "maximumMessageTime",
-        task1.getIOConfig().getMaximumMessageTime().minusMinutes(61 + 60).isBeforeNow()
+    Assertions.assertTrue(
+        task1.getIOConfig().getMaximumMessageTime().minusMinutes(61 + 60).isBeforeNow(),
+        "maximumMessageTime"
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         task1.getIOConfig().getMaximumMessageTime(),
         task2.getIOConfig().getMaximumMessageTime()
     );
@@ -860,7 +854,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
   /**
    * Test generating the starting offsets from the partition high water marks in Kafka.
    */
-  @Test
   public void testLatestOffset() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, false, "PT1H", null, null);
@@ -883,7 +876,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     KafkaIndexTask task = captured.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1101L,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -891,7 +884,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .get(new KafkaTopicPartition(false, topic, 0))
             .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1101L,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -899,7 +892,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .get(new KafkaTopicPartition(false, topic, 1))
             .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1101L,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -912,7 +905,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
   /**
    * Test if partitionIds get updated
    */
-  @Test
   public void testPartitionIdsUpdates() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, false, "PT1H", null, null);
@@ -934,11 +926,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    Assert.assertFalse(supervisor.isPartitionIdsEmpty());
+    Assertions.assertFalse(supervisor.isPartitionIdsEmpty());
   }
 
 
-  @Test
   public void testAlwaysUsesEarliestOffsetForNewlyDiscoveredPartitions() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, false, "PT1H", null, null);
@@ -960,7 +951,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     KafkaIndexTask task = captured.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         10,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -968,7 +959,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .get(new KafkaTopicPartition(false, topic, 0))
             .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         10,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -976,7 +967,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .get(new KafkaTopicPartition(false, topic, 1))
             .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         10,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -1004,7 +995,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     //check if start from earliest offset
     task = newcaptured.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -1012,7 +1003,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .get(new KafkaTopicPartition(false, topic, 3))
             .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -1020,7 +1011,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             .get(new KafkaTopicPartition(false, topic, 4))
             .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         task.getIOConfig()
             .getStartSequenceNumbers()
@@ -1035,7 +1026,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * contains the offsets from previous single-topic config of the last built segments, where the previous topic does
    * match the new configuration.
    */
-  @Test
   public void testDatasourceMetadataSingleTopicToSingleTopicMatch() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -1063,22 +1053,22 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     KafkaIndexTask task = captured.getValue();
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         10L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 0))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         20L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 1))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         30L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
@@ -1092,7 +1082,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * contains the offsets from previous single-topic config of the last built segments, where the previous topic does
    * match the new configuration.
    */
-  @Test
   public void testDatasourceMetadataSingleTopicToMultiTopicMatch() throws Exception
   {
     multiTopic = true;
@@ -1120,29 +1109,29 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     KafkaIndexTask task = captured.getValue();
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         10L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 0))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         20L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 1))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         30L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 2))
                   .longValue()
     );
-    Assert.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
   }
 
   /**
@@ -1150,7 +1139,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * contains the offsets from previous single-topic config of the last built segments, where the previous topic does
    * not match the new configuration.
    */
-  @Test
   public void testDatasourceMetadataSingleTopicToMultiTopicNotMatch() throws Exception
   {
     multiTopic = true;
@@ -1178,36 +1166,35 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     KafkaIndexTask task = captured.getValue();
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         0L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 0))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 1))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 2))
                   .longValue()
     );
-    Assert.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
   }
 
   /**
    * Test generating the starting offsets for single-topic config from the partition data stored in druid_dataSource which
    * contains the offsets from previous multi-topic config of the last built segments.
    */
-  @Test
   public void testDatasourceMetadataMultiTopicToSingleTopic() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -1240,36 +1227,35 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     KafkaIndexTask task = captured.getValue();
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         10L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 0))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         20L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 1))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         30L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 2))
                   .longValue()
     );
-    Assert.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
   }
 
   /**
    * Test generating the starting offsets for muti-topic config from the partition data stored in druid_dataSource which
    * contains the offsets from previous multi-topic config of the last built segments.
    */
-  @Test
   public void testDatasourceMetadataMultiTopicToMultiTopic() throws Exception
   {
     multiTopic = true;
@@ -1299,32 +1285,31 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     KafkaIndexTask task = captured.getValue();
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertEquals(
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertEquals(
         10L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 0))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         20L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 1))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         30L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(true, topic, 2))
                   .longValue()
     );
-    Assert.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
+    Assertions.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
   }
 
-  @Test
   public void testBadMetadataOffsets() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -1349,15 +1334,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.start();
     supervisor.runInternal();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "org.apache.druid.java.util.common.ISE",
         supervisor.getStateManager().getExceptionEvents().get(0).getExceptionClass()
     );
     AlertEvent alert = serviceEmitter.getAlerts().get(0);
-    Assert.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
+    Assertions.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
   }
 
-  @Test
   public void testDontKillTasksWithMismatchedType() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, null);
@@ -1402,7 +1386,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testKillBadPartitionAssignment() throws Exception
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null);
@@ -1529,7 +1512,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
 
-  @Test
   public void testRequeueTaskWhenFailed() throws Exception
   {
     supervisor = getTestableSupervisor(2, 2, true, "PT1H", null, null);
@@ -1613,14 +1595,13 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    Assert.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
-    Assert.assertEquals(
+    Assertions.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
+    Assertions.assertEquals(
         iHaveFailed.getIOConfig().getBaseSequenceName(),
         ((KafkaIndexTask) aNewTaskCapture.getValue()).getIOConfig().getBaseSequenceName()
     );
   }
 
-  @Test
   public void testRequeueTaskWithServerPrioritiesWhenFailed() throws Exception
   {
     supervisor = getTestableSupervisor(null, 2, 2, true, true, "PT1H", null, null, false, kafkaHost, null, Map.of(1, 1, 2, 1));
@@ -1677,8 +1658,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
       EasyMock.expect(taskStorage.getTask(task.getId())).andReturn(Optional.of(task)).anyTimes();
       observedServerPriorities.add(((KafkaIndexTask) task).getServerPriority());
     }
-    Assert.assertEquals(4, tasks.size());
-    Assert.assertEquals(List.of(2, 1, 2, 1), observedServerPriorities);
+    Assertions.assertEquals(4, tasks.size());
+    Assertions.assertEquals(List.of(2, 1, 2, 1), observedServerPriorities);
 
     EasyMock.replay(taskStorage);
     EasyMock.replay(taskQueue);
@@ -1709,13 +1690,13 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    Assert.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
+    Assertions.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
     KafkaIndexTask retriedTask = (KafkaIndexTask) aNewTaskCapture.getValue();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         iHaveFailed.getIOConfig().getBaseSequenceName(),
         retriedTask.getIOConfig().getBaseSequenceName()
     );
-    Assert.assertEquals(Integer.valueOf(1), retriedTask.getServerPriority());
+    Assertions.assertEquals(Integer.valueOf(1), retriedTask.getServerPriority());
   }
 
   /**
@@ -1723,7 +1704,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * must not go out of sync when a newly-submitted task dies before the next supervisor run observes it. Otherwise, the orphan priority entry
    * makes {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} throw on the replacement attempt.
    */
-  @Test
   public void testReplacementSubmittedWhenPriorityTaskDiesBeforeDiscovery() throws Exception
   {
     // replicas=2, taskCount=1, priorities {0:1, 1:1}
@@ -1760,11 +1740,11 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     final List<Task> run1Tasks = captured.getValues();
-    Assert.assertEquals(2, run1Tasks.size());
+    Assertions.assertEquals(2, run1Tasks.size());
     final KafkaIndexTask orphan = (KafkaIndexTask) run1Tasks.get(0);
     final KafkaIndexTask survivor = (KafkaIndexTask) run1Tasks.get(1);
     // Sanity check: the two replicas must hold the two configured priorities.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(0, 1),
         Set.of(orphan.getServerPriority(), survivor.getServerPriority())
     );
@@ -1793,10 +1773,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     // The replacement task should take the orphan's priority, not duplicate the survivor's or block.
     final KafkaIndexTask replacement = (KafkaIndexTask) replacementCapture.getValue();
-    Assert.assertEquals(orphan.getServerPriority(), replacement.getServerPriority());
+    Assertions.assertEquals(orphan.getServerPriority(), replacement.getServerPriority());
   }
 
-  @Test
   public void testRequeueAdoptedTaskWhenFailed() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, null);
@@ -1850,7 +1829,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     // check that replica tasks are created with the same minimumMessageTime as tasks inherited from another supervisor
-    Assert.assertEquals(now, ((KafkaIndexTask) captured.getValue()).getIOConfig().getMinimumMessageTime());
+    Assertions.assertEquals(now, ((KafkaIndexTask) captured.getValue()).getIOConfig().getMinimumMessageTime());
 
     // test that a task failing causes a new task to be re-queued with the same parameters
     String runningTaskId = captured.getValue().getId();
@@ -1888,22 +1867,21 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.runInternal();
     verifyAll();
 
-    Assert.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
-    Assert.assertEquals(
+    Assertions.assertNotEquals(iHaveFailed.getId(), aNewTaskCapture.getValue().getId());
+    Assertions.assertEquals(
         iHaveFailed.getIOConfig().getBaseSequenceName(),
         ((KafkaIndexTask) aNewTaskCapture.getValue()).getIOConfig().getBaseSequenceName()
     );
 
     // check that failed tasks are recreated with the same minimumMessageTime as the task it replaced, even if that
     // task came from another supervisor
-    Assert.assertEquals(now, ((KafkaIndexTask) aNewTaskCapture.getValue()).getIOConfig().getMinimumMessageTime());
-    Assert.assertEquals(
+    Assertions.assertEquals(now, ((KafkaIndexTask) aNewTaskCapture.getValue()).getIOConfig().getMinimumMessageTime());
+    Assertions.assertEquals(
         maxi,
         ((KafkaIndexTask) aNewTaskCapture.getValue()).getIOConfig().getMaximumMessageTime()
     );
   }
 
-  @Test
   public void testQueueNextTasksOnSuccess() throws Exception
   {
     supervisor = getTestableSupervisor(2, 2, true, "PT1H", null, null);
@@ -2002,10 +1980,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     // make sure we killed the right task (sequenceName for replicas are the same)
-    Assert.assertTrue(shutdownTaskIdCapture.getValue().contains(iAmSuccess.getIOConfig().getBaseSequenceName()));
+    Assertions.assertTrue(shutdownTaskIdCapture.getValue().contains(iAmSuccess.getIOConfig().getBaseSequenceName()));
   }
 
-  @Test
   public void testBeginPublishAndQueueNextTasks() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -2089,21 +2066,21 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     for (Task task : captured.getValues()) {
       KafkaIndexTask kafkaIndexTask = (KafkaIndexTask) task;
-      Assert.assertEquals(dataSchema, kafkaIndexTask.getDataSchema());
-      Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), kafkaIndexTask.getTuningConfig());
+      Assertions.assertEquals(dataSchema, kafkaIndexTask.getDataSchema());
+      Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), kafkaIndexTask.getTuningConfig());
 
       KafkaIndexTaskIOConfig taskConfig = kafkaIndexTask.getIOConfig();
-      Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-      Assert.assertTrue("isUseTransaction", taskConfig.isUseTransaction());
+      Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+      Assertions.assertTrue(taskConfig.isUseTransaction(), "isUseTransaction");
 
-      Assert.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
-      Assert.assertEquals(
+      Assertions.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
+      Assertions.assertEquals(
           10L,
           (long) taskConfig.getStartSequenceNumbers()
                            .getPartitionSequenceNumberMap()
                            .get(new KafkaTopicPartition(false, topic, 0))
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           35L,
           (long) taskConfig.getStartSequenceNumbers()
                            .getPartitionSequenceNumberMap()
@@ -2112,7 +2089,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
-  @Test
   public void testDiscoverExistingPublishingTask() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -2178,53 +2154,53 @@ public class KafkaSupervisorTest extends EasyMockSupport
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, report.getId());
+    Assertions.assertEquals(DATASOURCE, report.getId());
 
     KafkaSupervisorReportPayload payload = report.getPayload();
 
-    Assert.assertEquals(DATASOURCE, payload.getDataSource());
-    Assert.assertEquals(3600L, payload.getDurationSeconds());
-    Assert.assertEquals(NUM_PARTITIONS, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(topic, payload.getStream());
-    Assert.assertEquals(0, payload.getActiveTasks().size());
-    Assert.assertEquals(1, payload.getPublishingTasks().size());
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
-    Assert.assertEquals(0, payload.getRecentErrors().size());
+    Assertions.assertEquals(DATASOURCE, payload.getDataSource());
+    Assertions.assertEquals(3600L, payload.getDurationSeconds());
+    Assertions.assertEquals(NUM_PARTITIONS, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(topic, payload.getStream());
+    Assertions.assertEquals(0, payload.getActiveTasks().size());
+    Assertions.assertEquals(1, payload.getPublishingTasks().size());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
+    Assertions.assertEquals(0, payload.getRecentErrors().size());
 
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
-    Assert.assertEquals("id1", publishingReport.getId());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 0L, 1, 0L, 2, 0L), publishingReport.getStartingOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 10L, 1, 20L, 2, 30L), publishingReport.getCurrentOffsets());
+    Assertions.assertEquals("id1", publishingReport.getId());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 0L, 1, 0L, 2, 0L), publishingReport.getStartingOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 10L, 1, 20L, 2, 30L), publishingReport.getCurrentOffsets());
 
     KafkaIndexTask capturedTask = captured.getValue();
-    Assert.assertEquals(dataSchema, capturedTask.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
+    Assertions.assertEquals(dataSchema, capturedTask.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
 
     KafkaIndexTaskIOConfig capturedTaskConfig = capturedTask.getIOConfig();
-    Assert.assertEquals(kafkaHost, capturedTaskConfig.getConsumerProperties().get("bootstrap.servers"));
-    Assert.assertEquals("myCustomValue", capturedTaskConfig.getConsumerProperties().get("myCustomKey"));
-    Assert.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", capturedTaskConfig.isUseTransaction());
+    Assertions.assertEquals(kafkaHost, capturedTaskConfig.getConsumerProperties().get("bootstrap.servers"));
+    Assertions.assertEquals("myCustomValue", capturedTaskConfig.getConsumerProperties().get("myCustomKey"));
+    Assertions.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
+    Assertions.assertTrue(capturedTaskConfig.isUseTransaction(), "isUseTransaction");
 
     // check that the new task was created with starting offsets matching where the publishing task finished
-    Assert.assertEquals(topic, capturedTaskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, capturedTaskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         10L,
         capturedTaskConfig.getStartSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 0))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         20L,
         capturedTaskConfig.getStartSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 1))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         30L,
         capturedTaskConfig.getStartSequenceNumbers()
                           .getPartitionSequenceNumberMap()
@@ -2232,22 +2208,22 @@ public class KafkaSupervisorTest extends EasyMockSupport
                           .longValue()
     );
 
-    Assert.assertEquals(topic, capturedTaskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, capturedTaskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         capturedTaskConfig.getEndSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 0))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         capturedTaskConfig.getEndSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 1))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         capturedTaskConfig.getEndSequenceNumbers()
                           .getPartitionSequenceNumberMap()
@@ -2256,7 +2232,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  @Test
   public void testDiscoverExistingPublishingTaskWithDifferentPartitionAllocation() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -2312,53 +2287,53 @@ public class KafkaSupervisorTest extends EasyMockSupport
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, report.getId());
+    Assertions.assertEquals(DATASOURCE, report.getId());
 
     KafkaSupervisorReportPayload payload = report.getPayload();
 
-    Assert.assertEquals(DATASOURCE, payload.getDataSource());
-    Assert.assertEquals(3600L, payload.getDurationSeconds());
-    Assert.assertEquals(NUM_PARTITIONS, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(topic, payload.getStream());
-    Assert.assertEquals(0, payload.getActiveTasks().size());
-    Assert.assertEquals(1, payload.getPublishingTasks().size());
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
-    Assert.assertEquals(0, payload.getRecentErrors().size());
+    Assertions.assertEquals(DATASOURCE, payload.getDataSource());
+    Assertions.assertEquals(3600L, payload.getDurationSeconds());
+    Assertions.assertEquals(NUM_PARTITIONS, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(topic, payload.getStream());
+    Assertions.assertEquals(0, payload.getActiveTasks().size());
+    Assertions.assertEquals(1, payload.getPublishingTasks().size());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
+    Assertions.assertEquals(0, payload.getRecentErrors().size());
 
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
-    Assert.assertEquals("id1", publishingReport.getId());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 0L, 2, 0L), publishingReport.getStartingOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 10L, 2, 30L), publishingReport.getCurrentOffsets());
+    Assertions.assertEquals("id1", publishingReport.getId());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 0L, 2, 0L), publishingReport.getStartingOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 10L, 2, 30L), publishingReport.getCurrentOffsets());
 
     KafkaIndexTask capturedTask = captured.getValue();
-    Assert.assertEquals(dataSchema, capturedTask.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
+    Assertions.assertEquals(dataSchema, capturedTask.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), capturedTask.getTuningConfig());
 
     KafkaIndexTaskIOConfig capturedTaskConfig = capturedTask.getIOConfig();
-    Assert.assertEquals(kafkaHost, capturedTaskConfig.getConsumerProperties().get("bootstrap.servers"));
-    Assert.assertEquals("myCustomValue", capturedTaskConfig.getConsumerProperties().get("myCustomKey"));
-    Assert.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", capturedTaskConfig.isUseTransaction());
+    Assertions.assertEquals(kafkaHost, capturedTaskConfig.getConsumerProperties().get("bootstrap.servers"));
+    Assertions.assertEquals("myCustomValue", capturedTaskConfig.getConsumerProperties().get("myCustomKey"));
+    Assertions.assertEquals("sequenceName-0", capturedTaskConfig.getBaseSequenceName());
+    Assertions.assertTrue(capturedTaskConfig.isUseTransaction(), "isUseTransaction");
 
     // check that the new task was created with starting offsets matching where the publishing task finished
-    Assert.assertEquals(topic, capturedTaskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, capturedTaskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         10L,
         capturedTaskConfig.getStartSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 0))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         capturedTaskConfig.getStartSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 1))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         30L,
         capturedTaskConfig.getStartSequenceNumbers()
                           .getPartitionSequenceNumberMap()
@@ -2366,22 +2341,22 @@ public class KafkaSupervisorTest extends EasyMockSupport
                           .longValue()
     );
 
-    Assert.assertEquals(topic, capturedTaskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, capturedTaskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         capturedTaskConfig.getEndSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 0))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         capturedTaskConfig.getEndSequenceNumbers()
                           .getPartitionSequenceNumberMap()
                           .get(new KafkaTopicPartition(false, topic, 1))
                           .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         capturedTaskConfig.getEndSequenceNumbers()
                           .getPartitionSequenceNumberMap()
@@ -2390,7 +2365,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  @Test
   public void testDiscoverExistingPublishingAndReadingTask() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -2483,20 +2457,20 @@ public class KafkaSupervisorTest extends EasyMockSupport
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, report.getId());
+    Assertions.assertEquals(DATASOURCE, report.getId());
 
     KafkaSupervisorReportPayload payload = report.getPayload();
 
-    Assert.assertEquals(DATASOURCE, payload.getDataSource());
-    Assert.assertEquals(3600L, payload.getDurationSeconds());
-    Assert.assertEquals(NUM_PARTITIONS, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(topic, payload.getStream());
-    Assert.assertEquals(1, payload.getActiveTasks().size());
-    Assert.assertEquals(1, payload.getPublishingTasks().size());
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
-    Assert.assertEquals(0, payload.getRecentErrors().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(DATASOURCE, payload.getDataSource());
+    Assertions.assertEquals(3600L, payload.getDurationSeconds());
+    Assertions.assertEquals(NUM_PARTITIONS, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(topic, payload.getStream());
+    Assertions.assertEquals(1, payload.getActiveTasks().size());
+    Assertions.assertEquals(1, payload.getPublishingTasks().size());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
+    Assertions.assertEquals(0, payload.getRecentErrors().size());
+    Assertions.assertEquals(
         singlePartitionMap(topic, 0, 10000, 1, 5000, 2, 0),
         payload.getMinimumLagMillis()
     );
@@ -2504,24 +2478,23 @@ public class KafkaSupervisorTest extends EasyMockSupport
     TaskReportData activeReport = payload.getActiveTasks().get(0);
     TaskReportData publishingReport = payload.getPublishingTasks().get(0);
 
-    Assert.assertEquals("id2", activeReport.getId());
-    Assert.assertEquals(startTime, activeReport.getStartTime());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 1L, 1, 2L, 2, 3L), activeReport.getStartingOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 4L, 1, 5L, 2, 6L), activeReport.getCurrentOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 3L, 1, 2L, 2, 1L), activeReport.getLag());
+    Assertions.assertEquals("id2", activeReport.getId());
+    Assertions.assertEquals(startTime, activeReport.getStartTime());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 1L, 1, 2L, 2, 3L), activeReport.getStartingOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 4L, 1, 5L, 2, 6L), activeReport.getCurrentOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 3L, 1, 2L, 2, 1L), activeReport.getLag());
 
-    Assert.assertEquals("id1", publishingReport.getId());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 0L, 1, 0L, 2, 0L), publishingReport.getStartingOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 1L, 1, 2L, 2, 3L), publishingReport.getCurrentOffsets());
-    Assert.assertNull(publishingReport.getLag());
+    Assertions.assertEquals("id1", publishingReport.getId());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 0L, 1, 0L, 2, 0L), publishingReport.getStartingOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 1L, 1, 2L, 2, 3L), publishingReport.getCurrentOffsets());
+    Assertions.assertNull(publishingReport.getLag());
 
-    Assert.assertEquals(singlePartitionMap(topic, 0, 7L, 1, 7L, 2, 7L), payload.getLatestOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 3L, 1, 2L, 2, 1L), payload.getMinimumLag());
-    Assert.assertEquals(6L, (long) payload.getAggregateLag());
-    Assert.assertTrue(payload.getOffsetsLastUpdated().plusMinutes(1).isAfterNow());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 7L, 1, 7L, 2, 7L), payload.getLatestOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 3L, 1, 2L, 2, 1L), payload.getMinimumLag());
+    Assertions.assertEquals(6L, (long) payload.getAggregateLag());
+    Assertions.assertTrue(payload.getOffsetsLastUpdated().plusMinutes(1).isAfterNow());
   }
 
-  @Test
   public void testReportWhenMultipleActiveTasks() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -2636,18 +2609,18 @@ public class KafkaSupervisorTest extends EasyMockSupport
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, report.getId());
+    Assertions.assertEquals(DATASOURCE, report.getId());
 
     KafkaSupervisorReportPayload payload = report.getPayload();
 
-    Assert.assertEquals(DATASOURCE, payload.getDataSource());
-    Assert.assertEquals(10L, payload.getDurationSeconds());
-    Assert.assertEquals(NUM_PARTITIONS, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(topic, payload.getStream());
-    Assert.assertEquals(2, payload.getActiveTasks().size());
-    Assert.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
-    Assert.assertEquals(0, payload.getRecentErrors().size());
+    Assertions.assertEquals(DATASOURCE, payload.getDataSource());
+    Assertions.assertEquals(10L, payload.getDurationSeconds());
+    Assertions.assertEquals(NUM_PARTITIONS, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(topic, payload.getStream());
+    Assertions.assertEquals(2, payload.getActiveTasks().size());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.RUNNING, payload.getDetailedState());
+    Assertions.assertEquals(0, payload.getRecentErrors().size());
 
     List<? extends TaskReportData> reportData = payload.getActiveTasks();
     reportData.sort(Comparator.comparing(TaskReportData::getId));
@@ -2655,23 +2628,22 @@ public class KafkaSupervisorTest extends EasyMockSupport
     TaskReportData id1TaskReport = reportData.get(0);
     TaskReportData id2TaskReport = reportData.get(1);
 
-    Assert.assertEquals("id2", id2TaskReport.getId());
-    Assert.assertEquals(singlePartitionMap(topic, 1, 0L), id2TaskReport.getStartingOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 1, 3L), id2TaskReport.getCurrentOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 1, 4L), id2TaskReport.getLag());
+    Assertions.assertEquals("id2", id2TaskReport.getId());
+    Assertions.assertEquals(singlePartitionMap(topic, 1, 0L), id2TaskReport.getStartingOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 1, 3L), id2TaskReport.getCurrentOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 1, 4L), id2TaskReport.getLag());
 
-    Assert.assertEquals("id1", id1TaskReport.getId());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 0L, 2, 0L), id1TaskReport.getStartingOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 2L, 2, 1L), id1TaskReport.getCurrentOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 5L, 2, 6L), id1TaskReport.getLag());
+    Assertions.assertEquals("id1", id1TaskReport.getId());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 0L, 2, 0L), id1TaskReport.getStartingOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 2L, 2, 1L), id1TaskReport.getCurrentOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 5L, 2, 6L), id1TaskReport.getLag());
 
-    Assert.assertEquals(singlePartitionMap(topic, 0, 7L, 1, 7L, 2, 7L), payload.getLatestOffsets());
-    Assert.assertEquals(singlePartitionMap(topic, 0, 5L, 1, 4L, 2, 6L), payload.getMinimumLag());
-    Assert.assertEquals(15L, (long) payload.getAggregateLag());
-    Assert.assertTrue(payload.getOffsetsLastUpdated().plusMinutes(1).isAfterNow());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 7L, 1, 7L, 2, 7L), payload.getLatestOffsets());
+    Assertions.assertEquals(singlePartitionMap(topic, 0, 5L, 1, 4L, 2, 6L), payload.getMinimumLag());
+    Assertions.assertEquals(15L, (long) payload.getAggregateLag());
+    Assertions.assertTrue(payload.getOffsetsLastUpdated().plusMinutes(1).isAfterNow());
   }
 
-  @Test
   public void testSupervisorIsIdleIfStreamInactive() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -2804,7 +2776,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.updateCurrentAndLatestOffsets();
     supervisor.runInternal();
 
-    Assert.assertNotEquals(supervisor.getState(), SupervisorStateManager.BasicState.IDLE);
+    Assertions.assertNotEquals(supervisor.getState(), SupervisorStateManager.BasicState.IDLE);
 
     EasyMock.reset(taskClient);
     EasyMock.expect(taskClient.getCurrentOffsetsAsync(EasyMock.contains("id1"), EasyMock.anyBoolean()))
@@ -2830,10 +2802,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.updateCurrentAndLatestOffsets();
     supervisor.runInternal();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
-  @Test
   public void testSupervisorIsIdleIfStreamInactiveWhenNoActiveTasks() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -2888,10 +2859,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.updateCurrentAndLatestOffsets();
     supervisor.runInternal();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
-  @Test
   public void testSupervisorNotIdleIfStreamInactiveWhenSuspended() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -2944,10 +2914,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.updateCurrentAndLatestOffsets();
     supervisor.runInternal();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.SUSPENDED, supervisor.getState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.SUSPENDED, supervisor.getState());
   }
 
-  @Test
   public void testSupervisorIsIdleIfStreamInactiveWhenSuspended() throws Exception
   {
     Map<String, String> config = ImmutableMap.of("idleConfig.enabled", "false",
@@ -3006,10 +2975,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.updateCurrentAndLatestOffsets();
     supervisor.runInternal();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
-  @Test
   public void testSupervisorIsIdleIfStreamInactiveWhenNoActiveTasksAndFewPendingTasks() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -3154,12 +3122,12 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.updateCurrentAndLatestOffsets();
     supervisor.runInternal();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
 
     supervisor.moveTaskGroupToPendingCompletion(0);
     supervisor.moveTaskGroupToPendingCompletion(1);
 
-    Assert.assertEquals(0, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(0, supervisor.getActiveTaskGroupsCount());
 
     EasyMock.reset(taskClient);
     EasyMock.expect(taskClient.getCurrentOffsetsAsync(EasyMock.contains("id1"), EasyMock.anyBoolean()))
@@ -3173,10 +3141,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.updateCurrentAndLatestOffsets();
     supervisor.runInternal();
 
-    Assert.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
+    Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
-  @Test
   public void testKillUnresponsiveTasksWhileGettingStartTime() throws Exception
   {
     supervisor = getTestableSupervisor(2, 2, true, "PT1H", null, null);
@@ -3233,7 +3200,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testKillUnresponsiveTasksWhilePausing() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -3316,13 +3282,13 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     for (Task task : captured.getValues()) {
       KafkaIndexTaskIOConfig taskConfig = ((KafkaIndexTask) task).getIOConfig();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           0L,
           (long) taskConfig.getStartSequenceNumbers()
                            .getPartitionSequenceNumberMap()
                            .get(new KafkaTopicPartition(false, topic, 0))
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           0L,
           (long) taskConfig.getStartSequenceNumbers()
                            .getPartitionSequenceNumberMap()
@@ -3331,7 +3297,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
-  @Test
   public void testKillUnresponsiveTasksWhileSettingEndOffsets() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -3420,13 +3385,13 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     for (Task task : captured.getValues()) {
       KafkaIndexTaskIOConfig taskConfig = ((KafkaIndexTask) task).getIOConfig();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           0L,
           (long) taskConfig.getStartSequenceNumbers()
                            .getPartitionSequenceNumberMap()
                            .get(new KafkaTopicPartition(false, topic, 0))
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           0L,
           (long) taskConfig.getStartSequenceNumbers()
                            .getPartitionSequenceNumberMap()
@@ -3435,14 +3400,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
-  @Test(expected = IllegalStateException.class)
   public void testStopNotStarted()
   {
-    supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
-    supervisor.stop(false);
+    assertThrows(IllegalStateException.class, () -> {
+      supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
+      supervisor.stop(false);
+    });
   }
 
-  @Test
   public void testStop()
   {
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
@@ -3457,7 +3422,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testStopGracefully() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -3591,7 +3555,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testResetNoTasks()
   {
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -3619,7 +3582,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
   }
 
-  @Test
   public void testResetDataSourceMetadata() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -3676,15 +3638,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
     catch (NullPointerException npe) {
       // Expected as there will be an attempt to EasyMock.reset partitionGroups offsets to NOT_SET
       // however there would be no entries in the map as we have not put nay data in kafka
-      Assert.assertNull(npe.getCause());
+      Assertions.assertNull(npe.getCause());
     }
     verifyAll();
 
-    Assert.assertEquals(DATASOURCE, captureDataSource.getValue());
-    Assert.assertEquals(expectedMetadata, captureDataSourceMetadata.getValue());
+    Assertions.assertEquals(DATASOURCE, captureDataSource.getValue());
+    Assertions.assertEquals(expectedMetadata, captureDataSourceMetadata.getValue());
   }
 
-  @Test
   public void testResetNoDataSourceMetadata()
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -3720,7 +3681,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testGetOffsetFromStorageForPartitionWithResetOffsetAutomatically() throws Exception
   {
     addSomeEvents(2);
@@ -3759,10 +3719,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     AlertEvent alert = serviceEmitter.getAlerts().get(0);
-    Assert.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
+    Assertions.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
   }
 
-  @Test
   public void testResetRunningTasks() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -3882,7 +3841,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testNoDataIngestionTasks()
   {
     final DateTime startTime = DateTimes.nowUtc();
@@ -3998,7 +3956,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCheckpointForInactiveTaskGroup()
       throws InterruptedException
   {
@@ -4126,10 +4084,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertTrue(serviceEmitter.getAlerts().isEmpty());
+    Assertions.assertTrue(serviceEmitter.getAlerts().isEmpty());
   }
 
-  @Test(timeout = 60_000L)
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testCheckpointForUnknownTaskGroup()
       throws InterruptedException
   {
@@ -4229,17 +4187,16 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
 
     AlertEvent alert = serviceEmitter.getAlerts().get(0);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Supervisor[testDS] for datasource[testDS] failed to handle notice",
         alert.getDescription()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot find taskGroup [0] among all activelyReadingTaskGroups [{}]",
         alert.getDataMap().get(AlertBuilder.EXCEPTION_MESSAGE_KEY)
     );
   }
 
-  @Test
   public void testSuspendedNoRunningTasks() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null, true, kafkaHost);
@@ -4255,7 +4212,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     ).anyTimes();
     // this asserts that taskQueue.add does not in fact get called because supervisor should be suspended
     EasyMock.expect(taskQueue.add(EasyMock.anyObject())).andAnswer((IAnswer) () -> {
-      Assert.fail();
+      Assertions.fail();
       return null;
     }).anyTimes();
     taskRunner.registerListener(EasyMock.anyObject(TaskRunnerListener.class), EasyMock.anyObject(Executor.class));
@@ -4266,7 +4223,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testSuspendedRunningTasks() throws Exception
   {
     // graceful shutdown is expected to be called on running tasks since state is suspended
@@ -4395,7 +4351,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testResetSuspended()
   {
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -4421,7 +4376,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testFailedInitializationAndRecovery() throws Exception
   {
     // Block the supervisor initialization with a bad hostname config, make sure this doesn't block the lifecycle
@@ -4451,8 +4405,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.isLifecycleStarted());
-    Assert.assertFalse(supervisor.isStarted());
+    Assertions.assertTrue(supervisor.isLifecycleStarted());
+    Assertions.assertFalse(supervisor.isStarted());
 
     verifyAll();
 
@@ -4482,40 +4436,40 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor.getIoConfig().getConsumerProperties().put("bootstrap.servers", kafkaHost);
     supervisor.tryInit();
 
-    Assert.assertTrue(supervisor.isLifecycleStarted());
-    Assert.assertTrue(supervisor.isStarted());
+    Assertions.assertTrue(supervisor.isLifecycleStarted());
+    Assertions.assertTrue(supervisor.isStarted());
 
     supervisor.runInternal();
     verifyAll();
 
     KafkaIndexTask task = captured.getValue();
-    Assert.assertEquals(dataSchema, task.getDataSchema());
-    Assert.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
+    Assertions.assertEquals(dataSchema, task.getDataSchema());
+    Assertions.assertEquals(tuningConfig.convertToTaskTuningConfig(), task.getTuningConfig());
 
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals(kafkaHost, taskConfig.getConsumerProperties().get("bootstrap.servers"));
-    Assert.assertEquals("myCustomValue", taskConfig.getConsumerProperties().get("myCustomKey"));
-    Assert.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
-    Assert.assertTrue("isUseTransaction", taskConfig.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", taskConfig.getMinimumMessageTime());
-    Assert.assertNull("maximumMessageTime", taskConfig.getMaximumMessageTime());
+    Assertions.assertEquals(kafkaHost, taskConfig.getConsumerProperties().get("bootstrap.servers"));
+    Assertions.assertEquals("myCustomValue", taskConfig.getConsumerProperties().get("myCustomKey"));
+    Assertions.assertEquals("sequenceName-0", taskConfig.getBaseSequenceName());
+    Assertions.assertTrue(taskConfig.isUseTransaction(), "isUseTransaction");
+    Assertions.assertNull(taskConfig.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertNull(taskConfig.getMaximumMessageTime(), "maximumMessageTime");
 
-    Assert.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, taskConfig.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals(
         0L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 0))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 1))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0L,
         taskConfig.getStartSequenceNumbers()
                   .getPartitionSequenceNumberMap()
@@ -4523,22 +4477,22 @@ public class KafkaSupervisorTest extends EasyMockSupport
                   .longValue()
     );
 
-    Assert.assertEquals(topic, taskConfig.getEndSequenceNumbers().getStream());
-    Assert.assertEquals(
+    Assertions.assertEquals(topic, taskConfig.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         taskConfig.getEndSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 0))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         taskConfig.getEndSequenceNumbers()
                   .getPartitionSequenceNumberMap()
                   .get(new KafkaTopicPartition(false, topic, 1))
                   .longValue()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Long.MAX_VALUE,
         taskConfig.getEndSequenceNumbers()
                   .getPartitionSequenceNumberMap()
@@ -4547,7 +4501,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  @Test
   public void testGetCurrentTotalStats()
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null, false, kafkaHost);
@@ -4585,13 +4538,12 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertEquals(2, stats.size());
-    Assert.assertEquals(ImmutableSet.of("0", "1"), stats.keySet());
-    Assert.assertEquals(ImmutableMap.of("task1", ImmutableMap.of("prop1", "val1")), stats.get("0"));
-    Assert.assertEquals(ImmutableMap.of("task2", ImmutableMap.of("prop2", "val2")), stats.get("1"));
+    Assertions.assertEquals(2, stats.size());
+    Assertions.assertEquals(ImmutableSet.of("0", "1"), stats.keySet());
+    Assertions.assertEquals(ImmutableMap.of("task1", ImmutableMap.of("prop1", "val1")), stats.get("0"));
+    Assertions.assertEquals(ImmutableMap.of("task2", ImmutableMap.of("prop2", "val2")), stats.get("1"));
   }
 
-  @Test
   public void testGetCurrentParseErrors()
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null, false, kafkaHost);
@@ -4659,10 +4611,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertEquals(ImmutableList.of(exception4, exception3, exception2, exception1), errors);
+    Assertions.assertEquals(ImmutableList.of(exception4, exception3, exception2, exception1), errors);
   }
 
-  @Test
   public void testDoNotKillCompatibleTasks()
       throws Exception
   {
@@ -4735,7 +4686,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testKillIncompatibleTasks()
       throws Exception
   {
@@ -4800,7 +4750,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
-  @Test
   public void testIsTaskCurrent()
   {
     DateTime minMessageTime = DateTimes.nowUtc();
@@ -4829,7 +4778,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         null
     );
 
-    Assert.assertNull(supervisor.computeUnassignedServerPriorities(taskGroup, 3));
+    Assertions.assertNull(supervisor.computeUnassignedServerPriorities(taskGroup, 3));
 
     DataSchema modifiedDataSchema = getDataSchema("some other datasource");
 
@@ -4940,15 +4889,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     replayAll();
 
-    Assert.assertTrue(supervisor.isTaskCurrent(42, "id0", taskMap));
-    Assert.assertTrue(supervisor.isTaskCurrent(42, "id1", taskMap));
-    Assert.assertFalse(supervisor.isTaskCurrent(42, "id2", taskMap));
-    Assert.assertFalse(supervisor.isTaskCurrent(42, "id3", taskMap));
-    Assert.assertFalse(supervisor.isTaskCurrent(42, "id4", taskMap));
+    Assertions.assertTrue(supervisor.isTaskCurrent(42, "id0", taskMap));
+    Assertions.assertTrue(supervisor.isTaskCurrent(42, "id1", taskMap));
+    Assertions.assertFalse(supervisor.isTaskCurrent(42, "id2", taskMap));
+    Assertions.assertFalse(supervisor.isTaskCurrent(42, "id3", taskMap));
+    Assertions.assertFalse(supervisor.isTaskCurrent(42, "id4", taskMap));
     verifyAll();
   }
 
-  @Test
   public void testSequenceNameDoesNotChangeWithTaskId()
   {
     final DateTime minMessageTime = DateTimes.nowUtc();
@@ -5007,7 +4955,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         task1.getDataSchema(),
         task1.getTuningConfig()
     );
-    Assert.assertNotNull(sequenceTask1);
+    Assertions.assertNotNull(sequenceTask1);
 
     final String sequenceTask2 = supervisor.generateSequenceName(
         task2.getIOConfig().getStartSequenceNumbers().getPartitionSequenceNumberMap(),
@@ -5016,15 +4964,14 @@ public class KafkaSupervisorTest extends EasyMockSupport
         task2.getDataSchema(),
         task2.getTuningConfig()
     );
-    Assert.assertNotNull(sequenceTask2);
+    Assertions.assertNotNull(sequenceTask2);
 
-    Assert.assertNotEquals(task1.getId(), task2.getId());
-    Assert.assertEquals(sequenceTask1, sequenceTask2);
+    Assertions.assertNotEquals(task1.getId(), task2.getId());
+    Assertions.assertEquals(sequenceTask1, sequenceTask2);
 
     verifyAll();
   }
 
-  @Test
   public void testResumeAllActivelyReadingTasks() throws Exception
   {
     supervisor = getTestableSupervisor(2, 3, true, "PT1H", null, null);
@@ -5217,12 +5164,11 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     Thread.sleep(1000);
 
-    Assert.assertEquals(failsToResumePausedTask.getId(), shutdownTaskId.getValue());
+    Assertions.assertEquals(failsToResumePausedTask.getId(), shutdownTaskId.getValue());
 
     verifyAll();
   }
 
-  @Test
   public void test_doesTaskMatchSupervisor()
   {
     supervisor = getTestableSupervisor("supervisorId", 1, 1, true, true, null, new Period("PT1H"), new Period("PT1H"), false, kafkaHost, null, null);
@@ -5231,20 +5177,19 @@ public class KafkaSupervisorTest extends EasyMockSupport
     EasyMock.expect(kafkaTaskMatch.getSupervisorId()).andReturn("supervisorId");
     EasyMock.replay(kafkaTaskMatch);
 
-    Assert.assertTrue(supervisor.doesTaskMatchSupervisor(kafkaTaskMatch));
+    Assertions.assertTrue(supervisor.doesTaskMatchSupervisor(kafkaTaskMatch));
 
     KafkaIndexTask kafkaTaskNoMatch = createMock(KafkaIndexTask.class);
     EasyMock.expect(kafkaTaskNoMatch.getSupervisorId()).andReturn(dataSchema.getDataSource());
     EasyMock.replay(kafkaTaskNoMatch);
 
-    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(kafkaTaskNoMatch));
+    Assertions.assertFalse(supervisor.doesTaskMatchSupervisor(kafkaTaskNoMatch));
 
     SeekableStreamIndexTask differentTaskType = createMock(SeekableStreamIndexTask.class);
     EasyMock.expect(differentTaskType.getSupervisorId()).andReturn("supervisorId");
     EasyMock.replay(differentTaskType);
   }
 
-  @Test
   public void test_autoScaler_doesNotRepeatScaleDownActions_ifTasksAreStillPublishing() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost1", 1234, -1);
@@ -5365,10 +5310,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     // Verify we have 3 actively reading task groups after discovery
-    Assert.assertEquals(
-        "Should have 3 actively reading task groups after discovery",
+    Assertions.assertEquals(
         3,
-        supervisor.getActivelyReadingTaskGroupsCount()
+        supervisor.getActivelyReadingTaskGroupsCount(),
+        "Should have 3 actively reading task groups after discovery"
     );
 
     // Reset and setup mocks for gracefulShutdownInternal
@@ -5393,10 +5338,10 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
 
     // After gracefulShutdownInternal, tasks should be moved to pendingCompletionTaskGroups
-    Assert.assertEquals(
-        "activelyReadingTaskGroups should be empty after gracefulShutdownInternal",
+    Assertions.assertEquals(
         0,
-        supervisor.getActivelyReadingTaskGroupsCount()
+        supervisor.getActivelyReadingTaskGroupsCount(),
+        "activelyReadingTaskGroups should be empty after gracefulShutdownInternal"
     );
 
     // Verify pendingCompletionTaskGroups is NOT empty (tasks were moved there)
@@ -5407,9 +5352,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
         break;
       }
     }
-    Assert.assertTrue(
-        "pendingCompletionTaskGroups should contain task groups after gracefulShutdownInternal",
-        hasPendingTasks
+    Assertions.assertTrue(
+        hasPendingTasks,
+        "pendingCompletionTaskGroups should contain task groups after gracefulShutdownInternal"
     );
 
     // Clear the partition assignments (this is called when task count has changed)
@@ -5423,24 +5368,23 @@ public class KafkaSupervisorTest extends EasyMockSupport
         break;
       }
     }
-    Assert.assertTrue(
+    Assertions.assertTrue(
+        stillHasPendingTasks,
         "pendingCompletionTaskGroups should be preserved after clearAllocationInfo() " +
-        "to prevent autoscaler from creating duplicate history entries",
-        stillHasPendingTasks
+        "to prevent autoscaler from creating duplicate history entries"
     );
 
     // Verify activelyReadingTaskGroups is still empty
-    Assert.assertEquals(
-        "activelyReadingTaskGroups should remain empty after clearAllocationInfo",
+    Assertions.assertEquals(
         0,
-        supervisor.getActivelyReadingTaskGroupsCount()
+        supervisor.getActivelyReadingTaskGroupsCount(),
+        "activelyReadingTaskGroups should remain empty after clearAllocationInfo"
     );
 
     // Verify that partitionOffsets have not been cleared either
-    Assert.assertFalse(supervisor.getPartitionOffsets().isEmpty());
+    Assertions.assertFalse(supervisor.getPartitionOffsets().isEmpty());
   }
 
-  @Test
   public void testComputeUnassignedServerPriorities_whenMultipleReplicasPerPriorityIsSet()
   {
     final Map<String, Object> consumerProperties = KafkaConsumerConfigs.getConsumerProperties();
@@ -5460,7 +5404,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         .withServerPriorityToReplicas(Map.of(10, 2, 20, 3))
         .build();
 
-    Assert.assertEquals(5, (int) kafkaSupervisorIOConfig.getReplicas());
+    Assertions.assertEquals(5, (int) kafkaSupervisorIOConfig.getReplicas());
 
     final KafkaIndexTaskClientFactory taskClientFactory = new KafkaIndexTaskClientFactory(null, null);
     final KafkaSupervisorSpec spec = new KafkaSupervisorSpec(
@@ -5503,7 +5447,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             Map.of()
         );
 
-    Assert.assertEquals(List.of(20, 20, 20, 10, 10), supervisor.computeUnassignedServerPriorities(taskGroup1, 5));
+    Assertions.assertEquals(List.of(20, 20, 20, 10, 10), supervisor.computeUnassignedServerPriorities(taskGroup1, 5));
 
     final SeekableStreamSupervisor<KafkaTopicPartition, Long, KafkaRecordEntity>.TaskGroup taskGroup2 =
         supervisor.addTaskGroupToActivelyReadingTaskGroup(
@@ -5516,7 +5460,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
             Map.of("task1", 10, "task2", 10)
         );
 
-    Assert.assertEquals(List.of(20, 20, 20), supervisor.computeUnassignedServerPriorities(taskGroup2, 3));
+    Assertions.assertEquals(List.of(20, 20, 20), supervisor.computeUnassignedServerPriorities(taskGroup2, 3));
 
     final SeekableStreamSupervisor<KafkaTopicPartition, Long, KafkaRecordEntity>.TaskGroup taskGroup3 =
         supervisor.addTaskGroupToActivelyReadingTaskGroup(
@@ -5529,10 +5473,9 @@ public class KafkaSupervisorTest extends EasyMockSupport
             Map.of("task1", 10, "task2", 10, "task3", 20)
         );
 
-    Assert.assertEquals(List.of(20, 20), supervisor.computeUnassignedServerPriorities(taskGroup3, 2));
+    Assertions.assertEquals(List.of(20, 20), supervisor.computeUnassignedServerPriorities(taskGroup3, 2));
   }
 
-  @Test
   public void testBoundedModeCreateTasksWithCorrectOffsets() throws JsonProcessingException
   {
     Map<String, Object> startOffsets = ImmutableMap.of(
@@ -5564,7 +5507,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
         .withBoundedStreamConfig(new BoundedStreamConfig(startOffsets, endOffsets))
         .build();
 
-    Assert.assertTrue(kafkaSupervisorIOConfig.isBounded());
+    Assertions.assertTrue(kafkaSupervisorIOConfig.isBounded());
 
     final KafkaIndexTaskClientFactory taskClientFactory = new KafkaIndexTaskClientFactory(null, null);
     final KafkaSupervisorSpec spec = new KafkaSupervisorSpec(
@@ -5598,33 +5541,32 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     // Test type conversion methods
     KafkaTopicPartition partition0 = supervisor.createPartitionIdFromString(topic + ":0");
-    Assert.assertEquals(topic, partition0.topic().get());
-    Assert.assertEquals(0, partition0.partition());
+    Assertions.assertEquals(topic, partition0.topic().get());
+    Assertions.assertEquals(0, partition0.partition());
 
     Long offset = supervisor.createSequenceOffsetFromObject(100);
-    Assert.assertEquals(Long.valueOf(100L), offset);
+    Assertions.assertEquals(Long.valueOf(100L), offset);
 
     offset = supervisor.createSequenceOffsetFromObject("200");
-    Assert.assertEquals(Long.valueOf(200L), offset);
+    Assertions.assertEquals(Long.valueOf(200L), offset);
 
     // Test offset comparison
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(500L, 100L));
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(100L, 100L));
-    Assert.assertFalse(supervisor.isOffsetAtOrBeyond(50L, 100L));
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(500L, 100L));
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(100L, 100L));
+    Assertions.assertFalse(supervisor.isOffsetAtOrBeyond(50L, 100L));
   }
 
-  @Test
   public void testCreateSequenceOffsetFromObject_invalidType()
   {
     Map<String, Object> startOffsets = ImmutableMap.of("0", 0, "1", 0);
     Map<String, Object> endOffsets = ImmutableMap.of("0", 100, "1", 100);
     supervisor = getTestableSupervisorWithBoundedConfig(1, 1, "PT1H", new BoundedStreamConfig(startOffsets, endOffsets));
 
-    Exception e = Assert.assertThrows(
+    Exception e = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> supervisor.createSequenceOffsetFromObject(new Object())
     );
-    Assert.assertTrue(e.getMessage().contains("Cannot convert"));
+    Assertions.assertTrue(e.getMessage().contains("Cannot convert"));
   }
 
   private void addSomeEvents(int numEventsPerPartition) throws Exception
@@ -5847,8 +5789,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -5932,8 +5874,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -6017,8 +5959,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -6363,7 +6305,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
-  @Test
   public void testBoundedStreamConfig_tasksIncludeBoundedConfig() throws Exception
   {
     Map<String, Long> startOffsets = ImmutableMap.of("0", 10L, "1", 20L, "2", 30L);
@@ -6390,28 +6331,27 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     // Task should be created with bounded config
     KafkaIndexTask task = captured.getValue();
-    Assert.assertNotNull(task);
-    Assert.assertEquals(boundedConfig, task.getIOConfig().getBoundedStreamConfig());
+    Assertions.assertNotNull(task);
+    Assertions.assertEquals(boundedConfig, task.getIOConfig().getBoundedStreamConfig());
 
     // Start offsets should come from bounded config
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals(10L, (long) taskConfig.getStartSequenceNumbers()
+    Assertions.assertEquals(10L, (long) taskConfig.getStartSequenceNumbers()
                                               .getPartitionSequenceNumberMap()
                                               .get(new KafkaTopicPartition(false, topic, 0)));
-    Assert.assertEquals(20L, (long) taskConfig.getStartSequenceNumbers()
+    Assertions.assertEquals(20L, (long) taskConfig.getStartSequenceNumbers()
                                               .getPartitionSequenceNumberMap()
                                               .get(new KafkaTopicPartition(false, topic, 1)));
-    Assert.assertEquals(30L, (long) taskConfig.getStartSequenceNumbers()
+    Assertions.assertEquals(30L, (long) taskConfig.getStartSequenceNumbers()
                                               .getPartitionSequenceNumberMap()
                                               .get(new KafkaTopicPartition(false, topic, 2)));
 
     // End offsets should match bounded config
-    Assert.assertEquals(100L, (long) taskConfig.getEndSequenceNumbers()
+    Assertions.assertEquals(100L, (long) taskConfig.getEndSequenceNumbers()
                                                 .getPartitionSequenceNumberMap()
                                                 .get(new KafkaTopicPartition(false, topic, 0)));
   }
 
-  @Test
   public void testBoundedStreamConfig_withCheckpoint_resumesFromCheckpoint() throws Exception
   {
     Map<String, Long> startOffsets = ImmutableMap.of("0", 0L, "1", 0L, "2", 0L);
@@ -6450,28 +6390,27 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
     // Task should be created with bounded config
     KafkaIndexTask task = captured.getValue();
-    Assert.assertNotNull(task);
-    Assert.assertEquals(boundedConfig, task.getIOConfig().getBoundedStreamConfig());
+    Assertions.assertNotNull(task);
+    Assertions.assertEquals(boundedConfig, task.getIOConfig().getBoundedStreamConfig());
 
     // Start offsets should resume from checkpoint
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
-    Assert.assertEquals(50L, (long) taskConfig.getStartSequenceNumbers()
+    Assertions.assertEquals(50L, (long) taskConfig.getStartSequenceNumbers()
                                               .getPartitionSequenceNumberMap()
                                               .get(new KafkaTopicPartition(false, topic, 0)));
-    Assert.assertEquals(60L, (long) taskConfig.getStartSequenceNumbers()
+    Assertions.assertEquals(60L, (long) taskConfig.getStartSequenceNumbers()
                                               .getPartitionSequenceNumberMap()
                                               .get(new KafkaTopicPartition(false, topic, 1)));
-    Assert.assertEquals(70L, (long) taskConfig.getStartSequenceNumbers()
+    Assertions.assertEquals(70L, (long) taskConfig.getStartSequenceNumbers()
                                               .getPartitionSequenceNumberMap()
                                               .get(new KafkaTopicPartition(false, topic, 2)));
 
     // End offsets should still match bounded config
-    Assert.assertEquals(100L, (long) taskConfig.getEndSequenceNumbers()
+    Assertions.assertEquals(100L, (long) taskConfig.getEndSequenceNumbers()
                                                 .getPartitionSequenceNumberMap()
                                                 .get(new KafkaTopicPartition(false, topic, 0)));
   }
 
-  @Test
   public void testBoundedStreamConfig_endOffsetsSetCorrectly() throws Exception
   {
     Map<String, Long> startOffsets = ImmutableMap.of("0", 0L, "1", 0L, "2", 0L);
@@ -6500,18 +6439,17 @@ public class KafkaSupervisorTest extends EasyMockSupport
     KafkaIndexTask task = captured.getValue();
     KafkaIndexTaskIOConfig taskConfig = task.getIOConfig();
 
-    Assert.assertEquals(150L, (long) taskConfig.getEndSequenceNumbers()
+    Assertions.assertEquals(150L, (long) taskConfig.getEndSequenceNumbers()
                                                 .getPartitionSequenceNumberMap()
                                                 .get(new KafkaTopicPartition(false, topic, 0)));
-    Assert.assertEquals(250L, (long) taskConfig.getEndSequenceNumbers()
+    Assertions.assertEquals(250L, (long) taskConfig.getEndSequenceNumbers()
                                                 .getPartitionSequenceNumberMap()
                                                 .get(new KafkaTopicPartition(false, topic, 1)));
-    Assert.assertEquals(350L, (long) taskConfig.getEndSequenceNumbers()
+    Assertions.assertEquals(350L, (long) taskConfig.getEndSequenceNumbers()
                                                 .getPartitionSequenceNumberMap()
                                                 .get(new KafkaTopicPartition(false, topic, 2)));
   }
 
-  @Test
   public void testBoundedStreamConfig_allPartitionsEmptyRange_completesImmediately() throws Exception
   {
     // All partitions have start == end (nothing to process)
@@ -6540,7 +6478,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     // With all partitions having empty ranges, supervisor should detect completion
     // State should transition to COMPLETED
     SupervisorReport<KafkaSupervisorReportPayload> report = supervisor.getStatus();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SupervisorStateManager.BasicState.COMPLETED,
         report.getPayload().getDetailedState()
     );
@@ -6584,8 +6522,8 @@ public class KafkaSupervisorTest extends EasyMockSupport
           ScheduledExecutorService connectExec
       )
       {
-        Assert.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
-        Assert.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
+        Assertions.assertEquals(TEST_HTTP_TIMEOUT.toStandardDuration(), tuningConfig.getHttpTimeout());
+        Assertions.assertEquals(TEST_CHAT_RETRIES, (long) tuningConfig.getChatRetries());
         return taskClient;
       }
     };
@@ -6622,7 +6560,6 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
-  @Test
   public void testBoundedMode_equalOffsetsIsEmpty()
   {
     // Kafka has exclusive end offsets, so start == end represents an EMPTY range
@@ -6631,7 +6568,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     supervisor = getTestableSupervisorWithBoundedConfig(1, 1, "PT1H", new BoundedStreamConfig(startOffsets, endOffsets));
 
     // Kafka uses exclusive end offsets
-    Assert.assertTrue("Kafka should have exclusive end offsets", supervisor.isEndOffsetExclusive());
+    Assertions.assertTrue(supervisor.isEndOffsetExclusive(), "Kafka should have exclusive end offsets");
 
     // Verify that start == end is treated correctly based on offset semantics
     // For exclusive offsets: start == end means ZERO records (empty)
@@ -6639,16 +6576,16 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Long end = 100L;
 
     // start >= end is true (they're equal)
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(start, end));
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(start, end));
 
     // For Kafka (exclusive), this IS an empty range
     // The empty range check should be: isOffsetAtOrBeyond(start, end)
     // Which evaluates to: true (IS empty)
     boolean shouldBeEmpty = supervisor.isOffsetAtOrBeyond(start, end);
 
-    Assert.assertTrue(
-        "For Kafka with exclusive end offsets, start == end should be considered an empty range",
-        shouldBeEmpty
+    Assertions.assertTrue(
+        shouldBeEmpty,
+        "For Kafka with exclusive end offsets, start == end should be considered an empty range"
     );
   }
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTest.java
@@ -117,6 +117,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -262,6 +263,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     kafkaServer = null;
   }
 
+  @Test
   public void testNoInitialStateWithAutoscaler() throws Exception
   {
     final int taskCountMax = 2;
@@ -455,6 +457,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     autoscaler.stop();
   }
 
+  @Test
   public void testGetTaskRunnerType() throws JsonProcessingException
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -485,6 +488,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertNull(indexTask.getServerPriority());
   }
 
+  @Test
   public void testCreateIndexTasksWithServerPrioritiesToAssign() throws JsonProcessingException
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -518,6 +522,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(Integer.valueOf(20), taskList.get(2).getServerPriority());
   }
 
+  @Test
   public void testNoInitialState() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -594,6 +599,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testSkipOffsetGaps() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -617,6 +623,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testMultiTask() throws Exception
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null);
@@ -697,6 +704,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testReplicas() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, null);
@@ -775,6 +783,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testLateMessageRejectionPeriod() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", new Period("PT1H"), null);
@@ -813,6 +822,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testEarlyMessageRejectionPeriod() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, new Period("PT1H"));
@@ -854,6 +864,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   /**
    * Test generating the starting offsets from the partition high water marks in Kafka.
    */
+  @Test
   public void testLatestOffset() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, false, "PT1H", null, null);
@@ -905,6 +916,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   /**
    * Test if partitionIds get updated
    */
+  @Test
   public void testPartitionIdsUpdates() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, false, "PT1H", null, null);
@@ -930,6 +942,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
 
+  @Test
   public void testAlwaysUsesEarliestOffsetForNewlyDiscoveredPartitions() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, false, "PT1H", null, null);
@@ -1026,6 +1039,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * contains the offsets from previous single-topic config of the last built segments, where the previous topic does
    * match the new configuration.
    */
+  @Test
   public void testDatasourceMetadataSingleTopicToSingleTopicMatch() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -1082,6 +1096,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * contains the offsets from previous single-topic config of the last built segments, where the previous topic does
    * match the new configuration.
    */
+  @Test
   public void testDatasourceMetadataSingleTopicToMultiTopicMatch() throws Exception
   {
     multiTopic = true;
@@ -1139,6 +1154,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * contains the offsets from previous single-topic config of the last built segments, where the previous topic does
    * not match the new configuration.
    */
+  @Test
   public void testDatasourceMetadataSingleTopicToMultiTopicNotMatch() throws Exception
   {
     multiTopic = true;
@@ -1195,6 +1211,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * Test generating the starting offsets for single-topic config from the partition data stored in druid_dataSource which
    * contains the offsets from previous multi-topic config of the last built segments.
    */
+  @Test
   public void testDatasourceMetadataMultiTopicToSingleTopic() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -1256,6 +1273,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * Test generating the starting offsets for muti-topic config from the partition data stored in druid_dataSource which
    * contains the offsets from previous multi-topic config of the last built segments.
    */
+  @Test
   public void testDatasourceMetadataMultiTopicToMultiTopic() throws Exception
   {
     multiTopic = true;
@@ -1310,6 +1328,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(3, taskConfig.getStartSequenceNumbers().getPartitionSequenceNumberMap().size());
   }
 
+  @Test
   public void testBadMetadataOffsets() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -1342,6 +1361,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
   }
 
+  @Test
   public void testDontKillTasksWithMismatchedType() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, null);
@@ -1386,6 +1406,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testKillBadPartitionAssignment() throws Exception
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null);
@@ -1512,6 +1533,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
 
+  @Test
   public void testRequeueTaskWhenFailed() throws Exception
   {
     supervisor = getTestableSupervisor(2, 2, true, "PT1H", null, null);
@@ -1602,6 +1624,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testRequeueTaskWithServerPrioritiesWhenFailed() throws Exception
   {
     supervisor = getTestableSupervisor(null, 2, 2, true, true, "PT1H", null, null, false, kafkaHost, null, Map.of(1, 1, 2, 1));
@@ -1704,6 +1727,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
    * must not go out of sync when a newly-submitted task dies before the next supervisor run observes it. Otherwise, the orphan priority entry
    * makes {@link SeekableStreamSupervisor#computeUnassignedServerPriorities} throw on the replacement attempt.
    */
+  @Test
   public void testReplacementSubmittedWhenPriorityTaskDiesBeforeDiscovery() throws Exception
   {
     // replicas=2, taskCount=1, priorities {0:1, 1:1}
@@ -1776,6 +1800,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(orphan.getServerPriority(), replacement.getServerPriority());
   }
 
+  @Test
   public void testRequeueAdoptedTaskWhenFailed() throws Exception
   {
     supervisor = getTestableSupervisor(2, 1, true, "PT1H", null, null);
@@ -1882,6 +1907,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testQueueNextTasksOnSuccess() throws Exception
   {
     supervisor = getTestableSupervisor(2, 2, true, "PT1H", null, null);
@@ -1983,6 +2009,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertTrue(shutdownTaskIdCapture.getValue().contains(iAmSuccess.getIOConfig().getBaseSequenceName()));
   }
 
+  @Test
   public void testBeginPublishAndQueueNextTasks() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -2089,6 +2116,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
+  @Test
   public void testDiscoverExistingPublishingTask() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -2232,6 +2260,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testDiscoverExistingPublishingTaskWithDifferentPartitionAllocation() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -2365,6 +2394,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testDiscoverExistingPublishingAndReadingTask() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -2495,6 +2525,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertTrue(payload.getOffsetsLastUpdated().plusMinutes(1).isAfterNow());
   }
 
+  @Test
   public void testReportWhenMultipleActiveTasks() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -2644,6 +2675,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertTrue(payload.getOffsetsLastUpdated().plusMinutes(1).isAfterNow());
   }
 
+  @Test
   public void testSupervisorIsIdleIfStreamInactive() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -2805,6 +2837,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
+  @Test
   public void testSupervisorIsIdleIfStreamInactiveWhenNoActiveTasks() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -2862,6 +2895,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
+  @Test
   public void testSupervisorNotIdleIfStreamInactiveWhenSuspended() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -2917,6 +2951,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(SupervisorStateManager.BasicState.SUSPENDED, supervisor.getState());
   }
 
+  @Test
   public void testSupervisorIsIdleIfStreamInactiveWhenSuspended() throws Exception
   {
     Map<String, String> config = ImmutableMap.of("idleConfig.enabled", "false",
@@ -2978,6 +3013,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
+  @Test
   public void testSupervisorIsIdleIfStreamInactiveWhenNoActiveTasksAndFewPendingTasks() throws Exception
   {
     supervisor = getTestableSupervisorForIdleBehaviour(
@@ -3144,6 +3180,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(SupervisorStateManager.BasicState.IDLE, supervisor.getState());
   }
 
+  @Test
   public void testKillUnresponsiveTasksWhileGettingStartTime() throws Exception
   {
     supervisor = getTestableSupervisor(2, 2, true, "PT1H", null, null);
@@ -3200,6 +3237,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testKillUnresponsiveTasksWhilePausing() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -3297,6 +3335,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
+  @Test
   public void testKillUnresponsiveTasksWhileSettingEndOffsets() throws Exception
   {
     final TaskLocation location = TaskLocation.create("testHost", 1234, -1);
@@ -3400,6 +3439,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
+  @Test
   public void testStopNotStarted()
   {
     assertThrows(IllegalStateException.class, () -> {
@@ -3408,6 +3448,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     });
   }
 
+  @Test
   public void testStop()
   {
     EasyMock.expect(taskMaster.getTaskRunner()).andReturn(Optional.of(taskRunner)).anyTimes();
@@ -3422,6 +3463,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testStopGracefully() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -3555,6 +3597,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testResetNoTasks()
   {
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -3582,6 +3625,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
 
   }
 
+  @Test
   public void testResetDataSourceMetadata() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -3646,6 +3690,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(expectedMetadata, captureDataSourceMetadata.getValue());
   }
 
+  @Test
   public void testResetNoDataSourceMetadata()
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null);
@@ -3681,6 +3726,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testGetOffsetFromStorageForPartitionWithResetOffsetAutomatically() throws Exception
   {
     addSomeEvents(2);
@@ -3722,6 +3768,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertTrue(alert.getDescription().startsWith("Exception in supervisor run loop for supervisor[testDS] for dataSource[testDS]"));
   }
 
+  @Test
   public void testResetRunningTasks() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost", 1234, -1);
@@ -3841,6 +3888,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testNoDataIngestionTasks()
   {
     final DateTime startTime = DateTimes.nowUtc();
@@ -3957,6 +4005,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Test
   public void testCheckpointForInactiveTaskGroup()
       throws InterruptedException
   {
@@ -4088,6 +4137,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
   }
 
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  @Test
   public void testCheckpointForUnknownTaskGroup()
       throws InterruptedException
   {
@@ -4197,6 +4247,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testSuspendedNoRunningTasks() throws Exception
   {
     supervisor = getTestableSupervisor(1, 1, true, "PT1H", null, null, true, kafkaHost);
@@ -4223,6 +4274,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testSuspendedRunningTasks() throws Exception
   {
     // graceful shutdown is expected to be called on running tasks since state is suspended
@@ -4351,6 +4403,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testResetSuspended()
   {
     EasyMock.expect(taskMaster.getTaskQueue()).andReturn(Optional.of(taskQueue)).anyTimes();
@@ -4376,6 +4429,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testFailedInitializationAndRecovery() throws Exception
   {
     // Block the supervisor initialization with a bad hostname config, make sure this doesn't block the lifecycle
@@ -4501,6 +4555,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testGetCurrentTotalStats()
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null, false, kafkaHost);
@@ -4544,6 +4599,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(ImmutableMap.of("task2", ImmutableMap.of("prop2", "val2")), stats.get("1"));
   }
 
+  @Test
   public void testGetCurrentParseErrors()
   {
     supervisor = getTestableSupervisor(1, 2, true, "PT1H", null, null, false, kafkaHost);
@@ -4614,6 +4670,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(ImmutableList.of(exception4, exception3, exception2, exception1), errors);
   }
 
+  @Test
   public void testDoNotKillCompatibleTasks()
       throws Exception
   {
@@ -4686,6 +4743,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testKillIncompatibleTasks()
       throws Exception
   {
@@ -4750,6 +4808,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testIsTaskCurrent()
   {
     DateTime minMessageTime = DateTimes.nowUtc();
@@ -4897,6 +4956,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testSequenceNameDoesNotChangeWithTaskId()
   {
     final DateTime minMessageTime = DateTimes.nowUtc();
@@ -4972,6 +5032,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void testResumeAllActivelyReadingTasks() throws Exception
   {
     supervisor = getTestableSupervisor(2, 3, true, "PT1H", null, null);
@@ -5169,6 +5230,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     verifyAll();
   }
 
+  @Test
   public void test_doesTaskMatchSupervisor()
   {
     supervisor = getTestableSupervisor("supervisorId", 1, 1, true, true, null, new Period("PT1H"), new Period("PT1H"), false, kafkaHost, null, null);
@@ -5190,6 +5252,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     EasyMock.replay(differentTaskType);
   }
 
+  @Test
   public void test_autoScaler_doesNotRepeatScaleDownActions_ifTasksAreStillPublishing() throws Exception
   {
     final TaskLocation location1 = TaskLocation.create("testHost1", 1234, -1);
@@ -5385,6 +5448,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertFalse(supervisor.getPartitionOffsets().isEmpty());
   }
 
+  @Test
   public void testComputeUnassignedServerPriorities_whenMultipleReplicasPerPriorityIsSet()
   {
     final Map<String, Object> consumerProperties = KafkaConsumerConfigs.getConsumerProperties();
@@ -5476,6 +5540,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertEquals(List.of(20, 20), supervisor.computeUnassignedServerPriorities(taskGroup3, 2));
   }
 
+  @Test
   public void testBoundedModeCreateTasksWithCorrectOffsets() throws JsonProcessingException
   {
     Map<String, Object> startOffsets = ImmutableMap.of(
@@ -5556,6 +5621,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     Assertions.assertFalse(supervisor.isOffsetAtOrBeyond(50L, 100L));
   }
 
+  @Test
   public void testCreateSequenceOffsetFromObject_invalidType()
   {
     Map<String, Object> startOffsets = ImmutableMap.of("0", 0, "1", 0);
@@ -6305,6 +6371,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     }
   }
 
+  @Test
   public void testBoundedStreamConfig_tasksIncludeBoundedConfig() throws Exception
   {
     Map<String, Long> startOffsets = ImmutableMap.of("0", 10L, "1", 20L, "2", 30L);
@@ -6352,6 +6419,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
                                                 .get(new KafkaTopicPartition(false, topic, 0)));
   }
 
+  @Test
   public void testBoundedStreamConfig_withCheckpoint_resumesFromCheckpoint() throws Exception
   {
     Map<String, Long> startOffsets = ImmutableMap.of("0", 0L, "1", 0L, "2", 0L);
@@ -6411,6 +6479,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
                                                 .get(new KafkaTopicPartition(false, topic, 0)));
   }
 
+  @Test
   public void testBoundedStreamConfig_endOffsetsSetCorrectly() throws Exception
   {
     Map<String, Long> startOffsets = ImmutableMap.of("0", 0L, "1", 0L, "2", 0L);
@@ -6450,6 +6519,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
                                                 .get(new KafkaTopicPartition(false, topic, 2)));
   }
 
+  @Test
   public void testBoundedStreamConfig_allPartitionsEmptyRange_completesImmediately() throws Exception
   {
     // All partitions have start == end (nothing to process)
@@ -6560,6 +6630,7 @@ public class KafkaSupervisorTest extends EasyMockSupport
     );
   }
 
+  @Test
   public void testBoundedMode_equalOffsetsIsEmpty()
   {
     // Kafka has exclusive end offsets, so start == end represents an EMPTY range

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfigTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorTuningConfigTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.indexing.TuningConfig;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class KafkaSupervisorTuningConfigTest
 {
@@ -56,21 +56,21 @@ public class KafkaSupervisorTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(150000, config.getMaxRowsInMemory());
-    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(0, config.getMaxPendingPersists());
-    Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
-    Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpecForIntermediatePersists());
-    Assert.assertFalse(config.isReportParseExceptions());
-    Assert.assertEquals(java.time.Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
-    Assert.assertNull(config.getWorkerThreads());
-    Assert.assertEquals(8L, (long) config.getChatRetries());
-    Assert.assertEquals(Duration.standardSeconds(10), config.getHttpTimeout());
-    Assert.assertEquals(Duration.standardSeconds(80), config.getShutdownTimeout());
-    Assert.assertEquals(Duration.standardSeconds(30), config.getOffsetFetchPeriod());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(150000, config.getMaxRowsInMemory());
+    Assertions.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(0, config.getMaxPendingPersists());
+    Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
+    Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpecForIntermediatePersists());
+    Assertions.assertFalse(config.isReportParseExceptions());
+    Assertions.assertEquals(java.time.Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+    Assertions.assertNull(config.getWorkerThreads());
+    Assertions.assertEquals(8L, (long) config.getChatRetries());
+    Assertions.assertEquals(Duration.standardSeconds(10), config.getHttpTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(80), config.getShutdownTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(30), config.getOffsetFetchPeriod());
   }
 
   @Test
@@ -105,24 +105,24 @@ public class KafkaSupervisorTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(100, config.getMaxRowsInMemory());
-    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(100, config.getMaxPendingPersists());
-    Assert.assertTrue(config.isReportParseExceptions());
-    Assert.assertEquals(100, config.getHandoffConditionTimeout());
-    Assert.assertEquals(12, (int) config.getWorkerThreads());
-    Assert.assertEquals(14L, (long) config.getChatRetries());
-    Assert.assertEquals(Duration.standardSeconds(15), config.getHttpTimeout());
-    Assert.assertEquals(Duration.standardSeconds(95), config.getShutdownTimeout());
-    Assert.assertEquals(Duration.standardSeconds(20), config.getOffsetFetchPeriod());
-    Assert.assertEquals(
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(100, config.getMaxRowsInMemory());
+    Assertions.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(100, config.getMaxPendingPersists());
+    Assertions.assertTrue(config.isReportParseExceptions());
+    Assertions.assertEquals(100, config.getHandoffConditionTimeout());
+    Assertions.assertEquals(12, (int) config.getWorkerThreads());
+    Assertions.assertEquals(14L, (long) config.getChatRetries());
+    Assertions.assertEquals(Duration.standardSeconds(15), config.getHttpTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(95), config.getShutdownTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(20), config.getOffsetFetchPeriod());
+    Assertions.assertEquals(
         IndexSpec.builder().withMetricCompression(CompressionStrategy.NONE).build(),
         config.getIndexSpec()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         IndexSpec.builder().withDimensionCompression(CompressionStrategy.UNCOMPRESSED).build(),
         config.getIndexSpecForIntermediatePersists()
     );

--- a/extensions-core/lookups-cached-global/pom.xml
+++ b/extensions-core/lookups-cached-global/pom.xml
@@ -107,8 +107,23 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/data/input/MapPopulatorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/data/input/MapPopulatorTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.data.input;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.Pair;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,97 +39,97 @@ public class MapPopulatorTest
   public void test_getByteLengthOfObject_string_stringLength()
   {
     String o = "string";
-    Assert.assertEquals((o.length() * Character.BYTES) + 40, MapPopulator.getByteLengthOfObject(o));
+    Assertions.assertEquals((o.length() * Character.BYTES) + 40, MapPopulator.getByteLengthOfObject(o));
   }
 
   @Test
   public void test_getByteLengthOfObject_double_8()
   {
-    Assert.assertEquals(EIGHT_BYTES, MapPopulator.getByteLengthOfObject(12.0));
+    Assertions.assertEquals(EIGHT_BYTES, MapPopulator.getByteLengthOfObject(12.0));
   }
 
   @Test
   public void test_getByteLengthOfObject_float_4()
   {
-    Assert.assertEquals(FOUR_BYTES, MapPopulator.getByteLengthOfObject(12.0F));
+    Assertions.assertEquals(FOUR_BYTES, MapPopulator.getByteLengthOfObject(12.0F));
   }
 
   @Test
   public void test_getByteLengthOfObject_int_4()
   {
-    Assert.assertEquals(FOUR_BYTES, MapPopulator.getByteLengthOfObject(12));
+    Assertions.assertEquals(FOUR_BYTES, MapPopulator.getByteLengthOfObject(12));
   }
 
   @Test
   public void test_getByteLengthOfObject_long_8()
   {
-    Assert.assertEquals(EIGHT_BYTES, MapPopulator.getByteLengthOfObject(12L));
+    Assertions.assertEquals(EIGHT_BYTES, MapPopulator.getByteLengthOfObject(12L));
   }
 
   @Test
   public void test_getByteLengthOfObject_null_0()
   {
-    Assert.assertEquals(0, MapPopulator.getByteLengthOfObject(null));
+    Assertions.assertEquals(0, MapPopulator.getByteLengthOfObject(null));
   }
 
   @Test
   public void test_getByteLengthOfObject_map_0()
   {
-    Assert.assertEquals(0, MapPopulator.getByteLengthOfObject(ImmutableMap.of()));
+    Assertions.assertEquals(0, MapPopulator.getByteLengthOfObject(ImmutableMap.of()));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_stringKeyAndStringValue_true()
   {
-    Assert.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined("key", "value"));
+    Assertions.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined("key", "value"));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_doubleKeyAndDoubleValue_true()
   {
-    Assert.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1.0, 2.0));
+    Assertions.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1.0, 2.0));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_floatKeyAndFloatValue_true()
   {
-    Assert.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1.0F, 2.0F));
+    Assertions.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1.0F, 2.0F));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_intKeyAndIntValue_true()
   {
-    Assert.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1, 2));
+    Assertions.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1, 2));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_longKeyAndLongValue_true()
   {
-    Assert.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1L, 2L));
+    Assertions.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(1L, 2L));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_nullKeyAndNullValue_true()
   {
-    Assert.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(null, null));
+    Assertions.assertTrue(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(null, null));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_mapKeyAndmapValue_false()
   {
-    Assert.assertFalse(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(ImmutableMap.of(), ImmutableMap.of()));
+    Assertions.assertFalse(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(ImmutableMap.of(), ImmutableMap.of()));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_nullKeyAndmapValue_false()
   {
-    Assert.assertFalse(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(null, ImmutableMap.of()));
+    Assertions.assertFalse(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(null, ImmutableMap.of()));
   }
 
   @Test
   public void test_canKeyAndValueTypesByteSizesBeDetermined_mapKeyAndNullValue_false()
   {
-    Assert.assertFalse(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(ImmutableMap.of(), null));
+    Assertions.assertFalse(MapPopulator.canKeyAndValueTypesByteSizesBeDetermined(ImmutableMap.of(), null));
   }
 
   @Test
@@ -139,10 +139,10 @@ public class MapPopulatorTest
     Map<String, String> map = new HashMap<>();
     MapPopulator.PopulateResult result =
         MapPopulator.populateAndWarnAtByteLimit(pairs.iterator(), map, -1, "");
-    Assert.assertTrue(map.isEmpty());
-    Assert.assertEquals(0, result.getEntries());
-    Assert.assertEquals(0, result.getLines());
-    Assert.assertEquals(0L, result.getBytes());
+    Assertions.assertTrue(map.isEmpty());
+    Assertions.assertEquals(0, result.getEntries());
+    Assertions.assertEquals(0, result.getLines());
+    Assertions.assertEquals(0L, result.getBytes());
   }
 
   @Test
@@ -160,10 +160,10 @@ public class MapPopulatorTest
     Map<Object, Object> map = new HashMap<>();
     MapPopulator.PopulateResult result =
         MapPopulator.populateAndWarnAtByteLimit(pairs.iterator(), map, -1, null);
-    Assert.assertEquals(expectedMap, map);
-    Assert.assertEquals(4, result.getEntries());
-    Assert.assertEquals(0, result.getLines());
-    Assert.assertEquals(0L, result.getBytes());
+    Assertions.assertEquals(expectedMap, map);
+    Assertions.assertEquals(4, result.getEntries());
+    Assertions.assertEquals(0, result.getLines());
+    Assertions.assertEquals(0L, result.getBytes());
   }
 
   @Test
@@ -181,10 +181,10 @@ public class MapPopulatorTest
     Map<Object, Object> map = new HashMap<>();
     MapPopulator.PopulateResult result =
         MapPopulator.populateAndWarnAtByteLimit(pairs.iterator(), map, 10, null);
-    Assert.assertEquals(expectedMap, map);
-    Assert.assertEquals(4, result.getEntries());
-    Assert.assertEquals(0, result.getLines());
-    Assert.assertEquals(192L, result.getBytes());
+    Assertions.assertEquals(expectedMap, map);
+    Assertions.assertEquals(4, result.getEntries());
+    Assertions.assertEquals(0, result.getLines());
+    Assertions.assertEquals(192L, result.getBytes());
   }
 
   @Test
@@ -199,9 +199,9 @@ public class MapPopulatorTest
     Map<Object, Object> map = new HashMap<>();
     MapPopulator.PopulateResult result =
         MapPopulator.populateAndWarnAtByteLimit(pairs.iterator(), map, 10, null);
-    Assert.assertEquals(expectedMap, map);
-    Assert.assertEquals(2, result.getEntries());
-    Assert.assertEquals(0, result.getLines());
-    Assert.assertEquals(0L, result.getBytes());
+    Assertions.assertEquals(expectedMap, map);
+    Assertions.assertEquals(2, result.getEntries());
+    Assertions.assertEquals(0, result.getLines());
+    Assertions.assertEquals(0L, result.getBytes());
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/LookupUtilsTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/LookupUtilsTest.java
@@ -32,9 +32,9 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.server.DruidNode;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
@@ -104,7 +104,7 @@ public class LookupUtilsTest
                                                       + "}";
   private ObjectMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     final Injector injector = makeInjector();
@@ -126,7 +126,7 @@ public class LookupUtilsTest
     Map<String, LookupExtractorFactoryContainer> actualLookup =
         LookupUtils.tryConvertObjectMapToLookupConfigMap(validLookupGeneric, mapper);
 
-    Assert.assertEquals(mapper.writeValueAsString(validLookupExpected), mapper.writeValueAsString(actualLookup));
+    Assertions.assertEquals(mapper.writeValueAsString(validLookupExpected), mapper.writeValueAsString(actualLookup));
   }
 
   @Test
@@ -141,7 +141,7 @@ public class LookupUtilsTest
     Map<String, LookupExtractorFactoryContainer> actualLookup =
         LookupUtils.tryConvertObjectMapToLookupConfigMap(validLookupGeneric, mapper);
 
-    Assert.assertTrue(actualLookup.isEmpty());
+    Assertions.assertTrue(actualLookup.isEmpty());
   }
 
   @Test
@@ -159,7 +159,7 @@ public class LookupUtilsTest
     Map<String, LookupExtractorFactoryContainer> actualLookup =
         LookupUtils.tryConvertObjectMapToLookupConfigMap(validLookupGeneric, mapper);
 
-    Assert.assertEquals(mapper.writeValueAsString(validLookupExpected), mapper.writeValueAsString(actualLookup));
+    Assertions.assertEquals(mapper.writeValueAsString(validLookupExpected), mapper.writeValueAsString(actualLookup));
   }
 
   private Injector makeInjector()

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
@@ -42,18 +42,21 @@ import org.apache.druid.query.lookup.namespace.UriExtractionNamespace;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.lookup.namespace.cache.CacheScheduler;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentMatchers;
 
 import javax.ws.rs.core.Response;
+
+import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -70,8 +73,8 @@ import static org.mockito.Mockito.when;
 public class NamespaceLookupExtractorFactoryTest
 {
   private final ObjectMapper mapper = new DefaultObjectMapper();
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private final CacheScheduler scheduler = mock(CacheScheduler.class);
   private final CacheScheduler.Entry entry = mock(CacheScheduler.Entry.class);
@@ -79,7 +82,7 @@ public class NamespaceLookupExtractorFactoryTest
       mock(CacheScheduler.VersionedCache.class);
 
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(
@@ -109,7 +112,7 @@ public class NamespaceLookupExtractorFactoryTest
   public void testSimpleSerde() throws Exception
   {
     final UriExtractionNamespace uriExtractionNamespace = new UriExtractionNamespace(
-        temporaryFolder.newFolder().toURI(),
+        newFolder(temporaryFolder, "junit").toURI(),
         null, null,
         new UriExtractionNamespace.ObjectMapperFlatDataParser(mapper),
         Period.millis(0),
@@ -120,7 +123,7 @@ public class NamespaceLookupExtractorFactoryTest
         uriExtractionNamespace,
         scheduler
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         uriExtractionNamespace,
         mapper.readValue(
             mapper.writeValueAsString(namespaceLookupExtractorFactory),
@@ -132,9 +135,10 @@ public class NamespaceLookupExtractorFactoryTest
   @Test
   public void testMissingSpec()
   {
-    Assert.assertThrows(
-        "extractionNamespace should be specified", NullPointerException.class,
-        () -> new NamespaceLookupExtractorFactory(null, null)
+    Assertions.assertThrows(
+        NullPointerException.class,
+        () -> new NamespaceLookupExtractorFactory(null, null),
+        "extractionNamespace should be specified"
     );
   }
 
@@ -148,8 +152,8 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
-    Assert.assertTrue(namespaceLookupExtractorFactory.close());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.close());
 
     verify(scheduler).scheduleAndWait(extractionNamespace, 60000L);
     verify(entry).close();
@@ -168,8 +172,8 @@ public class NamespaceLookupExtractorFactoryTest
         false,
         scheduler
     );
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
-    Assert.assertTrue(namespaceLookupExtractorFactory.close());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.close());
 
     verify(scheduler).schedule(any());
     verify(entry).close();
@@ -189,7 +193,7 @@ public class NamespaceLookupExtractorFactoryTest
         false,
         scheduler
     );
-    Assert.assertFalse(namespaceLookupExtractorFactory.start());
+    Assertions.assertFalse(namespaceLookupExtractorFactory.start());
 
     verify(scheduler).scheduleAndWait(extractionNamespace, 1L);
     verifyNoMoreInteractions(scheduler, entry, versionedCache);
@@ -205,9 +209,9 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
-    Assert.assertTrue(namespaceLookupExtractorFactory.close());
-    Assert.assertTrue(namespaceLookupExtractorFactory.close());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.close());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.close());
 
     verify(entry).close();
     verify(scheduler).scheduleAndWait(extractionNamespace, 60000L);
@@ -224,8 +228,8 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
     verify(scheduler).scheduleAndWait(extractionNamespace, 60000L);
     verifyNoMoreInteractions(scheduler, entry, versionedCache);
   }
@@ -245,10 +249,10 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
     final LookupExtractor extractor = namespaceLookupExtractorFactory.get();
-    Assert.assertNull(extractor.apply("foo"));
-    Assert.assertTrue(namespaceLookupExtractorFactory.close());
+    Assertions.assertNull(extractor.apply("foo"));
+    Assertions.assertTrue(namespaceLookupExtractorFactory.close());
 
     verify(scheduler).scheduleAndWait(extractionNamespace, 60000L);
     verify(entry).getCacheState();
@@ -277,8 +281,8 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
-    Assert.assertThrows(ISE.class, () -> namespaceLookupExtractorFactory.get());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertThrows(ISE.class, () -> namespaceLookupExtractorFactory.get());
 
     verify(scheduler).scheduleAndWait(extractionNamespace, 60000L);
     verify(entry).getCacheState();
@@ -309,9 +313,9 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertTrue(namespaceLookupExtractorFactory.start());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.start());
     namespaceLookupExtractorFactory.awaitInitialization();
-    Assert.assertThrows(ISE.class, () -> namespaceLookupExtractorFactory.get());
+    Assertions.assertThrows(ISE.class, () -> namespaceLookupExtractorFactory.get());
     verify(scheduler).scheduleAndWait(extractionNamespace, 60000L);
     verify(entry, times(2)).getCacheState();
     verify(entry).awaitTotalUpdatesWithTimeout(1, 1);
@@ -358,9 +362,9 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertFalse(namespaceLookupExtractorFactory.start());
+    Assertions.assertFalse(namespaceLookupExtractorFactory.start());
     // true because it never fully started
-    Assert.assertTrue(namespaceLookupExtractorFactory.close());
+    Assertions.assertTrue(namespaceLookupExtractorFactory.close());
 
     verify(scheduler).scheduleAndWait(
         extractionNamespace,
@@ -385,27 +389,29 @@ public class NamespaceLookupExtractorFactoryTest
         en1,
         scheduler
     );
-    Assert.assertTrue(f1.replaces(f2));
-    Assert.assertTrue(f2.replaces(f1));
-    Assert.assertFalse(f1.replaces(f1b));
-    Assert.assertFalse(f1b.replaces(f1));
-    Assert.assertFalse(f1.replaces(f1));
-    Assert.assertTrue(f1.replaces(mock(LookupExtractorFactory.class)));
+    Assertions.assertTrue(f1.replaces(f2));
+    Assertions.assertTrue(f2.replaces(f1));
+    Assertions.assertFalse(f1.replaces(f1b));
+    Assertions.assertFalse(f1b.replaces(f1));
+    Assertions.assertFalse(f1.replaces(f1));
+    Assertions.assertTrue(f1.replaces(mock(LookupExtractorFactory.class)));
 
     verifyNoInteractions(en1, en2);
   }
 
-  @Test(expected = ISE.class)
+  @Test
   public void testMustBeStarted()
   {
-    final ExtractionNamespace extractionNamespace = () -> 0;
+    assertThrows(ISE.class, () -> {
+      final ExtractionNamespace extractionNamespace = () -> 0;
 
-    final NamespaceLookupExtractorFactory namespaceLookupExtractorFactory = new NamespaceLookupExtractorFactory(
-        extractionNamespace,
-        scheduler
-    );
+      final NamespaceLookupExtractorFactory namespaceLookupExtractorFactory = new NamespaceLookupExtractorFactory(
+          extractionNamespace,
+          scheduler
+      );
 
-    namespaceLookupExtractorFactory.get();
+      namespaceLookupExtractorFactory.get();
+    });
   }
 
   // Note this does NOT catch problems with returning factories as failed in error messages.
@@ -417,24 +423,24 @@ public class NamespaceLookupExtractorFactoryTest
     mapper.registerSubtypes(NamespaceLookupExtractorFactory.class);
     final String str = "{ \"type\": \"cachedNamespace\", \"extractionNamespace\": { \"type\": \"uri\", \"uriPrefix\": \"s3://bucket/prefix/\", \"fileRegex\": \"foo.*\\\\.gz\", \"namespaceParseSpec\": { \"format\": \"customJson\", \"keyFieldName\": \"someKey\", \"valueFieldName\": \"someVal\" }, \"pollPeriod\": \"PT5M\", \"maxHeapPercentage\": 10 } } }";
     final LookupExtractorFactory factory = mapper.readValue(str, LookupExtractorFactory.class);
-    Assert.assertTrue(factory instanceof NamespaceLookupExtractorFactory);
+    Assertions.assertTrue(factory instanceof NamespaceLookupExtractorFactory);
     final NamespaceLookupExtractorFactory namespaceLookupExtractorFactory = (NamespaceLookupExtractorFactory) factory;
-    Assert.assertNotNull(mapper.writeValueAsString(factory));
-    Assert.assertFalse(factory.replaces(mapper.readValue(
+    Assertions.assertNotNull(mapper.writeValueAsString(factory));
+    Assertions.assertFalse(factory.replaces(mapper.readValue(
         mapper.writeValueAsString(factory),
         LookupExtractorFactory.class
     )));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         UriExtractionNamespace.class,
         namespaceLookupExtractorFactory.getExtractionNamespace().getClass()
     );
-    Assert.assertFalse(namespaceLookupExtractorFactory.replaces(mapper.readValue(str, LookupExtractorFactory.class)));
+    Assertions.assertFalse(namespaceLookupExtractorFactory.replaces(mapper.readValue(str, LookupExtractorFactory.class)));
     final Map<String, Object> map = new HashMap<>(mapper.readValue(
         str,
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     ));
     map.put("firstCacheTimeout", "1");
-    Assert.assertTrue(namespaceLookupExtractorFactory.replaces(mapper.convertValue(map, LookupExtractorFactory.class)));
+    Assertions.assertTrue(namespaceLookupExtractorFactory.replaces(mapper.convertValue(map, LookupExtractorFactory.class)));
   }
 
   @Test
@@ -445,24 +451,24 @@ public class NamespaceLookupExtractorFactoryTest
     mapper.registerSubtypes(NamespaceLookupExtractorFactory.class);
     final String str = "{ \"type\": \"cachedNamespace\", \"extractionNamespace\": { \"type\": \"staticMap\", \"map\": {\"foo\":\"bar\"} }, \"firstCacheTimeout\":10000 }";
     final LookupExtractorFactory lookupExtractorFactory = mapper.readValue(str, LookupExtractorFactory.class);
-    Assert.assertTrue(lookupExtractorFactory.start());
+    Assertions.assertTrue(lookupExtractorFactory.start());
     try {
       final LookupIntrospectHandler handler = lookupExtractorFactory.getIntrospectHandler();
-      Assert.assertNotNull(handler);
+      Assertions.assertNotNull(handler);
       final Class<? extends LookupIntrospectHandler> clazz = handler.getClass();
-      Assert.assertNotNull(clazz.getMethod("getVersion").invoke(handler));
-      Assert.assertEquals(ImmutableSet.of("foo"), ((Response) clazz.getMethod("getKeys").invoke(handler)).getEntity());
-      Assert.assertEquals(
+      Assertions.assertNotNull(clazz.getMethod("getVersion").invoke(handler));
+      Assertions.assertEquals(ImmutableSet.of("foo"), ((Response) clazz.getMethod("getKeys").invoke(handler)).getEntity());
+      Assertions.assertEquals(
           ImmutableList.of("bar"),
           ImmutableList.copyOf((Collection) ((Response) clazz.getMethod("getValues").invoke(handler)).getEntity())
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableMap.builder().put("foo", "bar").build(),
           ((Response) clazz.getMethod("getMap").invoke(handler)).getEntity()
       );
     }
     finally {
-      Assert.assertTrue(lookupExtractorFactory.close());
+      Assertions.assertTrue(lookupExtractorFactory.close());
     }
   }
 
@@ -479,7 +485,7 @@ public class NamespaceLookupExtractorFactoryTest
     final NamespaceLookupExtractorFactory factory2 =
         (NamespaceLookupExtractorFactory) mapper.readValue(str2, LookupExtractorFactory.class);
 
-    Assert.assertSame(factory1.getCacheScheduler(), factory2.getCacheScheduler());
+    Assertions.assertSame(factory1.getCacheScheduler(), factory2.getCacheScheduler());
   }
 
   private Injector makeInjector()
@@ -506,10 +512,10 @@ public class NamespaceLookupExtractorFactoryTest
         extractionNamespace,
         scheduler
     );
-    Assert.assertTrue(lookupExtractorFactory.start());
+    Assertions.assertTrue(lookupExtractorFactory.start());
 
     final LookupIntrospectHandler handler = lookupExtractorFactory.getIntrospectHandler();
-    Assert.assertNotNull(handler);
+    Assertions.assertNotNull(handler);
     final Class<? extends LookupIntrospectHandler> clazz = handler.getClass();
 
     verify(scheduler).scheduleAndWait(eq(extractionNamespace), anyLong());
@@ -520,7 +526,7 @@ public class NamespaceLookupExtractorFactoryTest
     when(entry.getCacheState()).thenReturn(CacheScheduler.NoCache.CACHE_NOT_INITIALIZED);
 
     final Response response = (Response) clazz.getMethod("getVersion").invoke(handler);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
 
     verify(entry).getCacheState();
     validateNotFound("getKeys", handler, clazz);
@@ -544,12 +550,21 @@ public class NamespaceLookupExtractorFactoryTest
     when(versionedCache.getVersion()).thenThrow(new ISE("some exception"));
 
     final Response response = (Response) clazz.getMethod(method).invoke(handler);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
 
     verify(entry).getCacheState();
     verify(entry, atMostOnce()).getCache();
     verify(versionedCache, atMostOnce()).getCache();
     verify(versionedCache).getVersion();
     verifyNoMoreInteractions(scheduler, entry, versionedCache);
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
@@ -52,7 +52,6 @@ import org.mockito.ArgumentMatchers;
 import javax.ws.rs.core.Response;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -560,11 +559,8 @@ public class NamespaceLookupExtractorFactoryTest
     verifyNoMoreInteractions(scheduler, entry, versionedCache);
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
@@ -560,7 +560,8 @@ public class NamespaceLookupExtractorFactoryTest
     verifyNoMoreInteractions(scheduler, entry, versionedCache);
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/NamespaceLookupExtractorFactoryTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.query.extraction.MapLookupExtractor;
@@ -562,9 +563,7 @@ public class NamespaceLookupExtractorFactoryTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JSONFlatDataParserTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JSONFlatDataParserTest.java
@@ -165,7 +165,8 @@ public class JSONFlatDataParserTest
   }
 
   @Test
-  public void testFailParseOnKeyMissing() {
+  public void testFailParseOnKeyMissing()
+  {
     Throwable exception = assertThrows(NullPointerException.class, () -> {
       final UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
           MAPPER,

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JSONFlatDataParserTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JSONFlatDataParserTest.java
@@ -28,18 +28,19 @@ import com.google.common.io.CharSink;
 import com.google.common.io.Files;
 import org.apache.druid.data.input.MapPopulator;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JSONFlatDataParserTest
 {
@@ -56,16 +57,14 @@ public class JSONFlatDataParserTest
       ImmutableMap.of("key", "foo1", "val", "bar", "otherVal", 3, "canBeEmpty", ""),
       ImmutableMap.of("key", "foo2", "val", "baz", "canBeEmpty", "notEmpty")
   );
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @TempDir
+  public File temporaryFolder;
   private File tmpFile;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
-    tmpFile = temporaryFolder.newFile("lookup.json");
+    tmpFile = File.createTempFile("lookup.json", null, temporaryFolder);
     final CharSink sink = Files.asByteSink(tmpFile).asCharSink(StandardCharsets.UTF_8);
     sink.writeLines(
         Iterables.transform(
@@ -97,8 +96,8 @@ public class JSONFlatDataParserTest
     );
     final Map<String, String> map = new HashMap<>();
     new MapPopulator<>(parser.getParser()).populate(Files.asByteSource(tmpFile), map);
-    Assert.assertEquals(VAL1, map.get(KEY1));
-    Assert.assertEquals(VAL2, map.get(KEY2));
+    Assertions.assertEquals(VAL1, map.get(KEY1));
+    Assertions.assertEquals(VAL2, map.get(KEY2));
   }
 
   @Test
@@ -115,8 +114,8 @@ public class JSONFlatDataParserTest
         map,
         100_000L,
         "namespace");
-    Assert.assertEquals(VAL1, map.get(KEY1));
-    Assert.assertEquals(VAL2, map.get(KEY2));
+    Assertions.assertEquals(VAL1, map.get(KEY1));
+    Assertions.assertEquals(VAL2, map.get(KEY2));
   }
 
   @Test
@@ -133,8 +132,8 @@ public class JSONFlatDataParserTest
         map,
         1L,
         "namespace");
-    Assert.assertEquals(VAL1, map.get(KEY1));
-    Assert.assertEquals(VAL2, map.get(KEY2));
+    Assertions.assertEquals(VAL1, map.get(KEY1));
+    Assertions.assertEquals(VAL2, map.get(KEY2));
   }
 
   @Test
@@ -147,8 +146,8 @@ public class JSONFlatDataParserTest
     );
     final Map<String, String> map = new HashMap<>();
     new MapPopulator<>(parser.getParser()).populate(Files.asByteSource(tmpFile), map);
-    Assert.assertEquals(OTHERVAL1, map.get(KEY1));
-    Assert.assertEquals(OTHERVAL2, map.get(KEY2));
+    Assertions.assertEquals(OTHERVAL1, map.get(KEY1));
+    Assertions.assertEquals(OTHERVAL2, map.get(KEY2));
   }
 
   @Test
@@ -161,23 +160,22 @@ public class JSONFlatDataParserTest
     );
     final Map<String, String> map = new HashMap<>();
     new MapPopulator<>(parser.getParser()).populate(Files.asByteSource(tmpFile), map);
-    Assert.assertEquals(CANBEEMPTY1, map.get(KEY1));
-    Assert.assertEquals(CANBEEMPTY2, map.get(KEY2));
+    Assertions.assertEquals(CANBEEMPTY1, map.get(KEY1));
+    Assertions.assertEquals(CANBEEMPTY2, map.get(KEY2));
   }
 
   @Test
-  public void testFailParseOnKeyMissing() throws Exception
-  {
-    final UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
-        MAPPER,
-        "keyWHOOPS",
-        "val"
-    );
-    final Map<String, String> map = new HashMap<>();
+  public void testFailParseOnKeyMissing() {
+    Throwable exception = assertThrows(NullPointerException.class, () -> {
+      final UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
+          MAPPER,
+          "keyWHOOPS",
+          "val"
+      );
+      final Map<String, String> map = new HashMap<>();
 
-    expectedException.expect(NullPointerException.class);
-    expectedException.expectMessage("Key column [keyWHOOPS] missing data in line");
-
-    new MapPopulator<>(parser.getParser()).populate(Files.asByteSource(tmpFile), map);
+      new MapPopulator<>(parser.getParser()).populate(Files.asByteSource(tmpFile), map);
+    });
+    assertTrue(exception.getMessage().contains("Key column [keyWHOOPS] missing data in line"));
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespaceUrlCheckTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/JdbcExtractionNamespaceUrlCheckTest.java
@@ -23,11 +23,13 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.server.initialization.JdbcAccessSecurityConfig;
 import org.joda.time.Period;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JdbcExtractionNamespaceUrlCheckTest
 {
@@ -36,10 +38,9 @@ public class JdbcExtractionNamespaceUrlCheckTest
   private static final String VAL_NAME = "valName";
   private static final String TS_COLUMN = "tsColumn";
 
-  public static class MySqlTest
+  @Nested
+  public class MySqlTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
@@ -82,41 +83,42 @@ public class JdbcExtractionNamespaceUrlCheckTest
     @Test
     public void testThrowWhenUrlHasNonAllowedPropertiesWhenEnforcingAllowedProperties()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
-      new JdbcExtractionNamespace(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcExtractionNamespace(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
-            }
-          },
-          TABLE_NAME,
-          KEY_NAME,
-          VAL_NAME,
-          TS_COLUMN,
-          "some filter",
-          new Period(10),
-          null,
-          0,
-          null,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:mysql://localhost:3306/db?invalid_key1=val1&valid_key2=val2";
+              }
+            },
+            TABLE_NAME,
+            KEY_NAME,
+            VAL_NAME,
+            TS_COLUMN,
+            "some filter",
+            new Period(10),
+            null,
+            0,
+            null,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]"));
     }
 
     @Test
@@ -158,10 +160,9 @@ public class JdbcExtractionNamespaceUrlCheckTest
     }
   }
 
-  public static class PostgreSqlTest
+  @Nested
+  public class PostgreSqlTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testCreateInstanceWhenUrlHasOnlyAllowedProperties()
@@ -204,41 +205,42 @@ public class JdbcExtractionNamespaceUrlCheckTest
     @Test
     public void testThrowWhenUrlHasNonAllowedPropertiesWhenEnforcingAllowedProperties()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]");
-      new JdbcExtractionNamespace(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcExtractionNamespace(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
-            }
-          },
-          TABLE_NAME,
-          KEY_NAME,
-          VAL_NAME,
-          TS_COLUMN,
-          "some filter",
-          new Period(10),
-          10L,
-          0,
-          null,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:postgresql://localhost:5432/db?invalid_key1=val1&valid_key2=val2";
+              }
+            },
+            TABLE_NAME,
+            KEY_NAME,
+            VAL_NAME,
+            TS_COLUMN,
+            "some filter",
+            new Period(10),
+            10L,
+            0,
+            null,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("The property [invalid_key1] is not in the allowed list [valid_key1, valid_key2]"));
     }
 
     @Test
@@ -282,93 +284,94 @@ public class JdbcExtractionNamespaceUrlCheckTest
     @Test
     public void testWhenInvalidUrlFormat()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Invalid URL format for PostgreSQL: [jdbc:postgresql://invalid-url::3006]");
-      new JdbcExtractionNamespace(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcExtractionNamespace(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:postgresql://invalid-url::3006";
-            }
-          },
-          TABLE_NAME,
-          KEY_NAME,
-          VAL_NAME,
-          TS_COLUMN,
-          "some filter",
-          new Period(10),
-          null,
-          0,
-          null,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:postgresql://invalid-url::3006";
+              }
+            },
+            TABLE_NAME,
+            KEY_NAME,
+            VAL_NAME,
+            TS_COLUMN,
+            "some filter",
+            new Period(10),
+            null,
+            0,
+            null,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("Invalid URL format for PostgreSQL: [jdbc:postgresql://invalid-url::3006]"));
     }
   }
 
-  public static class UnknownSchemeTest
+  @Nested
+  public class UnknownSchemeTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testThrowWhenUnknownFormatIsNotAllowed()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Unknown JDBC connection scheme: mydb");
-      new JdbcExtractionNamespace(
-          new MetadataStorageConnectorConfig()
-          {
-            @Override
-            public String getConnectURI()
+      Throwable exception = assertThrows(IllegalArgumentException.class, () -> {
+        new JdbcExtractionNamespace(
+            new MetadataStorageConnectorConfig()
             {
-              return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
-            }
-          },
-          TABLE_NAME,
-          KEY_NAME,
-          VAL_NAME,
-          TS_COLUMN,
-          "some filter",
-          new Period(10),
-          null,
-          0,
-          null,
-          new JdbcAccessSecurityConfig()
-          {
-            @Override
-            public Set<String> getAllowedProperties()
+              @Override
+              public String getConnectURI()
+              {
+                return "jdbc:mydb://localhost:5432/db?valid_key1=val1&valid_key2=val2";
+              }
+            },
+            TABLE_NAME,
+            KEY_NAME,
+            VAL_NAME,
+            TS_COLUMN,
+            "some filter",
+            new Period(10),
+            null,
+            0,
+            null,
+            new JdbcAccessSecurityConfig()
             {
-              return ImmutableSet.of("valid_key1", "valid_key2");
-            }
+              @Override
+              public Set<String> getAllowedProperties()
+              {
+                return ImmutableSet.of("valid_key1", "valid_key2");
+              }
 
-            @Override
-            public boolean isAllowUnknownJdbcUrlFormat()
-            {
-              return false;
-            }
+              @Override
+              public boolean isAllowUnknownJdbcUrlFormat()
+              {
+                return false;
+              }
 
-            @Override
-            public boolean isEnforceAllowedProperties()
-            {
-              return true;
+              @Override
+              public boolean isEnforceAllowedProperties()
+              {
+                return true;
+              }
             }
-          }
-      );
+        );
+      });
+      assertTrue(exception.getMessage().contains("Unknown JDBC connection scheme: mydb"));
     }
 
     @Test

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/StaticMapExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/StaticMapExtractionNamespaceTest.java
@@ -22,9 +22,9 @@ package org.apache.druid.query.lookup.namespace;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -34,7 +34,7 @@ public class StaticMapExtractionNamespaceTest
   private static final ObjectMapper MAPPER = new DefaultObjectMapper();
   private static String MAP_STRING;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpStatic() throws Exception
   {
     MAP_STRING = MAPPER.writeValueAsString(MAP);
@@ -45,14 +45,14 @@ public class StaticMapExtractionNamespaceTest
   {
     final String str = "{\"type\":\"staticMap\", \"map\":" + MAP_STRING + "}";
     final StaticMapExtractionNamespace extractionNamespace = MAPPER.readValue(str, StaticMapExtractionNamespace.class);
-    Assert.assertEquals(MAP, extractionNamespace.getMap());
-    Assert.assertEquals(0L, extractionNamespace.getPollMs());
-    Assert.assertEquals(extractionNamespace, MAPPER.readValue(str, StaticMapExtractionNamespace.class));
-    Assert.assertNotEquals(
+    Assertions.assertEquals(MAP, extractionNamespace.getMap());
+    Assertions.assertEquals(0L, extractionNamespace.getPollMs());
+    Assertions.assertEquals(extractionNamespace, MAPPER.readValue(str, StaticMapExtractionNamespace.class));
+    Assertions.assertNotEquals(
         extractionNamespace,
         new StaticMapExtractionNamespace(ImmutableMap.of("foo", "not_bar"))
     );
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         extractionNamespace,
         new StaticMapExtractionNamespace(ImmutableMap.of("not_foo", "bar"))
     );

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/query/lookup/namespace/UriExtractionNamespaceTest.java
@@ -32,11 +32,13 @@ import org.apache.druid.guice.GuiceInjectableValues;
 import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
@@ -89,7 +91,7 @@ public class UriExtractionNamespaceTest
             "col3"
         ), "col2", "col3"
     );
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
+    Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
   }
   @Test
   public void testCSVWithHeader()
@@ -102,39 +104,43 @@ public class UriExtractionNamespaceTest
         1
     );
     // parser return empyt list as the 1 row header need to be skipped.
-    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("row to skip "));
+    Assertions.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("row to skip "));
     //Header also need to be skipped.
-    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("col1,col2,col3"));
+    Assertions.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("col1,col2,col3"));
     // test the header is parsed
-    Assert.assertEquals(ImmutableList.of("col1", "col2", "col3"), parser.getParser().getFieldNames());
+    Assertions.assertEquals(ImmutableList.of("col1", "col2", "col3"), parser.getParser().getFieldNames());
     // The third row will parse to data
-    Assert.assertEquals(ImmutableMap.of("val2", "val3"), parser.getParser().parseToMap("val1,val2,val3"));
+    Assertions.assertEquals(ImmutableMap.of("val2", "val3"), parser.getParser().parseToMap("val1,val2,val3"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadCSV()
   {
-    UriExtractionNamespace.CSVFlatDataParser parser = new UriExtractionNamespace.CSVFlatDataParser(
-        ImmutableList.of(
-            "col1",
-            "col2",
-            "col3"
-        ), "col2", "col3ADFSDF"
-    );
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
+    assertThrows(IllegalArgumentException.class, () -> {
+      UriExtractionNamespace.CSVFlatDataParser parser = new UriExtractionNamespace.CSVFlatDataParser(
+          ImmutableList.of(
+              "col1",
+              "col2",
+              "col3"
+          ), "col2", "col3ADFSDF"
+      );
+      Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testBadCSV2()
   {
-    UriExtractionNamespace.CSVFlatDataParser parser = new UriExtractionNamespace.CSVFlatDataParser(
-        ImmutableList.of(
-            "col1",
-            "col2",
-            "col3"
-        ), "col2", "col3"
-    );
-    Map<String, String> map = parser.getParser().parseToMap("A");
+    assertThrows(NullPointerException.class, () -> {
+      UriExtractionNamespace.CSVFlatDataParser parser = new UriExtractionNamespace.CSVFlatDataParser(
+          ImmutableList.of(
+              "col1",
+              "col2",
+              "col3"
+          ), "col2", "col3"
+      );
+      Map<String, String> map = parser.getParser().parseToMap("A");
+    });
   }
 
   @Test
@@ -146,7 +152,7 @@ public class UriExtractionNamespaceTest
         null, "col2",
         "col3"
     );
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A|B|C"));
+    Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A|B|C"));
   }
 
   @Test
@@ -158,7 +164,7 @@ public class UriExtractionNamespaceTest
         "\\u0002", "col2",
         "col3"
     );
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A\\u0001B\\u0001C"));
+    Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A\\u0001B\\u0001C"));
   }
   @Test
   public void testWithHeaderAndListDelimiterTSV()
@@ -172,40 +178,44 @@ public class UriExtractionNamespaceTest
         1
     );
     // skipping one row
-    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("Skipping some rows"));
+    Assertions.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("Skipping some rows"));
     // skip the header as well
-    Assert.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("col1\\u0001col2\\u0001col3"));
+    Assertions.assertEquals(ImmutableMap.of(), parser.getParser().parseToMap("col1\\u0001col2\\u0001col3"));
     // test if the headers are parsed well.
-    Assert.assertEquals(ImmutableList.of("col1", "col2", "col3"), parser.getParser().getFieldNames());
+    Assertions.assertEquals(ImmutableList.of("col1", "col2", "col3"), parser.getParser().getFieldNames());
     // test if the data row is parsed correctly
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A\\u0001B\\u0001C"));
+    Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A\\u0001B\\u0001C"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testBadTSV()
   {
-    UriExtractionNamespace.TSVFlatDataParser parser = new UriExtractionNamespace.TSVFlatDataParser(
-        ImmutableList.of("col1", "col2", "col3fdsfds"),
-        ",",
-        null, "col2",
-        "col3"
-    );
-    Map<String, String> map = parser.getParser().parseToMap("A,B,C");
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
+    assertThrows(IllegalArgumentException.class, () -> {
+      UriExtractionNamespace.TSVFlatDataParser parser = new UriExtractionNamespace.TSVFlatDataParser(
+          ImmutableList.of("col1", "col2", "col3fdsfds"),
+          ",",
+          null, "col2",
+          "col3"
+      );
+      Map<String, String> map = parser.getParser().parseToMap("A,B,C");
+      Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
+    });
   }
 
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testBadTSV2()
   {
-    UriExtractionNamespace.TSVFlatDataParser parser = new UriExtractionNamespace.TSVFlatDataParser(
-        ImmutableList.of("col1", "col2", "col3"),
-        ",",
-        null, "col2",
-        "col3"
-    );
-    Map<String, String> map = parser.getParser().parseToMap("A");
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
+    assertThrows(NullPointerException.class, () -> {
+      UriExtractionNamespace.TSVFlatDataParser parser = new UriExtractionNamespace.TSVFlatDataParser(
+          ImmutableList.of("col1", "col2", "col3"),
+          ",",
+          null, "col2",
+          "col3"
+      );
+      Map<String, String> map = parser.getParser().parseToMap("A");
+      Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("A,B,C"));
+    });
   }
 
   @Test
@@ -218,7 +228,7 @@ public class UriExtractionNamespaceTest
         keyField,
         valueField
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of("B", "C"),
         parser.getParser()
               .parseToMap(
@@ -232,19 +242,20 @@ public class UriExtractionNamespaceTest
   }
 
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testJSONFlatDataParserBad()
   {
-    final String keyField = "keyField";
-    final String valueField = "valueField";
-    UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
-        new ObjectMapper(),
-        keyField,
-        valueField
-    );
-    Assert.assertEquals(
-        ImmutableMap.of("B", "C"),
-        parser.getParser()
+    assertThrows(NullPointerException.class, () -> {
+      final String keyField = "keyField";
+      final String valueField = "valueField";
+      UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
+          new ObjectMapper(),
+          keyField,
+          valueField
+      );
+      Assertions.assertEquals(
+          ImmutableMap.of("B", "C"),
+          parser.getParser()
               .parseToMap(
                   StringUtils.format(
                       "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
@@ -252,22 +263,24 @@ public class UriExtractionNamespaceTest
                       valueField
                   )
               )
-    );
+      );
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testJSONFlatDataParserBad2()
   {
-    final String keyField = "keyField";
-    final String valueField = "valueField";
-    UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
-        registerTypes(new ObjectMapper()),
-        null,
-        valueField
-    );
-    Assert.assertEquals(
-        ImmutableMap.of("B", "C"),
-        parser.getParser()
+    assertThrows(IllegalArgumentException.class, () -> {
+      final String keyField = "keyField";
+      final String valueField = "valueField";
+      UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
+          registerTypes(new ObjectMapper()),
+          null,
+          valueField
+      );
+      Assertions.assertEquals(
+          ImmutableMap.of("B", "C"),
+          parser.getParser()
               .parseToMap(
                   StringUtils.format(
                       "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
@@ -275,22 +288,24 @@ public class UriExtractionNamespaceTest
                       valueField
                   )
               )
-    );
+      );
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testJSONFlatDataParserBad3()
   {
-    final String keyField = "keyField";
-    final String valueField = "valueField";
-    UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
-        registerTypes(new ObjectMapper()),
-        keyField,
-        null
-    );
-    Assert.assertEquals(
-        ImmutableMap.of("B", "C"),
-        parser.getParser()
+    assertThrows(IllegalArgumentException.class, () -> {
+      final String keyField = "keyField";
+      final String valueField = "valueField";
+      UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
+          registerTypes(new ObjectMapper()),
+          keyField,
+          null
+      );
+      Assertions.assertEquals(
+          ImmutableMap.of("B", "C"),
+          parser.getParser()
               .parseToMap(
                   StringUtils.format(
                       "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
@@ -298,22 +313,24 @@ public class UriExtractionNamespaceTest
                       valueField
                   )
               )
-    );
+      );
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testJSONFlatDataParserBad4()
   {
-    final String keyField = "keyField";
-    final String valueField = "valueField";
-    UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
-        registerTypes(new ObjectMapper()),
-        "",
-        ""
-    );
-    Assert.assertEquals(
-        ImmutableMap.of("B", "C"),
-        parser.getParser()
+    assertThrows(IllegalArgumentException.class, () -> {
+      final String keyField = "keyField";
+      final String valueField = "valueField";
+      UriExtractionNamespace.JSONFlatDataParser parser = new UriExtractionNamespace.JSONFlatDataParser(
+          registerTypes(new ObjectMapper()),
+          "",
+          ""
+      );
+      Assertions.assertEquals(
+          ImmutableMap.of("B", "C"),
+          parser.getParser()
               .parseToMap(
                   StringUtils.format(
                       "{\"%sDFSDFDS\":\"B\", \"%s\":\"C\", \"FOO\":\"BAR\"}",
@@ -321,7 +338,8 @@ public class UriExtractionNamespaceTest
                       valueField
                   )
               )
-    );
+      );
+    });
   }
 
   @Test
@@ -330,7 +348,7 @@ public class UriExtractionNamespaceTest
     UriExtractionNamespace.ObjectMapperFlatDataParser parser = new UriExtractionNamespace.ObjectMapperFlatDataParser(
         registerTypes(new ObjectMapper())
     );
-    Assert.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("{\"B\":\"C\"}"));
+    Assertions.assertEquals(ImmutableMap.of("B", "C"), parser.getParser().parseToMap("{\"B\":\"C\"}"));
   }
 
   @Test
@@ -354,7 +372,7 @@ public class UriExtractionNamespaceTest
           str,
           UriExtractionNamespace.FlatDataParser.class
       );
-      Assert.assertEquals(str, mapper.writeValueAsString(parser2));
+      Assertions.assertEquals(str, mapper.writeValueAsString(parser2));
     }
   }
 
@@ -374,7 +392,7 @@ public class UriExtractionNamespaceTest
         new UriExtractionNamespace.JSONFlatDataParser(mapper, "keyField", "valueField"),
         new UriExtractionNamespace.TSVFlatDataParser(ImmutableList.of("A", "B"), ",", null, "A", "B")
     )) {
-      Assert.assertFalse(parser.toString().contains("@"));
+      Assertions.assertFalse(parser.toString().contains("@"));
     }
   }
 
@@ -387,13 +405,13 @@ public class UriExtractionNamespaceTest
         UriExtractionNamespace.class
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         UriExtractionNamespace.ObjectMapperFlatDataParser.class.getName(),
         namespace.getNamespaceParseSpec().getClass().getName()
     );
-    Assert.assertEquals("file:/foo", namespace.getUriPrefix().toString());
-    Assert.assertEquals("a.b.c", namespace.getFileRegex());
-    Assert.assertEquals(5L * 60_000L, namespace.getPollMs());
+    Assertions.assertEquals("file:/foo", namespace.getUriPrefix().toString());
+    Assertions.assertEquals("a.b.c", namespace.getFileRegex());
+    Assertions.assertEquals(5L * 60_000L, namespace.getPollMs());
   }
 
   @Test
@@ -405,22 +423,24 @@ public class UriExtractionNamespaceTest
         UriExtractionNamespace.class
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         UriExtractionNamespace.ObjectMapperFlatDataParser.class.getName(),
         namespace.getNamespaceParseSpec().getClass().getName()
     );
-    Assert.assertEquals("file:/foo", namespace.getUri().toString());
-    Assert.assertEquals(5L * 60_000L, namespace.getPollMs());
+    Assertions.assertEquals("file:/foo", namespace.getUri().toString());
+    Assertions.assertEquals(5L * 60_000L, namespace.getPollMs());
   }
 
-  @Test(expected = JsonMappingException.class)
-  public void testExplicitJsonException() throws IOException
+  @Test
+  public void testExplicitJsonException()
   {
-    final ObjectMapper mapper = registerTypes(new DefaultObjectMapper());
-    mapper.readValue(
-        "{\"type\":\"uri\", \"uri\":\"file:/foo\", \"namespaceParseSpec\":{\"format\":\"simpleJson\"}, \"pollPeriod\":\"PT5M\", \"versionRegex\":\"a.b.c\", \"namespace\":\"testNamespace\"}",
-        UriExtractionNamespace.class
-    );
+    assertThrows(JsonMappingException.class, () -> {
+      final ObjectMapper mapper = registerTypes(new DefaultObjectMapper());
+      mapper.readValue(
+          "{\"type\":\"uri\", \"uri\":\"file:/foo\", \"namespaceParseSpec\":{\"format\":\"simpleJson\"}, \"pollPeriod\":\"PT5M\", \"versionRegex\":\"a.b.c\", \"namespace\":\"testNamespace\"}",
+          UriExtractionNamespace.class
+      );
+    });
   }
 
   @Test
@@ -435,8 +455,7 @@ public class UriExtractionNamespaceTest
         keyField,
         valueField
     );
-    Assert.assertEquals(
-        "num string value",
+    Assertions.assertEquals(
         ImmutableMap.of("B", nString),
         parser.getParser()
               .parseToMap(
@@ -446,10 +465,10 @@ public class UriExtractionNamespaceTest
                       valueField,
                       n
                   )
-              )
+              ),
+        "num string value"
     );
-    Assert.assertEquals(
-        "num string key",
+    Assertions.assertEquals(
         ImmutableMap.of(nString, "C"),
         parser.getParser()
               .parseToMap(
@@ -459,10 +478,10 @@ public class UriExtractionNamespaceTest
                       n,
                       valueField
                   )
-              )
+              ),
+        "num string key"
     );
-    Assert.assertEquals(
-        "num value",
+    Assertions.assertEquals(
         ImmutableMap.of("B", nString),
         parser.getParser()
               .parseToMap(
@@ -472,10 +491,10 @@ public class UriExtractionNamespaceTest
                       valueField,
                       n
                   )
-              )
+              ),
+        "num value"
     );
-    Assert.assertEquals(
-        "num key",
+    Assertions.assertEquals(
         ImmutableMap.of(nString, "C"),
         parser.getParser()
               .parseToMap(
@@ -485,7 +504,8 @@ public class UriExtractionNamespaceTest
                       n,
                       valueField
                   )
-              )
+              ),
+        "num key"
     );
   }
 
@@ -497,7 +517,7 @@ public class UriExtractionNamespaceTest
     );
     final int n = 341879;
     final String nString = StringUtils.format("%d", n);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of("key", nString),
         parser.getParser().parseToMap(StringUtils.format("{\"key\":%d}", n))
     );

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
@@ -81,9 +81,9 @@ public class JdbcCacheGeneratorTest
   @Test
   public void indicatesMissingJdbcJarsWithTsColumn()
   {
-    Throwable exception = assertThrows(IllegalStateException.class, () -> {
-      String tsColumn = "tsColumn";
-      JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
+    final Throwable exception = assertThrows(IllegalStateException.class, () -> {
+      final String tsColumn = "tsColumn";
+      final JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
           MISSING_METADATA_STORAGE_CONNECTOR_CONFIG,
           tsColumn
       );
@@ -96,10 +96,10 @@ public class JdbcCacheGeneratorTest
   @Test
   public void indicatesMissingJdbcJarsWithoutTsColumn()
   {
-    Throwable exception = assertThrows(IllegalStateException.class, () -> {
-      String missingTsColumn = null;
+    final Throwable exception = assertThrows(IllegalStateException.class, () -> {
+      final String missingTsColumn = null;
       @SuppressWarnings("ConstantConditions")  // for missingTsColumn
-      JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
+      final JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
           MISSING_METADATA_STORAGE_CONNECTOR_CONFIG,
           missingTsColumn
       );

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/JdbcCacheGeneratorTest.java
@@ -32,15 +32,16 @@ import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.utils.JvmUtils;
 import org.easymock.EasyMock;
 import org.joda.time.Period;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JdbcCacheGeneratorTest
 {
@@ -71,10 +72,7 @@ public class JdbcCacheGeneratorTest
 
   private JdbcCacheGenerator target;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new JdbcCacheGenerator(JvmUtils.getRuntimeInfo());
@@ -83,32 +81,32 @@ public class JdbcCacheGeneratorTest
   @Test
   public void indicatesMissingJdbcJarsWithTsColumn()
   {
-    String tsColumn = "tsColumn";
-    JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
-        MISSING_METADATA_STORAGE_CONNECTOR_CONFIG,
-        tsColumn
-    );
+    Throwable exception = assertThrows(IllegalStateException.class, () -> {
+      String tsColumn = "tsColumn";
+      JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
+          MISSING_METADATA_STORAGE_CONNECTOR_CONFIG,
+          tsColumn
+      );
 
-    exception.expect(IllegalStateException.class);
-    exception.expectMessage(MISSING_JDB_DRIVER_JAR_MSG);
-
-    target.generateCache(missingJarNamespace, KEY, LAST_VERSION, CACHE_MANAGER.allocateCache());
+      target.generateCache(missingJarNamespace, KEY, LAST_VERSION, CACHE_MANAGER.allocateCache());
+    });
+    assertTrue(exception.getMessage().contains(MISSING_JDB_DRIVER_JAR_MSG));
   }
 
   @Test
   public void indicatesMissingJdbcJarsWithoutTsColumn()
   {
-    String missingTsColumn = null;
-    @SuppressWarnings("ConstantConditions")  // for missingTsColumn
-        JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
-        MISSING_METADATA_STORAGE_CONNECTOR_CONFIG,
-        missingTsColumn
-    );
+    Throwable exception = assertThrows(IllegalStateException.class, () -> {
+      String missingTsColumn = null;
+      @SuppressWarnings("ConstantConditions")  // for missingTsColumn
+      JdbcExtractionNamespace missingJarNamespace = createJdbcExtractionNamespace(
+          MISSING_METADATA_STORAGE_CONNECTOR_CONFIG,
+          missingTsColumn
+      );
 
-    exception.expect(IllegalStateException.class);
-    exception.expectMessage(MISSING_JDB_DRIVER_JAR_MSG);
-
-    target.generateCache(missingJarNamespace, KEY, LAST_VERSION, CACHE_MANAGER.allocateCache());
+      target.generateCache(missingJarNamespace, KEY, LAST_VERSION, CACHE_MANAGER.allocateCache());
+    });
+    assertTrue(exception.getMessage().contains(MISSING_JDB_DRIVER_JAR_MSG));
   }
 
   @SuppressWarnings("SameParameterValue")

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/NamespacedExtractorModuleTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/NamespacedExtractorModuleTest.java
@@ -37,12 +37,11 @@ import org.apache.druid.server.lookup.namespace.cache.OnHeapNamespaceExtractionC
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.utils.JvmUtils;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.Writer;
@@ -58,11 +57,11 @@ public class NamespacedExtractorModuleTest
   private CacheScheduler scheduler;
   private Lifecycle lifecycle;
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
   private NamespaceExtractionCacheManager cacheManager;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     final Map<Class<? extends ExtractionNamespace>, CacheGenerator<?>> factoryMap =
@@ -92,7 +91,7 @@ public class NamespacedExtractorModuleTest
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     lifecycle.stop();
@@ -101,7 +100,7 @@ public class NamespacedExtractorModuleTest
   @Test
   public void testNewTask() throws Exception
   {
-    final File tmpFile = temporaryFolder.newFile();
+    final File tmpFile = File.createTempFile("junit", null, temporaryFolder);
     try (Writer out = Files.newWriter(tmpFile, StandardCharsets.UTF_8)) {
       out.write(MAPPER.writeValueAsString(ImmutableMap.of("foo", "bar")));
     }
@@ -121,16 +120,16 @@ public class NamespacedExtractorModuleTest
     );
     CacheHandler cache = cacheManager.allocateCache();
     String version = factory.generateCache(namespace, null, null, cache);
-    Assert.assertNotNull(version);
+    Assertions.assertNotNull(version);
     Map<String, String> map = cache.getCache();
-    Assert.assertEquals("bar", map.get("foo"));
-    Assert.assertNull(map.get("baz"));
+    Assertions.assertEquals("bar", map.get("foo"));
+    Assertions.assertNull(map.get("baz"));
   }
 
   @Test
   public void testListNamespaces() throws Exception
   {
-    final File tmpFile = temporaryFolder.newFile();
+    final File tmpFile = File.createTempFile("junit", null, temporaryFolder);
     try (Writer out = Files.newWriter(tmpFile, StandardCharsets.UTF_8)) {
       out.write(MAPPER.writeValueAsString(ImmutableMap.of("foo", "bar")));
     }
@@ -143,16 +142,16 @@ public class NamespacedExtractorModuleTest
         null
     );
     try (CacheScheduler.Entry entry = scheduler.scheduleAndWait(namespace, 1_000)) {
-      Assert.assertNotNull(entry);
+      Assertions.assertNotNull(entry);
       entry.awaitTotalUpdates(1);
-      Assert.assertEquals(1, scheduler.getActiveEntries());
+      Assertions.assertEquals(1, scheduler.getActiveEntries());
     }
   }
 
   @Test//(timeout = 60_000L)
   public void testDeleteNamespaces() throws Exception
   {
-    final File tmpFile = temporaryFolder.newFile();
+    final File tmpFile = File.createTempFile("junit", null, temporaryFolder);
     try (Writer out = Files.newWriter(tmpFile, StandardCharsets.UTF_8)) {
       out.write(MAPPER.writeValueAsString(ImmutableMap.of("foo", "bar")));
     }
@@ -167,14 +166,14 @@ public class NamespacedExtractorModuleTest
         null
     );
     try (CacheScheduler.Entry entry = scheduler.scheduleAndWait(namespace, 1_000)) {
-      Assert.assertNotNull(entry);
+      Assertions.assertNotNull(entry);
     }
   }
 
   @Test
   public void testNewUpdate() throws Exception
   {
-    final File tmpFile = temporaryFolder.newFile();
+    final File tmpFile = File.createTempFile("junit", null, temporaryFolder);
     try (Writer out = Files.newWriter(tmpFile, StandardCharsets.UTF_8)) {
       out.write(MAPPER.writeValueAsString(ImmutableMap.of("foo", "bar")));
     }
@@ -188,11 +187,11 @@ public class NamespacedExtractorModuleTest
         null,
         null
     );
-    Assert.assertEquals(0, scheduler.getActiveEntries());
+    Assertions.assertEquals(0, scheduler.getActiveEntries());
     try (CacheScheduler.Entry entry = scheduler.scheduleAndWait(namespace, 10_000)) {
-      Assert.assertNotNull(entry);
+      Assertions.assertNotNull(entry);
       entry.awaitTotalUpdates(1);
-      Assert.assertEquals(1, scheduler.getActiveEntries());
+      Assertions.assertEquals(1, scheduler.getActiveEntries());
     }
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/StaticMapCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/StaticMapCacheGeneratorTest.java
@@ -27,13 +27,15 @@ import org.apache.druid.server.lookup.namespace.cache.CacheScheduler;
 import org.apache.druid.server.lookup.namespace.cache.NamespaceExtractionCacheManager;
 import org.apache.druid.server.lookup.namespace.cache.OnHeapNamespaceExtractionCacheManager;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class StaticMapCacheGeneratorTest
 {
@@ -43,7 +45,7 @@ public class StaticMapCacheGeneratorTest
   private CacheScheduler scheduler;
   private NamespaceExtractionCacheManager cacheManager;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     lifecycle = new Lifecycle();
@@ -61,7 +63,7 @@ public class StaticMapCacheGeneratorTest
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     lifecycle.stop();
@@ -74,18 +76,20 @@ public class StaticMapCacheGeneratorTest
     final StaticMapExtractionNamespace namespace = new StaticMapExtractionNamespace(MAP);
     CacheHandler cache = cacheManager.allocateCache();
     final String version = factory.generateCache(namespace, null, null, cache);
-    Assert.assertNotNull(version);
-    Assert.assertEquals(factory.getVersion(), version);
-    Assert.assertEquals(MAP, cache.getCache());
+    Assertions.assertNotNull(version);
+    Assertions.assertEquals(factory.getVersion(), version);
+    Assertions.assertEquals(MAP, cache.getCache());
 
   }
 
-  @Test(expected = AssertionError.class)
+  @Test
   public void testNonNullLastVersionCausesAssertionError()
   {
-    final StaticMapCacheGenerator factory = new StaticMapCacheGenerator();
-    final StaticMapExtractionNamespace namespace = new StaticMapExtractionNamespace(MAP);
-    CacheHandler cache = cacheManager.allocateCache();
-    factory.generateCache(namespace, null, factory.getVersion(), cache);
+    assertThrows(AssertionError.class, () -> {
+      final StaticMapCacheGenerator factory = new StaticMapCacheGenerator();
+      final StaticMapExtractionNamespace namespace = new StaticMapExtractionNamespace(MAP);
+      CacheHandler cache = cacheManager.allocateCache();
+      factory.generateCache(namespace, null, factory.getVersion(), cache);
+    });
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.SearchableVersionedDataFinder;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.query.lookup.namespace.UriExtractionNamespace;
@@ -301,7 +301,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void simpleTest(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
+  public void simpleTest(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     Assertions.assertEquals(0, scheduler.getActiveEntries());
@@ -314,7 +314,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void simpleTestRegex(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
+  public void simpleTestRegex(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     final UriExtractionNamespace namespace = new UriExtractionNamespace(
@@ -336,7 +336,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void simplePileONamespacesTest(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
+  public void simplePileONamespacesTest(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     final int size = 128;
@@ -369,7 +369,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testLoadOnlyOnce(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
+  public void testLoadOnlyOnce(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     Assertions.assertEquals(0, scheduler.getActiveEntries());
@@ -388,7 +388,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testMissing(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
+  public void testMissing(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     assertThrows(FileNotFoundException.class, () -> {
@@ -407,7 +407,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testMissingRegex(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
+  public void testMissingRegex(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     assertThrows(FileNotFoundException.class, () -> {
@@ -427,7 +427,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testExceptionalCreationDoubleURI(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
+  public void testExceptionalCreationDoubleURI(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     assertThrows(IAE.class, () -> {
@@ -445,7 +445,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testExceptionalCreationURIWithPattern(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
+  public void testExceptionalCreationURIWithPattern(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     assertThrows(IAE.class, () -> {
@@ -463,7 +463,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testExceptionalCreationURIWithLegacyPattern(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
+  public void testExceptionalCreationURIWithLegacyPattern(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     assertThrows(IAE.class, () -> {
@@ -481,7 +481,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testLegacyMix(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
+  public void testLegacyMix(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     assertThrows(IAE.class, () -> {
@@ -499,7 +499,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testBadPattern(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
+  public void testBadPattern(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     assertThrows(IAE.class, () -> {
@@ -517,7 +517,7 @@ public class UriCacheGeneratorTest
 
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
-  public void testWeirdSchemaOnExactURI(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
+  public void testWeirdSchemaOnExactURI(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     final UriExtractionNamespace extractionNamespace = new UriExtractionNamespace(
@@ -543,7 +543,7 @@ public class UriCacheGeneratorTest
   @MethodSource("getParameters")
   @ParameterizedTest(name = "{0}")
   @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
-  public void testDeleteOnScheduleFail(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
+  public void testDeleteOnScheduleFail(String suffix, Function<File, OutputStream> outStreamSupplier, Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
   {
     initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     Assertions.assertNull(scheduler.scheduleAndWait(
@@ -565,7 +565,8 @@ public class UriCacheGeneratorTest
     Assertions.assertEquals(0, scheduler.getActiveEntries());
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.SearchableVersionedDataFinder;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.query.lookup.namespace.UriExtractionNamespace;
@@ -567,9 +568,7 @@ public class UriCacheGeneratorTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
@@ -565,11 +565,8 @@ public class UriCacheGeneratorTest
     Assertions.assertEquals(0, scheduler.getActiveEntries());
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/UriCacheGeneratorTest.java
@@ -40,14 +40,13 @@ import org.apache.druid.server.lookup.namespace.cache.OnHeapNamespaceExtractionC
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.utils.JvmUtils;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -67,13 +66,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class UriCacheGeneratorTest
 {
   private static final String FAKE_SCHEME = "wabblywoo";
@@ -117,7 +118,6 @@ public class UriCacheGeneratorTest
       }
   );
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> getParameters()
   {
     final List<Object[]> compressionParams = ImmutableList.of(
@@ -217,20 +217,20 @@ public class UriCacheGeneratorTest
     };
   }
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
-  private final String suffix;
+  private String suffix;
 
-  private final Function<File, OutputStream> outStreamSupplier;
-  private final Lifecycle lifecycle;
-  private final NamespaceExtractionCacheManager cacheManager;
-  private final CacheScheduler scheduler;
+  private Function<File, OutputStream> outStreamSupplier;
+  private Lifecycle lifecycle;
+  private NamespaceExtractionCacheManager cacheManager;
+  private CacheScheduler scheduler;
   private File tmpFile;
   private UriCacheGenerator generator;
   private UriExtractionNamespace namespace;
 
-  public UriCacheGeneratorTest(
+  public void initUriCacheGeneratorTest(
       String suffix,
       Function<File, OutputStream> outStreamSupplier,
       Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator
@@ -238,22 +238,32 @@ public class UriCacheGeneratorTest
   {
     this.suffix = suffix;
     this.outStreamSupplier = outStreamSupplier;
-    this.lifecycle = new Lifecycle();
     this.cacheManager = cacheManagerCreator.apply(lifecycle);
     this.scheduler = new CacheScheduler(
         new NoopServiceEmitter(),
         ImmutableMap.of(UriExtractionNamespace.class, new UriCacheGenerator(FINDERS, JvmUtils.getRuntimeInfo())),
         cacheManager
     );
+    try {
+      initializeUriCacheGeneratorTest();
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
+    lifecycle = new Lifecycle();
     lifecycle.start();
-    File tmpFileParent = new File(temporaryFolder.newFolder(), "☃");
-    Assert.assertTrue(tmpFileParent.mkdir());
-    Assert.assertTrue(tmpFileParent.isDirectory());
+  }
+
+  private void initializeUriCacheGeneratorTest() throws Exception
+  {
+    File tmpFileParent = new File(newFolder(temporaryFolder, "junit"), "☃");
+    Assertions.assertTrue(tmpFileParent.mkdir());
+    Assertions.assertTrue(tmpFileParent.isDirectory());
     tmpFile = Files.createTempFile(tmpFileParent.toPath(), "druidTestURIExtractionNS", suffix).toFile();
     final ObjectMapper mapper = new DefaultObjectMapper();
     try (OutputStream ostream = outStreamSupplier.apply(tmpFile);
@@ -282,26 +292,30 @@ public class UriCacheGeneratorTest
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     lifecycle.stop();
   }
 
-  @Test
-  public void simpleTest() throws InterruptedException
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void simpleTest(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
   {
-    Assert.assertEquals(0, scheduler.getActiveEntries());
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    Assertions.assertEquals(0, scheduler.getActiveEntries());
     CacheScheduler.Entry entry = scheduler.schedule(namespace);
     CacheSchedulerTest.waitFor(entry);
     Map<String, String> map = entry.getCache();
-    Assert.assertEquals("bar", map.get("foo"));
-    Assert.assertEquals(null, map.get("baz"));
+    Assertions.assertEquals("bar", map.get("foo"));
+    Assertions.assertEquals(null, map.get("baz"));
   }
 
-  @Test
-  public void simpleTestRegex() throws InterruptedException
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void simpleTestRegex(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
   {
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     final UriExtractionNamespace namespace = new UriExtractionNamespace(
         null,
         Paths.get(this.namespace.getUri()).getParent().toUri(),
@@ -314,14 +328,16 @@ public class UriCacheGeneratorTest
     CacheScheduler.Entry entry = scheduler.schedule(namespace);
     CacheSchedulerTest.waitFor(entry);
     Map<String, String> map = entry.getCache();
-    Assert.assertNotNull(map);
-    Assert.assertEquals("bar", map.get("foo"));
-    Assert.assertEquals(null, map.get("baz"));
+    Assertions.assertNotNull(map);
+    Assertions.assertEquals("bar", map.get("foo"));
+    Assertions.assertEquals(null, map.get("baz"));
   }
 
-  @Test
-  public void simplePileONamespacesTest() throws InterruptedException
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void simplePileONamespacesTest(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws InterruptedException
   {
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     final int size = 128;
     List<CacheScheduler.Entry> entries = new ArrayList<>(size);
     for (int i = 0; i < size; ++i) {
@@ -343,134 +359,166 @@ public class UriCacheGeneratorTest
 
     for (CacheScheduler.Entry entry : entries) {
       final Map<String, String> map = entry.getCache();
-      Assert.assertEquals("bar", map.get("foo"));
-      Assert.assertEquals(null, map.get("baz"));
+      Assertions.assertEquals("bar", map.get("foo"));
+      Assertions.assertEquals(null, map.get("baz"));
       entry.close();
     }
-    Assert.assertEquals(0, scheduler.getActiveEntries());
+    Assertions.assertEquals(0, scheduler.getActiveEntries());
   }
 
-  @Test
-  public void testLoadOnlyOnce() throws Exception
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testLoadOnlyOnce(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
   {
-    Assert.assertEquals(0, scheduler.getActiveEntries());
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    Assertions.assertEquals(0, scheduler.getActiveEntries());
 
     CacheHandler cache = cacheManager.allocateCache();
     String newVersion = generator.generateCache(namespace, null, null, cache);
-    Assert.assertNotNull(newVersion);
+    Assertions.assertNotNull(newVersion);
     Map<String, String> map = cache.getCache();
-    Assert.assertEquals("bar", map.get("foo"));
-    Assert.assertEquals(null, map.get("baz"));
+    Assertions.assertEquals("bar", map.get("foo"));
+    Assertions.assertEquals(null, map.get("baz"));
     String version = newVersion;
-    Assert.assertNotNull(version);
+    Assertions.assertNotNull(version);
 
-    Assert.assertNull(generator.generateCache(namespace, null, version, cacheManager.allocateCache()));
+    Assertions.assertNull(generator.generateCache(namespace, null, version, cacheManager.allocateCache()));
   }
 
-  @Test(expected = FileNotFoundException.class)
-  public void testMissing() throws Exception
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testMissing(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
-    UriExtractionNamespace badNamespace = new UriExtractionNamespace(
-        namespace.getUri(),
-        null, null,
-        namespace.getNamespaceParseSpec(),
-        Period.millis((int) namespace.getPollMs()),
-        null,
-        null
-    );
-    Assert.assertTrue(new File(namespace.getUri()).delete());
-    generator.generateCache(badNamespace, null, null, cacheManager.allocateCache());
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    assertThrows(FileNotFoundException.class, () -> {
+      UriExtractionNamespace badNamespace = new UriExtractionNamespace(
+          namespace.getUri(),
+          null, null,
+          namespace.getNamespaceParseSpec(),
+          Period.millis((int) namespace.getPollMs()),
+          null,
+          null
+      );
+      Assertions.assertTrue(new File(namespace.getUri()).delete());
+      generator.generateCache(badNamespace, null, null, cacheManager.allocateCache());
+    });
   }
 
-  @Test(expected = FileNotFoundException.class)
-  public void testMissingRegex() throws Exception
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testMissingRegex(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
-    UriExtractionNamespace badNamespace = new UriExtractionNamespace(
-        null,
-        Paths.get(namespace.getUri()).getParent().toUri(),
-        Pattern.quote(Paths.get(namespace.getUri()).getFileName().toString()),
-        namespace.getNamespaceParseSpec(),
-        Period.millis((int) namespace.getPollMs()),
-        null,
-        null
-    );
-    Assert.assertTrue(new File(namespace.getUri()).delete());
-    generator.generateCache(badNamespace, null, null, cacheManager.allocateCache());
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    assertThrows(FileNotFoundException.class, () -> {
+      UriExtractionNamespace badNamespace = new UriExtractionNamespace(
+          null,
+          Paths.get(namespace.getUri()).getParent().toUri(),
+          Pattern.quote(Paths.get(namespace.getUri()).getFileName().toString()),
+          namespace.getNamespaceParseSpec(),
+          Period.millis((int) namespace.getPollMs()),
+          null,
+          null
+      );
+      Assertions.assertTrue(new File(namespace.getUri()).delete());
+      generator.generateCache(badNamespace, null, null, cacheManager.allocateCache());
+    });
   }
 
-  @Test(expected = IAE.class)
-  public void testExceptionalCreationDoubleURI()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testExceptionalCreationDoubleURI(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
-    new UriExtractionNamespace(
-        namespace.getUri(),
-        namespace.getUri(),
-        null,
-        namespace.getNamespaceParseSpec(),
-        Period.millis((int) namespace.getPollMs()),
-        null,
-        null
-    );
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    assertThrows(IAE.class, () -> {
+      new UriExtractionNamespace(
+          namespace.getUri(),
+          namespace.getUri(),
+          null,
+          namespace.getNamespaceParseSpec(),
+          Period.millis((int) namespace.getPollMs()),
+          null,
+          null
+      );
+    });
   }
 
-  @Test(expected = IAE.class)
-  public void testExceptionalCreationURIWithPattern()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testExceptionalCreationURIWithPattern(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
-    new UriExtractionNamespace(
-        namespace.getUri(),
-        null,
-        "",
-        namespace.getNamespaceParseSpec(),
-        Period.millis((int) namespace.getPollMs()),
-        null,
-        null
-    );
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    assertThrows(IAE.class, () -> {
+      new UriExtractionNamespace(
+          namespace.getUri(),
+          null,
+          "",
+          namespace.getNamespaceParseSpec(),
+          Period.millis((int) namespace.getPollMs()),
+          null,
+          null
+      );
+    });
   }
 
-  @Test(expected = IAE.class)
-  public void testExceptionalCreationURIWithLegacyPattern()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testExceptionalCreationURIWithLegacyPattern(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
-    new UriExtractionNamespace(
-        namespace.getUri(),
-        null,
-        null,
-        namespace.getNamespaceParseSpec(),
-        Period.millis((int) namespace.getPollMs()),
-        "",
-        null
-    );
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    assertThrows(IAE.class, () -> {
+      new UriExtractionNamespace(
+          namespace.getUri(),
+          null,
+          null,
+          namespace.getNamespaceParseSpec(),
+          Period.millis((int) namespace.getPollMs()),
+          "",
+          null
+      );
+    });
   }
 
-  @Test(expected = IAE.class)
-  public void testLegacyMix()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testLegacyMix(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
-    new UriExtractionNamespace(
-        null,
-        namespace.getUri(),
-        "",
-        namespace.getNamespaceParseSpec(),
-        Period.millis((int) namespace.getPollMs()),
-        "",
-        null
-    );
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    assertThrows(IAE.class, () -> {
+      new UriExtractionNamespace(
+          null,
+          namespace.getUri(),
+          "",
+          namespace.getNamespaceParseSpec(),
+          Period.millis((int) namespace.getPollMs()),
+          "",
+          null
+      );
+    });
   }
 
-  @Test(expected = IAE.class)
-  public void testBadPattern()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testBadPattern(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator)
   {
-    new UriExtractionNamespace(
-        null,
-        namespace.getUri(),
-        "[",
-        namespace.getNamespaceParseSpec(),
-        Period.millis((int) namespace.getPollMs()),
-        null,
-        null
-    );
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    assertThrows(IAE.class, () -> {
+      new UriExtractionNamespace(
+          null,
+          namespace.getUri(),
+          "[",
+          namespace.getNamespaceParseSpec(),
+          Period.millis((int) namespace.getPollMs()),
+          null,
+          null
+      );
+    });
   }
 
-  @Test
-  public void testWeirdSchemaOnExactURI() throws Exception
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testWeirdSchemaOnExactURI(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
   {
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
     final UriExtractionNamespace extractionNamespace = new UriExtractionNamespace(
         new URI(
             FAKE_SCHEME,
@@ -488,13 +536,16 @@ public class UriCacheGeneratorTest
         null,
         null
     );
-    Assert.assertNotNull(generator.generateCache(extractionNamespace, null, null, cacheManager.allocateCache()));
+    Assertions.assertNotNull(generator.generateCache(extractionNamespace, null, null, cacheManager.allocateCache()));
   }
 
-  @Test(timeout = 60_000L)
-  public void testDeleteOnScheduleFail() throws Exception
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testDeleteOnScheduleFail(String suffix,Function<File, OutputStream> outStreamSupplier,Function<Lifecycle, NamespaceExtractionCacheManager> cacheManagerCreator) throws Exception
   {
-    Assert.assertNull(scheduler.scheduleAndWait(
+    initUriCacheGeneratorTest(suffix, outStreamSupplier, cacheManagerCreator);
+    Assertions.assertNull(scheduler.scheduleAndWait(
         new UriExtractionNamespace(
             new URI("file://tmp/I_DONT_REALLY_EXIST" + UUID.randomUUID()),
             null,
@@ -510,6 +561,15 @@ public class UriCacheGeneratorTest
         ),
         500
     ));
-    Assert.assertEquals(0, scheduler.getActiveEntries());
+    Assertions.assertEquals(0, scheduler.getActiveEntries());
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
@@ -547,9 +548,7 @@ public class CacheSchedulerTest
   private static File newFolder(File root, String... subDirs) throws IOException {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
@@ -52,7 +52,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -545,11 +544,8 @@ public class CacheSchedulerTest
     Assertions.assertEquals(pre, scheduler.updatesStarted());
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
-    String subFolder = String.join("/", subDirs);
-    File result = new File(root, subFolder);
-    FileUtils.mkdirp(result);
-    return result;
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs));
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
@@ -40,18 +40,18 @@ import org.apache.druid.server.lookup.namespace.NamespaceExtractionConfig;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.utils.JvmUtils;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -71,7 +71,6 @@ import java.util.concurrent.TimeoutException;
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class CacheSchedulerTest
 {
   public static final Function<Lifecycle, NamespaceExtractionCacheManager> CREATE_ON_HEAP_CACHE_MANAGER =
@@ -103,7 +102,6 @@ public class CacheSchedulerTest
         }
       };
 
-  @Parameterized.Parameters
   public static Collection<Object[]> data()
   {
     return Arrays.asList(new Object[][]{{CREATE_ON_HEAP_CACHE_MANAGER}});
@@ -118,28 +116,26 @@ public class CacheSchedulerTest
   private static final String KEY = "foo";
   private static final String VALUE = "bar";
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-  private final Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager;
+  @TempDir
+  public File temporaryFolder;
+  private Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager;
   private Lifecycle lifecycle;
   private NamespaceExtractionCacheManager cacheManager;
   private CacheScheduler scheduler;
   private File tmpFile;
 
-  public CacheSchedulerTest(
+  public void initCacheSchedulerTest(
       Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager
-  )
+  ) throws Exception
   {
     this.createCacheManager = createCacheManager;
+    initializeCacheScheduler();
   }
 
-  @Before
-  public void setUp() throws Exception
+  private void initializeCacheScheduler() throws Exception
   {
-    lifecycle = new Lifecycle();
-    lifecycle.start();
     cacheManager = createCacheManager.apply(lifecycle);
-    final Path tmpDir = temporaryFolder.newFolder().toPath();
+    final Path tmpDir = newFolder(temporaryFolder, "junit").toPath();
     final CacheGenerator<UriExtractionNamespace> cacheGenerator = (extractionNamespace, id, lastVersion, cache) -> {
       Thread.sleep(2); // To make absolutely sure there is a unique currentTimeMillis
       String version = Long.toString(System.currentTimeMillis());
@@ -168,15 +164,25 @@ public class CacheSchedulerTest
     }
   }
 
-  @After
+  @BeforeEach
+  public void setUp() throws Exception
+  {
+    lifecycle = new Lifecycle();
+    lifecycle.start();
+  }
+
+  @AfterEach
   public void tearDown()
   {
     lifecycle.stop();
   }
 
-  @Test(timeout = 60_000L)
-  public void testSimpleSubmission() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testSimpleSubmission(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     UriExtractionNamespace namespace = new UriExtractionNamespace(
         tmpFile.toURI(),
         null, null,
@@ -189,12 +195,15 @@ public class CacheSchedulerTest
     );
     CacheScheduler.Entry entry = scheduler.schedule(namespace);
     waitFor(entry);
-    Assert.assertEquals(VALUE, entry.getCache().get(KEY));
+    Assertions.assertEquals(VALUE, entry.getCache().get(KEY));
   }
 
-  @Test(timeout = 60_000L)
-  public void testInitialization() throws InterruptedException, TimeoutException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testInitialization(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     UriExtractionNamespace namespace = new UriExtractionNamespace(
         tmpFile.toURI(),
         null, null,
@@ -207,12 +216,15 @@ public class CacheSchedulerTest
     );
     CacheScheduler.Entry entry = scheduler.schedule(namespace);
     entry.awaitTotalUpdatesWithTimeout(1, 2000);
-    Assert.assertEquals(VALUE, entry.getCache().get(KEY));
+    Assertions.assertEquals(VALUE, entry.getCache().get(KEY));
   }
 
-  @Test(timeout = 60_000L)
-  public void testPeriodicUpdatesScheduled() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testPeriodicUpdatesScheduled(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     final int repeatCount = 5;
     final long delay = 5;
     try {
@@ -220,19 +232,19 @@ public class CacheSchedulerTest
       final long start = System.currentTimeMillis();
       try (CacheScheduler.Entry entry = scheduler.schedule(namespace)) {
 
-        Assert.assertFalse(entry.getUpdaterFuture().isDone());
-        Assert.assertFalse(entry.getUpdaterFuture().isCancelled());
+        Assertions.assertFalse(entry.getUpdaterFuture().isDone());
+        Assertions.assertFalse(entry.getUpdaterFuture().isCancelled());
 
         entry.awaitTotalUpdates(repeatCount);
 
         long minEnd = start + ((repeatCount - 1) * delay);
         long end = System.currentTimeMillis();
-        Assert.assertTrue(
-            StringUtils.format(
+        Assertions.assertTrue(
+            minEnd <= end, StringUtils.format(
                 "Didn't wait long enough between runs. Expected more than %d was %d",
                 minEnd - start,
                 end - start
-            ), minEnd <= end
+            )
         );
       }
     }
@@ -244,9 +256,12 @@ public class CacheSchedulerTest
   }
 
 
-  @Test(timeout = 60_000L) // This is very fast when run locally. Speed on Travis completely depends on noisy neighbors.
-  public void testConcurrentAddDelete() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS) // This is very fast when run locally. Speed on Travis completely depends on noisy neighbors.
+  public void testConcurrentAddDelete(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     final int threads = 10;
     final int deletesPerThread = 5;
     ListeningExecutorService executorService = MoreExecutors.listeningDecorator(
@@ -317,9 +332,12 @@ public class CacheSchedulerTest
     checkNoMoreRunning();
   }
 
-  @Test(timeout = 60_000L)
-  public void testSimpleDelete() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testSimpleDelete(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     testDelete();
   }
 
@@ -328,17 +346,17 @@ public class CacheSchedulerTest
     final long period = 1_000L; // Give it some time between attempts to update
     final UriExtractionNamespace namespace = getUriExtractionNamespace(period);
     CacheScheduler.Entry entry = scheduler.scheduleAndWait(namespace, 10_000);
-    Assert.assertNotNull(entry);
+    Assertions.assertNotNull(entry);
     final Future<?> future = entry.getUpdaterFuture();
-    Assert.assertFalse(future.isCancelled());
-    Assert.assertFalse(future.isDone());
+    Assertions.assertFalse(future.isCancelled());
+    Assertions.assertFalse(future.isDone());
     entry.awaitTotalUpdates(1);
 
-    Assert.assertEquals(VALUE, entry.getCache().get(KEY));
+    Assertions.assertEquals(VALUE, entry.getCache().get(KEY));
     entry.close();
 
     try {
-      Assert.assertNull(future.get());
+      Assertions.assertNull(future.get());
     }
     catch (CancellationException e) {
       // Ignore
@@ -349,8 +367,8 @@ public class CacheSchedulerTest
       }
     }
 
-    Assert.assertTrue(future.isCancelled());
-    Assert.assertTrue(future.isDone());
+    Assertions.assertTrue(future.isCancelled());
+    Assertions.assertTrue(future.isDone());
   }
 
   private UriExtractionNamespace getUriExtractionNamespace(long period)
@@ -367,10 +385,13 @@ public class CacheSchedulerTest
     );
   }
 
-  @Test(timeout = 60_000L)
-  public void testShutdown()
-      throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testShutdown(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager)
+      throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     final long period = 5L;
     try {
 
@@ -380,12 +401,12 @@ public class CacheSchedulerTest
         final Future<?> future = entry.getUpdaterFuture();
         entry.awaitNextUpdates(1);
 
-        Assert.assertFalse(future.isCancelled());
-        Assert.assertFalse(future.isDone());
+        Assertions.assertFalse(future.isCancelled());
+        Assertions.assertFalse(future.isDone());
 
         final long prior = scheduler.updatesStarted();
         entry.awaitNextUpdates(1);
-        Assert.assertTrue(scheduler.updatesStarted() > prior);
+        Assertions.assertTrue(scheduler.updatesStarted() > prior);
       }
     }
     finally {
@@ -397,20 +418,23 @@ public class CacheSchedulerTest
 
     checkNoMoreRunning();
 
-    Assert.assertTrue(cacheManager.scheduledExecutorService().isShutdown());
-    Assert.assertTrue(cacheManager.scheduledExecutorService().isTerminated());
+    Assertions.assertTrue(cacheManager.scheduledExecutorService().isShutdown());
+    Assertions.assertTrue(cacheManager.scheduledExecutorService().isTerminated());
   }
 
-  @Test(timeout = 60_000L)
-  public void testRunCount() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testRunCount(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     final int numWaits = 5;
     try {
       final UriExtractionNamespace namespace = getUriExtractionNamespace((long) 5);
       try (CacheScheduler.Entry entry = scheduler.schedule(namespace)) {
         final Future<?> future = entry.getUpdaterFuture();
         entry.awaitNextUpdates(numWaits);
-        Assert.assertFalse(future.isDone());
+        Assertions.assertFalse(future.isDone());
       }
     }
     finally {
@@ -419,7 +443,7 @@ public class CacheSchedulerTest
     while (!cacheManager.waitForServiceToEnd(1_000, TimeUnit.MILLISECONDS)) {
       // keep waiting
     }
-    Assert.assertTrue(scheduler.updatesStarted() >= numWaits);
+    Assertions.assertTrue(scheduler.updatesStarted() >= numWaits);
     checkNoMoreRunning();
   }
 
@@ -427,21 +451,27 @@ public class CacheSchedulerTest
    * Tests that even if entry.close() wasn't called, the scheduled task is cancelled when the entry becomes
    * unreachable.
    */
-  @Test(timeout = 60_000L)
-  public void testEntryCloseForgotten() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testEntryCloseForgotten(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     scheduleDanglingEntry();
-    Assert.assertEquals(1, scheduler.getActiveEntries());
+    Assertions.assertEquals(1, scheduler.getActiveEntries());
     while (scheduler.getActiveEntries() > 0) {
       System.gc();
       Thread.sleep(1000);
     }
-    Assert.assertEquals(0, scheduler.getActiveEntries());
+    Assertions.assertEquals(0, scheduler.getActiveEntries());
   }
 
-  @Test(timeout = 60_000L)
-  public void testSimpleSubmissionSuccessWithWait() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testSimpleSubmissionSuccessWithWait(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     UriExtractionNamespace namespace = new UriExtractionNamespace(
         tmpFile.toURI(),
         null, null,
@@ -454,13 +484,16 @@ public class CacheSchedulerTest
     );
     CacheScheduler.Entry entry = scheduler.scheduleAndWait(namespace, 10_000L);
     waitFor(entry);
-    Assert.assertEquals(VALUE, entry.getCache().get(KEY));
+    Assertions.assertEquals(VALUE, entry.getCache().get(KEY));
   }
 
 
-  @Test(timeout = 20_000L)
-  public void testSimpleSubmissionFailureWithWait() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 20_000L, unit = TimeUnit.MILLISECONDS)
+  public void testSimpleSubmissionFailureWithWait(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initCacheSchedulerTest(createCacheManager);
     JdbcExtractionNamespace namespace = new JdbcExtractionNamespace(
         new MetadataStorageConnectorConfig()
         {
@@ -505,9 +538,18 @@ public class CacheSchedulerTest
 
   private void checkNoMoreRunning() throws InterruptedException
   {
-    Assert.assertEquals(0, scheduler.getActiveEntries());
+    Assertions.assertEquals(0, scheduler.getActiveEntries());
     final long pre = scheduler.updatesStarted();
     Thread.sleep(100L);
-    Assert.assertEquals(pre, scheduler.updatesStarted());
+    Assertions.assertEquals(pre, scheduler.updatesStarted());
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    String subFolder = String.join("/", subDirs);
+    File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/CacheSchedulerTest.java
@@ -545,7 +545,8 @@ public class CacheSchedulerTest
     Assertions.assertEquals(pre, scheduler.updatesStarted());
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     String subFolder = String.join("/", subDirs);
     File result = new File(root, subFolder);
     FileUtils.mkdirp(result);

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
 import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.TestDerbyConnector;
 import org.apache.druid.query.lookup.namespace.CacheGenerator;
 import org.apache.druid.query.lookup.namespace.ExtractionNamespace;
@@ -42,17 +43,22 @@ import org.apache.druid.server.lookup.namespace.NamespaceExtractionConfig;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.utils.JvmUtils;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.exceptions.UnableToObtainConnectionException;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -66,11 +72,10 @@ import java.util.concurrent.locks.ReentrantLock;
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class JdbcExtractionNamespaceTest
 {
-  @Rule
-  public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule = new TestDerbyConnector.DerbyConnectorRule();
+  @RegisterExtension
+  public final DerbyConnectorExtension derbyConnectorRule = new DerbyConnectorExtension();
 
   private static final Logger log = new Logger(JdbcExtractionNamespaceTest.class);
   private static final String TABLE_NAME = "abstractDbRenameTest";
@@ -85,8 +90,51 @@ public class JdbcExtractionNamespaceTest
       "empty string", new String[]{"empty string", "0"}
   );
 
+  private static class DerbyConnectorExtension implements BeforeEachCallback, AfterEachCallback
+  {
+    private final TestDerbyConnector connector = new TestDerbyConnector();
 
-  @Parameterized.Parameters(name = "{0}")
+    @Override
+    public void beforeEach(ExtensionContext context)
+    {
+      connector.createDatabase();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context)
+    {
+      try {
+        new DBI(connector.getJdbcUri() + ";drop=true").open().close();
+      }
+      catch (UnableToObtainConnectionException e) {
+        final SQLException cause = (SQLException) e.getCause();
+        Assertions.assertEquals(
+            "08006",
+            cause.getSQLState(),
+            StringUtils.format("Derby not shutdown: [%s]", cause)
+        );
+      }
+    }
+
+    public TestDerbyConnector getConnector()
+    {
+      return connector;
+    }
+
+    public MetadataStorageConnectorConfig getMetadataConnectorConfig()
+    {
+      return new MetadataStorageConnectorConfig()
+      {
+        @Override
+        public String getConnectURI()
+        {
+          return connector.getJdbcUri();
+        }
+      };
+    }
+  }
+
+
   public static Collection<Object[]> getParameters()
   {
     return ImmutableList.of(
@@ -95,14 +143,21 @@ public class JdbcExtractionNamespaceTest
     );
   }
 
-  public JdbcExtractionNamespaceTest(
+  public void initJdbcExtractionNamespaceTest(
       String tsColumn
   )
   {
     this.tsColumn = tsColumn;
+    this.lifecycle = new Lifecycle();
+    try {
+      initializeJdbcExtractionNamespaceTest();
+    }
+    catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  private final String tsColumn;
+  private String tsColumn;
   private CacheScheduler scheduler;
   private Lifecycle lifecycle;
   private AtomicLong updates;
@@ -111,10 +166,8 @@ public class JdbcExtractionNamespaceTest
   private ListeningExecutorService setupTeardownService;
   private Handle handleRef = null;
 
-  @Before
-  public void setup() throws Exception
+  private void initializeJdbcExtractionNamespaceTest() throws Exception
   {
-    lifecycle = new Lifecycle();
     updates = new AtomicLong(0L);
     updateLock = new ReentrantLock(true);
     closer = Closer.create();
@@ -123,7 +176,7 @@ public class JdbcExtractionNamespaceTest
     final ListenableFuture<Handle> setupFuture = setupTeardownService.submit(
         () -> {
           final Handle handle = derbyConnectorRule.getConnector().getDBI().open();
-          Assert.assertEquals(
+          Assertions.assertEquals(
               0,
               handle.createStatement(
                   StringUtils.format(
@@ -159,7 +212,7 @@ public class JdbcExtractionNamespaceTest
             if (scheduler == null) {
               return;
             }
-            Assert.assertEquals(0, scheduler.getActiveEntries());
+            Assertions.assertEquals(0, scheduler.getActiveEntries());
           });
           for (Map.Entry<String, String[]> entry : RENAMES.entrySet()) {
             try {
@@ -238,10 +291,10 @@ public class JdbcExtractionNamespaceTest
     try (final Closeable ignore = () -> setupFuture.cancel(true)) {
       handleRef = setupFuture.get(10, TimeUnit.SECONDS);
     }
-    Assert.assertNotNull(handleRef);
+    Assertions.assertNotNull(handleRef);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws InterruptedException, ExecutionException, TimeoutException, IOException
   {
     final ListenableFuture<?> tearDownFuture = setupTeardownService.submit(
@@ -304,17 +357,20 @@ public class JdbcExtractionNamespaceTest
           updateTs, filter, key, val
       );
     }
-    Assert.assertEquals(1, handle.createStatement(query).setQueryTimeout(1).execute());
+    Assertions.assertEquals(1, handle.createStatement(query).setQueryTimeout(1).execute());
     handle.commit();
     // Some internals have timing resolution no better than MS. This is to help make sure that checks for timings
     // have elapsed at least to the next ms... 2 is for good measure.
     Thread.sleep(2);
   }
 
-  @Test(timeout = 60_000L)
-  public void testMappingWithoutFilter()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testMappingWithoutFilter(String tsColumn)
       throws InterruptedException
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
         TABLE_NAME,
@@ -336,20 +392,23 @@ public class JdbcExtractionNamespaceTest
         String key = e.getKey();
         String[] val = e.getValue();
         String field = val[0];
-        Assert.assertEquals(
-            "non-null check",
+        Assertions.assertEquals(
             field,
-            map.get(key)
+            map.get(key),
+            "non-null check"
         );
       }
-      Assert.assertEquals("null check", null, map.get("baz"));
+      Assertions.assertEquals(null, map.get("baz"), "null check");
     }
   }
 
-  @Test(timeout = 60_000L)
-  public void testMappingWithFilter()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testMappingWithFilter(String tsColumn)
       throws InterruptedException
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
         TABLE_NAME,
@@ -374,22 +433,25 @@ public class JdbcExtractionNamespaceTest
         String filterVal = val[1];
 
         if ("1".equals(filterVal)) {
-          Assert.assertEquals(
-              "non-null check",
+          Assertions.assertEquals(
               field,
-              map.get(key)
+              map.get(key),
+              "non-null check"
           );
         } else {
-          Assert.assertEquals("non-null check", null, map.get(key));
+          Assertions.assertEquals(null, map.get(key), "non-null check");
         }
       }
     }
   }
 
-  @Test(timeout = 60_000L)
-  public void testEmptyTable()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testEmptyTable(String tsColumn)
       throws InterruptedException
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     // Delete existing rows from table.
     final Handle handle = derbyConnectorRule.getConnector().getDBI().open();
     handle.createStatement(
@@ -412,14 +474,17 @@ public class JdbcExtractionNamespaceTest
     try (CacheScheduler.Entry entry = scheduler.schedule(extractionNamespace)) {
       CacheSchedulerTest.waitFor(entry);
       final Map<String, String> map = entry.getCache();
-      Assert.assertTrue(map.isEmpty());
+      Assertions.assertTrue(map.isEmpty());
     }
   }
 
-  @Test(timeout = 60_000L)
-  public void testSkipOld()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testSkipOld(String tsColumn)
       throws InterruptedException
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     try (final CacheScheduler.Entry entry = ensureEntry()) {
       assertUpdated(entry, "foo", "bar");
       if (tsColumn != null) {
@@ -429,9 +494,11 @@ public class JdbcExtractionNamespaceTest
     }
   }
 
-  @Test
-  public void testRandomJitter()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testRandomJitter(String tsColumn)
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
         TABLE_NAME,
@@ -447,12 +514,14 @@ public class JdbcExtractionNamespaceTest
     );
     long jitter = extractionNamespace.getJitterMills();
     // jitter will be a random value between 0 and 120 seconds.
-    Assert.assertTrue(jitter >= 0 && jitter <= 120000);
+    Assertions.assertTrue(jitter >= 0 && jitter <= 120000);
   }
 
-  @Test
-  public void testRandomJitterNotSpecified()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testRandomJitterNotSpecified(String tsColumn)
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
         TABLE_NAME,
@@ -467,13 +536,16 @@ public class JdbcExtractionNamespaceTest
         new JdbcAccessSecurityConfig()
     );
     // jitter will be a random value between 0 and 120 seconds.
-    Assert.assertEquals(0, extractionNamespace.getJitterMills());
+    Assertions.assertEquals(0, extractionNamespace.getJitterMills());
   }
 
-  @Test(timeout = 60_000L)
-  public void testFindNew()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testFindNew(String tsColumn)
       throws InterruptedException
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     try (final CacheScheduler.Entry entry = ensureEntry()) {
       assertUpdated(entry, "foo", "bar");
       insertValues(handleRef, "foo", "baz", null, "2900-01-01 00:00:00");
@@ -481,22 +553,27 @@ public class JdbcExtractionNamespaceTest
     }
   }
 
-  @Test(timeout = 60_000L)
-  public void testIgnoresNullValues()
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testIgnoresNullValues(String tsColumn)
       throws InterruptedException
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     try (final CacheScheduler.Entry entry = ensureEntry()) {
       insertValues(handleRef, "fooz", null, null, "2900-01-01 00:00:00");
       waitForUpdates(1_000L, 2L);
       Thread.sleep(100);
       Set set = entry.getCache().keySet();
-      Assert.assertFalse(set.contains("fooz"));
+      Assertions.assertFalse(set.contains("fooz"));
     }
   }
 
-  @Test
-  public void testSerde() throws IOException
+  @MethodSource("getParameters")
+  @ParameterizedTest(name = "{0}")
+  public void testSerde(String tsColumn) throws IOException
   {
+    initJdbcExtractionNamespaceTest(tsColumn);
     final JdbcAccessSecurityConfig securityConfig = new JdbcAccessSecurityConfig();
     final JdbcExtractionNamespace extractionNamespace = new JdbcExtractionNamespace(
         derbyConnectorRule.getMetadataConnectorConfig(),
@@ -519,7 +596,7 @@ public class JdbcExtractionNamespaceTest
         ExtractionNamespace.class
     );
 
-    Assert.assertEquals(extractionNamespace, extractionNamespace2);
+    Assertions.assertEquals(extractionNamespace, extractionNamespace2);
   }
 
   private CacheScheduler.Entry ensureEntry()
@@ -542,10 +619,10 @@ public class JdbcExtractionNamespaceTest
 
     waitForUpdates(1_000L, 2L);
 
-    Assert.assertEquals(
-        "sanity check not correct",
+    Assertions.assertEquals(
         "bar",
-        entry.getCache().get("foo")
+        entry.getCache().get("foo"),
+        "sanity check not correct"
     );
     return entry;
   }
@@ -568,7 +645,7 @@ public class JdbcExtractionNamespaceTest
       log.debug("Waiting for updateLock");
       updateLock.lockInterruptibly();
       try {
-        Assert.assertTrue("Failed waiting for update", System.currentTimeMillis() - startTime < timeout);
+        Assertions.assertTrue(System.currentTimeMillis() - startTime < timeout, "Failed waiting for update");
         post = updates.get();
       }
       finally {
@@ -589,10 +666,10 @@ public class JdbcExtractionNamespaceTest
       map = entry.getCache();
     }
 
-    Assert.assertEquals(
-        "update check",
+    Assertions.assertEquals(
         expected,
-        map.get(key)
+        map.get(key),
+        "update check"
     );
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/JdbcExtractionNamespaceTest.java
@@ -107,7 +107,11 @@ public class JdbcExtractionNamespaceTest
         new DBI(connector.getJdbcUri() + ";drop=true").open().close();
       }
       catch (UnableToObtainConnectionException e) {
-        final SQLException cause = (SQLException) e.getCause();
+        final SQLException cause = Assertions.assertInstanceOf(
+            SQLException.class,
+            e.getCause(),
+            "Expected Derby shutdown failure to wrap a SQLException"
+        );
         Assertions.assertEquals(
             "08006",
             cause.getSQLState(),

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManagersTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/NamespaceExtractionCacheManagersTest.java
@@ -26,11 +26,11 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,10 +39,8 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(Parameterized.class)
 public class NamespaceExtractionCacheManagersTest
 {
-  @Parameterized.Parameters
   public static Collection<Object[]> data()
   {
     return Arrays.asList(new Object[][]{
@@ -51,27 +49,30 @@ public class NamespaceExtractionCacheManagersTest
     });
   }
 
-  private final Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager;
+  private Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager;
   private Lifecycle lifecycle;
   private NamespaceExtractionCacheManager manager;
 
-  public NamespaceExtractionCacheManagersTest(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager)
+  public void initNamespaceExtractionCacheManagersTest(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager)
   {
 
     this.createCacheManager = createCacheManager;
+    manager = createCacheManager.apply(lifecycle);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     lifecycle = new Lifecycle();
     lifecycle.start();
-    manager = createCacheManager.apply(lifecycle);
   }
 
-  @Test(timeout = 60_000L)
-  public void testRacyCreation() throws Exception
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testRacyCreation(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws Exception
   {
+    initNamespaceExtractionCacheManagersTest(createCacheManager);
     final int concurrentThreads = 10;
     final ListeningExecutorService service = MoreExecutors.listeningDecorator(Execs.multiThreaded(
         concurrentThreads,
@@ -104,23 +105,26 @@ public class NamespaceExtractionCacheManagersTest
       service.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
     }
 
-    Assert.assertEquals(0, manager.cacheCount());
+    Assertions.assertEquals(0, manager.cacheCount());
   }
 
   /**
    * Tests that even if CacheHandler.close() wasn't called, the cache is cleaned up when it becomes unreachable.
    */
-  @Test(timeout = 60_000L)
-  public void testCacheCloseForgotten() throws InterruptedException
+  @MethodSource("data")
+  @ParameterizedTest
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
+  public void testCacheCloseForgotten(Function<Lifecycle, NamespaceExtractionCacheManager> createCacheManager) throws InterruptedException
   {
-    Assert.assertEquals(0, manager.cacheCount());
+    initNamespaceExtractionCacheManagersTest(createCacheManager);
+    Assertions.assertEquals(0, manager.cacheCount());
     createDanglingCache();
-    Assert.assertEquals(1, manager.cacheCount());
+    Assertions.assertEquals(1, manager.cacheCount());
     while (manager.cacheCount() > 0) {
       System.gc();
       Thread.sleep(1000);
     }
-    Assert.assertEquals(0, manager.cacheCount());
+    Assertions.assertEquals(0, manager.cacheCount());
   }
 
   private void createDanglingCache()

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManagerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/OffHeapNamespaceExtractionCacheManagerTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.guice.annotations.Self;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.lookup.namespace.NamespaceExtractionModule;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -61,6 +61,6 @@ public class OffHeapNamespaceExtractionCacheManagerTest
     properties.clear();
     properties.put(NamespaceExtractionModule.TYPE_PREFIX, "offHeap");
     final NamespaceExtractionCacheManager manager = injector.getInstance(NamespaceExtractionCacheManager.class);
-    Assert.assertEquals(OffHeapNamespaceExtractionCacheManager.class, manager.getClass());
+    Assertions.assertEquals(OffHeapNamespaceExtractionCacheManager.class, manager.getClass());
   }
 }

--- a/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManagerTest.java
+++ b/extensions-core/lookups-cached-global/src/test/java/org/apache/druid/server/lookup/namespace/cache/OnHeapNamespaceExtractionCacheManagerTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.server.lookup.namespace.NamespaceExtractionModule;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -42,7 +42,7 @@ public class OnHeapNamespaceExtractionCacheManagerTest
   public void testInjection()
   {
     final NamespaceExtractionCacheManager manager = getCacheManager();
-    Assert.assertEquals(OnHeapNamespaceExtractionCacheManager.class, manager.getClass());
+    Assertions.assertEquals(OnHeapNamespaceExtractionCacheManager.class, manager.getClass());
   }
 
   @Test
@@ -52,7 +52,7 @@ public class OnHeapNamespaceExtractionCacheManagerTest
     CacheHandler handler = manager.allocateCache();
     handler.getCache().put("some key", "some value");
     CacheHandler immutableHandler = manager.attachCache(handler);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> immutableHandler.getCache().put("other key", "other value")
     );
@@ -64,7 +64,7 @@ public class OnHeapNamespaceExtractionCacheManagerTest
     NamespaceExtractionCacheManager manager = getCacheManager();
     CacheHandler handler = manager.createCache();
     handler.getCache().put("some key", "some value");
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ISE.class,
         () -> manager.attachCache(handler)
     );


### PR DESCRIPTION
## Description

Migrates the Google extensions, Kafka indexing service, and cached-global lookup extension tests from JUnit 4 to JUnit 5.

This is part of [#13948](https://github.com/apache/druid/issues/13948) and follows [#19875](https://github.com/apache/druid/pull/19875), [#19876](https://github.com/apache/druid/pull/19876), and [#19877](https://github.com/apache/druid/pull/19877).

The migration preserves parameterized-test setup and per-test lifecycle behavior, including the Derby-backed JDBC lookup tests and temporary-file fixtures.

## Modules

- `extensions-core/google-extensions`
- `extensions-core/kafka-indexing-service`
- `extensions-core/lookups-cached-global`

## Transitional dependency

The migrated Kafka test class is Jupiter-only. Its module temporarily retains `junit:junit` because the shared `indexing-service` test-jar superclass still exposes JUnit 4 `TemporaryFolder` and Derby rule types. That shared stream-ingestion fixture will be removed in the coordinated Kinesis/Kafka follow-up.

## Testing

- `mvn -ntp -pl extensions-core/kafka-indexing-service -am -DskipTests -Dweb.console.skip=true -Pskip-static-checks -T1C test-compile`: `BUILD SUCCESS`.
- `KafkaIndexTaskTest#testKafkaTaskContainsAllTaskDimensions`: 2 parameterized invocations passed after restoring the shared `CliPeonTest` fixture.
- A prior full Kafka execution reached 92 parameterized invocations; the only remaining failure was the existing `FileTaskLogs` payload-provisioning error. A subsequent full rerun was blocked locally because Testcontainers could not find Docker.
- `git diff --check` passed.
