### PR TITLE
test: migrate datasketches extension tests to JUnit 5

### DIFF
--- a/extensions-core/datasketches/pom.xml
+++ b/extensions-core/datasketches/pom.xml
@@ -145,6 +145,12 @@
     </dependency>
 
     <!-- Test Dependencies -->
+    <!--
+      AggregationTestHelper comes from processing's test-jar and currently exposes
+      org.junit.rules.TemporaryFolder in its public test-helper API. Keep the JUnit 4
+      API dependency (but not the Vintage engine) until that shared helper is migrated
+      to a JUnit 5-compatible temp-directory API.
+    -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -162,22 +168,12 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
@@ -64,7 +64,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -466,7 +465,7 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     return results.get(0).getColumns().get(columnName);
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException
+  private static File newFolder(File root, String... subDirs)
   {
     return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs) + "-");
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
@@ -57,13 +57,14 @@ import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -82,15 +83,15 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
   protected static final String SKETCH_COLUMN = "sketch";
   protected static final String DIM_COLUMN = "dim";
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   private IndexIO indexIO;
   private IndexMergerV9 indexMerger;
   private QueryRunnerFactory<SegmentAnalysis, SegmentMetadataQuery> queryRunnerFactory;
   private Closer closer;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     final ObjectMapper jsonMapper = TestHelper.makeJsonMapper();
@@ -147,7 +148,7 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     // Create a QueryableIndex (simulates historical/persisted segment)
     IncrementalIndex indexToPersist = closer.register(createIncrementalIndex(aggregators));
     addRows(indexToPersist, 100, 200);
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = newFolder(tempFolder, "junit");
     indexMerger.persist(indexToPersist, segmentDir, IndexSpec.getDefault(), null);
     QueryableIndex queryableIndex = closer.register(indexIO.loadIndex(segmentDir));
 
@@ -174,54 +175,54 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     Sequence<SegmentAnalysis> results = mergedRunner.run(QueryPlus.wrap(query));
     List<SegmentAnalysis> resultList = results.toList();
 
-    Assert.assertEquals(1, resultList.size());
+    Assertions.assertEquals(1, resultList.size());
     SegmentAnalysis mergedAnalysis = resultList.get(0);
 
     // Verify row count: 100 rows per segment, no rollup due to unique timestamps
-    Assert.assertEquals("Merged row count should be 200", 200, mergedAnalysis.getNumRows());
+    Assertions.assertEquals(200, mergedAnalysis.getNumRows(), "Merged row count should be 200");
 
-    Assert.assertEquals("Should have 4 columns", 4, mergedAnalysis.getColumns().size());
-    Assert.assertTrue("Should contain __time column", mergedAnalysis.getColumns().containsKey("__time"));
-    Assert.assertTrue("Should contain dim column", mergedAnalysis.getColumns().containsKey(DIM_COLUMN));
-    Assert.assertTrue("Should contain count column", mergedAnalysis.getColumns().containsKey("count"));
-    Assert.assertTrue("Should contain sketch column", mergedAnalysis.getColumns().containsKey(SKETCH_COLUMN));
+    Assertions.assertEquals(4, mergedAnalysis.getColumns().size(), "Should have 4 columns");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey("__time"), "Should contain __time column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey(DIM_COLUMN), "Should contain dim column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey("count"), "Should contain count column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey(SKETCH_COLUMN), "Should contain sketch column");
 
     // Verify no column has merge errors
     for (Map.Entry<String, ColumnAnalysis> entry : mergedAnalysis.getColumns().entrySet()) {
-      Assert.assertFalse(
-          "Column '" + entry.getKey() + "' should not have error: " + entry.getValue().getErrorMessage(),
-          entry.getValue().isError()
+      Assertions.assertFalse(
+          entry.getValue().isError(),
+          "Column '" + entry.getKey() + "' should not have error: " + entry.getValue().getErrorMessage()
       );
     }
 
     // Make sure the merge went through ok
     ColumnAnalysis timeColumnAnalysis = mergedAnalysis.getColumns().get("__time");
-    Assert.assertEquals(ColumnType.LONG, timeColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals(ColumnType.LONG, timeColumnAnalysis.getTypeSignature());
     ColumnAnalysis dimColumnAnalysis = mergedAnalysis.getColumns().get(DIM_COLUMN);
-    Assert.assertEquals(ColumnType.STRING, dimColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals(ColumnType.STRING, dimColumnAnalysis.getTypeSignature());
     ColumnAnalysis countColumnAnalysis = mergedAnalysis.getColumns().get("count");
-    Assert.assertEquals(ColumnType.LONG, countColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals(ColumnType.LONG, countColumnAnalysis.getTypeSignature());
     ColumnAnalysis sketchColumnAnalysis = mergedAnalysis.getColumns().get(SKETCH_COLUMN);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedCanonicalColumnType(),
         sketchColumnAnalysis.getTypeSignature()
     );
-    Assert.assertFalse("Sketch column should not have multiple values", sketchColumnAnalysis.isHasMultipleValues());
+    Assertions.assertFalse(sketchColumnAnalysis.isHasMultipleValues(), "Sketch column should not have multiple values");
 
-    Assert.assertNotNull("Aggregators should be present", mergedAnalysis.getAggregators());
-    Assert.assertEquals("Should have exactly 2 aggregators", 2, mergedAnalysis.getAggregators().size());
-    Assert.assertTrue(
-        "Should contain count aggregator",
-        mergedAnalysis.getAggregators().containsKey("count")
+    Assertions.assertNotNull(mergedAnalysis.getAggregators(), "Aggregators should be present");
+    Assertions.assertEquals(2, mergedAnalysis.getAggregators().size(), "Should have exactly 2 aggregators");
+    Assertions.assertTrue(
+        mergedAnalysis.getAggregators().containsKey("count"),
+        "Should contain count aggregator"
     );
-    Assert.assertTrue(
-        "Should contain sketch aggregator",
-        mergedAnalysis.getAggregators().containsKey(SKETCH_COLUMN)
+    Assertions.assertTrue(
+        mergedAnalysis.getAggregators().containsKey(SKETCH_COLUMN),
+        "Should contain sketch aggregator"
     );
 
     // Verify sketch aggregator
     AggregatorFactory sketchAggregator = mergedAnalysis.getAggregators().get(SKETCH_COLUMN);
-    Assert.assertNotNull("Sketch aggregator should not be null", sketchAggregator);
+    Assertions.assertNotNull(sketchAggregator, "Sketch aggregator should not be null");
     assertMergedSketchAggregator(sketchAggregator, SKETCH_COLUMN);
   }
 
@@ -240,13 +241,13 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     // Create two persisted segments
     IncrementalIndex index1 = closer.register(createIncrementalIndex(aggregators));
     addRows(index1, 0, 100);
-    File segmentDir1 = tempFolder.newFolder();
+    File segmentDir1 = newFolder(tempFolder, "junit");
     indexMerger.persist(index1, segmentDir1, IndexSpec.getDefault(), null);
     QueryableIndex queryableIndex1 = closer.register(indexIO.loadIndex(segmentDir1));
 
     IncrementalIndex index2 = closer.register(createIncrementalIndex(aggregators));
     addRows(index2, 100, 200);
-    File segmentDir2 = tempFolder.newFolder();
+    File segmentDir2 = newFolder(tempFolder, "junit");
     indexMerger.persist(index2, segmentDir2, IndexSpec.getDefault(), null);
     QueryableIndex queryableIndex2 = closer.register(indexIO.loadIndex(segmentDir2));
 
@@ -256,10 +257,10 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     ColumnAnalysis analysis1 = analyzeColumn(segment1, SKETCH_COLUMN);
     ColumnAnalysis analysis2 = analyzeColumn(segment2, SKETCH_COLUMN);
 
-    Assert.assertEquals(
-        "Both persisted segments should report the same type",
+    Assertions.assertEquals(
         analysis1.getTypeSignature(),
-        analysis2.getTypeSignature()
+        analysis2.getTypeSignature(),
+        "Both persisted segments should report the same type"
     );
 
     SegmentMetadataQuery query = Druids.newSegmentMetadataQueryBuilder()
@@ -285,42 +286,42 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     Sequence<SegmentAnalysis> results = mergedRunner.run(QueryPlus.wrap(query));
     List<SegmentAnalysis> resultList = results.toList();
 
-    Assert.assertEquals(1, resultList.size());
+    Assertions.assertEquals(1, resultList.size());
     SegmentAnalysis mergedAnalysis = resultList.get(0);
 
     // Verify all columns exist
-    Assert.assertEquals("Should have 4 columns", 4, mergedAnalysis.getColumns().size());
-    Assert.assertTrue("Should contain __time column", mergedAnalysis.getColumns().containsKey("__time"));
-    Assert.assertTrue("Should contain dim column", mergedAnalysis.getColumns().containsKey(DIM_COLUMN));
-    Assert.assertTrue("Should contain count column", mergedAnalysis.getColumns().containsKey("count"));
-    Assert.assertTrue("Should contain sketch column", mergedAnalysis.getColumns().containsKey(SKETCH_COLUMN));
+    Assertions.assertEquals(4, mergedAnalysis.getColumns().size(), "Should have 4 columns");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey("__time"), "Should contain __time column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey(DIM_COLUMN), "Should contain dim column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey("count"), "Should contain count column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey(SKETCH_COLUMN), "Should contain sketch column");
 
     // Verify no column has merge errors
     for (Map.Entry<String, ColumnAnalysis> entry : mergedAnalysis.getColumns().entrySet()) {
-      Assert.assertFalse(
-          "Column '" + entry.getKey() + "' should not have error: " + entry.getValue().getErrorMessage(),
-          entry.getValue().isError()
+      Assertions.assertFalse(
+          entry.getValue().isError(),
+          "Column '" + entry.getKey() + "' should not have error: " + entry.getValue().getErrorMessage()
       );
     }
 
     // Verify time
     ColumnAnalysis timeColumnAnalysis = mergedAnalysis.getColumns().get("__time");
-    Assert.assertEquals(ColumnType.LONG, timeColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals(ColumnType.LONG, timeColumnAnalysis.getTypeSignature());
 
     // Verify dim column: type STRING, min/max/cardinality
     ColumnAnalysis dimColumnAnalysis = mergedAnalysis.getColumns().get(DIM_COLUMN);
-    Assert.assertEquals(ColumnType.STRING, dimColumnAnalysis.getTypeSignature());
-    Assert.assertEquals("dim min value", "dim_value_0", dimColumnAnalysis.getMinValue());
-    Assert.assertEquals("dim max value", "dim_value_9", dimColumnAnalysis.getMaxValue());
-    Assert.assertEquals("dim cardinality should be 10", 10, dimColumnAnalysis.getCardinality().intValue());
+    Assertions.assertEquals(ColumnType.STRING, dimColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals("dim_value_0", dimColumnAnalysis.getMinValue(), "dim min value");
+    Assertions.assertEquals("dim_value_9", dimColumnAnalysis.getMaxValue(), "dim max value");
+    Assertions.assertEquals(10, dimColumnAnalysis.getCardinality().intValue(), "dim cardinality should be 10");
 
     // Verify count column: type LONG (min/max not computed for metric columns by default)
     ColumnAnalysis countColumnAnalysis = mergedAnalysis.getColumns().get("count");
-    Assert.assertEquals(ColumnType.LONG, countColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals(ColumnType.LONG, countColumnAnalysis.getTypeSignature());
 
     // Verify count column: ensure type signature matches
     ColumnAnalysis sketchColumnAnalysis = mergedAnalysis.getColumns().get(SKETCH_COLUMN);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedCanonicalColumnType(),
         sketchColumnAnalysis.getTypeSignature()
     );
@@ -351,10 +352,10 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     ColumnAnalysis analysis1 = analyzeColumn(segment1, SKETCH_COLUMN);
     ColumnAnalysis analysis2 = analyzeColumn(segment2, SKETCH_COLUMN);
 
-    Assert.assertEquals(
-        "Both realtime segments should report the same type",
+    Assertions.assertEquals(
         analysis1.getTypeSignature(),
-        analysis2.getTypeSignature()
+        analysis2.getTypeSignature(),
+        "Both realtime segments should report the same type"
     );
 
     SegmentMetadataQuery query = Druids.newSegmentMetadataQueryBuilder()
@@ -380,42 +381,42 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     Sequence<SegmentAnalysis> results = mergedRunner.run(QueryPlus.wrap(query));
     List<SegmentAnalysis> resultList = results.toList();
 
-    Assert.assertEquals(1, resultList.size());
+    Assertions.assertEquals(1, resultList.size());
     SegmentAnalysis mergedAnalysis = resultList.get(0);
 
     // Verify all columns exist
-    Assert.assertEquals("Should have 4 columns", 4, mergedAnalysis.getColumns().size());
-    Assert.assertTrue("Should contain __time column", mergedAnalysis.getColumns().containsKey("__time"));
-    Assert.assertTrue("Should contain dim column", mergedAnalysis.getColumns().containsKey(DIM_COLUMN));
-    Assert.assertTrue("Should contain count column", mergedAnalysis.getColumns().containsKey("count"));
-    Assert.assertTrue("Should contain sketch column", mergedAnalysis.getColumns().containsKey(SKETCH_COLUMN));
+    Assertions.assertEquals(4, mergedAnalysis.getColumns().size(), "Should have 4 columns");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey("__time"), "Should contain __time column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey(DIM_COLUMN), "Should contain dim column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey("count"), "Should contain count column");
+    Assertions.assertTrue(mergedAnalysis.getColumns().containsKey(SKETCH_COLUMN), "Should contain sketch column");
 
     // Verify no column has merge errors
     for (Map.Entry<String, ColumnAnalysis> entry : mergedAnalysis.getColumns().entrySet()) {
-      Assert.assertFalse(
-          "Column '" + entry.getKey() + "' should not have error: " + entry.getValue().getErrorMessage(),
-          entry.getValue().isError()
+      Assertions.assertFalse(
+          entry.getValue().isError(),
+          "Column '" + entry.getKey() + "' should not have error: " + entry.getValue().getErrorMessage()
       );
     }
 
     // Verify time
     ColumnAnalysis timeColumnAnalysis = mergedAnalysis.getColumns().get("__time");
-    Assert.assertEquals(ColumnType.LONG, timeColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals(ColumnType.LONG, timeColumnAnalysis.getTypeSignature());
 
     // Verify dim column: type STRING, min/max/cardinality
     ColumnAnalysis dimColumnAnalysis = mergedAnalysis.getColumns().get(DIM_COLUMN);
-    Assert.assertEquals(ColumnType.STRING, dimColumnAnalysis.getTypeSignature());
-    Assert.assertEquals("dim min value", "dim_value_0", dimColumnAnalysis.getMinValue());
-    Assert.assertEquals("dim max value", "dim_value_9", dimColumnAnalysis.getMaxValue());
-    Assert.assertEquals("dim cardinality should be 10", 10, dimColumnAnalysis.getCardinality().intValue());
+    Assertions.assertEquals(ColumnType.STRING, dimColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals("dim_value_0", dimColumnAnalysis.getMinValue(), "dim min value");
+    Assertions.assertEquals("dim_value_9", dimColumnAnalysis.getMaxValue(), "dim max value");
+    Assertions.assertEquals(10, dimColumnAnalysis.getCardinality().intValue(), "dim cardinality should be 10");
 
     // Verify count column: type LONG (min/max not computed for metric columns by default)
     ColumnAnalysis countColumnAnalysis = mergedAnalysis.getColumns().get("count");
-    Assert.assertEquals(ColumnType.LONG, countColumnAnalysis.getTypeSignature());
+    Assertions.assertEquals(ColumnType.LONG, countColumnAnalysis.getTypeSignature());
 
     // Verify count column: ensure type signature matches
     ColumnAnalysis sketchColumnAnalysis = mergedAnalysis.getColumns().get(SKETCH_COLUMN);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedCanonicalColumnType(),
         sketchColumnAnalysis.getTypeSignature()
     );
@@ -461,7 +462,11 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     QueryRunner<SegmentAnalysis> runner = queryRunnerFactory.createRunner(segment);
     List<SegmentAnalysis> results = runner.run(QueryPlus.wrap(query)).toList();
 
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     return results.get(0).getColumns().get(columnName);
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException {
+    return Files.createTempDirectory(root.toPath(), String.join("-", subDirs) + "-").toFile();
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
@@ -466,7 +466,8 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
     return results.get(0).getColumns().get(columnName);
   }
 
-  private static File newFolder(File root, String... subDirs) throws IOException {
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
     return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs) + "-");
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/BaseSketchBuildSegmentMetadataQueryTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.query.aggregation.datasketches;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -64,7 +65,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -467,6 +467,6 @@ public abstract class BaseSketchBuildSegmentMetadataQueryTest extends Initialize
   }
 
   private static File newFolder(File root, String... subDirs) throws IOException {
-    return Files.createTempDirectory(root.toPath(), String.join("-", subDirs) + "-").toFile();
+    return FileUtils.createTempDirInLocation(root.toPath(), String.join("-", subDirs) + "-");
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorFactoryTest.java
@@ -40,9 +40,9 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
@@ -64,7 +64,7 @@ public class HllSketchAggregatorFactoryTest
 
   private TestHllSketchAggregatorFactory target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     target = new TestHllSketchAggregatorFactory(NAME, FIELD_NAME, LG_K, TGT_HLL_TYPE, STRING_ENCODING, ROUND);
@@ -73,27 +73,27 @@ public class HllSketchAggregatorFactoryTest
   @Test
   public void testIsRound()
   {
-    Assert.assertEquals(ROUND, target.isRound());
+    Assertions.assertEquals(ROUND, target.isRound());
   }
 
   @Test
   public void testStringEncoding()
   {
-    Assert.assertEquals(STRING_ENCODING, target.getStringEncoding());
+    Assertions.assertEquals(STRING_ENCODING, target.getStringEncoding());
   }
 
   @Test
   public void testFinalizeComputationNull()
   {
-    Assert.assertEquals(0.0D, target.finalizeComputation(null));
+    Assertions.assertEquals(0.0D, target.finalizeComputation(null));
   }
 
   @Test
   public void testFinalizeComputationRound()
   {
     Object actual = target.finalizeComputation(getMockSketch());
-    Assert.assertTrue(actual instanceof Long);
-    Assert.assertEquals(3L, actual);
+    Assertions.assertTrue(actual instanceof Long);
+    Assertions.assertEquals(3L, actual);
   }
 
   private static HllSketch getMockSketch()
@@ -116,8 +116,8 @@ public class HllSketchAggregatorFactoryTest
         !ROUND
     );
     Object actual = t.finalizeComputation(getMockSketch());
-    Assert.assertTrue(actual instanceof Double);
-    Assert.assertEquals(ESTIMATE, actual);
+    Assertions.assertTrue(actual instanceof Double);
+    Assertions.assertEquals(ESTIMATE, actual);
   }
 
   @Test
@@ -129,13 +129,13 @@ public class HllSketchAggregatorFactoryTest
   @Test
   public void testEqualsOtherNull()
   {
-    Assert.assertNotEquals(target, null);
+    Assertions.assertNotEquals(target, null);
   }
 
   @Test
   public void testEqualsOtherDiffClass()
   {
-    Assert.assertNotEquals(target, NAME);
+    Assertions.assertNotEquals(target, NAME);
   }
 
   @Test
@@ -149,8 +149,8 @@ public class HllSketchAggregatorFactoryTest
         STRING_ENCODING,
         ROUND
     );
-    Assert.assertNotEquals(target, other);
-    Assert.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
+    Assertions.assertNotEquals(target, other);
+    Assertions.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
   }
 
   @Test
@@ -164,8 +164,8 @@ public class HllSketchAggregatorFactoryTest
         STRING_ENCODING,
         ROUND
     );
-    Assert.assertNotEquals(target, other);
-    Assert.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
+    Assertions.assertNotEquals(target, other);
+    Assertions.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
   }
 
   @Test
@@ -179,8 +179,8 @@ public class HllSketchAggregatorFactoryTest
         STRING_ENCODING,
         ROUND
     );
-    Assert.assertNotEquals(target, other);
-    Assert.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
+    Assertions.assertNotEquals(target, other);
+    Assertions.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
   }
 
   @Test
@@ -194,8 +194,8 @@ public class HllSketchAggregatorFactoryTest
         STRING_ENCODING,
         ROUND
     );
-    Assert.assertNotEquals(target, other);
-    Assert.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
+    Assertions.assertNotEquals(target, other);
+    Assertions.assertFalse(Arrays.equals(target.getCacheKey(), other.getCacheKey()));
   }
 
   @Test
@@ -209,10 +209,10 @@ public class HllSketchAggregatorFactoryTest
         STRING_ENCODING,
         !ROUND
     );
-    Assert.assertNotEquals(target, other);
+    Assertions.assertNotEquals(target, other);
 
     // Rounding does not affect per-segment results, so it does not affect cache key
-    Assert.assertArrayEquals(target.getCacheKey(), other.getCacheKey());
+    Assertions.assertArrayEquals(target.getCacheKey(), other.getCacheKey());
   }
 
   @Test
@@ -226,8 +226,8 @@ public class HllSketchAggregatorFactoryTest
         STRING_ENCODING,
         ROUND
     );
-    Assert.assertEquals(target, other);
-    Assert.assertArrayEquals(target.getCacheKey(), other.getCacheKey());
+    Assertions.assertEquals(target, other);
+    Assertions.assertArrayEquals(target.getCacheKey(), other.getCacheKey());
   }
 
   @Test
@@ -261,9 +261,9 @@ public class HllSketchAggregatorFactoryTest
         false,
         false
     );
-    Assert.assertNotNull(other.substituteCombiningFactory(factory));
-    Assert.assertNotNull(factory.substituteCombiningFactory(other));
-    Assert.assertNull(factory.substituteCombiningFactory(incompatible));
+    Assertions.assertNotNull(other.substituteCombiningFactory(factory));
+    Assertions.assertNotNull(factory.substituteCombiningFactory(other));
+    Assertions.assertNull(factory.substituteCombiningFactory(incompatible));
   }
 
   @Test
@@ -281,7 +281,7 @@ public class HllSketchAggregatorFactoryTest
       }
 
       Pattern expectedPattern = testPatternForToString(field);
-      Assert.assertTrue("Missing \"" + field.getName() + "\"", expectedPattern.matcher(string).find());
+      Assertions.assertTrue(expectedPattern.matcher(string).find(), "Missing \"" + field.getName() + "\"");
     }
   }
 
@@ -360,7 +360,7 @@ public class HllSketchAggregatorFactoryTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -28,6 +28,7 @@ import org.apache.druid.data.input.MapBasedRow;
 import org.apache.druid.data.input.impl.DelimitedInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringEncoding;
 import org.apache.druid.java.util.common.granularity.Granularities;
@@ -54,7 +55,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -137,7 +137,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
     final int minTimestamp = 0;
     final int maxRowCount = 10;
 
-    File segmentDir1 = Files.createTempDirectory(timeseriesFolder.toPath(), "hll").toFile();
+    File segmentDir1 = FileUtils.createTempDirInLocation(timeseriesFolder.toPath(), "hll");
     timeseriesHelper.createIndex(
         inputFile,
         inputRowSchema,
@@ -150,7 +150,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         true
     );
 
-    File segmentDir2 = Files.createTempDirectory(timeseriesFolder.toPath(), "hll").toFile();
+    File segmentDir2 = FileUtils.createTempDirInLocation(timeseriesFolder.toPath(), "hll");
     timeseriesHelper.createIndex(
         inputFile,
         inputRowSchema,

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -48,49 +48,46 @@ import org.apache.druid.query.groupby.epinephelinae.GrouperTestUtil;
 import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-@RunWith(Parameterized.class)
 public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 {
   private static final boolean ROUND = true;
 
-  private final AggregationTestHelper groupByHelper;
-  private final AggregationTestHelper timeseriesHelper;
-  private final QueryContexts.Vectorize vectorize;
-  private final StringEncoding stringEncoding;
+  private AggregationTestHelper groupByHelper;
+  private AggregationTestHelper timeseriesHelper;
+  private QueryContexts.Vectorize vectorize;
+  private StringEncoding stringEncoding;
 
-  @Rule
-  public final TemporaryFolder groupByFolder = new TemporaryFolder();
+  @TempDir
+  private File groupByFolder;
 
-  @Rule
-  public final TemporaryFolder timeseriesFolder = new TemporaryFolder();
+  @TempDir
+  private File timeseriesFolder;
 
-  public HllSketchAggregatorTest(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding)
+  public void initHllSketchAggregatorTest(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding)
   {
     HllSketchModule.registerSerde();
-    groupByHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    groupByHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         new HllSketchModule().getJacksonModules(), config, groupByFolder
     );
-    timeseriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelper(
+    timeseriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
         new HllSketchModule().getJacksonModules(), timeseriesFolder
     );
     this.vectorize = QueryContexts.Vectorize.fromString(vectorize);
     this.stringEncoding = stringEncoding;
   }
 
-  @Parameterized.Parameters(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -106,9 +103,11 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @Test
-  public void ingestSketches() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void ingestSketches(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile()),
         buildInputRowSchema(List.of("dim", "multiDim")),
@@ -120,14 +119,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildGroupByQuery("HLLSketchMerge", "sketch", !ROUND, stringEncoding)
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(200, (double) row.get(0), 0.1);
+    Assertions.assertEquals(200, (double) row.get(0), 0.1);
   }
 
-  @Test
-  public void ingestSketchesTimeseries() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void ingestSketchesTimeseries(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     final File inputFile = new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile());
     final InputRowSchema inputRowSchema = buildInputRowSchema(List.of("dim", "multiDim"));
     final DelimitedInputFormat inputFormat = buildInputFormat(List.of("timestamp", "dim", "multiDim", "sketch"));
@@ -136,7 +137,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
     final int minTimestamp = 0;
     final int maxRowCount = 10;
 
-    File segmentDir1 = timeseriesFolder.newFolder();
+    File segmentDir1 = Files.createTempDirectory(timeseriesFolder.toPath(), "hll").toFile();
     timeseriesHelper.createIndex(
         inputFile,
         inputRowSchema,
@@ -149,7 +150,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         true
     );
 
-    File segmentDir2 = timeseriesFolder.newFolder();
+    File segmentDir2 = Files.createTempDirectory(timeseriesFolder.toPath(), "hll").toFile();
     timeseriesHelper.createIndex(
         inputFile,
         inputRowSchema,
@@ -167,14 +168,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildTimeseriesQuery("HLLSketchMerge", "sketch", !ROUND)
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     Result<TimeseriesResultValue> row = results.get(0);
-    Assert.assertEquals(200, (double) row.getValue().getMetric("sketch"), 0.1);
+    Assertions.assertEquals(200, (double) row.getValue().getMetric("sketch"), 0.1);
   }
 
-  @Test
-  public void buildSketchesAtIngestionTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void buildSketchesAtIngestionTime(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
         buildInputRowSchema(List.of("dim")),
@@ -186,14 +189,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildGroupByQuery("HLLSketchMerge", "sketch", !ROUND, stringEncoding)
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(200, (double) row.get(0), 0.1);
+    Assertions.assertEquals(200, (double) row.get(0), 0.1);
   }
 
-  @Test
-  public void buildSketchesAtIngestionTimeTimeseries() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void buildSketchesAtIngestionTimeTimeseries(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<Result<TimeseriesResultValue>> seq = timeseriesHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
         buildInputRowSchema(List.of("dim")),
@@ -205,14 +210,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildTimeseriesQuery("HLLSketchMerge", "sketch", !ROUND)
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     Result<TimeseriesResultValue> row = results.get(0);
-    Assert.assertEquals(200, (double) row.getValue().getMetric("sketch"), 0.1);
+    Assertions.assertEquals(200, (double) row.getValue().getMetric("sketch"), 0.1);
   }
 
-  @Test
-  public void buildSketchesAtQueryTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void buildSketchesAtQueryTime(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
         buildInputRowSchema(List.of("dim", "multiDim", "id")),
@@ -224,14 +231,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildGroupByQuery("HLLSketchBuild", "id", !ROUND, stringEncoding)
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(200, (double) row.get(0), 0.1);
+    Assertions.assertEquals(200, (double) row.get(0), 0.1);
   }
 
-  @Test
-  public void buildSketchesAtQueryTimeTimeseries() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void buildSketchesAtQueryTimeTimeseries(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<Result<TimeseriesResultValue>> seq = timeseriesHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
         buildInputRowSchema(List.of("dim", "multiDim", "id")),
@@ -243,14 +252,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildTimeseriesQuery("HLLSketchBuild", "id", !ROUND)
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     Result<TimeseriesResultValue> row = results.get(0);
-    Assert.assertEquals(200, (double) row.getValue().getMetric("sketch"), 0.1);
+    Assertions.assertEquals(200, (double) row.getValue().getMetric("sketch"), 0.1);
   }
 
-  @Test
-  public void unsuccessfulComplexTypesInHLL() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void unsuccessfulComplexTypesInHLL(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     try {
       Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
           new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile()),
@@ -264,14 +275,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
       );
     }
     catch (RuntimeException e) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           e.getMessage().contains("Invalid input [index_hll] of type [COMPLEX<hyperUnique>] for [HLLSketchBuild]"));
     }
   }
 
-  @Test
-  public void buildSketchesAtQueryTimeMultiValue() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void buildSketchesAtQueryTimeMultiValue(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
         buildInputRowSchema(List.of("dim", "multiDim", "id")),
@@ -283,14 +296,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildGroupByQuery("HLLSketchBuild", "multiDim", !ROUND, stringEncoding)
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(14, (double) row.get(0), 0.1);
+    Assertions.assertEquals(14, (double) row.get(0), 0.1);
   }
 
-  @Test
-  public void roundBuildSketch() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void roundBuildSketch(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_raw.tsv").getFile()),
         buildInputRowSchema(List.of("dim", "multiDim", "id")),
@@ -302,14 +317,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildGroupByQuery("HLLSketchBuild", "id", ROUND, stringEncoding)
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(200L, (long) row.get(0));
+    Assertions.assertEquals(200L, (long) row.get(0));
   }
 
-  @Test
-  public void roundMergeSketch() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void roundMergeSketch(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile()),
         buildInputRowSchema(List.of("dim", "multiDim")),
@@ -321,14 +338,16 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         buildGroupByQuery("HLLSketchMerge", "sketch", ROUND, stringEncoding)
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(200L, (long) row.get(0));
+    Assertions.assertEquals(200L, (long) row.get(0));
   }
 
-  @Test
-  public void testPostAggs() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void testPostAggs(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile()),
         buildInputRowSchema(List.of("dim", "multiDim")),
@@ -389,19 +408,21 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
                                    + "  Coupon Count   : 200\n";
 
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals(200, (double) row.get(0), 0.1);
-    Assert.assertEquals(200, (double) row.get(1), 0.1);
-    Assert.assertArrayEquals(new double[]{200, 200, 200}, (double[]) row.get(2), 0.1);
-    Assert.assertEquals(expectedSummary, row.get(3));
+    Assertions.assertEquals(200, (double) row.get(0), 0.1);
+    Assertions.assertEquals(200, (double) row.get(1), 0.1);
+    Assertions.assertArrayEquals(new double[]{200, 200, 200}, (double[]) row.get(2), 0.1);
+    Assertions.assertEquals(expectedSummary, row.get(3));
     // union with self = self
-    Assert.assertEquals(expectedSummary, ((HllSketchHolder) row.get(4)).getSketch().toString());
+    Assertions.assertEquals(expectedSummary, ((HllSketchHolder) row.get(4)).getSketch().toString());
   }
 
-  @Test
-  public void testRelocation()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
+  public void testRelocation(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding)
   {
+    initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
     HllSketchHolder sketchHolder = new HllSketchHolder(null, new HllSketch());
     sketchHolder.getSketch().update(1);
@@ -412,7 +433,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
         columnSelectorFactory,
         HllSketchHolder.class
     );
-    Assert.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
+    Assertions.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
   }
 
   private static InputRowSchema buildInputRowSchema(List<String> dimensions)
@@ -508,4 +529,5 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
                  .context(ImmutableMap.of(QueryContexts.VECTORIZE_KEY, vectorize.toString()))
                  .build();
   }
+
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchAggregatorTest.java
@@ -105,7 +105,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void ingestSketches(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void ingestSketches(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
@@ -126,7 +126,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void ingestSketchesTimeseries(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void ingestSketchesTimeseries(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     final File inputFile = new File(this.getClass().getClassLoader().getResource("hll/hll_sketches.tsv").getFile());
@@ -175,7 +175,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void buildSketchesAtIngestionTime(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void buildSketchesAtIngestionTime(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
@@ -196,7 +196,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void buildSketchesAtIngestionTimeTimeseries(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void buildSketchesAtIngestionTimeTimeseries(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<Result<TimeseriesResultValue>> seq = timeseriesHelper.createIndexAndRunQueryOnSegment(
@@ -217,7 +217,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void buildSketchesAtQueryTime(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void buildSketchesAtQueryTime(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
@@ -238,7 +238,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void buildSketchesAtQueryTimeTimeseries(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void buildSketchesAtQueryTimeTimeseries(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<Result<TimeseriesResultValue>> seq = timeseriesHelper.createIndexAndRunQueryOnSegment(
@@ -259,7 +259,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void unsuccessfulComplexTypesInHLL(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void unsuccessfulComplexTypesInHLL(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     try {
@@ -282,7 +282,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void buildSketchesAtQueryTimeMultiValue(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void buildSketchesAtQueryTimeMultiValue(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
@@ -303,7 +303,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void roundBuildSketch(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void roundBuildSketch(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
@@ -324,7 +324,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void roundMergeSketch(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void roundMergeSketch(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
@@ -345,7 +345,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void testPostAggs(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding) throws Exception
+  public void testPostAggs(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding) throws Exception
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     Sequence<ResultRow> seq = groupByHelper.createIndexAndRunQueryOnSegment(
@@ -420,7 +420,7 @@ public class HllSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}, stringEncoding = {2}")
-  public void testRelocation(GroupByQueryConfig config,String vectorize,StringEncoding stringEncoding)
+  public void testRelocation(GroupByQueryConfig config, String vectorize, StringEncoding stringEncoding)
   {
     initHllSketchAggregatorTest(config, vectorize, stringEncoding);
     final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildAggregatorFactoryTest.java
@@ -25,8 +25,8 @@ import org.apache.datasketches.hll.TgtHllType;
 import org.apache.druid.java.util.common.StringEncoding;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -55,7 +55,7 @@ public class HllSketchBuildAggregatorFactoryTest
 
     final String serializedString = jsonMapper.writeValueAsString(factory);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"type\":\"HLLSketchBuild\",\"name\":\"foo\",\"fieldName\":\"bar\",\"lgK\":18,\"tgtHllType\":\"HLL_8\","
         + "\"stringEncoding\":\"utf8\",\"shouldFinalize\":false,\"round\":true}",
         serializedString
@@ -66,7 +66,7 @@ public class HllSketchBuildAggregatorFactoryTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, factory2);
+    Assertions.assertEquals(factory, factory2);
   }
 
   @Test
@@ -84,7 +84,7 @@ public class HllSketchBuildAggregatorFactoryTest
 
     final String serializedString = jsonMapper.writeValueAsString(factory);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"type\":\"HLLSketchBuild\","
         + "\"name\":\"foo\","
         + "\"fieldName\":\"bar\","
@@ -99,7 +99,7 @@ public class HllSketchBuildAggregatorFactoryTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, factory2);
+    Assertions.assertEquals(factory, factory2);
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildSegmentMetadataQueryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildSegmentMetadataQueryTest.java
@@ -25,7 +25,7 @@ import org.apache.druid.java.util.common.StringEncoding;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.BaseSketchBuildSegmentMetadataQueryTest;
 import org.apache.druid.segment.column.ColumnType;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class HllSketchBuildSegmentMetadataQueryTest extends BaseSketchBuildSegmentMetadataQueryTest
 {
@@ -51,24 +51,24 @@ public class HllSketchBuildSegmentMetadataQueryTest extends BaseSketchBuildSegme
   @Override
   protected void assertMergedSketchAggregator(AggregatorFactory aggregator, String sketchColumn)
   {
-    Assert.assertTrue(
-        "Sketch aggregator should be HllSketchMergeAggregatorFactory but was " + aggregator.getClass().getName(),
-        aggregator instanceof HllSketchMergeAggregatorFactory
+    Assertions.assertTrue(
+        aggregator instanceof HllSketchMergeAggregatorFactory,
+        "Sketch aggregator should be HllSketchMergeAggregatorFactory but was " + aggregator.getClass().getName()
     );
 
     HllSketchMergeAggregatorFactory hllAggregator = (HllSketchMergeAggregatorFactory) aggregator;
-    Assert.assertEquals("Aggregator name should match", sketchColumn, hllAggregator.getName());
-    Assert.assertEquals("Field name should match", sketchColumn, hllAggregator.getFieldName());
-    Assert.assertEquals("lgK should be default value", HllSketchAggregatorFactory.DEFAULT_LG_K, hllAggregator.getLgK());
-    Assert.assertEquals(
-        "tgtHllType should be default value",
+    Assertions.assertEquals(sketchColumn, hllAggregator.getName(), "Aggregator name should match");
+    Assertions.assertEquals(sketchColumn, hllAggregator.getFieldName(), "Field name should match");
+    Assertions.assertEquals(HllSketchAggregatorFactory.DEFAULT_LG_K, hllAggregator.getLgK(), "lgK should be default value");
+    Assertions.assertEquals(
         TgtHllType.HLL_4.name(),
-        hllAggregator.getTgtHllType()
+        hllAggregator.getTgtHllType(),
+        "tgtHllType should be default value"
     );
-    Assert.assertEquals(
-        "stringEncoding should be default value",
+    Assertions.assertEquals(
         StringEncoding.UTF16LE,
-        hllAggregator.getStringEncoding()
+        hllAggregator.getStringEncoding(),
+        "stringEncoding should be default value"
     );
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildUtilTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchBuildUtilTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.DimensionDictionarySelector;
 import org.apache.druid.segment.IdLookup;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
@@ -227,7 +227,7 @@ public class HllSketchBuildUtilTest extends InitializedNullHandlingTest
 
   private void assertSketchEstimate(final long estimate)
   {
-    Assert.assertEquals((double) estimate, sketch.getEstimate(), 0.1);
+    Assertions.assertEquals((double) estimate, sketch.getEstimate(), 0.1);
   }
 
   private static class TestDictionarySelector implements DimensionDictionarySelector

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderObjectStrategyTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderObjectStrategyTest.java
@@ -23,8 +23,8 @@ import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.hll.HllSketch;
 import org.apache.datasketches.hll.TgtHllType;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -42,7 +42,7 @@ public class HllSketchHolderObjectStrategyTest
 
     ByteBuffer buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
     HllSketchHolderObjectStrategy objectStrategy = new HllSketchHolderObjectStrategy();
-    Assert.assertTrue(objectStrategy.readRetainsBufferReference());
+    Assertions.assertTrue(objectStrategy.readRetainsBufferReference());
 
     // valid sketch should not explode when copied, which reads the memory
     objectStrategy.fromByteBufferSafe(buf, bytes.length).getSketch().copy();
@@ -55,7 +55,7 @@ public class HllSketchHolderObjectStrategyTest
       }
 
       final ByteBuffer buf2 = ByteBuffer.wrap(garbage2).order(ByteOrder.LITTLE_ENDIAN);
-      Assert.assertThrows(
+      Assertions.assertThrows(
           Exception.class, // can throw either SketchesArgumentException or IndexOutOfBoundsException
           () -> objectStrategy.fromByteBufferSafe(buf2, garbage2.length).getSketch().copy()
       );
@@ -64,7 +64,7 @@ public class HllSketchHolderObjectStrategyTest
     // non sketch that is too short to contain header should fail with regular java buffer exception
     final byte[] garbage = new byte[]{0x01, 0x02};
     final ByteBuffer buf3 = ByteBuffer.wrap(garbage).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         SketchesArgumentException.class,
         () -> objectStrategy.fromByteBufferSafe(buf3, garbage.length).getSketch().copy()
     );
@@ -72,7 +72,7 @@ public class HllSketchHolderObjectStrategyTest
     // non sketch that is long enough to check (this one doesn't actually need 'safe' read)
     final byte[] garbageLonger = StringUtils.toUtf8("notasketch");
     final ByteBuffer buf4 = ByteBuffer.wrap(garbageLonger).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         SketchesArgumentException.class,
         () -> objectStrategy.fromByteBufferSafe(buf4, garbageLonger.length).getSketch().copy()
     );
@@ -102,22 +102,22 @@ public class HllSketchHolderObjectStrategyTest
           buf.position(1);
           buf.put(compactBytes);
           buf.position(1);
-          Assert.assertEquals(
-              "Compact array littleEndian " + description,
+          Assertions.assertEquals(
               expectEmpty,
-              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, compactBytes.length)
+              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, compactBytes.length),
+              "Compact array littleEndian " + description
           );
-          Assert.assertEquals(1, buf.position());
+          Assertions.assertEquals(1, buf.position());
 
           // -----------------------------
           // Compact array, big endian buf
           buf.order(ByteOrder.BIG_ENDIAN);
-          Assert.assertEquals(
-              "Compact array bigEndian " + description,
+          Assertions.assertEquals(
               expectEmpty,
-              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, compactBytes.length)
+              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, compactBytes.length),
+              "Compact array bigEndian " + description
           );
-          Assert.assertEquals(1, buf.position());
+          Assertions.assertEquals(1, buf.position());
 
           // ----------------------------------
           // Updatable array, little endian buf
@@ -128,22 +128,22 @@ public class HllSketchHolderObjectStrategyTest
           buf.position(1);
           buf.put(updatableBytes);
           buf.position(1);
-          Assert.assertEquals(
-              "Updatable array littleEndian " + description,
+          Assertions.assertEquals(
               expectEmpty,
-              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, updatableBytes.length)
+              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, updatableBytes.length),
+              "Updatable array littleEndian " + description
           );
-          Assert.assertEquals(1, buf.position());
+          Assertions.assertEquals(1, buf.position());
 
           // -------------------------------
           // Updatable array, big endian buf
           buf.order(ByteOrder.BIG_ENDIAN);
-          Assert.assertEquals(
-              "Updatable array bigEndian " + description,
+          Assertions.assertEquals(
               expectEmpty,
-              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, updatableBytes.length)
+              HllSketchHolderObjectStrategy.isSafeToConvertToNullSketch(buf, updatableBytes.length),
+              "Updatable array bigEndian " + description
           );
-          Assert.assertEquals(1, buf.position());
+          Assertions.assertEquals(1, buf.position());
         }
       }
     }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchHolderTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.aggregation.datasketches.hll;
 import org.apache.datasketches.hll.HllSketch;
 import org.apache.datasketches.hll.TgtHllType;
 import org.apache.datasketches.hll.Union;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HllSketchHolderTest
 {
@@ -38,8 +38,8 @@ public class HllSketchHolderTest
 
     HllSketchHolder result = holder1.merge(holder2);
 
-    Assert.assertSame(holder1, result);
-    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
+    Assertions.assertSame(holder1, result);
+    Assertions.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -50,8 +50,8 @@ public class HllSketchHolderTest
 
     HllSketchHolder result = holder1.merge(holder2);
 
-    Assert.assertSame(holder2, result);
-    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
+    Assertions.assertSame(holder2, result);
+    Assertions.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -62,8 +62,8 @@ public class HllSketchHolderTest
 
     HllSketchHolder result = holder1.merge(holder2);
 
-    Assert.assertSame(holder1, result);
-    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
+    Assertions.assertSame(holder1, result);
+    Assertions.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -74,8 +74,8 @@ public class HllSketchHolderTest
 
     HllSketchHolder result = holder1.merge(holder2);
 
-    Assert.assertSame(holder1, result);
-    Assert.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
+    Assertions.assertSame(holder1, result);
+    Assertions.assertEquals(NUM_VALUES * 2, result.getEstimate(), 0.01);
   }
 
   @Test
@@ -90,7 +90,7 @@ public class HllSketchHolderTest
 
     HllSketchHolder optimizedResult = holder1.merge(holder2);
 
-    Assert.assertEquals(naiveHolder1.getEstimate(), optimizedResult.getEstimate(), 0.0);
+    Assertions.assertEquals(naiveHolder1.getEstimate(), optimizedResult.getEstimate(), 0.0);
   }
 
   @Test
@@ -101,7 +101,7 @@ public class HllSketchHolderTest
 
     HllSketchHolder result = holder1.merge(holder2);
 
-    Assert.assertEquals(TgtHllType.HLL_4, result.getSketch().getTgtHllType());
+    Assertions.assertEquals(TgtHllType.HLL_4, result.getSketch().getTgtHllType());
   }
 
   @Test
@@ -114,7 +114,7 @@ public class HllSketchHolderTest
 
     double estimate = result.getEstimate();
     double expected = NUM_VALUES + (double) NUM_VALUES / 2;
-    Assert.assertEquals(expected, estimate, expected * 0.01);
+    Assertions.assertEquals(expected, estimate, expected * 0.01);
   }
 
   private static HllSketchHolder makeSketchHolder(int startValue, int endValue)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -130,8 +130,7 @@ public class HllSketchMergeAggregatorFactoryTest
           SHOULD_FINALIZE,
           ROUND
       );
-      HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-      Assertions.assertEquals(LG_K, result.getLgK());
+      targetRound.getMergingFactory(other);
     });
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchMergeAggregatorFactoryTest.java
@@ -33,11 +33,12 @@ import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.vector.TestVectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+
 
 public class HllSketchMergeAggregatorFactoryTest
 {
@@ -55,7 +56,7 @@ public class HllSketchMergeAggregatorFactoryTest
   private ColumnSelectorFactory metricFactory;
   private VectorColumnSelectorFactory vectorFactory;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     targetRound = new HllSketchMergeAggregatorFactory(
@@ -82,50 +83,56 @@ public class HllSketchMergeAggregatorFactoryTest
     vectorFactory = new TestVectorColumnSelectorFactory().addCapabilities(FIELD_NAME, columnCapabilities);
   }
 
-  @Test(expected = AggregatorFactoryNotMergeableException.class)
-  public void testGetMergingFactoryBadName() throws Exception
+  @Test
+  public void testGetMergingFactoryBadName()
   {
-    HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
-        NAME + "-diff",
-        FIELD_NAME,
-        LG_K,
-        TGT_HLL_TYPE,
-        STRING_ENCODING,
-        SHOULD_FINALIZE,
-        ROUND
-    );
-    targetRound.getMergingFactory(other);
+    Assertions.assertThrows(AggregatorFactoryNotMergeableException.class, () -> {
+      HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
+          NAME + "-diff",
+          FIELD_NAME,
+          LG_K,
+          TGT_HLL_TYPE,
+          STRING_ENCODING,
+          SHOULD_FINALIZE,
+          ROUND
+      );
+      targetRound.getMergingFactory(other);
+    });
   }
 
-  @Test(expected = AggregatorFactoryNotMergeableException.class)
-  public void testGetMergingFactoryBadType() throws Exception
+  @Test
+  public void testGetMergingFactoryBadType()
   {
-    HllSketchBuildAggregatorFactory other = new HllSketchBuildAggregatorFactory(
-        NAME,
-        FIELD_NAME,
-        LG_K,
-        TGT_HLL_TYPE,
-        STRING_ENCODING,
-        SHOULD_FINALIZE,
-        ROUND
-    );
-    targetRound.getMergingFactory(other);
+    Assertions.assertThrows(AggregatorFactoryNotMergeableException.class, () -> {
+      HllSketchBuildAggregatorFactory other = new HllSketchBuildAggregatorFactory(
+          NAME,
+          FIELD_NAME,
+          LG_K,
+          TGT_HLL_TYPE,
+          STRING_ENCODING,
+          SHOULD_FINALIZE,
+          ROUND
+      );
+      targetRound.getMergingFactory(other);
+    });
   }
 
-  @Test(expected = AggregatorFactoryNotMergeableException.class)
-  public void testGetMergingFactoryDifferentStringEncoding() throws Exception
+  @Test
+  public void testGetMergingFactoryDifferentStringEncoding()
   {
-    HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
-        NAME,
-        FIELD_NAME,
-        LG_K,
-        TGT_HLL_TYPE,
-        StringEncoding.UTF8,
-        SHOULD_FINALIZE,
-        ROUND
-    );
-    HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    Assert.assertEquals(LG_K, result.getLgK());
+    Assertions.assertThrows(AggregatorFactoryNotMergeableException.class, () -> {
+      HllSketchMergeAggregatorFactory other = new HllSketchMergeAggregatorFactory(
+          NAME,
+          FIELD_NAME,
+          LG_K,
+          TGT_HLL_TYPE,
+          StringEncoding.UTF8,
+          SHOULD_FINALIZE,
+          ROUND
+      );
+      HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
+      Assertions.assertEquals(LG_K, result.getLgK());
+    });
   }
 
   @Test
@@ -142,7 +149,7 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    Assert.assertEquals(LG_K, result.getLgK());
+    Assertions.assertEquals(LG_K, result.getLgK());
   }
 
   @Test
@@ -159,7 +166,7 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    Assert.assertEquals(largerLgK, result.getLgK());
+    Assertions.assertEquals(largerLgK, result.getLgK());
   }
 
   @Test
@@ -176,7 +183,7 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    Assert.assertEquals(TGT_HLL_TYPE, result.getTgtHllType());
+    Assertions.assertEquals(TGT_HLL_TYPE, result.getTgtHllType());
   }
 
   @Test
@@ -193,35 +200,35 @@ public class HllSketchMergeAggregatorFactoryTest
         ROUND
     );
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(other);
-    Assert.assertEquals(largerTgtHllType, result.getTgtHllType());
+    Assertions.assertEquals(largerTgtHllType, result.getTgtHllType());
   }
 
   @Test
   public void testGetMergingFactoryThisNoRoundOtherNoRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetNoRound.getMergingFactory(targetNoRound);
-    Assert.assertFalse(result.isRound());
+    Assertions.assertFalse(result.isRound());
   }
 
   @Test
   public void testGetMergingFactoryThisNoRoundOtherRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetNoRound.getMergingFactory(targetRound);
-    Assert.assertTrue(result.isRound());
+    Assertions.assertTrue(result.isRound());
   }
 
   @Test
   public void testGetMergingFactoryThisRoundOtherNoRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetNoRound);
-    Assert.assertTrue(result.isRound());
+    Assertions.assertTrue(result.isRound());
   }
 
   @Test
   public void testGetMergingFactoryThisRoundOtherRound() throws Exception
   {
     HllSketchAggregatorFactory result = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetRound);
-    Assert.assertTrue(result.isRound());
+    Assertions.assertTrue(result.isRound());
   }
 
   @Test
@@ -242,7 +249,7 @@ public class HllSketchMergeAggregatorFactoryTest
 
     final String serializedString = jsonMapper.writeValueAsString(factory);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"type\":\"HLLSketchMerge\",\"name\":\"foo\",\"fieldName\":\"bar\",\"lgK\":18,\"tgtHllType\":\"HLL_8\","
         + "\"stringEncoding\":\"utf8\",\"shouldFinalize\":false,\"round\":true}",
         serializedString
@@ -253,7 +260,7 @@ public class HllSketchMergeAggregatorFactoryTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, factory2);
+    Assertions.assertEquals(factory, factory2);
   }
 
   @Test
@@ -274,7 +281,7 @@ public class HllSketchMergeAggregatorFactoryTest
 
     final String serializedString = jsonMapper.writeValueAsString(factory);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "{\"type\":\"HLLSketchMerge\","
         + "\"name\":\"foo\","
         + "\"fieldName\":\"bar\","
@@ -289,7 +296,7 @@ public class HllSketchMergeAggregatorFactoryTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, factory2);
+    Assertions.assertEquals(factory, factory2);
   }
 
   @Test
@@ -302,8 +309,8 @@ public class HllSketchMergeAggregatorFactoryTest
   public void testWithName() throws Exception
   {
     HllSketchAggregatorFactory factory = (HllSketchAggregatorFactory) targetRound.getMergingFactory(targetRound);
-    Assert.assertEquals(factory, factory.withName(targetRound.getName()));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName(targetRound.getName()));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 
   @Test
@@ -314,8 +321,8 @@ public class HllSketchMergeAggregatorFactoryTest
             FIELD_NAME,
             ColumnCapabilitiesImpl.createDefault().setType(ColumnType.NESTED_DATA)
         );
-    Throwable exception = Assert.assertThrows(DruidException.class, () -> targetRound.factorize(metricFactory));
-    Assert.assertEquals(
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> targetRound.factorize(metricFactory));
+    Assertions.assertEquals(
         "Using aggregator [HLLSketchMerge] is not supported for complex columns with type [COMPLEX<json>].",
         exception.getMessage()
     );
@@ -324,8 +331,8 @@ public class HllSketchMergeAggregatorFactoryTest
   @Test
   public void testFactorizeBufferedOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(DruidException.class, () -> targetRound.factorizeBuffered(metricFactory));
-    Assert.assertEquals(
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> targetRound.factorizeBuffered(metricFactory));
+    Assertions.assertEquals(
         "Using aggregator [HLLSketchMerge] is not supported for complex columns with type [COMPLEX<json>].",
         exception.getMessage()
     );
@@ -334,8 +341,8 @@ public class HllSketchMergeAggregatorFactoryTest
   @Test
   public void testFactorizeVectorOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(DruidException.class, () -> targetRound.factorizeVector(vectorFactory));
-    Assert.assertEquals(
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> targetRound.factorizeVector(vectorFactory));
+    Assertions.assertEquals(
         "Using aggregator [HLLSketchMerge] is not supported for complex columns with type [COMPLEX<json>].",
         exception.getMessage()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchToEstimatePostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchToEstimatePostAggregatorTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HllSketchToEstimatePostAggregatorTest
 {
@@ -51,8 +51,8 @@ public class HllSketchToEstimatePostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -64,7 +64,7 @@ public class HllSketchToEstimatePostAggregatorTest
         true
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "HllSketchToEstimatePostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, round=true}",
         postAgg.toString()
     );
@@ -113,7 +113,7 @@ public class HllSketchToEstimatePostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchToEstimateWithBoundsPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchToEstimateWithBoundsPostAggregatorTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HllSketchToEstimateWithBoundsPostAggregatorTest
 {
@@ -44,8 +44,8 @@ public class HllSketchToEstimateWithBoundsPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -57,7 +57,7 @@ public class HllSketchToEstimateWithBoundsPostAggregatorTest
         2
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "HllSketchToEstimateWithBoundsPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, numStdDev=2}",
         postAgg.toString()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchToStringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchToStringPostAggregatorTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class HllSketchToStringPostAggregatorTest
 {
@@ -43,8 +43,8 @@ public class HllSketchToStringPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -55,7 +55,7 @@ public class HllSketchToStringPostAggregatorTest
         new FieldAccessPostAggregator("field1", "sketch")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "HllSketchToStringPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}}",
         postAgg.toString()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchUnionPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/HllSketchUnionPostAggregatorTest.java
@@ -25,8 +25,8 @@ import org.apache.datasketches.hll.TgtHllType;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -51,8 +51,8 @@ public class HllSketchUnionPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class HllSketchUnionPostAggregatorTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "HllSketchUnionPostAggregator{name='post', fields=[FieldAccessPostAggregator{name='field1', fieldName='sketch'}, FieldAccessPostAggregator{name='field2', fieldName='sketch'}], lgK=12, tgtHllType=HLL_4}",
         postAgg.toString()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/hll/sql/HllSketchSqlAggregatorTest.java
@@ -88,7 +88,7 @@ import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -513,7 +513,7 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
   {
-    DruidException druidException = Assert.assertThrows(
+    DruidException druidException = Assertions.assertThrows(
         DruidException.class,
         () -> testQuery(
             "SELECT APPROX_COUNT_DISTINCT_DS_HLL(double_first_added) FROM druid.wikipedia_first_last",
@@ -521,7 +521,7 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
             ImmutableList.of()
         )
     );
-    Assert.assertTrue(druidException.getMessage().contains(
+    Assertions.assertTrue(druidException.getMessage().contains(
         "Cannot apply 'APPROX_COUNT_DISTINCT_DS_HLL' to arguments of type 'APPROX_COUNT_DISTINCT_DS_HLL(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"
     ));
   }
@@ -1121,7 +1121,7 @@ public class HllSketchSqlAggregatorTest extends BaseCalciteQueryTest
       );
     }
     catch (IllegalArgumentException e) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           e.getMessage().contains("Input byte[] should at least have 2 bytes for base64 bytes")
       );
     }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchAggregatorFactoryTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -66,7 +66,7 @@ public class KllDoublesSketchAggregatorFactoryTest
         json,
         AggregatorFactory.class
     );
-    Assert.assertEquals(factory, fromJson);
+    Assertions.assertEquals(factory, fromJson);
   }
 
   @Test
@@ -79,8 +79,8 @@ public class KllDoublesSketchAggregatorFactoryTest
         null
     );
 
-    Assert.assertEquals(KllSketchAggregatorFactory.DEFAULT_K, factory.getK());
-    Assert.assertEquals(KllSketchAggregatorFactory.DEFAULT_MAX_STREAM_LENGTH, factory.getMaxStreamLength());
+    Assertions.assertEquals(KllSketchAggregatorFactory.DEFAULT_K, factory.getK());
+    Assertions.assertEquals(KllSketchAggregatorFactory.DEFAULT_MAX_STREAM_LENGTH, factory.getMaxStreamLength());
   }
 
   @Test
@@ -92,10 +92,10 @@ public class KllDoublesSketchAggregatorFactoryTest
         200,
         null
     );
-    Assert.assertEquals(1644, factory.guessAggregatorHeapFootprint(1));
-    Assert.assertEquals(1644, factory.guessAggregatorHeapFootprint(100));
-    Assert.assertEquals(3428, factory.guessAggregatorHeapFootprint(1000));
-    Assert.assertEquals(6388, factory.guessAggregatorHeapFootprint(1_000_000_000_000L));
+    Assertions.assertEquals(1644, factory.guessAggregatorHeapFootprint(1));
+    Assertions.assertEquals(1644, factory.guessAggregatorHeapFootprint(100));
+    Assertions.assertEquals(3428, factory.guessAggregatorHeapFootprint(1000));
+    Assertions.assertEquals(6388, factory.guessAggregatorHeapFootprint(1_000_000_000_000L));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class KllDoublesSketchAggregatorFactoryTest
         200,
         null
     );
-    Assert.assertEquals(5708, factory.getMaxIntermediateSize());
+    Assertions.assertEquals(5708, factory.getMaxIntermediateSize());
 
     factory = new KllDoublesSketchAggregatorFactory(
         "myFactory",
@@ -115,7 +115,7 @@ public class KllDoublesSketchAggregatorFactoryTest
         200,
         1_000_000_000_000L
     );
-    Assert.assertEquals(6388, factory.getMaxIntermediateSize());
+    Assertions.assertEquals(6388, factory.getMaxIntermediateSize());
   }
 
   @Test
@@ -139,7 +139,7 @@ public class KllDoublesSketchAggregatorFactoryTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)
@@ -163,12 +163,12 @@ public class KllDoublesSketchAggregatorFactoryTest
     AggregatorFactory sketch4 = new KllDoublesSketchAggregatorFactory("sketch", "y", 200, null);
     AggregatorFactory sketch5 = new KllDoublesSketchAggregatorFactory("sketch", "x", 300, null);
 
-    Assert.assertNotNull(sketch.substituteCombiningFactory(sketch2));
-    Assert.assertNotNull(sketch3.substituteCombiningFactory(sketch2));
-    Assert.assertNotNull(sketch3.substituteCombiningFactory(sketch));
-    Assert.assertNotNull(sketch2.substituteCombiningFactory(sketch));
-    Assert.assertNull(sketch.substituteCombiningFactory(sketch3));
-    Assert.assertNull(sketch.substituteCombiningFactory(sketch4));
-    Assert.assertNull(sketch.substituteCombiningFactory(sketch5));
+    Assertions.assertNotNull(sketch.substituteCombiningFactory(sketch2));
+    Assertions.assertNotNull(sketch3.substituteCombiningFactory(sketch2));
+    Assertions.assertNotNull(sketch3.substituteCombiningFactory(sketch));
+    Assertions.assertNotNull(sketch2.substituteCombiningFactory(sketch));
+    Assertions.assertNull(sketch.substituteCombiningFactory(sketch3));
+    Assertions.assertNull(sketch.substituteCombiningFactory(sketch4));
+    Assertions.assertNull(sketch.substituteCombiningFactory(sketch5));
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchAggregatorTest.java
@@ -100,7 +100,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
   // this is to test Json properties and equals
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -119,7 +119,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
   // this is to test Json properties and equals for the combining factory
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -136,7 +136,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void ingestingSketches(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void ingestingSketches(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -211,7 +211,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -320,7 +320,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -449,7 +449,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -527,7 +527,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<Result<TimeseriesResultValue>> seq = timeSeriesHelper.createIndexAndRunQueryOnSegment(
@@ -577,7 +577,7 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchAggregatorTest.java
@@ -43,13 +43,11 @@ import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,33 +55,31 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-@RunWith(Parameterized.class)
 public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 {
-  private final GroupByQueryConfig config;
-  private final AggregationTestHelper helper;
-  private final AggregationTestHelper timeSeriesHelper;
+  private GroupByQueryConfig config;
+  private AggregationTestHelper helper;
+  private AggregationTestHelper timeSeriesHelper;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private File tempFolder;
 
-  public KllDoublesSketchAggregatorTest(final GroupByQueryConfig config, final String vectorize)
+  public void initKllDoublesSketchAggregatorTest(final GroupByQueryConfig config, final String vectorize)
   {
     this.config = config;
     KllSketchModule.registerSerde();
     KllSketchModule module = new KllSketchModule();
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         module.getJacksonModules(),
         config,
         tempFolder
     ).withQueryContext(ImmutableMap.of(QueryContexts.VECTORIZE_KEY, vectorize));
-    timeSeriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelper(
+    timeSeriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
         module.getJacksonModules(),
         tempFolder
     ).withQueryContext(ImmutableMap.of(QueryContexts.VECTORIZE_KEY, vectorize));
   }
 
-  @Parameterized.Parameters(name = "groupByConfig = {0}, vectorize = {1}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -95,16 +91,18 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
   // this is to test Json properties and equals
-  @Test
-  public void serializeDeserializeFactoryWithFieldName() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
     new KllSketchModule().getJacksonModules().forEach(objectMapper::registerModule);
     KllDoublesSketchAggregatorFactory factory =
@@ -115,13 +113,15 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, other);
+    Assertions.assertEquals(factory, other);
   }
 
   // this is to test Json properties and equals for the combining factory
-  @Test
-  public void serializeDeserializeCombiningFactoryWithFieldName() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
     new KllSketchModule().getJacksonModules().forEach(objectMapper::registerModule);
     KllDoublesSketchAggregatorFactory factory = new KllDoublesSketchMergeAggregatorFactory("name", 200);
@@ -131,12 +131,14 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, other);
+    Assertions.assertEquals(factory, other);
   }
 
-  @Test
-  public void ingestingSketches() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void ingestingSketches(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_doubles_sketch_data.tsv").getFile()),
         new InputRowSchema(
@@ -176,40 +178,42 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object nonExistentSketchObject = row.get(1);
-    Assert.assertTrue(nonExistentSketchObject instanceof Long);
+    Assertions.assertTrue(nonExistentSketchObject instanceof Long);
     long nonExistentSketchValue = (long) nonExistentSketchObject;
-    Assert.assertEquals(0, nonExistentSketchValue);
+    Assertions.assertEquals(0, nonExistentSketchValue);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     // post agg
     Object quantilesObject = row.get(2);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(3);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
       // 400 items uniformly distributed into 4 bins
-      Assert.assertEquals(100, bin, 100 * 0.2);
+      Assertions.assertEquals(100, bin, 100 * 0.2);
     }
   }
 
-  @Test
-  public void buildingSketchesAtIngestionTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_doubles_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -266,57 +270,59 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     Object sketchObjectWithNulls = row.get(1);
-    Assert.assertTrue(sketchObjectWithNulls instanceof Long);
+    Assertions.assertTrue(sketchObjectWithNulls instanceof Long);
     long sketchValueWithNulls = (long) sketchObjectWithNulls;
-    Assert.assertEquals(355, sketchValueWithNulls);
+    Assertions.assertEquals(355, sketchValueWithNulls);
 
     // post agg
     Object quantilesObject = row.get(3);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(4);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
-    Assert.assertEquals(4, histogram.length);
+    Assertions.assertEquals(4, histogram.length);
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly distributed into 4 bins
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly distributed into 4 bins
     }
 
     // post agg with nulls
     Object quantilesObjectWithNulls = row.get(5);
-    Assert.assertTrue(quantilesObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(quantilesObjectWithNulls instanceof double[]);
     double[] quantilesWithNulls = (double[]) quantilesObjectWithNulls;
-    Assert.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
-    Assert.assertEquals(7.5, quantilesWithNulls[1], 0.07); // median value
-    Assert.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
+    Assertions.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
+    Assertions.assertEquals(7.5, quantilesWithNulls[1], 0.07); // median value
+    Assertions.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
 
     // post agg with nulls
     Object histogramObjectWithNulls = row.get(6);
-    Assert.assertTrue(histogramObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(histogramObjectWithNulls instanceof double[]);
     double[] histogramWithNulls = (double[]) histogramObjectWithNulls;
-    Assert.assertEquals(4, histogramWithNulls.length);
+    Assertions.assertEquals(4, histogramWithNulls.length);
     for (final double bin : histogramWithNulls) {
-      Assert.assertEquals(100, bin, 50); // distribution is skewed due to nulls
+      Assertions.assertEquals(100, bin, 50); // distribution is skewed due to nulls
     }
   }
 
-  @Test
-  public void buildingSketchesAtQueryTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_doubles_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -379,45 +385,45 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     Object sketchObjectWithNulls = row.get(1);
-    Assert.assertTrue(sketchObjectWithNulls instanceof Long);
+    Assertions.assertTrue(sketchObjectWithNulls instanceof Long);
     long sketchValueWithNulls = (long) sketchObjectWithNulls;
-    Assert.assertEquals(355, sketchValueWithNulls);
+    Assertions.assertEquals(355, sketchValueWithNulls);
 
     // post agg
     Object quantileObject = row.get(2);
-    Assert.assertTrue(quantileObject instanceof Double);
-    Assert.assertEquals(0.5, (double) quantileObject, 0.05); // median value
+    Assertions.assertTrue(quantileObject instanceof Double);
+    Assertions.assertEquals(0.5, (double) quantileObject, 0.05); // median value
 
     // post agg
     Object quantilesObject = row.get(3);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(4);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
       // distributed into 4 bins
     }
 
     // post agg with nulls
     Object quantileObjectWithNulls = row.get(5);
-    Assert.assertTrue(quantileObjectWithNulls instanceof Double);
-    Assert.assertEquals(
+    Assertions.assertTrue(quantileObjectWithNulls instanceof Double);
+    Assertions.assertEquals(
         7.5,
         (double) quantileObjectWithNulls,
         0.1
@@ -425,25 +431,27 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
     // post agg with nulls
     Object quantilesObjectWithNulls = row.get(6);
-    Assert.assertTrue(quantilesObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(quantilesObjectWithNulls instanceof double[]);
     double[] quantilesWithNulls = (double[]) quantilesObjectWithNulls;
-    Assert.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
-    Assert.assertEquals(7.5, quantilesWithNulls[1], 0.1); // median value
-    Assert.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
+    Assertions.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
+    Assertions.assertEquals(7.5, quantilesWithNulls[1], 0.1); // median value
+    Assertions.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
 
     // post agg with nulls
     Object histogramObjectWithNulls = row.get(7);
-    Assert.assertTrue(histogramObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(histogramObjectWithNulls instanceof double[]);
     double[] histogramWithNulls = (double[]) histogramObjectWithNulls;
     for (final double bin : histogramWithNulls) {
-      Assert.assertEquals(100, bin, 80); // distribution is skewed due to nulls/0s
+      Assertions.assertEquals(100, bin, 80); // distribution is skewed due to nulls/0s
       // distributed into 4 bins
     }
   }
 
-  @Test
-  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_doubles_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -486,40 +494,42 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     // post agg
     Object quantileObject = row.get(1);
-    Assert.assertTrue(quantileObject instanceof Double);
-    Assert.assertEquals(0.5, (double) quantileObject, 0.05); // median value
+    Assertions.assertTrue(quantileObject instanceof Double);
+    Assertions.assertEquals(0.5, (double) quantileObject, 0.05); // median value
 
     // post agg
     Object quantilesObject = row.get(2);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(3);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
       // distributed into 4 bins
     }
   }
 
-  @Test
-  public void timeSeriesQueryInputAsFloat() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<Result<TimeseriesResultValue>> seq = timeSeriesHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_doubles_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -562,12 +572,14 @@ public class KllDoublesSketchAggregatorTest extends InitializedNullHandlingTest
               .build()
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
   }
 
-  @Test
-  public void testSuccessWhenMaxStreamLengthHit() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_doubles_sketch_build_data.tsv").getFile()),
         new InputRowSchema(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchComplexMetricSerdeTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchComplexMetricSerdeTest.java
@@ -25,8 +25,8 @@ import org.apache.datasketches.kll.KllDoublesSketch;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.segment.data.ObjectStrategy;
 import org.apache.druid.segment.serde.ComplexMetricExtractor;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -42,7 +42,7 @@ public class KllDoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "")),
         "foo"
     );
-    Assert.assertEquals(0, sketch.getNumRetained());
+    Assertions.assertEquals(0, sketch.getNumRetained());
   }
 
   @Test
@@ -54,8 +54,8 @@ public class KllDoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "777")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(777d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(777d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -67,8 +67,8 @@ public class KllDoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "-133")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(-133d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(-133d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -80,8 +80,8 @@ public class KllDoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "3.1")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(3.1d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(3.1d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -93,8 +93,8 @@ public class KllDoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", ".1")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(0.1d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(0.1d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class KllDoublesSketchComplexMetricSerdeTest
   {
     final KllDoublesSketchComplexMetricSerde serde = new KllDoublesSketchComplexMetricSerde();
     final ObjectStrategy<KllDoublesSketch> objectStrategy = serde.getObjectStrategy();
-    Assert.assertTrue(objectStrategy.readRetainsBufferReference());
+    Assertions.assertTrue(objectStrategy.readRetainsBufferReference());
 
     KllDoublesSketch sketch = KllDoublesSketch.newHeapInstance();
     sketch.update(1.1);
@@ -123,7 +123,7 @@ public class KllDoublesSketchComplexMetricSerdeTest
       }
 
       final ByteBuffer buf2 = ByteBuffer.wrap(garbage2).order(ByteOrder.LITTLE_ENDIAN);
-      Assert.assertThrows(
+      Assertions.assertThrows(
           Exception.class,
           () -> objectStrategy.fromByteBufferSafe(buf2, garbage2.length).toByteArray()
       );
@@ -132,7 +132,7 @@ public class KllDoublesSketchComplexMetricSerdeTest
     // non sketch that is too short to contain header should fail with regular java buffer exception
     final byte[] garbage = new byte[]{0x01, 0x02};
     final ByteBuffer buf3 = ByteBuffer.wrap(garbage).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         Exception.class,
         () -> objectStrategy.fromByteBufferSafe(buf3, garbage.length).toByteArray()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchMergeAggregatorFactoryTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.AggregatorFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -58,6 +58,6 @@ public class KllDoublesSketchMergeAggregatorFactoryTest
         json,
         AggregatorFactory.class
     );
-    Assert.assertEquals(factory, fromJson);
+    Assertions.assertEquals(factory, fromJson);
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchOperationsTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchOperationsTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.query.aggregation.datasketches.kll;
 
 import org.apache.datasketches.kll.KllDoublesSketch;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -37,13 +37,13 @@ public class KllDoublesSketchOperationsTest
     final byte[] bytes = sketch.toByteArray();
     final String base64 = StringUtils.encodeBase64String(bytes);
 
-    Assert.assertArrayEquals(bytes, KllDoublesSketchOperations.deserializeSafe(sketch).toByteArray());
-    Assert.assertArrayEquals(bytes, KllDoublesSketchOperations.deserializeSafe(bytes).toByteArray());
-    Assert.assertArrayEquals(bytes, KllDoublesSketchOperations.deserializeSafe(base64).toByteArray());
+    Assertions.assertArrayEquals(bytes, KllDoublesSketchOperations.deserializeSafe(sketch).toByteArray());
+    Assertions.assertArrayEquals(bytes, KllDoublesSketchOperations.deserializeSafe(bytes).toByteArray());
+    Assertions.assertArrayEquals(bytes, KllDoublesSketchOperations.deserializeSafe(base64).toByteArray());
 
     final byte[] trunacted = Arrays.copyOfRange(bytes, 0, 20);
-    Assert.assertThrows(IndexOutOfBoundsException.class, () -> KllDoublesSketchOperations.deserializeSafe(trunacted));
-    Assert.assertThrows(
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> KllDoublesSketchOperations.deserializeSafe(trunacted));
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> KllDoublesSketchOperations.deserializeSafe(StringUtils.encodeBase64String(trunacted))
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToCDFPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToCDFPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class KllDoublesSketchToCDFPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -61,8 +59,8 @@ public class KllDoublesSketchToCDFPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -74,7 +72,7 @@ public class KllDoublesSketchToCDFPostAggregatorTest
         new double[]{0.25, 0.75}
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllDoublesSketchToCDFPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, splitPoints=[0.25, 0.75]}",
         postAgg.toString()
     );
@@ -83,14 +81,15 @@ public class KllDoublesSketchToCDFPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing histograms is not supported");
-    final PostAggregator postAgg = new KllDoublesSketchToCDFPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new double[]{0.25, 0.75}
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllDoublesSketchToCDFPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new double[]{0.25, 0.75}
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing histograms is not supported"));
   }
 
   @Test
@@ -118,10 +117,10 @@ public class KllDoublesSketchToCDFPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertTrue(Double.isNaN(histogram[0]));
-    Assert.assertTrue(Double.isNaN(histogram[1]));
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertTrue(Double.isNaN(histogram[0]));
+    Assertions.assertTrue(Double.isNaN(histogram[1]));
   }
 
   @Test
@@ -147,10 +146,10 @@ public class KllDoublesSketchToCDFPostAggregatorTest
     );
 
     final double[] cdf = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(cdf);
-    Assert.assertEquals(2, cdf.length);
-    Assert.assertEquals(0.5, cdf[0], 0);
-    Assert.assertEquals(1.0, cdf[1], 0);
+    Assertions.assertNotNull(cdf);
+    Assertions.assertEquals(2, cdf.length);
+    Assertions.assertEquals(0.5, cdf[0], 0);
+    Assertions.assertEquals(1.0, cdf[1], 0);
   }
 
   @Test
@@ -173,7 +172,7 @@ public class KllDoublesSketchToCDFPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToHistogramPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToHistogramPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class KllDoublesSketchToHistogramPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -62,8 +60,8 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -76,7 +74,7 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllDoublesSketchToHistogramPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, splitPoints=[0.25, 0.75], numBins=null}",
         postAgg.toString()
     );
@@ -85,15 +83,16 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing histograms is not supported");
-    final PostAggregator postAgg = new KllDoublesSketchToHistogramPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new double[]{0.25, 0.75},
-        null
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllDoublesSketchToHistogramPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new double[]{0.25, 0.75},
+          null
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing histograms is not supported"));
   }
 
   @Test
@@ -122,10 +121,10 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertTrue(Double.isNaN(histogram[0]));
-    Assert.assertTrue(Double.isNaN(histogram[1]));
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertTrue(Double.isNaN(histogram[0]));
+    Assertions.assertTrue(Double.isNaN(histogram[1]));
   }
 
   @Test
@@ -152,10 +151,10 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(3.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(3.0, histogram[1], 0);
   }
 
   @Test
@@ -182,10 +181,10 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(0.0, histogram[0], 0);
-    Assert.assertEquals(6.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(0.0, histogram[0], 0);
+    Assertions.assertEquals(6.0, histogram[1], 0);
   }
 
   @Test
@@ -212,10 +211,10 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(3.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(3.0, histogram[1], 0);
   }
 
   @Test
@@ -242,10 +241,10 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(1.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(1.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
   }
 
   @Test
@@ -272,11 +271,11 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(3, histogram.length);
-    Assert.assertEquals(1.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
-    Assert.assertEquals(0.0, histogram[2], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(3, histogram.length);
+    Assertions.assertEquals(1.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertEquals(0.0, histogram[2], 0);
   }
 
   @Test
@@ -303,10 +302,10 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
   }
 
   @Test
@@ -333,11 +332,11 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(3, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
-    Assert.assertEquals(0.0, histogram[2], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(3, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertEquals(0.0, histogram[2], 0);
   }
 
   @Test
@@ -361,7 +360,7 @@ public class KllDoublesSketchToHistogramPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToQuantilePostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToQuantilePostAggregatorTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class KllDoublesSketchToQuantilePostAggregatorTest
 {
@@ -44,8 +44,8 @@ public class KllDoublesSketchToQuantilePostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -57,7 +57,7 @@ public class KllDoublesSketchToQuantilePostAggregatorTest
         0.5
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllDoublesSketchToQuantilePostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, fraction=0.5}",
         postAgg.toString()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToQuantilesPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToQuantilesPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class KllDoublesSketchToQuantilesPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -61,8 +59,8 @@ public class KllDoublesSketchToQuantilesPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -74,7 +72,7 @@ public class KllDoublesSketchToQuantilesPostAggregatorTest
         new double[] {0, 0.5, 1}
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllDoublesSketchToQuantilesPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, fractions=[0.0, 0.5, 1.0]}",
         postAgg.toString()
     );
@@ -83,14 +81,15 @@ public class KllDoublesSketchToQuantilesPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing arrays of quantiles is not supported");
-    final PostAggregator postAgg = new KllDoublesSketchToQuantilesPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new double[] {0, 0.5, 1}
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllDoublesSketchToQuantilesPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new double[]{0, 0.5, 1}
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing arrays of quantiles is not supported"));
   }
 
   @Test
@@ -118,11 +117,11 @@ public class KllDoublesSketchToQuantilesPostAggregatorTest
     );
 
     final double[] quantiles = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(quantiles);
-    Assert.assertEquals(3, quantiles.length);
-    Assert.assertTrue(Double.isNaN(quantiles[0]));
-    Assert.assertTrue(Double.isNaN(quantiles[1]));
-    Assert.assertTrue(Double.isNaN(quantiles[2]));
+    Assertions.assertNotNull(quantiles);
+    Assertions.assertEquals(3, quantiles.length);
+    Assertions.assertTrue(Double.isNaN(quantiles[0]));
+    Assertions.assertTrue(Double.isNaN(quantiles[1]));
+    Assertions.assertTrue(Double.isNaN(quantiles[2]));
   }
 
   @Test
@@ -148,11 +147,11 @@ public class KllDoublesSketchToQuantilesPostAggregatorTest
     );
 
     final double[] quantiles = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(quantiles);
-    Assert.assertEquals(3, quantiles.length);
-    Assert.assertEquals(1.0, quantiles[0], 0);
-    Assert.assertEquals(3.0, quantiles[1], 0);
-    Assert.assertEquals(5.0, quantiles[2], 0);
+    Assertions.assertNotNull(quantiles);
+    Assertions.assertEquals(3, quantiles.length);
+    Assertions.assertEquals(1.0, quantiles[0], 0);
+    Assertions.assertEquals(3.0, quantiles[1], 0);
+    Assertions.assertEquals(5.0, quantiles[2], 0);
   }
 
   @Test
@@ -175,7 +174,7 @@ public class KllDoublesSketchToQuantilesPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToRankPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToRankPostAggregatorTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -55,8 +55,8 @@ public class KllDoublesSketchToRankPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class KllDoublesSketchToRankPostAggregatorTest
         0
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllDoublesSketchToRankPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, value=0.0}",
         postAgg.toString()
     );
@@ -99,7 +99,7 @@ public class KllDoublesSketchToRankPostAggregatorTest
     );
 
     final double rank = (double) postAgg.compute(fields);
-    Assert.assertTrue(Double.isNaN(rank));
+    Assertions.assertTrue(Double.isNaN(rank));
   }
 
   @Test
@@ -125,7 +125,7 @@ public class KllDoublesSketchToRankPostAggregatorTest
     );
 
     final double rank = (double) postAgg.compute(fields);
-    Assert.assertEquals(0.5, rank, 0);
+    Assertions.assertEquals(0.5, rank, 0);
   }
 
   @Test
@@ -148,7 +148,7 @@ public class KllDoublesSketchToRankPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToStringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllDoublesSketchToStringPostAggregatorTest.java
@@ -25,15 +25,13 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KllDoublesSketchToStringPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -49,8 +47,8 @@ public class KllDoublesSketchToStringPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -61,7 +59,7 @@ public class KllDoublesSketchToStringPostAggregatorTest
         new FieldAccessPostAggregator("field1", "sketch")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllDoublesSketchToStringPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}}",
         postAgg.toString()
     );
@@ -70,13 +68,14 @@ public class KllDoublesSketchToStringPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing sketch summaries is not supported");
-    final PostAggregator postAgg = new KllDoublesSketchToStringPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch")
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllDoublesSketchToStringPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch")
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing sketch summaries is not supported"));
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchAggregatorFactoryTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -66,7 +66,7 @@ public class KllFloatsSketchAggregatorFactoryTest
         json,
         AggregatorFactory.class
     );
-    Assert.assertEquals(factory, fromJson);
+    Assertions.assertEquals(factory, fromJson);
   }
 
   @Test
@@ -79,8 +79,8 @@ public class KllFloatsSketchAggregatorFactoryTest
         null
     );
 
-    Assert.assertEquals(KllSketchAggregatorFactory.DEFAULT_K, factory.getK());
-    Assert.assertEquals(KllSketchAggregatorFactory.DEFAULT_MAX_STREAM_LENGTH, factory.getMaxStreamLength());
+    Assertions.assertEquals(KllSketchAggregatorFactory.DEFAULT_K, factory.getK());
+    Assertions.assertEquals(KllSketchAggregatorFactory.DEFAULT_MAX_STREAM_LENGTH, factory.getMaxStreamLength());
   }
 
   @Test
@@ -92,10 +92,10 @@ public class KllFloatsSketchAggregatorFactoryTest
         200,
         null
     );
-    Assert.assertEquals(836, factory.guessAggregatorHeapFootprint(1));
-    Assert.assertEquals(836, factory.guessAggregatorHeapFootprint(100));
-    Assert.assertEquals(1732, factory.guessAggregatorHeapFootprint(1000));
-    Assert.assertEquals(3272, factory.guessAggregatorHeapFootprint(1_000_000_000_000L));
+    Assertions.assertEquals(836, factory.guessAggregatorHeapFootprint(1));
+    Assertions.assertEquals(836, factory.guessAggregatorHeapFootprint(100));
+    Assertions.assertEquals(1732, factory.guessAggregatorHeapFootprint(1000));
+    Assertions.assertEquals(3272, factory.guessAggregatorHeapFootprint(1_000_000_000_000L));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class KllFloatsSketchAggregatorFactoryTest
         200,
         null
     );
-    Assert.assertEquals(2912, factory.getMaxIntermediateSize());
+    Assertions.assertEquals(2912, factory.getMaxIntermediateSize());
 
     factory = new KllFloatsSketchAggregatorFactory(
         "myFactory",
@@ -115,7 +115,7 @@ public class KllFloatsSketchAggregatorFactoryTest
         200,
         1_000_000_000_000L
     );
-    Assert.assertEquals(3272, factory.getMaxIntermediateSize());
+    Assertions.assertEquals(3272, factory.getMaxIntermediateSize());
   }
 
   @Test
@@ -139,7 +139,7 @@ public class KllFloatsSketchAggregatorFactoryTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchAggregatorTest.java
@@ -43,13 +43,11 @@ import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,33 +55,31 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-@RunWith(Parameterized.class)
 public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 {
-  private final GroupByQueryConfig config;
-  private final AggregationTestHelper helper;
-  private final AggregationTestHelper timeSeriesHelper;
+  private GroupByQueryConfig config;
+  private AggregationTestHelper helper;
+  private AggregationTestHelper timeSeriesHelper;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private File tempFolder;
 
-  public KllFloatsSketchAggregatorTest(final GroupByQueryConfig config, final String vectorize)
+  public void initKllFloatsSketchAggregatorTest(final GroupByQueryConfig config, final String vectorize)
   {
     this.config = config;
     KllSketchModule.registerSerde();
     KllSketchModule module = new KllSketchModule();
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         module.getJacksonModules(),
         config,
         tempFolder
     ).withQueryContext(ImmutableMap.of(QueryContexts.VECTORIZE_KEY, vectorize));
-    timeSeriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelper(
+    timeSeriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
         module.getJacksonModules(),
         tempFolder
     ).withQueryContext(ImmutableMap.of(QueryContexts.VECTORIZE_KEY, vectorize));
   }
 
-  @Parameterized.Parameters(name = "groupByConfig = {0}, vectorize = {1}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -95,16 +91,18 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
   // this is to test Json properties and equals
-  @Test
-  public void serializeDeserializeFactoryWithFieldName() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
     new KllSketchModule().getJacksonModules().forEach(objectMapper::registerModule);
     KllFloatsSketchAggregatorFactory factory =
@@ -115,13 +113,15 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, other);
+    Assertions.assertEquals(factory, other);
   }
 
   // this is to test Json properties and equals for the combining factory
-  @Test
-  public void serializeDeserializeCombiningFactoryWithFieldName() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
     new KllSketchModule().getJacksonModules().forEach(objectMapper::registerModule);
     KllFloatsSketchAggregatorFactory factory = new KllFloatsSketchMergeAggregatorFactory("name", 200);
@@ -131,12 +131,14 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, other);
+    Assertions.assertEquals(factory, other);
   }
 
-  @Test
-  public void ingestingSketches() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void ingestingSketches(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_floats_sketch_data.tsv").getFile()),
         new InputRowSchema(
@@ -176,40 +178,42 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object nonExistentSketchObject = row.get(1);
-    Assert.assertTrue(nonExistentSketchObject instanceof Long);
+    Assertions.assertTrue(nonExistentSketchObject instanceof Long);
     long nonExistentSketchValue = (long) nonExistentSketchObject;
-    Assert.assertEquals(0, nonExistentSketchValue);
+    Assertions.assertEquals(0, nonExistentSketchValue);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     // post agg
     Object quantilesObject = row.get(2);
-    Assert.assertTrue(quantilesObject instanceof float[]);
+    Assertions.assertTrue(quantilesObject instanceof float[]);
     float[] quantiles = (float[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5f, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1f, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5f, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1f, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(3);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
       // 400 items uniformly distributed into 4 bins
-      Assert.assertEquals(100, bin, 100 * 0.2);
+      Assertions.assertEquals(100, bin, 100 * 0.2);
     }
   }
 
-  @Test
-  public void buildingSketchesAtIngestionTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_floats_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -266,57 +270,59 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     Object sketchObjectWithNulls = row.get(1);
-    Assert.assertTrue(sketchObjectWithNulls instanceof Long);
+    Assertions.assertTrue(sketchObjectWithNulls instanceof Long);
     long sketchValueWithNulls = (long) sketchObjectWithNulls;
-    Assert.assertEquals(355, sketchValueWithNulls);
+    Assertions.assertEquals(355, sketchValueWithNulls);
 
     // post agg
     Object quantilesObject = row.get(3);
-    Assert.assertTrue(quantilesObject instanceof float[]);
+    Assertions.assertTrue(quantilesObject instanceof float[]);
     float[] quantiles = (float[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5f, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1f, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5f, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1f, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(4);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
-    Assert.assertEquals(4, histogram.length);
+    Assertions.assertEquals(4, histogram.length);
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly distributed into 4 bins
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly distributed into 4 bins
     }
 
     // post agg with nulls
     Object quantilesObjectWithNulls = row.get(5);
-    Assert.assertTrue(quantilesObjectWithNulls instanceof float[]);
+    Assertions.assertTrue(quantilesObjectWithNulls instanceof float[]);
     float[] quantilesWithNulls = (float[]) quantilesObjectWithNulls;
-    Assert.assertEquals(5f, quantilesWithNulls[0], 0.05); // min value
-    Assert.assertEquals(7.5f, quantilesWithNulls[1], 0.07); // median value
-    Assert.assertEquals(10f, quantilesWithNulls[2], 0.05); // max value
+    Assertions.assertEquals(5f, quantilesWithNulls[0], 0.05); // min value
+    Assertions.assertEquals(7.5f, quantilesWithNulls[1], 0.07); // median value
+    Assertions.assertEquals(10f, quantilesWithNulls[2], 0.05); // max value
 
     // post agg with nulls
     Object histogramObjectWithNulls = row.get(6);
-    Assert.assertTrue(histogramObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(histogramObjectWithNulls instanceof double[]);
     double[] histogramWithNulls = (double[]) histogramObjectWithNulls;
-    Assert.assertEquals(4, histogramWithNulls.length);
+    Assertions.assertEquals(4, histogramWithNulls.length);
     for (final double bin : histogramWithNulls) {
-      Assert.assertEquals(100, bin, 50); // distribution is skewed due to nulls
+      Assertions.assertEquals(100, bin, 50); // distribution is skewed due to nulls
     }
   }
 
-  @Test
-  public void buildingSketchesAtQueryTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_floats_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -379,45 +385,45 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     Object sketchObjectWithNulls = row.get(1);
-    Assert.assertTrue(sketchObjectWithNulls instanceof Long);
+    Assertions.assertTrue(sketchObjectWithNulls instanceof Long);
     long sketchValueWithNulls = (long) sketchObjectWithNulls;
-    Assert.assertEquals(355, sketchValueWithNulls);
+    Assertions.assertEquals(355, sketchValueWithNulls);
 
     // post agg
     Object quantileObject = row.get(2);
-    Assert.assertTrue(quantileObject instanceof Float);
-    Assert.assertEquals(0.5f, (float) quantileObject, 0.05); // median value
+    Assertions.assertTrue(quantileObject instanceof Float);
+    Assertions.assertEquals(0.5f, (float) quantileObject, 0.05); // median value
 
     // post agg
     Object quantilesObject = row.get(3);
-    Assert.assertTrue(quantilesObject instanceof float[]);
+    Assertions.assertTrue(quantilesObject instanceof float[]);
     float[] quantiles = (float[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5f, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1f, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5f, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1f, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(4);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
       // distributed into 4 bins
     }
 
     // post agg with nulls
     Object quantileObjectWithNulls = row.get(5);
-    Assert.assertTrue(quantileObjectWithNulls instanceof Float);
-    Assert.assertEquals(
+    Assertions.assertTrue(quantileObjectWithNulls instanceof Float);
+    Assertions.assertEquals(
         7.5f,
         (float) quantileObjectWithNulls,
         0.1
@@ -425,25 +431,27 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 
     // post agg with nulls
     Object quantilesObjectWithNulls = row.get(6);
-    Assert.assertTrue(quantilesObjectWithNulls instanceof float[]);
+    Assertions.assertTrue(quantilesObjectWithNulls instanceof float[]);
     float[] quantilesWithNulls = (float[]) quantilesObjectWithNulls;
-    Assert.assertEquals(5f, quantilesWithNulls[0], 0.05); // min value
-    Assert.assertEquals(7.5f, quantilesWithNulls[1], 0.1); // median value
-    Assert.assertEquals(10f, quantilesWithNulls[2], 0.05); // max value
+    Assertions.assertEquals(5f, quantilesWithNulls[0], 0.05); // min value
+    Assertions.assertEquals(7.5f, quantilesWithNulls[1], 0.1); // median value
+    Assertions.assertEquals(10f, quantilesWithNulls[2], 0.05); // max value
 
     // post agg with nulls
     Object histogramObjectWithNulls = row.get(7);
-    Assert.assertTrue(histogramObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(histogramObjectWithNulls instanceof double[]);
     double[] histogramWithNulls = (double[]) histogramObjectWithNulls;
     for (final double bin : histogramWithNulls) {
-      Assert.assertEquals(100, bin, 80); // distribution is skewed due to nulls/0s
+      Assertions.assertEquals(100, bin, 80); // distribution is skewed due to nulls/0s
       // distributed into 4 bins
     }
   }
 
-  @Test
-  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_floats_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -486,40 +494,42 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     // post agg
     Object quantileObject = row.get(1);
-    Assert.assertTrue(quantileObject instanceof Float);
-    Assert.assertEquals(0.5f, (float) quantileObject, 0.05); // median value
+    Assertions.assertTrue(quantileObject instanceof Float);
+    Assertions.assertEquals(0.5f, (float) quantileObject, 0.05); // median value
 
     // post agg
     Object quantilesObject = row.get(2);
-    Assert.assertTrue(quantilesObject instanceof float[]);
+    Assertions.assertTrue(quantilesObject instanceof float[]);
     float[] quantiles = (float[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5f, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1f, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5f, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1f, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(3);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
       // distributed into 4 bins
     }
   }
 
-  @Test
-  public void timeSeriesQueryInputAsFloat() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<Result<TimeseriesResultValue>> seq = timeSeriesHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_floats_sketch_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -562,12 +572,14 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
               .build()
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
   }
 
-  @Test
-  public void testSuccessWhenMaxStreamLengthHit() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("kll/kll_floats_sketch_build_data.tsv").getFile()),
         new InputRowSchema(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchAggregatorTest.java
@@ -100,7 +100,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
   // this is to test Json properties and equals
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -119,7 +119,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
   // this is to test Json properties and equals for the combining factory
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -136,7 +136,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void ingestingSketches(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void ingestingSketches(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -211,7 +211,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -320,7 +320,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -449,7 +449,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -527,7 +527,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<Result<TimeseriesResultValue>> seq = timeSeriesHelper.createIndexAndRunQueryOnSegment(
@@ -577,7 +577,7 @@ public class KllFloatsSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initKllFloatsSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchComplexMetricSerdeTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchComplexMetricSerdeTest.java
@@ -25,8 +25,8 @@ import org.apache.datasketches.kll.KllFloatsSketch;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.segment.data.ObjectStrategy;
 import org.apache.druid.segment.serde.ComplexMetricExtractor;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -42,7 +42,7 @@ public class KllFloatsSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "")),
         "foo"
     );
-    Assert.assertEquals(0, sketch.getNumRetained());
+    Assertions.assertEquals(0, sketch.getNumRetained());
   }
 
   @Test
@@ -54,8 +54,8 @@ public class KllFloatsSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "777")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(777d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(777d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -67,8 +67,8 @@ public class KllFloatsSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "-133")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(-133d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(-133d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -80,8 +80,8 @@ public class KllFloatsSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "3.1")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(3.1d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(3.1d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -93,8 +93,8 @@ public class KllFloatsSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", ".1")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(0.1d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(0.1d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class KllFloatsSketchComplexMetricSerdeTest
   {
     final KllFloatsSketchComplexMetricSerde serde = new KllFloatsSketchComplexMetricSerde();
     final ObjectStrategy<KllFloatsSketch> objectStrategy = serde.getObjectStrategy();
-    Assert.assertTrue(objectStrategy.readRetainsBufferReference());
+    Assertions.assertTrue(objectStrategy.readRetainsBufferReference());
 
     KllFloatsSketch sketch = KllFloatsSketch.newHeapInstance();
     sketch.update(1.1f);
@@ -123,7 +123,7 @@ public class KllFloatsSketchComplexMetricSerdeTest
       }
 
       final ByteBuffer buf2 = ByteBuffer.wrap(garbage2).order(ByteOrder.LITTLE_ENDIAN);
-      Assert.assertThrows(
+      Assertions.assertThrows(
           Exception.class,
           () -> objectStrategy.fromByteBufferSafe(buf2, garbage2.length).toByteArray()
       );
@@ -132,7 +132,7 @@ public class KllFloatsSketchComplexMetricSerdeTest
     // non sketch that is too short to contain header should fail with regular java buffer exception
     final byte[] garbage = new byte[]{0x01, 0x02};
     final ByteBuffer buf3 = ByteBuffer.wrap(garbage).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         Exception.class,
         () -> objectStrategy.fromByteBufferSafe(buf3, garbage.length).toByteArray()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchMergeAggregatorFactoryTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.AggregatorFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -58,6 +58,6 @@ public class KllFloatsSketchMergeAggregatorFactoryTest
         json,
         AggregatorFactory.class
     );
-    Assert.assertEquals(factory, fromJson);
+    Assertions.assertEquals(factory, fromJson);
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchOperationsTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchOperationsTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.query.aggregation.datasketches.kll;
 
 import org.apache.datasketches.kll.KllFloatsSketch;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -37,13 +37,13 @@ public class KllFloatsSketchOperationsTest
     final byte[] bytes = sketch.toByteArray();
     final String base64 = StringUtils.encodeBase64String(bytes);
 
-    Assert.assertArrayEquals(bytes, KllFloatsSketchOperations.deserializeSafe(sketch).toByteArray());
-    Assert.assertArrayEquals(bytes, KllFloatsSketchOperations.deserializeSafe(bytes).toByteArray());
-    Assert.assertArrayEquals(bytes, KllFloatsSketchOperations.deserializeSafe(base64).toByteArray());
+    Assertions.assertArrayEquals(bytes, KllFloatsSketchOperations.deserializeSafe(sketch).toByteArray());
+    Assertions.assertArrayEquals(bytes, KllFloatsSketchOperations.deserializeSafe(bytes).toByteArray());
+    Assertions.assertArrayEquals(bytes, KllFloatsSketchOperations.deserializeSafe(base64).toByteArray());
 
     final byte[] trunacted = Arrays.copyOfRange(bytes, 0, 20);
-    Assert.assertThrows(IndexOutOfBoundsException.class, () -> KllFloatsSketchOperations.deserializeSafe(trunacted));
-    Assert.assertThrows(
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> KllFloatsSketchOperations.deserializeSafe(trunacted));
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> KllFloatsSketchOperations.deserializeSafe(StringUtils.encodeBase64String(trunacted))
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToCDFPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToCDFPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class KllFloatsSketchToCDFPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -61,8 +59,8 @@ public class KllFloatsSketchToCDFPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -74,7 +72,7 @@ public class KllFloatsSketchToCDFPostAggregatorTest
         new float[]{0.25f, 0.75f}
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllFloatsSketchToCDFPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, splitPoints=[0.25, 0.75]}",
         postAgg.toString()
     );
@@ -83,14 +81,15 @@ public class KllFloatsSketchToCDFPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing histograms is not supported");
-    final PostAggregator postAgg = new KllFloatsSketchToCDFPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new float[]{0.25f, 0.75f}
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllFloatsSketchToCDFPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new float[]{0.25f, 0.75f}
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing histograms is not supported"));
   }
 
   @Test
@@ -118,10 +117,10 @@ public class KllFloatsSketchToCDFPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertTrue(Double.isNaN(histogram[0]));
-    Assert.assertTrue(Double.isNaN(histogram[1]));
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertTrue(Double.isNaN(histogram[0]));
+    Assertions.assertTrue(Double.isNaN(histogram[1]));
   }
 
   @Test
@@ -147,10 +146,10 @@ public class KllFloatsSketchToCDFPostAggregatorTest
     );
 
     final double[] cdf = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(cdf);
-    Assert.assertEquals(2, cdf.length);
-    Assert.assertEquals(0.5, cdf[0], 0);
-    Assert.assertEquals(1.0, cdf[1], 0);
+    Assertions.assertNotNull(cdf);
+    Assertions.assertEquals(2, cdf.length);
+    Assertions.assertEquals(0.5, cdf[0], 0);
+    Assertions.assertEquals(1.0, cdf[1], 0);
   }
 
   @Test
@@ -173,7 +172,7 @@ public class KllFloatsSketchToCDFPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToHistogramPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToHistogramPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class KllFloatsSketchToHistogramPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -62,8 +60,8 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -76,7 +74,7 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllFloatsSketchToHistogramPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, splitPoints=[0.25, 0.75], numBins=null}",
         postAgg.toString()
     );
@@ -85,15 +83,16 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing histograms is not supported");
-    final PostAggregator postAgg = new KllFloatsSketchToHistogramPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new float[]{0.25f, 0.75f},
-        null
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllFloatsSketchToHistogramPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new float[]{0.25f, 0.75f},
+          null
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing histograms is not supported"));
   }
 
   @Test
@@ -122,10 +121,10 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertTrue(Double.isNaN(histogram[0]));
-    Assert.assertTrue(Double.isNaN(histogram[1]));
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertTrue(Double.isNaN(histogram[0]));
+    Assertions.assertTrue(Double.isNaN(histogram[1]));
   }
 
   @Test
@@ -152,10 +151,10 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(3.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(3.0, histogram[1], 0);
   }
 
   @Test
@@ -182,10 +181,10 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(0.0, histogram[0], 0);
-    Assert.assertEquals(6.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(0.0, histogram[0], 0);
+    Assertions.assertEquals(6.0, histogram[1], 0);
   }
 
   @Test
@@ -212,10 +211,10 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(3.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(3.0, histogram[1], 0);
   }
 
   @Test
@@ -242,10 +241,10 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(1.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(1.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
   }
 
   @Test
@@ -272,11 +271,11 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(3, histogram.length);
-    Assert.assertEquals(1.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
-    Assert.assertEquals(0.0, histogram[2], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(3, histogram.length);
+    Assertions.assertEquals(1.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertEquals(0.0, histogram[2], 0);
   }
 
   @Test
@@ -303,10 +302,10 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
   }
 
   @Test
@@ -333,11 +332,11 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(3, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
-    Assert.assertEquals(0.0, histogram[2], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(3, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertEquals(0.0, histogram[2], 0);
   }
 
   @Test
@@ -361,7 +360,7 @@ public class KllFloatsSketchToHistogramPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToQuantilePostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToQuantilePostAggregatorTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class KllFloatsSketchToQuantilePostAggregatorTest
 {
@@ -44,8 +44,8 @@ public class KllFloatsSketchToQuantilePostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -57,7 +57,7 @@ public class KllFloatsSketchToQuantilePostAggregatorTest
         0.5
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllFloatsSketchToQuantilePostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, fraction=0.5}",
         postAgg.toString()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToQuantilesPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToQuantilesPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class KllFloatsSketchToQuantilesPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -61,8 +59,8 @@ public class KllFloatsSketchToQuantilesPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -74,7 +72,7 @@ public class KllFloatsSketchToQuantilesPostAggregatorTest
         new double[] {0, 0.5, 1}
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllFloatsSketchToQuantilesPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, fractions=[0.0, 0.5, 1.0]}",
         postAgg.toString()
     );
@@ -83,14 +81,15 @@ public class KllFloatsSketchToQuantilesPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing arrays of quantiles is not supported");
-    final PostAggregator postAgg = new KllFloatsSketchToQuantilesPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new double[] {0, 0.5, 1}
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllFloatsSketchToQuantilesPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new double[]{0, 0.5, 1}
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing arrays of quantiles is not supported"));
   }
 
   @Test
@@ -118,11 +117,11 @@ public class KllFloatsSketchToQuantilesPostAggregatorTest
     );
 
     final float[] quantiles = (float[]) postAgg.compute(fields);
-    Assert.assertNotNull(quantiles);
-    Assert.assertEquals(3, quantiles.length);
-    Assert.assertTrue(Float.isNaN(quantiles[0]));
-    Assert.assertTrue(Float.isNaN(quantiles[1]));
-    Assert.assertTrue(Float.isNaN(quantiles[2]));
+    Assertions.assertNotNull(quantiles);
+    Assertions.assertEquals(3, quantiles.length);
+    Assertions.assertTrue(Float.isNaN(quantiles[0]));
+    Assertions.assertTrue(Float.isNaN(quantiles[1]));
+    Assertions.assertTrue(Float.isNaN(quantiles[2]));
   }
 
   @Test
@@ -148,11 +147,11 @@ public class KllFloatsSketchToQuantilesPostAggregatorTest
     );
 
     final float[] quantiles = (float[]) postAgg.compute(fields);
-    Assert.assertNotNull(quantiles);
-    Assert.assertEquals(3, quantiles.length);
-    Assert.assertEquals(1f, quantiles[0], 0);
-    Assert.assertEquals(3f, quantiles[1], 0);
-    Assert.assertEquals(5f, quantiles[2], 0);
+    Assertions.assertNotNull(quantiles);
+    Assertions.assertEquals(3, quantiles.length);
+    Assertions.assertEquals(1f, quantiles[0], 0);
+    Assertions.assertEquals(3f, quantiles[1], 0);
+    Assertions.assertEquals(5f, quantiles[2], 0);
   }
 
   @Test
@@ -175,7 +174,7 @@ public class KllFloatsSketchToQuantilesPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToRankPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToRankPostAggregatorTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -55,8 +55,8 @@ public class KllFloatsSketchToRankPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class KllFloatsSketchToRankPostAggregatorTest
         0
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllFloatsSketchToRankPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, value=0.0}",
         postAgg.toString()
     );
@@ -99,7 +99,7 @@ public class KllFloatsSketchToRankPostAggregatorTest
     );
 
     final double rank = (double) postAgg.compute(fields);
-    Assert.assertTrue(Double.isNaN(rank));
+    Assertions.assertTrue(Double.isNaN(rank));
   }
 
   @Test
@@ -125,7 +125,7 @@ public class KllFloatsSketchToRankPostAggregatorTest
     );
 
     final double rank = (double) postAgg.compute(fields);
-    Assert.assertEquals(0.5, rank, 0);
+    Assertions.assertEquals(0.5, rank, 0);
   }
 
   @Test
@@ -148,7 +148,7 @@ public class KllFloatsSketchToRankPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToStringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/kll/KllFloatsSketchToStringPostAggregatorTest.java
@@ -25,15 +25,13 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class KllFloatsSketchToStringPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -49,8 +47,8 @@ public class KllFloatsSketchToStringPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -61,7 +59,7 @@ public class KllFloatsSketchToStringPostAggregatorTest
         new FieldAccessPostAggregator("field1", "sketch")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "KllFloatsSketchToStringPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}}",
         postAgg.toString()
     );
@@ -70,13 +68,14 @@ public class KllFloatsSketchToStringPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing sketch summaries is not supported");
-    final PostAggregator postAgg = new KllFloatsSketchToStringPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch")
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new KllFloatsSketchToStringPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch")
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing sketch summaries is not supported"));
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorFactoryTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -70,7 +70,7 @@ public class DoublesSketchAggregatorFactoryTest
         json,
         AggregatorFactory.class
     );
-    Assert.assertEquals(factory, fromJson);
+    Assertions.assertEquals(factory, fromJson);
   }
 
   @Test
@@ -84,8 +84,8 @@ public class DoublesSketchAggregatorFactoryTest
         null
     );
 
-    Assert.assertEquals(DoublesSketchAggregatorFactory.DEFAULT_K, factory.getK());
-    Assert.assertEquals(DoublesSketchAggregatorFactory.DEFAULT_MAX_STREAM_LENGTH, factory.getMaxStreamLength());
+    Assertions.assertEquals(DoublesSketchAggregatorFactory.DEFAULT_K, factory.getK());
+    Assertions.assertEquals(DoublesSketchAggregatorFactory.DEFAULT_MAX_STREAM_LENGTH, factory.getMaxStreamLength());
   }
 
   @Test
@@ -98,10 +98,10 @@ public class DoublesSketchAggregatorFactoryTest
         null,
         null
     );
-    Assert.assertEquals(64, factory.guessAggregatorHeapFootprint(1));
-    Assert.assertEquals(1056, factory.guessAggregatorHeapFootprint(100));
-    Assert.assertEquals(4128, factory.guessAggregatorHeapFootprint(1000));
-    Assert.assertEquals(34848, factory.guessAggregatorHeapFootprint(1_000_000_000_000L));
+    Assertions.assertEquals(64, factory.guessAggregatorHeapFootprint(1));
+    Assertions.assertEquals(1056, factory.guessAggregatorHeapFootprint(100));
+    Assertions.assertEquals(4128, factory.guessAggregatorHeapFootprint(1000));
+    Assertions.assertEquals(34848, factory.guessAggregatorHeapFootprint(1_000_000_000_000L));
   }
 
   @Test
@@ -114,7 +114,7 @@ public class DoublesSketchAggregatorFactoryTest
         null,
         null
     );
-    Assert.assertEquals(24608L, factory.getMaxIntermediateSize());
+    Assertions.assertEquals(24608L, factory.getMaxIntermediateSize());
 
     factory = new DoublesSketchAggregatorFactory(
         "myFactory",
@@ -123,7 +123,7 @@ public class DoublesSketchAggregatorFactoryTest
         1_000_000_000_000L,
         null
     );
-    Assert.assertEquals(34848L, factory.getMaxIntermediateSize());
+    Assertions.assertEquals(34848L, factory.getMaxIntermediateSize());
   }
 
   @Test
@@ -150,7 +150,7 @@ public class DoublesSketchAggregatorFactoryTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)
@@ -178,8 +178,8 @@ public class DoublesSketchAggregatorFactoryTest
         1000L,
         null
     );
-    Assert.assertEquals(factory, factory.withName("myFactory"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("myFactory"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 
   @Test
@@ -195,11 +195,11 @@ public class DoublesSketchAggregatorFactoryTest
     final double[] values = new double[]{1, 2, 3, 4, 5, 6};
     final TestDoubleColumnSelectorImpl selector = new TestDoubleColumnSelectorImpl(values);
     final Aggregator agg1 = new DoublesSketchBuildAggregator(selector, 8);
-    Assert.assertNotNull(factory.combine(null, agg1.get()));
-    Assert.assertNotNull(factory.combine(agg1.get(), null));
+    Assertions.assertNotNull(factory.combine(null, agg1.get()));
+    Assertions.assertNotNull(factory.combine(agg1.get(), null));
     AggregateCombiner ac = factory.makeAggregateCombiner();
     ac.fold(new TestDoublesSketchColumnValueSelector());
-    Assert.assertNotNull(ac.getObject());
+    Assertions.assertNotNull(ac.getObject());
   }
 
   @Test
@@ -210,10 +210,10 @@ public class DoublesSketchAggregatorFactoryTest
     final DoublesSketchAggregatorFactory sketch3 = new DoublesSketchAggregatorFactory("another", "x", 2048, 1000L, null);
     final DoublesSketchAggregatorFactory incompatible = new DoublesSketchAggregatorFactory("incompatible", "y", 1024, 1000L, null);
 
-    Assert.assertNotNull(sketch.substituteCombiningFactory(sketch2));
-    Assert.assertNotNull(sketch.substituteCombiningFactory(sketch3));
-    Assert.assertNull(sketch2.substituteCombiningFactory(sketch3));
-    Assert.assertNull(sketch.substituteCombiningFactory(incompatible));
-    Assert.assertNull(sketch3.substituteCombiningFactory(sketch));
+    Assertions.assertNotNull(sketch.substituteCombiningFactory(sketch2));
+    Assertions.assertNotNull(sketch.substituteCombiningFactory(sketch3));
+    Assertions.assertNull(sketch2.substituteCombiningFactory(sketch3));
+    Assertions.assertNull(sketch.substituteCombiningFactory(incompatible));
+    Assertions.assertNull(sketch3.substituteCombiningFactory(sketch));
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
@@ -100,7 +100,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
   // this is to test Json properties and equals
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -118,7 +118,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
   // this is to test Json properties and equals for the combining factory
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
@@ -135,7 +135,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void ingestingSketches(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void ingestingSketches(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -210,7 +210,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -319,7 +319,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -448,7 +448,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -526,7 +526,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<Result<TimeseriesResultValue>> seq = timeSeriesHelper.createIndexAndRunQueryOnSegment(
@@ -576,7 +576,7 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
-  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchAggregatorTest.java
@@ -43,13 +43,11 @@ import org.apache.druid.query.groupby.GroupByQueryRunnerTest;
 import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -57,33 +55,31 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-@RunWith(Parameterized.class)
 public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 {
-  private final GroupByQueryConfig config;
-  private final AggregationTestHelper helper;
-  private final AggregationTestHelper timeSeriesHelper;
+  private GroupByQueryConfig config;
+  private AggregationTestHelper helper;
+  private AggregationTestHelper timeSeriesHelper;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private File tempFolder;
 
-  public DoublesSketchAggregatorTest(final GroupByQueryConfig config, final String vectorize)
+  public void initDoublesSketchAggregatorTest(final GroupByQueryConfig config, final String vectorize)
   {
     this.config = config;
     DoublesSketchModule.registerSerde();
     DoublesSketchModule module = new DoublesSketchModule();
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         module.getJacksonModules(),
         config,
         tempFolder
     ).withQueryContext(ImmutableMap.of(QueryContexts.VECTORIZE_KEY, vectorize));
-    timeSeriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelper(
+    timeSeriesHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
         module.getJacksonModules(),
         tempFolder
     ).withQueryContext(ImmutableMap.of(QueryContexts.VECTORIZE_KEY, vectorize));
   }
 
-  @Parameterized.Parameters(name = "groupByConfig = {0}, vectorize = {1}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -95,16 +91,18 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
   // this is to test Json properties and equals
-  @Test
-  public void serializeDeserializeFactoryWithFieldName() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void serializeDeserializeFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
     new DoublesSketchModule().getJacksonModules().forEach(objectMapper::registerModule);
     DoublesSketchAggregatorFactory factory = new DoublesSketchAggregatorFactory("name", "filedName", 128);
@@ -114,13 +112,15 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, other);
+    Assertions.assertEquals(factory, other);
   }
 
   // this is to test Json properties and equals for the combining factory
-  @Test
-  public void serializeDeserializeCombiningFactoryWithFieldName() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void serializeDeserializeCombiningFactoryWithFieldName(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     ObjectMapper objectMapper = new DefaultObjectMapper();
     new DoublesSketchModule().getJacksonModules().forEach(objectMapper::registerModule);
     DoublesSketchAggregatorFactory factory = new DoublesSketchMergeAggregatorFactory("name", 128);
@@ -130,12 +130,14 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
         AggregatorFactory.class
     );
 
-    Assert.assertEquals(factory, other);
+    Assertions.assertEquals(factory, other);
   }
 
-  @Test
-  public void ingestingSketches() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void ingestingSketches(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("quantiles/doubles_sketch_data.tsv").getFile()),
         new InputRowSchema(
@@ -175,40 +177,42 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object nonExistentSketchObject = row.get(1);
-    Assert.assertTrue(nonExistentSketchObject instanceof Long);
+    Assertions.assertTrue(nonExistentSketchObject instanceof Long);
     long nonExistentSketchValue = (long) nonExistentSketchObject;
-    Assert.assertEquals(0, nonExistentSketchValue);
+    Assertions.assertEquals(0, nonExistentSketchValue);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     // post agg
     Object quantilesObject = row.get(2);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(3);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
       // 400 items uniformly distributed into 4 bins
-      Assert.assertEquals(100, bin, 100 * 0.2);
+      Assertions.assertEquals(100, bin, 100 * 0.2);
     }
   }
 
-  @Test
-  public void buildingSketchesAtIngestionTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("quantiles/doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -265,57 +269,59 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     Object sketchObjectWithNulls = row.get(1);
-    Assert.assertTrue(sketchObjectWithNulls instanceof Long);
+    Assertions.assertTrue(sketchObjectWithNulls instanceof Long);
     long sketchValueWithNulls = (long) sketchObjectWithNulls;
-    Assert.assertEquals(377, sketchValueWithNulls);
+    Assertions.assertEquals(377, sketchValueWithNulls);
 
     // post agg
     Object quantilesObject = row.get(3);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(4);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
-    Assert.assertEquals(4, histogram.length);
+    Assertions.assertEquals(4, histogram.length);
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly distributed into 4 bins
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly distributed into 4 bins
     }
 
     // post agg with nulls
     Object quantilesObjectWithNulls = row.get(5);
-    Assert.assertTrue(quantilesObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(quantilesObjectWithNulls instanceof double[]);
     double[] quantilesWithNulls = (double[]) quantilesObjectWithNulls;
-    Assert.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
-    Assert.assertEquals(7.55, quantilesWithNulls[1], 0.05); // median value
-    Assert.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
+    Assertions.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
+    Assertions.assertEquals(7.55, quantilesWithNulls[1], 0.05); // median value
+    Assertions.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
 
     // post agg with nulls
     Object histogramObjectWithNulls = row.get(6);
-    Assert.assertTrue(histogramObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(histogramObjectWithNulls instanceof double[]);
     double[] histogramWithNulls = (double[]) histogramObjectWithNulls;
-    Assert.assertEquals(4, histogramWithNulls.length);
+    Assertions.assertEquals(4, histogramWithNulls.length);
     for (final double bin : histogramWithNulls) {
-      Assert.assertEquals(100, bin, 50); // distribution is skewed due to nulls
+      Assertions.assertEquals(100, bin, 50); // distribution is skewed due to nulls
     }
   }
 
-  @Test
-  public void buildingSketchesAtQueryTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("quantiles/doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -378,45 +384,45 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     Object sketchObjectWithNulls = row.get(1);
-    Assert.assertTrue(sketchObjectWithNulls instanceof Long);
+    Assertions.assertTrue(sketchObjectWithNulls instanceof Long);
     long sketchValueWithNulls = (long) sketchObjectWithNulls;
-    Assert.assertEquals(377, sketchValueWithNulls);
+    Assertions.assertEquals(377, sketchValueWithNulls);
 
     // post agg
     Object quantileObject = row.get(2);
-    Assert.assertTrue(quantileObject instanceof Double);
-    Assert.assertEquals(0.5, (double) quantileObject, 0.05); // median value
+    Assertions.assertTrue(quantileObject instanceof Double);
+    Assertions.assertEquals(0.5, (double) quantileObject, 0.05); // median value
 
     // post agg
     Object quantilesObject = row.get(3);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(4);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
       // distributed into 4 bins
     }
 
     // post agg with nulls
     Object quantileObjectWithNulls = row.get(5);
-    Assert.assertTrue(quantileObjectWithNulls instanceof Double);
-    Assert.assertEquals(
+    Assertions.assertTrue(quantileObjectWithNulls instanceof Double);
+    Assertions.assertEquals(
         7.5,
         (double) quantileObjectWithNulls,
         0.1
@@ -424,25 +430,27 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
 
     // post agg with nulls
     Object quantilesObjectWithNulls = row.get(6);
-    Assert.assertTrue(quantilesObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(quantilesObjectWithNulls instanceof double[]);
     double[] quantilesWithNulls = (double[]) quantilesObjectWithNulls;
-    Assert.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
-    Assert.assertEquals(7.5, quantilesWithNulls[1], 0.1); // median value
-    Assert.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
+    Assertions.assertEquals(5.0, quantilesWithNulls[0], 0.05); // min value
+    Assertions.assertEquals(7.5, quantilesWithNulls[1], 0.1); // median value
+    Assertions.assertEquals(10.0, quantilesWithNulls[2], 0.05); // max value
 
     // post agg with nulls
     Object histogramObjectWithNulls = row.get(7);
-    Assert.assertTrue(histogramObjectWithNulls instanceof double[]);
+    Assertions.assertTrue(histogramObjectWithNulls instanceof double[]);
     double[] histogramWithNulls = (double[]) histogramObjectWithNulls;
     for (final double bin : histogramWithNulls) {
-      Assert.assertEquals(100, bin, 80); // distribution is skewed due to nulls/0s
+      Assertions.assertEquals(100, bin, 80); // distribution is skewed due to nulls/0s
       // distributed into 4 bins
     }
   }
 
-  @Test
-  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void queryingDataWithFieldNameValueAsFloatInsteadOfSketch(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("quantiles/doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -485,40 +493,42 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
 
     Object sketchObject = row.get(0);
-    Assert.assertTrue(sketchObject instanceof Long);
+    Assertions.assertTrue(sketchObject instanceof Long);
     long sketchValue = (long) sketchObject;
-    Assert.assertEquals(400, sketchValue);
+    Assertions.assertEquals(400, sketchValue);
 
     // post agg
     Object quantileObject = row.get(1);
-    Assert.assertTrue(quantileObject instanceof Double);
-    Assert.assertEquals(0.5, (double) quantileObject, 0.05); // median value
+    Assertions.assertTrue(quantileObject instanceof Double);
+    Assertions.assertEquals(0.5, (double) quantileObject, 0.05); // median value
 
     // post agg
     Object quantilesObject = row.get(2);
-    Assert.assertTrue(quantilesObject instanceof double[]);
+    Assertions.assertTrue(quantilesObject instanceof double[]);
     double[] quantiles = (double[]) quantilesObject;
-    Assert.assertEquals(0, quantiles[0], 0.05); // min value
-    Assert.assertEquals(0.5, quantiles[1], 0.05); // median value
-    Assert.assertEquals(1, quantiles[2], 0.05); // max value
+    Assertions.assertEquals(0, quantiles[0], 0.05); // min value
+    Assertions.assertEquals(0.5, quantiles[1], 0.05); // median value
+    Assertions.assertEquals(1, quantiles[2], 0.05); // max value
 
     // post agg
     Object histogramObject = row.get(3);
-    Assert.assertTrue(histogramObject instanceof double[]);
+    Assertions.assertTrue(histogramObject instanceof double[]);
     double[] histogram = (double[]) histogramObject;
     for (final double bin : histogram) {
-      Assert.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
+      Assertions.assertEquals(100, bin, 100 * 0.2); // 400 items uniformly
       // distributed into 4 bins
     }
   }
 
-  @Test
-  public void timeSeriesQueryInputAsFloat() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void timeSeriesQueryInputAsFloat(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<Result<TimeseriesResultValue>> seq = timeSeriesHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("quantiles/doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -561,12 +571,14 @@ public class DoublesSketchAggregatorTest extends InitializedNullHandlingTest
               .build()
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
   }
 
-  @Test
-  public void testSuccessWhenMaxStreamLengthHit() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "groupByConfig = {0}, vectorize = {1}")
+  public void testSuccessWhenMaxStreamLengthHit(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initDoublesSketchAggregatorTest(config, vectorize);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("quantiles/doubles_build_data.tsv").getFile()),
         new InputRowSchema(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchComplexMetricSerdeTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchComplexMetricSerdeTest.java
@@ -26,8 +26,8 @@ import org.apache.datasketches.quantiles.DoublesUnion;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.segment.data.ObjectStrategy;
 import org.apache.druid.segment.serde.ComplexMetricExtractor;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -43,7 +43,7 @@ public class DoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "")),
         "foo"
     );
-    Assert.assertEquals(0, sketch.getNumRetained());
+    Assertions.assertEquals(0, sketch.getNumRetained());
   }
 
   @Test
@@ -55,8 +55,8 @@ public class DoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "777")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(777d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(777d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -68,8 +68,8 @@ public class DoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "-133")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(-133d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(-133d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -81,8 +81,8 @@ public class DoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", "3.1")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(3.1d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(3.1d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -94,8 +94,8 @@ public class DoublesSketchComplexMetricSerdeTest
         new MapBasedInputRow(0L, ImmutableList.of(), ImmutableMap.of("foo", ".1")),
         "foo"
     );
-    Assert.assertEquals(1, sketch.getNumRetained());
-    Assert.assertEquals(0.1d, sketch.getMaxItem(), 0.01d);
+    Assertions.assertEquals(1, sketch.getNumRetained());
+    Assertions.assertEquals(0.1d, sketch.getMaxItem(), 0.01d);
   }
 
   @Test
@@ -108,7 +108,7 @@ public class DoublesSketchComplexMetricSerdeTest
 
     ByteBuffer buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
     ObjectStrategy<DoublesSketch> objectStrategy = serde.getObjectStrategy();
-    Assert.assertTrue(objectStrategy.readRetainsBufferReference());
+    Assertions.assertTrue(objectStrategy.readRetainsBufferReference());
 
     // valid sketch should not explode when copied, which reads the memory
     objectStrategy.fromByteBufferSafe(buf, bytes.length).toByteArray(true);
@@ -121,17 +121,17 @@ public class DoublesSketchComplexMetricSerdeTest
       }
 
       final ByteBuffer buf2 = ByteBuffer.wrap(garbage2).order(ByteOrder.LITTLE_ENDIAN);
-      Assert.assertThrows(
-          "i " + subset,
+      Assertions.assertThrows(
           IndexOutOfBoundsException.class,
-          () -> objectStrategy.fromByteBufferSafe(buf2, garbage2.length).toByteArray(true)
+          () -> objectStrategy.fromByteBufferSafe(buf2, garbage2.length).toByteArray(true),
+          "i " + subset
       );
     }
 
     // non sketch that is too short to contain header should fail with regular java buffer exception
     final byte[] garbage = new byte[]{0x01, 0x02};
     final ByteBuffer buf3 = ByteBuffer.wrap(garbage).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> objectStrategy.fromByteBufferSafe(buf3, garbage.length).toByteArray(true)
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchMergeAggregatorFactoryTest.java
@@ -24,8 +24,8 @@ import com.fasterxml.jackson.databind.jsontype.NamedType;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.AggregatorFactory;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -59,7 +59,7 @@ public class DoublesSketchMergeAggregatorFactoryTest
         json,
         AggregatorFactory.class
     );
-    Assert.assertEquals(factory, fromJson);
+    Assertions.assertEquals(factory, fromJson);
   }
 
   @Test
@@ -71,7 +71,7 @@ public class DoublesSketchMergeAggregatorFactoryTest
         1000L,
         null
     );
-    Assert.assertEquals(factory, factory.withName("myFactory"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("myFactory"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchOperationsTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchOperationsTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.query.aggregation.datasketches.quantiles;
 
 import org.apache.datasketches.quantiles.DoublesUnion;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -36,13 +36,13 @@ public class DoublesSketchOperationsTest
     final byte[] bytes = union.getResult().toByteArray();
     final String base64 = StringUtils.encodeBase64String(bytes);
 
-    Assert.assertArrayEquals(bytes, DoublesSketchOperations.deserializeSafe(union.getResult()).toByteArray());
-    Assert.assertArrayEquals(bytes, DoublesSketchOperations.deserializeSafe(bytes).toByteArray());
-    Assert.assertArrayEquals(bytes, DoublesSketchOperations.deserializeSafe(base64).toByteArray());
+    Assertions.assertArrayEquals(bytes, DoublesSketchOperations.deserializeSafe(union.getResult()).toByteArray());
+    Assertions.assertArrayEquals(bytes, DoublesSketchOperations.deserializeSafe(bytes).toByteArray());
+    Assertions.assertArrayEquals(bytes, DoublesSketchOperations.deserializeSafe(base64).toByteArray());
 
     final byte[] trunacted = Arrays.copyOfRange(bytes, 0, 4);
-    Assert.assertThrows(IndexOutOfBoundsException.class, () -> DoublesSketchOperations.deserializeSafe(trunacted));
-    Assert.assertThrows(
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> DoublesSketchOperations.deserializeSafe(trunacted));
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> DoublesSketchOperations.deserializeSafe(StringUtils.encodeBase64(trunacted))
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToCDFPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToCDFPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class DoublesSketchToCDFPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -61,8 +59,8 @@ public class DoublesSketchToCDFPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -74,7 +72,7 @@ public class DoublesSketchToCDFPostAggregatorTest
         new double[]{0.25, 0.75}
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "DoublesSketchToCDFPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, splitPoints=[0.25, 0.75]}",
         postAgg.toString()
     );
@@ -83,14 +81,15 @@ public class DoublesSketchToCDFPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing histograms is not supported");
-    final PostAggregator postAgg = new DoublesSketchToCDFPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new double[]{0.25, 0.75}
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new DoublesSketchToCDFPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new double[]{0.25, 0.75}
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing histograms is not supported"));
   }
 
   @Test
@@ -118,10 +117,10 @@ public class DoublesSketchToCDFPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertTrue(Double.isNaN(histogram[0]));
-    Assert.assertTrue(Double.isNaN(histogram[1]));
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertTrue(Double.isNaN(histogram[0]));
+    Assertions.assertTrue(Double.isNaN(histogram[1]));
   }
 
   @Test
@@ -147,10 +146,10 @@ public class DoublesSketchToCDFPostAggregatorTest
     );
 
     final double[] cdf = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(cdf);
-    Assert.assertEquals(2, cdf.length);
-    Assert.assertEquals(0.5, cdf[0], 0);
-    Assert.assertEquals(1.0, cdf[1], 0);
+    Assertions.assertNotNull(cdf);
+    Assertions.assertEquals(2, cdf.length);
+    Assertions.assertEquals(0.5, cdf[0], 0);
+    Assertions.assertEquals(1.0, cdf[1], 0);
   }
 
   @Test
@@ -173,7 +172,7 @@ public class DoublesSketchToCDFPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToHistogramPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToHistogramPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class DoublesSketchToHistogramPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -62,8 +60,8 @@ public class DoublesSketchToHistogramPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -76,7 +74,7 @@ public class DoublesSketchToHistogramPostAggregatorTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "DoublesSketchToHistogramPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, splitPoints=[0.25, 0.75], numBins=null}",
         postAgg.toString()
     );
@@ -85,15 +83,16 @@ public class DoublesSketchToHistogramPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing histograms is not supported");
-    final PostAggregator postAgg = new DoublesSketchToHistogramPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new double[]{0.25, 0.75},
-        null
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new DoublesSketchToHistogramPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new double[]{0.25, 0.75},
+          null
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing histograms is not supported"));
   }
 
   @Test
@@ -122,10 +121,10 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertTrue(Double.isNaN(histogram[0]));
-    Assert.assertTrue(Double.isNaN(histogram[1]));
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertTrue(Double.isNaN(histogram[0]));
+    Assertions.assertTrue(Double.isNaN(histogram[1]));
   }
 
   @Test
@@ -152,10 +151,10 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(3.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(3.0, histogram[1], 0);
   }
 
   @Test
@@ -182,10 +181,10 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(0.0, histogram[0], 0);
-    Assert.assertEquals(6.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(0.0, histogram[0], 0);
+    Assertions.assertEquals(6.0, histogram[1], 0);
   }
 
   @Test
@@ -212,10 +211,10 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(3.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(3.0, histogram[1], 0);
   }
 
   @Test
@@ -242,10 +241,10 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(1.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(1.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
   }
 
   @Test
@@ -272,11 +271,11 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(3, histogram.length);
-    Assert.assertEquals(1.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
-    Assert.assertEquals(0.0, histogram[2], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(3, histogram.length);
+    Assertions.assertEquals(1.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertEquals(0.0, histogram[2], 0);
   }
 
   @Test
@@ -303,10 +302,10 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(2, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(2, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
   }
 
   @Test
@@ -333,11 +332,11 @@ public class DoublesSketchToHistogramPostAggregatorTest
     );
 
     final double[] histogram = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(histogram);
-    Assert.assertEquals(3, histogram.length);
-    Assert.assertEquals(3.0, histogram[0], 0);
-    Assert.assertEquals(0.0, histogram[1], 0);
-    Assert.assertEquals(0.0, histogram[2], 0);
+    Assertions.assertNotNull(histogram);
+    Assertions.assertEquals(3, histogram.length);
+    Assertions.assertEquals(3.0, histogram[0], 0);
+    Assertions.assertEquals(0.0, histogram[1], 0);
+    Assertions.assertEquals(0.0, histogram[2], 0);
   }
 
   @Test
@@ -361,7 +360,7 @@ public class DoublesSketchToHistogramPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToQuantilePostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToQuantilePostAggregatorTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DoublesSketchToQuantilePostAggregatorTest
 {
@@ -44,8 +44,8 @@ public class DoublesSketchToQuantilePostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -57,7 +57,7 @@ public class DoublesSketchToQuantilePostAggregatorTest
         0.5
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "DoublesSketchToQuantilePostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, fraction=0.5}",
         postAgg.toString()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToQuantilesPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToQuantilesPostAggregatorTest.java
@@ -33,18 +33,16 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class DoublesSketchToQuantilesPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -61,8 +59,8 @@ public class DoublesSketchToQuantilesPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -74,7 +72,7 @@ public class DoublesSketchToQuantilesPostAggregatorTest
         new double[] {0, 0.5, 1}
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "DoublesSketchToQuantilesPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, fractions=[0.0, 0.5, 1.0]}",
         postAgg.toString()
     );
@@ -83,14 +81,15 @@ public class DoublesSketchToQuantilesPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing arrays of quantiles is not supported");
-    final PostAggregator postAgg = new DoublesSketchToQuantilesPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch"),
-        new double[] {0, 0.5, 1}
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new DoublesSketchToQuantilesPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch"),
+          new double[]{0, 0.5, 1}
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing arrays of quantiles is not supported"));
   }
 
   @Test
@@ -118,11 +117,11 @@ public class DoublesSketchToQuantilesPostAggregatorTest
     );
 
     final double[] quantiles = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(quantiles);
-    Assert.assertEquals(3, quantiles.length);
-    Assert.assertTrue(Double.isNaN(quantiles[0]));
-    Assert.assertTrue(Double.isNaN(quantiles[1]));
-    Assert.assertTrue(Double.isNaN(quantiles[2]));
+    Assertions.assertNotNull(quantiles);
+    Assertions.assertEquals(3, quantiles.length);
+    Assertions.assertTrue(Double.isNaN(quantiles[0]));
+    Assertions.assertTrue(Double.isNaN(quantiles[1]));
+    Assertions.assertTrue(Double.isNaN(quantiles[2]));
   }
 
   @Test
@@ -148,11 +147,11 @@ public class DoublesSketchToQuantilesPostAggregatorTest
     );
 
     final double[] quantiles = (double[]) postAgg.compute(fields);
-    Assert.assertNotNull(quantiles);
-    Assert.assertEquals(3, quantiles.length);
-    Assert.assertEquals(1.0, quantiles[0], 0);
-    Assert.assertEquals(3.0, quantiles[1], 0);
-    Assert.assertEquals(5.0, quantiles[2], 0);
+    Assertions.assertNotNull(quantiles);
+    Assertions.assertEquals(3, quantiles.length);
+    Assertions.assertEquals(1.0, quantiles[0], 0);
+    Assertions.assertEquals(3.0, quantiles[1], 0);
+    Assertions.assertEquals(5.0, quantiles[2], 0);
   }
 
   @Test
@@ -175,7 +174,7 @@ public class DoublesSketchToQuantilesPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToRankPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToRankPostAggregatorTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -55,8 +55,8 @@ public class DoublesSketchToRankPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class DoublesSketchToRankPostAggregatorTest
         0
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "DoublesSketchToRankPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}, value=0.0}",
         postAgg.toString()
     );
@@ -99,7 +99,7 @@ public class DoublesSketchToRankPostAggregatorTest
     );
 
     final double rank = (double) postAgg.compute(fields);
-    Assert.assertTrue(Double.isNaN(rank));
+    Assertions.assertTrue(Double.isNaN(rank));
   }
 
   @Test
@@ -125,7 +125,7 @@ public class DoublesSketchToRankPostAggregatorTest
     );
 
     final double rank = (double) postAgg.compute(fields);
-    Assert.assertEquals(0.5, rank, 0);
+    Assertions.assertEquals(0.5, rank, 0);
   }
 
   @Test
@@ -148,7 +148,7 @@ public class DoublesSketchToRankPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("sketch", null)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToStringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/DoublesSketchToStringPostAggregatorTest.java
@@ -25,15 +25,13 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DoublesSketchToStringPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -49,8 +47,8 @@ public class DoublesSketchToStringPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -61,7 +59,7 @@ public class DoublesSketchToStringPostAggregatorTest
         new FieldAccessPostAggregator("field1", "sketch")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "DoublesSketchToStringPostAggregator{name='post', field=FieldAccessPostAggregator{name='field1', fieldName='sketch'}}",
         postAgg.toString()
     );
@@ -70,13 +68,14 @@ public class DoublesSketchToStringPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing sketch summaries is not supported");
-    final PostAggregator postAgg = new DoublesSketchToStringPostAggregator(
-        "post",
-        new FieldAccessPostAggregator("field1", "sketch")
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new DoublesSketchToStringPostAggregator(
+          "post",
+          new FieldAccessPostAggregator("field1", "sketch")
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing sketch summaries is not supported"));
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/quantiles/sql/DoublesSketchSqlAggregatorTest.java
@@ -72,7 +72,7 @@ import org.apache.druid.sql.calcite.util.SqlTestFramework.StandardComponentSuppl
 import org.apache.druid.sql.calcite.util.TestDataBuilder;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -1121,12 +1121,12 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
 
     try {
       testQuery(query, ImmutableList.of(), ImmutableList.of());
-      Assert.fail("Expected DruidException but query succeeded");
+      Assertions.fail("Expected DruidException but query succeeded");
     }
     catch (DruidException e) {
-      Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
-      Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-      Assert.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_QUANTILE_DS'"));
+      Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+      Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+      Assertions.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_QUANTILE_DS'"));
     }
   }
 
@@ -1138,12 +1138,12 @@ public class DoublesSketchSqlAggregatorTest extends BaseCalciteQueryTest
 
     try {
       testQuery(query, ImmutableList.of(), ImmutableList.of());
-      Assert.fail("Expected DruidException but query succeeded");
+      Assertions.fail("Expected DruidException but query succeeded");
     }
     catch (DruidException e) {
-      Assert.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
-      Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-      Assert.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_QUANTILE_DS'"));
+      Assertions.assertEquals(DruidException.Persona.USER, e.getTargetPersona());
+      Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+      Assertions.assertTrue(e.getMessage().contains("Cannot apply 'APPROX_QUANTILE_DS'"));
     }
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/BufferHashGrouperUsingSketchMergeAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/BufferHashGrouperUsingSketchMergeAggregatorFactoryTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.query.groupby.epinephelinae.GroupByTestColumnSelectorFac
 import org.apache.druid.query.groupby.epinephelinae.Grouper;
 import org.apache.druid.query.groupby.epinephelinae.GrouperTestUtil;
 import org.apache.druid.query.groupby.epinephelinae.IntKey;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 
@@ -80,19 +80,19 @@ public class BufferHashGrouperUsingSketchMergeAggregatorFactoryTest
       columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("sketch", sketchHolder)));
 
       for (int i = 0; i < expectedMaxSize; i++) {
-        Assert.assertTrue(String.valueOf(i), grouper.aggregate(new IntKey(i)).isOk());
+        Assertions.assertTrue(grouper.aggregate(new IntKey(i)).isOk(), String.valueOf(i));
       }
 
       updateSketch.update(3);
       columnSelectorFactory.setRow(new MapBasedRow(0, ImmutableMap.of("sketch", sketchHolder)));
 
       for (int i = 0; i < expectedMaxSize; i++) {
-        Assert.assertTrue(String.valueOf(i), grouper.aggregate(new IntKey(i)).isOk());
+        Assertions.assertTrue(grouper.aggregate(new IntKey(i)).isOk(), String.valueOf(i));
       }
 
       Object[] holders = Lists.newArrayList(grouper.iterator(true)).get(0).getValues();
 
-      Assert.assertEquals(2.0d, ((SketchHolder) holders[0]).getEstimate(), 0);
+      Assertions.assertEquals(2.0d, ((SketchHolder) holders[0]).getEstimate(), 0);
     }
     finally {
       grouper.close();

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
@@ -59,13 +59,11 @@ import org.apache.druid.query.groupby.epinephelinae.GroupByTestColumnSelectorFac
 import org.apache.druid.query.groupby.epinephelinae.GrouperTestUtil;
 import org.apache.druid.query.groupby.orderby.DefaultLimitSpec;
 import org.apache.druid.query.groupby.orderby.OrderByColumnSpec;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -79,19 +77,18 @@ import java.util.stream.Collectors;
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class SketchAggregationTest
 {
-  private final AggregationTestHelper helper;
-  private final QueryContexts.Vectorize vectorize;
+  private AggregationTestHelper helper;
+  private QueryContexts.Vectorize vectorize;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private File tempFolder;
 
-  public SketchAggregationTest(final GroupByQueryConfig config, final String vectorize)
+  public void initSketchAggregationTest(final GroupByQueryConfig config, final String vectorize)
   {
     SketchModule.registerSerde();
-    this.helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    this.helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         new SketchModule().getJacksonModules(),
         config,
         tempFolder
@@ -99,7 +96,6 @@ public class SketchAggregationTest
     this.vectorize = QueryContexts.Vectorize.fromString(vectorize);
   }
 
-  @Parameterized.Parameters(name = "config = {0}, vectorize = {1}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -111,15 +107,17 @@ public class SketchAggregationTest
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
-  @Test
-  public void testSketchDataIngestAndGpByQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSketchDataIngestAndGpByQuery(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
         .setDataSource("test_datasource")
         .setGranularity(Granularities.ALL)
@@ -219,8 +217,8 @@ public class SketchAggregationTest
                                    + "   Seed Hash               : 93cc | 37836\n"
                                    + "### END SKETCH SUMMARY\n";
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertEquals(
         ResultRow.fromLegacyRow(
             new MapBasedRow(
                 DateTimes.of("2014-10-19T00:00:00.000Z"),
@@ -249,9 +247,11 @@ public class SketchAggregationTest
     );
   }
 
-  @Test
-  public void testEmptySketchAggregateCombine() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testEmptySketchAggregateCombine(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
         .setDataSource("test_datasource")
         .setGranularity(Granularities.ALL)
@@ -280,8 +280,8 @@ public class SketchAggregationTest
     );
 
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertEquals(
         ResultRow.fromLegacyRow(
             new MapBasedRow(
                 DateTimes.of("2019-07-14T00:00:00.000Z"),
@@ -297,9 +297,11 @@ public class SketchAggregationTest
     );
   }
 
-  @Test
-  public void testThetaCardinalityOnSimpleColumn() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testThetaCardinalityOnSimpleColumn(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
         .setDataSource("test_datasource")
         .setGranularity(Granularities.ALL)
@@ -383,8 +385,8 @@ public class SketchAggregationTest
     );
 
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(5, results.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(5, results.size());
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedRow(
                 DateTimes.of("2014-10-19T00:00:00.000Z"),
@@ -456,41 +458,45 @@ public class SketchAggregationTest
     );
   }
 
-  @Test
-  public void testSketchMergeAggregatorFactorySerde() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSketchMergeAggregatorFactorySerde(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initSketchAggregationTest(config, vectorize);
     assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, null, null, null));
     assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, false, true, null));
     assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, true, false, null));
     assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, true, false, 2));
   }
 
-  @Test
-  public void testSketchMergeFinalization()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSketchMergeFinalization(final GroupByQueryConfig config,final String vectorize)
   {
+    initSketchAggregationTest(config, vectorize);
     SketchHolder sketch = SketchHolder.of(Sketches.updateSketchBuilder().setNominalEntries(128).build());
 
     SketchMergeAggregatorFactory agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, null, null, null);
-    Assert.assertEquals(0.0, ((Double) agg.finalizeComputation(sketch)).doubleValue(), 0.0001);
+    Assertions.assertEquals(0.0, ((Double) agg.finalizeComputation(sketch)).doubleValue(), 0.0001);
 
     agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, true, null, null);
-    Assert.assertEquals(0.0, ((Double) agg.finalizeComputation(sketch)).doubleValue(), 0.0001);
+    Assertions.assertEquals(0.0, ((Double) agg.finalizeComputation(sketch)).doubleValue(), 0.0001);
 
     agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, false, null, null);
-    Assert.assertEquals(sketch, agg.finalizeComputation(sketch));
+    Assertions.assertEquals(sketch, agg.finalizeComputation(sketch));
 
     agg = new SketchMergeAggregatorFactory("name", "fieldName", 16, true, null, 2);
     SketchEstimateWithErrorBounds est = (SketchEstimateWithErrorBounds) agg.finalizeComputation(sketch);
-    Assert.assertEquals(0.0, est.getEstimate(), 0.0001);
-    Assert.assertEquals(0.0, est.getHighBound(), 0.0001);
-    Assert.assertEquals(0.0, est.getLowBound(), 0.0001);
-    Assert.assertEquals(2, est.getNumStdDev());
+    Assertions.assertEquals(0.0, est.getEstimate(), 0.0001);
+    Assertions.assertEquals(0.0, est.getHighBound(), 0.0001);
+    Assertions.assertEquals(0.0, est.getLowBound(), 0.0001);
+    Assertions.assertEquals(2, est.getNumStdDev());
 
   }
 
   private void assertAggregatorFactorySerde(AggregatorFactory agg) throws Exception
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         agg,
         helper.getObjectMapper().readValue(
             helper.getObjectMapper().writeValueAsString(agg),
@@ -499,9 +505,11 @@ public class SketchAggregationTest
     );
   }
 
-  @Test
-  public void testSketchEstimatePostAggregatorSerde() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSketchEstimatePostAggregatorSerde(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initSketchAggregationTest(config, vectorize);
     assertPostAggregatorSerde(
         new SketchEstimatePostAggregator(
             "name",
@@ -527,9 +535,11 @@ public class SketchAggregationTest
     );
   }
 
-  @Test
-  public void testSketchSetPostAggregatorSerde() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSketchSetPostAggregatorSerde(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initSketchAggregationTest(config, vectorize);
     assertPostAggregatorSerde(
         new SketchSetPostAggregator(
             "name",
@@ -555,9 +565,11 @@ public class SketchAggregationTest
     );
   }
 
-  @Test
-  public void testCacheKey()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testCacheKey(final GroupByQueryConfig config,final String vectorize)
   {
+    initSketchAggregationTest(config, vectorize);
     final SketchMergeAggregatorFactory factory1 = new SketchMergeAggregatorFactory(
         "name",
         "fieldName",
@@ -583,13 +595,15 @@ public class SketchAggregationTest
         null
     );
 
-    Assert.assertTrue(Arrays.equals(factory1.getCacheKey(), factory2.getCacheKey()));
-    Assert.assertFalse(Arrays.equals(factory1.getCacheKey(), factory3.getCacheKey()));
+    Assertions.assertTrue(Arrays.equals(factory1.getCacheKey(), factory2.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(factory1.getCacheKey(), factory3.getCacheKey()));
   }
 
-  @Test
-  public void testRetentionDataIngestAndGpByQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testRetentionDataIngestAndGpByQuery(final GroupByQueryConfig config,final String vectorize) throws Exception
   {
+    initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
         .setDataSource("test_datasource")
         .setGranularity(Granularities.ALL)
@@ -675,8 +689,8 @@ public class SketchAggregationTest
     );
 
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedRow(
                 DateTimes.of("2014-10-19T00:00:00.000Z"),
@@ -697,20 +711,22 @@ public class SketchAggregationTest
     );
   }
 
-  @Test
-  public void testSketchAggregatorFactoryComparator()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSketchAggregatorFactoryComparator(final GroupByQueryConfig config,final String vectorize)
   {
+    initSketchAggregationTest(config, vectorize);
     Comparator<Object> comparator = SketchHolder.COMPARATOR;
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, comparator.compare(null, null));
+    Assertions.assertEquals(0, comparator.compare(null, null));
 
     Union union1 = (Union) SetOperation.builder().setNominalEntries(1 << 4).build(Family.UNION);
     union1.update("a");
     union1.update("b");
     Sketch sketch1 = union1.getResult();
 
-    Assert.assertEquals(-1, comparator.compare(null, SketchHolder.of(sketch1)));
-    Assert.assertEquals(1, comparator.compare(SketchHolder.of(sketch1), null));
+    Assertions.assertEquals(-1, comparator.compare(null, SketchHolder.of(sketch1)));
+    Assertions.assertEquals(1, comparator.compare(SketchHolder.of(sketch1), null));
 
     Union union2 = (Union) SetOperation.builder().setNominalEntries(1 << 4).build(Family.UNION);
     union2.update("a");
@@ -718,17 +734,19 @@ public class SketchAggregationTest
     union2.update("c");
     Sketch sketch2 = union2.getResult();
 
-    Assert.assertEquals(-1, comparator.compare(SketchHolder.of(sketch1), SketchHolder.of(sketch2)));
-    Assert.assertEquals(-1, comparator.compare(SketchHolder.of(sketch1), SketchHolder.of(union2)));
-    Assert.assertEquals(1, comparator.compare(SketchHolder.of(sketch2), SketchHolder.of(sketch1)));
-    Assert.assertEquals(1, comparator.compare(SketchHolder.of(sketch2), SketchHolder.of(union1)));
-    Assert.assertEquals(1, comparator.compare(SketchHolder.of(union2), SketchHolder.of(union1)));
-    Assert.assertEquals(1, comparator.compare(SketchHolder.of(union2), SketchHolder.of(sketch1)));
+    Assertions.assertEquals(-1, comparator.compare(SketchHolder.of(sketch1), SketchHolder.of(sketch2)));
+    Assertions.assertEquals(-1, comparator.compare(SketchHolder.of(sketch1), SketchHolder.of(union2)));
+    Assertions.assertEquals(1, comparator.compare(SketchHolder.of(sketch2), SketchHolder.of(sketch1)));
+    Assertions.assertEquals(1, comparator.compare(SketchHolder.of(sketch2), SketchHolder.of(union1)));
+    Assertions.assertEquals(1, comparator.compare(SketchHolder.of(union2), SketchHolder.of(union1)));
+    Assertions.assertEquals(1, comparator.compare(SketchHolder.of(union2), SketchHolder.of(sketch1)));
   }
 
-  @Test
-  public void testRelocation()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testRelocation(final GroupByQueryConfig config,final String vectorize)
   {
+    initSketchAggregationTest(config, vectorize);
     final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
     SketchHolder sketchHolder = SketchHolder.of(Sketches.updateSketchBuilder().setNominalEntries(16).build());
     UpdateSketch updateSketch = (UpdateSketch) sketchHolder.getSketch();
@@ -740,12 +758,14 @@ public class SketchAggregationTest
         columnSelectorFactory,
         SketchHolder.class
     );
-    Assert.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
+    Assertions.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
   }
 
-  @Test
-  public void testUpdateUnionWithNullInList()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testUpdateUnionWithNullInList(final GroupByQueryConfig config,final String vectorize)
   {
+    initSketchAggregationTest(config, vectorize);
     List<String> value = new ArrayList<>();
     value.add("foo");
     value.add(null);
@@ -755,32 +775,36 @@ public class SketchAggregationTest
     final TestObjectColumnSelector selector = new TestObjectColumnSelector(columnValues);
     final Aggregator agg = new SketchAggregator(selector, 4096);
     agg.aggregate();
-    Assert.assertFalse(agg.isNull());
-    Assert.assertNotNull(agg.get());
-    Assert.assertTrue(agg.get() instanceof SketchHolder);
-    Assert.assertEquals(2, ((SketchHolder) agg.get()).getEstimate(), 0);
-    Assert.assertNotNull(((SketchHolder) agg.get()).getSketch());
-    Assert.assertEquals(2, ((SketchHolder) agg.get()).getSketch().getEstimate(), 0);
+    Assertions.assertFalse(agg.isNull());
+    Assertions.assertNotNull(agg.get());
+    Assertions.assertTrue(agg.get() instanceof SketchHolder);
+    Assertions.assertEquals(2, ((SketchHolder) agg.get()).getEstimate(), 0);
+    Assertions.assertNotNull(((SketchHolder) agg.get()).getSketch());
+    Assertions.assertEquals(2, ((SketchHolder) agg.get()).getSketch().getEstimate(), 0);
   }
 
-  @Test
-  public void testUpdateUnionWithDouble()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testUpdateUnionWithDouble(final GroupByQueryConfig config,final String vectorize)
   {
+    initSketchAggregationTest(config, vectorize);
     Double[] columnValues = new Double[]{2.0};
     final TestObjectColumnSelector selector = new TestObjectColumnSelector(columnValues);
     final Aggregator agg = new SketchAggregator(selector, 4096);
     agg.aggregate();
-    Assert.assertFalse(agg.isNull());
-    Assert.assertNotNull(agg.get());
-    Assert.assertTrue(agg.get() instanceof SketchHolder);
-    Assert.assertEquals(1, ((SketchHolder) agg.get()).getEstimate(), 0);
-    Assert.assertNotNull(((SketchHolder) agg.get()).getSketch());
-    Assert.assertEquals(1, ((SketchHolder) agg.get()).getSketch().getEstimate(), 0);
+    Assertions.assertFalse(agg.isNull());
+    Assertions.assertNotNull(agg.get());
+    Assertions.assertTrue(agg.get() instanceof SketchHolder);
+    Assertions.assertEquals(1, ((SketchHolder) agg.get()).getEstimate(), 0);
+    Assertions.assertNotNull(((SketchHolder) agg.get()).getSketch());
+    Assertions.assertEquals(1, ((SketchHolder) agg.get()).getSketch().getEstimate(), 0);
   }
 
-  @Test
-  public void testAggregateWithSize()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testAggregateWithSize(final GroupByQueryConfig config,final String vectorize)
   {
+    initSketchAggregationTest(config, vectorize);
     final String[] columnValues = new String[20];
     for (int i = 0; i < columnValues.length; ++i) {
       columnValues[i] = "" + i;
@@ -790,37 +814,37 @@ public class SketchAggregationTest
     final SketchAggregator agg = new SketchAggregator(selector, 128);
 
     // Verify initial size of sketch
-    Assert.assertEquals(48L, agg.getInitialSizeBytes());
-    Assert.assertEquals(328L, agg.aggregateWithSize());
+    Assertions.assertEquals(48L, agg.getInitialSizeBytes());
+    Assertions.assertEquals(328L, agg.aggregateWithSize());
 
     // Verify that subsequent size deltas are zero
     for (int i = 1; i < 16; ++i) {
       selector.increment();
       long sizeDelta = agg.aggregateWithSize();
-      Assert.assertEquals(0, sizeDelta);
+      Assertions.assertEquals(0, sizeDelta);
     }
 
     // Verify that size delta is positive when sketch resizes
     selector.increment();
     long deltaAtResize = agg.aggregateWithSize();
-    Assert.assertEquals(1792, deltaAtResize);
+    Assertions.assertEquals(1792, deltaAtResize);
 
     for (int i = 17; i < columnValues.length; ++i) {
       selector.increment();
       long sizeDelta = agg.aggregateWithSize();
-      Assert.assertEquals(0, sizeDelta);
+      Assertions.assertEquals(0, sizeDelta);
     }
 
     // Verify unique count estimate
     SketchHolder sketchHolder = (SketchHolder) agg.get();
-    Assert.assertEquals(columnValues.length, sketchHolder.getEstimate(), 0);
-    Assert.assertNotNull(sketchHolder.getSketch());
-    Assert.assertEquals(columnValues.length, sketchHolder.getSketch().getEstimate(), 0);
+    Assertions.assertEquals(columnValues.length, sketchHolder.getEstimate(), 0);
+    Assertions.assertNotNull(sketchHolder.getSketch());
+    Assertions.assertEquals(columnValues.length, sketchHolder.getSketch().getEstimate(), 0);
   }
 
   private void assertPostAggregatorSerde(PostAggregator agg) throws Exception
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         agg,
         helper.getObjectMapper().readValue(
             helper.getObjectMapper().writeValueAsString(agg),

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationTest.java
@@ -115,7 +115,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSketchDataIngestAndGpByQuery(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testSketchDataIngestAndGpByQuery(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
@@ -249,7 +249,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testEmptySketchAggregateCombine(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testEmptySketchAggregateCombine(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
@@ -299,7 +299,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testThetaCardinalityOnSimpleColumn(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testThetaCardinalityOnSimpleColumn(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
@@ -460,7 +460,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSketchMergeAggregatorFactorySerde(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testSketchMergeAggregatorFactorySerde(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initSketchAggregationTest(config, vectorize);
     assertAggregatorFactorySerde(new SketchMergeAggregatorFactory("name", "fieldName", 16, null, null, null));
@@ -471,7 +471,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSketchMergeFinalization(final GroupByQueryConfig config,final String vectorize)
+  public void testSketchMergeFinalization(final GroupByQueryConfig config, final String vectorize)
   {
     initSketchAggregationTest(config, vectorize);
     SketchHolder sketch = SketchHolder.of(Sketches.updateSketchBuilder().setNominalEntries(128).build());
@@ -507,7 +507,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSketchEstimatePostAggregatorSerde(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testSketchEstimatePostAggregatorSerde(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initSketchAggregationTest(config, vectorize);
     assertPostAggregatorSerde(
@@ -537,7 +537,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSketchSetPostAggregatorSerde(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testSketchSetPostAggregatorSerde(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initSketchAggregationTest(config, vectorize);
     assertPostAggregatorSerde(
@@ -567,7 +567,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testCacheKey(final GroupByQueryConfig config,final String vectorize)
+  public void testCacheKey(final GroupByQueryConfig config, final String vectorize)
   {
     initSketchAggregationTest(config, vectorize);
     final SketchMergeAggregatorFactory factory1 = new SketchMergeAggregatorFactory(
@@ -601,7 +601,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testRetentionDataIngestAndGpByQuery(final GroupByQueryConfig config,final String vectorize) throws Exception
+  public void testRetentionDataIngestAndGpByQuery(final GroupByQueryConfig config, final String vectorize) throws Exception
   {
     initSketchAggregationTest(config, vectorize);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
@@ -713,7 +713,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSketchAggregatorFactoryComparator(final GroupByQueryConfig config,final String vectorize)
+  public void testSketchAggregatorFactoryComparator(final GroupByQueryConfig config, final String vectorize)
   {
     initSketchAggregationTest(config, vectorize);
     Comparator<Object> comparator = SketchHolder.COMPARATOR;
@@ -744,7 +744,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testRelocation(final GroupByQueryConfig config,final String vectorize)
+  public void testRelocation(final GroupByQueryConfig config, final String vectorize)
   {
     initSketchAggregationTest(config, vectorize);
     final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
@@ -763,7 +763,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testUpdateUnionWithNullInList(final GroupByQueryConfig config,final String vectorize)
+  public void testUpdateUnionWithNullInList(final GroupByQueryConfig config, final String vectorize)
   {
     initSketchAggregationTest(config, vectorize);
     List<String> value = new ArrayList<>();
@@ -785,7 +785,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testUpdateUnionWithDouble(final GroupByQueryConfig config,final String vectorize)
+  public void testUpdateUnionWithDouble(final GroupByQueryConfig config, final String vectorize)
   {
     initSketchAggregationTest(config, vectorize);
     Double[] columnValues = new Double[]{2.0};
@@ -802,7 +802,7 @@ public class SketchAggregationTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testAggregateWithSize(final GroupByQueryConfig config,final String vectorize)
+  public void testAggregateWithSize(final GroupByQueryConfig config, final String vectorize)
   {
     initSketchAggregationTest(config, vectorize);
     final String[] columnValues = new String[20];

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
@@ -34,7 +34,6 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.query.Druids;
-import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.Result;
 import org.apache.druid.query.aggregation.AggregationTestHelper;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
@@ -53,7 +52,6 @@ import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -71,18 +69,9 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
   @TempDir
   private File tempFolder;
 
-  private GroupByQueryConfig config;
-  private QueryContexts.Vectorize vectorize;
-
   private SketchModule sm;
   private File s1;
   private File s2;
-
-  public void initSketchAggregationWithSimpleDataTest(GroupByQueryConfig config, String vectorize)
-  {
-    this.config = config;
-    this.vectorize = QueryContexts.Vectorize.fromString(vectorize);
-  }
 
   public static Collection<?> constructorFeeder()
   {
@@ -95,8 +84,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
     return constructors;
   }
 
-  @BeforeEach
-  public void setup() throws Exception
+  private void setup(final GroupByQueryConfig config) throws Exception
   {
     SketchModule.registerSerde();
     sm = new SketchModule();
@@ -150,7 +138,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
   public void testSimpleDataIngestAndGpByQuery(GroupByQueryConfig config, String vectorize) throws Exception
   {
-    initSketchAggregationWithSimpleDataTest(config, vectorize);
+    setup(config);
     try (
         final AggregationTestHelper gpByQueryAggregationTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
             sm.getJacksonModules(),
@@ -309,7 +297,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
   public void testSimpleDataIngestAndTimeseriesQuery(GroupByQueryConfig config, String vectorize) throws Exception
   {
-    initSketchAggregationWithSimpleDataTest(config, vectorize);
+    setup(config);
     AggregationTestHelper timeseriesQueryAggregationTestHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
         sm.getJacksonModules(),
         tempFolder
@@ -392,7 +380,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
   public void testSimpleDataIngestAndTopNQuery(GroupByQueryConfig config, String vectorize) throws Exception
   {
-    initSketchAggregationWithSimpleDataTest(config, vectorize);
+    setup(config);
     AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelperWithTempDir(
         sm.getJacksonModules(),
         tempFolder
@@ -479,7 +467,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
   public void testTopNQueryWithSketchConstant(GroupByQueryConfig config, String vectorize) throws Exception
   {
-    initSketchAggregationWithSimpleDataTest(config, vectorize);
+    setup(config);
     AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelperWithTempDir(
         sm.getJacksonModules(),
         tempFolder

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
@@ -148,7 +148,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSimpleDataIngestAndGpByQuery(GroupByQueryConfig config,String vectorize) throws Exception
+  public void testSimpleDataIngestAndGpByQuery(GroupByQueryConfig config, String vectorize) throws Exception
   {
     initSketchAggregationWithSimpleDataTest(config, vectorize);
     try (
@@ -307,7 +307,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSimpleDataIngestAndTimeseriesQuery(GroupByQueryConfig config,String vectorize) throws Exception
+  public void testSimpleDataIngestAndTimeseriesQuery(GroupByQueryConfig config, String vectorize) throws Exception
   {
     initSketchAggregationWithSimpleDataTest(config, vectorize);
     AggregationTestHelper timeseriesQueryAggregationTestHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
@@ -390,7 +390,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testSimpleDataIngestAndTopNQuery(GroupByQueryConfig config,String vectorize) throws Exception
+  public void testSimpleDataIngestAndTopNQuery(GroupByQueryConfig config, String vectorize) throws Exception
   {
     initSketchAggregationWithSimpleDataTest(config, vectorize);
     AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelperWithTempDir(
@@ -477,7 +477,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "config = {0}, vectorize = {1}")
-  public void testTopNQueryWithSketchConstant(GroupByQueryConfig config,String vectorize) throws Exception
+  public void testTopNQueryWithSketchConstant(GroupByQueryConfig config, String vectorize) throws Exception
   {
     initSketchAggregationWithSimpleDataTest(config, vectorize);
     AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelperWithTempDir(

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
@@ -30,6 +30,7 @@ import org.apache.druid.data.input.impl.DelimitedInputFormat;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.query.Druids;
@@ -58,7 +59,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -108,7 +108,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
         )
     ) {
 
-      s1 = Files.createTempDirectory(tempFolder.toPath(), "sketch").toFile();
+      s1 = FileUtils.createTempDirInLocation(tempFolder.toPath(), "sketch");
       final InputRowSchema schema = new InputRowSchema(
           new TimestampSpec("timestamp", "yyyyMMddHH", null),
           new DimensionsSpec(DimensionsSpec.getDefaultSchemas(List.of("product"))),
@@ -129,7 +129,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
           5000
       );
 
-      s2 = Files.createTempDirectory(tempFolder.toPath(), "sketch").toFile();
+      s2 = FileUtils.createTempDirInLocation(tempFolder.toPath(), "sketch");
       toolchest.createIndex(
           new File(this.getClass().getClassLoader().getResource("simple_test_data.tsv").getFile()),
           schema,

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregationWithSimpleDataTest.java
@@ -51,15 +51,14 @@ import org.apache.druid.query.topn.NumericTopNMetricSpec;
 import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -67,26 +66,24 @@ import java.util.List;
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class SketchAggregationWithSimpleDataTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private File tempFolder;
 
-  private final GroupByQueryConfig config;
-  private final QueryContexts.Vectorize vectorize;
+  private GroupByQueryConfig config;
+  private QueryContexts.Vectorize vectorize;
 
   private SketchModule sm;
   private File s1;
   private File s2;
 
-  public SketchAggregationWithSimpleDataTest(GroupByQueryConfig config, String vectorize)
+  public void initSketchAggregationWithSimpleDataTest(GroupByQueryConfig config, String vectorize)
   {
     this.config = config;
     this.vectorize = QueryContexts.Vectorize.fromString(vectorize);
   }
 
-  @Parameterized.Parameters(name = "config = {0}, vectorize = {1}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -98,20 +95,20 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
     return constructors;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     SketchModule.registerSerde();
     sm = new SketchModule();
     try (
-        final AggregationTestHelper toolchest = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+        final AggregationTestHelper toolchest = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
             sm.getJacksonModules(),
             config,
             tempFolder
         )
     ) {
 
-      s1 = tempFolder.newFolder();
+      s1 = Files.createTempDirectory(tempFolder.toPath(), "sketch").toFile();
       final InputRowSchema schema = new InputRowSchema(
           new TimestampSpec("timestamp", "yyyyMMddHH", null),
           new DimensionsSpec(DimensionsSpec.getDefaultSchemas(List.of("product"))),
@@ -132,7 +129,7 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
           5000
       );
 
-      s2 = tempFolder.newFolder();
+      s2 = Files.createTempDirectory(tempFolder.toPath(), "sketch").toFile();
       toolchest.createIndex(
           new File(this.getClass().getClassLoader().getResource("simple_test_data.tsv").getFile()),
           schema,
@@ -149,11 +146,13 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
     }
   }
 
-  @Test
-  public void testSimpleDataIngestAndGpByQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSimpleDataIngestAndGpByQuery(GroupByQueryConfig config,String vectorize) throws Exception
   {
+    initSketchAggregationWithSimpleDataTest(config, vectorize);
     try (
-        final AggregationTestHelper gpByQueryAggregationTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+        final AggregationTestHelper gpByQueryAggregationTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
             sm.getJacksonModules(),
             config,
             tempFolder
@@ -232,8 +231,8 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
       );
 
       List<MapBasedRow> results = seq.map(row -> row.toMapBasedRow(groupByQuery)).toList();
-      Assert.assertEquals(5, results.size());
-      Assert.assertEquals(
+      Assertions.assertEquals(5, results.size());
+      Assertions.assertEquals(
           ImmutableList.of(
               new MapBasedRow(
                   DateTimes.of("2014-10-19T00:00:00.000Z"),
@@ -306,10 +305,12 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
     }
   }
 
-  @Test
-  public void testSimpleDataIngestAndTimeseriesQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSimpleDataIngestAndTimeseriesQuery(GroupByQueryConfig config,String vectorize) throws Exception
   {
-    AggregationTestHelper timeseriesQueryAggregationTestHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelper(
+    initSketchAggregationWithSimpleDataTest(config, vectorize);
+    AggregationTestHelper timeseriesQueryAggregationTestHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
         sm.getJacksonModules(),
         tempFolder
     );
@@ -376,21 +377,23 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
 
     Result<TimeseriesResultValue> result = Iterables.getOnlyElement(seq.toList());
 
-    Assert.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
+    Assertions.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
 
-    Assert.assertEquals(50.0, result.getValue().getDoubleMetric("sketch_count"), 0.01);
-    Assert.assertEquals(50.0, result.getValue().getDoubleMetric("sketchEstimatePostAgg"), 0.01);
-    Assert.assertEquals(50.0, result.getValue().getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
-    Assert.assertEquals(50.0, result.getValue().getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
-    Assert.assertEquals(0.0, result.getValue().getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
-    Assert.assertEquals(0.0, result.getValue().getDoubleMetric("non_existing_col_validation"), 0.01);
+    Assertions.assertEquals(50.0, result.getValue().getDoubleMetric("sketch_count"), 0.01);
+    Assertions.assertEquals(50.0, result.getValue().getDoubleMetric("sketchEstimatePostAgg"), 0.01);
+    Assertions.assertEquals(50.0, result.getValue().getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(50.0, result.getValue().getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(0.0, result.getValue().getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
+    Assertions.assertEquals(0.0, result.getValue().getDoubleMetric("non_existing_col_validation"), 0.01);
   }
 
 
-  @Test
-  public void testSimpleDataIngestAndTopNQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testSimpleDataIngestAndTopNQuery(GroupByQueryConfig config,String vectorize) throws Exception
   {
-    AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelper(
+    initSketchAggregationWithSimpleDataTest(config, vectorize);
+    AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelperWithTempDir(
         sm.getJacksonModules(),
         tempFolder
     );
@@ -460,22 +463,24 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
 
     Result<TopNResultValue> result = Iterables.getOnlyElement(seq.toList());
 
-    Assert.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
+    Assertions.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
 
     DimensionAndMetricValueExtractor value = Iterables.getOnlyElement(result.getValue().getValue());
-    Assert.assertEquals(38.0, value.getDoubleMetric("sketch_count"), 0.01);
-    Assert.assertEquals(38.0, value.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
-    Assert.assertEquals(38.0, value.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
-    Assert.assertEquals(38.0, value.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
-    Assert.assertEquals(0.0, value.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
-    Assert.assertEquals(0.0, value.getDoubleMetric("non_existing_col_validation"), 0.01);
-    Assert.assertEquals("product_3", value.getDimensionValue("product"));
+    Assertions.assertEquals(38.0, value.getDoubleMetric("sketch_count"), 0.01);
+    Assertions.assertEquals(38.0, value.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
+    Assertions.assertEquals(38.0, value.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(38.0, value.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(0.0, value.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
+    Assertions.assertEquals(0.0, value.getDoubleMetric("non_existing_col_validation"), 0.01);
+    Assertions.assertEquals("product_3", value.getDimensionValue("product"));
   }
 
-  @Test
-  public void testTopNQueryWithSketchConstant() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "config = {0}, vectorize = {1}")
+  public void testTopNQueryWithSketchConstant(GroupByQueryConfig config,String vectorize) throws Exception
   {
-    AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelper(
+    initSketchAggregationWithSimpleDataTest(config, vectorize);
+    AggregationTestHelper topNQueryAggregationTestHelper = AggregationTestHelper.createTopNQueryAggregationTestHelperWithTempDir(
         sm.getJacksonModules(),
         tempFolder
     );
@@ -550,34 +555,34 @@ public class SketchAggregationWithSimpleDataTest extends InitializedNullHandling
 
     Result<TopNResultValue> result = Iterables.getOnlyElement(seq.toList());
 
-    Assert.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
+    Assertions.assertEquals(DateTimes.of("2014-10-20T00:00:00.000Z"), result.getTimestamp());
 
     DimensionAndMetricValueExtractor value1 = Iterables.get(result.getValue().getValue(), 0);
-    Assert.assertEquals(38.0, value1.getDoubleMetric("sketch_count"), 0.01);
-    Assert.assertEquals(38.0, value1.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
-    Assert.assertEquals(2.0, value1.getDoubleMetric("sketchEstimatePostAggForSketchConstant"), 0.01);
-    Assert.assertEquals(39.0, value1.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
-    Assert.assertEquals(1.0, value1.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
-    Assert.assertEquals(37.0, value1.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
-    Assert.assertEquals("product_3", value1.getDimensionValue("product"));
+    Assertions.assertEquals(38.0, value1.getDoubleMetric("sketch_count"), 0.01);
+    Assertions.assertEquals(38.0, value1.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
+    Assertions.assertEquals(2.0, value1.getDoubleMetric("sketchEstimatePostAggForSketchConstant"), 0.01);
+    Assertions.assertEquals(39.0, value1.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(1.0, value1.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(37.0, value1.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
+    Assertions.assertEquals("product_3", value1.getDimensionValue("product"));
 
     DimensionAndMetricValueExtractor value2 = Iterables.get(result.getValue().getValue(), 1);
-    Assert.assertEquals(42.0, value2.getDoubleMetric("sketch_count"), 0.01);
-    Assert.assertEquals(42.0, value2.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
-    Assert.assertEquals(2.0, value2.getDoubleMetric("sketchEstimatePostAggForSketchConstant"), 0.01);
-    Assert.assertEquals(42.0, value2.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
-    Assert.assertEquals(2.0, value2.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
-    Assert.assertEquals(40.0, value2.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
-    Assert.assertEquals("product_1", value2.getDimensionValue("product"));
+    Assertions.assertEquals(42.0, value2.getDoubleMetric("sketch_count"), 0.01);
+    Assertions.assertEquals(42.0, value2.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
+    Assertions.assertEquals(2.0, value2.getDoubleMetric("sketchEstimatePostAggForSketchConstant"), 0.01);
+    Assertions.assertEquals(42.0, value2.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(2.0, value2.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(40.0, value2.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
+    Assertions.assertEquals("product_1", value2.getDimensionValue("product"));
 
     DimensionAndMetricValueExtractor value3 = Iterables.get(result.getValue().getValue(), 2);
-    Assert.assertEquals(42.0, value3.getDoubleMetric("sketch_count"), 0.01);
-    Assert.assertEquals(42.0, value3.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
-    Assert.assertEquals(2.0, value3.getDoubleMetric("sketchEstimatePostAggForSketchConstant"), 0.01);
-    Assert.assertEquals(42.0, value3.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
-    Assert.assertEquals(2.0, value3.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
-    Assert.assertEquals(40.0, value3.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
-    Assert.assertEquals("product_2", value3.getDimensionValue("product"));
+    Assertions.assertEquals(42.0, value3.getDoubleMetric("sketch_count"), 0.01);
+    Assertions.assertEquals(42.0, value3.getDoubleMetric("sketchEstimatePostAgg"), 0.01);
+    Assertions.assertEquals(2.0, value3.getDoubleMetric("sketchEstimatePostAggForSketchConstant"), 0.01);
+    Assertions.assertEquals(42.0, value3.getDoubleMetric("sketchUnionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(2.0, value3.getDoubleMetric("sketchIntersectionPostAggEstimate"), 0.01);
+    Assertions.assertEquals(40.0, value3.getDoubleMetric("sketchAnotBPostAggEstimate"), 0.01);
+    Assertions.assertEquals("product_2", value3.getDimensionValue("product"));
   }
 
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchAggregatorFactoryTest.java
@@ -41,9 +41,9 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.vector.TestVectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SketchAggregatorFactoryTest
 {
@@ -56,7 +56,7 @@ public class SketchAggregatorFactoryTest
   private ColumnSelectorFactory metricFactory;
   private VectorColumnSelectorFactory vectorFactory;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     final ColumnCapabilitiesImpl columnCapabilities = ColumnCapabilitiesImpl.createDefault().setType(ColumnType.NESTED_DATA);
@@ -67,20 +67,20 @@ public class SketchAggregatorFactoryTest
   @Test
   public void testGuessAggregatorHeapFootprint()
   {
-    Assert.assertEquals(288, AGGREGATOR_16384.guessAggregatorHeapFootprint(1));
-    Assert.assertEquals(1056, AGGREGATOR_16384.guessAggregatorHeapFootprint(100));
-    Assert.assertEquals(262176, AGGREGATOR_16384.guessAggregatorHeapFootprint(1_000_000_000_000L));
+    Assertions.assertEquals(288, AGGREGATOR_16384.guessAggregatorHeapFootprint(1));
+    Assertions.assertEquals(1056, AGGREGATOR_16384.guessAggregatorHeapFootprint(100));
+    Assertions.assertEquals(262176, AGGREGATOR_16384.guessAggregatorHeapFootprint(1_000_000_000_000L));
 
-    Assert.assertEquals(288, AGGREGATOR_32768.guessAggregatorHeapFootprint(1));
-    Assert.assertEquals(1056, AGGREGATOR_32768.guessAggregatorHeapFootprint(100));
-    Assert.assertEquals(524320, AGGREGATOR_32768.guessAggregatorHeapFootprint(1_000_000_000_000L));
+    Assertions.assertEquals(288, AGGREGATOR_32768.guessAggregatorHeapFootprint(1));
+    Assertions.assertEquals(1056, AGGREGATOR_32768.guessAggregatorHeapFootprint(100));
+    Assertions.assertEquals(524320, AGGREGATOR_32768.guessAggregatorHeapFootprint(1_000_000_000_000L));
   }
 
   @Test
   public void testMaxIntermediateSize()
   {
-    Assert.assertEquals(262176, AGGREGATOR_16384.getMaxIntermediateSize());
-    Assert.assertEquals(524320, AGGREGATOR_32768.getMaxIntermediateSize());
+    Assertions.assertEquals(262176, AGGREGATOR_16384.getMaxIntermediateSize());
+    Assertions.assertEquals(524320, AGGREGATOR_32768.getMaxIntermediateSize());
   }
 
   @Test
@@ -93,10 +93,10 @@ public class SketchAggregatorFactoryTest
     EasyMock.replay(colSelectorFactory);
 
     AggregatorAndSize aggregatorAndSize = AGGREGATOR_16384.factorizeWithSize(colSelectorFactory);
-    Assert.assertEquals(48, aggregatorAndSize.getInitialSizeBytes());
+    Assertions.assertEquals(48, aggregatorAndSize.getInitialSizeBytes());
 
     aggregatorAndSize = AGGREGATOR_32768.factorizeWithSize(colSelectorFactory);
-    Assert.assertEquals(48, aggregatorAndSize.getInitialSizeBytes());
+    Assertions.assertEquals(48, aggregatorAndSize.getInitialSizeBytes());
   }
 
   @Test
@@ -152,7 +152,7 @@ public class SketchAggregatorFactoryTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)
@@ -183,36 +183,36 @@ public class SketchAggregatorFactoryTest
   @Test
   public void testWithName()
   {
-    Assert.assertEquals(AGGREGATOR_16384, AGGREGATOR_16384.withName("x"));
-    Assert.assertEquals("newTest", AGGREGATOR_16384.withName("newTest").getName());
+    Assertions.assertEquals(AGGREGATOR_16384, AGGREGATOR_16384.withName("x"));
+    Assertions.assertEquals("newTest", AGGREGATOR_16384.withName("newTest").getName());
   }
 
   @Test
   public void testFactorizeOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorize(metricFactory));
-    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorize(metricFactory));
+    Assertions.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 
   @Test
   public void testFactorizeWithSizeOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeWithSize(metricFactory));
-    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeWithSize(metricFactory));
+    Assertions.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 
   @Test
   public void testFactorizeBufferedOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeBuffered(metricFactory));
-    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeBuffered(metricFactory));
+    Assertions.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 
   @Test
   public void testFactorizeVectorOnUnsupportedComplexColumn()
   {
-    Throwable exception = Assert.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeVector(vectorFactory));
-    Assert.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
+    Throwable exception = Assertions.assertThrows(DruidException.class, () -> AGGREGATOR_16384.factorizeVector(vectorFactory));
+    Assertions.assertEquals("Unsupported input [x] of type [COMPLEX<json>] for aggregator [COMPLEX<thetaSketchBuild>].", exception.getMessage());
   }
 
   @Test
@@ -223,9 +223,9 @@ public class SketchAggregatorFactoryTest
     AggregatorFactory sketch3 = new SketchMergeAggregatorFactory("sketch", "x", null, false, false, 3);
     AggregatorFactory sketch4 = new SketchMergeAggregatorFactory("sketch", "y", null, false, false, null);
 
-    Assert.assertNotNull(sketch1.substituteCombiningFactory(sketch2));
-    Assert.assertNotNull(sketch1.substituteCombiningFactory(sketch3));
-    Assert.assertNull(sketch1.substituteCombiningFactory(sketch4));
-    Assert.assertNull(sketch2.substituteCombiningFactory(sketch1));
+    Assertions.assertNotNull(sketch1.substituteCombiningFactory(sketch2));
+    Assertions.assertNotNull(sketch1.substituteCombiningFactory(sketch3));
+    Assertions.assertNull(sketch1.substituteCombiningFactory(sketch4));
+    Assertions.assertNull(sketch2.substituteCombiningFactory(sketch1));
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBoundsTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchEstimateWithErrorBoundsTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.query.aggregation.datasketches.theta;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -36,7 +36,7 @@ public class SketchEstimateWithErrorBoundsTest
 
     SketchEstimateWithErrorBounds est = new SketchEstimateWithErrorBounds(100.0, 101.5, 98.5, 2);
     
-    Assert.assertEquals(est, mapper.readValue(
+    Assertions.assertEquals(est, mapper.readValue(
             mapper.writeValueAsString(est), SketchEstimateWithErrorBounds.class));
   }
 

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchHolderObjectStrategyTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchHolderObjectStrategyTest.java
@@ -24,8 +24,8 @@ import org.apache.datasketches.common.SketchesArgumentException;
 import org.apache.datasketches.theta.SetOperation;
 import org.apache.datasketches.theta.Union;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -36,7 +36,7 @@ public class SketchHolderObjectStrategyTest
   public void testSafeRead()
   {
     SketchHolderObjectStrategy objectStrategy = new SketchHolderObjectStrategy();
-    Assert.assertTrue(objectStrategy.readRetainsBufferReference());
+    Assertions.assertTrue(objectStrategy.readRetainsBufferReference());
     Union union = (Union) SetOperation.builder().setNominalEntries(1024).build(Family.UNION);
     union.update(1234L);
 
@@ -55,7 +55,7 @@ public class SketchHolderObjectStrategyTest
       }
 
       final ByteBuffer buf2 = ByteBuffer.wrap(garbage2).order(ByteOrder.LITTLE_ENDIAN);
-      Assert.assertThrows(
+      Assertions.assertThrows(
           IndexOutOfBoundsException.class,
           () -> objectStrategy.fromByteBufferSafe(buf2, garbage2.length).getSketch().compact().getCompactBytes()
       );
@@ -64,7 +64,7 @@ public class SketchHolderObjectStrategyTest
     // non sketch that is too short to contain header should fail with regular java buffer exception
     final byte[] garbage = new byte[]{0x01, 0x02};
     final ByteBuffer buf3 = ByteBuffer.wrap(garbage).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> objectStrategy.fromByteBufferSafe(buf3, garbage.length).getSketch().compact().getCompactBytes()
     );
@@ -72,7 +72,7 @@ public class SketchHolderObjectStrategyTest
     // non sketch that is long enough to check (this one doesn't actually need 'safe' read)
     final byte[] garbageLonger = StringUtils.toUtf8("notasketch");
     final ByteBuffer buf4 = ByteBuffer.wrap(garbageLonger).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         SketchesArgumentException.class,
         () -> objectStrategy.fromByteBufferSafe(buf4, garbageLonger.length).getSketch().compact().getCompactBytes()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchHolderTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchHolderTest.java
@@ -23,8 +23,8 @@ import org.apache.datasketches.common.Family;
 import org.apache.datasketches.theta.SetOperation;
 import org.apache.datasketches.theta.Union;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -38,13 +38,13 @@ public class SketchHolderTest
     final byte[] bytes = union.getResult().toByteArray();
     final String base64 = StringUtils.encodeBase64String(bytes);
 
-    Assert.assertArrayEquals(bytes, SketchHolder.deserializeSafe(union.getResult()).getSketch().toByteArray());
-    Assert.assertArrayEquals(bytes, SketchHolder.deserializeSafe(bytes).getSketch().toByteArray());
-    Assert.assertArrayEquals(bytes, SketchHolder.deserializeSafe(base64).getSketch().toByteArray());
+    Assertions.assertArrayEquals(bytes, SketchHolder.deserializeSafe(union.getResult()).getSketch().toByteArray());
+    Assertions.assertArrayEquals(bytes, SketchHolder.deserializeSafe(bytes).getSketch().toByteArray());
+    Assertions.assertArrayEquals(bytes, SketchHolder.deserializeSafe(base64).getSketch().toByteArray());
 
     final byte[] trunacted = Arrays.copyOfRange(bytes, 0, 10);
-    Assert.assertThrows(IndexOutOfBoundsException.class, () -> SketchHolder.deserializeSafe(trunacted));
-    Assert.assertThrows(
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> SketchHolder.deserializeSafe(trunacted));
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> SketchHolder.deserializeSafe(StringUtils.encodeBase64String(trunacted))
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchSetPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchSetPostAggregatorTest.java
@@ -31,31 +31,30 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class SketchSetPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testConstructorNumFields()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Illegal number of fields[0], must be > 1");
-    new SketchSetPostAggregator(
-        "summary",
-        "UNION",
-        null,
-        ImmutableList.of()
-    );
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      new SketchSetPostAggregator(
+          "summary",
+          "UNION",
+          null,
+          ImmutableList.of()
+      );
+    });
+    assertTrue(exception.getMessage().contains("Illegal number of fields[0], must be > 1"));
   }
 
   @Test
@@ -94,8 +93,8 @@ public class SketchSetPostAggregatorTest
           PostAggregator.class
       );
 
-      Assert.assertEquals(there, andBackAgain);
-      Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+      Assertions.assertEquals(there, andBackAgain);
+      Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
     }
   }
 
@@ -112,7 +111,7 @@ public class SketchSetPostAggregatorTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "SketchSetPostAggregator{name='summary', fields=[FieldAccessPostAggregator{name='field1', fieldName='sketch'}, FieldAccessPostAggregator{name='field2', fieldName='sketch'}], func=UNION, size=16384}",
         postAgg.toString()
     );
@@ -154,7 +153,7 @@ public class SketchSetPostAggregatorTest
     );
     SketchHolder holder1 = (SketchHolder) postAgg1.compute(ImmutableMap.of());
     SketchHolder holder2 = (SketchHolder) postAgg2.compute(ImmutableMap.of());
-    Assert.assertEquals(0, postAgg1.getComparator().compare(holder1, holder2));
+    Assertions.assertEquals(0, postAgg1.getComparator().compare(holder1, holder2));
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchToStringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/SketchToStringPostAggregatorTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.TestObjectColumnSelector;
 import org.apache.druid.query.aggregation.post.FieldAccessPostAggregator;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,8 +53,8 @@ public class SketchToStringPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -65,7 +65,7 @@ public class SketchToStringPostAggregatorTest
         new FieldAccessPostAggregator("field", "sketch")
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "SketchToStringPostAggregator{name='summary', field=FieldAccessPostAggregator{name='field', fieldName='sketch'}}",
         postAgg.toString()
     );
@@ -95,7 +95,7 @@ public class SketchToStringPostAggregatorTest
     );
     String summary1 = (String) postAgg1.compute(ImmutableMap.of());
     String summary2 = (String) postAgg2.compute(ImmutableMap.of());
-    Assert.assertEquals(0, postAgg1.getComparator().compare(summary1, summary2));
+    Assertions.assertEquals(0, postAgg1.getComparator().compare(summary1, summary2));
   }
 
   @Test
@@ -123,8 +123,8 @@ public class SketchToStringPostAggregatorTest
     );
 
     final String summary = (String) postAgg.compute(fields);
-    Assert.assertNotNull(summary);
-    Assert.assertTrue(summary.contains("SUMMARY"));
+    Assertions.assertNotNull(summary);
+    Assertions.assertTrue(summary.contains("SUMMARY"));
   }
 
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/ThetaSketchBuildSegmentMetadataQueryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/ThetaSketchBuildSegmentMetadataQueryTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.query.aggregation.AggregatorFactory;
 import org.apache.druid.query.aggregation.datasketches.BaseSketchBuildSegmentMetadataQueryTest;
 import org.apache.druid.segment.column.ColumnType;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 public class ThetaSketchBuildSegmentMetadataQueryTest extends BaseSketchBuildSegmentMetadataQueryTest
 {
@@ -51,17 +51,17 @@ public class ThetaSketchBuildSegmentMetadataQueryTest extends BaseSketchBuildSeg
   @Override
   protected void assertMergedSketchAggregator(AggregatorFactory aggregator, String sketchColumn)
   {
-    Assert.assertTrue(
-        "Sketch aggregator should be SketchMergeAggregatorFactory but was " + aggregator.getClass().getName(),
-        aggregator instanceof SketchMergeAggregatorFactory
+    Assertions.assertTrue(
+        aggregator instanceof SketchMergeAggregatorFactory,
+        "Sketch aggregator should be SketchMergeAggregatorFactory but was " + aggregator.getClass().getName()
     );
 
     SketchMergeAggregatorFactory thetaAggregator = (SketchMergeAggregatorFactory) aggregator;
-    Assert.assertEquals("Aggregator name should match", sketchColumn, thetaAggregator.getName());
-    Assert.assertEquals("Field name should match", sketchColumn, thetaAggregator.getFieldName());
-    Assert.assertEquals("size should be default value", SketchAggregatorFactory.DEFAULT_MAX_SKETCH_SIZE, thetaAggregator.getSize());
-    Assert.assertFalse("shouldFinalize should be false", thetaAggregator.getShouldFinalize());
-    Assert.assertFalse("isInputThetaSketch should be false", thetaAggregator.getIsInputThetaSketch());
-    Assert.assertNull("errorBoundsStdDev should be null", thetaAggregator.getErrorBoundsStdDev());
+    Assertions.assertEquals(sketchColumn, thetaAggregator.getName(), "Aggregator name should match");
+    Assertions.assertEquals(sketchColumn, thetaAggregator.getFieldName(), "Field name should match");
+    Assertions.assertEquals(SketchAggregatorFactory.DEFAULT_MAX_SKETCH_SIZE, thetaAggregator.getSize(), "size should be default value");
+    Assertions.assertFalse(thetaAggregator.getShouldFinalize(), "shouldFinalize should be false");
+    Assertions.assertFalse(thetaAggregator.getIsInputThetaSketch(), "isInputThetaSketch should be false");
+    Assertions.assertNull(thetaAggregator.getErrorBoundsStdDev(), "errorBoundsStdDev should be null");
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
@@ -45,13 +45,11 @@ import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.groupby.epinephelinae.GroupByTestColumnSelectorFactory;
 import org.apache.druid.query.groupby.epinephelinae.GrouperTestUtil;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,27 +60,25 @@ import java.util.List;
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
 {
-  private final AggregationTestHelper helper;
+  private AggregationTestHelper helper;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private File tempFolder;
 
-  public OldApiSketchAggregationTest(final GroupByQueryConfig config)
+  public void initOldApiSketchAggregationTest(final GroupByQueryConfig config)
   {
     OldApiSketchModule sm = new OldApiSketchModule();
     sm.configure(null);
 
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         sm.getJacksonModules(),
         config,
         tempFolder
     );
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -92,15 +88,17 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
-  @Test
-  public void testSimpleDataIngestAndQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSimpleDataIngestAndQuery(final GroupByQueryConfig config) throws Exception
   {
+    initOldApiSketchAggregationTest(config);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
         .setDataSource("test_datasource")
         .setGranularity(Granularities.ALL)
@@ -172,8 +170,8 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     );
 
     List results = seq.toList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertEquals(
         ResultRow.fromLegacyRow(
             new MapBasedRow(
                 DateTimes.of("2014-10-19T00:00:00.000Z"),
@@ -193,9 +191,11 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testSketchDataIngestAndQuery() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSketchDataIngestAndQuery(final GroupByQueryConfig config) throws Exception
   {
+    initOldApiSketchAggregationTest(config);
     final GroupByQuery groupByQuery = GroupByQuery.builder()
         .setDataSource("test_datasource")
         .setGranularity(Granularities.ALL)
@@ -267,8 +267,8 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     );
 
     List results = seq.toList();
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, results.size());
+    Assertions.assertEquals(
         ResultRow.fromLegacyRow(
             new MapBasedRow(
                 DateTimes.of("2014-10-19T00:00:00.000Z"),
@@ -288,23 +288,27 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testSketchMergeAggregatorFactorySerde() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSketchMergeAggregatorFactorySerde(final GroupByQueryConfig config) throws Exception
   {
+    initOldApiSketchAggregationTest(config);
     assertAggregatorFactorySerde(new OldSketchMergeAggregatorFactory("name", "fieldName", 16, null));
     assertAggregatorFactorySerde(new OldSketchMergeAggregatorFactory("name", "fieldName", 16, false));
     assertAggregatorFactorySerde(new OldSketchMergeAggregatorFactory("name", "fieldName", 16, true));
   }
 
-  @Test
-  public void testSketchBuildAggregatorFactorySerde() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSketchBuildAggregatorFactorySerde(final GroupByQueryConfig config) throws Exception
   {
+    initOldApiSketchAggregationTest(config);
     assertAggregatorFactorySerde(new OldSketchBuildAggregatorFactory("name", "fieldName", 16));
   }
 
   private void assertAggregatorFactorySerde(AggregatorFactory agg) throws Exception
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         agg,
         helper.getObjectMapper().readValue(
             helper.getObjectMapper().writeValueAsString(agg),
@@ -313,9 +317,11 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testSketchEstimatePostAggregatorSerde() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSketchEstimatePostAggregatorSerde(final GroupByQueryConfig config) throws Exception
   {
+    initOldApiSketchAggregationTest(config);
     assertPostAggregatorSerde(
         new OldSketchEstimatePostAggregator(
             "name",
@@ -324,9 +330,11 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testSketchSetPostAggregatorSerde() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testSketchSetPostAggregatorSerde(final GroupByQueryConfig config) throws Exception
   {
+    initOldApiSketchAggregationTest(config);
     assertPostAggregatorSerde(
         new OldSketchSetPostAggregator(
             "name",
@@ -340,9 +348,11 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testRelocation()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testRelocation(final GroupByQueryConfig config)
   {
+    initOldApiSketchAggregationTest(config);
     final GroupByTestColumnSelectorFactory columnSelectorFactory = GrouperTestUtil.newColumnSelectorFactory();
     SketchHolder sketchHolder = SketchHolder.of(Sketches.updateSketchBuilder().setNominalEntries(16).build());
     UpdateSketch updateSketch = (UpdateSketch) sketchHolder.getSketch();
@@ -354,29 +364,33 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
         columnSelectorFactory,
         SketchHolder.class
     );
-    Assert.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
+    Assertions.assertEquals(holders[0].getEstimate(), holders[1].getEstimate(), 0);
   }
 
-  @Test
-  public void testWithNameMerge()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testWithNameMerge(final GroupByQueryConfig config)
   {
+    initOldApiSketchAggregationTest(config);
     OldSketchMergeAggregatorFactory factory = new OldSketchMergeAggregatorFactory("name", "fieldName", 16, null);
-    Assert.assertEquals(factory, factory.withName("name"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("name"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 
 
-  @Test
-  public void testWithNameBuild()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testWithNameBuild(final GroupByQueryConfig config)
   {
+    initOldApiSketchAggregationTest(config);
     OldSketchBuildAggregatorFactory factory = new OldSketchBuildAggregatorFactory("name", "fieldName", 16);
-    Assert.assertEquals(factory, factory.withName("name"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("name"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 
   private void assertPostAggregatorSerde(PostAggregator agg) throws Exception
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         agg,
         helper.getObjectMapper().readValue(
             helper.getObjectMapper().writeValueAsString(agg),

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/oldapi/OldApiSketchAggregationTest.java
@@ -91,7 +91,10 @@ public class OldApiSketchAggregationTest extends InitializedNullHandlingTest
   @AfterEach
   public void teardown() throws IOException
   {
-    helper.close();
+    if (helper != null) {
+      helper.close();
+      helper = null;
+    }
   }
 
   @MethodSource("constructorFeeder")

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -76,7 +76,7 @@ import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -379,7 +379,7 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
   @Test
   public void testApproxCountDistinctFunctionOnUnsupportedComplexColumn()
   {
-    DruidException druidException = Assert.assertThrows(
+    DruidException druidException = Assertions.assertThrows(
         DruidException.class,
         () -> testQuery(
             "SELECT APPROX_COUNT_DISTINCT_DS_THETA(double_first_added) FROM druid.wikipedia_first_last",
@@ -387,7 +387,7 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
             ImmutableList.of()
         )
     );
-    Assert.assertTrue(druidException.getMessage().contains(
+    Assertions.assertTrue(druidException.getMessage().contains(
         "Cannot apply 'APPROX_COUNT_DISTINCT_DS_THETA' to arguments of type 'APPROX_COUNT_DISTINCT_DS_THETA(<COMPLEX<SERIALIZABLEPAIRLONGDOUBLE>>)'"
     ));
   }
@@ -1148,7 +1148,7 @@ public class ThetaSketchSqlAggregatorTest extends BaseCalciteQueryTest
       );
     }
     catch (IllegalArgumentException e) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           e.getMessage().contains("requires a ThetaSketch as the argument")
       );
     }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/theta/sql/ThetaSketchSqlAggregatorTest.java
@@ -77,7 +77,6 @@ import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Period;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregationTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregationTest.java
@@ -48,13 +48,11 @@ import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,24 +60,25 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-@RunWith(Parameterized.class)
 public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
-  private final AggregationTestHelper helper;
-  private final AggregationTestHelper tsHelper;
+  @TempDir
+  private File tempFolder;
+  private AggregationTestHelper helper;
+  private AggregationTestHelper tsHelper;
 
-  public ArrayOfDoublesSketchAggregationTest(final GroupByQueryConfig config)
+  public void initArrayOfDoublesSketchAggregationTest(final GroupByQueryConfig config)
   {
     ArrayOfDoublesSketchModule.registerSerde();
     DruidModule module = new ArrayOfDoublesSketchModule();
-    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    helper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         module.getJacksonModules(), config, tempFolder);
-    tsHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelper(module.getJacksonModules(), tempFolder);
+    tsHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
+        module.getJacksonModules(),
+        tempFolder
+    );
   }
 
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -89,15 +88,17 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
     return constructors;
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     helper.close();
   }
 
-  @Test
-  public void ingestingSketches() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void ingestingSketches(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/array_of_doubles_sketch_data.tsv").getFile()),
         new InputRowSchema(
@@ -179,23 +180,23 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    Assert.assertEquals("non_existing_sketch", 0, (double) row.get(1), 0);
-    Assert.assertEquals("estimate", 40.0, (double) row.get(2), 0);
-    Assert.assertArrayEquals("estimateAndBounds", new double[]{40.0, 40.0, 40.0}, (double[]) row.get(3), 0);
-    Assert.assertEquals("union", 40.0, (double) row.get(5), 0);
-    Assert.assertEquals("intersection", 40.0, (double) row.get(6), 0);
-    Assert.assertEquals("anotb", 0, (double) row.get(7), 0);
-    Assert.assertArrayEquals("variances", new double[]{0.0}, (double[]) row.get(9), 0);
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(0, (double) row.get(1), 0, "non_existing_sketch");
+    Assertions.assertEquals(40.0, (double) row.get(2), 0, "estimate");
+    Assertions.assertArrayEquals(new double[]{40.0, 40.0, 40.0}, (double[]) row.get(3), 0, "estimateAndBounds");
+    Assertions.assertEquals(40.0, (double) row.get(5), 0, "union");
+    Assertions.assertEquals(40.0, (double) row.get(6), 0, "intersection");
+    Assertions.assertEquals(0, (double) row.get(7), 0, "anotb");
+    Assertions.assertArrayEquals(new double[]{0.0}, (double[]) row.get(9), 0, "variances");
 
     Object obj = row.get(4); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(1.0, ds.getMinItem(), 0);
-    Assert.assertEquals(1.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(1.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(1.0, ds.getMaxItem(), 0);
 
     final String expectedSummary = "### HeapArrayOfDoublesCompactSketch SUMMARY: \n"
                                    + "   Estimate                : 40.0\n"
@@ -208,12 +209,14 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                                    + "   Retained Entries        : 40\n"
                                    + "   Seed Hash               : 93cc | 37836\n"
                                    + "### END SKETCH SUMMARY\n";
-    Assert.assertEquals("summary", expectedSummary, row.get(8));
+    Assertions.assertEquals(expectedSummary, row.get(8), "summary");
   }
 
-  @Test
-  public void ingestingSketchesTwoValues() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void ingestingSketchesTwoValues(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/array_of_doubles_sketch_data_two_values.tsv")
                      .getFile()),
@@ -287,32 +290,34 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    Assert.assertEquals("estimate", 40.0, (double) row.get(1), 0);
-    Assert.assertEquals("union", 40.0, (double) row.get(3), 0);
-    Assert.assertEquals("intersection", 40.0, (double) row.get(4), 0);
-    Assert.assertEquals("anotb", 0, (double) row.get(5), 0);
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(40.0, (double) row.get(1), 0, "estimate");
+    Assertions.assertEquals(40.0, (double) row.get(3), 0, "union");
+    Assertions.assertEquals(40.0, (double) row.get(4), 0, "intersection");
+    Assertions.assertEquals(0, (double) row.get(5), 0, "anotb");
 
     Object meansObj = row.get(6); // means
-    Assert.assertTrue(meansObj instanceof double[]);
+    Assertions.assertTrue(meansObj instanceof double[]);
     double[] means = (double[]) meansObj;
-    Assert.assertEquals(2, means.length);
-    Assert.assertEquals(1.0, means[0], 0);
-    Assert.assertEquals(2.0, means[1], 0);
+    Assertions.assertEquals(2, means.length);
+    Assertions.assertEquals(1.0, means[0], 0);
+    Assertions.assertEquals(2.0, means[1], 0);
 
     Object quantilesObj = row.get(2); // quantiles-sketch
-    Assert.assertTrue(quantilesObj instanceof DoublesSketch);
+    Assertions.assertTrue(quantilesObj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) quantilesObj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(1.0, ds.getMinItem(), 0);
-    Assert.assertEquals(1.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(1.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(1.0, ds.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtIngestionTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtIngestionTime(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/array_of_doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -381,25 +386,27 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    Assert.assertEquals("estimate", 40.0, (double) row.get(1), 0);
-    Assert.assertEquals("union", 40.0, (double) row.get(3), 0);
-    Assert.assertEquals("intersection", 40.0, (double) row.get(4), 0);
-    Assert.assertEquals("anotb", 0, (double) row.get(5), 0);
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(40.0, (double) row.get(1), 0, "estimate");
+    Assertions.assertEquals(40.0, (double) row.get(3), 0, "union");
+    Assertions.assertEquals(40.0, (double) row.get(4), 0, "intersection");
+    Assertions.assertEquals(0, (double) row.get(5), 0, "anotb");
 
     Object obj = row.get(2);  // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(1.0, ds.getMinItem(), 0);
-    Assert.assertEquals(1.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(1.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(1.0, ds.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtIngestionTimeTwoValues() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtIngestionTimeTwoValues(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(
             this.getClass().getClassLoader().getResource("tuple/array_of_doubles_build_data_two_values.tsv").getFile()),
@@ -473,32 +480,34 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    Assert.assertEquals("estimate", 40.0, (double) row.get(1), 0);
-    Assert.assertEquals("union", 40.0, (double) row.get(3), 0);
-    Assert.assertEquals("intersection", 40.0, (double) row.get(4), 0);
-    Assert.assertEquals("anotb", 0, (double) row.get(5), 0);
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(40.0, (double) row.get(1), 0, "estimate");
+    Assertions.assertEquals(40.0, (double) row.get(3), 0, "union");
+    Assertions.assertEquals(40.0, (double) row.get(4), 0, "intersection");
+    Assertions.assertEquals(0, (double) row.get(5), 0, "anotb");
 
     Object meansObj = row.get(6); // means
-    Assert.assertTrue(meansObj instanceof double[]);
+    Assertions.assertTrue(meansObj instanceof double[]);
     double[] means = (double[]) meansObj;
-    Assert.assertEquals(2, means.length);
-    Assert.assertEquals(1.0, means[0], 0);
-    Assert.assertEquals(2.0, means[1], 0);
+    Assertions.assertEquals(2, means.length);
+    Assertions.assertEquals(1.0, means[0], 0);
+    Assertions.assertEquals(2.0, means[1], 0);
 
     Object obj = row.get(2); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(2.0, ds.getMinItem(), 0);
-    Assert.assertEquals(2.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(2.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(2.0, ds.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtIngestionTimeTwoValuesAndNumericalKey() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtIngestionTimeTwoValuesAndNumericalKey(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(
             this.getClass().getClassLoader().getResource(
@@ -578,32 +587,34 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    Assert.assertEquals("estimate", 40.0, (double) row.get(1), 0);
-    Assert.assertEquals("union", 40.0, (double) row.get(3), 0);
-    Assert.assertEquals("intersection", 40.0, (double) row.get(4), 0);
-    Assert.assertEquals("anotb", 0, (double) row.get(5), 0);
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(40.0, (double) row.get(1), 0, "estimate");
+    Assertions.assertEquals(40.0, (double) row.get(3), 0, "union");
+    Assertions.assertEquals(40.0, (double) row.get(4), 0, "intersection");
+    Assertions.assertEquals(0, (double) row.get(5), 0, "anotb");
 
     Object meansObj = row.get(6); // means
-    Assert.assertTrue(meansObj instanceof double[]);
+    Assertions.assertTrue(meansObj instanceof double[]);
     double[] means = (double[]) meansObj;
-    Assert.assertEquals(2, means.length);
-    Assert.assertEquals(1.0, means[0], 0);
-    Assert.assertEquals(2.0, means[1], 0);
+    Assertions.assertEquals(2, means.length);
+    Assertions.assertEquals(1.0, means[0], 0);
+    Assertions.assertEquals(2.0, means[1], 0);
 
     Object obj = row.get(2); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(2.0, ds.getMinItem(), 0);
-    Assert.assertEquals(2.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(2.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(2.0, ds.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtIngestionTimeThreeValuesAndNulls() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtIngestionTimeThreeValuesAndNulls(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(
             this.getClass()
@@ -686,40 +697,42 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 30.0, (double) row.get(0), 0);
-    Assert.assertEquals("estimate", 30.0, (double) row.get(1), 0);
-    Assert.assertEquals("union", 30.0, (double) row.get(3), 0);
-    Assert.assertEquals("intersection", 30.0, (double) row.get(4), 0);
-    Assert.assertEquals("anotb", 0, (double) row.get(5), 0);
+    Assertions.assertEquals(30.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(30.0, (double) row.get(1), 0, "estimate");
+    Assertions.assertEquals(30.0, (double) row.get(3), 0, "union");
+    Assertions.assertEquals(30.0, (double) row.get(4), 0, "intersection");
+    Assertions.assertEquals(0, (double) row.get(5), 0, "anotb");
 
     Object meansObj = row.get(6); // means
-    Assert.assertTrue(meansObj instanceof double[]);
+    Assertions.assertTrue(meansObj instanceof double[]);
     double[] means = (double[]) meansObj;
-    Assert.assertEquals(3, means.length);
-    Assert.assertEquals(1.0, means[0], 0);
-    Assert.assertEquals(2.0, means[1], 0);
-    Assert.assertEquals(3.0, means[2], 0.1);
+    Assertions.assertEquals(3, means.length);
+    Assertions.assertEquals(1.0, means[0], 0);
+    Assertions.assertEquals(2.0, means[1], 0);
+    Assertions.assertEquals(3.0, means[2], 0.1);
 
     Object obj = row.get(2); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(30, ds.getN());
-    Assert.assertEquals(2.0, ds.getMinItem(), 0);
-    Assert.assertEquals(2.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(30, ds.getN());
+    Assertions.assertEquals(2.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(2.0, ds.getMaxItem(), 0);
 
     Object objSketch2 = row.get(7); // quantiles-sketch-with-nulls
-    Assert.assertTrue(objSketch2 instanceof DoublesSketch);
+    Assertions.assertTrue(objSketch2 instanceof DoublesSketch);
     DoublesSketch ds2 = (DoublesSketch) objSketch2;
-    Assert.assertEquals(30, ds2.getN());
-    Assert.assertEquals(3.0, ds2.getMinItem(), 0);
-    Assert.assertEquals(3.0, ds2.getMaxItem(), 0);
+    Assertions.assertEquals(30, ds2.getN());
+    Assertions.assertEquals(3.0, ds2.getMinItem(), 0);
+    Assertions.assertEquals(3.0, ds2.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtQueryTime() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtQueryTime(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/array_of_doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -795,26 +808,28 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("cnt", 40.0, Double.parseDouble(row.get(1).toString()), 0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    Assert.assertEquals("estimate", 40.0, Double.parseDouble(row.get(2).toString()), 0);
-    Assert.assertEquals("union", 40.0, Double.parseDouble(row.get(4).toString()), 0);
-    Assert.assertEquals("intersection", 40.0, Double.parseDouble(row.get(5).toString()), 0);
-    Assert.assertEquals("anotb", 0, Double.parseDouble(row.get(6).toString()), 0);
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(1).toString()), 0, "cnt");
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(2).toString()), 0, "estimate");
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(4).toString()), 0, "union");
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(5).toString()), 0, "intersection");
+    Assertions.assertEquals(0, Double.parseDouble(row.get(6).toString()), 0, "anotb");
 
     Object obj = row.get(3); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(1.0, ds.getMinItem(), 0);
-    Assert.assertEquals(1.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(1.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(1.0, ds.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtQueryTimeUseNumerical() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtQueryTimeUseNumerical(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/array_of_doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -890,26 +905,28 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("cnt", 40.0, Double.parseDouble(row.get(1).toString()), 0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    Assert.assertEquals("estimate", 40.0, Double.parseDouble(row.get(2).toString()), 0);
-    Assert.assertEquals("union", 40.0, Double.parseDouble(row.get(4).toString()), 0);
-    Assert.assertEquals("intersection", 40.0, Double.parseDouble(row.get(5).toString()), 0);
-    Assert.assertEquals("anotb", 0, Double.parseDouble(row.get(6).toString()), 0);
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(1).toString()), 0, "cnt");
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(2).toString()), 0, "estimate");
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(4).toString()), 0, "union");
+    Assertions.assertEquals(40.0, Double.parseDouble(row.get(5).toString()), 0, "intersection");
+    Assertions.assertEquals(0, Double.parseDouble(row.get(6).toString()), 0, "anotb");
 
     Object obj = row.get(3); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(1.0, ds.getMinItem(), 0);
-    Assert.assertEquals(1.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(1.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(1.0, ds.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtQueryTimeTimeseries() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtQueryTimeTimeseries(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<Result<TimeseriesResultValue>> seq = tsHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/array_of_doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -985,26 +1002,28 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
               .build()
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     TimeseriesResultValue row = results.get(0).getValue();
-    Assert.assertEquals("cnt", 40.0, row.getDoubleMetric("cnt"), 0);
-    Assert.assertEquals("sketch", 40.0, row.getDoubleMetric("sketch"), 0);
-    Assert.assertEquals("estimate", 40.0, row.getDoubleMetric("estimate"), 0);
-    Assert.assertEquals("union", 40.0, row.getDoubleMetric("union"), 0);
-    Assert.assertEquals("intersection", 40.0, row.getDoubleMetric("intersection"), 0);
-    Assert.assertEquals("anotb", 0, row.getDoubleMetric("anotb"), 0);
+    Assertions.assertEquals(40.0, row.getDoubleMetric("cnt"), 0, "cnt");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("sketch"), 0, "sketch");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("estimate"), 0, "estimate");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("union"), 0, "union");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("intersection"), 0, "intersection");
+    Assertions.assertEquals(0, row.getDoubleMetric("anotb"), 0, "anotb");
 
     Object obj = row.getMetric("quantiles-sketch"); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(1.0, ds.getMinItem(), 0);
-    Assert.assertEquals(1.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(1.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(1.0, ds.getMaxItem(), 0);
   }
 
-  @Test
-  public void buildingSketchesAtQueryTimeUsingNumericalTimeseries() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtQueryTimeUsingNumericalTimeseries(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<Result<TimeseriesResultValue>> seq = tsHelper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/array_of_doubles_build_data.tsv").getFile()),
         new InputRowSchema(
@@ -1080,28 +1099,30 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
               .build()
     );
     List<Result<TimeseriesResultValue>> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     TimeseriesResultValue row = results.get(0).getValue();
-    Assert.assertEquals("cnt", 40.0, row.getDoubleMetric("cnt"), 0);
-    Assert.assertEquals("sketch", 40.0, row.getDoubleMetric("sketch"), 0);
-    Assert.assertEquals("estimate", 40.0, row.getDoubleMetric("estimate"), 0);
-    Assert.assertEquals("union", 40.0, row.getDoubleMetric("union"), 0);
-    Assert.assertEquals("intersection", 40.0, row.getDoubleMetric("intersection"), 0);
-    Assert.assertEquals("anotb", 0, row.getDoubleMetric("anotb"), 0);
+    Assertions.assertEquals(40.0, row.getDoubleMetric("cnt"), 0, "cnt");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("sketch"), 0, "sketch");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("estimate"), 0, "estimate");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("union"), 0, "union");
+    Assertions.assertEquals(40.0, row.getDoubleMetric("intersection"), 0, "intersection");
+    Assertions.assertEquals(0, row.getDoubleMetric("anotb"), 0, "anotb");
 
     Object obj = row.getMetric("quantiles-sketch"); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(40, ds.getN());
-    Assert.assertEquals(1.0, ds.getMinItem(), 0);
-    Assert.assertEquals(1.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds.getN());
+    Assertions.assertEquals(1.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(1.0, ds.getMaxItem(), 0);
   }
 
   // Two buckets with statistically significant difference.
   // See GenerateTestData class for details.
-  @Test
-  public void buildingSketchesAtQueryTimeTwoBucketsTest() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtQueryTimeTwoBucketsTest(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass().getClassLoader().getResource("tuple/bucket_test_data.tsv").getFile()),
         new InputRowSchema(
@@ -1148,22 +1169,24 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
     Object obj = row.get(2); // p-value
-    Assert.assertTrue(obj instanceof double[]);
+    Assertions.assertTrue(obj instanceof double[]);
     double[] array = (double[]) obj;
-    Assert.assertEquals(1, array.length);
+    Assertions.assertEquals(1, array.length);
     double pValue = array[0];
     // Test and control buckets were constructed to have different means, so we
     // expect very low p value
-    Assert.assertEquals(0, pValue, 0.001);
+    Assertions.assertEquals(0, pValue, 0.001);
   }
 
   // Three buckets with null values
-  @Test
-  public void buildingSketchesAtQueryTimeWithNullsTest() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void buildingSketchesAtQueryTimeWithNullsTest(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
         new File(this.getClass()
                      .getClassLoader()
@@ -1267,52 +1290,54 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 30.0, (double) row.get(0), 0);
-    Assert.assertEquals("sketchNoNulls", 40.0, (double) row.get(1), 0);
-    Assert.assertEquals("estimate", 30.0, (double) row.get(2), 0);
-    Assert.assertEquals("estimateNoNulls", 40.0, (double) row.get(3), 0);
-    Assert.assertEquals("union", 30.0, (double) row.get(5), 0);
-    Assert.assertEquals("intersection", 30.0, (double) row.get(6), 0);
-    Assert.assertEquals("anotb", 0, (double) row.get(7), 0);
+    Assertions.assertEquals(30.0, (double) row.get(0), 0, "sketch");
+    Assertions.assertEquals(40.0, (double) row.get(1), 0, "sketchNoNulls");
+    Assertions.assertEquals(30.0, (double) row.get(2), 0, "estimate");
+    Assertions.assertEquals(40.0, (double) row.get(3), 0, "estimateNoNulls");
+    Assertions.assertEquals(30.0, (double) row.get(5), 0, "union");
+    Assertions.assertEquals(30.0, (double) row.get(6), 0, "intersection");
+    Assertions.assertEquals(0, (double) row.get(7), 0, "anotb");
 
     Object meansObj = row.get(8); // means
-    Assert.assertTrue(meansObj instanceof double[]);
+    Assertions.assertTrue(meansObj instanceof double[]);
     double[] means = (double[]) meansObj;
-    Assert.assertEquals(3, means.length);
-    Assert.assertEquals(1.0, means[0], 0);
-    Assert.assertEquals(2.0, means[1], 0);
-    Assert.assertEquals(3.0, means[2], 0.1);
+    Assertions.assertEquals(3, means.length);
+    Assertions.assertEquals(1.0, means[0], 0);
+    Assertions.assertEquals(2.0, means[1], 0);
+    Assertions.assertEquals(3.0, means[2], 0.1);
 
     Object obj = row.get(4); // quantiles-sketch
-    Assert.assertTrue(obj instanceof DoublesSketch);
+    Assertions.assertTrue(obj instanceof DoublesSketch);
     DoublesSketch ds = (DoublesSketch) obj;
-    Assert.assertEquals(30, ds.getN());
-    Assert.assertEquals(2.0, ds.getMinItem(), 0);
-    Assert.assertEquals(2.0, ds.getMaxItem(), 0);
+    Assertions.assertEquals(30, ds.getN());
+    Assertions.assertEquals(2.0, ds.getMinItem(), 0);
+    Assertions.assertEquals(2.0, ds.getMaxItem(), 0);
 
     Object objSketch2 = row.get(9); // quantiles-sketch-with-nulls
-    Assert.assertTrue(objSketch2 instanceof DoublesSketch);
+    Assertions.assertTrue(objSketch2 instanceof DoublesSketch);
     DoublesSketch ds2 = (DoublesSketch) objSketch2;
-    Assert.assertEquals(30, ds2.getN());
-    Assert.assertEquals(3.0, ds2.getMinItem(), 0);
-    Assert.assertEquals(3.0, ds2.getMaxItem(), 0);
+    Assertions.assertEquals(30, ds2.getN());
+    Assertions.assertEquals(3.0, ds2.getMinItem(), 0);
+    Assertions.assertEquals(3.0, ds2.getMaxItem(), 0);
 
     Object objSketch3 = row.get(10); // quantiles-sketch-no-nulls
-    Assert.assertTrue(objSketch3 instanceof DoublesSketch);
+    Assertions.assertTrue(objSketch3 instanceof DoublesSketch);
     DoublesSketch ds3 = (DoublesSketch) objSketch3;
-    Assert.assertEquals(40, ds3.getN());
-    Assert.assertEquals(0.0, ds3.getMinItem(), 0);
-    Assert.assertEquals(3.0, ds3.getMaxItem(), 0);
+    Assertions.assertEquals(40, ds3.getN());
+    Assertions.assertEquals(0.0, ds3.getMinItem(), 0);
+    Assertions.assertEquals(3.0, ds3.getMaxItem(), 0);
   }
 
 
   //Test ConstantTupleSketchPost-Agg and Base64 Encoding
 
-  @Test
-  public void testConstantAndBase64WithEstimateSumPostAgg() throws Exception
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "{0}")
+  public void testConstantAndBase64WithEstimateSumPostAgg(final GroupByQueryConfig config) throws Exception
   {
+    initArrayOfDoublesSketchAggregationTest(config);
     final String externalSketchBase64 =
         "AQEJAwgCzJP/////////fwIAAAAAAAAAbakWvEpmYR4+utyjb2+2IAAAAAAAAPA/AAAAAAAAAEAAAAAAAADwPwAAAAAAAABA";
     Sequence<ResultRow> seq = helper.createIndexAndRunQueryOnSegment(
@@ -1372,27 +1397,27 @@ public class ArrayOfDoublesSketchAggregationTest extends InitializedNullHandling
                     .build()
     );
     List<ResultRow> results = seq.toList();
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     ResultRow row = results.get(0);
-    Assert.assertEquals("sketch", 40.0, (double) row.get(0), 0);
-    //Assert.assertEquals("estimateSum", 40.0, (double) row.get(1), 0);
+    Assertions.assertEquals(40.0, (double) row.get(0), 0, "sketch");
+    //Assertions.assertEquals(40.0, (double) row.get(1), 0, "estimateSum");
 
     Object estimateSumObj = row.get(1); // estimateSum
-    Assert.assertTrue(estimateSumObj instanceof double[]);
+    Assertions.assertTrue(estimateSumObj instanceof double[]);
     double[] estimateSum = (double[]) estimateSumObj;
-    Assert.assertEquals(2, estimateSum.length);
-    Assert.assertEquals(40.0, estimateSum[0], 0);
-    Assert.assertEquals(80.0, estimateSum[1], 0);
+    Assertions.assertEquals(2, estimateSum.length);
+    Assertions.assertEquals(40.0, estimateSum[0], 0);
+    Assertions.assertEquals(80.0, estimateSum[1], 0);
 
     Object intersectEstimateSumObj = row.get(2); // intersectEstimateSum
-    Assert.assertTrue(intersectEstimateSumObj instanceof double[]);
+    Assertions.assertTrue(intersectEstimateSumObj instanceof double[]);
     double[] intersectEstimateSum = (double[]) intersectEstimateSumObj;
-    Assert.assertEquals(2, intersectEstimateSum.length);
-    Assert.assertEquals(4.0, intersectEstimateSum[0], 0);
-    Assert.assertEquals(8.0, intersectEstimateSum[1], 0);
+    Assertions.assertEquals(2, intersectEstimateSum.length);
+    Assertions.assertEquals(4.0, intersectEstimateSum[0], 0);
+    Assertions.assertEquals(8.0, intersectEstimateSum[1], 0);
 
     //convert intersected to base64 string
-    Assert.assertEquals("intersectionString", "AQEJAwgCzJP/////////fwIAAAAAAAAAbakWvEpmYR4+utyjb2+2IAAAAAAAAABAAAAAAAAAEEAAAAAAAAAAQAAAAAAAABBA", (String) row.get(3));
+    Assertions.assertEquals("AQEJAwgCzJP/////////fwIAAAAAAAAAbakWvEpmYR4+utyjb2+2IAAAAAAAAABAAAAAAAAAEEAAAAAAAAAAQAAAAAAAABBA", (String) row.get(3), "intersectionString");
 
 
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchAggregatorFactoryTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ArrayOfDoublesSketchAggregatorFactoryTest
 {
@@ -61,11 +61,11 @@ public class ArrayOfDoublesSketchAggregatorFactoryTest
     );
 
     combiner.reset(selector);
-    Assert.assertEquals(1, combiner.getObject().getEstimate(), 0);
+    Assertions.assertEquals(1, combiner.getObject().getEstimate(), 0);
 
     selector.increment();
     combiner.fold(selector);
-    Assert.assertEquals(3, combiner.getObject().getEstimate(), 0);
+    Assertions.assertEquals(3, combiner.getObject().getEstimate(), 0);
   }
 
   @Test
@@ -101,7 +101,7 @@ public class ArrayOfDoublesSketchAggregatorFactoryTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)
@@ -117,8 +117,8 @@ public class ArrayOfDoublesSketchAggregatorFactoryTest
   public void testWithName()
   {
     AggregatorFactory factory = new ArrayOfDoublesSketchAggregatorFactory("name", "", null, null, null);
-    Assert.assertEquals(factory, factory.withName("name"));
-    Assert.assertEquals("newTest", factory.withName("newTest").getName());
+    Assertions.assertEquals(factory, factory.withName("name"));
+    Assertions.assertEquals("newTest", factory.withName("newTest").getName());
   }
 
   @Test
@@ -129,12 +129,12 @@ public class ArrayOfDoublesSketchAggregatorFactoryTest
     AggregatorFactory other = new ArrayOfDoublesSketchAggregatorFactory("other", "x", 8192, null, null);
     AggregatorFactory incompatible = new ArrayOfDoublesSketchAggregatorFactory("incompatible", "x", 2048, null, null);
     AggregatorFactory incompatible2 = new ArrayOfDoublesSketchAggregatorFactory("sketch", "y", null, null, null);
-    Assert.assertNotNull(sketch.substituteCombiningFactory(other));
-    Assert.assertNotNull(sketch.substituteCombiningFactory(sketch2));
-    Assert.assertNull(sketch.substituteCombiningFactory(incompatible));
-    Assert.assertNotNull(sketch.substituteCombiningFactory(sketch));
-    Assert.assertNull(other.substituteCombiningFactory(sketch));
-    Assert.assertNull(sketch.substituteCombiningFactory(incompatible2));
-    Assert.assertNull(other.substituteCombiningFactory(incompatible2));
+    Assertions.assertNotNull(sketch.substituteCombiningFactory(other));
+    Assertions.assertNotNull(sketch.substituteCombiningFactory(sketch2));
+    Assertions.assertNull(sketch.substituteCombiningFactory(incompatible));
+    Assertions.assertNotNull(sketch.substituteCombiningFactory(sketch));
+    Assertions.assertNull(other.substituteCombiningFactory(sketch));
+    Assertions.assertNull(sketch.substituteCombiningFactory(incompatible2));
+    Assertions.assertNull(other.substituteCombiningFactory(incompatible2));
   }
 }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchConstantPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchConstantPostAggregatorTest.java
@@ -24,8 +24,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.aggregation.PostAggregator;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
 public class ArrayOfDoublesSketchConstantPostAggregatorTest
@@ -38,7 +38,7 @@ public class ArrayOfDoublesSketchConstantPostAggregatorTest
         "constant_sketch",
         value
     );
-    Assert.assertNotNull(postAgg.getSketchValue());
+    Assertions.assertNotNull(postAgg.getSketchValue());
   }
 
 
@@ -50,7 +50,7 @@ public class ArrayOfDoublesSketchConstantPostAggregatorTest
         "AQEJAwgBzJP/////////fwIAAAAAAAAAzT6NGdX0aWUOJvS5EIhpLwAAAAAAAAAAAAAAAAAAAAA="
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchConstantPostAggregator{name='constant_sketch', value='AQEJAwgBzJP/////////fwIAAAAAAAAAzT6NGdX0aWUOJvS5EIhpLwAAAAAAAAAAAAAAAAAAAAA='}",
         postAgg.toString()
     );
@@ -64,7 +64,7 @@ public class ArrayOfDoublesSketchConstantPostAggregatorTest
         "AQEJAwgBzJP/////////fwIAAAAAAAAAzT6NGdX0aWUOJvS5EIhpLwAAAAAAAAAAAAAAAAAAAAA="
     );
 
-    Assert.assertEquals(Comparators.alwaysEqual(), postAgg.getComparator());
+    Assertions.assertEquals(Comparators.alwaysEqual(), postAgg.getComparator());
   }
 
   @Test
@@ -81,8 +81,8 @@ public class ArrayOfDoublesSketchConstantPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchObjectStrategyTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchObjectStrategyTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.query.aggregation.datasketches.tuple;
 
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUpdatableSketch;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUpdatableSketchBuilder;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -33,7 +33,7 @@ public class ArrayOfDoublesSketchObjectStrategyTest
   public void testSafeRead()
   {
     ArrayOfDoublesSketchObjectStrategy objectStrategy = new ArrayOfDoublesSketchObjectStrategy();
-    Assert.assertTrue(objectStrategy.readRetainsBufferReference());
+    Assertions.assertTrue(objectStrategy.readRetainsBufferReference());
     ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().setNominalEntries(1024)
                                                                                      .setNumberOfValues(4)
                                                                                      .build();
@@ -54,7 +54,7 @@ public class ArrayOfDoublesSketchObjectStrategyTest
       }
 
       final ByteBuffer buf2 = ByteBuffer.wrap(garbage2).order(ByteOrder.LITTLE_ENDIAN);
-      Assert.assertThrows(
+      Assertions.assertThrows(
           IndexOutOfBoundsException.class,
           () -> objectStrategy.fromByteBufferSafe(buf2, garbage2.length).compact().toByteArray()
       );
@@ -63,7 +63,7 @@ public class ArrayOfDoublesSketchObjectStrategyTest
     // non sketch that is too short to contain header should fail with regular java buffer exception
     final byte[] garbage = new byte[]{0x01, 0x02};
     final ByteBuffer buf3 = ByteBuffer.wrap(garbage).order(ByteOrder.LITTLE_ENDIAN);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> objectStrategy.fromByteBufferSafe(buf3, garbage.length).compact().toByteArray()
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchOperationsTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchOperationsTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.aggregation.datasketches.tuple;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUpdatableSketch;
 import org.apache.datasketches.tuple.arrayofdoubles.ArrayOfDoublesUpdatableSketchBuilder;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -41,13 +41,13 @@ public class ArrayOfDoublesSketchOperationsTest
     final byte[] bytes = sketch.toByteArray();
     final String base64 = StringUtils.encodeBase64String(bytes);
 
-    Assert.assertArrayEquals(bytes, ArrayOfDoublesSketchOperations.deserializeSafe(sketch).toByteArray());
-    Assert.assertArrayEquals(bytes, ArrayOfDoublesSketchOperations.deserializeSafe(bytes).toByteArray());
-    Assert.assertArrayEquals(bytes, ArrayOfDoublesSketchOperations.deserializeSafe(base64).toByteArray());
+    Assertions.assertArrayEquals(bytes, ArrayOfDoublesSketchOperations.deserializeSafe(sketch).toByteArray());
+    Assertions.assertArrayEquals(bytes, ArrayOfDoublesSketchOperations.deserializeSafe(bytes).toByteArray());
+    Assertions.assertArrayEquals(bytes, ArrayOfDoublesSketchOperations.deserializeSafe(base64).toByteArray());
 
     final byte[] trunacted = Arrays.copyOfRange(bytes, 0, 10);
-    Assert.assertThrows(IndexOutOfBoundsException.class, () -> ArrayOfDoublesSketchOperations.deserializeSafe(trunacted));
-    Assert.assertThrows(
+    Assertions.assertThrows(IndexOutOfBoundsException.class, () -> ArrayOfDoublesSketchOperations.deserializeSafe(trunacted));
+    Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> ArrayOfDoublesSketchOperations.deserializeSafe(StringUtils.encodeBase64String(trunacted))
     );

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchSetOpPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchSetOpPostAggregatorTest.java
@@ -38,32 +38,31 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class ArrayOfDoublesSketchSetOpPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testConstructorNumArgs()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Illegal number of fields[0], must be > 1");
-    final PostAggregator there = new ArrayOfDoublesSketchSetOpPostAggregator(
-        "a",
-        "UNION",
-        null,
-        null,
-        ImmutableList.of()
-    );
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator there = new ArrayOfDoublesSketchSetOpPostAggregator(
+          "a",
+          "UNION",
+          null,
+          null,
+          ImmutableList.of()
+      );
+    });
+    assertTrue(exception.getMessage().contains("Illegal number of fields[0], must be > 1"));
   }
   @Test
   public void testSerde() throws JsonProcessingException
@@ -82,8 +81,8 @@ public class ArrayOfDoublesSketchSetOpPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -97,7 +96,7 @@ public class ArrayOfDoublesSketchSetOpPostAggregatorTest
         Arrays.asList(new ConstantPostAggregator("", 0), new ConstantPostAggregator("", 0))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchSetOpPostAggregator{name='a', fields=[ConstantPostAggregator{name='', constantValue=0}, ConstantPostAggregator{name='', constantValue=0}], operation=UNION, nominalEntries=16, numberOfValues=1000}",
         postAgg.toString()
     );
@@ -157,8 +156,8 @@ public class ArrayOfDoublesSketchSetOpPostAggregatorTest
     ArrayOfDoublesSketch sketch2 = postAgg2.compute(ImmutableMap.of());
 
     // comparator compares value of each sketches estimate so should be identical
-    Assert.assertEquals(0, comparator.compare(sketch1, sketch2));
-    Assert.assertEquals(0, Double.compare(sketch1.getEstimate(), sketch2.getEstimate()));
+    Assertions.assertEquals(0, comparator.compare(sketch1, sketch2));
+    Assertions.assertEquals(0, Double.compare(sketch1.getEstimate(), sketch2.getEstimate()));
   }
 
   @Test
@@ -195,7 +194,7 @@ public class ArrayOfDoublesSketchSetOpPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchSetOpPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchSetOpPostAggregatorTest.java
@@ -54,7 +54,7 @@ public class ArrayOfDoublesSketchSetOpPostAggregatorTest
   public void testConstructorNumArgs()
   {
     Throwable exception = Assertions.assertThrows(IAE.class, () -> {
-      final PostAggregator there = new ArrayOfDoublesSketchSetOpPostAggregator(
+      new ArrayOfDoublesSketchSetOpPostAggregator(
           "a",
           "UNION",
           null,

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchTTestPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchTTestPostAggregatorTest.java
@@ -37,43 +37,43 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class ArrayOfDoublesSketchTTestPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testConstructorTooFewPostAggInputs()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Illegal number of fields[1], must be 2");
-    new ArrayOfDoublesSketchTTestPostAggregator(
-        "a",
-        ImmutableList.of(new ConstantPostAggregator("", 0))
-    );
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      new ArrayOfDoublesSketchTTestPostAggregator(
+          "a",
+          ImmutableList.of(new ConstantPostAggregator("", 0))
+      );
+    });
+    assertTrue(exception.getMessage().contains("Illegal number of fields[1], must be 2"));
   }
 
   @Test
   public void testConstructorTooManyPostAggInputs()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Illegal number of fields[3], must be 2");
-    new ArrayOfDoublesSketchTTestPostAggregator(
-        "a",
-        Arrays.asList(
-            new ConstantPostAggregator("", 0),
-            new ConstantPostAggregator("", 0),
-            new ConstantPostAggregator("", 0)
-        )
-    );
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      new ArrayOfDoublesSketchTTestPostAggregator(
+          "a",
+          Arrays.asList(
+              new ConstantPostAggregator("", 0),
+              new ConstantPostAggregator("", 0),
+              new ConstantPostAggregator("", 0)
+          )
+      );
+    });
+    assertTrue(exception.getMessage().contains("Illegal number of fields[3], must be 2"));
   }
 
   @Test
@@ -90,8 +90,8 @@ public class ArrayOfDoublesSketchTTestPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -102,7 +102,7 @@ public class ArrayOfDoublesSketchTTestPostAggregatorTest
         Arrays.asList(new ConstantPostAggregator("", 0), new ConstantPostAggregator("", 0))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchTTestPostAggregator{name='a', fields=[ConstantPostAggregator{name='', constantValue=0}, ConstantPostAggregator{name='', constantValue=0}]}",
         postAgg.toString()
     );
@@ -111,13 +111,14 @@ public class ArrayOfDoublesSketchTTestPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing arrays of p values is not supported");
-    PostAggregator postAgg = new ArrayOfDoublesSketchTTestPostAggregator(
-        "a",
-        Arrays.asList(new ConstantPostAggregator("", 0), new ConstantPostAggregator("", 0))
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      PostAggregator postAgg = new ArrayOfDoublesSketchTTestPostAggregator(
+          "a",
+          Arrays.asList(new ConstantPostAggregator("", 0), new ConstantPostAggregator("", 0))
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing arrays of p values is not supported"));
   }
 
   @Test
@@ -133,23 +134,24 @@ public class ArrayOfDoublesSketchTTestPostAggregatorTest
   @Test
   public void testComputeMismatchedSketches()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Sketches have different number of values: 2 and 100");
-    ArrayOfDoublesUpdatableSketch s1 = new ArrayOfDoublesUpdatableSketchBuilder().setNominalEntries(16)
-                                                                                 .setNumberOfValues(2)
-                                                                                 .build();
-    ArrayOfDoublesUpdatableSketch s2 = new ArrayOfDoublesUpdatableSketchBuilder().setNominalEntries(16)
-                                                                                 .setNumberOfValues(100)
-                                                                                 .build();
-    PostAggregator field1 = EasyMock.createMock(PostAggregator.class);
-    EasyMock.expect(field1.compute(EasyMock.anyObject(Map.class))).andReturn(s1).anyTimes();
-    PostAggregator field2 = EasyMock.createMock(PostAggregator.class);
-    EasyMock.expect(field2.compute(EasyMock.anyObject(Map.class))).andReturn(s2).anyTimes();
-    EasyMock.replay(field1, field2);
-    new ArrayOfDoublesSketchTTestPostAggregator(
-        "a",
-        Arrays.asList(field1, field2)
-    ).compute(ImmutableMap.of());
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      ArrayOfDoublesUpdatableSketch s1 = new ArrayOfDoublesUpdatableSketchBuilder().setNominalEntries(16)
+          .setNumberOfValues(2)
+          .build();
+      ArrayOfDoublesUpdatableSketch s2 = new ArrayOfDoublesUpdatableSketchBuilder().setNominalEntries(16)
+          .setNumberOfValues(100)
+          .build();
+      PostAggregator field1 = EasyMock.createMock(PostAggregator.class);
+      EasyMock.expect(field1.compute(EasyMock.anyObject(Map.class))).andReturn(s1).anyTimes();
+      PostAggregator field2 = EasyMock.createMock(PostAggregator.class);
+      EasyMock.expect(field2.compute(EasyMock.anyObject(Map.class))).andReturn(s2).anyTimes();
+      EasyMock.replay(field1, field2);
+      new ArrayOfDoublesSketchTTestPostAggregator(
+          "a",
+          Arrays.asList(field1, field2)
+      ).compute(ImmutableMap.of());
+    });
+    assertTrue(exception.getMessage().contains("Sketches have different number of values: 2 and 100"));
   }
 
   @Test
@@ -174,7 +176,7 @@ public class ArrayOfDoublesSketchTTestPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToBase64StringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToBase64StringPostAggregatorTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -57,8 +57,8 @@ public class ArrayOfDoublesSketchToBase64StringPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -69,7 +69,7 @@ public class ArrayOfDoublesSketchToBase64StringPostAggregatorTest
         new ConstantPostAggregator("", 0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToBase64StringPostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}}",
         postAgg.toString()
     );
@@ -92,7 +92,7 @@ public class ArrayOfDoublesSketchToBase64StringPostAggregatorTest
         "a",
         field1
     );
-    Assert.assertNotNull("output string should not be null", postAgg.compute(ImmutableMap.of()));
+    Assertions.assertNotNull(postAgg.compute(ImmutableMap.of()), "output string should not be null");
   }
 
   @Test
@@ -102,8 +102,8 @@ public class ArrayOfDoublesSketchToBase64StringPostAggregatorTest
         "a",
         new ConstantPostAggregator("", 0)
     );
-    Exception exception = Assert.assertThrows(IAE.class, () -> postAgg.getComparator());
-    Assert.assertEquals("Comparing sketch summaries is not supported", exception.getMessage());
+    Exception exception = Assertions.assertThrows(IAE.class, () -> postAgg.getComparator());
+    Assertions.assertEquals("Comparing sketch summaries is not supported", exception.getMessage());
   }
 
   @Test
@@ -135,7 +135,7 @@ public class ArrayOfDoublesSketchToBase64StringPostAggregatorTest
             )
             .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
             .addTimeColumn()
             .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToEstimateAndBoundsPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToEstimateAndBoundsPostAggregatorTest.java
@@ -25,15 +25,13 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.query.aggregation.PostAggregator;
 import org.apache.druid.query.aggregation.post.ConstantPostAggregator;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ArrayOfDoublesSketchToEstimateAndBoundsPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -50,8 +48,8 @@ public class ArrayOfDoublesSketchToEstimateAndBoundsPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -63,7 +61,7 @@ public class ArrayOfDoublesSketchToEstimateAndBoundsPostAggregatorTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToEstimateAndBoundsPostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}, numStdDevs=1}",
         postAgg.toString()
     );
@@ -72,14 +70,15 @@ public class ArrayOfDoublesSketchToEstimateAndBoundsPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing arrays of estimates and error bounds is not supported");
-    final PostAggregator postAgg = new ArrayOfDoublesSketchToEstimateAndBoundsPostAggregator(
-        "a",
-        new ConstantPostAggregator("", 0),
-        null
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new ArrayOfDoublesSketchToEstimateAndBoundsPostAggregator(
+          "a",
+          new ConstantPostAggregator("", 0),
+          null
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing arrays of estimates and error bounds is not supported"));
   }
 
   @Test

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToEstimatePostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToEstimatePostAggregatorTest.java
@@ -35,8 +35,8 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -56,8 +56,8 @@ public class ArrayOfDoublesSketchToEstimatePostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class ArrayOfDoublesSketchToEstimatePostAggregatorTest
         new ConstantPostAggregator("", 0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToEstimatePostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}}",
         postAgg.toString()
     );
@@ -104,7 +104,7 @@ public class ArrayOfDoublesSketchToEstimatePostAggregatorTest
     // estimate1 is 1.0, estimate2 is 2.0
     Double estimate1 = postAgg1.compute(ImmutableMap.of());
     Double estimate2 = postAgg2.compute(ImmutableMap.of());
-    Assert.assertEquals(-1, postAgg1.getComparator().compare(estimate1, estimate2));
+    Assertions.assertEquals(-1, postAgg1.getComparator().compare(estimate1, estimate2));
   }
 
   @Test
@@ -135,7 +135,7 @@ public class ArrayOfDoublesSketchToEstimatePostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToMeansPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToMeansPostAggregatorTest.java
@@ -32,15 +32,13 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ArrayOfDoublesSketchToMeansPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -56,8 +54,8 @@ public class ArrayOfDoublesSketchToMeansPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +66,7 @@ public class ArrayOfDoublesSketchToMeansPostAggregatorTest
         new ConstantPostAggregator("", 0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToMeansPostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}}",
         postAgg.toString()
     );
@@ -77,13 +75,14 @@ public class ArrayOfDoublesSketchToMeansPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing arrays of mean values is not supported");
-    final PostAggregator postAgg = new ArrayOfDoublesSketchToMeansPostAggregator(
-        "a",
-        new ConstantPostAggregator("", 0)
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new ArrayOfDoublesSketchToMeansPostAggregator(
+          "a",
+          new ConstantPostAggregator("", 0)
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing arrays of mean values is not supported"));
   }
 
   @Test
@@ -114,7 +113,7 @@ public class ArrayOfDoublesSketchToMeansPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToMetricsSumEstimatePostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToMetricsSumEstimatePostAggregatorTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -58,8 +58,8 @@ public class ArrayOfDoublesSketchToMetricsSumEstimatePostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -70,7 +70,7 @@ public class ArrayOfDoublesSketchToMetricsSumEstimatePostAggregatorTest
         new ConstantPostAggregator("", 0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToMetricsSumEstimatePostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}}",
         postAgg.toString()
     );
@@ -97,7 +97,7 @@ public class ArrayOfDoublesSketchToMetricsSumEstimatePostAggregatorTest
         field1
     );
     double[] expectedOutput = {4.0, 8.0};
-    Assert.assertTrue(Arrays.equals(expectedOutput, (double[]) postAgg.compute(ImmutableMap.of())));
+    Assertions.assertTrue(Arrays.equals(expectedOutput, (double[]) postAgg.compute(ImmutableMap.of())));
   }
 
 
@@ -108,8 +108,8 @@ public class ArrayOfDoublesSketchToMetricsSumEstimatePostAggregatorTest
         "a",
         new ConstantPostAggregator("", 0)
     );
-    Exception exception = Assert.assertThrows(IAE.class, () -> postAgg.getComparator());
-    Assert.assertEquals("Comparing arrays of estimate values is not supported", exception.getMessage());
+    Exception exception = Assertions.assertThrows(IAE.class, () -> postAgg.getComparator());
+    Assertions.assertEquals("Comparing arrays of estimate values is not supported", exception.getMessage());
   }
 
   @Test
@@ -141,7 +141,7 @@ public class ArrayOfDoublesSketchToMetricsSumEstimatePostAggregatorTest
             )
             .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
             .addTimeColumn()
             .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToNumEntriesPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToNumEntriesPostAggregatorTest.java
@@ -35,8 +35,8 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -56,8 +56,8 @@ public class ArrayOfDoublesSketchToNumEntriesPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
 
@@ -69,7 +69,7 @@ public class ArrayOfDoublesSketchToNumEntriesPostAggregatorTest
         new ConstantPostAggregator("", 0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToNumEntriesPostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}}",
         postAgg.toString()
     );
@@ -105,7 +105,7 @@ public class ArrayOfDoublesSketchToNumEntriesPostAggregatorTest
     // computes number of entries per sketch, which is 1 for s1 and 2 for s2
     Integer numEntries1 = postAgg1.compute(ImmutableMap.of());
     Integer numEntries2 = postAgg2.compute(ImmutableMap.of());
-    Assert.assertEquals(-1, postAgg1.getComparator().compare(numEntries1, numEntries2));
+    Assertions.assertEquals(-1, postAgg1.getComparator().compare(numEntries1, numEntries2));
   }
 
   @Test
@@ -136,7 +136,7 @@ public class ArrayOfDoublesSketchToNumEntriesPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToQuantilesSketchPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToQuantilesSketchPostAggregatorTest.java
@@ -36,8 +36,8 @@ import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -60,8 +60,8 @@ public class ArrayOfDoublesSketchToQuantilesSketchPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -74,7 +74,7 @@ public class ArrayOfDoublesSketchToQuantilesSketchPostAggregatorTest
         16
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToQuantilesSketchPostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}, column=2, k=16}",
         postAgg.toString()
     );
@@ -116,7 +116,7 @@ public class ArrayOfDoublesSketchToQuantilesSketchPostAggregatorTest
     DoublesSketch sketch2 = postAgg2.compute(ImmutableMap.of());
 
     // comparator compares value of getN, which is 1 for sketch1 and 2 for sketch2
-    Assert.assertEquals(-1, comparator.compare(sketch1, sketch2));
+    Assertions.assertEquals(-1, comparator.compare(sketch1, sketch2));
   }
 
   @Test
@@ -149,7 +149,7 @@ public class ArrayOfDoublesSketchToQuantilesSketchPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToStringPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToStringPostAggregatorTest.java
@@ -32,15 +32,13 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ArrayOfDoublesSketchToStringPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -56,8 +54,8 @@ public class ArrayOfDoublesSketchToStringPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +66,7 @@ public class ArrayOfDoublesSketchToStringPostAggregatorTest
         new ConstantPostAggregator("", 0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToStringPostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}}",
         postAgg.toString()
     );
@@ -77,13 +75,14 @@ public class ArrayOfDoublesSketchToStringPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing sketch summaries is not supported");
-    final PostAggregator postAgg = new ArrayOfDoublesSketchToStringPostAggregator(
-        "a",
-        new ConstantPostAggregator("", 0)
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new ArrayOfDoublesSketchToStringPostAggregator(
+          "a",
+          new ConstantPostAggregator("", 0)
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing sketch summaries is not supported"));
   }
 
   @Test
@@ -114,7 +113,7 @@ public class ArrayOfDoublesSketchToStringPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToVariancesPostAggregatorTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/tuple/ArrayOfDoublesSketchToVariancesPostAggregatorTest.java
@@ -32,15 +32,13 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ArrayOfDoublesSketchToVariancesPostAggregatorTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testSerde() throws JsonProcessingException
@@ -56,8 +54,8 @@ public class ArrayOfDoublesSketchToVariancesPostAggregatorTest
         PostAggregator.class
     );
 
-    Assert.assertEquals(there, andBackAgain);
-    Assert.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
+    Assertions.assertEquals(there, andBackAgain);
+    Assertions.assertArrayEquals(there.getCacheKey(), andBackAgain.getCacheKey());
   }
 
   @Test
@@ -68,7 +66,7 @@ public class ArrayOfDoublesSketchToVariancesPostAggregatorTest
         new ConstantPostAggregator("", 0)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "ArrayOfDoublesSketchToVariancesPostAggregator{name='a', field=ConstantPostAggregator{name='', constantValue=0}}",
         postAgg.toString()
     );
@@ -77,13 +75,14 @@ public class ArrayOfDoublesSketchToVariancesPostAggregatorTest
   @Test
   public void testComparator()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Comparing arrays of variance values is not supported");
-    final PostAggregator postAgg = new ArrayOfDoublesSketchToVariancesPostAggregator(
-        "a",
-        new ConstantPostAggregator("", 0)
-    );
-    postAgg.getComparator();
+    Throwable exception = Assertions.assertThrows(IAE.class, () -> {
+      final PostAggregator postAgg = new ArrayOfDoublesSketchToVariancesPostAggregator(
+          "a",
+          new ConstantPostAggregator("", 0)
+      );
+      postAgg.getComparator();
+    });
+    assertTrue(exception.getMessage().contains("Comparing arrays of variance values is not supported"));
   }
 
   @Test
@@ -114,7 +113,7 @@ public class ArrayOfDoublesSketchToVariancesPostAggregatorTest
               )
               .build();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         RowSignature.builder()
                     .addTimeColumn()
                     .add("count", ColumnType.LONG)

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/util/ToObjectVectorColumnProcessorFactoryTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/query/aggregation/datasketches/util/ToObjectVectorColumnProcessorFactoryTest.java
@@ -34,21 +34,22 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.vector.VectorCursor;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHandlingTest
 {
   private CursorFactory cursorFactory;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     final QueryableIndex index = TestIndex.getMMappedTestIndex();
@@ -101,7 +102,7 @@ public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHan
   @Test
   public void testString()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(
             "automotive",
             "business",
@@ -121,7 +122,7 @@ public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHan
   @Test
   public void testLong()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(1000L, 1100L, 1200L, 1300L, 1400L, 1500L, 1600L, 1700L, 1800L, 1400L),
         readColumn("qualityLong", 10)
     );
@@ -130,7 +131,7 @@ public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHan
   @Test
   public void testFloat()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(10000f, 11000f, 12000f, 13000f, 14000f, 15000f, 16000f, 17000f, 18000f, 14000f),
         readColumn("qualityFloat", 10)
     );
@@ -139,7 +140,7 @@ public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHan
   @Test
   public void testDouble()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(10000.0, 11000.0, 12000.0, 13000.0, 14000.0, 15000.0, 16000.0, 17000.0, 18000.0, 14000.0),
         readColumn("qualityDouble", 10)
     );
@@ -148,7 +149,7 @@ public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHan
   @Test
   public void testMultiString()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(
             Arrays.asList("a", "preferred"),
             Arrays.asList("b", "preferred"),
@@ -169,7 +170,7 @@ public class ToObjectVectorColumnProcessorFactoryTest extends InitializedNullHan
   public void testComplexSketch()
   {
     final Object sketch = Iterables.getOnlyElement(readColumn("quality_uniques", 1));
-    MatcherAssert.assertThat(sketch, CoreMatchers.instanceOf(HyperLogLogCollector.class));
+    assertThat(sketch, CoreMatchers.instanceOf(HyperLogLogCollector.class));
   }
 
   private CursorHolder makeCursorHolder()

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/segment/DatasketchesProjectionTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/segment/DatasketchesProjectionTest.java
@@ -45,6 +45,7 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
 import org.apache.druid.java.util.common.io.Closer;
+import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.DruidProcessingConfig;
 import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.aggregation.datasketches.hll.HllSketchBuildAggregatorFactory;
@@ -71,13 +72,13 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -91,10 +92,10 @@ import java.util.stream.Collectors;
 /**
  * like {@link CursorFactoryProjectionTest} but for sketch aggs
  */
-@RunWith(Parameterized.class)
 public class DatasketchesProjectionTest extends InitializedNullHandlingTest
 {
   private static final Closer CLOSER = Closer.create();
+  private static final Logger LOG = new Logger(DatasketchesProjectionTest.class);
 
   private static final List<AggregateProjectionSpec> PROJECTIONS = Collections.singletonList(
       AggregateProjectionSpec.builder("a_projection")
@@ -135,7 +136,6 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
                                                 .build()
                  ).collect(Collectors.toList());
 
-  @Parameterized.Parameters(name = "name: {0}, sortByDim: {3}, autoSchema: {4}")
   public static Collection<?> constructorFeeder()
   {
     HllSketchModule.registerSerde();
@@ -211,7 +211,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException
   {
     CLOSER.close();
@@ -234,19 +234,24 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
                        .rows(CursorFactoryProjectionTest.ROWS);
   }
 
-  public final CursorFactory projectionsCursorFactory;
-  public final TimeBoundaryInspector projectionsTimeBoundaryInspector;
+  public CursorFactory projectionsCursorFactory;
+  public TimeBoundaryInspector projectionsTimeBoundaryInspector;
 
-  private final GroupingEngine groupingEngine;
+  private GroupingEngine groupingEngine;
 
-  private final NonBlockingPool<ByteBuffer> nonBlockingPool;
-  public final boolean sortByDim;
-  public final boolean autoSchema;
+  private NonBlockingPool<ByteBuffer> nonBlockingPool;
+  public boolean sortByDim;
+  public boolean autoSchema;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  private final Closer closer = Closer.create();
 
-  public DatasketchesProjectionTest(
+  @AfterEach
+  public void cleanupResources() throws IOException
+  {
+    closer.close();
+  }
+
+  public void initDatasketchesProjectionTest(
       String name,
       CursorFactory projectionsCursorFactory,
       TimeBoundaryInspector projectionsTimeBoundaryInspector,
@@ -258,7 +263,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
     this.projectionsTimeBoundaryInspector = projectionsTimeBoundaryInspector;
     this.sortByDim = sortByDim;
     this.autoSchema = autoSchema;
-    this.nonBlockingPool = closer.closeLater(
+    this.nonBlockingPool = closeLater(
         new CloseableStupidPool<>(
             "GroupByQueryEngine-bufferPool",
             () -> ByteBuffer.allocate(1 << 24)
@@ -268,7 +273,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
         new DruidProcessingConfig(),
         GroupByQueryConfig::new,
         new GroupByResourcesReservationPool(
-            closer.closeLater(
+            closeLater(
                 new CloseableDefaultBlockingPool<>(
                     () -> ByteBuffer.allocate(1 << 24),
                     5
@@ -284,9 +289,26 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  public void testProjectionSingleDim()
+  private <T extends Closeable> T closeLater(final T closeable)
   {
+    closer.register(
+        () -> {
+          try {
+            closeable.close();
+          }
+          catch (IOException e) {
+            LOG.warn(e, "Error closing [%s]", closeable);
+          }
+        }
+    );
+    return closeable;
+  }
+
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "name: {0}, sortByDim: {3}, autoSchema: {4}")
+  public void testProjectionSingleDim(String name,CursorFactory projectionsCursorFactory,TimeBoundaryInspector projectionsTimeBoundaryInspector,boolean sortByDim,boolean autoSchema)
+  {
+    initDatasketchesProjectionTest(name, projectionsCursorFactory, projectionsTimeBoundaryInspector, sortByDim, autoSchema);
     // test can use the single dimension projection
     final GroupByQuery query =
         GroupByQuery.builder()
@@ -310,7 +332,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
         rowCount++;
         cursor.advance();
       }
-      Assert.assertEquals(3, rowCount);
+      Assertions.assertEquals(3, rowCount);
     }
     final Sequence<ResultRow> resultRows = groupingEngine.process(
         query,
@@ -320,7 +342,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
         null
     );
     final List<ResultRow> results = resultRows.toList();
-    Assert.assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
     List<Object[]> expectedResults = getSingleDimExpected();
     final RowSignature querySignature = query.getResultRowSignature(RowSignature.Finalization.NO);
     for (int i = 0; i < expectedResults.size(); i++) {
@@ -332,9 +354,11 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
     }
   }
 
-  @Test
-  public void testProjectionSingleDimNoProjections()
+  @MethodSource("constructorFeeder")
+  @ParameterizedTest(name = "name: {0}, sortByDim: {3}, autoSchema: {4}")
+  public void testProjectionSingleDimNoProjections(String name,CursorFactory projectionsCursorFactory,TimeBoundaryInspector projectionsTimeBoundaryInspector,boolean sortByDim,boolean autoSchema)
   {
+    initDatasketchesProjectionTest(name, projectionsCursorFactory, projectionsTimeBoundaryInspector, sortByDim, autoSchema);
     // test can use the single dimension projection
     final GroupByQuery query =
         GroupByQuery.builder()
@@ -359,7 +383,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
         rowCount++;
         cursor.advance();
       }
-      Assert.assertEquals(8, rowCount);
+      Assertions.assertEquals(8, rowCount);
     }
     final Sequence<ResultRow> resultRows = groupingEngine.process(
         query,
@@ -369,7 +393,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
         null
     );
     final List<ResultRow> results = resultRows.toList();
-    Assert.assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
     List<Object[]> expectedResults = getSingleDimExpected();
     final RowSignature querySignature = query.getResultRowSignature(RowSignature.Finalization.NO);
     for (int i = 0; i < expectedResults.size(); i++) {
@@ -443,54 +467,54 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
 
   private void assertResults(Object[] expected, Object[] actual, RowSignature signature)
   {
-    Assert.assertEquals(expected.length, actual.length);
+    Assertions.assertEquals(expected.length, actual.length);
     for (int i = 0; i < expected.length; i++) {
       if (signature.getColumnType(i).get().equals(ColumnType.ofComplex(HllSketchModule.BUILD_TYPE_NAME))) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((HllSketchHolder) expected[i]).getEstimate(),
             ((HllSketchHolder) actual[i]).getEstimate(),
             0.01
         );
       } else if (signature.getColumnType(i).get().equals(DoublesSketchModule.TYPE)) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((DoublesSketch) expected[i]).getMinItem(),
             ((DoublesSketch) actual[i]).getMinItem(),
             0.01
         );
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((DoublesSketch) expected[i]).getMaxItem(),
             ((DoublesSketch) actual[i]).getMaxItem(),
             0.01
         );
       } else if (signature.getColumnType(i).get().equals(ArrayOfDoublesSketchModule.BUILD_TYPE)) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((ArrayOfDoublesSketch) expected[i]).getEstimate(),
             ((ArrayOfDoublesSketch) actual[i]).getEstimate(),
             0.01
         );
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((ArrayOfDoublesSketch) expected[i]).getLowerBound(0),
             ((ArrayOfDoublesSketch) actual[i]).getLowerBound(0),
             0.01
         );
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((ArrayOfDoublesSketch) expected[i]).getUpperBound(0),
             ((ArrayOfDoublesSketch) actual[i]).getUpperBound(0),
             0.01
         );
       } else if (signature.getColumnType(i).get().equals(KllSketchModule.DOUBLES_TYPE)) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((KllDoublesSketch) expected[i]).getMinItem(),
             ((KllDoublesSketch) actual[i]).getMinItem(),
             0.01
         );
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((KllDoublesSketch) expected[i]).getMaxItem(),
             ((KllDoublesSketch) actual[i]).getMaxItem(),
             0.01
         );
       } else {
-        Assert.assertEquals(expected[i], actual[i]);
+        Assertions.assertEquals(expected[i], actual[i]);
       }
     }
   }

--- a/extensions-core/datasketches/src/test/java/org/apache/druid/segment/DatasketchesProjectionTest.java
+++ b/extensions-core/datasketches/src/test/java/org/apache/druid/segment/DatasketchesProjectionTest.java
@@ -306,7 +306,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "name: {0}, sortByDim: {3}, autoSchema: {4}")
-  public void testProjectionSingleDim(String name,CursorFactory projectionsCursorFactory,TimeBoundaryInspector projectionsTimeBoundaryInspector,boolean sortByDim,boolean autoSchema)
+  public void testProjectionSingleDim(String name, CursorFactory projectionsCursorFactory, TimeBoundaryInspector projectionsTimeBoundaryInspector, boolean sortByDim, boolean autoSchema)
   {
     initDatasketchesProjectionTest(name, projectionsCursorFactory, projectionsTimeBoundaryInspector, sortByDim, autoSchema);
     // test can use the single dimension projection
@@ -356,7 +356,7 @@ public class DatasketchesProjectionTest extends InitializedNullHandlingTest
 
   @MethodSource("constructorFeeder")
   @ParameterizedTest(name = "name: {0}, sortByDim: {3}, autoSchema: {4}")
-  public void testProjectionSingleDimNoProjections(String name,CursorFactory projectionsCursorFactory,TimeBoundaryInspector projectionsTimeBoundaryInspector,boolean sortByDim,boolean autoSchema)
+  public void testProjectionSingleDimNoProjections(String name, CursorFactory projectionsCursorFactory, TimeBoundaryInspector projectionsTimeBoundaryInspector, boolean sortByDim, boolean autoSchema)
   {
     initDatasketchesProjectionTest(name, projectionsCursorFactory, projectionsTimeBoundaryInspector, sortByDim, autoSchema);
     // test can use the single dimension projection

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -96,6 +96,7 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -111,13 +112,19 @@ import java.util.stream.Collectors;
  */
 public class AggregationTestHelper implements Closeable
 {
+  @FunctionalInterface
+  private interface TempFolderProvider
+  {
+    File newFolder() throws IOException;
+  }
+
   private final ObjectMapper mapper;
   private final IndexMerger indexMerger;
   private final IndexIO indexIO;
   private final QueryToolChest toolChest;
   private final QueryRunnerFactory factory;
 
-  private final TemporaryFolder tempFolder;
+  private final TempFolderProvider tempFolderProvider;
   private final Closer resourceCloser;
 
   private final Map<String, Object> queryContext;
@@ -128,7 +135,7 @@ public class AggregationTestHelper implements Closeable
       IndexIO indexIO,
       QueryToolChest toolchest,
       QueryRunnerFactory factory,
-      TemporaryFolder tempFolder,
+      TempFolderProvider tempFolderProvider,
       List<? extends Module> jsonModulesToRegister,
       Closer resourceCloser,
       Map<String, Object> queryContext
@@ -139,7 +146,7 @@ public class AggregationTestHelper implements Closeable
     this.indexIO = indexIO;
     this.toolChest = toolchest;
     this.factory = factory;
-    this.tempFolder = tempFolder;
+    this.tempFolderProvider = tempFolderProvider;
     this.resourceCloser = resourceCloser;
     this.queryContext = queryContext;
 
@@ -152,6 +159,32 @@ public class AggregationTestHelper implements Closeable
       List<? extends Module> jsonModulesToRegister,
       GroupByQueryConfig config,
       TemporaryFolder tempFolder
+  )
+  {
+    return createGroupByQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        config,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createGroupByQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      GroupByQueryConfig config,
+      File tempFolder
+  )
+  {
+    return createGroupByQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        config,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createGroupByQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      GroupByQueryConfig config,
+      TempFolderProvider tempFolderProvider
   )
   {
     final Closer closer = Closer.create();
@@ -179,7 +212,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         factory.getToolchest(),
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         closer,
         Collections.emptyMap()
@@ -189,6 +222,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createTimeseriesQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createTimeseriesQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createTimeseriesQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createTimeseriesQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -214,7 +269,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         Closer.create(),
         Collections.emptyMap()
@@ -224,6 +279,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createTopNQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createTopNQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createTopNQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createTopNQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createTopNQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -261,7 +338,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         resourceCloser,
         Collections.emptyMap()
@@ -271,6 +348,28 @@ public class AggregationTestHelper implements Closeable
   public static AggregationTestHelper createScanQueryAggregationTestHelper(
       List<? extends Module> jsonModulesToRegister,
       TemporaryFolder tempFolder
+  )
+  {
+    return createScanQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  public static AggregationTestHelper createScanQueryAggregationTestHelperWithTempDir(
+      List<? extends Module> jsonModulesToRegister,
+      File tempFolder
+  )
+  {
+    return createScanQueryAggregationTestHelper(
+        jsonModulesToRegister,
+        tempFolderProvider(tempFolder)
+    );
+  }
+
+  private static AggregationTestHelper createScanQueryAggregationTestHelper(
+      List<? extends Module> jsonModulesToRegister,
+      TempFolderProvider tempFolderProvider
   )
   {
     ObjectMapper mapper = TestHelper.makeJsonMapper();
@@ -299,11 +398,21 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolchest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         jsonModulesToRegister,
         resourceCloser,
         Collections.emptyMap()
     );
+  }
+
+  private static TempFolderProvider tempFolderProvider(final TemporaryFolder tempFolder)
+  {
+    return tempFolder::newFolder;
+  }
+
+  private static TempFolderProvider tempFolderProvider(final File tempFolder)
+  {
+    return () -> Files.createTempDirectory(tempFolder.toPath(), "druid-").toFile();
   }
 
   public AggregationTestHelper withQueryContext(final Map<String, Object> queryContext)
@@ -316,7 +425,7 @@ public class AggregationTestHelper implements Closeable
         indexIO,
         toolChest,
         factory,
-        tempFolder,
+        tempFolderProvider,
         Collections.emptyList(),
         resourceCloser,
         newContext
@@ -334,7 +443,7 @@ public class AggregationTestHelper implements Closeable
       Query<T> query
   ) throws Exception
   {
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = tempFolderProvider.newFolder();
     createIndex(inputDataFile, inputSchema, inputFormat, aggregators, segmentDir, minTimestamp, gran, maxRowCount);
     return runQueryOnSegments(Collections.singletonList(segmentDir), query);
   }
@@ -350,7 +459,7 @@ public class AggregationTestHelper implements Closeable
       Query<T> query
   ) throws Exception
   {
-    File segmentDir = tempFolder.newFolder();
+    File segmentDir = tempFolderProvider.newFolder();
     createIndex(inputDataStream, inputSchema, inputFormat, aggregators, segmentDir, minTimestamp, gran, maxRowCount, true);
     return runQueryOnSegments(Collections.singletonList(segmentDir), query);
   }
@@ -439,7 +548,7 @@ public class AggregationTestHelper implements Closeable
           return inputDataStream;
         }
       };
-      InputEntityReader reader = inputFormat.createReader(inputSchema, streamEntity, tempFolder.newFolder());
+      InputEntityReader reader = inputFormat.createReader(inputSchema, streamEntity, tempFolderProvider.newFolder());
       AggregatorFactory[] metrics = aggregators.toArray(new AggregatorFactory[0]);
       index = new OnheapIncrementalIndex.Builder()
           .setIndexSchema(
@@ -458,7 +567,7 @@ public class AggregationTestHelper implements Closeable
         while (iter.hasNext()) {
           InputRow row = iter.next();
           if (!index.canAppendRow()) {
-            File tmp = tempFolder.newFolder();
+            File tmp = tempFolderProvider.newFolder();
             toMerge.add(tmp);
             indexMerger.persist(index, tmp, IndexSpec.getDefault(), null);
             index.close();
@@ -480,7 +589,7 @@ public class AggregationTestHelper implements Closeable
       }
 
       if (toMerge.size() > 0) {
-        File tmp = tempFolder.newFolder();
+        File tmp = tempFolderProvider.newFolder();
         toMerge.add(tmp);
         indexMerger.persist(index, tmp, IndexSpec.getDefault(), null);
 
@@ -510,7 +619,7 @@ public class AggregationTestHelper implements Closeable
   ) throws Exception
   {
     if (outDir == null) {
-      outDir = tempFolder.newFolder();
+      outDir = tempFolderProvider.newFolder();
     }
     indexMerger.persist(index, outDir, IndexSpec.getDefault(), null);
 

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -407,7 +407,7 @@ public class AggregationTestHelper implements Closeable
 
   private static TempFolderProvider tempFolderProvider(final TemporaryFolder tempFolder)
   {
-    return tempFolder::newFolder;
+    return () -> tempFolder.newFolder();
   }
 
   private static TempFolderProvider tempFolderProvider(final File tempFolder)

--- a/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/query/aggregation/AggregationTestHelper.java
@@ -33,6 +33,7 @@ import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -96,7 +97,6 @@ import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -412,7 +412,7 @@ public class AggregationTestHelper implements Closeable
 
   private static TempFolderProvider tempFolderProvider(final File tempFolder)
   {
-    return () -> Files.createTempDirectory(tempFolder.toPath(), "druid-").toFile();
+    return () -> FileUtils.createTempDirInLocation(tempFolder.toPath(), "druid-");
   }
 
   public AggregationTestHelper withQueryContext(final Map<String, Object> queryContext)


### PR DESCRIPTION
## Description

Migrates the `extensions-core/datasketches` test suite from JUnit 4 to JUnit 5.

This is Batch 7 of the extensions-core migration and is part of [#13948](https://github.com/apache/druid/issues/13948).

Depends on the earlier migration batches in [#19875](https://github.com/apache/druid/pull/19875), [#19876](https://github.com/apache/druid/pull/19876), [#19877](https://github.com/apache/druid/pull/19877), [#19878](https://github.com/apache/druid/pull/19878), [#19879](https://github.com/apache/druid/pull/19879), and [#19880](https://github.com/apache/druid/pull/19880).

The migration replaces JUnit 4 assertions, lifecycle methods, and temporary-folder rules with Jupiter equivalents. The shared `AggregationTestHelper` supports the migrated `@TempDir` callers while retaining its legacy overload for the remaining migration work.

## Tests

```text
mvn -ntp test -pl extensions-core/datasketches -am \
  -Dtest='org.apache.druid.query.aggregation.datasketches.**,org.apache.druid.segment.DatasketchesProjectionTest' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Pskip-static-checks -Dweb.console.skip=true -T1C
```

Result: 1,049 tests passed; 0 failures, errors, or skips.
