### PR TITLE
test: migrate s3 extension tests to JUnit 5

### DIFF
--- a/extensions-core/s3-extensions/pom.xml
+++ b/extensions-core/s3-extensions/pom.xml
@@ -177,11 +177,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
       <scope>test</scope>
@@ -214,6 +209,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/catalog/model/table/S3InputSourceDefnTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/catalog/model/table/S3InputSourceDefnTest.java
@@ -38,8 +38,8 @@ import org.apache.druid.data.input.s3.S3InputSourceTest;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.storage.s3.S3StorageDruidModule;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -48,11 +48,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test the catalog definition on top of the S3 input source. Here we assume that
@@ -96,7 +96,8 @@ public class S3InputSourceDefnTest
   /**
    * Finish up Jackson configuration: add the required S3 input source subtype.
    */
-  @Before
+
+  @BeforeEach
   public void setup()
   {
     mapper.registerModules(new S3InputSourceDruidModule().getJacksonModules());

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceConfigTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class S3InputSourceConfigTest
 {
@@ -40,7 +40,7 @@ public class S3InputSourceConfigTest
         new DefaultPasswordProvider("the-secret-token")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         config,
         mapper.readValue(mapper.writeValueAsString(config), S3InputSourceConfig.class)
     );
@@ -58,7 +58,7 @@ public class S3InputSourceConfigTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         config,
         mapper.readValue(mapper.writeValueAsString(config), S3InputSourceConfig.class)
     );

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceFactoryTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceFactoryTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.data.input.s3;
 import org.apache.druid.storage.s3.S3InputDataConfig;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -53,6 +53,6 @@ public class S3InputSourceFactoryTest
         null,
         null
     );
-    Assert.assertTrue(s3Builder.create(fileUris) instanceof S3InputSource);
+    Assertions.assertTrue(s3Builder.create(fileUris) instanceof S3InputSource);
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -52,6 +52,7 @@ import org.apache.druid.data.input.impl.systemfield.SystemField;
 import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
@@ -1139,7 +1140,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        Files.createTempDirectory(temporaryFolder.toPath(), "s3-input").toFile()
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "s3-input")
     );
 
     CloseableIterator<InputRow> iterator = reader.read();
@@ -1187,7 +1188,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        Files.createTempDirectory(temporaryFolder.toPath(), "s3-input").toFile()
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "s3-input")
     );
     try (CloseableIterator<InputRow> readerIterator = reader.read()) {
       final IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, readerIterator::hasNext);
@@ -1235,7 +1236,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        Files.createTempDirectory(temporaryFolder.toPath(), "s3-input").toFile()
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "s3-input")
     );
 
     CloseableIterator<InputRow> iterator = reader.read();

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -95,7 +95,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -70,12 +70,9 @@ import org.easymock.IArgumentMatcher;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -93,9 +90,11 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -182,11 +181,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     INPUT_DATA_CONFIG.setMaxListingLength(MAX_LISTING_LENGTH);
   }
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void testGetUris()
@@ -205,7 +201,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         EXPECTED_URIS,
         withUris.getUris()
     );
@@ -228,7 +224,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         PREFIXES,
         withPrefixes.getPrefixes()
     );
@@ -251,7 +247,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "**.parquet",
         withUris.getObjectGlob()
     );
@@ -274,8 +270,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
     final S3InputSource serdeWithUris = MAPPER.readValue(MAPPER.writeValueAsString(withUris), S3InputSource.class);
-    Assert.assertEquals(withUris, serdeWithUris);
-    Assert.assertEquals(Collections.emptySet(), serdeWithUris.getConfiguredSystemFields());
+    Assertions.assertEquals(withUris, serdeWithUris);
+    Assertions.assertEquals(Collections.emptySet(), serdeWithUris.getConfiguredSystemFields());
   }
 
   @Test
@@ -297,8 +293,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
     final S3InputSource serdeWithUris = MAPPER.readValue(MAPPER.writeValueAsString(withUris), S3InputSource.class);
-    Assert.assertEquals(withUris, serdeWithUris);
-    Assert.assertEquals(
+    Assertions.assertEquals(withUris, serdeWithUris);
+    Assertions.assertEquals(
         EnumSet.of(SystemField.URI, SystemField.BUCKET, SystemField.PATH),
         serdeWithUris.getConfiguredSystemFields()
     );
@@ -322,7 +318,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     );
     final S3InputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), S3InputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
   }
 
   @Test
@@ -343,7 +339,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     );
     final S3InputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), S3InputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
   }
 
   @Test
@@ -369,7 +365,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), S3InputSource.class);
     // This is to force the s3ClientSupplier to initialize the ServerSideEncryptingAmazonS3
     serdeWithPrefixes.createEntity(new CloudObjectLocation("bucket", "path"));
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
   }
 
@@ -396,11 +392,11 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         MAPPER.readValue(MAPPER.writeValueAsString(withSessionToken), S3InputSource.class);
     // This is to force the s3ClientSupplier to initialize the ServerSideEncryptingAmazonS3
     serdeWithSessionToken.createEntity(new CloudObjectLocation("bucket", "path"));
-    Assert.assertEquals(withSessionToken, serdeWithSessionToken);
+    Assertions.assertEquals(withSessionToken, serdeWithSessionToken);
     // Verify that the session token is properly set
-    Assert.assertNotNull(serdeWithSessionToken.getS3InputSourceConfig());
-    Assert.assertNotNull(serdeWithSessionToken.getS3InputSourceConfig().getSessionToken());
-    Assert.assertEquals("mySessionToken", serdeWithSessionToken.getS3InputSourceConfig().getSessionToken().getPassword());
+    Assertions.assertNotNull(serdeWithSessionToken.getS3InputSourceConfig());
+    Assertions.assertNotNull(serdeWithSessionToken.getS3InputSourceConfig().getSessionToken());
+    Assertions.assertEquals("mySessionToken", serdeWithSessionToken.getS3InputSourceConfig().getSessionToken().getPassword());
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
   }
 
@@ -455,9 +451,9 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertNotNull(inputSourceWithSessionToken.getS3InputSourceConfig());
-    Assert.assertNotNull(inputSourceWithSessionToken.getS3InputSourceConfig().getSessionToken());
-    Assert.assertEquals(
+    Assertions.assertNotNull(inputSourceWithSessionToken.getS3InputSourceConfig());
+    Assertions.assertNotNull(inputSourceWithSessionToken.getS3InputSourceConfig().getSessionToken());
+    Assertions.assertEquals(
         "mySessionToken",
         inputSourceWithSessionToken.getS3InputSourceConfig().getSessionToken().getPassword()
     );
@@ -477,8 +473,8 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertNotNull(inputSourceWithoutSessionToken.getS3InputSourceConfig());
-    Assert.assertNull(inputSourceWithoutSessionToken.getS3InputSourceConfig().getSessionToken());
+    Assertions.assertNotNull(inputSourceWithoutSessionToken.getS3InputSourceConfig());
+    Assertions.assertNull(inputSourceWithoutSessionToken.getS3InputSourceConfig().getSessionToken());
   }
 
   @Test
@@ -497,7 +493,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null,
         null
     );
-    Assert.assertEquals(Collections.singleton(S3InputSource.TYPE_KEY), inputSource.getTypes());
+    Assertions.assertEquals(Collections.singleton(S3InputSource.TYPE_KEY), inputSource.getTypes());
   }
 
   @Test
@@ -554,7 +550,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         mockAwsEndpointConfig,
         mockAwsClientConfig
     );
-    Assert.assertNotNull(withPrefixes);
+    Assertions.assertNotNull(withPrefixes);
     // This is to force the s3ClientSupplier to initialize the ServerSideEncryptingAmazonS3
     withPrefixes.createEntity(new CloudObjectLocation("bucket", "path"));
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
@@ -595,7 +591,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         ENDPOINT_CONFIG,
         CLIENT_CONFIG
     );
-    Assert.assertNotNull(withPrefixes);
+    Assertions.assertNotNull(withPrefixes);
     // This is to force the s3ClientSupplier to initialize the ServerSideEncryptingAmazonS3
     withPrefixes.createEntity(new CloudObjectLocation("bucket", "path"));
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
@@ -623,7 +619,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     );
     final S3InputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), S3InputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
   }
 
@@ -648,7 +644,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     );
     final S3InputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), S3InputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
   }
 
@@ -670,146 +666,153 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     );
     final S3InputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), S3InputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
   }
 
   @Test
   public void testWithNullJsonProps()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3InputSource(
+            SERVICE,
+            SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+            INPUT_DATA_CONFIG,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
     );
   }
 
   @Test
   public void testIllegalObjectsAndUris()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        EXPECTED_URIS,
-        null,
-        EXPECTED_OBJECTS,
-        null,
-        null,
-        null,
-        null,
-        null
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3InputSource(
+            SERVICE,
+            SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+            INPUT_DATA_CONFIG,
+            EXPECTED_URIS,
+            null,
+            EXPECTED_OBJECTS,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
     );
   }
 
   @Test
   public void testIllegalObjectsAndPrefixes()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        null,
-        PREFIXES,
-        EXPECTED_OBJECTS,
-        null,
-        null,
-        null,
-        null,
-        null
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3InputSource(
+            SERVICE,
+            SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+            INPUT_DATA_CONFIG,
+            null,
+            PREFIXES,
+            EXPECTED_OBJECTS,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
     );
   }
 
   @Test
   public void testIllegalUrisAndPrefixes()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        EXPECTED_URIS,
-        PREFIXES,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3InputSource(
+            SERVICE,
+            SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+            INPUT_DATA_CONFIG,
+            EXPECTED_URIS,
+            PREFIXES,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
     );
   }
 
   @Test
   public void testSerdeWithInvalidArgs()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        EXPECTED_URIS,
-        PREFIXES,
-        EXPECTED_LOCATION,
-        null,
-        null,
-        null,
-        null,
-        null
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3InputSource(
+            SERVICE,
+            SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+            INPUT_DATA_CONFIG,
+            EXPECTED_URIS,
+            PREFIXES,
+            EXPECTED_LOCATION,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
     );
   }
 
   @Test
   public void testSerdeWithOtherInvalidArgs()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        EXPECTED_URIS,
-        PREFIXES,
-        ImmutableList.of(),
-        null,
-        null,
-        null,
-        null,
-        null
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3InputSource(
+            SERVICE,
+            SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+            INPUT_DATA_CONFIG,
+            EXPECTED_URIS,
+            PREFIXES,
+            ImmutableList.of(),
+            null,
+            null,
+            null,
+            null,
+            null
+        )
     );
   }
 
   @Test
   public void testSerdeWithOtherOtherInvalidArgs()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        ImmutableList.of(),
-        PREFIXES,
-        EXPECTED_LOCATION,
-        null,
-        null,
-        null,
-        null,
-        null
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3InputSource(
+            SERVICE,
+            SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+            INPUT_DATA_CONFIG,
+            ImmutableList.of(),
+            PREFIXES,
+            EXPECTED_LOCATION,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
     );
   }
 
@@ -840,7 +843,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(5, null)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(S3_CLIENT);
   }
 
@@ -871,7 +874,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(5, null)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(S3_CLIENT);
   }
 
@@ -902,7 +905,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(5, null)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(S3_CLIENT);
   }
 
@@ -933,7 +936,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(5, null)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(S3_CLIENT);
   }
 
@@ -964,7 +967,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(null, 1)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(S3_CLIENT);
   }
 
@@ -995,7 +998,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(null, 1)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(S3_CLIENT);
   }
 
@@ -1026,7 +1029,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(new HumanReadableBytes(CONTENT.length * 3L), null)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(EXPECTED_URIS.stream().map(CloudObjectLocation::new).collect(Collectors.toList())),
         splits.map(InputSplit::get).collect(Collectors.toList())
     );
@@ -1059,7 +1062,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         new JsonInputFormat(JSONPathSpec.DEFAULT, null, null, null, null),
         null
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(ImmutableList.of(new CloudObjectLocation(EXPECTED_URIS.get(0)))),
         splits.map(InputSplit::get).collect(Collectors.toList())
     );
@@ -1088,15 +1091,19 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    expectedException.expectMessage("Failed to get object summaries from S3 bucket[bar], prefix[foo/file2.csv]");
-    expectedException.expectCause(
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("can't list that bucket"))
+    final RuntimeException exception = Assertions.assertThrows(
+        RuntimeException.class,
+        () -> inputSource.createSplits(
+            new JsonInputFormat(JSONPathSpec.DEFAULT, null, null, null, null),
+            null
+        ).collect(Collectors.toList())
     );
-
-    inputSource.createSplits(
-        new JsonInputFormat(JSONPathSpec.DEFAULT, null, null, null, null),
-        null
-    ).collect(Collectors.toList());
+    Assertions.assertTrue(
+        exception.getMessage().contains(
+            "Failed to get object summaries from S3 bucket[bar], prefix[foo/file2.csv]"
+        )
+    );
+    Assertions.assertTrue(exception.getCause().getMessage().contains("can't list that bucket"));
   }
 
   @Test
@@ -1132,16 +1139,16 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        temporaryFolder.newFolder()
+        Files.createTempDirectory(temporaryFolder.toPath(), "s3-input").toFile()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();
 
     while (iterator.hasNext()) {
       InputRow nextRow = iterator.next();
-      Assert.assertEquals(NOW, nextRow.getTimestamp());
-      Assert.assertEquals("hello", nextRow.getDimension("dim1").get(0));
-      Assert.assertEquals("world", nextRow.getDimension("dim2").get(0));
+      Assertions.assertEquals(NOW, nextRow.getTimestamp());
+      Assertions.assertEquals("hello", nextRow.getDimension("dim1").get(0));
+      Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
 
     EasyMock.verify(S3_CLIENT);
@@ -1180,10 +1187,10 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        temporaryFolder.newFolder()
+        Files.createTempDirectory(temporaryFolder.toPath(), "s3-input").toFile()
     );
     try (CloseableIterator<InputRow> readerIterator = reader.read()) {
-      final IllegalStateException e = Assert.assertThrows(IllegalStateException.class, readerIterator::hasNext);
+      final IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, readerIterator::hasNext);
       MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
       MatcherAssert.assertThat(e.getCause().getCause(), CoreMatchers.instanceOf(SdkClientException.class));
       MatcherAssert.assertThat(
@@ -1228,16 +1235,16 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        temporaryFolder.newFolder()
+        Files.createTempDirectory(temporaryFolder.toPath(), "s3-input").toFile()
     );
 
     CloseableIterator<InputRow> iterator = reader.read();
 
     while (iterator.hasNext()) {
       InputRow nextRow = iterator.next();
-      Assert.assertEquals(NOW, nextRow.getTimestamp());
-      Assert.assertEquals("hello", nextRow.getDimension("dim1").get(0));
-      Assert.assertEquals("world", nextRow.getDimension("dim2").get(0));
+      Assertions.assertEquals(NOW, nextRow.getTimestamp());
+      Assertions.assertEquals("hello", nextRow.getDimension("dim1").get(0));
+      Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
 
     EasyMock.verify(S3_CLIENT);
@@ -1262,16 +1269,16 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         EnumSet.of(SystemField.URI, SystemField.BUCKET, SystemField.PATH),
         inputSource.getConfiguredSystemFields()
     );
 
     final S3Entity entity = new S3Entity(null, new CloudObjectLocation("foo", "bar"), 0);
 
-    Assert.assertEquals("s3://foo/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
-    Assert.assertEquals("foo", inputSource.getSystemFieldValue(entity, SystemField.BUCKET));
-    Assert.assertEquals("bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
+    Assertions.assertEquals("s3://foo/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
+    Assertions.assertEquals("foo", inputSource.getSystemFieldValue(entity, SystemField.BUCKET));
+    Assertions.assertEquals("bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
   }
 
   @Test

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ObjectSummaryIteratorTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ObjectSummaryIteratorTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.storage.s3;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -189,11 +189,11 @@ public class ObjectSummaryIteratorTest
         1
     );
 
-    Assert.assertEquals(1, listCalls.get());
-    Assert.assertTrue(iterator.hasNext());
-    Assert.assertEquals(1, listCalls.get());
-    Assert.assertEquals("foo/file", iterator.next().getKey());
-    Assert.assertEquals(1, listCalls.get());
+    Assertions.assertEquals(1, listCalls.get());
+    Assertions.assertTrue(iterator.hasNext());
+    Assertions.assertEquals(1, listCalls.get());
+    Assertions.assertEquals("foo/file", iterator.next().getKey());
+    Assertions.assertEquals(1, listCalls.get());
   }
 
   private static void test(
@@ -225,10 +225,10 @@ public class ObjectSummaryIteratorTest
         )
     );
 
-    Assert.assertEquals(
-        prefixes.toString(),
+    Assertions.assertEquals(
         expectedObjects.stream().map(obj -> S3Utils.summaryToUri(obj, TEST_BUCKET)).collect(Collectors.toList()),
-        actualObjects.stream().map(obj -> S3Utils.summaryToUri(obj.getS3Object(), obj.getBucket())).collect(Collectors.toList())
+        actualObjects.stream().map(obj -> S3Utils.summaryToUri(obj.getS3Object(), obj.getBucket())).collect(Collectors.toList()),
+        prefixes.toString()
     );
   }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
@@ -33,7 +33,6 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -98,8 +99,7 @@ public class S3DataSegmentArchiverTest
       ))
       .size(0)
       .build();
-
-
+  @BeforeAll
   public static void setUpStatic()
   {
     PUSHER_CONFIG.setBaseKey("push_base");

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
@@ -99,6 +99,7 @@ public class S3DataSegmentArchiverTest
       ))
       .size(0)
       .build();
+
   @BeforeAll
   public static void setUpStatic()
   {

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentArchiverTest.java
@@ -32,9 +32,9 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.Map;
@@ -100,7 +100,7 @@ public class S3DataSegmentArchiverTest
       .size(0)
       .build();
 
-  @BeforeClass
+
   public static void setUpStatic()
   {
     PUSHER_CONFIG.setBaseKey("push_base");
@@ -127,7 +127,7 @@ public class S3DataSegmentArchiverTest
         return archivedSegment;
       }
     };
-    Assert.assertEquals(archivedSegment, archiver.archive(SOURCE_SEGMENT));
+    Assertions.assertEquals(archivedSegment, archiver.archive(SOURCE_SEGMENT));
   }
 
   @Test
@@ -141,7 +141,7 @@ public class S3DataSegmentArchiverTest
         return SOURCE_SEGMENT;
       }
     };
-    Assert.assertNull(archiver.archive(SOURCE_SEGMENT));
+    Assertions.assertNull(archiver.archive(SOURCE_SEGMENT));
   }
 
   @Test
@@ -164,7 +164,7 @@ public class S3DataSegmentArchiverTest
         return archivedSegment;
       }
     };
-    Assert.assertEquals(archivedSegment, archiver.restore(SOURCE_SEGMENT));
+    Assertions.assertEquals(archivedSegment, archiver.restore(SOURCE_SEGMENT));
   }
 
   @Test
@@ -178,6 +178,6 @@ public class S3DataSegmentArchiverTest
         return SOURCE_SEGMENT;
       }
     };
-    Assert.assertNull(archiver.restore(SOURCE_SEGMENT));
+    Assertions.assertNull(archiver.restore(SOURCE_SEGMENT));
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentKillerTest.java
@@ -29,13 +29,13 @@ import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockExtension;
 import org.easymock.EasyMockSupport;
 import org.easymock.LogicalOperator;
 import org.easymock.Mock;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.exception.AbortedException;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -53,7 +53,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
-@RunWith(EasyMockRunner.class)
+@ExtendWith(EasyMockExtension.class)
 public class S3DataSegmentKillerTest extends EasyMockSupport
 {
   private static final String KEY_1 = "key1";
@@ -147,7 +147,7 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     catch (ISE e) {
       thrownISEException = true;
     }
-    Assert.assertTrue(thrownISEException);
+    Assertions.assertTrue(thrownISEException);
     EasyMock.verify(s3Client, segmentPusherConfig, inputDataConfig);
   }
 
@@ -280,7 +280,7 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
     EasyMock.verify(s3Client, segmentPusherConfig, inputDataConfig);
   }
 
@@ -380,11 +380,11 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     EasyMock.replay(s3Client, segmentPusherConfig, inputDataConfig);
     segmentKiller = new S3DataSegmentKiller(Suppliers.ofInstance(s3Client), segmentPusherConfig, inputDataConfig);
 
-    SegmentLoadingException thrown = Assert.assertThrows(
+    SegmentLoadingException thrown = Assertions.assertThrows(
         SegmentLoadingException.class,
         () -> segmentKiller.kill(ImmutableList.of(DATA_SEGMENT_1, DATA_SEGMENT_2))
     );
-    Assert.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
+    Assertions.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
   }
 
   @Test
@@ -408,12 +408,12 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     for (int ii = 0; ii < 501; ii++) {
       builder.add(DATA_SEGMENT_1);
     }
-    SegmentLoadingException thrown = Assert.assertThrows(
+    SegmentLoadingException thrown = Assertions.assertThrows(
         SegmentLoadingException.class,
         () -> segmentKiller.kill(builder.build())
     );
 
-    Assert.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
+    Assertions.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
   }
 
   @Test
@@ -433,11 +433,11 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     EasyMock.replay(s3Client, segmentPusherConfig, inputDataConfig);
     segmentKiller = new S3DataSegmentKiller(Suppliers.ofInstance(s3Client), segmentPusherConfig, inputDataConfig);
 
-    SegmentLoadingException thrown = Assert.assertThrows(
+    SegmentLoadingException thrown = Assertions.assertThrows(
         SegmentLoadingException.class,
         () -> segmentKiller.kill(ImmutableList.of(DATA_SEGMENT_1, DATA_SEGMENT_2))
     );
-    Assert.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
+    Assertions.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
   }
 
   @Test
@@ -463,17 +463,17 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
 
     // Verify the second request only contained the failed key
     List<DeleteObjectsRequest> requests = capturedRequests.getValues();
-    Assert.assertEquals(2, requests.size());
+    Assertions.assertEquals(2, requests.size());
 
     List<String> firstKeys = requests.get(0).delete().objects()
                                  .stream().map(ObjectIdentifier::key).collect(java.util.stream.Collectors.toList());
-    Assert.assertTrue("First request should contain KEY_1_PATH", firstKeys.contains(KEY_1_PATH));
-    Assert.assertTrue("First request should contain KEY_2_PATH", firstKeys.contains(KEY_2_PATH));
+    Assertions.assertTrue(firstKeys.contains(KEY_1_PATH), "First request should contain KEY_1_PATH");
+    Assertions.assertTrue(firstKeys.contains(KEY_2_PATH), "First request should contain KEY_2_PATH");
 
     List<String> retryKeys = requests.get(1).delete().objects()
                                  .stream().map(ObjectIdentifier::key).collect(java.util.stream.Collectors.toList());
-    Assert.assertEquals("Retry should only contain the failed key", 1, retryKeys.size());
-    Assert.assertEquals(KEY_1_PATH, retryKeys.get(0));
+    Assertions.assertEquals(1, retryKeys.size(), "Retry should only contain the failed key");
+    Assertions.assertEquals(KEY_1_PATH, retryKeys.get(0));
   }
 
   @Test
@@ -490,11 +490,11 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     EasyMock.replay(s3Client, segmentPusherConfig, inputDataConfig);
     segmentKiller = new S3DataSegmentKiller(Suppliers.ofInstance(s3Client), segmentPusherConfig, inputDataConfig);
 
-    SegmentLoadingException thrown = Assert.assertThrows(
+    SegmentLoadingException thrown = Assertions.assertThrows(
         SegmentLoadingException.class,
         () -> segmentKiller.kill(ImmutableList.of(DATA_SEGMENT_1, DATA_SEGMENT_2))
     );
-    Assert.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
+    Assertions.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
   }
 
   @Test
@@ -531,11 +531,11 @@ public class S3DataSegmentKillerTest extends EasyMockSupport
     EasyMock.replay(s3Client, segmentPusherConfig, inputDataConfig);
     segmentKiller = new S3DataSegmentKiller(Suppliers.ofInstance(s3Client), segmentPusherConfig, inputDataConfig);
 
-    SegmentLoadingException thrown = Assert.assertThrows(
+    SegmentLoadingException thrown = Assertions.assertThrows(
         SegmentLoadingException.class,
         () -> segmentKiller.kill(ImmutableList.of(DATA_SEGMENT_1, DATA_SEGMENT_2))
     );
-    Assert.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
+    Assertions.assertEquals("Couldn't delete segments from S3. See the task logs for more details.", thrown.getMessage());
   }
 
   @Test

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentMoverTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentMoverTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.java.util.common.MapUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.regions.Region;
@@ -94,12 +94,12 @@ public class S3DataSegmentMoverTest
     );
 
     Map<String, Object> targetLoadSpec = movedSegment.getLoadSpec();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "targetBaseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
         MapUtils.getString(targetLoadSpec, "key")
     );
-    Assert.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
-    Assert.assertTrue(mockS3Client.didMove());
+    Assertions.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
+    Assertions.assertTrue(mockS3Client.didMove());
   }
 
   @Test
@@ -123,12 +123,12 @@ public class S3DataSegmentMoverTest
 
     Map<String, Object> targetLoadSpec = movedSegment.getLoadSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "targetBaseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
         MapUtils.getString(targetLoadSpec, "key")
     );
-    Assert.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
-    Assert.assertFalse(mockS3Client.didMove());
+    Assertions.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
+    Assertions.assertFalse(mockS3Client.didMove());
   }
 
   @Test
@@ -162,15 +162,15 @@ public class S3DataSegmentMoverTest
 
     final Map<String, Object> targetLoadSpec = movedSegment.getLoadSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "targetBaseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
         MapUtils.getString(targetLoadSpec, "key")
     );
-    Assert.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
-    Assert.assertFalse(mockS3Client.didMove());
+    Assertions.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
+    Assertions.assertFalse(mockS3Client.didMove());
   }
 
-  @Test(expected = SegmentLoadingException.class)
+  @Test
   public void testMoveException() throws Exception
   {
     MockAmazonS3Client mockS3Client = new MockAmazonS3Client();
@@ -179,9 +179,12 @@ public class S3DataSegmentMoverTest
         new S3DataSegmentPusherConfig()
     );
 
-    mover.move(
-        SOURCE_SEGMENT,
-        ImmutableMap.of("baseKey", "targetBaseKey", "bucket", "archive")
+    Assertions.assertThrows(
+        SegmentLoadingException.class,
+        () -> mover.move(
+            SOURCE_SEGMENT,
+            ImmutableMap.of("baseKey", "targetBaseKey", "bucket", "archive")
+        )
     );
   }
 
@@ -211,7 +214,7 @@ public class S3DataSegmentMoverTest
     ), ImmutableMap.of("bucket", "DOES NOT EXIST", "baseKey", "baseKey"));
   }
 
-  @Test(expected = SegmentLoadingException.class)
+  @Test
   public void testFailsToMoveMissing() throws Exception
   {
     MockAmazonS3Client mockS3Client = new MockAmazonS3Client();
@@ -219,22 +222,25 @@ public class S3DataSegmentMoverTest
         Suppliers.ofInstance(mockS3Client),
         new S3DataSegmentPusherConfig()
     );
-    mover.move(new DataSegment(
-        "test",
-        Intervals.of("2013-01-01/2013-01-02"),
-        "1",
-        ImmutableMap.of(
-            "key",
-            "baseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
-            "bucket",
-            "DOES NOT EXIST"
-        ),
-        ImmutableList.of("dim1", "dim1"),
-        ImmutableList.of("metric1", "metric2"),
-        NoneShardSpec.instance(),
-        0,
-        1
-    ), ImmutableMap.of("bucket", "DOES NOT EXIST", "baseKey", "baseKey2"));
+    Assertions.assertThrows(
+        SegmentLoadingException.class,
+        () -> mover.move(new DataSegment(
+            "test",
+            Intervals.of("2013-01-01/2013-01-02"),
+            "1",
+            ImmutableMap.of(
+                "key",
+                "baseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
+                "bucket",
+                "DOES NOT EXIST"
+            ),
+            ImmutableList.of("dim1", "dim1"),
+            ImmutableList.of("metric1", "metric2"),
+            NoneShardSpec.instance(),
+            0,
+            1
+        ), ImmutableMap.of("bucket", "DOES NOT EXIST", "baseKey", "baseKey2"))
+    );
   }
 
   private static class MockAmazonS3Client extends ServerSideEncryptingAmazonS3

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPullerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPullerTest.java
@@ -99,7 +99,7 @@ public class S3DataSegmentPullerTest
       outputStream.write(value);
     }
 
-    final File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "gzTestDir").toFile();
+    final File tmpDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "gzTestDir");
 
     EasyMock.expect(s3Client.getObject(EasyMock.eq(bucket), EasyMock.eq(key)))
             .andAnswer(() -> new ResponseInputStream<>(
@@ -140,7 +140,7 @@ public class S3DataSegmentPullerTest
       outputStream.write(value);
     }
 
-    File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "gzTestDir").toFile();
+    File tmpDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "gzTestDir");
 
     S3Exception exception = (S3Exception) S3Exception.builder()
         .message("S3DataSegmentPullerTest")
@@ -187,7 +187,7 @@ public class S3DataSegmentPullerTest
       outputStream.write(value);
     }
 
-    File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "gzTestDir").toFile();
+    File tmpDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "gzTestDir");
 
     S3Exception exception = (S3Exception) S3Exception.builder()
         .message("S3DataSegmentPullerTest")
@@ -313,7 +313,7 @@ public class S3DataSegmentPullerTest
         .build();
     EasyMock.expect(s3Client.listObjectsV2(EasyMock.anyObject())).andReturn(listResponse).once();
 
-    final File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "noZipTestDir").toFile();
+    final File tmpDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "noZipTestDir");
 
     EasyMock.expect(s3Client.getObject(EasyMock.eq(bucket), EasyMock.eq(keyPrefix + "meta.smoosh")))
             .andAnswer(() -> new ResponseInputStream<>(

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPullerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPullerTest.java
@@ -25,10 +25,9 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.http.AbortableInputStream;
@@ -55,8 +54,8 @@ import java.util.zip.GZIPOutputStream;
  */
 public class S3DataSegmentPullerTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void testSimpleGetVersion() throws IOException
@@ -81,7 +80,7 @@ public class S3DataSegmentPullerTest
 
     EasyMock.verify(s3Client);
 
-    Assert.assertEquals(StringUtils.format("%d", Instant.ofEpochMilli(0).toEpochMilli()), version);
+    Assertions.assertEquals(StringUtils.format("%d", Instant.ofEpochMilli(0).toEpochMilli()), version);
   }
 
   @Test
@@ -93,14 +92,14 @@ public class S3DataSegmentPullerTest
     final ServerSideEncryptingAmazonS3 s3Client = EasyMock.createStrictMock(ServerSideEncryptingAmazonS3.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("gzTest.gz");
+    final File tmpFile = new File(temporaryFolder, "gzTest.gz");
 
     try (final FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
          final OutputStream outputStream = new GZIPOutputStream(fileOutputStream)) {
       outputStream.write(value);
     }
 
-    final File tmpDir = temporaryFolder.newFolder("gzTestDir");
+    final File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "gzTestDir").toFile();
 
     EasyMock.expect(s3Client.getObject(EasyMock.eq(bucket), EasyMock.eq(key)))
             .andAnswer(() -> new ResponseInputStream<>(
@@ -119,10 +118,10 @@ public class S3DataSegmentPullerTest
     );
     EasyMock.verify(s3Client);
 
-    Assert.assertEquals(value.length, result.size());
+    Assertions.assertEquals(value.length, result.size());
     File expected = new File(tmpDir, "renames-0");
-    Assert.assertTrue(expected.exists());
-    Assert.assertEquals(value.length, expected.length());
+    Assertions.assertTrue(expected.exists());
+    Assertions.assertEquals(value.length, expected.length());
   }
 
   @Test
@@ -134,14 +133,14 @@ public class S3DataSegmentPullerTest
     final ServerSideEncryptingAmazonS3 s3Client = EasyMock.createStrictMock(ServerSideEncryptingAmazonS3.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("gzTest.gz");
+    final File tmpFile = new File(temporaryFolder, "gzTest.gz");
 
     try (final FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
          final OutputStream outputStream = new GZIPOutputStream(fileOutputStream)) {
       outputStream.write(value);
     }
 
-    File tmpDir = temporaryFolder.newFolder("gzTestDir");
+    File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "gzTestDir").toFile();
 
     S3Exception exception = (S3Exception) S3Exception.builder()
         .message("S3DataSegmentPullerTest")
@@ -157,7 +156,7 @@ public class S3DataSegmentPullerTest
     S3DataSegmentPuller puller = new S3DataSegmentPuller(s3Client);
 
     EasyMock.replay(s3Client);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         SegmentLoadingException.class,
         () -> puller.getSegmentFiles(
             new CloudObjectLocation(
@@ -169,7 +168,7 @@ public class S3DataSegmentPullerTest
     EasyMock.verify(s3Client);
 
     File expected = new File(tmpDir, "renames-0");
-    Assert.assertFalse(expected.exists());
+    Assertions.assertFalse(expected.exists());
   }
 
   @Test
@@ -181,14 +180,14 @@ public class S3DataSegmentPullerTest
     final ServerSideEncryptingAmazonS3 s3Client = EasyMock.createStrictMock(ServerSideEncryptingAmazonS3.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("gzTest.gz");
+    final File tmpFile = new File(temporaryFolder, "gzTest.gz");
 
     try (final FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
          final OutputStream outputStream = new GZIPOutputStream(fileOutputStream)) {
       outputStream.write(value);
     }
 
-    File tmpDir = temporaryFolder.newFolder("gzTestDir");
+    File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "gzTestDir").toFile();
 
     S3Exception exception = (S3Exception) S3Exception.builder()
         .message("S3DataSegmentPullerTest")
@@ -218,10 +217,10 @@ public class S3DataSegmentPullerTest
     );
     EasyMock.verify(s3Client);
 
-    Assert.assertEquals(value.length, result.size());
+    Assertions.assertEquals(value.length, result.size());
     File expected = new File(tmpDir, "renames-0");
-    Assert.assertTrue(expected.exists());
-    Assert.assertEquals(value.length, expected.length());
+    Assertions.assertTrue(expected.exists());
+    Assertions.assertEquals(value.length, expected.length());
   }
 
   @Test
@@ -233,7 +232,7 @@ public class S3DataSegmentPullerTest
     final ServerSideEncryptingAmazonS3 s3Client = EasyMock.createStrictMock(ServerSideEncryptingAmazonS3.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("testObjectFile");
+    final File tmpFile = new File(temporaryFolder, "testObjectFile");
 
     try (OutputStream outputStream = new FileOutputStream(tmpFile)) {
       outputStream.write(value);
@@ -250,7 +249,7 @@ public class S3DataSegmentPullerTest
     InputStream stream = puller.buildFileObject(URI.create(StringUtils.format("s3://%s/%s", bucket, key)))
                                .openInputStream();
     EasyMock.verify(s3Client);
-    Assert.assertEquals(bucket, IOUtils.toString(stream, StandardCharsets.UTF_8));
+    Assertions.assertEquals(bucket, IOUtils.toString(stream, StandardCharsets.UTF_8));
   }
 
   @Test
@@ -262,7 +261,7 @@ public class S3DataSegmentPullerTest
     final ServerSideEncryptingAmazonS3 s3Client = EasyMock.createStrictMock(ServerSideEncryptingAmazonS3.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("testObjectFile");
+    final File tmpFile = new File(temporaryFolder, "testObjectFile");
 
     try (OutputStream outputStream = Files.newOutputStream(tmpFile.toPath())) {
       outputStream.write(value);
@@ -281,7 +280,7 @@ public class S3DataSegmentPullerTest
     long modifiedDate = puller.buildFileObject(URI.create(StringUtils.format("s3://%s/%s", bucket, key)))
                               .getLastModified();
     EasyMock.verify(s3Client);
-    Assert.assertEquals(0, modifiedDate);
+    Assertions.assertEquals(0, modifiedDate);
   }
 
   @Test
@@ -292,8 +291,8 @@ public class S3DataSegmentPullerTest
     final ServerSideEncryptingAmazonS3 s3Client = EasyMock.createStrictMock(ServerSideEncryptingAmazonS3.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("meta.smoosh");
-    final File tmpFile2 = temporaryFolder.newFile("00000.smoosh");
+    final File tmpFile = new File(temporaryFolder, "meta.smoosh");
+    final File tmpFile2 = new File(temporaryFolder, "00000.smoosh");
 
     try (OutputStream outputStream = new FileOutputStream(tmpFile)) {
       outputStream.write(value);
@@ -314,7 +313,7 @@ public class S3DataSegmentPullerTest
         .build();
     EasyMock.expect(s3Client.listObjectsV2(EasyMock.anyObject())).andReturn(listResponse).once();
 
-    final File tmpDir = temporaryFolder.newFolder("noZipTestDir");
+    final File tmpDir = Files.createTempDirectory(temporaryFolder.toPath(), "noZipTestDir").toFile();
 
     EasyMock.expect(s3Client.getObject(EasyMock.eq(bucket), EasyMock.eq(keyPrefix + "meta.smoosh")))
             .andAnswer(() -> new ResponseInputStream<>(
@@ -340,12 +339,12 @@ public class S3DataSegmentPullerTest
     );
     EasyMock.verify(s3Client);
 
-    Assert.assertEquals(value.length + value.length, result.size());
+    Assertions.assertEquals(value.length + value.length, result.size());
     File expected = new File(tmpDir, "meta.smoosh");
-    Assert.assertTrue(expected.exists());
-    Assert.assertEquals(value.length, expected.length());
+    Assertions.assertTrue(expected.exists());
+    Assertions.assertEquals(value.length, expected.length());
     expected = new File(tmpDir, "00000.smoosh");
-    Assert.assertTrue(expected.exists());
-    Assert.assertEquals(value.length, expected.length());
+    Assertions.assertTrue(expected.exists());
+    Assertions.assertEquals(value.length, expected.length());
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherConfigTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.storage.s3;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Iterators;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -45,7 +45,7 @@ public class S3DataSegmentPusherConfigTest
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
     Map<String, String> expected = JSON_MAPPER.readValue(jsonConfig, Map.class);
     Map<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), Map.class);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -57,7 +57,7 @@ public class S3DataSegmentPusherConfigTest
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
     Map<String, String> expected = JSON_MAPPER.readValue(expectedJsonConfig, Map.class);
     Map<String, String> actual = JSON_MAPPER.readValue(JSON_MAPPER.writeValueAsString(config), Map.class);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -69,8 +69,8 @@ public class S3DataSegmentPusherConfigTest
 
     S3DataSegmentPusherConfig config = JSON_MAPPER.readValue(jsonConfig, S3DataSegmentPusherConfig.class);
     Set<ConstraintViolation<S3DataSegmentPusherConfig>> violations = validator.validate(config);
-    Assert.assertEquals(1, violations.size());
+    Assertions.assertEquals(1, violations.size());
     ConstraintViolation violation = Iterators.getOnlyElement(violations.iterator());
-    Assert.assertEquals("must be greater than or equal to 1", violation.getMessage());
+    Assertions.assertEquals("must be greater than or equal to 1", violation.getMessage());
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3DataSegmentPusherTest.java
@@ -25,13 +25,9 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.services.s3.model.Grant;
 import software.amazon.awssdk.services.s3.model.Grantee;
@@ -50,8 +46,8 @@ import java.util.regex.Pattern;
  */
 public class S3DataSegmentPusherTest
 {
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   @Test
   public void testPush() throws Exception
@@ -74,7 +70,7 @@ public class S3DataSegmentPusherTest
   @Test
   public void testEntityTooLarge()
   {
-    final DruidException exception = Assert.assertThrows(
+    final DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () ->
         testPushInternalForEntityTooLarge(
@@ -83,10 +79,7 @@ public class S3DataSegmentPusherTest
         )
     );
 
-    MatcherAssert.assertThat(
-            exception,
-            ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Got error[EntityTooLarge] from S3"))
-    );
+    Assertions.assertTrue(exception.getMessage().startsWith("Got error[EntityTooLarge] from S3"));
   }
 
   @Test
@@ -123,7 +116,7 @@ public class S3DataSegmentPusherTest
         new byte[]{0x0, 0x0, 0x0, 0x1}
     );
     // V1 (test fixture) → not V10 → rangeable stamped as false (skips legacy HEAD probe).
-    Assert.assertEquals(Boolean.FALSE, segment.getLoadSpec().get("rangeable"));
+    Assertions.assertEquals(Boolean.FALSE, segment.getLoadSpec().get("rangeable"));
   }
 
   @Test
@@ -161,8 +154,8 @@ public class S3DataSegmentPusherTest
         config,
         new byte[]{0x0, 0x0, 0x0, 0x0A}
     );
-    Assert.assertEquals(10, (int) segment.getBinaryVersion());
-    Assert.assertEquals(Boolean.TRUE, segment.getLoadSpec().get("rangeable"));
+    Assertions.assertEquals(10, (int) segment.getBinaryVersion());
+    Assertions.assertEquals(Boolean.TRUE, segment.getLoadSpec().get("rangeable"));
   }
 
   @Test
@@ -188,7 +181,7 @@ public class S3DataSegmentPusherTest
         "key/foo/2015-01-01T00:00:00\\.000Z_2016-01-01T00:00:00\\.000Z/0/0/index\\.zip",
         s3Client
     );
-    Assert.assertFalse(segment.getLoadSpec().containsKey("rangeable"));
+    Assertions.assertFalse(segment.getLoadSpec().containsKey("rangeable"));
   }
 
   private void testPushInternal(boolean useUniquePath, String matcher) throws Exception
@@ -242,7 +235,7 @@ public class S3DataSegmentPusherTest
     config.setBaseKey("key");
     // Default version.bin is V1 for historical reasons.
     DataSegment segment = validate(useUniquePath, matcher, s3Client, config, new byte[]{0x0, 0x0, 0x0, 0x1});
-    Assert.assertEquals(1, (int) segment.getBinaryVersion());
+    Assertions.assertEquals(1, (int) segment.getBinaryVersion());
     return segment;
   }
 
@@ -257,7 +250,7 @@ public class S3DataSegmentPusherTest
     S3DataSegmentPusher pusher = new S3DataSegmentPusher(s3Client, config);
 
     // Create a mock segment on disk
-    File tmp = tempFolder.newFile("version.bin");
+    File tmp = new File(tempFolder, "version.bin");
 
     Files.write(versionBytes, tmp);
     final long size = versionBytes.length;
@@ -274,15 +267,15 @@ public class S3DataSegmentPusherTest
             size
     );
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, useUniquePath);
+    DataSegment segment = pusher.push(tempFolder, segmentToPush, useUniquePath);
 
-    Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
-    Assert.assertEquals("bucket", segment.getLoadSpec().get("bucket"));
-    Assert.assertTrue(
-            segment.getLoadSpec().get("key").toString(),
-            Pattern.compile(matcher).matcher(segment.getLoadSpec().get("key").toString()).matches()
+    Assertions.assertEquals(segmentToPush.getSize(), segment.getSize());
+    Assertions.assertEquals("bucket", segment.getLoadSpec().get("bucket"));
+    Assertions.assertTrue(
+            Pattern.compile(matcher).matcher(segment.getLoadSpec().get("key").toString()).matches(),
+            segment.getLoadSpec().get("key").toString()
     );
-    Assert.assertEquals("s3_zip", segment.getLoadSpec().get("type"));
+    Assertions.assertEquals("s3_zip", segment.getLoadSpec().get("type"));
 
     EasyMock.verify(s3Client);
     return segment;

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3InputDataConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3InputDataConfigTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class S3InputDataConfigTest
 {
@@ -48,7 +48,7 @@ public class S3InputDataConfigTest
     catch (JsonProcessingException e) {
       exceptionThrown = true;
     }
-    Assert.assertTrue(exceptionThrown);
+    Assertions.assertTrue(exceptionThrown);
   }
 
   @Test
@@ -61,7 +61,7 @@ public class S3InputDataConfigTest
     catch (JsonProcessingException e) {
       exceptionThrown = true;
     }
-    Assert.assertTrue(exceptionThrown);
+    Assertions.assertTrue(exceptionThrown);
   }
 
   @Test
@@ -71,7 +71,7 @@ public class S3InputDataConfigTest
         formatTemplate(S3InputDataConfig.MAX_LISTING_LENGTH_MIN),
         S3InputDataConfig.class
     );
-    Assert.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MIN, inputDataConfig.getMaxListingLength());
+    Assertions.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MIN, inputDataConfig.getMaxListingLength());
   }
 
   @Test
@@ -81,7 +81,7 @@ public class S3InputDataConfigTest
         formatTemplate(S3InputDataConfig.MAX_LISTING_LENGTH_MAX),
         S3InputDataConfig.class
     );
-    Assert.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MAX, inputDataConfig.getMaxListingLength());
+    Assertions.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MAX, inputDataConfig.getMaxListingLength());
   }
 
   @Test
@@ -95,7 +95,7 @@ public class S3InputDataConfigTest
     catch (IAE e) {
       exceptionThrown = true;
     }
-    Assert.assertTrue(exceptionThrown);
+    Assertions.assertTrue(exceptionThrown);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class S3InputDataConfigTest
     catch (IAE e) {
       exceptionThrown = true;
     }
-    Assert.assertTrue(exceptionThrown);
+    Assertions.assertTrue(exceptionThrown);
   }
 
   @Test
@@ -117,7 +117,7 @@ public class S3InputDataConfigTest
   {
     inputDataConfig = new S3InputDataConfig();
     inputDataConfig.setMaxListingLength(S3InputDataConfig.MAX_LISTING_LENGTH_MIN);
-    Assert.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MIN, inputDataConfig.getMaxListingLength());
+    Assertions.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MIN, inputDataConfig.getMaxListingLength());
   }
 
   @Test
@@ -125,14 +125,14 @@ public class S3InputDataConfigTest
   {
     inputDataConfig = new S3InputDataConfig();
     inputDataConfig.setMaxListingLength(S3InputDataConfig.MAX_LISTING_LENGTH_MAX);
-    Assert.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MAX, inputDataConfig.getMaxListingLength());
+    Assertions.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MAX, inputDataConfig.getMaxListingLength());
   }
 
   @Test
   public void test_construct_maxListingLengthDefaultsToMax()
   {
     inputDataConfig = new S3InputDataConfig();
-    Assert.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MAX, inputDataConfig.getMaxListingLength());
+    Assertions.assertEquals(S3InputDataConfig.MAX_LISTING_LENGTH_MAX, inputDataConfig.getMaxListingLength());
   }
 
   private static String formatTemplate(int maxListingLength)

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageConnectorProviderTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageConnectorProviderTest.java
@@ -43,8 +43,8 @@ import org.apache.druid.storage.s3.output.S3StorageConnectorModule;
 import org.apache.druid.storage.s3.output.S3StorageConnectorProvider;
 import org.apache.druid.storage.s3.output.S3UploadManager;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Properties;
@@ -66,11 +66,11 @@ public class S3StorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".tempDir", "/tmp");
     StorageConnectorProvider s3StorageConnectorProvider = getStorageConnectorProvider(properties);
 
-    Assert.assertTrue(s3StorageConnectorProvider instanceof S3StorageConnectorProvider);
-    Assert.assertTrue(s3StorageConnectorProvider.createStorageConnector(tempDir) instanceof S3StorageConnector);
-    Assert.assertEquals("bucket", ((S3StorageConnectorProvider) s3StorageConnectorProvider).getBucket());
-    Assert.assertEquals("prefix", ((S3StorageConnectorProvider) s3StorageConnectorProvider).getPrefix());
-    Assert.assertEquals(new File("/tmp"), ((S3StorageConnectorProvider) s3StorageConnectorProvider).getTempDir());
+    Assertions.assertTrue(s3StorageConnectorProvider instanceof S3StorageConnectorProvider);
+    Assertions.assertTrue(s3StorageConnectorProvider.createStorageConnector(tempDir) instanceof S3StorageConnector);
+    Assertions.assertEquals("bucket", ((S3StorageConnectorProvider) s3StorageConnectorProvider).getBucket());
+    Assertions.assertEquals("prefix", ((S3StorageConnectorProvider) s3StorageConnectorProvider).getPrefix());
+    Assertions.assertEquals(new File("/tmp"), ((S3StorageConnectorProvider) s3StorageConnectorProvider).getTempDir());
 
   }
 
@@ -82,10 +82,10 @@ public class S3StorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".type", "s3");
     properties.setProperty(CUSTOM_NAMESPACE + ".bucket", "bucket");
     properties.setProperty(CUSTOM_NAMESPACE + ".tempDir", "/tmp");
-    Assert.assertThrows(
-        "Missing required creator property 'prefix'",
+    Assertions.assertThrows(
         ProvisionException.class,
-        () -> getStorageConnectorProvider(properties)
+        () -> getStorageConnectorProvider(properties),
+        "Missing required creator property 'prefix'"
     );
   }
 
@@ -98,10 +98,10 @@ public class S3StorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".type", "s3");
     properties.setProperty(CUSTOM_NAMESPACE + ".prefix", "prefix");
     properties.setProperty(CUSTOM_NAMESPACE + ".tempDir", "/tmp");
-    Assert.assertThrows(
-        "Missing required creator property 'bucket'",
+    Assertions.assertThrows(
         ProvisionException.class,
-        () -> getStorageConnectorProvider(properties)
+        () -> getStorageConnectorProvider(properties),
+        "Missing required creator property 'bucket'"
     );
   }
 
@@ -114,10 +114,10 @@ public class S3StorageConnectorProviderTest
     properties.setProperty(CUSTOM_NAMESPACE + ".bucket", "bucket");
     properties.setProperty(CUSTOM_NAMESPACE + ".prefix", "prefix");
 
-    Assert.assertThrows(
-        "tempDir is null in s3 config",
+    Assertions.assertThrows(
         NullPointerException.class,
-        () -> getStorageConnectorProvider(properties).createStorageConnector(null)
+        () -> getStorageConnectorProvider(properties).createStorageConnector(null),
+        "tempDir is null in s3 config"
     );
   }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageDruidModuleTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3StorageDruidModuleTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.guice.StartupInjectorBuilder;
 import org.apache.druid.segment.loading.OmniDataSegmentArchiver;
 import org.apache.druid.segment.loading.OmniDataSegmentKiller;
 import org.apache.druid.segment.loading.OmniDataSegmentMover;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class S3StorageDruidModuleTest
 {
@@ -38,8 +38,8 @@ public class S3StorageDruidModuleTest
   {
     Injector injector = createInjector();
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
-    Assert.assertTrue(killer.getKillers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
-    Assert.assertSame(
+    Assertions.assertTrue(killer.getKillers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
+    Assertions.assertSame(
         killer.getKillers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get(),
         killer.getKillers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get()
     );
@@ -50,8 +50,8 @@ public class S3StorageDruidModuleTest
   {
     Injector injector = createInjector();
     OmniDataSegmentArchiver archiver = injector.getInstance(OmniDataSegmentArchiver.class);
-    Assert.assertTrue(archiver.getArchivers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
-    Assert.assertSame(
+    Assertions.assertTrue(archiver.getArchivers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
+    Assertions.assertSame(
         archiver.getArchivers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get(),
         archiver.getArchivers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get()
     );
@@ -62,8 +62,8 @@ public class S3StorageDruidModuleTest
   {
     Injector injector = createInjector();
     OmniDataSegmentMover mover = injector.getInstance(OmniDataSegmentMover.class);
-    Assert.assertTrue(mover.getMovers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
-    Assert.assertSame(
+    Assertions.assertTrue(mover.getMovers().containsKey(S3StorageDruidModule.SCHEME_S3_ZIP));
+    Assertions.assertSame(
         mover.getMovers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get(),
         mover.getMovers().get(S3StorageDruidModule.SCHEME_S3_ZIP).get()
     );

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TaskLogsTest.java
@@ -28,14 +28,13 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockExtension;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
@@ -64,7 +63,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@RunWith(EasyMockRunner.class)
+@ExtendWith(EasyMockExtension.class)
 public class S3TaskLogsTest extends EasyMockSupport
 {
 
@@ -89,8 +88,8 @@ public class S3TaskLogsTest extends EasyMockSupport
   @Mock
   private ServerSideEncryptingAmazonS3 s3Client;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   @Test
   public void testTaskLogsPushWithAclDisabled() throws Exception
@@ -100,8 +99,8 @@ public class S3TaskLogsTest extends EasyMockSupport
 
     List<Grant> grantList = testPushInternal(true, ownerId, ownerDisplayName);
 
-    Assert.assertNotNull("Grant list should not be null", grantList);
-    Assert.assertEquals("Grant list should be empty as ACL is disabled", 0, grantList.size());
+    Assertions.assertNotNull(grantList, "Grant list should not be null");
+    Assertions.assertEquals(0, grantList.size(), "Grant list should be empty as ACL is disabled");
   }
 
   @Test
@@ -112,15 +111,19 @@ public class S3TaskLogsTest extends EasyMockSupport
 
     List<Grant> grantList = testPushInternal(false, ownerId, ownerDisplayName);
 
-    Assert.assertNotNull("Grant list should not be null", grantList);
-    Assert.assertEquals("Grant list size should be equal to 1", 1, grantList.size());
+    Assertions.assertNotNull(grantList, "Grant list should not be null");
+    Assertions.assertEquals(1, grantList.size(), "Grant list size should be equal to 1");
     Grant grant = grantList.get(0);
-    Assert.assertEquals(
-        "The Grantee identifier should be test_owner",
+    Assertions.assertEquals(
         "test_owner",
-        grant.grantee().id()
+        grant.grantee().id(),
+        "The Grantee identifier should be test_owner"
     );
-    Assert.assertEquals("The Grant should have full control permission", Permission.FULL_CONTROL, grant.permission());
+    Assertions.assertEquals(
+        Permission.FULL_CONTROL,
+        grant.permission(),
+        "The Grant should have full control permission"
+    );
   }
 
   @Test
@@ -140,7 +143,7 @@ public class S3TaskLogsTest extends EasyMockSupport
     S3TaskLogs s3TaskLogs = new S3TaskLogs(() -> s3Client, config, inputDataConfig, timeSupplier);
 
     String taskId = "index_test-datasource_2019-06-18T13:30:28.887Z";
-    File logFile = tempFolder.newFile("status.json");
+    File logFile = File.createTempFile("status", ".json", tempFolder);
 
     s3TaskLogs.pushTaskLog(taskId, logFile);
 
@@ -167,13 +170,13 @@ public class S3TaskLogsTest extends EasyMockSupport
     S3InputDataConfig inputDataConfig = new S3InputDataConfig();
     S3TaskLogs s3TaskLogs = new S3TaskLogs(() -> s3Client, config, inputDataConfig, timeSupplier);
 
-    File payloadFile = tempFolder.newFile("task.json");
+    File payloadFile = File.createTempFile("task", ".json", tempFolder);
     String taskId = "index_test-datasource_2019-06-18T13:30:28.887Z";
     s3TaskLogs.pushTaskPayload(taskId, payloadFile);
 
-    Assert.assertEquals(TEST_BUCKET, bucketCapture.getValue());
-    Assert.assertEquals("prefix/" + taskId + "/task.json", keyCapture.getValue());
-    Assert.assertEquals(payloadFile, fileCapture.getValue());
+    Assertions.assertEquals(TEST_BUCKET, bucketCapture.getValue());
+    Assertions.assertEquals("prefix/" + taskId + "/task.json", keyCapture.getValue());
+    Assertions.assertEquals(payloadFile, fileCapture.getValue());
     EasyMock.verify(s3Client);
   }
 
@@ -212,11 +215,11 @@ public class S3TaskLogsTest extends EasyMockSupport
     Optional<InputStream> payloadResponse = s3TaskLogs.streamTaskPayload(taskId);
 
     GetObjectRequest getObjectRequest = getObjectRequestCapture.getValue().build();
-    Assert.assertEquals(TEST_BUCKET, getObjectRequest.bucket());
-    Assert.assertEquals("prefix/" + taskId + "/task.json", getObjectRequest.key());
-    Assert.assertTrue(payloadResponse.isPresent());
+    Assertions.assertEquals(TEST_BUCKET, getObjectRequest.bucket());
+    Assertions.assertEquals("prefix/" + taskId + "/task.json", getObjectRequest.key());
+    Assertions.assertTrue(payloadResponse.isPresent());
 
-    Assert.assertEquals(taskPayloadString, IOUtils.toString(payloadResponse.get(), Charset.defaultCharset()));
+    Assertions.assertEquals(taskPayloadString, IOUtils.toString(payloadResponse.get(), Charset.defaultCharset()));
     EasyMock.verify(s3Client);
   }
 
@@ -329,7 +332,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
 
     EasyMock.verify(s3Client, timeSupplier);
   }
@@ -428,7 +431,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
 
     EasyMock.verify(s3Client, timeSupplier);
   }
@@ -460,7 +463,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       taskLogs = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(LOG_CONTENTS, taskLogs);
+    Assertions.assertEquals(LOG_CONTENTS, taskLogs);
   }
 
   @Test
@@ -490,7 +493,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       taskLogs = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
+    Assertions.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
   }
 
   @Test
@@ -520,7 +523,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       taskLogs = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
+    Assertions.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
   }
 
 
@@ -550,7 +553,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       report = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(REPORT_CONTENTS, report);
+    Assertions.assertEquals(REPORT_CONTENTS, report);
   }
 
   @Test
@@ -579,7 +582,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       report = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(STATUS_CONTENTS, report);
+    Assertions.assertEquals(STATUS_CONTENTS, report);
   }
 
   @Test
@@ -620,7 +623,7 @@ public class S3TaskLogsTest extends EasyMockSupport
       report = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(STATUS_CONTENTS, report);
+    Assertions.assertEquals(STATUS_CONTENTS, report);
   }
 
   @Nonnull
@@ -671,7 +674,7 @@ public class S3TaskLogsTest extends EasyMockSupport
     S3TaskLogs s3TaskLogs = new S3TaskLogs(() -> s3Client, config, inputDataConfig, timeSupplier);
 
     String taskId = "index_test-datasource_2019-06-18T13:30:28.887Z";
-    File logFile = tempFolder.newFile("test_log_file");
+    File logFile = File.createTempFile("test_log_file", ".tmp", tempFolder);
 
     s3TaskLogs.pushTaskLog(taskId, logFile);
 
@@ -681,10 +684,10 @@ public class S3TaskLogsTest extends EasyMockSupport
   @Test
   public void testEnsureQuotated()
   {
-    Assert.assertEquals("\"etag\"", S3TaskLogs.ensureQuotated("etag"));
-    Assert.assertNull(S3TaskLogs.ensureQuotated(null));
-    Assert.assertEquals("\"etag", S3TaskLogs.ensureQuotated("\"etag"));
-    Assert.assertEquals("etag\"", S3TaskLogs.ensureQuotated("etag\""));
+    Assertions.assertEquals("\"etag\"", S3TaskLogs.ensureQuotated("etag"));
+    Assertions.assertNull(S3TaskLogs.ensureQuotated(null));
+    Assertions.assertEquals("\"etag", S3TaskLogs.ensureQuotated("\"etag"));
+    Assertions.assertEquals("etag\"", S3TaskLogs.ensureQuotated("etag\""));
   }
 
   @Test
@@ -697,6 +700,6 @@ public class S3TaskLogsTest extends EasyMockSupport
         .ifMatch(S3TaskLogs.ensureQuotated(eTag))
         .range("bytes=0-1")
         .build();
-    Assert.assertEquals("\"" + eTag + "\"", request.ifMatch());
+    Assertions.assertEquals("\"" + eTag + "\"", request.ifMatch());
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TimestampVersionedDataFinderTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TimestampVersionedDataFinderTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.storage.s3;
 
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -75,7 +75,7 @@ public class S3TimestampVersionedDataFinderTest
 
     URI expected = URI.create(StringUtils.format("s3://%s/%s", bucket, object1.key()));
 
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 
   @Test
@@ -104,7 +104,7 @@ public class S3TimestampVersionedDataFinderTest
 
     EasyMock.verify(s3Client);
 
-    Assert.assertEquals(null, latest);
+    Assertions.assertEquals(null, latest);
   }
 
   @Test
@@ -142,7 +142,7 @@ public class S3TimestampVersionedDataFinderTest
 
     URI expected = URI.create(StringUtils.format("s3://%s/%s", bucket, object0.key()));
 
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 
   @Test
@@ -177,6 +177,6 @@ public class S3TimestampVersionedDataFinderTest
 
     URI expected = URI.create(StringUtils.format("s3://%s/%s", bucket, object0.key()));
 
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TimestampVersionedDataFinderTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TimestampVersionedDataFinderTest.java
@@ -104,7 +104,7 @@ public class S3TimestampVersionedDataFinderTest
 
     EasyMock.verify(s3Client);
 
-    Assertions.assertEquals(null, latest);
+    Assertions.assertNull(latest);
   }
 
   @Test

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TransferConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3TransferConfigTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.storage.s3;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class S3TransferConfigTest
 {
@@ -28,9 +28,9 @@ public class S3TransferConfigTest
   public void testDefaultValues()
   {
     S3TransferConfig config = new S3TransferConfig();
-    Assert.assertTrue(config.isUseTransferManager());
-    Assert.assertEquals(20 * 1024 * 1024L, config.getMinimumUploadPartSize());
-    Assert.assertEquals(20 * 1024 * 1024L, config.getMultipartUploadThreshold());
+    Assertions.assertTrue(config.isUseTransferManager());
+    Assertions.assertEquals(20 * 1024 * 1024L, config.getMinimumUploadPartSize());
+    Assertions.assertEquals(20 * 1024 * 1024L, config.getMultipartUploadThreshold());
   }
 
   @Test
@@ -38,7 +38,7 @@ public class S3TransferConfigTest
   {
     S3TransferConfig config = new S3TransferConfig();
     config.setUseTransferManager(true);
-    Assert.assertTrue(config.isUseTransferManager());
+    Assertions.assertTrue(config.isUseTransferManager());
   }
 
   @Test
@@ -46,7 +46,7 @@ public class S3TransferConfigTest
   {
     S3TransferConfig config = new S3TransferConfig();
     config.setMinimumUploadPartSize(10 * 1024 * 1024L);
-    Assert.assertEquals(10 * 1024 * 1024L, config.getMinimumUploadPartSize());
+    Assertions.assertEquals(10 * 1024 * 1024L, config.getMinimumUploadPartSize());
   }
 
   @Test
@@ -54,6 +54,6 @@ public class S3TransferConfigTest
   {
     S3TransferConfig config = new S3TransferConfig();
     config.setMultipartUploadThreshold(10 * 1024 * 1024L);
-    Assert.assertEquals(10 * 1024 * 1024L, config.getMultipartUploadThreshold());
+    Assertions.assertEquals(10 * 1024 * 1024L, config.getMultipartUploadThreshold());
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/S3UtilsTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.common.aws.AWSEndpointConfig;
 import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
@@ -49,7 +49,7 @@ public class S3UtilsTest
   {
     final int maxRetries = 3;
     final AtomicInteger count = new AtomicInteger();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IOException.class,
         () -> S3Utils.retryS3Operation(
             () -> {
@@ -58,7 +58,7 @@ public class S3UtilsTest
             },
             maxRetries
         ));
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
@@ -67,7 +67,7 @@ public class S3UtilsTest
     // Transient TLS "Tag mismatch!" should be retried, not treated as terminal. See issue #19616.
     final int maxRetries = 3;
     final AtomicInteger count = new AtomicInteger();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         SSLException.class,
         () -> S3Utils.retryS3Operation(
             () -> {
@@ -76,14 +76,14 @@ public class S3UtilsTest
             },
             maxRetries
         ));
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
   public void testRetryWith4XXErrors()
   {
     final AtomicInteger count = new AtomicInteger();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IOException.class,
         () -> S3Utils.retryS3Operation(
             () -> {
@@ -99,7 +99,7 @@ public class S3UtilsTest
             },
             3
         ));
-    Assert.assertEquals(1, count.get());
+    Assertions.assertEquals(1, count.get());
   }
 
   @Test
@@ -121,7 +121,7 @@ public class S3UtilsTest
         },
         maxRetries
     );
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
@@ -129,7 +129,7 @@ public class S3UtilsTest
   {
     final int maxRetries = 3;
     final AtomicInteger count = new AtomicInteger();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IOException.class,
         () -> S3Utils.retryS3Operation(
             () -> {
@@ -146,7 +146,7 @@ public class S3UtilsTest
             maxRetries
         )
     );
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
@@ -169,7 +169,7 @@ public class S3UtilsTest
         },
         maxRetries
     );
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
@@ -194,7 +194,7 @@ public class S3UtilsTest
         },
         maxRetries
     );
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
@@ -216,7 +216,7 @@ public class S3UtilsTest
         },
         maxRetries
     );
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
@@ -238,14 +238,14 @@ public class S3UtilsTest
         },
         maxRetries
     );
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   @Test
   public void testNoRetryWithS3InternalErrorNon200Status()
   {
     final AtomicInteger count = new AtomicInteger();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         Exception.class,
         () -> S3Utils.retryS3Operation(
             () -> {
@@ -259,14 +259,14 @@ public class S3UtilsTest
             3
         )
     );
-    Assert.assertEquals(1, count.get());
+    Assertions.assertEquals(1, count.get());
   }
 
   @Test
   public void testNoRetryWithS3SlowDownNon200Status()
   {
     final AtomicInteger count = new AtomicInteger();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         Exception.class,
         () -> S3Utils.retryS3Operation(
             () -> {
@@ -280,14 +280,14 @@ public class S3UtilsTest
             3
         )
     );
-    Assert.assertEquals(1, count.get());
+    Assertions.assertEquals(1, count.get());
   }
 
   @Test
   public void testRetryWithS3Status200ButDifferentError()
   {
     final AtomicInteger count = new AtomicInteger();
-    Assert.assertThrows(
+    Assertions.assertThrows(
         Exception.class,
         () -> S3Utils.retryS3Operation(
             () -> {
@@ -301,7 +301,7 @@ public class S3UtilsTest
             3
         )
     );
-    Assert.assertEquals(1, count.get());
+    Assertions.assertEquals(1, count.get());
   }
 
   @Test
@@ -350,12 +350,12 @@ public class S3UtilsTest
     // First request should have both keys
     List<String> firstKeys = capturedRequests.getValues().get(0).delete().objects()
                                  .stream().map(ObjectIdentifier::key).collect(Collectors.toList());
-    Assert.assertEquals(List.of("a", "b"), firstKeys);
+    Assertions.assertEquals(List.of("a", "b"), firstKeys);
 
     // Second request should only have the failed key
     List<String> secondKeys = capturedRequests.getValues().get(1).delete().objects()
                                   .stream().map(ObjectIdentifier::key).collect(Collectors.toList());
-    Assert.assertEquals(List.of("b"), secondKeys);
+    Assertions.assertEquals(List.of("b"), secondKeys);
   }
 
   @Test
@@ -372,12 +372,12 @@ public class S3UtilsTest
     EasyMock.replay(s3Client);
 
     List<ObjectIdentifier> keys = List.of(ObjectIdentifier.builder().key("a").build());
-    S3MultiObjectDeleteException thrown = Assert.assertThrows(
+    S3MultiObjectDeleteException thrown = Assertions.assertThrows(
         S3MultiObjectDeleteException.class,
         () -> S3Utils.deleteBucketKeys(s3Client, "bucket", keys, 2)
     );
-    Assert.assertEquals(1, thrown.getErrors().size());
-    Assert.assertEquals("a", thrown.getErrors().get(0).key());
+    Assertions.assertEquals(1, thrown.getErrors().size());
+    Assertions.assertEquals("a", thrown.getErrors().get(0).key());
     EasyMock.verify(s3Client);
   }
 
@@ -403,12 +403,12 @@ public class S3UtilsTest
         ObjectIdentifier.builder().key("a").build(),
         ObjectIdentifier.builder().key("b").build()
     );
-    S3MultiObjectDeleteException thrown = Assert.assertThrows(
+    S3MultiObjectDeleteException thrown = Assertions.assertThrows(
         S3MultiObjectDeleteException.class,
         () -> S3Utils.deleteBucketKeys(s3Client, "bucket", keys, 1)
     );
-    Assert.assertEquals(1, thrown.getErrors().size());
-    Assert.assertEquals("b", thrown.getErrors().get(0).key());
+    Assertions.assertEquals(1, thrown.getErrors().size());
+    Assertions.assertEquals("b", thrown.getErrors().get(0).key());
     EasyMock.verify(s3Client);
   }
 
@@ -429,7 +429,7 @@ public class S3UtilsTest
         },
         maxRetries
     );
-    Assert.assertEquals(maxRetries, count.get());
+    Assertions.assertEquals(maxRetries, count.get());
   }
 
   private static final ObjectMapper JSON = new ObjectMapper();
@@ -442,31 +442,31 @@ public class S3UtilsTest
   @Test
   public void testUseHttpsNullClientConfigSchemelessEndpointReturnsTrue() throws IOException
   {
-    Assert.assertTrue(S3Utils.useHttps(null, endpointWith("{\"url\":\"s3.example.com\"}")));
+    Assertions.assertTrue(S3Utils.useHttps(null, endpointWith("{\"url\":\"s3.example.com\"}")));
   }
 
   @Test
   public void testUseHttpsNullClientConfigHttpEndpointReturnsFalse() throws IOException
   {
-    Assert.assertFalse(S3Utils.useHttps(null, endpointWith("{\"url\":\"http://s3.example.com\"}")));
+    Assertions.assertFalse(S3Utils.useHttps(null, endpointWith("{\"url\":\"http://s3.example.com\"}")));
   }
 
   @Test
   public void testUseHttpsNullClientConfigHttpsEndpointReturnsTrue() throws IOException
   {
-    Assert.assertTrue(S3Utils.useHttps(null, endpointWith("{\"url\":\"https://s3.example.com\"}")));
+    Assertions.assertTrue(S3Utils.useHttps(null, endpointWith("{\"url\":\"https://s3.example.com\"}")));
   }
 
   @Test
   public void testUseHttpsNullClientConfigNullEndpointUrlReturnsTrue() throws IOException
   {
-    Assert.assertTrue(S3Utils.useHttps(null, new AWSEndpointConfig()));
+    Assertions.assertTrue(S3Utils.useHttps(null, new AWSEndpointConfig()));
   }
 
   @Test
   public void testUseHttpsDefaultClientConfigSchemelessEndpointReturnsTrue() throws IOException
   {
     // Sanity check: default AWSClientConfig protocol is "https"; schemeless URL inherits "https".
-    Assert.assertTrue(S3Utils.useHttps(new AWSClientConfig(), endpointWith("{\"url\":\"s3.example.com\"}")));
+    Assertions.assertTrue(S3Utils.useHttps(new AWSClientConfig(), endpointWith("{\"url\":\"s3.example.com\"}")));
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3Test.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3Test.java
@@ -21,11 +21,10 @@ package org.apache.druid.storage.s3;
 
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -46,14 +45,15 @@ import java.util.concurrent.CompletableFuture;
 
 public class ServerSideEncryptingAmazonS3Test
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private S3Client mockS3Client;
   private ServerSideEncryption mockServerSideEncryption;
   private S3TransferConfig mockTransferConfig;
 
-  @Before
+
+  @BeforeEach
   public void setup()
   {
     mockS3Client = EasyMock.createMock(S3Client.class);
@@ -80,15 +80,15 @@ public class ServerSideEncryptingAmazonS3Test
     transferManagerField.setAccessible(true);
     Object transferManager = transferManagerField.get(s3);
 
-    Assert.assertNull("TransferManager should be null when no async client provided", transferManager);
-    Assert.assertNotNull(s3);
-    Assert.assertEquals(mockS3Client, s3.getS3Client());
+    Assertions.assertNull(transferManager, "TransferManager should be null when no async client provided");
+    Assertions.assertNotNull(s3);
+    Assertions.assertEquals(mockS3Client, s3.getS3Client());
   }
 
   @Test
   public void testUpload() throws IOException
   {
-    File testFile = temporaryFolder.newFile("test-upload.txt");
+    File testFile = File.createTempFile("test-upload", ".txt", temporaryFolder);
 
     PutObjectResponse mockResponse = PutObjectResponse.builder().build();
 
@@ -121,7 +121,7 @@ public class ServerSideEncryptingAmazonS3Test
   @Test
   public void testUpload_WithGrantFullControlHeaderFormatted() throws IOException
   {
-    final File testFile = temporaryFolder.newFile("test-upload-acl.txt");
+    final File testFile = File.createTempFile("test-upload-acl", ".txt", temporaryFolder);
     PutObjectResponse mockResponse = PutObjectResponse.builder().build();
 
     // Set up transfer config to return false for useTransferManager
@@ -149,7 +149,7 @@ public class ServerSideEncryptingAmazonS3Test
     );
     s3.upload("bucket", "key", testFile, grant);
 
-    Assert.assertEquals("id=\"canonical-id\"", requestCapture.getValue().grantFullControl());
+    Assertions.assertEquals("id=\"canonical-id\"", requestCapture.getValue().grantFullControl());
     EasyMock.verify(mockServerSideEncryption);
     EasyMock.verify(mockS3Client);
   }
@@ -157,7 +157,7 @@ public class ServerSideEncryptingAmazonS3Test
   @Test
   public void testPutObjectWithFile() throws IOException
   {
-    File testFile = temporaryFolder.newFile("test-put-object.txt");
+    File testFile = File.createTempFile("test-put-object", ".txt", temporaryFolder);
 
     PutObjectResponse mockResponse = PutObjectResponse.builder().build();
 
@@ -182,7 +182,7 @@ public class ServerSideEncryptingAmazonS3Test
     );
     PutObjectResponse response = s3.putObject("bucket", "key", testFile);
 
-    Assert.assertNotNull(response);
+    Assertions.assertNotNull(response);
     EasyMock.verify(mockServerSideEncryption);
     EasyMock.verify(mockS3Client);
   }
@@ -208,8 +208,11 @@ public class ServerSideEncryptingAmazonS3Test
     transferManagerField.setAccessible(true);
     Object transferManager = transferManagerField.get(s3);
 
-    Assert.assertNotNull("TransferManager should be created when async client is provided", transferManager);
-    Assert.assertTrue("TransferManager should be S3TransferManager instance", transferManager instanceof S3TransferManager);
+    Assertions.assertNotNull(transferManager, "TransferManager should be created when async client is provided");
+    Assertions.assertTrue(
+        transferManager instanceof S3TransferManager,
+        "TransferManager should be S3TransferManager instance"
+    );
   }
 
   @Test
@@ -233,13 +236,13 @@ public class ServerSideEncryptingAmazonS3Test
     transferManagerField.setAccessible(true);
     Object transferManager = transferManagerField.get(s3);
 
-    Assert.assertNull("TransferManager should be null when disabled", transferManager);
+    Assertions.assertNull(transferManager, "TransferManager should be null when disabled");
   }
 
   @Test
   public void testBuilder() throws IOException
   {
-    File testFile = temporaryFolder.newFile("test-builder.txt");
+    File testFile = File.createTempFile("test-builder", ".txt", temporaryFolder);
 
     S3Client builtClient = EasyMock.createMock(S3Client.class);
     EasyMock.replay(builtClient);
@@ -250,8 +253,8 @@ public class ServerSideEncryptingAmazonS3Test
 
     ServerSideEncryptingAmazonS3 s3 = builder.build();
 
-    Assert.assertNotNull(s3);
-    Assert.assertEquals(builtClient, s3.getS3Client());
+    Assertions.assertNotNull(s3);
+    Assertions.assertEquals(builtClient, s3.getS3Client());
   }
 
   @Test
@@ -273,21 +276,21 @@ public class ServerSideEncryptingAmazonS3Test
 
     ServerSideEncryptingAmazonS3 s3 = builder.build();
 
-    Assert.assertNotNull(s3);
-    Assert.assertEquals(builtClient, s3.getS3Client());
+    Assertions.assertNotNull(s3);
+    Assertions.assertEquals(builtClient, s3.getS3Client());
 
     // Verify transfer manager was created
     Field transferManagerField = ServerSideEncryptingAmazonS3.class.getDeclaredField("transferManager");
     transferManagerField.setAccessible(true);
     Object transferManager = transferManagerField.get(s3);
 
-    Assert.assertNotNull("TransferManager should be created with async client", transferManager);
+    Assertions.assertNotNull(transferManager, "TransferManager should be created with async client");
   }
 
   @Test
   public void testUpload_UsesTransferManagerWhenAvailable() throws IOException, NoSuchFieldException, IllegalAccessException
   {
-    File testFile = temporaryFolder.newFile("test-async-upload.txt");
+    File testFile = File.createTempFile("test-async-upload", ".txt", temporaryFolder);
 
     // Set up transfer config to return true for useTransferManager
     EasyMock.expect(mockTransferConfig.isUseTransferManager()).andReturn(true).anyTimes();
@@ -343,15 +346,15 @@ public class ServerSideEncryptingAmazonS3Test
 
     // Verify the upload request has correct bucket and key
     UploadFileRequest capturedRequest = uploadRequestCapture.getValue();
-    Assert.assertEquals("test-bucket", capturedRequest.putObjectRequest().bucket());
-    Assert.assertEquals("test-key", capturedRequest.putObjectRequest().key());
-    Assert.assertEquals(testFile.toPath(), capturedRequest.source());
+    Assertions.assertEquals("test-bucket", capturedRequest.putObjectRequest().bucket());
+    Assertions.assertEquals("test-key", capturedRequest.putObjectRequest().key());
+    Assertions.assertEquals(testFile.toPath(), capturedRequest.source());
   }
 
   @Test
   public void testUpload_UsesTransferManagerWithAclGrant() throws IOException, NoSuchFieldException, IllegalAccessException
   {
-    File testFile = temporaryFolder.newFile("test-async-upload-acl.txt");
+    File testFile = File.createTempFile("test-async-upload-acl", ".txt", temporaryFolder);
 
     // Set up transfer config
     EasyMock.expect(mockTransferConfig.isUseTransferManager()).andReturn(true).anyTimes();
@@ -403,6 +406,6 @@ public class ServerSideEncryptingAmazonS3Test
 
     // Verify the ACL grant was applied
     UploadFileRequest capturedRequest = uploadRequestCapture.getValue();
-    Assert.assertEquals("id=\"test-canonical-id\"", capturedRequest.putObjectRequest().grantFullControl());
+    Assertions.assertEquals("id=\"test-canonical-id\"", capturedRequest.putObjectRequest().grantFullControl());
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3Test.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3Test.java
@@ -240,10 +240,8 @@ public class ServerSideEncryptingAmazonS3Test
   }
 
   @Test
-  public void testBuilder() throws IOException
+  public void testBuilder()
   {
-    File testFile = File.createTempFile("test-builder", ".txt", temporaryFolder);
-
     S3Client builtClient = EasyMock.createMock(S3Client.class);
     EasyMock.replay(builtClient);
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/TestAWSCredentialsProvider.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/TestAWSCredentialsProvider.java
@@ -27,10 +27,9 @@ import org.apache.druid.common.aws.AWSModule;
 import org.apache.druid.common.aws.AWSProxyConfig;
 import org.apache.druid.metadata.DefaultPasswordProvider;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -42,8 +41,8 @@ import java.nio.charset.StandardCharsets;
 
 public class TestAWSCredentialsProvider
 {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  public File folder;
 
   private final AWSModule awsModule = new AWSModule();
   private final S3StorageDruidModule s3Module = new S3StorageDruidModule();
@@ -58,8 +57,8 @@ public class TestAWSCredentialsProvider
 
     AwsCredentialsProvider provider = awsModule.getAWSCredentialsProvider(config);
     AwsCredentials credentials = provider.resolveCredentials();
-    Assert.assertEquals("accessKeySample", credentials.accessKeyId());
-    Assert.assertEquals("secretKeySample", credentials.secretAccessKey());
+    Assertions.assertEquals("accessKeySample", credentials.accessKeyId());
+    Assertions.assertEquals("secretKeySample", credentials.secretAccessKey());
 
     // try to create
     ServerSideEncryptingAmazonS3.Builder amazonS3ClientBuilder = s3Module.getServerSideEncryptingAmazonS3Builder(
@@ -81,7 +80,7 @@ public class TestAWSCredentialsProvider
     AWSCredentialsConfig config = EasyMock.createMock(AWSCredentialsConfig.class);
     EasyMock.expect(config.getAccessKey()).andReturn(new DefaultPasswordProvider(""));
     EasyMock.expect(config.getSecretKey()).andReturn(new DefaultPasswordProvider(""));
-    File file = folder.newFile();
+    File file = File.createTempFile("credentials", ".properties", folder);
     try (BufferedWriter out = Files.newWriter(file, StandardCharsets.UTF_8)) {
       out.write("sessionToken=sessionTokenSample\nsecretKey=secretKeySample\naccessKey=accessKeySample\n");
     }
@@ -90,11 +89,11 @@ public class TestAWSCredentialsProvider
 
     AwsCredentialsProvider provider = awsModule.getAWSCredentialsProvider(config);
     AwsCredentials credentials = provider.resolveCredentials();
-    Assert.assertTrue(credentials instanceof AwsSessionCredentials);
+    Assertions.assertTrue(credentials instanceof AwsSessionCredentials);
     AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentials;
-    Assert.assertEquals("accessKeySample", sessionCredentials.accessKeyId());
-    Assert.assertEquals("secretKeySample", sessionCredentials.secretAccessKey());
-    Assert.assertEquals("sessionTokenSample", sessionCredentials.sessionToken());
+    Assertions.assertEquals("accessKeySample", sessionCredentials.accessKeyId());
+    Assertions.assertEquals("secretKeySample", sessionCredentials.secretAccessKey());
+    Assertions.assertEquals("sessionTokenSample", sessionCredentials.sessionToken());
 
     // try to create
     ServerSideEncryptingAmazonS3.Builder amazonS3ClientBuilder = s3Module.getServerSideEncryptingAmazonS3Builder(

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/TestFileSessionCredentialsProvider.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/TestFileSessionCredentialsProvider.java
@@ -21,10 +21,9 @@ package org.apache.druid.storage.s3;
 
 import com.google.common.io.Files;
 import org.apache.druid.common.aws.FileSessionCredentialsProvider;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 
@@ -35,23 +34,26 @@ import java.nio.charset.StandardCharsets;
 
 public class TestFileSessionCredentialsProvider
 {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  public File folder;
 
   @Test
   public void test() throws IOException
   {
-    File file = folder.newFile();
+    File file = File.createTempFile("credentials", ".properties", folder);
     try (BufferedWriter out = Files.newWriter(file, StandardCharsets.UTF_8)) {
       out.write("sessionToken=sessionTokenSample\nsecretKey=secretKeySample\naccessKey=accessKeySample\n");
     }
 
     FileSessionCredentialsProvider provider = new FileSessionCredentialsProvider(file.getAbsolutePath());
     AwsCredentials credentials = provider.resolveCredentials();
-    Assert.assertTrue("Credentials should be session credentials", credentials instanceof AwsSessionCredentials);
+    Assertions.assertTrue(
+        credentials instanceof AwsSessionCredentials,
+        "Credentials should be session credentials"
+    );
     AwsSessionCredentials sessionCredentials = (AwsSessionCredentials) credentials;
-    Assert.assertEquals("sessionTokenSample", sessionCredentials.sessionToken());
-    Assert.assertEquals("accessKeySample", sessionCredentials.accessKeyId());
-    Assert.assertEquals("secretKeySample", sessionCredentials.secretAccessKey());
+    Assertions.assertEquals("sessionTokenSample", sessionCredentials.sessionToken());
+    Assertions.assertEquals("accessKeySample", sessionCredentials.accessKeyId());
+    Assertions.assertEquals("secretKeySample", sessionCredentials.secretAccessKey());
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -28,12 +28,10 @@ import org.apache.druid.storage.s3.NoopServerSideEncryption;
 import org.apache.druid.storage.s3.S3TransferConfig;
 import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -50,6 +48,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -57,11 +56,8 @@ import java.util.stream.Collectors;
 
 public class RetryableS3OutputStreamTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @TempDir
+  public File temporaryFolder;
 
   private final TestAmazonS3 s3 = new TestAmazonS3(0);
   private final String path = "resultId";
@@ -71,10 +67,11 @@ public class RetryableS3OutputStreamTest
 
   private S3UploadManager s3UploadManager;
 
-  @Before
+
+  @BeforeEach
   public void setup() throws IOException
   {
-    final File tempDir = temporaryFolder.newFolder();
+    final File tempDir = Files.createTempDirectory(temporaryFolder.toPath(), "s3output").toFile();
     chunkSize = 10L;
     config = new S3OutputConfig(
         "TEST",
@@ -125,7 +122,7 @@ public class RetryableS3OutputStreamTest
       }
     }
     // each chunk is 10 bytes, so there should be 10 chunks.
-    Assert.assertEquals(10, s3.partRequests.size());
+    Assertions.assertEquals(10, s3.partRequests.size());
     s3.assertCompleted(chunkSize, Integer.BYTES * 25);
   }
 
@@ -143,7 +140,7 @@ public class RetryableS3OutputStreamTest
       out.write(bb.array());
     }
     // each chunk 10 bytes, so there should be 2 chunks.
-    Assert.assertEquals(2, s3.partRequests.size());
+    Assertions.assertEquals(2, s3.partRequests.size());
     s3.assertCompleted(chunkSize, Integer.BYTES * 3);
   }
 
@@ -158,7 +155,7 @@ public class RetryableS3OutputStreamTest
       }
     }
     // each chunk 128 bytes, so there should be 5 chunks.
-    Assert.assertEquals(5, s3.partRequests.size());
+    Assertions.assertEquals(5, s3.partRequests.size());
     s3.assertCompleted(chunkSize, 600);
   }
 
@@ -174,7 +171,7 @@ public class RetryableS3OutputStreamTest
       }
     }
     // each chunk 128 bytes, so there should be 5 chunks.
-    Assert.assertEquals(5, s3.partRequests.size());
+    Assertions.assertEquals(5, s3.partRequests.size());
     s3.assertCompleted(chunkSize, fileSize);
   }
 
@@ -194,7 +191,7 @@ public class RetryableS3OutputStreamTest
       }
     }
     // each chunk is 10 bytes, so there should be 10 chunks.
-    Assert.assertEquals(10, s3.partRequests.size());
+    Assertions.assertEquals(10, s3.partRequests.size());
     s3.assertCompleted(chunkSize, Integer.BYTES * 25);
   }
 
@@ -278,33 +275,33 @@ public class RetryableS3OutputStreamTest
 
     private void assertCompleted(long chunkSize, long expectedFileSize)
     {
-      Assert.assertNotNull(completeRequest);
-      Assert.assertFalse(cancelled);
+      Assertions.assertNotNull(completeRequest);
+      Assertions.assertFalse(cancelled);
 
       Set<Integer> partNumbersFromRequest = partRequests.stream().map(UploadPartRequest::partNumber).collect(Collectors.toSet());
-      Assert.assertEquals(partRequests.size(), partNumbersFromRequest.size());
+      Assertions.assertEquals(partRequests.size(), partNumbersFromRequest.size());
 
       // Verify sizes of uploaded chunks
       int numSmallerChunks = 0;
       for (UploadPartRequest part : partRequests) {
-        Assert.assertTrue(part.contentLength() <= chunkSize);
+        Assertions.assertTrue(part.contentLength() <= chunkSize);
         if (part.contentLength() < chunkSize) {
           ++numSmallerChunks;
         }
       }
-      Assert.assertTrue(numSmallerChunks <= 1);
+      Assertions.assertTrue(numSmallerChunks <= 1);
 
       final List<CompletedPart> completedParts = completeRequest.multipartUpload().parts();
-      Assert.assertEquals(partRequests.size(), completedParts.size());
-      Assert.assertEquals(
+      Assertions.assertEquals(partRequests.size(), completedParts.size());
+      Assertions.assertEquals(
           partNumbersFromRequest,
           completedParts.stream().map(CompletedPart::partNumber).collect(Collectors.toSet())
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           partNumbersFromRequest.stream().map(partNumber -> "etag-" + partNumber).collect(Collectors.toSet()),
           completedParts.stream().map(CompletedPart::eTag).collect(Collectors.toSet())
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedFileSize,
           partRequests.stream().mapToLong(UploadPartRequest::contentLength).sum()
       );
@@ -312,8 +309,8 @@ public class RetryableS3OutputStreamTest
 
     private void assertCancelled()
     {
-      Assert.assertTrue(cancelled);
-      Assert.assertNull(completeRequest);
+      Assertions.assertTrue(cancelled);
+      Assertions.assertNull(completeRequest);
     }
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.storage.s3.output;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.DruidProcessingConfigTest;
@@ -49,7 +49,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.storage.s3.output;
 
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.DruidProcessingConfigTest;
@@ -71,7 +72,7 @@ public class RetryableS3OutputStreamTest
   @BeforeEach
   public void setup() throws IOException
   {
-    final File tempDir = Files.createTempDirectory(temporaryFolder.toPath(), "s3output").toFile();
+    final File tempDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "s3output");
     chunkSize = 10L;
     config = new S3OutputConfig(
         "TEST",

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3ExportStorageProviderTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3ExportStorageProviderTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.storage.s3.output;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.error.DruidException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -44,15 +44,15 @@ public class S3ExportStorageProviderTest
     S3ExportStorageProvider.validateS3Prefix(ImmutableList.of("s3://bucket-name"), "bucket-name", "validPath");
     S3ExportStorageProvider.validateS3Prefix(validPrefixes, "bucket-name", "validPath1/../validPath2/");
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> S3ExportStorageProvider.validateS3Prefix(validPrefixes, "incorrect-bucket", "validPath1/")
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> S3ExportStorageProvider.validateS3Prefix(validPrefixes, "bucket-name", "invalidPath1")
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> S3ExportStorageProvider.validateS3Prefix(validPrefixes, "bucket-name", "validPath123")
     );
@@ -61,7 +61,7 @@ public class S3ExportStorageProviderTest
   @Test
   public void testExportManifestFilePath()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "s3://export-bucket/export/table/file1",
         new S3ExportStorageProvider("export-bucket", "export/table", null, null).getFilePathForManifest("file1")
     );

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
@@ -20,19 +20,18 @@
 package org.apache.druid.storage.s3.output;
 
 import org.apache.druid.java.util.common.HumanReadableBytes;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class S3OutputConfigTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @TempDir
+  public Path temporaryFolder;
   private static String BUCKET = "BUCKET";
   private static String PREFIX = "PREFIX";
   private static int MAX_RETRY_COUNT = 0;
@@ -42,17 +41,17 @@ public class S3OutputConfigTest
   {
     long chunkSize = S3OutputConfig.S3_MULTIPART_UPLOAD_MAX_PART_SIZE_BYTES + 1;
 
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "chunkSize[5368709121] should be >= "
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new S3OutputConfig(
+            BUCKET,
+            PREFIX,
+            Files.createTempDirectory(temporaryFolder, "s3output").toFile(),
+            HumanReadableBytes.valueOf(chunkSize),
+            MAX_RETRY_COUNT,
+            true
+        )
     );
-    new S3OutputConfig(
-        BUCKET,
-        PREFIX,
-        temporaryFolder.newFolder(),
-        HumanReadableBytes.valueOf(chunkSize),
-        MAX_RETRY_COUNT,
-        true
-    );
+    Assertions.assertTrue(exception.getMessage().contains("chunkSize[5368709121] should be >= "));
   }
 }

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class S3OutputConfigTest

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputConfigTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.s3.output;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class S3OutputConfigTest
         () -> new S3OutputConfig(
             BUCKET,
             PREFIX,
-            Files.createTempDirectory(temporaryFolder, "s3output").toFile(),
+            FileUtils.createTempDirInLocation(temporaryFolder, "s3output"),
             HumanReadableBytes.valueOf(chunkSize),
             MAX_RETRY_COUNT,
             true

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputSerdeTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3OutputSerdeTest.java
@@ -26,10 +26,8 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,10 +35,6 @@ import java.io.IOException;
 public class S3OutputSerdeTest
 {
   private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
 
   @Test
   public void sanity() throws IOException
@@ -61,12 +55,12 @@ public class S3OutputSerdeTest
         2
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         json,
         MAPPER.writeValueAsString(s3OutputConfig)
     );
 
-    Assert.assertEquals(s3OutputConfig, MAPPER.readValue(json, S3OutputConfig.class));
+    Assertions.assertEquals(s3OutputConfig, MAPPER.readValue(json, S3OutputConfig.class));
   }
 
   @Test
@@ -78,9 +72,11 @@ public class S3OutputSerdeTest
                                            + "  \"chunkSize\":104857600,\n"
                                            + "  \"maxRetry\": 2\n"
                                            + "}\n");
-    expectedException.expect(MismatchedInputException.class);
-    expectedException.expectMessage("Missing required creator property 'prefix'");
-    MAPPER.readValue(json, S3OutputConfig.class);
+    final MismatchedInputException exception = Assertions.assertThrows(
+        MismatchedInputException.class,
+        () -> MAPPER.readValue(json, S3OutputConfig.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Missing required creator property 'prefix'"));
   }
 
   @Test
@@ -92,9 +88,11 @@ public class S3OutputSerdeTest
                                            + "  \"chunkSize\":104857600,\n"
                                            + "  \"maxRetry\": 2\n"
                                            + "}\n");
-    expectedException.expect(MismatchedInputException.class);
-    expectedException.expectMessage("Missing required creator property 'bucket'");
-    MAPPER.readValue(json, S3OutputConfig.class);
+    final MismatchedInputException exception = Assertions.assertThrows(
+        MismatchedInputException.class,
+        () -> MAPPER.readValue(json, S3OutputConfig.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Missing required creator property 'bucket'"));
   }
 
   @Test
@@ -113,7 +111,7 @@ public class S3OutputSerdeTest
         null,
         null
     );
-    Assert.assertEquals(s3OutputConfig, MAPPER.readValue(json, S3OutputConfig.class));
+    Assertions.assertEquals(s3OutputConfig, MAPPER.readValue(json, S3OutputConfig.class));
   }
 
 
@@ -128,9 +126,11 @@ public class S3OutputSerdeTest
                                            + "  \"chunkSize\":104,\n"
                                            + "  \"maxRetry\": 2\n"
                                            + "}\n");
-    expectedException.expect(ValueInstantiationException.class);
-    expectedException.expectMessage("chunkSize[104] should be >=");
-    MAPPER.readValue(json, S3OutputConfig.class);
+    final ValueInstantiationException exception = Assertions.assertThrows(
+        ValueInstantiationException.class,
+        () -> MAPPER.readValue(json, S3OutputConfig.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("chunkSize[104] should be >="));
   }
 
   private static String jsonStringReadyForAssert(String input)

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3UploadManagerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3UploadManagerTest.java
@@ -26,12 +26,11 @@ import org.apache.druid.storage.s3.ServerSideEncryptingAmazonS3;
 import org.apache.druid.utils.RuntimeInfo;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
@@ -39,24 +38,26 @@ import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.concurrent.Future;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class S3UploadManagerTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private S3UploadManager s3UploadManager;
   private S3OutputConfig s3OutputConfig;
   private S3ExportConfig s3ExportConfig;
   private StubServiceEmitter serviceEmitter;
 
-  @Before
+
+  @BeforeEach
   public void setUp() throws IOException
   {
-    File tempDir = temporaryFolder.newFolder("s3output");
+    File tempDir = Files.createTempDirectory(temporaryFolder.toPath(), "s3output").toFile();
     s3OutputConfig = new S3OutputConfig("bucket", "prefix", tempDir, new HumanReadableBytes("100MiB"), 1);
     s3ExportConfig = new S3ExportConfig("tempDir", new HumanReadableBytes("200MiB"), 1, null);
     serviceEmitter = new StubServiceEmitter();
@@ -70,7 +71,7 @@ public class S3UploadManagerTest
     ServerSideEncryptingAmazonS3 s3Client = EasyMock.mock(ServerSideEncryptingAmazonS3.class);
 
     // Create a real temp file with actual content
-    File chunkFile = temporaryFolder.newFile("chunk-test.tmp");
+    File chunkFile = File.createTempFile("chunk-test", ".tmp", temporaryFolder);
     try (FileOutputStream fos = new FileOutputStream(chunkFile)) {
       fos.write(new byte[1024]);
     }
@@ -87,8 +88,8 @@ public class S3UploadManagerTest
     Future<UploadPartResponse> result = s3UploadManager.queueChunkForUpload(s3Client, "test-key", chunkId, chunkFile, "upload-id", s3OutputConfig);
 
     UploadPartResponse futureResult = result.get();
-    Assert.assertNotNull(futureResult);
-    Assert.assertEquals("etag", futureResult.eTag());
+    Assertions.assertNotNull(futureResult);
+    Assertions.assertEquals("etag", futureResult.eTag());
 
     serviceEmitter.verifyEmitted("s3/upload/part/queuedTime", 1);
     serviceEmitter.verifyEmitted("s3/upload/part/queueSize", 1);
@@ -135,7 +136,7 @@ public class S3UploadManagerTest
     ServerSideEncryptingAmazonS3 s3Client = EasyMock.mock(ServerSideEncryptingAmazonS3.class);
 
     // Create a real temp file with actual content
-    File chunkFile = temporaryFolder.newFile("upload-part-test.tmp");
+    File chunkFile = File.createTempFile("upload-part-test", ".tmp", temporaryFolder);
     try (FileOutputStream fos = new FileOutputStream(chunkFile)) {
       fos.write(new byte[1024]);
     }
@@ -158,7 +159,8 @@ public class S3UploadManagerTest
     assertEquals(uploadPartResponse, result);
   }
 
-  @After
+
+  @AfterEach
   public void teardown()
   {
     s3UploadManager.stop();

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3UploadManagerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3UploadManagerTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.storage.s3.output;
 
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
 import org.apache.druid.query.DruidProcessingConfigTest;
@@ -57,7 +58,7 @@ public class S3UploadManagerTest
   @BeforeEach
   public void setUp() throws IOException
   {
-    File tempDir = Files.createTempDirectory(temporaryFolder.toPath(), "s3output").toFile();
+    File tempDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "s3output");
     s3OutputConfig = new S3OutputConfig("bucket", "prefix", tempDir, new HumanReadableBytes("100MiB"), 1);
     s3ExportConfig = new S3ExportConfig("tempDir", new HumanReadableBytes("200MiB"), 1, null);
     serviceEmitter = new StubServiceEmitter();

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3UploadManagerTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/S3UploadManagerTest.java
@@ -39,7 +39,6 @@ import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.concurrent.Future;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
## Description

Migrates the `extensions-core/s3-extensions` test suite from JUnit 4 to JUnit 5.

This is Batch 6 of the extensions-core migration and is part of [#13948](https://github.com/apache/druid/issues/13948).

Depends on the earlier migration batches in [#19875](https://github.com/apache/druid/pull/19875), [#19876](https://github.com/apache/druid/pull/19876), [#19877](https://github.com/apache/druid/pull/19877), [#19878](https://github.com/apache/druid/pull/19878), and [#19879](https://github.com/apache/druid/pull/19879).

The migration replaces JUnit 4 assertions, rules, and lifecycle methods with Jupiter equivalents, including `@TempDir` and `assertThrows`.

## Tests

```text
mvn -ntp test -pl extensions-core/s3-extensions -am \
  -Dtest='org.apache.druid.catalog.model.table.S3InputSourceDefnTest,org.apache.druid.data.input.s3.**,org.apache.druid.storage.s3.**' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Pskip-static-checks -Dweb.console.skip=true -T1C
```

Result: 235 tests passed; 0 failures, errors, or skips.
