### PR TITLE
test: migrate histogram extension tests to JUnit 5

### DIFF
--- a/extensions-core/histogram/pom.xml
+++ b/extensions-core/histogram/pom.xml
@@ -119,11 +119,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <scope>test</scope>

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
@@ -35,14 +35,13 @@ import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -51,25 +50,23 @@ import java.util.List;
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class ApproximateHistogramAggregationTest extends InitializedNullHandlingTest
 {
   private AggregationTestHelper helper;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
-  public ApproximateHistogramAggregationTest(final GroupByQueryConfig config)
+  public void initApproximateHistogramAggregationTest(final GroupByQueryConfig config)
   {
     ApproximateHistogramDruidModule.registerSerde();
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         Lists.newArrayList(new ApproximateHistogramDruidModule().getJacksonModules()),
         config,
         tempFolder
     );
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -79,32 +76,34 @@ public class ApproximateHistogramAggregationTest extends InitializedNullHandling
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
-  @Test
-  public void testIngestWithNullsIgnoredAndQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIngestWithNullsIgnoredAndQuery(final GroupByQueryConfig config) throws Exception
   {
+    initApproximateHistogramAggregationTest(config);
     MapBasedRow row = ingestAndQuery(true);
-    Assert.assertEquals(92.782760, row.getMetric("index_min").floatValue(), 0.0001);
-    Assert.assertEquals(135.109191, row.getMetric("index_max").floatValue(), 0.0001);
-    Assert.assertEquals(133.69340, row.getMetric("index_quantile").floatValue(), 0.0001);
-    Assert.assertEquals(
+    Assertions.assertEquals(92.782760, row.getMetric("index_min").floatValue(), 0.0001);
+    Assertions.assertEquals(135.109191, row.getMetric("index_max").floatValue(), 0.0001);
+    Assertions.assertEquals(133.69340, row.getMetric("index_quantile").floatValue(), 0.0001);
+    Assertions.assertEquals(
         new Quantiles(new float[]{0.2f, 0.7f}, new float[]{92.78276f, 103.195305f}, 92.78276f, 135.109191f),
         row.getRaw("index_quantiles")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Histogram{breaks=[92.0, 94.0, 96.0, 98.0, 100.0, 106.0, 108.0, 134.0, 136.0], counts=[1.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]}",
         row.getRaw("index_buckets").toString()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Histogram{breaks=[50.0, 100.0], counts=[3.0]}",
         row.getRaw("index_custom").toString()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Histogram{breaks=[71.61954498291016, 92.78276062011719, 113.94597625732422, 135.10919189453125], counts=[1.0, 3.0, 1.0]}",
         row.getRaw("index_equal").toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregationTest.java
@@ -37,9 +37,9 @@ import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramAggregatorTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -70,20 +70,18 @@ public class ApproximateHistogramAggregatorTest extends InitializedNullHandlingT
 
     ApproximateHistogram h = ((ApproximateHistogram) agg.get(buf, position));
 
-    Assert.assertArrayEquals(
-        "final bin positions don't match expected positions",
-        new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions, 0.01f
+    Assertions.assertArrayEquals(
+        new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions, 0.01f, "final bin positions don't match expected positions"
     );
 
-    Assert.assertArrayEquals(
-        "final bin counts don't match expected counts",
-        new long[]{1, 2, 3, 3, 1}, h.bins()
+    Assertions.assertArrayEquals(
+        new long[]{1, 2, 3, 3, 1}, h.bins(), "final bin counts don't match expected counts"
     );
 
-    Assert.assertEquals("getMin value doesn't match expected getMin", 2, h.min(), 0);
-    Assert.assertEquals("getMax value doesn't match expected getMax", 45, h.max(), 0);
+    Assertions.assertEquals(2, h.min(), 0, "getMin value doesn't match expected getMin");
+    Assertions.assertEquals(45, h.max(), 0, "getMax value doesn't match expected getMax");
 
-    Assert.assertEquals("bin count doesn't match expected bin count", 5, h.binCount());
+    Assertions.assertEquals(5, h.binCount(), "bin count doesn't match expected bin count");
   }
 
   @Test
@@ -112,10 +110,10 @@ public class ApproximateHistogramAggregatorTest extends InitializedNullHandlingT
     JsonNode expectedJson = objectMapper.readTree(
             "{\"breaks\":[23.0,23.0,23.0,23.0,23.0,23.0],\"counts\":[0.0,0.0,0.0,0.0,0.0]}");
     JsonNode actualJson = objectMapper.readTree(finalStringHumanReadable);
-    Assert.assertEquals(expectedJson, actualJson);
+    Assertions.assertEquals(expectedJson, actualJson);
     Object finalizedObjectBinary = binaryFactory.finalizeComputation(agg.get());
     String finalStringBinary = objectMapper.writeValueAsString(finalizedObjectBinary);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"//sBQbgAAA==\"",
         finalStringBinary
     );
@@ -141,7 +139,7 @@ public class ApproximateHistogramAggregatorTest extends InitializedNullHandlingT
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("approxHisto", null)
@@ -167,7 +165,7 @@ public class ApproximateHistogramAggregatorTest extends InitializedNullHandlingT
         null,
         false
     );
-    Assert.assertEquals(factory, factory.withName("approxHisto"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("approxHisto"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerdeTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingSerdeTest.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.segment.data.ObjectStrategy;
 import org.apache.druid.segment.serde.ComplexMetricExtractor;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,34 +45,34 @@ public class ApproximateHistogramFoldingSerdeTest
 
     final MapBasedInputRow row = new MapBasedInputRow(0L, ImmutableList.of(), theMap);
 
-    Assert.assertEquals(
-        "nullValue",
+    Assertions.assertEquals(
         new ApproximateHistogram(0),
-        extractor.extractValue(row, "nullValue")
+        extractor.extractValue(row, "nullValue"),
+        "nullValue"
     );
 
-    Assert.assertEquals(
-        "missingValue",
+    Assertions.assertEquals(
         new ApproximateHistogram(0),
-        extractor.extractValue(row, "missingValue")
+        extractor.extractValue(row, "missingValue"),
+        "missingValue"
     );
 
-    Assert.assertEquals(
-        "listValue",
+    Assertions.assertEquals(
         makeHistogram(1, 2, 3),
-        extractor.extractValue(row, "listValue")
+        extractor.extractValue(row, "listValue"),
+        "listValue"
     );
 
-    Assert.assertEquals(
-        "stringValue",
+    Assertions.assertEquals(
         makeHistogram(1),
-        extractor.extractValue(row, "stringValue")
+        extractor.extractValue(row, "stringValue"),
+        "stringValue"
     );
 
-    Assert.assertEquals(
-        "numberValue",
+    Assertions.assertEquals(
         makeHistogram(1),
-        extractor.extractValue(row, "numberValue")
+        extractor.extractValue(row, "numberValue"),
+        "numberValue"
     );
   }
 
@@ -81,7 +81,7 @@ public class ApproximateHistogramFoldingSerdeTest
   {
     final ApproximateHistogramFoldingSerde serde = new ApproximateHistogramFoldingSerde();
     final ObjectStrategy<ApproximateHistogram> strategy = serde.getObjectStrategy();
-    Assert.assertFalse(strategy.readRetainsBufferReference());
+    Assertions.assertFalse(strategy.readRetainsBufferReference());
   }
 
 

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingVectorAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramFoldingVectorAggregatorTest.java
@@ -25,9 +25,9 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -41,7 +41,7 @@ public class ApproximateHistogramFoldingVectorAggregatorTest
   private ApproximateHistogram h1;
   private ApproximateHistogram h2;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
 
@@ -79,10 +79,10 @@ public class ApproximateHistogramFoldingVectorAggregatorTest
   public void doNotVectorizedNonComplexTypes()
   {
     ApproximateHistogramFoldingAggregatorFactory factory = buildHistogramFactory("string_field");
-    Assert.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
+    Assertions.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
 
     factory = buildHistogramFactory("double_field");
-    Assert.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
+    Assertions.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
   }
 
   @Test
@@ -90,17 +90,17 @@ public class ApproximateHistogramFoldingVectorAggregatorTest
   {
     ApproximateHistogramFoldingAggregatorFactory factory = buildHistogramFactory();
     ByteBuffer byteBuffer = ByteBuffer.allocate(factory.getMaxIntermediateSize());
-    Assert.assertTrue(factory.canVectorize(vectorColumnSelectorFactory));
+    Assertions.assertTrue(factory.canVectorize(vectorColumnSelectorFactory));
     VectorAggregator vectorAggregator = factory.factorizeVector(vectorColumnSelectorFactory);
     vectorAggregator.init(byteBuffer, 0);
     vectorAggregator.aggregate(byteBuffer, 0, 0, 4);
     ApproximateHistogram h = (ApproximateHistogram) vectorAggregator.get(byteBuffer, 0);
 
-    Assert.assertArrayEquals(new float[]{19.6f, 45.0f}, h.positions(), 0.1f);
-    Assert.assertArrayEquals(new long[]{9, 1}, h.bins());
-    Assert.assertEquals(10, h.count());
-    Assert.assertEquals(2.0f, h.min(), 0.1f);
-    Assert.assertEquals(45.0f, h.max(), 0.1f);
+    Assertions.assertArrayEquals(new float[]{19.6f, 45.0f}, h.positions(), 0.1f);
+    Assertions.assertArrayEquals(new long[]{9, 1}, h.bins());
+    Assertions.assertEquals(10, h.count());
+    Assertions.assertEquals(2.0f, h.min(), 0.1f);
+    Assertions.assertEquals(45.0f, h.max(), 0.1f);
   }
 
   @Test
@@ -118,8 +118,8 @@ public class ApproximateHistogramFoldingVectorAggregatorTest
     ApproximateHistogram actualH1 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, 0);
     ApproximateHistogram actualH2 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, positions[1]);
 
-    Assert.assertEquals(actualH1, h1);
-    Assert.assertEquals(actualH2, h2);
+    Assertions.assertEquals(actualH1, h1);
+    Assertions.assertEquals(actualH2, h2);
 
   }
 
@@ -127,8 +127,8 @@ public class ApproximateHistogramFoldingVectorAggregatorTest
   public void testWithName()
   {
     ApproximateHistogramFoldingAggregatorFactory factory = buildHistogramFactory();
-    Assert.assertEquals(factory, factory.withName("approximateHistoFold"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("approximateHistoFold"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 
   private ApproximateHistogramFoldingAggregatorFactory buildHistogramFactory()

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -37,30 +37,30 @@ import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  */
-@RunWith(Parameterized.class)
 public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlingTest
 {
   private static final Closer RESOURCE_CLOSER = Closer.create();
   private static TestGroupByBuffers BUFFER_POOLS = null;
 
-  private final QueryRunner<ResultRow> runner;
-  private final GroupByQueryRunnerFactory factory;
+  private QueryRunner<ResultRow> runner;
+  private GroupByQueryRunnerFactory factory;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass()
   {
     if (BUFFER_POOLS == null) {
@@ -68,14 +68,13 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass()
   {
     BUFFER_POOLS.close();
     BUFFER_POOLS = null;
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     setUpClass();
@@ -110,7 +109,7 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
     return constructors;
   }
 
-  public ApproximateHistogramGroupByQueryTest(
+  public void initApproximateHistogramGroupByQueryTest(
       String testName,
       GroupByQueryRunnerFactory factory,
       QueryRunner runner
@@ -121,15 +120,21 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
     ApproximateHistogramDruidModule.registerSerde();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     RESOURCE_CLOSER.close();
   }
 
-  @Test
-  public void testGroupByWithApproximateHistogramAgg()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testGroupByWithApproximateHistogramAgg(
+      String testName,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner
+  )
   {
+    initApproximateHistogramGroupByQueryTest(testName, factory, runner);
     ApproximateHistogramAggregatorFactory aggFactory = new ApproximateHistogramAggregatorFactory(
         "apphisto",
         "index",
@@ -189,51 +194,59 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
     TestHelper.assertExpectedObjects(expectedResults, results, "approx-histo");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGroupByWithSameNameComplexPostAgg()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testGroupByWithSameNameComplexPostAgg(
+      String testName,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner
+  )
   {
-    ApproximateHistogramAggregatorFactory aggFactory = new ApproximateHistogramAggregatorFactory(
-        "quantile",
-        "index",
-        10,
-        5,
-        Float.NEGATIVE_INFINITY,
-        Float.POSITIVE_INFINITY,
-        false
-    );
+    initApproximateHistogramGroupByQueryTest(testName, factory, runner);
+    assertThrows(IllegalArgumentException.class, () -> {
+      ApproximateHistogramAggregatorFactory aggFactory = new ApproximateHistogramAggregatorFactory(
+          "quantile",
+          "index",
+          10,
+          5,
+          Float.NEGATIVE_INFINITY,
+          Float.POSITIVE_INFINITY,
+          false
+      );
 
-    GroupByQuery query = new GroupByQuery.Builder()
-        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
-        .setGranularity(QueryRunnerTestHelper.ALL_GRAN).setDimensions(new DefaultDimensionSpec(
-            QueryRunnerTestHelper.MARKET_DIMENSION,
-            "marketalias"
-        ))
-        .setInterval(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
-        .setLimitSpec(
-            new DefaultLimitSpec(
-                Collections.singletonList(new OrderByColumnSpec("marketalias", OrderByColumnSpec.Direction.DESCENDING)),
-                1
-            )
-        ).setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, aggFactory)
-        .setPostAggregatorSpecs(
-            Collections.singletonList(
-                new QuantilePostAggregator("quantile", "quantile", 0.5f)
-            )
-        )
-        .build();
+      GroupByQuery query = new GroupByQuery.Builder()
+          .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+          .setGranularity(QueryRunnerTestHelper.ALL_GRAN).setDimensions(new DefaultDimensionSpec(
+          QueryRunnerTestHelper.MARKET_DIMENSION,
+          "marketalias"
+      ))
+          .setInterval(QueryRunnerTestHelper.FULL_ON_INTERVAL_SPEC)
+          .setLimitSpec(
+              new DefaultLimitSpec(
+                  Collections.singletonList(new OrderByColumnSpec("marketalias", OrderByColumnSpec.Direction.DESCENDING)),
+                  1
+              )
+          ).setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, aggFactory)
+          .setPostAggregatorSpecs(
+              Collections.singletonList(
+                  new QuantilePostAggregator("quantile", "quantile", 0.5f)
+              )
+          )
+          .build();
 
-    List<ResultRow> expectedResults = Collections.singletonList(
-        GroupByQueryRunnerTestHelper.createExpectedRow(
-            query,
-            "1970-01-01T00:00:00.000Z",
-            "marketalias", "upfront",
-            "rows", 186L,
-            "quantile", 880.9881f
-        )
-    );
+      List<ResultRow> expectedResults = Collections.singletonList(
+          GroupByQueryRunnerTestHelper.createExpectedRow(
+              query,
+              "1970-01-01T00:00:00.000Z",
+              "marketalias", "upfront",
+              "rows", 186L,
+              "quantile", 880.9881f
+          )
+      );
 
-    Iterable<ResultRow> results = runner.run(QueryPlus.wrap(GroupByQueryRunnerTestHelper.populateResourceId(query)))
-                                        .toList();
-    TestHelper.assertExpectedObjects(expectedResults, results, "approx-histo");
+      Iterable<ResultRow> results = runner.run(QueryPlus.wrap(GroupByQueryRunnerTestHelper.populateResourceId(query)))
+          .toList();
+      TestHelper.assertExpectedObjects(expectedResults, results, "approx-histo");
+    });
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -99,7 +99,7 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
             config.toString(),
             runner.toString()
         );
-        constructors.add(new Object[]{testName, factory, runner});
+        constructors.add(new Object[]{testName, runner});
       }
     }
 
@@ -116,7 +116,6 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
   @ParameterizedTest(name = "{0}")
   public void testGroupByWithApproximateHistogramAgg(
       String testName,
-      GroupByQueryRunnerFactory factory,
       QueryRunner runner
   )
   {
@@ -184,7 +183,6 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
   @ParameterizedTest(name = "{0}")
   public void testGroupByWithSameNameComplexPostAgg(
       String testName,
-      GroupByQueryRunnerFactory factory,
       QueryRunner runner
   )
   {

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramGroupByQueryTest.java
@@ -57,9 +57,6 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
   private static final Closer RESOURCE_CLOSER = Closer.create();
   private static TestGroupByBuffers BUFFER_POOLS = null;
 
-  private QueryRunner<ResultRow> runner;
-  private GroupByQueryRunnerFactory factory;
-
   @BeforeAll
   public static void setUpClass()
   {
@@ -109,17 +106,6 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
     return constructors;
   }
 
-  public void initApproximateHistogramGroupByQueryTest(
-      String testName,
-      GroupByQueryRunnerFactory factory,
-      QueryRunner runner
-  )
-  {
-    this.factory = factory;
-    this.runner = runner;
-    ApproximateHistogramDruidModule.registerSerde();
-  }
-
   @AfterEach
   public void teardown() throws IOException
   {
@@ -134,7 +120,7 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
       QueryRunner runner
   )
   {
-    initApproximateHistogramGroupByQueryTest(testName, factory, runner);
+    ApproximateHistogramDruidModule.registerSerde();
     ApproximateHistogramAggregatorFactory aggFactory = new ApproximateHistogramAggregatorFactory(
         "apphisto",
         "index",
@@ -202,7 +188,7 @@ public class ApproximateHistogramGroupByQueryTest extends InitializedNullHandlin
       QueryRunner runner
   )
   {
-    initApproximateHistogramGroupByQueryTest(testName, factory, runner);
+    ApproximateHistogramDruidModule.registerSerde();
     assertThrows(IllegalArgumentException.class, () -> {
       ApproximateHistogramAggregatorFactory aggFactory = new ApproximateHistogramAggregatorFactory(
           "quantile",

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramPostAggregatorTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -68,7 +68,7 @@ public class ApproximateHistogramPostAggregatorTest extends InitializedNullHandl
         "price",
         5
     );
-    Assert.assertEquals(ah.toHistogram(5), approximateHistogramPostAggregator.compute(metricValues));
+    Assertions.assertEquals(ah.toHistogram(5), approximateHistogramPostAggregator.compute(metricValues));
   }
 
   @Test
@@ -91,7 +91,7 @@ public class ApproximateHistogramPostAggregatorTest extends InitializedNullHandl
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("approxHisto", null)

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTest.java
@@ -21,9 +21,9 @@ package org.apache.druid.query.aggregation.histogram;
 
 import com.google.common.collect.Iterators;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -80,20 +80,18 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(5, VALUES);
 
     // (2, 1), (9.5, 2), (19.33, 3), (32.67, 3), (45, 1)
-    Assert.assertArrayEquals(
-        "final bin positions match expected positions",
-        new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions(), 0.1f
+    Assertions.assertArrayEquals(
+        new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions(), 0.1f, "final bin positions match expected positions"
     );
 
-    Assert.assertArrayEquals(
-        "final bin positions match expected positions",
-        new long[]{1, 2, 3, 3, 1}, h.bins()
+    Assertions.assertArrayEquals(
+        new long[]{1, 2, 3, 3, 1}, h.bins(), "final bin positions match expected positions"
     );
 
-    Assert.assertEquals("min value matches expexted min", 2, h.min(), 0);
-    Assert.assertEquals("max value matches expexted max", 45, h.max(), 0);
+    Assertions.assertEquals(2, h.min(), 0, "min value matches expexted min");
+    Assertions.assertEquals(45, h.max(), 0, "max value matches expexted max");
 
-    Assert.assertEquals("bin count matches expected bin count", 5, h.binCount());
+    Assertions.assertEquals(5, h.binCount(), "bin count matches expected bin count");
   }
 
   @Test
@@ -116,28 +114,24 @@ public class ApproximateHistogramTest
     mergedFast.foldFast(h1);
     mergedFast.foldFast(h2);
 
-    Assert.assertArrayEquals(
-        "final bin positions match expected positions",
-        new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, merged.positions(), 0.1f
+    Assertions.assertArrayEquals(
+        new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, merged.positions(), 0.1f, "final bin positions match expected positions"
     );
-    Assert.assertArrayEquals(
-        "final bin positions match expected positions",
-        new float[]{11.2f, 30.25f, 45f}, mergedFast.positions(), 0.1f
+    Assertions.assertArrayEquals(
+        new float[]{11.2f, 30.25f, 45f}, mergedFast.positions(), 0.1f, "final bin positions match expected positions"
     );
 
-    Assert.assertArrayEquals(
-        "final bin counts match expected counts",
-        new long[]{1, 2, 3, 3, 1}, merged.bins()
+    Assertions.assertArrayEquals(
+        new long[]{1, 2, 3, 3, 1}, merged.bins(), "final bin counts match expected counts"
     );
-    Assert.assertArrayEquals(
-        "final bin counts match expected counts",
-        new long[]{5, 4, 1}, mergedFast.bins()
+    Assertions.assertArrayEquals(
+        new long[]{5, 4, 1}, mergedFast.bins(), "final bin counts match expected counts"
     );
 
-    Assert.assertEquals("merged max matches expected value", 45f, merged.max(), 0.1f);
-    Assert.assertEquals("mergedfast max matches expected value", 45f, mergedFast.max(), 0.1f);
-    Assert.assertEquals("merged min matches expected value", 2f, merged.min(), 0.1f);
-    Assert.assertEquals("mergedfast min matches expected value", 2f, mergedFast.min(), 0.1f);
+    Assertions.assertEquals(45f, merged.max(), 0.1f, "merged max matches expected value");
+    Assertions.assertEquals(45f, mergedFast.max(), 0.1f, "mergedfast max matches expected value");
+    Assertions.assertEquals(2f, merged.min(), 0.1f, "merged min matches expected value");
+    Assertions.assertEquals(2f, mergedFast.min(), 0.1f, "mergedfast min matches expected value");
 
     // fold where merged bincount is less than total bincount
     ApproximateHistogram a = buildHistogram(10, new float[]{1, 2, 3, 4, 5, 6});
@@ -147,7 +141,7 @@ public class ApproximateHistogramTest
     a.fold(b, null, null, null);
     aFast.foldFast(b);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ApproximateHistogram(
             6,
             new float[]{1, 2, 3, 4, 5, 6, 0, 0, 0, 0},
@@ -155,7 +149,7 @@ public class ApproximateHistogramTest
             1, 6
         ), a
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ApproximateHistogram(
             6,
             new float[]{1, 2, 3, 4, 5, 6, 0, 0, 0, 0},
@@ -173,14 +167,12 @@ public class ApproximateHistogramTest
       h4.offer(v);
     }
     h3.fold(h4, null, null, null);
-    Assert.assertArrayEquals(
-        "final bin positions match expected positions",
+    Assertions.assertArrayEquals(
         new float[]{-50.98f, -21.77f, -9.81f, 3.73f, 13.72f, 20.1f, 29f, 44.79f, 53.8f, 64.67f},
-        h3.positions(), 0.1f
+        h3.positions(), 0.1f, "final bin positions match expected positions"
     );
-    Assert.assertArrayEquals(
-        "final bin counts match expected counts",
-        new long[]{1, 1, 3, 6, 12, 32, 6, 1, 2, 6}, h3.bins()
+    Assertions.assertArrayEquals(
+        new long[]{1, 1, 3, 6, 12, 32, 6, 1, 2, 6}, h3.bins(), "final bin counts match expected counts"
     );
 
   }
@@ -215,14 +207,14 @@ public class ApproximateHistogramTest
     h1Fast.foldFast(h3);
     h4Fast.foldFast(h2);
 
-    Assert.assertEquals(h3, h1);
-    Assert.assertEquals(h4, h3);
-    Assert.assertEquals(h3, h1Fast);
-    Assert.assertEquals(h3, h4Fast);
+    Assertions.assertEquals(h3, h1);
+    Assertions.assertEquals(h4, h3);
+    Assertions.assertEquals(h3, h1Fast);
+    Assertions.assertEquals(h3, h4Fast);
   }
 
     //@Test
-  @Ignore
+  @Disabled
   @SuppressWarnings("unused") //TODO rewrite using JMH and move to the benchmarks module
   public void testFoldSpeed()
   {
@@ -274,34 +266,34 @@ public class ApproximateHistogramTest
   {
     ApproximateHistogram h = buildHistogram(5, VALUES);
 
-    Assert.assertEquals(0.0f, h.sum(0), 0.01);
-    Assert.assertEquals(1.0f, h.sum(2), 0.01);
-    Assert.assertEquals(1.16f, h.sum(5), 0.01);
-    Assert.assertEquals(3.28f, h.sum(15), 0.01);
-    Assert.assertEquals(VALUES.length, h.sum(45), 0.01);
-    Assert.assertEquals(VALUES.length, h.sum(46), 0.01);
+    Assertions.assertEquals(0.0f, h.sum(0), 0.01);
+    Assertions.assertEquals(1.0f, h.sum(2), 0.01);
+    Assertions.assertEquals(1.16f, h.sum(5), 0.01);
+    Assertions.assertEquals(3.28f, h.sum(15), 0.01);
+    Assertions.assertEquals(VALUES.length, h.sum(45), 0.01);
+    Assertions.assertEquals(VALUES.length, h.sum(46), 0.01);
 
     ApproximateHistogram h2 = buildHistogram(5, VALUES2);
 
-    Assert.assertEquals(0.0f, h2.sum(0), 0.01);
-    Assert.assertEquals(0.0f, h2.sum(1f), 0.01);
-    Assert.assertEquals(1.0f, h2.sum(1.5f), 0.01);
-    Assert.assertEquals(1.125f, h2.sum(2f), 0.001);
-    Assert.assertEquals(2.0625f, h2.sum(5.75f), 0.001);
-    Assert.assertEquals(3.0f, h2.sum(9.5f), 0.01);
-    Assert.assertEquals(11.0f, h2.sum(45.5f), 0.01);
-    Assert.assertEquals(12.0f, h2.sum(46f), 0.01);
-    Assert.assertEquals(12.0f, h2.sum(47f), 0.01);
+    Assertions.assertEquals(0.0f, h2.sum(0), 0.01);
+    Assertions.assertEquals(0.0f, h2.sum(1f), 0.01);
+    Assertions.assertEquals(1.0f, h2.sum(1.5f), 0.01);
+    Assertions.assertEquals(1.125f, h2.sum(2f), 0.001);
+    Assertions.assertEquals(2.0625f, h2.sum(5.75f), 0.001);
+    Assertions.assertEquals(3.0f, h2.sum(9.5f), 0.01);
+    Assertions.assertEquals(11.0f, h2.sum(45.5f), 0.01);
+    Assertions.assertEquals(12.0f, h2.sum(46f), 0.01);
+    Assertions.assertEquals(12.0f, h2.sum(47f), 0.01);
   }
 
   @Test
   public void testSerializeCompact()
   {
     ApproximateHistogram h = buildHistogram(5, VALUES);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assertions.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
 
     ApproximateHistogram h2 = new ApproximateHistogram(50).fold(h, null, null, null);
-    Assert.assertEquals(h2, ApproximateHistogram.fromBytes(h2.toBytes()));
+    Assertions.assertEquals(h2, ApproximateHistogram.fromBytes(h2.toBytes()));
   }
 
   @Test
@@ -310,7 +302,7 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(5, VALUES);
     ByteBuffer buf = ByteBuffer.allocate(h.getDenseStorageSize());
     h.toBytesDense(buf);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(buf.array()));
+    Assertions.assertEquals(h, ApproximateHistogram.fromBytes(buf.array()));
   }
 
   @Test
@@ -319,57 +311,52 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(5, VALUES);
     ByteBuffer buf = ByteBuffer.allocate(h.getSparseStorageSize());
     h.toBytesSparse(buf);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(buf.array()));
+    Assertions.assertEquals(h, ApproximateHistogram.fromBytes(buf.array()));
   }
 
   @Test
   public void testSerializeCompactExact()
   {
     ApproximateHistogram h = buildHistogram(50, new float[]{1f, 2f, 3f, 4f, 5f});
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assertions.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
 
     h = buildHistogram(5, new float[]{1f, 2f, 3f});
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assertions.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
 
     h = new ApproximateHistogram(40).fold(h, null, null, null);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assertions.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
   }
 
   @Test
   public void testSerializeEmpty()
   {
     ApproximateHistogram h = new ApproximateHistogram(50);
-    Assert.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
+    Assertions.assertEquals(h, ApproximateHistogram.fromBytes(h.toBytes()));
   }
 
   @Test
   public void testQuantileSmaller()
   {
     ApproximateHistogram h = buildHistogram(20, VALUES5);
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{5f},
-        h.getQuantiles(new float[]{.5f}), 0.1f
+        h.getQuantiles(new float[]{.5f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{3.33f, 6.67f},
-        h.getQuantiles(new float[]{.333f, .666f}), 0.1f
+        h.getQuantiles(new float[]{.333f, .666f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{2.5f, 5f, 7.5f},
-        h.getQuantiles(new float[]{.25f, .5f, .75f}), 0.1f
+        h.getQuantiles(new float[]{.25f, .5f, .75f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{2f, 4f, 6f, 8f},
-        h.getQuantiles(new float[]{.2f, .4f, .6f, .8f}), 0.1f
+        h.getQuantiles(new float[]{.2f, .4f, .6f, .8f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f},
-        h.getQuantiles(new float[]{.1f, .2f, .3f, .4f, .5f, .6f, .7f, .8f, .9f}), 0.1f
+        h.getQuantiles(new float[]{.1f, .2f, .3f, .4f, .5f, .6f, .7f, .8f, .9f}), 0.1f, "expected quantiles match actual quantiles"
     );
   }
 
@@ -377,30 +364,25 @@ public class ApproximateHistogramTest
   public void testQuantileEqualSize()
   {
     ApproximateHistogram h = buildHistogram(10, VALUES5);
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{5f},
-        h.getQuantiles(new float[]{.5f}), 0.1f
+        h.getQuantiles(new float[]{.5f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{3.33f, 6.67f},
-        h.getQuantiles(new float[]{.333f, .666f}), 0.1f
+        h.getQuantiles(new float[]{.333f, .666f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{2.5f, 5f, 7.5f},
-        h.getQuantiles(new float[]{.25f, .5f, .75f}), 0.1f
+        h.getQuantiles(new float[]{.25f, .5f, .75f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{2f, 4f, 6f, 8f},
-        h.getQuantiles(new float[]{.2f, .4f, .6f, .8f}), 0.1f
+        h.getQuantiles(new float[]{.2f, .4f, .6f, .8f}), 0.1f, "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{1f, 2f, 3f, 4f, 5f, 6f, 7f, 8f, 9f},
-        h.getQuantiles(new float[]{.1f, .2f, .3f, .4f, .5f, .6f, .7f, .8f, .9f}), 0.1f
+        h.getQuantiles(new float[]{.1f, .2f, .3f, .4f, .5f, .6f, .7f, .8f, .9f}), 0.1f, "expected quantiles match actual quantiles"
     );
   }
 
@@ -409,28 +391,28 @@ public class ApproximateHistogramTest
   {
     ApproximateHistogram h = buildHistogram(20, VALUES7);
 
-    Assert.assertTrue(
-        "min value incorrect",
-        VALUES7[0] == h.min()
+    Assertions.assertTrue(
+        VALUES7[0] == h.min(),
+        "min value incorrect"
     );
-    Assert.assertTrue(
-        "max value incorrect",
-        VALUES7[VALUES7.length - 1] == h.max()
+    Assertions.assertTrue(
+        VALUES7[VALUES7.length - 1] == h.max(),
+        "max value incorrect"
     );
 
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{1.8f, 3.6f, 5.4f, 7.2f, 9f, 11.05f, 12.37f, 17f, 23.5f},
         h.getQuantiles(new float[]{.1f, .2f, .3f, .4f, .5f, .6f, .7f, .8f, .9f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
 
     // Test for outliers (0.05f and 0.95f, which should be min <= value <= max)
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{h.min(), h.max()},
         h.getQuantiles(new float[]{.05f, .95f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
   }
 
@@ -438,35 +420,35 @@ public class ApproximateHistogramTest
   public void testQuantileBigger()
   {
     ApproximateHistogram h = buildHistogram(5, VALUES5);
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{4.5f},
         h.getQuantiles(new float[]{.5f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{2.83f, 6.17f},
         h.getQuantiles(new float[]{.333f, .666f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{2f, 4.5f, 7f},
         h.getQuantiles(new float[]{.25f, .5f, .75f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{1.5f, 3.5f, 5.5f, 7.5f},
         h.getQuantiles(new float[]{.2f, .4f, .6f, .8f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{1f, 1.5f, 2.5f, 3.5f, 4.5f, 5.5f, 6.5f, 7.5f, 8.5f},
         h.getQuantiles(new float[]{.1f, .2f, .3f, .4f, .5f, .6f, .7f, .8f, .9f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
   }
 
@@ -479,29 +461,29 @@ public class ApproximateHistogramTest
     }
     ApproximateHistogram h = buildHistogram(100, thousand);
 
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{493.5f},
         h.getQuantiles(new float[]{.5f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{327.5f, 662f},
         h.getQuantiles(new float[]{.333f, .666f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{244.5f, 493.5f, 746f},
         h.getQuantiles(new float[]{.25f, .5f, .75f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
-    Assert.assertArrayEquals(
-        "expected quantiles match actual quantiles",
+    Assertions.assertArrayEquals(
         new float[]{96.5f, 196.53f, 294.5f, 395.5f, 493.5f, 597f, 696f, 795f, 895.25f},
         h.getQuantiles(new float[]{.1f, .2f, .3f, .4f, .5f, .6f, .7f, .8f, .9f}),
-        0.1f
+        0.1f,
+        "expected quantiles match actual quantiles"
     );
   }
 
@@ -522,8 +504,8 @@ public class ApproximateHistogramTest
       h.foldFast(hHigh);
     }
 
-    Assert.assertEquals(20f, h.sum(lowerLimit), .7f);
-    Assert.assertEquals(VALUES6.length + 20f, h.sum(upperLimit), 0.01);
+    Assertions.assertEquals(20f, h.sum(lowerLimit), .7f);
+    Assertions.assertEquals(VALUES6.length + 20f, h.sum(upperLimit), 0.01);
   }
 
   @Test
@@ -533,16 +515,14 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
     Histogram h2 = h.toHistogram(.05f, 0f);
 
-    Assert.assertArrayEquals(
-        "expected counts match actual counts",
+    Assertions.assertArrayEquals(
         new double[]{1f, 2f, 1f, 1f, 0f, 1f, 1f},
-        h2.getCounts(), 0.1f
+        h2.getCounts(), 0.1f, "expected counts match actual counts"
     );
 
-    Assert.assertArrayEquals(
-        "expected breaks match actual breaks",
+    Assertions.assertArrayEquals(
         new double[]{-5.05f, 0f, .05f, .1f, .15f, .95f, 1f, 2f},
-        h2.getBreaks(), 0.1f
+        h2.getBreaks(), 0.1f, "expected breaks match actual breaks"
     );
   }
 
@@ -553,18 +533,18 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
     Histogram h2 = h.toHistogram(.05f, 0f);
 
-    Assert.assertArrayEquals(
-        "expected counts match actual counts",
+    Assertions.assertArrayEquals(
         new double[]{1f, 2f, 1f, 1f, 0f, 1f, 1f, 1f},
         h2.getCounts(),
-        0.1f
+        0.1f,
+        "expected counts match actual counts"
     );
 
-    Assert.assertArrayEquals(
-        "expected breaks match actual breaks",
+    Assertions.assertArrayEquals(
         new double[]{-5.05f, 0f, .05f, .1f, .15f, .9f, .95f, 1f, 2.05f},
         h2.getBreaks(),
-        0.1f
+        0.1f,
+        "expected breaks match actual breaks"
     );
   }
 
@@ -575,18 +555,18 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
     Histogram h2 = h.toHistogram(1f, 0f);
 
-    Assert.assertArrayEquals(
-        "expected counts match actual counts",
+    Assertions.assertArrayEquals(
         new double[]{2f, 4f},
         h2.getCounts(),
-        0.1f
+        0.1f,
+        "expected counts match actual counts"
     );
 
-    Assert.assertArrayEquals(
-        "expected breaks match actual breaks",
+    Assertions.assertArrayEquals(
         new double[]{-1f, 0f, 1f},
         h2.getBreaks(),
-        0.1f
+        0.1f,
+        "expected breaks match actual breaks"
     );
   }
 
@@ -597,18 +577,18 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(50, values, 0.5f, 1f);
     Histogram h3 = h.toHistogram(0.2f, 0);
 
-    Assert.assertArrayEquals(
-        "Expected counts match actual counts",
+    Assertions.assertArrayEquals(
         new double[]{3f, 2f, 1f},
         h3.getCounts(),
-        0.1f
+        0.1f,
+        "Expected counts match actual counts"
     );
 
-    Assert.assertArrayEquals(
-        "expected breaks match actual breaks",
+    Assertions.assertArrayEquals(
         new double[]{-0.2f, 0.5f, 0.7f, 0.9f},
         h3.getBreaks(),
-        0.1f
+        0.1f,
+        "expected breaks match actual breaks"
     );
   }
 
@@ -618,18 +598,18 @@ public class ApproximateHistogramTest
     ApproximateHistogram h = buildHistogram(50, values, 0f, 1f);
     Histogram h4 = h.toHistogram(0.5f, 0);
 
-    Assert.assertArrayEquals(
-        "Expected counts match actual counts",
+    Assertions.assertArrayEquals(
         new double[]{2, 1},
         h4.getCounts(),
-        0.1f
+        0.1f,
+        "Expected counts match actual counts"
     );
 
-    Assert.assertArrayEquals(
-        "Expected breaks match actual breaks",
+    Assertions.assertArrayEquals(
         new double[]{0f, 0.5f, 1f},
         h4.getBreaks(),
-        0.1f
+        0.1f,
+        "Expected breaks match actual breaks"
     );
   }
 
@@ -637,7 +617,7 @@ public class ApproximateHistogramTest
   public void testEmptyHistogram()
   {
     ApproximateHistogram h = new ApproximateHistogram(50);
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{Float.NaN, Float.NaN},
         h.getQuantiles(new float[]{0.8f, 0.9f}),
         1e-9f

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
@@ -36,10 +36,9 @@ import org.apache.druid.query.topn.TopNQueryRunnerTest;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -47,36 +46,36 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(Parameterized.class)
 public class ApproximateHistogramTopNQueryTest extends InitializedNullHandlingTest
 {
   private static final Closer RESOURCE_CLOSER = Closer.create();
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws IOException
   {
     RESOURCE_CLOSER.close();
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     // Don't test with non-time-ordered segments, because results vary too much due to order-dependence.
     return QueryRunnerTestHelper.transformToConstructionFeeder(TopNQueryRunnerTest.queryRunners(false));
   }
 
-  private final QueryRunner runner;
+  private QueryRunner runner;
 
-  public ApproximateHistogramTopNQueryTest(
+  public void initApproximateHistogramTopNQueryTest(
       QueryRunner runner
   )
   {
     this.runner = runner;
   }
 
-  @Test
-  public void testTopNWithApproximateHistogramAgg()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testTopNWithApproximateHistogramAgg(QueryRunner runner)
   {
+    initApproximateHistogramTopNQueryTest(runner);
     ApproximateHistogramAggregatorFactory factory = new ApproximateHistogramAggregatorFactory(
         "apphisto",
         "index",

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramTopNQueryTest.java
@@ -62,20 +62,10 @@ public class ApproximateHistogramTopNQueryTest extends InitializedNullHandlingTe
     return QueryRunnerTestHelper.transformToConstructionFeeder(TopNQueryRunnerTest.queryRunners(false));
   }
 
-  private QueryRunner runner;
-
-  public void initApproximateHistogramTopNQueryTest(
-      QueryRunner runner
-  )
-  {
-    this.runner = runner;
-  }
-
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "{0}")
   public void testTopNWithApproximateHistogramAgg(QueryRunner runner)
   {
-    initApproximateHistogramTopNQueryTest(runner);
     ApproximateHistogramAggregatorFactory factory = new ApproximateHistogramAggregatorFactory(
         "apphisto",
         "index",

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramVectorAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ApproximateHistogramVectorAggregatorTest.java
@@ -26,9 +26,9 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -53,7 +53,7 @@ public class ApproximateHistogramVectorAggregatorTest
   };
   private VectorColumnSelectorFactory vectorColumnSelectorFactory;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     VectorValueSelector vectorValueSelector_1 = createMock(VectorValueSelector.class);
@@ -89,10 +89,10 @@ public class ApproximateHistogramVectorAggregatorTest
   public void doNotVectorizedNonNumericTypes()
   {
     ApproximateHistogramAggregatorFactory factory = buildHistogramAggFactory("string_field");
-    Assert.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
+    Assertions.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
 
     factory = buildHistogramAggFactory("complex_field");
-    Assert.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
+    Assertions.assertFalse(factory.canVectorize(vectorColumnSelectorFactory));
   }
 
   @Test
@@ -100,15 +100,15 @@ public class ApproximateHistogramVectorAggregatorTest
   {
     ApproximateHistogramAggregatorFactory factory = buildHistogramAggFactory("field_1");
     ByteBuffer byteBuffer = ByteBuffer.allocate(factory.getMaxIntermediateSizeWithNulls());
-    Assert.assertTrue(factory.canVectorize(vectorColumnSelectorFactory));
+    Assertions.assertTrue(factory.canVectorize(vectorColumnSelectorFactory));
     VectorAggregator vectorAggregator = factory.factorizeVector(vectorColumnSelectorFactory);
     vectorAggregator.init(byteBuffer, 0);
     vectorAggregator.aggregate(byteBuffer, 0, 0, 11);
     ApproximateHistogram h = (ApproximateHistogram) vectorAggregator.get(byteBuffer, 0);
 
     // (2, 1), (9.5, 2), (19.33, 3), (32.67, 3), (45, 1)
-    Assert.assertArrayEquals(new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions(), 0.1f);
-    Assert.assertArrayEquals(new long[]{1, 2, 3, 3, 1}, h.bins());
+    Assertions.assertArrayEquals(new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions(), 0.1f);
+    Assertions.assertArrayEquals(new long[]{1, 2, 3, 3, 1}, h.bins());
 
     factory = buildHistogramAggFactory("field_2");
     vectorAggregator = factory.factorizeVector(vectorColumnSelectorFactory);
@@ -116,8 +116,8 @@ public class ApproximateHistogramVectorAggregatorTest
     vectorAggregator.aggregate(byteBuffer, 0, 0, 10);
     h = (ApproximateHistogram) vectorAggregator.get(byteBuffer, 0);
 
-    Assert.assertArrayEquals(new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions(), 0.1f);
-    Assert.assertArrayEquals(new long[]{1, 2, 3, 3, 1}, h.bins());
+    Assertions.assertArrayEquals(new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h.positions(), 0.1f);
+    Assertions.assertArrayEquals(new long[]{1, 2, 3, 3, 1}, h.bins());
 
   }
 
@@ -140,11 +140,11 @@ public class ApproximateHistogramVectorAggregatorTest
     vectorAggregator.aggregate(byteBuffer, 2, positions, new int[]{10, 0}, 0);
 
     ApproximateHistogram h0 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, 0);
-    Assert.assertEquals(0, h0.count());
+    Assertions.assertEquals(0, h0.count());
 
     ApproximateHistogram h1 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, size);
-    Assert.assertArrayEquals(new float[]{23}, h1.positions(), 0.1f);
-    Assert.assertArrayEquals(new long[]{1}, h1.bins());
+    Assertions.assertArrayEquals(new float[]{23}, h1.positions(), 0.1f);
+    Assertions.assertArrayEquals(new long[]{1}, h1.bins());
   }
 
   @Test
@@ -164,12 +164,12 @@ public class ApproximateHistogramVectorAggregatorTest
     }
 
     ApproximateHistogram h0 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, 0);
-    Assert.assertArrayEquals(new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h0.positions(), 0.1f);
-    Assert.assertArrayEquals(new long[]{1, 2, 3, 3, 1}, h0.bins());
+    Assertions.assertArrayEquals(new float[]{2, 9.5f, 19.33f, 32.67f, 45f}, h0.positions(), 0.1f);
+    Assertions.assertArrayEquals(new long[]{1, 2, 3, 3, 1}, h0.bins());
 
     ApproximateHistogram h2 = (ApproximateHistogram) vectorAggregator.get(byteBuffer, size);
-    Assert.assertArrayEquals(new float[]{19}, h2.positions(), 0.1f);
-    Assert.assertArrayEquals(new long[]{10}, h2.bins());
+    Assertions.assertArrayEquals(new float[]{19}, h2.positions(), 0.1f);
+    Assertions.assertArrayEquals(new long[]{10}, h2.bins());
   }
 
   private ApproximateHistogramAggregatorFactory buildHistogramAggFactory(String fieldName)

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ArrayUtilsTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/ArrayUtilsTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.aggregation.histogram;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ArrayUtilsTest
 {
@@ -32,9 +32,9 @@ public class ArrayUtilsTest
     int hash3 = ArrayUtils.hashCode(new long[]{1L, 2L, 3L}, 0, 1);
     int hash4 = ArrayUtils.hashCode(new long[]{1L, 2L, 3L}, 0, 1);
 
-    Assert.assertEquals(hash1, hash2);
-    Assert.assertNotEquals(hash1, hash3);
-    Assert.assertEquals(hash3, hash4);
+    Assertions.assertEquals(hash1, hash2);
+    Assertions.assertNotEquals(hash1, hash3);
+    Assertions.assertEquals(hash3, hash4);
   }
 
   @Test
@@ -45,9 +45,9 @@ public class ArrayUtilsTest
     int hash3 = ArrayUtils.hashCode(new float[]{1.0f, 2.0f, 3.0f}, 0, 1);
     int hash4 = ArrayUtils.hashCode(new float[]{1.0f, 2.0f, 3.0f}, 0, 1);
 
-    Assert.assertEquals(hash1, hash2);
-    Assert.assertNotEquals(hash1, hash3);
-    Assert.assertEquals(hash3, hash4);
+    Assertions.assertEquals(hash1, hash2);
+    Assertions.assertNotEquals(hash1, hash3);
+    Assertions.assertEquals(hash3, hash4);
   }
 
   @Test
@@ -58,8 +58,8 @@ public class ArrayUtilsTest
     int hash3 = ArrayUtils.hashCode(new double[]{1.0, 2.0, 3.0}, 0, 1);
     int hash4 = ArrayUtils.hashCode(new double[]{1.0, 2.0, 3.0}, 0, 1);
 
-    Assert.assertEquals(hash1, hash2);
-    Assert.assertNotEquals(hash1, hash3);
-    Assert.assertEquals(hash3, hash4);
+    Assertions.assertEquals(hash1, hash2);
+    Assertions.assertNotEquals(hash1, hash3);
+    Assertions.assertEquals(hash3, hash4);
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/BucketsPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/BucketsPostAggregatorTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.aggregation.histogram;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class BucketsPostAggregatorTest
 {
@@ -39,11 +39,11 @@ public class BucketsPostAggregatorTest
         BucketsPostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertEquals(there.getBucketSize(), andBackAgain.getBucketSize(), 0.0001);
-    Assert.assertEquals(there.getOffset(), andBackAgain.getOffset(), 0.0001);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
-    Assert.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertEquals(there.getBucketSize(), andBackAgain.getBucketSize(), 0.0001);
+    Assertions.assertEquals(there.getOffset(), andBackAgain.getOffset(), 0.0001);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
   }
 
   @Test
@@ -52,7 +52,7 @@ public class BucketsPostAggregatorTest
     PostAggregator postAgg =
         new BucketsPostAggregator("buckets_post_aggregator", "test_field", 2f, 4f);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "BucketsPostAggregator{name='buckets_post_aggregator', fieldName='test_field', bucketSize=2.0, offset=4.0}",
         postAgg.toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/CustomBucketsPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/CustomBucketsPostAggregatorTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.aggregation.histogram;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CustomBucketsPostAggregatorTest
 {
@@ -39,9 +39,9 @@ public class CustomBucketsPostAggregatorTest
         CustomBucketsPostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
-    Assert.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
   }
 
   @Test
@@ -50,7 +50,7 @@ public class CustomBucketsPostAggregatorTest
     PostAggregator postAgg =
         new CustomBucketsPostAggregator("buckets_post_aggregator", "test_field", new float[]{2f, 4f});
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "CustomBucketsPostAggregator{name='buckets_post_aggregator', fieldName='test_field', breaks=[2.0, 4.0]}",
         postAgg.toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/EqualBucketsPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/EqualBucketsPostAggregatorTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.aggregation.histogram;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class EqualBucketsPostAggregatorTest
 {
@@ -39,9 +39,9 @@ public class EqualBucketsPostAggregatorTest
         EqualBucketsPostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
-    Assert.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
   }
 
   @Test
@@ -50,7 +50,7 @@ public class EqualBucketsPostAggregatorTest
     PostAggregator postAgg =
         new EqualBucketsPostAggregator("buckets_post_aggregator", "test_field", 3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "EqualBucketsPostAggregator{name='buckets_post_aggregator', fieldName='test_field', numBuckets=3}",
         postAgg.toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
@@ -37,9 +37,9 @@ import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramAggregationTest.java
@@ -35,15 +35,14 @@ import org.apache.druid.query.groupby.GroupByQueryConfig;
 import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -54,25 +53,23 @@ import java.util.List;
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlingTest
 {
-  private final AggregationTestHelper helper;
+  private AggregationTestHelper helper;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
-  public FixedBucketsHistogramAggregationTest(final GroupByQueryConfig config)
+  public void initFixedBucketsHistogramAggregationTest(final GroupByQueryConfig config)
   {
     ApproximateHistogramDruidModule.registerSerde();
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         Lists.newArrayList(new ApproximateHistogramDruidModule().getJacksonModules()),
         config,
         tempFolder
     );
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -82,21 +79,23 @@ public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlin
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
-  @Test
-  public void testIngestWithNullsIgnoredAndQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testIngestWithNullsIgnoredAndQuery(final GroupByQueryConfig config) throws Exception
   {
+    initFixedBucketsHistogramAggregationTest(config);
     MapBasedRow row = ingestAndQuery(this.getClass().getClassLoader().getResourceAsStream("sample.data.tsv"));
     FixedBucketsHistogram histogram = (FixedBucketsHistogram) row.getRaw("index_fbh");
-    Assert.assertEquals(5, histogram.getCount());
-    Assert.assertEquals(92.782760, row.getMetric("index_min").floatValue(), 0.0001);
-    Assert.assertEquals(135.109191, row.getMetric("index_max").floatValue(), 0.0001);
-    Assert.assertEquals(135.9499969482422, row.getMetric("index_quantile").floatValue(), 0.0001);
+    Assertions.assertEquals(5, histogram.getCount());
+    Assertions.assertEquals(92.782760, row.getMetric("index_min").floatValue(), 0.0001);
+    Assertions.assertEquals(135.109191, row.getMetric("index_max").floatValue(), 0.0001);
+    Assertions.assertEquals(135.9499969482422, row.getMetric("index_quantile").floatValue(), 0.0001);
   }
 
   /**
@@ -105,9 +104,11 @@ public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlin
    * {@link org.apache.druid.query.aggregation.AggregateCombiner#reset} gets called. This is the only path
    * that calls this method.
    */
-  @Test
-  public void testAggregateCombinerReset() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testAggregateCombinerReset(final GroupByQueryConfig config) throws Exception
   {
+    initFixedBucketsHistogramAggregationTest(config);
     String inputRows = "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t10\n"
                        + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t20\n"
                        + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t30\n"
@@ -120,11 +121,11 @@ public class FixedBucketsHistogramAggregationTest extends InitializedNullHandlin
                        + "2011-04-15T00:00:00.000Z\tspot\thealth\tpreferred\ta\u0001preferred\t50\n";
     MapBasedRow row = ingestAndQuery(new ByteArrayInputStream(inputRows.getBytes(StandardCharsets.UTF_8)));
     FixedBucketsHistogram histogram = (FixedBucketsHistogram) row.getRaw("index_fbh");
-    Assert.assertEquals(10, histogram.getCount());
-    Assert.assertEquals(10, row.getMetric("index_min").floatValue(), 0.0001);
-    Assert.assertEquals(50, row.getMetric("index_max").floatValue(), 0.0001);
+    Assertions.assertEquals(10, histogram.getCount());
+    Assertions.assertEquals(10, row.getMetric("index_min").floatValue(), 0.0001);
+    Assertions.assertEquals(50, row.getMetric("index_max").floatValue(), 0.0001);
     // Current interpolation logic doesn't consider min/max: it assumes the values seen were evenly-distributed between 50 and 51.
-    Assert.assertEquals(50.95, row.getMetric("index_quantile").floatValue(), 0.0001);
+    Assertions.assertEquals(50.95, row.getMetric("index_quantile").floatValue(), 0.0001);
   }
 
   private MapBasedRow ingestAndQuery(InputStream inputDataStream) throws Exception

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramBufferAggregatorTest.java
@@ -30,8 +30,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -79,15 +79,14 @@ public class FixedBucketsHistogramBufferAggregatorTest
 
     FixedBucketsHistogram h = ((FixedBucketsHistogram) agg.get(buf, position));
 
-    Assert.assertArrayEquals(
-        "final bin counts don't match expected counts",
-        new long[]{2, 3, 1, 3, 1}, h.getHistogram()
+    Assertions.assertArrayEquals(
+        new long[]{2, 3, 1, 3, 1}, h.getHistogram(), "final bin counts don't match expected counts"
     );
 
-    Assert.assertEquals("getMin value doesn't match expected getMin", 2, h.getMin(), 0);
-    Assert.assertEquals("getMax value doesn't match expected getMax", 45, h.getMax(), 0);
+    Assertions.assertEquals(2, h.getMin(), 0, "getMin value doesn't match expected getMin");
+    Assertions.assertEquals(45, h.getMax(), 0, "getMax value doesn't match expected getMax");
 
-    Assert.assertEquals("count doesn't match expected count", 10, h.getCount());
+    Assertions.assertEquals(10, h.getCount(), "count doesn't match expected count");
   }
 
   @Test
@@ -130,14 +129,14 @@ public class FixedBucketsHistogramBufferAggregatorTest
 
     Object finalizedObjectHumanReadable = humanReadableFactory.finalizeComputation(agg.get());
     String finalStringHumanReadable = objectMapper.writeValueAsString(finalizedObjectHumanReadable);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"{lowerLimit=0.0, upperLimit=50.0, numBuckets=5, upperOutlierCount=0, lowerOutlierCount=0, missingValueCount=0, histogram=[0, 0, 1, 0, 0], outlierHandlingMode=overflow, count=1, max=23.0, min=23.0}\"",
         finalStringHumanReadable
     );
 
     Object finalizedObjectBinary = binaryFactory.finalizeComputation(agg.get());
     String finalStringBinary = objectMapper.writeValueAsString(finalizedObjectBinary);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "\"AQIAAAAAAAAAAEBJAAAAAAAAAAAABQEAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEA3AAAAAAAAQDcAAAAAAAAAAAABAAAAAgAAAAAAAAAB\"",
         finalStringBinary
     );
@@ -163,7 +162,7 @@ public class FixedBucketsHistogramBufferAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("fixedHisto", null)
@@ -189,7 +188,7 @@ public class FixedBucketsHistogramBufferAggregatorTest
         FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
         false
     );
-    Assert.assertEquals(factory, factory.withName("billy"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("billy"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
@@ -57,9 +57,6 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
   private static final Closer RESOURCE_CLOSER = Closer.create();
   private static TestGroupByBuffers BUFFER_POOLS = null;
 
-  private QueryRunner<ResultRow> runner;
-  private GroupByQueryRunnerFactory factory;
-
   @BeforeAll
   public static void setUpClass()
   {
@@ -109,19 +106,6 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
     return constructors;
   }
 
-  @SuppressWarnings("unused")
-  public void initFixedBucketsHistogramGroupByQueryTest(
-      String testName,
-      GroupByQueryRunnerFactory factory,
-      QueryRunner runner
-  )
-  {
-    this.factory = factory;
-    this.runner = runner;
-
-    ApproximateHistogramDruidModule.registerSerde();
-  }
-
   @AfterEach
   public void teardown() throws IOException
   {
@@ -136,7 +120,7 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
       QueryRunner runner
   )
   {
-    initFixedBucketsHistogramGroupByQueryTest(testName, factory, runner);
+    ApproximateHistogramDruidModule.registerSerde();
     FixedBucketsHistogramAggregatorFactory aggFactory = new FixedBucketsHistogramAggregatorFactory(
         "histo",
         "index",
@@ -204,7 +188,7 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
       QueryRunner runner
   )
   {
-    initFixedBucketsHistogramGroupByQueryTest(testName, factory, runner);
+    ApproximateHistogramDruidModule.registerSerde();
     assertThrows(IllegalArgumentException.class, () -> {
       FixedBucketsHistogramAggregatorFactory aggFactory = new FixedBucketsHistogramAggregatorFactory(
           "histo",

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
@@ -37,30 +37,30 @@ import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  */
-@RunWith(Parameterized.class)
 public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandlingTest
 {
   private static final Closer RESOURCE_CLOSER = Closer.create();
   private static TestGroupByBuffers BUFFER_POOLS = null;
 
-  private final QueryRunner<ResultRow> runner;
-  private final GroupByQueryRunnerFactory factory;
+  private QueryRunner<ResultRow> runner;
+  private GroupByQueryRunnerFactory factory;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass()
   {
     if (BUFFER_POOLS == null) {
@@ -68,14 +68,13 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass()
   {
     BUFFER_POOLS.close();
     BUFFER_POOLS = null;
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     setUpClass();
@@ -111,7 +110,7 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
   }
 
   @SuppressWarnings("unused")
-  public FixedBucketsHistogramGroupByQueryTest(
+  public void initFixedBucketsHistogramGroupByQueryTest(
       String testName,
       GroupByQueryRunnerFactory factory,
       QueryRunner runner
@@ -123,15 +122,21 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
     ApproximateHistogramDruidModule.registerSerde();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     RESOURCE_CLOSER.close();
   }
 
-  @Test
-  public void testGroupByWithFixedHistogramAgg()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testGroupByWithFixedHistogramAgg(
+      String testName,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner
+  )
   {
+    initFixedBucketsHistogramGroupByQueryTest(testName, factory, runner);
     FixedBucketsHistogramAggregatorFactory aggFactory = new FixedBucketsHistogramAggregatorFactory(
         "histo",
         "index",
@@ -191,51 +196,59 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
     TestHelper.assertExpectedObjects(expectedResults, results, "fixed-histo");
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGroupByWithSameNameComplexPostAgg()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testGroupByWithSameNameComplexPostAgg(
+      String testName,
+      GroupByQueryRunnerFactory factory,
+      QueryRunner runner
+  )
   {
-    FixedBucketsHistogramAggregatorFactory aggFactory = new FixedBucketsHistogramAggregatorFactory(
-        "histo",
-        "index",
-        10,
-        0,
-        2000,
-        FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
-        false
-    );
+    initFixedBucketsHistogramGroupByQueryTest(testName, factory, runner);
+    assertThrows(IllegalArgumentException.class, () -> {
+      FixedBucketsHistogramAggregatorFactory aggFactory = new FixedBucketsHistogramAggregatorFactory(
+          "histo",
+          "index",
+          10,
+          0,
+          2000,
+          FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW,
+          false
+      );
 
-    GroupByQuery query = new GroupByQuery.Builder()
-        .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
-        .setGranularity(QueryRunnerTestHelper.ALL_GRAN).setDimensions(new DefaultDimensionSpec(
-            QueryRunnerTestHelper.MARKET_DIMENSION,
-            "marketalias"
-        ))
-        .setInterval(QueryRunnerTestHelper.FULL_ON_INTERVAL)
-        .setLimitSpec(
-            new DefaultLimitSpec(
-                Collections.singletonList(new OrderByColumnSpec("marketalias", OrderByColumnSpec.Direction.DESCENDING)),
-                1
-            )
-        ).setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, aggFactory)
-        .setPostAggregatorSpecs(
-            Collections.singletonList(
-                new QuantilePostAggregator("quantile", "quantile", 0.5f)
-            )
-        )
-        .build();
+      GroupByQuery query = new GroupByQuery.Builder()
+          .setDataSource(QueryRunnerTestHelper.DATA_SOURCE)
+          .setGranularity(QueryRunnerTestHelper.ALL_GRAN).setDimensions(new DefaultDimensionSpec(
+          QueryRunnerTestHelper.MARKET_DIMENSION,
+          "marketalias"
+      ))
+          .setInterval(QueryRunnerTestHelper.FULL_ON_INTERVAL)
+          .setLimitSpec(
+              new DefaultLimitSpec(
+                  Collections.singletonList(new OrderByColumnSpec("marketalias", OrderByColumnSpec.Direction.DESCENDING)),
+                  1
+              )
+          ).setAggregatorSpecs(QueryRunnerTestHelper.ROWS_COUNT, aggFactory)
+          .setPostAggregatorSpecs(
+              Collections.singletonList(
+                  new QuantilePostAggregator("quantile", "quantile", 0.5f)
+              )
+          )
+          .build();
 
-    List<ResultRow> expectedResults = Collections.singletonList(
-        GroupByQueryRunnerTestHelper.createExpectedRow(
-            query,
-            "1970-01-01T00:00:00.000Z",
-            "marketalias", "upfront",
-            "rows", 186L,
-            "quantile", 969.6969604492188f
-        )
-    );
+      List<ResultRow> expectedResults = Collections.singletonList(
+          GroupByQueryRunnerTestHelper.createExpectedRow(
+              query,
+              "1970-01-01T00:00:00.000Z",
+              "marketalias", "upfront",
+              "rows", 186L,
+              "quantile", 969.6969604492188f
+          )
+      );
 
-    Iterable<ResultRow> results = runner.run(QueryPlus.wrap(GroupByQueryRunnerTestHelper.populateResourceId(query)))
-                                        .toList();
-    TestHelper.assertExpectedObjects(expectedResults, results, "fixed-histo");
+      Iterable<ResultRow> results = runner.run(QueryPlus.wrap(GroupByQueryRunnerTestHelper.populateResourceId(query)))
+          .toList();
+      TestHelper.assertExpectedObjects(expectedResults, results, "fixed-histo");
+    });
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramGroupByQueryTest.java
@@ -99,7 +99,7 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
             config.toString(),
             runner.toString()
         );
-        constructors.add(new Object[]{testName, factory, runner});
+        constructors.add(new Object[]{testName, runner});
       }
     }
 
@@ -116,7 +116,6 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
   @ParameterizedTest(name = "{0}")
   public void testGroupByWithFixedHistogramAgg(
       String testName,
-      GroupByQueryRunnerFactory factory,
       QueryRunner runner
   )
   {
@@ -184,7 +183,6 @@ public class FixedBucketsHistogramGroupByQueryTest extends InitializedNullHandli
   @ParameterizedTest(name = "{0}")
   public void testGroupByWithSameNameComplexPostAgg(
       String testName,
-      GroupByQueryRunnerFactory factory,
       QueryRunner runner
   )
   {

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTest.java
@@ -23,8 +23,8 @@ import org.apache.commons.math3.distribution.NormalDistribution;
 import org.apache.commons.math3.random.JDKRandomGenerator;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.segment.data.ObjectStrategy;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Random;
 
@@ -85,7 +85,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{2.5f, 20.0f, 46.76f},
         quantiles,
         0.01f
@@ -112,7 +112,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 25.0f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{125.04082f, 248.84348f, 501.67166f, 979.7799f},
         quantiles,
         0.01f
@@ -141,7 +141,7 @@ public class FixedBucketsHistogramTest
     }
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 25.0f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{38565.324f, 43297.95f, 50091.902f, 70509.125f},
         quantiles,
         0.01f
@@ -161,7 +161,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{3.0f, 20.0f, 47.52f},
         quantiles,
         0.01f
@@ -181,7 +181,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{14.857142f, 20.0f, 28.4f},
         quantiles,
         0.01f
@@ -201,7 +201,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{-8.5f, 20.0f, 67.6f},
         quantiles,
         0.01f
@@ -221,7 +221,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{2.125f, 5.5f, 9.82f},
         quantiles,
         0.01f
@@ -241,7 +241,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{2.125f, 5.5f, 9.82f},
         quantiles,
         0.01f
@@ -261,7 +261,7 @@ public class FixedBucketsHistogramTest
 
     float[] quantiles = h.percentilesFloat(new double[]{12.5f, 50.0f, 98f});
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new float[]{3.25f, 10f, 25.88f},
         quantiles,
         0.01f
@@ -304,46 +304,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{3, 1, 2, 2, 1}, h.getHistogram());
-    Assert.assertEquals(9, h.getCount());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(19, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(2, h.getLowerOutlierCount());
-    Assert.assertEquals(2, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{3, 1, 2, 2, 1}, h.getHistogram());
+    Assertions.assertEquals(9, h.getCount());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(19, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(2, h.getLowerOutlierCount());
+    Assertions.assertEquals(2, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{5, 1, 2, 2, 3}, hClip.getHistogram());
-    Assert.assertEquals(13, hClip.getCount());
-    Assert.assertEquals(0, hClip.getMin(), 0.01);
-    Assert.assertEquals(20, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{5, 1, 2, 2, 3}, hClip.getHistogram());
+    Assertions.assertEquals(13, hClip.getCount());
+    Assertions.assertEquals(0, hClip.getMin(), 0.01);
+    Assertions.assertEquals(20, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{3, 1, 2, 2, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(9, hIgnore.getCount());
-    Assert.assertEquals(1, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(19, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{3, 1, 2, 2, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(9, hIgnore.getCount());
+    Assertions.assertEquals(1, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(19, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -382,46 +382,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, h.getHistogram());
-    Assert.assertEquals(5, h.getCount());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(19, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(4, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, h.getHistogram());
+    Assertions.assertEquals(5, h.getCount());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(19, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(4, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 1, 5}, hClip.getHistogram());
-    Assert.assertEquals(9, hClip.getCount());
-    Assert.assertEquals(1, hClip.getMin(), 0.01);
-    Assert.assertEquals(20, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 1, 5}, hClip.getHistogram());
+    Assertions.assertEquals(9, hClip.getCount());
+    Assertions.assertEquals(1, hClip.getMin(), 0.01);
+    Assertions.assertEquals(20, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(5, hIgnore.getCount());
-    Assert.assertEquals(1, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(19, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(5, hIgnore.getCount());
+    Assertions.assertEquals(1, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(19, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -460,46 +460,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, h.getHistogram());
-    Assert.assertEquals(5, h.getCount());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(19, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(4, h.getLowerOutlierCount());
-    Assert.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, h.getHistogram());
+    Assertions.assertEquals(5, h.getCount());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(19, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(4, h.getLowerOutlierCount());
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{6, 1, 0, 1, 1}, hClip.getHistogram());
-    Assert.assertEquals(9, hClip.getCount());
-    Assert.assertEquals(0, hClip.getMin(), 0.01);
-    Assert.assertEquals(19, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{6, 1, 0, 1, 1}, hClip.getHistogram());
+    Assertions.assertEquals(9, hClip.getCount());
+    Assertions.assertEquals(0, hClip.getMin(), 0.01);
+    Assertions.assertEquals(19, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(5, hIgnore.getCount());
-    Assert.assertEquals(1, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(19, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 1, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(5, hIgnore.getCount());
+    Assertions.assertEquals(1, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(19, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
 
@@ -540,46 +540,46 @@ public class FixedBucketsHistogramTest
 
     h.combineHistogram(h2);
 
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, h.getHistogram());
-    Assert.assertEquals(7, h.getCount());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(19, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(2, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, h.getHistogram());
+    Assertions.assertEquals(7, h.getCount());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(19, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(2, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 2, 4}, hClip.getHistogram());
-    Assert.assertEquals(9, hClip.getCount());
-    Assert.assertEquals(1, hClip.getMin(), 0.01);
-    Assert.assertEquals(20, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 2, 4}, hClip.getHistogram());
+    Assertions.assertEquals(9, hClip.getCount());
+    Assertions.assertEquals(1, hClip.getMin(), 0.01);
+    Assertions.assertEquals(20, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, hIgnore.getHistogram());
-    Assert.assertEquals(7, hIgnore.getCount());
-    Assert.assertEquals(1, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(19, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, hIgnore.getHistogram());
+    Assertions.assertEquals(7, hIgnore.getCount());
+    Assertions.assertEquals(1, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(19, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -619,46 +619,46 @@ public class FixedBucketsHistogramTest
 
     h.combineHistogram(h2);
 
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(12, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(32, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, h.getHistogram());
-    Assert.assertEquals(6, h.getCount());
-    Assert.assertEquals(12, h.getMin(), 0.01);
-    Assert.assertEquals(29, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(3, h.getLowerOutlierCount());
-    Assert.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(12, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(32, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, h.getHistogram());
+    Assertions.assertEquals(6, h.getCount());
+    Assertions.assertEquals(12, h.getMin(), 0.01);
+    Assertions.assertEquals(29, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(3, h.getLowerOutlierCount());
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(12, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(32, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{5, 2, 0, 1, 1}, hClip.getHistogram());
-    Assert.assertEquals(9, hClip.getCount());
-    Assert.assertEquals(12, hClip.getMin(), 0.01);
-    Assert.assertEquals(29, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(12, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(32, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{5, 2, 0, 1, 1}, hClip.getHistogram());
+    Assertions.assertEquals(9, hClip.getCount());
+    Assertions.assertEquals(12, hClip.getMin(), 0.01);
+    Assertions.assertEquals(29, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(12, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(32, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(6, hIgnore.getCount());
-    Assert.assertEquals(12, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(29, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(12, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(32, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(6, hIgnore.getCount());
+    Assertions.assertEquals(12, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(29, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -697,46 +697,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(10, h.getNumBuckets());
-    Assert.assertEquals(5.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(50, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 0, 1, 2, 1, 1, 1, 0, 0, 1}, h.getHistogram());
-    Assert.assertEquals(8, h.getCount());
-    Assert.assertEquals(2, h.getMin(), 0.01);
-    Assert.assertEquals(48, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(1, h.getLowerOutlierCount());
-    Assert.assertEquals(1, h.getUpperOutlierCount());
+    Assertions.assertEquals(10, h.getNumBuckets());
+    Assertions.assertEquals(5.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(50, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 0, 1, 2, 1, 1, 1, 0, 0, 1}, h.getHistogram());
+    Assertions.assertEquals(8, h.getCount());
+    Assertions.assertEquals(2, h.getMin(), 0.01);
+    Assertions.assertEquals(48, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(1, h.getLowerOutlierCount());
+    Assertions.assertEquals(1, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(10, hClip.getNumBuckets());
-    Assert.assertEquals(5.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(50, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 0, 1, 2, 1, 1, 1, 0, 0, 2}, hClip.getHistogram());
-    Assert.assertEquals(10, hClip.getCount());
-    Assert.assertEquals(0, hClip.getMin(), 0.01);
-    Assert.assertEquals(50, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(10, hClip.getNumBuckets());
+    Assertions.assertEquals(5.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(50, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 0, 1, 2, 1, 1, 1, 0, 0, 2}, hClip.getHistogram());
+    Assertions.assertEquals(10, hClip.getCount());
+    Assertions.assertEquals(0, hClip.getMin(), 0.01);
+    Assertions.assertEquals(50, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(10, hIgnore.getNumBuckets());
-    Assert.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(50, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 0, 1, 2, 1, 1, 1, 0, 0, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(8, hIgnore.getCount());
-    Assert.assertEquals(2, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(48, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(10, hIgnore.getNumBuckets());
+    Assertions.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(50, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 0, 1, 2, 1, 1, 1, 0, 0, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(8, hIgnore.getCount());
+    Assertions.assertEquals(2, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(48, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -775,46 +775,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(4, h.getNumBuckets());
-    Assert.assertEquals(5.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(10, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(30, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 2, 1, 1}, h.getHistogram());
-    Assert.assertEquals(5, h.getCount());
-    Assert.assertEquals(11, h.getMin(), 0.01);
-    Assert.assertEquals(29, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(2, h.getLowerOutlierCount());
-    Assert.assertEquals(3, h.getUpperOutlierCount());
+    Assertions.assertEquals(4, h.getNumBuckets());
+    Assertions.assertEquals(5.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(10, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(30, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 2, 1, 1}, h.getHistogram());
+    Assertions.assertEquals(5, h.getCount());
+    Assertions.assertEquals(11, h.getMin(), 0.01);
+    Assertions.assertEquals(29, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(2, h.getLowerOutlierCount());
+    Assertions.assertEquals(3, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(4, hClip.getNumBuckets());
-    Assert.assertEquals(5.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(10, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(30, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{3, 2, 1, 4}, hClip.getHistogram());
-    Assert.assertEquals(10, hClip.getCount());
-    Assert.assertEquals(10, hClip.getMin(), 0.01);
-    Assert.assertEquals(30, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(4, hClip.getNumBuckets());
+    Assertions.assertEquals(5.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(10, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(30, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{3, 2, 1, 4}, hClip.getHistogram());
+    Assertions.assertEquals(10, hClip.getCount());
+    Assertions.assertEquals(10, hClip.getMin(), 0.01);
+    Assertions.assertEquals(30, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(4, hIgnore.getNumBuckets());
-    Assert.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(10, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(30, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 2, 1, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(5, hIgnore.getCount());
-    Assert.assertEquals(11, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(29, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(4, hIgnore.getNumBuckets());
+    Assertions.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(10, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(30, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 2, 1, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(5, hIgnore.getCount());
+    Assertions.assertEquals(11, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(29, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -837,18 +837,18 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(6, h.getNumBuckets());
-    Assert.assertEquals(1.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(6, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 1, 1, 1, 1, 1}, h.getHistogram());
-    Assert.assertEquals(6, h.getCount());
-    Assert.assertEquals(0, h.getMin(), 0.01);
-    Assert.assertEquals(5.25, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(6, h.getNumBuckets());
+    Assertions.assertEquals(1.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(6, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 1, 1, 1, 1, 1}, h.getHistogram());
+    Assertions.assertEquals(6, h.getCount());
+    Assertions.assertEquals(0, h.getMin(), 0.01);
+    Assertions.assertEquals(5.25, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
   }
 
 
@@ -888,46 +888,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, h.getHistogram());
-    Assert.assertEquals(9, h.getCount());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(18, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(1, h.getLowerOutlierCount());
-    Assert.assertEquals(1, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, h.getHistogram());
+    Assertions.assertEquals(9, h.getCount());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(18, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(1, h.getLowerOutlierCount());
+    Assertions.assertEquals(1, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{3, 3, 1, 1, 3}, hClip.getHistogram());
-    Assert.assertEquals(11, hClip.getCount());
-    Assert.assertEquals(0, hClip.getMin(), 0.01);
-    Assert.assertEquals(20, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{3, 3, 1, 1, 3}, hClip.getHistogram());
+    Assertions.assertEquals(11, hClip.getCount());
+    Assertions.assertEquals(0, hClip.getMin(), 0.01);
+    Assertions.assertEquals(20, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, hIgnore.getHistogram());
-    Assert.assertEquals(9, hIgnore.getCount());
-    Assert.assertEquals(1, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(18, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, hIgnore.getHistogram());
+    Assertions.assertEquals(9, hIgnore.getCount());
+    Assertions.assertEquals(1, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(18, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -966,46 +966,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertEquals(7, h.getCount());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, h.getHistogram());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(19, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(1, h.getLowerOutlierCount());
-    Assert.assertEquals(2, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertEquals(7, h.getCount());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, h.getHistogram());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(19, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(1, h.getLowerOutlierCount());
+    Assertions.assertEquals(2, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertEquals(10, hClip.getCount());
-    Assert.assertArrayEquals(new long[]{3, 1, 0, 2, 4}, hClip.getHistogram());
-    Assert.assertEquals(0, hClip.getMin(), 0.01);
-    Assert.assertEquals(20, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertEquals(10, hClip.getCount());
+    Assertions.assertArrayEquals(new long[]{3, 1, 0, 2, 4}, hClip.getHistogram());
+    Assertions.assertEquals(0, hClip.getMin(), 0.01);
+    Assertions.assertEquals(20, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertEquals(7, hIgnore.getCount());
-    Assert.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, hIgnore.getHistogram());
-    Assert.assertEquals(1, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(19, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertEquals(7, hIgnore.getCount());
+    Assertions.assertArrayEquals(new long[]{2, 1, 0, 2, 2}, hIgnore.getHistogram());
+    Assertions.assertEquals(1, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(19, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -1044,46 +1044,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(12, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(32, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, h.getHistogram());
-    Assert.assertEquals(6, h.getCount());
-    Assert.assertEquals(13, h.getMin(), 0.01);
-    Assert.assertEquals(29, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(4, h.getLowerOutlierCount());
-    Assert.assertEquals(1, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(12, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(32, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, h.getHistogram());
+    Assertions.assertEquals(6, h.getCount());
+    Assertions.assertEquals(13, h.getMin(), 0.01);
+    Assertions.assertEquals(29, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(4, h.getLowerOutlierCount());
+    Assertions.assertEquals(1, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(5, hClip.getNumBuckets());
-    Assert.assertEquals(4.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(12, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(32, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{6, 2, 0, 1, 2}, hClip.getHistogram());
-    Assert.assertEquals(11, hClip.getCount());
-    Assert.assertEquals(12, hClip.getMin(), 0.01);
-    Assert.assertEquals(32, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(5, hClip.getNumBuckets());
+    Assertions.assertEquals(4.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(12, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(32, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{6, 2, 0, 1, 2}, hClip.getHistogram());
+    Assertions.assertEquals(11, hClip.getCount());
+    Assertions.assertEquals(12, hClip.getMin(), 0.01);
+    Assertions.assertEquals(32, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(5, hIgnore.getNumBuckets());
-    Assert.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(12, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(32, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(6, hIgnore.getCount());
-    Assert.assertEquals(13, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(29, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(5, hIgnore.getNumBuckets());
+    Assertions.assertEquals(4.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(12, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(32, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 2, 0, 1, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(6, hIgnore.getCount());
+    Assertions.assertEquals(13, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(29, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -1123,46 +1123,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(10, h.getNumBuckets());
-    Assert.assertEquals(5.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(50, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 0, 2, 2, 1, 1, 1, 0, 0, 1}, h.getHistogram());
-    Assert.assertEquals(9, h.getCount());
-    Assert.assertEquals(2, h.getMin(), 0.01);
-    Assert.assertEquals(48, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(1, h.getLowerOutlierCount());
-    Assert.assertEquals(1, h.getUpperOutlierCount());
+    Assertions.assertEquals(10, h.getNumBuckets());
+    Assertions.assertEquals(5.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(50, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 0, 2, 2, 1, 1, 1, 0, 0, 1}, h.getHistogram());
+    Assertions.assertEquals(9, h.getCount());
+    Assertions.assertEquals(2, h.getMin(), 0.01);
+    Assertions.assertEquals(48, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(1, h.getLowerOutlierCount());
+    Assertions.assertEquals(1, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(10, hClip.getNumBuckets());
-    Assert.assertEquals(5.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(50, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 0, 2, 2, 1, 1, 1, 0, 0, 2}, hClip.getHistogram());
-    Assert.assertEquals(11, hClip.getCount());
-    Assert.assertEquals(0, hClip.getMin(), 0.01);
-    Assert.assertEquals(50, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(10, hClip.getNumBuckets());
+    Assertions.assertEquals(5.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(50, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 0, 2, 2, 1, 1, 1, 0, 0, 2}, hClip.getHistogram());
+    Assertions.assertEquals(11, hClip.getCount());
+    Assertions.assertEquals(0, hClip.getMin(), 0.01);
+    Assertions.assertEquals(50, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(10, hIgnore.getNumBuckets());
-    Assert.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(50, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 0, 2, 2, 1, 1, 1, 0, 0, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(9, hIgnore.getCount());
-    Assert.assertEquals(2, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(48, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(10, hIgnore.getNumBuckets());
+    Assertions.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(50, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 0, 2, 2, 1, 1, 1, 0, 0, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(9, hIgnore.getCount());
+    Assertions.assertEquals(2, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(48, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -1201,46 +1201,46 @@ public class FixedBucketsHistogramTest
     );
 
     h.combineHistogram(h2);
-    Assert.assertEquals(4, h.getNumBuckets());
-    Assert.assertEquals(5.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(10, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(30, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 2, 1, 1}, h.getHistogram());
-    Assert.assertEquals(5, h.getCount());
-    Assert.assertEquals(11, h.getMin(), 0.01);
-    Assert.assertEquals(29, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(1, h.getLowerOutlierCount());
-    Assert.assertEquals(2, h.getUpperOutlierCount());
+    Assertions.assertEquals(4, h.getNumBuckets());
+    Assertions.assertEquals(5.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(10, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(30, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 2, 1, 1}, h.getHistogram());
+    Assertions.assertEquals(5, h.getCount());
+    Assertions.assertEquals(11, h.getMin(), 0.01);
+    Assertions.assertEquals(29, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(1, h.getLowerOutlierCount());
+    Assertions.assertEquals(2, h.getUpperOutlierCount());
 
     hClip.combineHistogram(h2);
-    Assert.assertEquals(4, hClip.getNumBuckets());
-    Assert.assertEquals(5.0, hClip.getBucketSize(), 0.01);
-    Assert.assertEquals(10, hClip.getLowerLimit(), 0.01);
-    Assert.assertEquals(30, hClip.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 2, 1, 3}, hClip.getHistogram());
-    Assert.assertEquals(8, hClip.getCount());
-    Assert.assertEquals(10, hClip.getMin(), 0.01);
-    Assert.assertEquals(30, hClip.getMax(), 0.01);
-    Assert.assertEquals(0, hClip.getMissingValueCount());
-    Assert.assertEquals(0, hClip.getLowerOutlierCount());
-    Assert.assertEquals(0, hClip.getUpperOutlierCount());
+    Assertions.assertEquals(4, hClip.getNumBuckets());
+    Assertions.assertEquals(5.0, hClip.getBucketSize(), 0.01);
+    Assertions.assertEquals(10, hClip.getLowerLimit(), 0.01);
+    Assertions.assertEquals(30, hClip.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.CLIP, hClip.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 2, 1, 3}, hClip.getHistogram());
+    Assertions.assertEquals(8, hClip.getCount());
+    Assertions.assertEquals(10, hClip.getMin(), 0.01);
+    Assertions.assertEquals(30, hClip.getMax(), 0.01);
+    Assertions.assertEquals(0, hClip.getMissingValueCount());
+    Assertions.assertEquals(0, hClip.getLowerOutlierCount());
+    Assertions.assertEquals(0, hClip.getUpperOutlierCount());
 
     hIgnore.combineHistogram(h2);
-    Assert.assertEquals(4, hIgnore.getNumBuckets());
-    Assert.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
-    Assert.assertEquals(10, hIgnore.getLowerLimit(), 0.01);
-    Assert.assertEquals(30, hIgnore.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 2, 1, 1}, hIgnore.getHistogram());
-    Assert.assertEquals(5, hIgnore.getCount());
-    Assert.assertEquals(11, hIgnore.getMin(), 0.01);
-    Assert.assertEquals(29, hIgnore.getMax(), 0.01);
-    Assert.assertEquals(0, hIgnore.getMissingValueCount());
-    Assert.assertEquals(0, hIgnore.getLowerOutlierCount());
-    Assert.assertEquals(0, hIgnore.getUpperOutlierCount());
+    Assertions.assertEquals(4, hIgnore.getNumBuckets());
+    Assertions.assertEquals(5.0, hIgnore.getBucketSize(), 0.01);
+    Assertions.assertEquals(10, hIgnore.getLowerLimit(), 0.01);
+    Assertions.assertEquals(30, hIgnore.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.IGNORE, hIgnore.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 2, 1, 1}, hIgnore.getHistogram());
+    Assertions.assertEquals(5, hIgnore.getCount());
+    Assertions.assertEquals(11, hIgnore.getMin(), 0.01);
+    Assertions.assertEquals(29, hIgnore.getMax(), 0.01);
+    Assertions.assertEquals(0, hIgnore.getMissingValueCount());
+    Assertions.assertEquals(0, hIgnore.getLowerOutlierCount());
+    Assertions.assertEquals(0, hIgnore.getUpperOutlierCount());
   }
 
   @Test
@@ -1263,18 +1263,18 @@ public class FixedBucketsHistogramTest
     );
 
     h.combine(h2.toBase64());
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, h.getHistogram());
-    Assert.assertEquals(9, h.getCount());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(18, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(1, h.getLowerOutlierCount());
-    Assert.assertEquals(1, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, h.getHistogram());
+    Assertions.assertEquals(9, h.getCount());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(18, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(1, h.getLowerOutlierCount());
+    Assertions.assertEquals(1, h.getUpperOutlierCount());
   }
 
   @Test
@@ -1297,18 +1297,18 @@ public class FixedBucketsHistogramTest
     );
 
     h.combine(h2);
-    Assert.assertEquals(5, h.getNumBuckets());
-    Assert.assertEquals(4.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(0, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(20, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, h.getHistogram());
-    Assert.assertEquals(9, h.getCount());
-    Assert.assertEquals(1, h.getMin(), 0.01);
-    Assert.assertEquals(18, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(1, h.getLowerOutlierCount());
-    Assert.assertEquals(1, h.getUpperOutlierCount());
+    Assertions.assertEquals(5, h.getNumBuckets());
+    Assertions.assertEquals(4.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(0, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(20, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 3, 1, 1, 2}, h.getHistogram());
+    Assertions.assertEquals(9, h.getCount());
+    Assertions.assertEquals(1, h.getMin(), 0.01);
+    Assertions.assertEquals(18, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(1, h.getLowerOutlierCount());
+    Assertions.assertEquals(1, h.getUpperOutlierCount());
   }
 
   @Test
@@ -1324,11 +1324,11 @@ public class FixedBucketsHistogramTest
     h.combine(10);
     h.combine(20);
 
-    Assert.assertEquals(0, h.getUpperOutlierCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(2, h.getCount());
-    Assert.assertEquals(10, h.getMin(), 0.01);
-    Assert.assertEquals(20, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(2, h.getCount());
+    Assertions.assertEquals(10, h.getMin(), 0.01);
+    Assertions.assertEquals(20, h.getMax(), 0.01);
   }
 
   @Test
@@ -1343,7 +1343,7 @@ public class FixedBucketsHistogramTest
 
     h.incrementMissing();
     h.incrementMissing();
-    Assert.assertEquals(2, h.getMissingValueCount());
+    Assertions.assertEquals(2, h.getMissingValueCount());
 
     FixedBucketsHistogram h2 = new FixedBucketsHistogram(
         0,
@@ -1356,7 +1356,7 @@ public class FixedBucketsHistogramTest
     h2.incrementMissing();
     h2.incrementMissing();
     h.combineHistogram(h2);
-    Assert.assertEquals(5, h.getMissingValueCount());
+    Assertions.assertEquals(5, h.getMissingValueCount());
   }
 
 
@@ -1378,11 +1378,11 @@ public class FixedBucketsHistogramTest
     h.add(10);
     h.add(199);
 
-    Assert.assertEquals(0, h.getUpperOutlierCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(2, h.getCount());
-    Assert.assertEquals(10, h.getMin(), 0.01);
-    Assert.assertEquals(199, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(2, h.getCount());
+    Assertions.assertEquals(10, h.getMin(), 0.01);
+    Assertions.assertEquals(199, h.getMax(), 0.01);
   }
 
   @Test
@@ -1403,11 +1403,11 @@ public class FixedBucketsHistogramTest
     h.add(10);
     h.add(199);
 
-    Assert.assertEquals(3, h.getUpperOutlierCount());
-    Assert.assertEquals(2, h.getLowerOutlierCount());
-    Assert.assertEquals(2, h.getCount());
-    Assert.assertEquals(10, h.getMin(), 0.01);
-    Assert.assertEquals(199, h.getMax(), 0.01);
+    Assertions.assertEquals(3, h.getUpperOutlierCount());
+    Assertions.assertEquals(2, h.getLowerOutlierCount());
+    Assertions.assertEquals(2, h.getCount());
+    Assertions.assertEquals(10, h.getMin(), 0.01);
+    Assertions.assertEquals(199, h.getMax(), 0.01);
   }
 
   @Test
@@ -1428,11 +1428,11 @@ public class FixedBucketsHistogramTest
     h.add(10);
     h.add(199);
 
-    Assert.assertEquals(0, h.getUpperOutlierCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(7, h.getCount());
-    Assert.assertEquals(0, h.getMin(), 0.01);
-    Assert.assertEquals(200, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(7, h.getCount());
+    Assertions.assertEquals(0, h.getMin(), 0.01);
+    Assertions.assertEquals(200, h.getMax(), 0.01);
   }
 
   @Test
@@ -1457,16 +1457,16 @@ public class FixedBucketsHistogramTest
 
     byte[] asBytesAuto = hFull.toBytes();
 
-    Assert.assertArrayEquals(fullWithHeader, asBytesAuto);
+    Assertions.assertArrayEquals(fullWithHeader, asBytesAuto);
 
     FixedBucketsHistogram fromFullWithHeader = FixedBucketsHistogram.fromBytes(fullWithHeader);
-    Assert.assertEquals(hFull, fromFullWithHeader);
+    Assertions.assertEquals(hFull, fromFullWithHeader);
 
     FixedBucketsHistogram fromSparse = FixedBucketsHistogram.fromBytes(sparse);
-    Assert.assertEquals(hFull, fromSparse);
+    Assertions.assertEquals(hFull, fromSparse);
 
     FixedBucketsHistogram fromBase64 = FixedBucketsHistogram.fromBase64(asBase64Full);
-    Assert.assertEquals(hFull, fromBase64);
+    Assertions.assertEquals(hFull, fromBase64);
   }
 
   @Test
@@ -1493,16 +1493,16 @@ public class FixedBucketsHistogramTest
 
     byte[] asBytesAuto = hSparse.toBytes();
 
-    Assert.assertArrayEquals(sparse, asBytesAuto);
+    Assertions.assertArrayEquals(sparse, asBytesAuto);
 
     FixedBucketsHistogram fromFullWithHeader = FixedBucketsHistogram.fromBytes(fullWithHeader);
-    Assert.assertEquals(hSparse, fromFullWithHeader);
+    Assertions.assertEquals(hSparse, fromFullWithHeader);
 
     FixedBucketsHistogram fromSparse = FixedBucketsHistogram.fromBytes(sparse);
-    Assert.assertEquals(hSparse, fromSparse);
+    Assertions.assertEquals(hSparse, fromSparse);
 
     FixedBucketsHistogram fromBase64 = FixedBucketsHistogram.fromBase64(asBase64Full);
-    Assert.assertEquals(hSparse, fromBase64);
+    Assertions.assertEquals(hSparse, fromBase64);
   }
 
   @Test
@@ -1510,6 +1510,6 @@ public class FixedBucketsHistogramTest
   {
     FixedBucketsHistogramSerde serde = new FixedBucketsHistogramSerde();
     ObjectStrategy<?> strategy = serde.getObjectStrategy();
-    Assert.assertFalse(strategy.readRetainsBufferReference());
+    Assertions.assertFalse(strategy.readRetainsBufferReference());
   }
 }

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
@@ -61,20 +61,10 @@ public class FixedBucketsHistogramTopNQueryTest extends InitializedNullHandlingT
     return QueryRunnerTestHelper.transformToConstructionFeeder(TopNQueryRunnerTest.queryRunners(true));
   }
 
-  private QueryRunner runner;
-
-  public void initFixedBucketsHistogramTopNQueryTest(
-      QueryRunner runner
-  )
-  {
-    this.runner = runner;
-  }
-
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "{0}")
   public void testTopNWithFixedHistogramAgg(QueryRunner runner)
   {
-    initFixedBucketsHistogramTopNQueryTest(runner);
     FixedBucketsHistogramAggregatorFactory factory = new FixedBucketsHistogramAggregatorFactory(
         "histo",
         "index",

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramTopNQueryTest.java
@@ -36,10 +36,9 @@ import org.apache.druid.query.topn.TopNQueryRunnerTest;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -47,35 +46,35 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(Parameterized.class)
 public class FixedBucketsHistogramTopNQueryTest extends InitializedNullHandlingTest
 {
   private static final Closer RESOURCE_CLOSER = Closer.create();
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws IOException
   {
     RESOURCE_CLOSER.close();
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return QueryRunnerTestHelper.transformToConstructionFeeder(TopNQueryRunnerTest.queryRunners(true));
   }
 
-  private final QueryRunner runner;
+  private QueryRunner runner;
 
-  public FixedBucketsHistogramTopNQueryTest(
+  public void initFixedBucketsHistogramTopNQueryTest(
       QueryRunner runner
   )
   {
     this.runner = runner;
   }
 
-  @Test
-  public void testTopNWithFixedHistogramAgg()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testTopNWithFixedHistogramAgg(QueryRunner runner)
   {
+    initFixedBucketsHistogramTopNQueryTest(runner);
     FixedBucketsHistogramAggregatorFactory factory = new FixedBucketsHistogramAggregatorFactory(
         "histo",
         "index",

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramVectorAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/FixedBucketsHistogramVectorAggregatorTest.java
@@ -26,9 +26,9 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorValueSelector;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -41,7 +41,7 @@ public class FixedBucketsHistogramVectorAggregatorTest
   private static final boolean[] NULL_VECTOR = {false, false, false, false, true, false};
   private VectorColumnSelectorFactory vectorColumnSelectorFactory;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     VectorValueSelector vectorValueSelector_1 = createMock(VectorValueSelector.class);
@@ -72,24 +72,24 @@ public class FixedBucketsHistogramVectorAggregatorTest
   {
     ByteBuffer byteBuffer = ByteBuffer.allocate(FixedBucketsHistogram.getFullStorageSize(2));
     FixedBucketsHistogramAggregatorFactory factory = buildHistogramAggFactory("field_1");
-    Assert.assertTrue(factory.canVectorize(vectorColumnSelectorFactory));
+    Assertions.assertTrue(factory.canVectorize(vectorColumnSelectorFactory));
     VectorAggregator vectorAggregator = factory.factorizeVector(vectorColumnSelectorFactory);
     vectorAggregator.init(byteBuffer, 0);
     vectorAggregator.aggregate(byteBuffer, 0, 0, 6);
     FixedBucketsHistogram h = (FixedBucketsHistogram) vectorAggregator.get(byteBuffer, 0);
 
-    Assert.assertEquals(2, h.getNumBuckets());
-    Assert.assertEquals(10.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(1, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(21, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 3}, h.getHistogram());
-    Assert.assertEquals(5, h.getCount());
-    Assert.assertEquals(1.0, h.getMin(), 0.01);
-    Assert.assertEquals(16.0, h.getMax(), 0.01);
-    Assert.assertEquals(1, h.getMissingValueCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(2, h.getNumBuckets());
+    Assertions.assertEquals(10.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(1, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(21, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 3}, h.getHistogram());
+    Assertions.assertEquals(5, h.getCount());
+    Assertions.assertEquals(1.0, h.getMin(), 0.01);
+    Assertions.assertEquals(16.0, h.getMax(), 0.01);
+    Assertions.assertEquals(1, h.getMissingValueCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
 
     factory = buildHistogramAggFactory("field_2");
     vectorAggregator = factory.factorizeVector(vectorColumnSelectorFactory);
@@ -97,18 +97,18 @@ public class FixedBucketsHistogramVectorAggregatorTest
     vectorAggregator.aggregate(byteBuffer, 0, 0, 6);
     h = (FixedBucketsHistogram) vectorAggregator.get(byteBuffer, 0);
 
-    Assert.assertEquals(2, h.getNumBuckets());
-    Assert.assertEquals(10.0, h.getBucketSize(), 0.01);
-    Assert.assertEquals(1, h.getLowerLimit(), 0.01);
-    Assert.assertEquals(21, h.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{2, 4}, h.getHistogram());
-    Assert.assertEquals(6, h.getCount());
-    Assert.assertEquals(1.0, h.getMin(), 0.01);
-    Assert.assertEquals(16.0, h.getMax(), 0.01);
-    Assert.assertEquals(0, h.getMissingValueCount());
-    Assert.assertEquals(0, h.getLowerOutlierCount());
-    Assert.assertEquals(0, h.getUpperOutlierCount());
+    Assertions.assertEquals(2, h.getNumBuckets());
+    Assertions.assertEquals(10.0, h.getBucketSize(), 0.01);
+    Assertions.assertEquals(1, h.getLowerLimit(), 0.01);
+    Assertions.assertEquals(21, h.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{2, 4}, h.getHistogram());
+    Assertions.assertEquals(6, h.getCount());
+    Assertions.assertEquals(1.0, h.getMin(), 0.01);
+    Assertions.assertEquals(16.0, h.getMax(), 0.01);
+    Assertions.assertEquals(0, h.getMissingValueCount());
+    Assertions.assertEquals(0, h.getLowerOutlierCount());
+    Assertions.assertEquals(0, h.getUpperOutlierCount());
   }
 
   @Test
@@ -125,33 +125,33 @@ public class FixedBucketsHistogramVectorAggregatorTest
 
     FixedBucketsHistogram h0 = (FixedBucketsHistogram) vectorAggregator.get(byteBuffer, 0);
 
-    Assert.assertEquals(2, h0.getNumBuckets());
-    Assert.assertEquals(10.0, h0.getBucketSize(), 0.01);
-    Assert.assertEquals(1, h0.getLowerLimit(), 0.01);
-    Assert.assertEquals(21, h0.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h0.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 0}, h0.getHistogram());
-    Assert.assertEquals(1, h0.getCount());
-    Assert.assertEquals(1.0, h0.getMin(), 0.01);
-    Assert.assertEquals(1.0, h0.getMax(), 0.01);
-    Assert.assertEquals(0, h0.getMissingValueCount());
-    Assert.assertEquals(0, h0.getLowerOutlierCount());
-    Assert.assertEquals(0, h0.getUpperOutlierCount());
+    Assertions.assertEquals(2, h0.getNumBuckets());
+    Assertions.assertEquals(10.0, h0.getBucketSize(), 0.01);
+    Assertions.assertEquals(1, h0.getLowerLimit(), 0.01);
+    Assertions.assertEquals(21, h0.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h0.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 0}, h0.getHistogram());
+    Assertions.assertEquals(1, h0.getCount());
+    Assertions.assertEquals(1.0, h0.getMin(), 0.01);
+    Assertions.assertEquals(1.0, h0.getMax(), 0.01);
+    Assertions.assertEquals(0, h0.getMissingValueCount());
+    Assertions.assertEquals(0, h0.getLowerOutlierCount());
+    Assertions.assertEquals(0, h0.getUpperOutlierCount());
 
     FixedBucketsHistogram h1 = (FixedBucketsHistogram) vectorAggregator.get(byteBuffer, positions[1]);
 
-    Assert.assertEquals(2, h1.getNumBuckets());
-    Assert.assertEquals(10.0, h1.getBucketSize(), 0.01);
-    Assert.assertEquals(1, h1.getLowerLimit(), 0.01);
-    Assert.assertEquals(21, h1.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h1.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{0, 1}, h1.getHistogram());
-    Assert.assertEquals(1, h1.getCount());
-    Assert.assertEquals(12.0, h1.getMin(), 0.01);
-    Assert.assertEquals(12.0, h1.getMax(), 0.01);
-    Assert.assertEquals(0, h1.getMissingValueCount());
-    Assert.assertEquals(0, h1.getLowerOutlierCount());
-    Assert.assertEquals(0, h1.getUpperOutlierCount());
+    Assertions.assertEquals(2, h1.getNumBuckets());
+    Assertions.assertEquals(10.0, h1.getBucketSize(), 0.01);
+    Assertions.assertEquals(1, h1.getLowerLimit(), 0.01);
+    Assertions.assertEquals(21, h1.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h1.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{0, 1}, h1.getHistogram());
+    Assertions.assertEquals(1, h1.getCount());
+    Assertions.assertEquals(12.0, h1.getMin(), 0.01);
+    Assertions.assertEquals(12.0, h1.getMax(), 0.01);
+    Assertions.assertEquals(0, h1.getMissingValueCount());
+    Assertions.assertEquals(0, h1.getLowerOutlierCount());
+    Assertions.assertEquals(0, h1.getUpperOutlierCount());
 
     // Tests when there is a level of indirection in accessing the vector
     byteBuffer = ByteBuffer.allocate(size * 2);
@@ -161,33 +161,33 @@ public class FixedBucketsHistogramVectorAggregatorTest
 
     FixedBucketsHistogram h2 = (FixedBucketsHistogram) vectorAggregator.get(byteBuffer, 0);
 
-    Assert.assertEquals(2, h2.getNumBuckets());
-    Assert.assertEquals(10.0, h2.getBucketSize(), 0.01);
-    Assert.assertEquals(1, h2.getLowerLimit(), 0.01);
-    Assert.assertEquals(21, h2.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h2.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{1, 0}, h2.getHistogram());
-    Assert.assertEquals(1, h2.getCount());
-    Assert.assertEquals(3.0, h2.getMin(), 0.01);
-    Assert.assertEquals(3.0, h2.getMax(), 0.01);
-    Assert.assertEquals(0, h2.getMissingValueCount());
-    Assert.assertEquals(0, h2.getLowerOutlierCount());
-    Assert.assertEquals(0, h2.getUpperOutlierCount());
+    Assertions.assertEquals(2, h2.getNumBuckets());
+    Assertions.assertEquals(10.0, h2.getBucketSize(), 0.01);
+    Assertions.assertEquals(1, h2.getLowerLimit(), 0.01);
+    Assertions.assertEquals(21, h2.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h2.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{1, 0}, h2.getHistogram());
+    Assertions.assertEquals(1, h2.getCount());
+    Assertions.assertEquals(3.0, h2.getMin(), 0.01);
+    Assertions.assertEquals(3.0, h2.getMax(), 0.01);
+    Assertions.assertEquals(0, h2.getMissingValueCount());
+    Assertions.assertEquals(0, h2.getLowerOutlierCount());
+    Assertions.assertEquals(0, h2.getUpperOutlierCount());
 
     FixedBucketsHistogram h3 = (FixedBucketsHistogram) vectorAggregator.get(byteBuffer, positions[1]);
 
-    Assert.assertEquals(2, h3.getNumBuckets());
-    Assert.assertEquals(10.0, h3.getBucketSize(), 0.01);
-    Assert.assertEquals(1, h3.getLowerLimit(), 0.01);
-    Assert.assertEquals(21, h3.getUpperLimit(), 0.01);
-    Assert.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h3.getOutlierHandlingMode());
-    Assert.assertArrayEquals(new long[]{0, 1}, h3.getHistogram());
-    Assert.assertEquals(1, h3.getCount());
-    Assert.assertEquals(14.0, h3.getMin(), 0.01);
-    Assert.assertEquals(14.0, h3.getMax(), 0.01);
-    Assert.assertEquals(0, h3.getMissingValueCount());
-    Assert.assertEquals(0, h3.getLowerOutlierCount());
-    Assert.assertEquals(0, h3.getUpperOutlierCount());
+    Assertions.assertEquals(2, h3.getNumBuckets());
+    Assertions.assertEquals(10.0, h3.getBucketSize(), 0.01);
+    Assertions.assertEquals(1, h3.getLowerLimit(), 0.01);
+    Assertions.assertEquals(21, h3.getUpperLimit(), 0.01);
+    Assertions.assertEquals(FixedBucketsHistogram.OutlierHandlingMode.OVERFLOW, h3.getOutlierHandlingMode());
+    Assertions.assertArrayEquals(new long[]{0, 1}, h3.getHistogram());
+    Assertions.assertEquals(1, h3.getCount());
+    Assertions.assertEquals(14.0, h3.getMin(), 0.01);
+    Assertions.assertEquals(14.0, h3.getMax(), 0.01);
+    Assertions.assertEquals(0, h3.getMissingValueCount());
+    Assertions.assertEquals(0, h3.getLowerOutlierCount());
+    Assertions.assertEquals(0, h3.getUpperOutlierCount());
 
   }
 

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/MaxPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/MaxPostAggregatorTest.java
@@ -23,8 +23,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -44,9 +44,9 @@ public class MaxPostAggregatorTest extends InitializedNullHandlingTest
         MaxPostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
-    Assert.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
   }
 
   @Test
@@ -67,10 +67,10 @@ public class MaxPostAggregatorTest extends InitializedNullHandlingTest
     metricValues.put(aggName, histo2);
     Object after = max.compute(metricValues);
 
-    Assert.assertEquals(-1, comp.compare(before, after));
-    Assert.assertEquals(0, comp.compare(before, before));
-    Assert.assertEquals(0, comp.compare(after, after));
-    Assert.assertEquals(1, comp.compare(after, before));
+    Assertions.assertEquals(-1, comp.compare(before, after));
+    Assertions.assertEquals(0, comp.compare(before, before));
+    Assertions.assertEquals(0, comp.compare(after, after));
+    Assertions.assertEquals(1, comp.compare(after, before));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class MaxPostAggregatorTest extends InitializedNullHandlingTest
     PostAggregator postAgg =
         new MaxPostAggregator("max", "test_field");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "MaxPostAggregator{fieldName='test_field'}",
         postAgg.toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/MinPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/MinPostAggregatorTest.java
@@ -23,8 +23,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -44,9 +44,9 @@ public class MinPostAggregatorTest extends InitializedNullHandlingTest
         MinPostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
-    Assert.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
   }
 
   @Test
@@ -67,10 +67,10 @@ public class MinPostAggregatorTest extends InitializedNullHandlingTest
     metricValues.put(aggName, histo2);
     Object after = min.compute(metricValues);
 
-    Assert.assertEquals(1, comp.compare(before, after));
-    Assert.assertEquals(0, comp.compare(before, before));
-    Assert.assertEquals(0, comp.compare(after, after));
-    Assert.assertEquals(-1, comp.compare(after, before));
+    Assertions.assertEquals(1, comp.compare(before, after));
+    Assertions.assertEquals(0, comp.compare(before, before));
+    Assertions.assertEquals(0, comp.compare(after, after));
+    Assertions.assertEquals(-1, comp.compare(after, before));
   }
 
   @Test
@@ -79,7 +79,7 @@ public class MinPostAggregatorTest extends InitializedNullHandlingTest
     PostAggregator postAgg =
         new MinPostAggregator("min", "test_field");
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "MinPostAggregator{fieldName='test_field'}",
         postAgg.toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilePostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilePostAggregatorTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.aggregation.histogram;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -43,9 +43,9 @@ public class QuantilePostAggregatorTest extends InitializedNullHandlingTest
         QuantilePostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
-    Assert.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
   }
 
   @Test
@@ -68,10 +68,10 @@ public class QuantilePostAggregatorTest extends InitializedNullHandlingTest
 
     Object after = quantile.compute(metricValues);
 
-    Assert.assertEquals(-1, comp.compare(before, after));
-    Assert.assertEquals(0, comp.compare(before, before));
-    Assert.assertEquals(0, comp.compare(after, after));
-    Assert.assertEquals(1, comp.compare(after, before));
+    Assertions.assertEquals(-1, comp.compare(before, after));
+    Assertions.assertEquals(0, comp.compare(before, before));
+    Assertions.assertEquals(0, comp.compare(after, after));
+    Assertions.assertEquals(1, comp.compare(after, before));
   }
 
   @Test
@@ -80,7 +80,7 @@ public class QuantilePostAggregatorTest extends InitializedNullHandlingTest
     QuantilePostAggregator postAgg =
         new QuantilePostAggregator("quantile", "testField", 0.9f);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "QuantilePostAggregator{name='quantile', fieldName='testField', probability=0.9}",
         postAgg.toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilesPostAggregatorTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilesPostAggregatorTest.java
@@ -21,15 +21,13 @@ package org.apache.druid.query.aggregation.histogram;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class QuantilesPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws Exception
@@ -43,17 +41,18 @@ public class QuantilesPostAggregatorTest
         QuantilesPostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
-    Assert.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there.getDependentFields(), andBackAgain.getDependentFields());
   }
 
   @Test
   public void testComparator()
   {
-    expectedException.expect(UnsupportedOperationException.class);
-    QuantilesPostAggregator quantiles = new QuantilesPostAggregator("quantiles", "someAgg", new float[]{0.3f, 0.9f});
-    quantiles.getComparator();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      QuantilesPostAggregator quantiles = new QuantilesPostAggregator("quantiles", "someAgg", new float[]{0.3f, 0.9f});
+      quantiles.getComparator();
+    });
   }
 
   @Test
@@ -62,7 +61,7 @@ public class QuantilesPostAggregatorTest
     QuantilesPostAggregator postAgg =
         new QuantilesPostAggregator("post", "test_field", new float[]{0.2f, 0.7f});
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "QuantilesPostAggregator{name='post', fieldName='test_field', probabilities=[0.2, 0.7]}",
         postAgg.toString()
     );

--- a/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilesTest.java
+++ b/extensions-core/histogram/src/test/java/org/apache/druid/query/aggregation/histogram/QuantilesTest.java
@@ -23,12 +23,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class QuantilesTest
 {
@@ -47,35 +48,35 @@ public class QuantilesTest
     );
 
     Object theObject = mapper.readValue(theString, Object.class);
-    MatcherAssert.assertThat(theObject, CoreMatchers.instanceOf(LinkedHashMap.class));
+    assertThat(theObject, CoreMatchers.instanceOf(LinkedHashMap.class));
 
     LinkedHashMap theMap = (LinkedHashMap) theObject;
 
     ArrayList theProbabilities = (ArrayList<Float>) theMap.get("probabilities");
 
-    Assert.assertEquals(probabilities.length, theProbabilities.size());
+    Assertions.assertEquals(probabilities.length, theProbabilities.size());
     for (int i = 0; i < theProbabilities.size(); ++i) {
-      Assert.assertEquals(probabilities[i], ((Number) theProbabilities.get(i)).floatValue(), 0.0001f);
+      Assertions.assertEquals(probabilities[i], ((Number) theProbabilities.get(i)).floatValue(), 0.0001f);
     }
 
     ArrayList theQuantiles = (ArrayList<Float>) theMap.get("quantiles");
 
-    Assert.assertEquals(quantiles.length, theQuantiles.size());
+    Assertions.assertEquals(quantiles.length, theQuantiles.size());
     for (int i = 0; i < theQuantiles.size(); ++i) {
-      Assert.assertEquals(quantiles[i], ((Number) theQuantiles.get(i)).floatValue(), 0.0001f);
+      Assertions.assertEquals(quantiles[i], ((Number) theQuantiles.get(i)).floatValue(), 0.0001f);
     }
 
-    Assert.assertEquals(
-        "serialized min. matches expected min.",
+    Assertions.assertEquals(
         min,
         ((Number) theMap.get("min")).floatValue(),
-        0.0001f
+        0.0001f,
+        "serialized min. matches expected min."
     );
-    Assert.assertEquals(
-        "serialized max. matches expected max.",
+    Assertions.assertEquals(
         max,
         ((Number) theMap.get("max")).floatValue(),
-        0.0001f
+        0.0001f,
+        "serialized max. matches expected max."
     );
 
 

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -96,6 +96,7 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -111,13 +112,19 @@ import java.util.stream.Collectors;
  */
 public class AggregationTestHelper implements Closeable
 {
+  @FunctionalInterface
+  private interface TempFolderProvider
+  {
+    File newFolder() throws IOException;
+  }
+
   private final ObjectMapper mapper;
   private final IndexMerger indexMerger;
   private final IndexIO indexIO;
   private final QueryToolChest toolChest;
   private final QueryRunnerFactory factory;
 
-  private final TemporaryFolder tempFolder;
+  private final TempFolderProvider tempFolderProvider;
   private final Closer resourceCloser;
 
   private final Map<String, Object> queryContext;
@@ -128,7 +135,7 @@ public class AggregationTestHelper implements Closeable
       IndexIO indexIO,
       QueryToolChest toolchest,
       QueryRunnerFactory factory,
-      TemporaryFolder tempFolder,
+      TempFolderProvider tempFolderProvider,
       List<? extends Module> jsonModulesToRegister,
       Closer resourceCloser,
       Map<String, Object> queryContext
@@ -139,7 +146,7 @@ public class AggregationTestHelper implements Closeable
     this.indexIO = indexIO;
     this.toolChest = toolchest;
     this.factory = factory;
-    this.tempFolder = tempFolder;
+    this.tempFolderProvider = tempFolderProvider;
     this.resourceCloser = resourceCloser;
     this.queryContext = queryContext;
 
@@ -152,6 +159,32 @@ public class AggregationTestHelper implements Closeable
       List<? extends Module> jsonModulesToRegister,
       GroupByQueryConfig config,
       TemporaryFolder tempFolder
+  )
+  {
+    return createGroupByQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        config,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createGroupByQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      GroupByQueryConfig config,
+      File tempFolder
+  )
+  {
+    return createGroupByQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        config,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createGroupByQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      GroupByQueryConfig config,
+      TempFolderProvider tempFolderProvider
   )
   {
     final Closer closer = Closer.create();
@@ -179,7 +212,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         factory.getToolchest(),
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         closer,
         Collections.emptyMap()
@@ -189,6 +222,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createTimeseriesQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createTimeseriesQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createTimeseriesQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -214,7 +269,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         Closer.create(),
         Collections.emptyMap()
@@ -224,6 +279,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createTopNQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createTopNQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createTopNQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createTopNQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createTopNQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -261,7 +338,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         resourceCloser,
         Collections.emptyMap()
@@ -271,6 +348,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createScanQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createScanQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createScanQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createScanQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createScanQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -299,11 +398,21 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         resourceCloser,
         Collections.emptyMap()
     );
+  }
+
+  private static TempFolderProvider tempFolderProvider(final TemporaryFolder tempFolder)
+  {
+    return tempFolder::newFolder;
+  }
+
+  private static TempFolderProvider tempFolderProvider(final File tempFolder)
+  {
+    return () -> Files.createTempDirectory(tempFolder.toPath(), "druid-").toFile();
   }
 
   public AggregationTestHelper withQueryContext(final Map<String, Object> queryContext)
@@ -316,7 +425,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolChest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         Collections.emptyList(),
         resourceCloser,
         newContext
@@ -334,7 +443,7 @@ public class AggregationTestHelper implements Closeable
       Query<T> query
   ) throws Exception
   {
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = tempFolderProvider.newFolder();
     createIndex(inputDataFile, inputSchema, inputFormat, aggregators, segmentDir, minTimestamp, gran, maxRowCount);
     return runQueryOnSegments(Collections.singletonList(segmentDir), query);
   }
@@ -350,7 +459,7 @@ public class AggregationTestHelper implements Closeable
       Query<T> query
   ) throws Exception
   {
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = tempFolderProvider.newFolder();
     createIndex(inputDataStream, inputSchema, inputFormat, aggregators, segmentDir, minTimestamp, gran, maxRowCount, true);
     return runQueryOnSegments(Collections.singletonList(segmentDir), query);
   }
@@ -439,7 +548,7 @@ public class AggregationTestHelper implements Closeable
           return inputDataStream;
         }
       };
-      InputEntityReader reader = inputFormat.createReader(inputSchema, streamEntity, tempFolder.newFolder());
+      InputEntityReader reader = inputFormat.createReader(inputSchema, streamEntity, tempFolderProvider.newFolder());
       AggregatorFactory[] metrics = aggregators.toArray(new AggregatorFactory[0]);
       index = new OnheapIncrementalIndex.Builder()
           .setIndexSchema(
@@ -458,7 +567,7 @@ public class AggregationTestHelper implements Closeable
         while (iter.hasNext()) {
           InputRow row = iter.next();
           if (!index.canAppendRow()) {
-            File tmp = tempFolder.newFolder();
+            File tmp = tempFolderProvider.newFolder();
             toMerge.add(tmp);
             indexMerger.persist(index, tmp, IndexSpec.getDefault(), null);
             index.close();
@@ -480,7 +589,7 @@ public class AggregationTestHelper implements Closeable
       }
 
       if (toMerge.size() > 0) {
-        File tmp = tempFolder.newFolder();
+        File tmp = tempFolderProvider.newFolder();
         toMerge.add(tmp);
         indexMerger.persist(index, tmp, IndexSpec.getDefault(), null);
 
@@ -510,7 +619,7 @@ public class AggregationTestHelper implements Closeable
   ) throws Exception
   {
     if (outDir == null) {
-      outDir = tempFolder.newFolder();
+      outDir = tempFolderProvider.newFolder();
     }
     indexMerger.persist(index, outDir, IndexSpec.getDefault(), null);
 

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -407,7 +407,7 @@ public class AggregationTestHelper implements Closeable
 
   private static TempFolderProvider tempFolderProvider(final TemporaryFolder tempFolder)
   {
-    return tempFolder::newFolder;
+    return () -> tempFolder.newFolder();
   }
 
   private static TempFolderProvider tempFolderProvider(final File tempFolder)

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -33,6 +33,7 @@ import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -96,7 +97,6 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -412,7 +412,7 @@ public class AggregationTestHelper implements Closeable
 
   private static TempFolderProvider tempFolderProvider(final File tempFolder)
   {
-    return () -> Files.createTempDirectory(tempFolder.toPath(), "druid-").toFile();
+    return () -> FileUtils.createTempDirInLocation(tempFolder.toPath(), "druid-");
   }
 
   public AggregationTestHelper withQueryContext(final Map<String, Object> queryContext)


### PR DESCRIPTION
## Description

Migrates the `extensions-core/histogram` test suite from JUnit 4 to JUnit 5.

This is Batch 5 of the extensions-core migration and is part of [#13948](https://github.com/apache/druid/issues/13948).

Depends on the earlier migration batches in [#19875](https://github.com/apache/druid/pull/19875), [#19876](https://github.com/apache/druid/pull/19876), [#19877](https://github.com/apache/druid/pull/19877), and [#19878](https://github.com/apache/druid/pull/19878).

The shared `AggregationTestHelper` now also accepts a JUnit 5 `@TempDir` directory while retaining the existing JUnit 4-compatible API for remaining migration batches.

## Tests

```text
mvn -ntp test -pl extensions-core/histogram -am \
  -Dtest='org.apache.druid.query.aggregation.histogram.**' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Pskip-static-checks -Dweb.console.skip=true -T1C
```

Result: 211 tests passed; 0 failures, errors, or skips.
