### PR TITLE
minor: remove pom stuff for java.security.manager after change to 25+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,6 @@
             <!-- required for SIMD for druid.expressions.useVectorApi -->
             --add-modules=jdk.incubator.vector
         </jdk.strong.encapsulation.argLine>
-        <jdk.security.manager.allow.argLine><!-- empty placeholder --></jdk.security.manager.allow.argLine>
         <repoOrgId>maven.org</repoOrgId>
         <repoOrgName>Maven Central Repository</repoOrgName>
         <repoOrgUrl>https://repo.maven.apache.org/maven2/</repoOrgUrl>
@@ -2027,7 +2026,6 @@
                         <argLine>
                             @{jacocoArgLine}
                             ${jdk.strong.encapsulation.argLine}
-                            ${jdk.security.manager.allow.argLine}
                             -Xmx2048m
                             -XX:MaxDirectMemorySize=2500m
                             -XX:+ExitOnOutOfMemoryError
@@ -2156,20 +2154,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>java-12+</id>
-            <activation>
-                <!-- Security Manager was permanently removed in JDK 24 (JEP 486); this flag is fatal on 24+ -->
-                <jdk>[12,24)</jdk>
-            </activation>
-            <properties>
-                <jdk.security.manager.allow.argLine>
-                  <!-- required for system-rules with Java >= 18 https://github.com/stefanbirkner/system-rules/issues/85 -->
-                  <!-- this option is only available starting in Java 12 -->
-                    -Djava.security.manager=allow
-                </jdk.security.manager.allow.argLine>
-            </properties>
-        </profile>
           <profile>
             <id>strict</id>
             <activation>


### PR DESCRIPTION
I think these aren't needed after #19707