### PR TITLE
test: stabilize QueryVirtualStorageTest metric assertions

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
@@ -193,8 +193,10 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
     LatchableEmitter emitter = historical.latchableEmitter();
     LatchableEmitter coordinatorEmitter = coordinator.latchableEmitter();
 
-    // Wait for any in-flight storage activity to settle before taking our baseline.
+    // VSF_READ_TIME is the final virtual-storage metric emitted by StorageMonitor for each monitor tick. Waiting for
+    // both metrics ensures the complete tick containing the last load-begin event has been processed before flushing.
     emitter.awaitMetricQuiescent(StorageMonitor.VSF_LOAD_BEGIN_COUNT, MONITOR_QUIESCE_TIMEOUT_MILLIS);
+    emitter.awaitMetricQuiescent(StorageMonitor.VSF_READ_TIME, MONITOR_QUIESCE_TIMEOUT_MILLIS);
     emitter.flush();
 
     // run the queries in order

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
@@ -266,7 +266,15 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
         aggregate -> aggregate.hasSumAtLeast(1)
     );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_READ_COUNT) > 0);
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_READ_BYTES),
+        aggregate -> aggregate.hasSumAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_READ_BYTES) > 0);
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_READ_TIME),
+        aggregate -> aggregate.hasCountAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_READ_TIME) >= 0);
     emitter.waitForEventAggregate(
         event -> event.hasMetricName(StorageMonitor.VSF_EVICT_COUNT),

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
@@ -207,7 +207,10 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
     Assertions.assertEquals(expectedResults[3], Long.parseLong(cluster.runSql(queries[3], dataSource)));
     assertQueryMetrics(4, expectedLoads[3]);
 
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT));
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT),
+        aggregate -> aggregate.hasSumAtLeast(24)
+    );
     long firstLoads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BEGIN_COUNT);
     Assertions.assertTrue(firstLoads >= 24, "expected " + 24 + " but only got " + firstLoads);
 
@@ -222,24 +225,53 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
       expectedTotalHits += (expectedLoads[nextQuery] - actualLoads);
     }
 
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_HIT_COUNT));
+    final long expectedTotalHitsForWait = expectedTotalHits;
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_HIT_COUNT),
+        aggregate -> aggregate.hasSumAtLeast(expectedTotalHitsForWait)
+    );
     long hits = emitter.getMetricEventLongSum(StorageMonitor.VSF_HIT_COUNT);
     Assertions.assertTrue(hits >= expectedTotalHits, "expected " + expectedTotalHits + " but only got " + hits);
     if (expectedTotalHits > 0) {
-      emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_HIT_BYTES));
+      emitter.waitForEventAggregate(
+          event -> event.hasMetricName(StorageMonitor.VSF_HIT_BYTES),
+          aggregate -> aggregate.hasSumAtLeast(1)
+      );
       Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_HIT_BYTES) > 0);
     }
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT));
+    final long expectedTotalLoadForWait = expectedTotalLoad;
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_COUNT),
+        aggregate -> aggregate.hasSumAtLeast(expectedTotalLoadForWait)
+    );
     long loads = emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BEGIN_COUNT);
     Assertions.assertTrue(loads >= expectedTotalLoad, "expected " + expectedTotalLoad + " but only got " + loads);
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BEGIN_BYTES),
+        aggregate -> aggregate.hasSumAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BEGIN_BYTES) > 0);
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_LOAD_COUNT),
+        aggregate -> aggregate.hasSumAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_COUNT) > 0);
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_LOAD_BYTES),
+        aggregate -> aggregate.hasSumAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_LOAD_BYTES) > 0);
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_READ_COUNT));
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_READ_COUNT),
+        aggregate -> aggregate.hasSumAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_READ_COUNT) > 0);
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_READ_BYTES) > 0);
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_READ_TIME) >= 0);
-    emitter.waitForNextEvent(event -> event.hasMetricName(StorageMonitor.VSF_EVICT_COUNT));
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_EVICT_COUNT),
+        aggregate -> aggregate.hasSumAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_EVICT_COUNT) > 0);
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_EVICT_BYTES) > 0);
     Assertions.assertEquals(0, emitter.getMetricEventLongSum(StorageMonitor.VSF_REJECT_COUNT));

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/query/QueryVirtualStorageTest.java
@@ -281,7 +281,15 @@ class QueryVirtualStorageTest extends EmbeddedClusterTestBase
         aggregate -> aggregate.hasSumAtLeast(1)
     );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_EVICT_COUNT) > 0);
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_EVICT_BYTES),
+        aggregate -> aggregate.hasSumAtLeast(1)
+    );
     Assertions.assertTrue(emitter.getMetricEventLongSum(StorageMonitor.VSF_EVICT_BYTES) > 0);
+    emitter.waitForEventAggregate(
+        event -> event.hasMetricName(StorageMonitor.VSF_REJECT_COUNT),
+        aggregate -> aggregate.hasCountAtLeast(1)
+    );
     Assertions.assertEquals(0, emitter.getMetricEventLongSum(StorageMonitor.VSF_REJECT_COUNT));
     Assertions.assertTrue(emitter.getLatestMetricEventValue(StorageMonitor.VSF_USED_BYTES, 0).longValue() > 0);
 

--- a/server/src/test/java/org/apache/druid/server/metrics/LatchableEmitter.java
+++ b/server/src/test/java/org/apache/druid/server/metrics/LatchableEmitter.java
@@ -82,8 +82,14 @@ public class LatchableEmitter extends StubServiceEmitter
   @Override
   public void emit(Event event)
   {
-    super.emit(event);
-    evaluateWaitConditions(event);
+    eventProcessingLock.lock();
+    try {
+      super.emit(event);
+      evaluateWaitConditions(event);
+    }
+    finally {
+      eventProcessingLock.unlock();
+    }
   }
 
   @Override


### PR DESCRIPTION
## Summary

- Stabilize the cumulative virtual storage metric assertions in `QueryVirtualStorageTest.testQueryPartials`.
- Replace race-prone `waitForNextEvent` calls with `LatchableEmitter.waitForEventAggregate` waits where the test reads cumulative metric totals.
- Preserve the existing metric thresholds and avoid sleeps, timeout increases, or weakened assertions.

## Root cause

`StorageMonitor` emits virtual storage metrics on periodic monitor ticks and resets the interval statistics after each tick. The test previously waited for only one future matching event with `waitForNextEvent`, then read a cumulative total. If that event represented an interval before the final segment load completed, the test could observe 23 loads even though a later metric event would bring the cumulative total to the required 24.

`waitForEventAggregate` evaluates already-processed matching events and continues collecting future matching events until the requested cumulative threshold is reached. The fix therefore removes the timing race while retaining the expected thresholds.

## Evidence

- [PR #19879 failed unit job](https://github.com/apache/druid/actions/runs/30932077038/job/92069160586): `QueryVirtualStorageTest.testQueryPartials` failed at the first load assertion with `expected 24 but only got 23`.
- [Independent PR #19876 run](https://github.com/apache/druid/actions/runs/30939895864): the same failure occurred on an unrelated commit.
- [Later PR #19876 run](https://github.com/apache/druid/actions/runs/30958625134): the same test passed, demonstrating intermittent behavior across unrelated commits.

This is a test-stability fix found while validating the JUnit 5 migration. It does not migrate JUnit, change production behavior, or change the expected metric thresholds. Related to [#13948](https://github.com/apache/druid/issues/13948).

## Validation

- `mvn -ntp test -pl embedded-tests -am -Dtest="org.apache.druid.testing.embedded.query.QueryVirtualStorageTest#testQueryPartials" -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C` — 1 test, 0 failures, 0 errors, 0 skipped; full reactor `BUILD SUCCESS`.
- `mvn -ntp -pl embedded-tests -am -DskipTests -Dweb.console.skip=true -Dcheckstyle.skip=false -Dspotbugs.skip=false checkstyle:check spotbugs:check -T1C` — `BUILD SUCCESS`; Checkstyle reported 0 violations and SpotBugs reported no bugs/errors.
- `git diff --check` — passed.
