### PR TITLE
feat: segment availability improvements

### DIFF
--- a/server/src/main/java/org/apache/druid/client/ImmutableDruidServer.java
+++ b/server/src/main/java/org/apache/druid/client/ImmutableDruidServer.java
@@ -21,7 +21,6 @@ package org.apache.druid.client;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
@@ -167,11 +166,7 @@ public class ImmutableDruidServer
 
   public String getURL()
   {
-    if (metadata.getHostAndTlsPort() != null) {
-      return StringUtils.nonStrictFormat("https://%s", metadata.getHostAndTlsPort());
-    } else {
-      return StringUtils.nonStrictFormat("http://%s", metadata.getHostAndPort());
-    }
+    return metadata.getURL();
   }
 
   @Override

--- a/server/src/main/java/org/apache/druid/server/coordination/DruidServerMetadata.java
+++ b/server/src/main/java/org/apache/druid/server/coordination/DruidServerMetadata.java
@@ -22,6 +22,7 @@ package org.apache.druid.server.coordination;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import org.apache.druid.java.util.common.StringUtils;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -74,6 +75,18 @@ public class DruidServerMetadata
   public String getHost()
   {
     return getHostAndTlsPort() != null ? getHostAndTlsPort() : getHostAndPort();
+  }
+
+  /**
+   * Base URL used to reach this server over HTTP, preferring TLS when the server announced a TLS port.
+   */
+  public String getURL()
+  {
+    if (getHostAndTlsPort() != null) {
+      return StringUtils.nonStrictFormat("https://%s", getHostAndTlsPort());
+    } else {
+      return StringUtils.nonStrictFormat("http://%s", getHostAndPort());
+    }
   }
 
   @Nullable

--- a/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/ServerHolder.java
@@ -23,6 +23,7 @@ import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.loading.LoadQueuePeon;
+import org.apache.druid.server.coordinator.loading.LoadQueueSnapshot;
 import org.apache.druid.server.coordinator.loading.PartialLoadProfile;
 import org.apache.druid.server.coordinator.loading.SegmentAction;
 import org.apache.druid.server.coordinator.loading.SegmentHolder;
@@ -32,6 +33,7 @@ import org.apache.druid.timeline.SegmentId;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -77,6 +79,13 @@ public class ServerHolder implements Comparable<ServerHolder>
    * Do not remove entries on load/drop success or failure during the run.
    */
   private final Map<DataSegment, SegmentAction> queuedSegments = new HashMap<>();
+
+  /**
+   * The {@link SegmentAction#MOVE_FROM} entries of {@link #queuedSegments}, kept as their own set so that
+   * {@link org.apache.druid.server.coordinator.balancer.CachingCostBalancerStrategy} need not take the peon's lock
+   * once per candidate server per segment.
+   */
+  private final Set<DataSegment> movingFromSegments = new HashSet<>();
 
   /**
    * Tracks the {@link PartialLoadProfile} for in-flight load operations on this server. Populated from the peon's
@@ -132,6 +141,34 @@ public class ServerHolder implements Comparable<ServerHolder>
       int maxLifetimeInQueue
   )
   {
+    this(
+        server,
+        peon,
+        // No inventory snapshot to reconcile against here; production goes through the overload below.
+        new LoadQueueSnapshot(peon.getSegmentsInQueue(), peon.getSegmentsMarkedToDrop()),
+        isDecommissioning,
+        isUnmanaged,
+        maxSegmentsInLoadQueue,
+        maxLifetimeInQueue
+    );
+  }
+
+  /**
+   * Creates a new ServerHolder from a pre-captured {@link LoadQueueSnapshot} rather than reading the peon directly,
+   * so that the queue and the server's segment set stay mutually consistent. See apache/druid#18764.
+   *
+   * @param queueSnapshot Atomically captured pending work for this server.
+   */
+  public ServerHolder(
+      ImmutableDruidServer server,
+      LoadQueuePeon peon,
+      LoadQueueSnapshot queueSnapshot,
+      boolean isDecommissioning,
+      boolean isUnmanaged,
+      int maxSegmentsInLoadQueue,
+      int maxLifetimeInQueue
+  )
+  {
     this.server = server;
     this.peon = peon;
     this.isDecommissioning = isDecommissioning;
@@ -144,13 +181,14 @@ public class ServerHolder implements Comparable<ServerHolder>
 
     final AtomicInteger movingSegmentCount = new AtomicInteger();
     final AtomicInteger loadingReplicaCount = new AtomicInteger();
-    initializeQueuedSegments(movingSegmentCount, loadingReplicaCount);
+    initializeQueuedSegments(queueSnapshot, movingSegmentCount, loadingReplicaCount);
 
     this.movingSegmentCount = movingSegmentCount.get();
     this.loadingReplicaCount = loadingReplicaCount.get();
   }
 
   private void initializeQueuedSegments(
+      LoadQueueSnapshot queueSnapshot,
       AtomicInteger movingSegmentCount,
       AtomicInteger loadingReplicaCount
   )
@@ -160,7 +198,12 @@ public class ServerHolder implements Comparable<ServerHolder>
     }
 
     final List<SegmentHolder> expiredSegments = new ArrayList<>();
-    for (SegmentHolder holder : peon.getSegmentsInQueue()) {
+    for (SegmentHolder holder : queueSnapshot.getSegmentsInQueue()) {
+      // HttpLoadQueuePeon already collapses a segment to one holder; this guards other snapshot sources that do not.
+      if (queuedSegments.containsKey(holder.getSegment())) {
+        continue;
+      }
+
       int runsInQueue = holder.incrementAndGetRunsInQueue();
       if (runsInQueue > maxLifetimeInQueue) {
         expiredSegments.add(holder);
@@ -180,8 +223,11 @@ public class ServerHolder implements Comparable<ServerHolder>
       }
     }
 
-    for (DataSegment segment : peon.getSegmentsMarkedToDrop()) {
-      addToQueuedSegments(segment, SegmentAction.MOVE_FROM);
+    for (DataSegment segment : queueSnapshot.getSegmentsMarkedToDrop()) {
+      // A MOVE_FROM that has already graduated to a queued DROP appears in both halves; the DROP is the later state.
+      if (!queuedSegments.containsKey(segment)) {
+        addToQueuedSegments(segment, SegmentAction.MOVE_FROM);
+      }
     }
 
     if (!expiredSegments.isEmpty()) {
@@ -200,6 +246,17 @@ public class ServerHolder implements Comparable<ServerHolder>
   public ImmutableDruidServer getServer()
   {
     return server;
+  }
+
+  /**
+   * Segments this server is expected to drop once their move completes: those the snapshot arrived with, plus any
+   * move started during this run.
+   *
+   * @see LoadQueuePeon#getSegmentsMarkedToDrop()
+   */
+  public Set<DataSegment> getSegmentsMarkedToDrop()
+  {
+    return Collections.unmodifiableSet(movingFromSegments);
   }
 
   public LoadQueuePeon getPeon()
@@ -505,6 +562,9 @@ public class ServerHolder implements Comparable<ServerHolder>
   private void addToQueuedSegments(DataSegment segment, SegmentAction action)
   {
     queuedSegments.put(segment, action);
+    if (action == SegmentAction.MOVE_FROM) {
+      movingFromSegments.add(segment);
+    }
 
     // Add to projected if load is started, remove from projected if drop has started
     if (action.isLoad()) {
@@ -523,6 +583,7 @@ public class ServerHolder implements Comparable<ServerHolder>
   private void removeFromQueuedSegments(DataSegment segment, SegmentAction action)
   {
     queuedSegments.remove(segment);
+    movingFromSegments.remove(segment);
 
     if (action.isLoad()) {
       projectedSegmentCounts.removeSegment(segment);

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/CachingCostBalancerStrategy.java
@@ -63,8 +63,9 @@ public class CachingCostBalancerStrategy extends CostBalancerStrategy
     cost -= costCacheForSegments(server, server.getPeon().getSegmentsToDrop())
         .computeCost(serverName, proposalSegment);
 
-    // minus the costs of segments that are marked to be dropped
-    cost -= costCacheForSegments(server, server.getPeon().getSegmentsMarkedToDrop())
+    // minus the costs of segments that are marked to be dropped. Read off the holder, not the peon: this runs once
+    // per candidate server per segment, and the peon's copy is behind a lock.
+    cost -= costCacheForSegments(server, server.getSegmentsMarkedToDrop())
         .computeCost(serverName, proposalSegment);
 
     if (server.getAvailableSize() <= 0) {

--- a/server/src/main/java/org/apache/druid/server/coordinator/duty/PrepareBalancerAndLoadQueues.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/duty/PrepareBalancerAndLoadQueues.java
@@ -30,6 +30,7 @@ import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import org.apache.druid.server.coordinator.ServerHolder;
 import org.apache.druid.server.coordinator.balancer.BalancerStrategy;
 import org.apache.druid.server.coordinator.balancer.BalancerStrategyFactory;
+import org.apache.druid.server.coordinator.loading.LoadQueuePeon;
 import org.apache.druid.server.coordinator.loading.LoadQueueTaskMaster;
 import org.apache.druid.server.coordinator.loading.SegmentLoadQueueManager;
 import org.apache.druid.server.coordinator.loading.SegmentLoadingConfig;
@@ -82,8 +83,10 @@ public class PrepareBalancerAndLoadQueues implements CoordinatorDuty
   @Override
   public DruidCoordinatorRuntimeParams run(DruidCoordinatorRuntimeParams params)
   {
-    List<ImmutableDruidServer> currentServers = prepareCurrentServers();
-    taskMaster.resetPeonsForNewServers(currentServers);
+    final List<DruidServer> currentServers = prepareCurrentServers();
+    taskMaster.resetPeonsForNewServers(
+        currentServers.stream().map(DruidServer::getMetadata).collect(Collectors.toList())
+    );
 
     final CoordinatorDynamicConfig dynamicConfig = params.getCoordinatorDynamicConfig();
     final SegmentLoadingConfig segmentLoadingConfig
@@ -137,32 +140,49 @@ public class PrepareBalancerAndLoadQueues implements CoordinatorDuty
     }
   }
 
-  private List<ImmutableDruidServer> prepareCurrentServers()
+  private List<DruidServer> prepareCurrentServers()
   {
     return serverInventoryView
         .getInventory()
         .stream()
         .filter(DruidServer::isSegmentReplicationOrBroadcastTarget)
-        .map(DruidServer::toImmutableDruidServer)
         .collect(Collectors.toList());
   }
 
+  /**
+   * Captures the current state of every managed server, pairing each server's segment set with its load queue.
+   * <p>
+   * The two captures are interleaved per server, and the queue is read <em>against</em> the segment set just copied,
+   * so an operation is reported as pending exactly when that copy does not yet reflect it. Copying every server's
+   * segment set first and only then reading the load queues (as this duty used to) leaves a window in which a
+   * completing operation is visible in neither. See apache/druid#18764.
+   */
   private DruidCluster prepareCluster(
       CoordinatorDynamicConfig dynamicConfig,
       SegmentLoadingConfig segmentLoadingConfig,
-      List<ImmutableDruidServer> currentServers
+      List<DruidServer> currentServers
   )
   {
     final Set<String> decommissioningServers = dynamicConfig.getDecommissioningNodes();
     final Set<String> unmanagedServers = new HashSet<>(dynamicConfig.getCloneServers().keySet());
     final DruidCluster.Builder cluster = DruidCluster.builder();
-    for (ImmutableDruidServer server : currentServers) {
+    for (DruidServer server : currentServers) {
+      final LoadQueuePeon peon = taskMaster.getPeonForServer(server.getName());
+      if (peon == null) {
+        // This Coordinator stopped being the leader between resetting the peons and now.
+        log.debug("No load queue peon for server[%s]. Skipping it in this run.", server.getName());
+        continue;
+      }
+
+      final ImmutableDruidServer immutableServer = server.toImmutableDruidServer();
+
       cluster.add(
           new ServerHolder(
-              server,
-              taskMaster.getPeonForServer(server),
-              decommissioningServers.contains(server.getHost()),
-              unmanagedServers.contains(server.getHost()),
+              immutableServer,
+              peon,
+              peon.getQueueSnapshot(immutableServer),
+              decommissioningServers.contains(immutableServer.getHost()),
+              unmanagedServers.contains(immutableServer.getHost()),
               segmentLoadingConfig.getMaxSegmentsInLoadQueue(),
               segmentLoadingConfig.getMaxLifetimeInLoadQueue()
           )

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeon.java
@@ -23,9 +23,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.common.config.Configs;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.RE;
@@ -50,6 +54,7 @@ import org.apache.druid.server.coordinator.stats.Stats;
 import org.apache.druid.server.http.SegmentLoadingCapabilities;
 import org.apache.druid.server.http.SegmentLoadingMode;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.timeline.SegmentId;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.joda.time.Duration;
@@ -61,9 +66,11 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -94,8 +101,14 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
 
   private final ConcurrentMap<DataSegment, SegmentHolder> segmentsToLoad = new ConcurrentHashMap<>();
   private final ConcurrentMap<DataSegment, SegmentHolder> segmentsToDrop = new ConcurrentHashMap<>();
-  private final Set<DataSegment> segmentsMarkedToDrop = ConcurrentHashMap.newKeySet();
   private final LoadingRateTracker loadingRateTracker = new LoadingRateTracker();
+
+  /**
+   * Segments marked to be dropped once the corresponding MOVE_TO has succeeded. The lock is what makes the hand-off
+   * of a segment from this set to {@link #queuedSegments} as a DROP atomic; see {@link #dropSegment}. This need not
+   * be thread-safe as all operations on it are synchronized with the {@link #lock}.
+   */
+  private final Set<DataSegment> segmentsMarkedToDrop = new HashSet<>();
 
   /**
    * Segments currently in queue ordered by priority and interval. This includes
@@ -103,6 +116,18 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
    * are synchronized with the {@link #lock}.
    */
   private final Set<SegmentHolder> queuedSegments = new TreeSet<>();
+
+  /**
+   * Operations the server has acknowledged but which the inventory view has not caught up to yet. Forgetting them at
+   * ack time would leave a window in which the operation is visible in neither the queue nor the inventory, and the
+   * Coordinator counts the replica as plainly loaded (or plainly absent). See apache/druid#18764.
+   * <p>
+   * Kept out of {@link #queuedSegments} so that {@link #doSegmentManagement} never re-sends them, but still reported
+   * by {@link #getSegmentsInQueue()}. Retired by {@link #getQueueSnapshot(ImmutableDruidServer)}.
+   * <p>
+   * This need not be thread-safe as all operations on it are synchronized with the {@link #lock}.
+   */
+  private final Map<SegmentId, SegmentHolder> segmentsAwaitingConfirmation = new HashMap<>();
 
   /**
    * Set of segments for which requests have been sent to the server and can
@@ -204,6 +229,8 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
     final List<DataSegmentChangeRequest> newRequests = new ArrayList<>(batchSize);
 
     synchronized (lock) {
+      expireStaleOperations();
+
       final Iterator<SegmentHolder> queuedSegmentIterator = queuedSegments.iterator();
 
       while (newRequests.size() < batchSize && queuedSegmentIterator.hasNext()) {
@@ -409,6 +436,9 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
             if (status.getState() == SegmentChangeStatus.State.FAILED) {
               onRequestFailed(holder, status);
             } else {
+              // Retain until the inventory view catches up, so the operation is never invisible in both.
+              holder.markAcknowledgedByServer();
+              segmentsAwaitingConfirmation.put(holder.getSegment().getId(), holder);
               onRequestCompleted(holder, RequestStatus.SUCCESS, status);
             }
           }
@@ -464,6 +494,8 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
       segmentsToDrop.clear();
       segmentsToLoad.clear();
       queuedSegments.clear();
+      segmentsAwaitingConfirmation.clear();
+      segmentsMarkedToDrop.clear();
       activeRequestSegments.clear();
       queuedSize.set(0L);
       loadingRateTracker.stop();
@@ -537,6 +569,9 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
         holder = new SegmentHolder(segment, SegmentAction.DROP, config.getLoadTimeout(), callback);
         segmentsToDrop.put(segment, holder);
         queuedSegments.add(holder);
+        // Graduate a pending MOVE_FROM to this DROP atomically; unmarking separately would leave a window in which
+        // the segment is in neither collection. See apache/druid#18764.
+        segmentsMarkedToDrop.remove(segment);
         processingExecutor.execute(this::doSegmentManagement);
         incrementStat(holder, RequestStatus.ASSIGNED, null);
       } else {
@@ -566,11 +601,9 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
   @Override
   public Set<SegmentHolder> getSegmentsInQueue()
   {
-    final Set<SegmentHolder> segmentsInQueue;
     synchronized (lock) {
-      segmentsInQueue = new HashSet<>(queuedSegments);
+      return collectSegmentsInQueue();
     }
-    return segmentsInQueue;
   }
 
   @Override
@@ -594,19 +627,107 @@ public class HttpLoadQueuePeon implements LoadQueuePeon
   @Override
   public void markSegmentToDrop(DataSegment dataSegment)
   {
-    segmentsMarkedToDrop.add(dataSegment);
+    synchronized (lock) {
+      segmentsMarkedToDrop.add(dataSegment);
+    }
   }
 
   @Override
   public void unmarkSegmentToDrop(DataSegment dataSegment)
   {
-    segmentsMarkedToDrop.remove(dataSegment);
+    synchronized (lock) {
+      segmentsMarkedToDrop.remove(dataSegment);
+    }
   }
 
   @Override
   public Set<DataSegment> getSegmentsMarkedToDrop()
   {
-    return Collections.unmodifiableSet(segmentsMarkedToDrop);
+    synchronized (lock) {
+      return ImmutableSet.copyOf(segmentsMarkedToDrop);
+    }
+  }
+
+  @Override
+  public LoadQueueSnapshot getQueueSnapshot()
+  {
+    synchronized (lock) {
+      return new LoadQueueSnapshot(collectSegmentsInQueue(), ImmutableSet.copyOf(segmentsMarkedToDrop));
+    }
+  }
+
+  @Override
+  public LoadQueueSnapshot getQueueSnapshot(ImmutableDruidServer inventory)
+  {
+    synchronized (lock) {
+      // A load is confirmed by the segment appearing, a drop by it disappearing. The opposite observation means the
+      // inventory still shows the pre-operation state, so the operation stays pending.
+      segmentsAwaitingConfirmation.entrySet().removeIf(entry -> {
+        final boolean nowLoaded = inventory.getSegment(entry.getKey()) != null;
+        if (entry.getValue().isLoad() != nowLoaded) {
+          return false;
+        }
+        log.trace(
+            "Server[%s] inventory confirmed request[%s] on segment[%s].",
+            serverId, entry.getValue().getAction(), entry.getKey()
+        );
+        return true;
+      });
+
+      return new LoadQueueSnapshot(collectSegmentsInQueue(), ImmutableSet.copyOf(segmentsMarkedToDrop));
+    }
+  }
+
+  /**
+   * Number of acknowledged operations the inventory view has not reflected yet. Persistently high means a lagging or
+   * broken inventory sync for this server.
+   */
+  public int getNumSegmentsAwaitingConfirmation()
+  {
+    synchronized (lock) {
+      return segmentsAwaitingConfirmation.size();
+    }
+  }
+
+  /**
+   * Force-expires acknowledged operations whose inventory confirmation never arrives, which would otherwise pin the
+   * Coordinator's view of the replica indefinitely.
+   */
+  @GuardedBy("lock")
+  private void expireStaleOperations()
+  {
+    final Duration timeout = config.getLoadTimeout();
+
+    segmentsAwaitingConfirmation.values().removeIf(holder -> {
+      if (holder.hasConfirmationTimedOut(timeout)) {
+        log.warn(
+            "Server[%s] never had request[%s] on segment[%s] confirmed by the inventory view within [%s].",
+            serverId, holder.getAction(), holder.getSegment().getId(), timeout
+        );
+        return true;
+      }
+      return false;
+    });
+  }
+
+  /**
+   * The queue as one holder per segment. A segment can appear in both collections -- an acked LOAD awaiting
+   * confirmation with a DROP queued behind it -- and {@link SegmentHolder#equals} includes the action, so both would
+   * survive into a plain set and make replica accounting depend on iteration order. The queued entry wins as the
+   * newer intent.
+   */
+  @GuardedBy("lock")
+  private Set<SegmentHolder> collectSegmentsInQueue()
+  {
+    final Map<SegmentId, SegmentHolder> holdersBySegment
+        = Maps.newHashMapWithExpectedSize(queuedSegments.size() + segmentsAwaitingConfirmation.size());
+    for (SegmentHolder holder : segmentsAwaitingConfirmation.values()) {
+      holdersBySegment.put(holder.getSegment().getId(), holder);
+    }
+    for (SegmentHolder holder : queuedSegments) {
+      holdersBySegment.put(holder.getSegment().getId(), holder);
+    }
+    return new HashSet<>(holdersBySegment.values());
   }
 
   private void onRequestFailed(SegmentHolder holder, SegmentChangeStatus status)

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueuePeon.java
@@ -19,6 +19,7 @@
 
 package org.apache.druid.server.coordinator.loading;
 
+import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
 import org.apache.druid.timeline.DataSegment;
 
@@ -47,6 +48,29 @@ public interface LoadQueuePeon
   void unmarkSegmentToDrop(DataSegment segmentToLoad);
 
   Set<DataSegment> getSegmentsMarkedToDrop();
+
+  /**
+   * Captures {@link #getSegmentsInQueue()} and {@link #getSegmentsMarkedToDrop()} atomically. The default
+   * implementation is not atomic and exists only for simple test peons.
+   *
+   * @see LoadQueueSnapshot
+   */
+  default LoadQueueSnapshot getQueueSnapshot()
+  {
+    return new LoadQueueSnapshot(getSegmentsInQueue(), getSegmentsMarkedToDrop());
+  }
+
+  /**
+   * Captures the queue as of {@code inventory}, retiring operations that {@code inventory} already reflects. A server
+   * acknowledges a request long before the Coordinator's inventory view syncs, so acknowledged operations must keep
+   * being reported as pending until then, or the replica briefly appears in neither. See apache/druid#18764.
+   *
+   * @param inventory Segment set for this server, as the caller will use it.
+   */
+  default LoadQueueSnapshot getQueueSnapshot(ImmutableDruidServer inventory)
+  {
+    return getQueueSnapshot();
+  }
 
   void loadSegment(DataSegment segment, SegmentAction action, LoadPeonCallback callback);
 

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueueSnapshot.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueueSnapshot.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.loading;
+
+import org.apache.druid.timeline.DataSegment;
+
+import java.util.Set;
+
+/**
+ * An atomically captured view of the pending work on a single {@link LoadQueuePeon}.
+ * <p>
+ * The two sets must be captured together under the peon's lock. A completing move takes the segment out of
+ * {@code segmentsMarkedToDrop} and into the queue as a DROP, so a reader interleaved between the two sees it in
+ * neither and counts the replica as plainly loaded. See apache/druid#18764.
+ */
+public class LoadQueueSnapshot
+{
+  private final Set<SegmentHolder> segmentsInQueue;
+  private final Set<DataSegment> segmentsMarkedToDrop;
+
+  public LoadQueueSnapshot(Set<SegmentHolder> segmentsInQueue, Set<DataSegment> segmentsMarkedToDrop)
+  {
+    this.segmentsInQueue = segmentsInQueue;
+    this.segmentsMarkedToDrop = segmentsMarkedToDrop;
+  }
+
+  /**
+   * Segments queued for load, drop or move, including those acknowledged by the server but not yet confirmed by the
+   * inventory view.
+   */
+  public Set<SegmentHolder> getSegmentsInQueue()
+  {
+    return segmentsInQueue;
+  }
+
+  /**
+   * Segments marked to be dropped once the corresponding MOVE_TO has finished.
+   */
+  public Set<DataSegment> getSegmentsMarkedToDrop()
+  {
+    return segmentsMarkedToDrop;
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueueTaskMaster.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/LoadQueueTaskMaster.java
@@ -22,12 +22,13 @@ package org.apache.druid.server.coordinator.loading;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Sets;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
-import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.server.coordination.DruidServerMetadata;
 import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
 import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -73,7 +74,7 @@ public class LoadQueueTaskMaster
     this.coordinatorDynamicConfigSupplier = coordinatorDynamicConfigSupplier;
   }
 
-  private LoadQueuePeon createPeon(ImmutableDruidServer server)
+  private LoadQueuePeon createPeon(DruidServerMetadata server)
   {
     return new HttpLoadQueuePeon(
         server.getURL(),
@@ -91,9 +92,14 @@ public class LoadQueueTaskMaster
     return loadManagementPeons;
   }
 
-  public LoadQueuePeon getPeonForServer(ImmutableDruidServer server)
+  /**
+   * Returns the peon for the named server, or null if this Coordinator is not the leader or the server is not
+   * currently part of the cluster.
+   */
+  @Nullable
+  public LoadQueuePeon getPeonForServer(String serverName)
   {
-    return loadManagementPeons.get(server.getName());
+    return loadManagementPeons.get(serverName);
   }
 
   /**
@@ -104,7 +110,7 @@ public class LoadQueueTaskMaster
    * {@link #onLeaderStop()} so that there are no stray peons if the Coordinator
    * is not leader anymore.
    */
-  public synchronized void resetPeonsForNewServers(List<ImmutableDruidServer> currentServers)
+  public synchronized void resetPeonsForNewServers(List<DruidServerMetadata> currentServers)
   {
     if (!isLeader.get()) {
       return;
@@ -113,7 +119,7 @@ public class LoadQueueTaskMaster
     final Set<String> oldServers = Sets.newHashSet(loadManagementPeons.keySet());
 
     // Start peons for new servers
-    for (ImmutableDruidServer server : currentServers) {
+    for (DruidServerMetadata server : currentServers) {
       loadManagementPeons.computeIfAbsent(server.getName(), serverName -> {
         LoadQueuePeon loadQueuePeon = createPeon(server);
         loadQueuePeon.start();
@@ -123,7 +129,7 @@ public class LoadQueueTaskMaster
     }
 
     // Remove peons for disappeared servers
-    for (ImmutableDruidServer server : currentServers) {
+    for (DruidServerMetadata server : currentServers) {
       oldServers.remove(server.getName());
     }
     for (String name : oldServers) {

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentHolder.java
@@ -87,6 +87,7 @@ public class SegmentHolder implements Comparable<SegmentHolder>
   // Guaranteed to store only non-null elements
   private final List<LoadPeonCallback> callbacks = new ArrayList<>();
   private final Stopwatch sinceRequestSentToServer = Stopwatch.createUnstarted();
+  private final Stopwatch sinceAcknowledgedByServer = Stopwatch.createUnstarted();
   private int runsInQueue = 0;
 
   public SegmentHolder(
@@ -203,6 +204,25 @@ public class SegmentHolder implements Comparable<SegmentHolder>
   public boolean hasRequestTimedOut()
   {
     return sinceRequestSentToServer.millisElapsed() > requestTimeout.getMillis();
+  }
+
+  /**
+   * Starts the clock on how long the inventory view has yet to reflect a request the server already acknowledged.
+   */
+  public void markAcknowledgedByServer()
+  {
+    if (!sinceAcknowledgedByServer.isRunning()) {
+      sinceAcknowledgedByServer.start();
+    }
+  }
+
+  /**
+   * Whether the inventory view has taken unreasonably long to reflect an acknowledged operation. The confirmation may
+   * never arrive, so such a holder is force-expired rather than retained forever.
+   */
+  public boolean hasConfirmationTimedOut(Duration confirmationTimeout)
+  {
+    return sinceAcknowledgedByServer.millisElapsed() > confirmationTimeout.getMillis();
   }
 
   public int incrementAndGetRunsInQueue()

--- a/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentLoadQueueManager.java
@@ -151,7 +151,8 @@ public class SegmentLoadQueueManager
                 && !peonA.getSegmentsToDrop().contains(segment)
                 && (taskMaster.isHttpLoading()
                     || serverInventoryView.isSegmentLoadedByServer(serverNameB, segment))) {
-              peonA.unmarkSegmentToDrop(segment);
+              // dropSegment retires the MOVE_FROM mark atomically with queueing the DROP; unmarking here first would
+              // leave a window in which the segment is in neither collection. See apache/druid#18764.
               peonA.dropSegment(segment, moveFinishCallback);
             } else {
               moveFinishCallback.execute(success);

--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -28,7 +28,6 @@ import org.apache.druid.client.DataSourcesSnapshot;
 import org.apache.druid.client.DruidDataSource;
 import org.apache.druid.client.DruidServer;
 import org.apache.druid.client.ImmutableDruidDataSource;
-import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.client.ServerInventoryView;
 import org.apache.druid.common.config.JacksonConfigManager;
 import org.apache.druid.discovery.DruidLeaderSelector;
@@ -852,7 +851,7 @@ public class DruidCoordinatorTest
     EasyMock.expect(loadQueueTaskMaster.getAllPeons()).andReturn(peonMap).anyTimes();
 
     EasyMock.expect(loadQueueTaskMaster.getPeonForServer(EasyMock.anyObject())).andAnswer(
-        () -> peonMap.get(((ImmutableDruidServer) EasyMock.getCurrentArgument(0)).getName())
+        () -> peonMap.get((String) EasyMock.getCurrentArgument(0))
     ).anyTimes();
   }
   

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/HttpLoadQueuePeonTest.java
@@ -22,6 +22,8 @@ package org.apache.druid.server.coordinator.loading;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.client.ImmutableDruidServer;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.http.client.HttpClient;
@@ -33,6 +35,7 @@ import org.apache.druid.server.coordination.DataSegmentChangeHandler;
 import org.apache.druid.server.coordination.DataSegmentChangeRequest;
 import org.apache.druid.server.coordination.DataSegmentChangeResponse;
 import org.apache.druid.server.coordination.SegmentChangeStatus;
+import org.apache.druid.server.coordination.ServerType;
 import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
 import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
@@ -58,6 +61,8 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -214,6 +219,162 @@ public class HttpLoadQueuePeonTest
   }
 
   @Test
+  public void testAcknowledgedLoadStaysInQueueUntilInventoryConfirmsIt()
+  {
+    final DataSegment segment = segments.get(0);
+    httpLoadQueuePeon.loadSegment(segment, SegmentAction.LOAD, null);
+
+    httpClient.sendRequestToServerAndHandleResponse();
+
+    // Until the inventory view catches up the load must still read as pending, or the replica is briefly neither
+    // loaded nor loading. See apache/druid#18764.
+    Assert.assertTrue(httpLoadQueuePeon.getSegmentsToLoad().isEmpty());
+    Assert.assertEquals(1, httpLoadQueuePeon.getNumSegmentsAwaitingConfirmation());
+    Assert.assertEquals(
+        Set.of(segment),
+        httpLoadQueuePeon.getSegmentsInQueue().stream()
+                         .map(SegmentHolder::getSegment)
+                         .collect(Collectors.toSet())
+    );
+
+    // An inventory without the segment yet keeps the load pending.
+    Assert.assertEquals(1, httpLoadQueuePeon.getQueueSnapshot(emptyInventory()).getSegmentsInQueue().size());
+    Assert.assertEquals(1, httpLoadQueuePeon.getNumSegmentsAwaitingConfirmation());
+
+    // An inventory that has caught up retires it.
+    Assert.assertTrue(httpLoadQueuePeon.getQueueSnapshot(inventoryWith(segment)).getSegmentsInQueue().isEmpty());
+    Assert.assertEquals(0, httpLoadQueuePeon.getNumSegmentsAwaitingConfirmation());
+  }
+
+  @Test
+  public void testAcknowledgedDropStaysInQueueUntilInventoryConfirmsIt()
+  {
+    final DataSegment segment = segments.get(0);
+    httpLoadQueuePeon.dropSegment(segment, null);
+
+    httpClient.sendRequestToServerAndHandleResponse();
+
+    Assert.assertTrue(httpLoadQueuePeon.getSegmentsToDrop().isEmpty());
+    Assert.assertEquals(1, httpLoadQueuePeon.getNumSegmentsAwaitingConfirmation());
+
+    // An inventory still showing the segment loaded is the pre-drop state.
+    httpLoadQueuePeon.getQueueSnapshot(inventoryWith(segment));
+    Assert.assertEquals(1, httpLoadQueuePeon.getNumSegmentsAwaitingConfirmation());
+
+    httpLoadQueuePeon.getQueueSnapshot(emptyInventory());
+    Assert.assertEquals(0, httpLoadQueuePeon.getNumSegmentsAwaitingConfirmation());
+  }
+
+  /**
+   * An inventory snapshot for this peon's server, standing in for a segment sync that has or has not caught up.
+   */
+  private static ImmutableDruidServer inventoryWith(DataSegment... loadedSegments)
+  {
+    final DruidServer server = new DruidServer(
+        "dummy", "dummy:4000", null, 10L << 30, null, ServerType.HISTORICAL, "tier1", 0
+    );
+    for (DataSegment segment : loadedSegments) {
+      server.addDataSegment(segment);
+    }
+    return server.toImmutableDruidServer();
+  }
+
+  private static ImmutableDruidServer emptyInventory()
+  {
+    return inventoryWith();
+  }
+
+  @Test
+  public void testFailedRequestIsNotRetainedForConfirmation()
+  {
+    final DataSegment segment = segments.get(0);
+    httpLoadQueuePeon.loadSegment(segment, SegmentAction.LOAD, null);
+
+    httpClient.failedSegments.add(segment);
+    httpClient.sendRequestToServerAndHandleResponse();
+
+    // A failed request changed nothing on the server, so there is no inventory update to wait for.
+    Assert.assertEquals(0, httpLoadQueuePeon.getNumSegmentsAwaitingConfirmation());
+    Assert.assertTrue(httpLoadQueuePeon.getSegmentsInQueue().isEmpty());
+  }
+
+  @Test
+  public void testMarkToDropGraduatesToQueuedDrop()
+  {
+    final DataSegment segment = segments.get(0);
+    httpLoadQueuePeon.markSegmentToDrop(segment);
+    Assert.assertEquals(Set.of(segment), httpLoadQueuePeon.getSegmentsMarkedToDrop());
+
+    httpLoadQueuePeon.dropSegment(segment, null);
+
+    // Queueing the drop retires the mark, so callers need not unmark separately. See apache/druid#18764.
+    Assert.assertTrue(httpLoadQueuePeon.getSegmentsMarkedToDrop().isEmpty());
+    Assert.assertEquals(Set.of(segment), httpLoadQueuePeon.getSegmentsToDrop());
+  }
+
+  @Test
+  public void testSegmentIsNeverAbsentFromBothHalvesOfQueueSnapshotDuringMoveCompletion()
+      throws InterruptedException
+  {
+    // Graduating a MOVE_FROM mark to a queued DROP must be atomic: a reader catching the moment in between sees the
+    // segment in neither collection and counts the replica as plainly loaded. See apache/druid#18764.
+    final DataSegment segment = segments.get(0);
+
+    // A seqlock over the window in which the invariant must hold: odd once the mark is in place, even again before
+    // teardown. A reader whose snapshot spans an unchanged odd generation knows it read entirely inside the window.
+    final AtomicLong generation = new AtomicLong();
+    final AtomicBoolean sawSegmentInNeither = new AtomicBoolean(false);
+    final AtomicBoolean stopReading = new AtomicBoolean(false);
+    final AtomicLong reads = new AtomicLong();
+
+    final Thread reader = new Thread(() -> {
+      while (!stopReading.get() && !sawSegmentInNeither.get()) {
+        final long before = generation.get();
+        if (before % 2 == 0) {
+          continue;
+        }
+
+        final LoadQueueSnapshot snapshot = httpLoadQueuePeon.getQueueSnapshot();
+        if (generation.get() != before) {
+          // The cycle ended mid-snapshot, so the segment is legitimately allowed to be absent.
+          continue;
+        }
+
+        reads.incrementAndGet();
+        final boolean queued = snapshot.getSegmentsInQueue().stream()
+                                       .anyMatch(holder -> holder.getSegment().equals(segment));
+        if (!queued && !snapshot.getSegmentsMarkedToDrop().contains(segment)) {
+          sawSegmentInNeither.set(true);
+        }
+      }
+    });
+
+    reader.start();
+    try {
+      for (int i = 0; i < 20_000 && !sawSegmentInNeither.get(); ++i) {
+        httpLoadQueuePeon.markSegmentToDrop(segment);
+        generation.incrementAndGet();
+
+        httpLoadQueuePeon.dropSegment(segment, null);
+
+        // Reset for the next cycle, outside the odd generation so the reader ignores it.
+        generation.incrementAndGet();
+        httpLoadQueuePeon.cancelOperation(segment);
+      }
+    }
+    finally {
+      stopReading.set(true);
+      reader.join(30_000);
+    }
+
+    Assert.assertTrue("Reader never sampled the window", reads.get() > 0);
+    Assert.assertFalse(
+        "Snapshot observed the segment neither queued nor marked to drop",
+        sawSegmentInNeither.get()
+    );
+  }
+
+  @Test
   public void testCancelLoad()
   {
     final DataSegment segment = segments.get(0);
@@ -357,6 +518,9 @@ public class HttpLoadQueuePeonTest
     final List<DataSegment> processedSegments = new ArrayList<>();
     final List<DataSegment> segmentsSentToServer = new ArrayList<>();
 
+    /** Segments for which the simulated server should report a failed change request. */
+    final Set<DataSegment> failedSegments = new HashSet<>();
+
     @Override
     public <Intermediate, Final> ListenableFuture<Final> go(
         Request request,
@@ -395,9 +559,17 @@ public class HttpLoadQueuePeonTest
 
         List<DataSegmentChangeResponse> statuses = new ArrayList<>(changeRequests.size());
         for (DataSegmentChangeRequest cr : changeRequests) {
+          final int numSentBefore = segmentsSentToServer.size();
           cr.go(this, null);
+
+          // The handler callbacks above reveal which segment the request was for.
+          final boolean failed = segmentsSentToServer.size() > numSentBefore
+                                 && failedSegments.contains(segmentsSentToServer.get(numSentBefore));
           statuses.add(
-              new DataSegmentChangeResponse(cr, SegmentChangeStatus.success())
+              new DataSegmentChangeResponse(
+                  cr,
+                  failed ? SegmentChangeStatus.failed("simulated failure") : SegmentChangeStatus.success()
+              )
           );
         }
         return (ListenableFuture<Final>) Futures.immediateFuture(

--- a/server/src/test/java/org/apache/druid/server/coordinator/loading/SegmentMoveConcurrencyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/loading/SegmentMoveConcurrencyTest.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.loading;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.client.ImmutableDruidServer;
+import org.apache.druid.java.util.common.RE;
+import org.apache.druid.java.util.common.concurrent.Execs;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.java.util.http.client.HttpClient;
+import org.apache.druid.java.util.http.client.Request;
+import org.apache.druid.java.util.http.client.response.HttpResponseHandler;
+import org.apache.druid.segment.TestHelper;
+import org.apache.druid.server.coordination.DataSegmentChangeCallback;
+import org.apache.druid.server.coordination.DataSegmentChangeHandler;
+import org.apache.druid.server.coordination.DataSegmentChangeRequest;
+import org.apache.druid.server.coordination.DataSegmentChangeResponse;
+import org.apache.druid.server.coordination.SegmentChangeStatus;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.CoordinatorDynamicConfig;
+import org.apache.druid.server.coordinator.CreateDataSegments;
+import org.apache.druid.server.coordinator.DruidCluster;
+import org.apache.druid.server.coordinator.DruidCoordinatorRuntimeParams;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.server.coordinator.balancer.BalancerStrategy;
+import org.apache.druid.server.coordinator.balancer.CostBalancerStrategy;
+import org.apache.druid.server.coordinator.config.HttpLoadQueuePeonConfig;
+import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
+import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorService;
+import org.apache.druid.server.coordinator.stats.Stats;
+import org.apache.druid.server.http.SegmentLoadingCapabilities;
+import org.apache.druid.server.http.SegmentLoadingMode;
+import org.apache.druid.timeline.DataSegment;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponse;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.jboss.netty.handler.codec.http.HttpVersion;
+import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Regression tests for apache/druid#18764.
+ * <p>
+ * A historical acknowledges a load or drop long before the Coordinator's inventory view reflects it. Forgetting the
+ * operation at ack time leaves a window in which it is visible in neither the load queue nor the inventory, so the
+ * replica looks plainly loaded; during a move that reads as over-replication and the Coordinator drops the last
+ * remaining replica. These tests reproduce that window: the server acks, but the inventory is not advanced.
+ */
+public class SegmentMoveConcurrencyTest
+{
+  private static final ObjectMapper MAPPER = TestHelper.makeJsonMapper();
+  private static final String TIER = "tier1";
+
+  private final DataSegment segment =
+      CreateDataSegments.ofDatasource("test")
+                        .forIntervals(1, Granularities.DAY)
+                        .startingAt("2022-01-01")
+                        .eachOfSizeInMb(100)
+                        .get(0);
+
+  private ListeningExecutorService exec;
+  private BalancerStrategy balancerStrategy;
+  private SegmentLoadQueueManager loadQueueManager;
+
+  private TestServer serverA;
+  private TestServer serverB;
+
+  @Before
+  public void setUp()
+  {
+    exec = MoreExecutors.listeningDecorator(Execs.multiThreaded(1, "SegmentMoveConcurrencyTest-%d"));
+    balancerStrategy = new CostBalancerStrategy(exec);
+    loadQueueManager = new SegmentLoadQueueManager(null, new TestTaskMaster());
+
+    serverA = new TestServer("histA");
+    serverB = new TestServer("histB");
+
+    // Starting state: the segment has exactly one replica, on server A.
+    serverA.druidServer.addDataSegment(segment);
+  }
+
+  @After
+  public void tearDown()
+  {
+    serverA.peon.stop();
+    serverB.peon.stop();
+    exec.shutdown();
+  }
+
+  @Test
+  public void testNoDropIsQueuedWhileTheSourceDropAwaitsInventoryConfirmation()
+  {
+    moveSegmentFromAtoB();
+
+    // B acks and its inventory catches up, so the load callback queues the drop on the source.
+    serverB.ackPendingRequests();
+    serverB.confirmInventory(true);
+    Assert.assertTrue(serverA.peon.getSegmentsToDrop().contains(segment));
+    Assert.assertTrue(serverA.peon.getSegmentsMarkedToDrop().isEmpty());
+
+    // A acks the drop but its inventory still reports the segment loaded: the state in the issue's trace between
+    // "Server[A] completed request[DROP]" and the next inventory sync.
+    serverA.ackPendingRequests();
+    Assert.assertTrue(serverA.peon.getSegmentsToDrop().isEmpty());
+    Assert.assertNotNull(serverA.druidServer.getSegment(segment.getId()));
+
+    final DruidCluster cluster = buildCluster();
+    final SegmentReplicaCount replicaCount = SegmentReplicaCountMap.create(cluster).getTotal(segment.getId());
+
+    // Both servers still report the segment loaded, but the in-flight drop on A must still be accounted for.
+    Assert.assertEquals(2, replicaCount.totalLoaded());
+    Assert.assertEquals(1, replicaCount.loadedNotDropping());
+
+    // With only one replica effectively loaded, there is no surplus and so no drop of B's replica.
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster);
+    params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER, 1));
+
+    Assert.assertEquals(
+        0L,
+        params.getCoordinatorStats().getSegmentStat(Stats.Segments.DROPPED, TIER, segment.getDataSource())
+    );
+    Assert.assertTrue(serverB.peon.getSegmentsToDrop().isEmpty());
+  }
+
+  @Test
+  public void testNoDropIsQueuedWhileTheSourceIsStillMarkedToDrop()
+  {
+    moveSegmentFromAtoB();
+
+    // B acks and its inventory catches up, but its load callback has not run, so A is still marked MOVE_FROM.
+    serverB.ackServerOnly();
+    serverB.confirmInventory(true);
+
+    final DruidCluster cluster = buildCluster();
+    final SegmentReplicaCount replicaCount = SegmentReplicaCountMap.create(cluster).getTotal(segment.getId());
+
+    Assert.assertEquals(2, replicaCount.totalLoaded());
+    Assert.assertEquals(1, replicaCount.moveCompletedPendingDrop());
+
+    final DruidCoordinatorRuntimeParams params = makeRuntimeParams(cluster);
+    params.getSegmentAssigner().replicateSegment(segment, ImmutableMap.of(TIER, 1));
+
+    Assert.assertEquals(
+        0L,
+        params.getCoordinatorStats().getSegmentStat(Stats.Segments.DROPPED, TIER, segment.getDataSource())
+    );
+    Assert.assertTrue(serverB.peon.getSegmentsToDrop().isEmpty());
+  }
+
+  @Test
+  public void testPendingSetTracksInFlightOperationsNotLoadedSegments()
+  {
+    // The retained-until-confirmed set must scale with load queue depth, not with segments held.
+    final List<DataSegment> manySegments =
+        CreateDataSegments.ofDatasource("scale")
+                          .forIntervals(1, Granularities.DAY)
+                          .startingAt("2024-01-01")
+                          .withNumPartitions(200)
+                          .eachOfSizeInMb(1);
+
+    for (DataSegment s : manySegments) {
+      serverB.peon.loadSegment(s, SegmentAction.LOAD, null);
+    }
+    serverB.ackPendingRequests();
+    Assert.assertEquals(manySegments.size(), serverB.peon.getNumSegmentsAwaitingConfirmation());
+
+    // Once the inventory reflects them they are all retired: 200 segments held, none tracked.
+    manySegments.forEach(serverB.druidServer::addDataSegment);
+    serverB.peon.getQueueSnapshot(serverB.druidServer.toImmutableDruidServer());
+
+    Assert.assertEquals(0, serverB.peon.getNumSegmentsAwaitingConfirmation());
+    Assert.assertEquals(manySegments.size(), serverB.druidServer.getTotalSegments());
+  }
+
+  /**
+   * Queues the move via the production code path, leaving both requests sent but not yet acknowledged.
+   */
+  private void moveSegmentFromAtoB()
+  {
+    final DruidCluster cluster = buildCluster();
+    final ServerHolder holderA = findHolder(cluster, serverA);
+    final ServerHolder holderB = findHolder(cluster, serverB);
+
+    Assert.assertTrue(loadQueueManager.moveSegment(segment, holderA, holderB, null));
+    Assert.assertTrue(serverA.peon.getSegmentsMarkedToDrop().contains(segment));
+  }
+
+  private DruidCluster buildCluster()
+  {
+    return DruidCluster.builder().addTier(TIER, serverA.toHolder(), serverB.toHolder()).build();
+  }
+
+  private ServerHolder findHolder(DruidCluster cluster, TestServer server)
+  {
+    return cluster.getManagedHistoricalsByTier(TIER)
+                  .stream()
+                  .filter(h -> h.getServer().getName().equals(server.druidServer.getName()))
+                  .findFirst()
+                  .orElseThrow(() -> new RE("No holder for server[%s]", server.druidServer.getName()));
+  }
+
+  private DruidCoordinatorRuntimeParams makeRuntimeParams(DruidCluster cluster)
+  {
+    return DruidCoordinatorRuntimeParams
+        .builder()
+        .withDruidCluster(cluster)
+        .withBalancerStrategy(balancerStrategy)
+        .withUsedSegments(segment)
+        .withDynamicConfigs(
+            CoordinatorDynamicConfig.builder()
+                                    .withSmartSegmentLoading(false)
+                                    .withUseRoundRobinSegmentAssignment(false)
+                                    .build()
+        )
+        .withSegmentAssignerUsing(loadQueueManager)
+        .build();
+  }
+
+  /**
+   * Answers the only question {@link SegmentLoadQueueManager#moveSegment} asks: whether loading is HTTP-based.
+   */
+  private static class TestTaskMaster extends LoadQueueTaskMaster
+  {
+    TestTaskMaster()
+    {
+      super(MAPPER, null, null, new HttpLoadQueuePeonConfig(null, null, null), null, null);
+    }
+  }
+
+  /**
+   * A historical with a real {@link HttpLoadQueuePeon} whose server responses and inventory updates are driven
+   * independently, so tests can hold the inventory back the way a real sync period does.
+   */
+  private class TestServer implements DataSegmentChangeHandler
+  {
+    private final DruidServer druidServer;
+    private final HttpLoadQueuePeon peon;
+    private final BlockingExecutorService processingExecutor;
+    private final BlockingExecutorService callbackExecutor;
+    private final List<DataSegment> segmentsSentToServer = new ArrayList<>();
+
+    TestServer(String name)
+    {
+      this.druidServer = new DruidServer(name, name, null, 10L << 30, null, ServerType.HISTORICAL, TIER, 0);
+      this.processingExecutor = new BlockingExecutorService(name + "-processing");
+      this.callbackExecutor = new BlockingExecutorService(name + "-callback");
+      this.peon = new HttpLoadQueuePeon(
+          "http://" + name + ":8083",
+          MAPPER,
+          new TestHttpClient(),
+          new HttpLoadQueuePeonConfig(null, null, 10),
+          () -> SegmentLoadingMode.NORMAL,
+          new WrappingScheduledExecutorService(name + "-%s", processingExecutor, true),
+          callbackExecutor
+      );
+      this.peon.start();
+    }
+
+    ServerHolder toHolder()
+    {
+      // Mirrors PrepareBalancerAndLoadQueues: the queue is read against the inventory snapshot it is paired with.
+      final ImmutableDruidServer inventory = druidServer.toImmutableDruidServer();
+      return new ServerHolder(inventory, peon, peon.getQueueSnapshot(inventory), false, false, 0, 1);
+    }
+
+    /**
+     * Acknowledges everything queued without running the callbacks, modelling a lagging callback executor.
+     */
+    void ackServerOnly()
+    {
+      processingExecutor.finishAllPendingTasks();
+    }
+
+    /**
+     * Acknowledges everything queued and runs the callbacks. The inventory is deliberately left untouched.
+     */
+    void ackPendingRequests()
+    {
+      processingExecutor.finishAllPendingTasks();
+      callbackExecutor.finishAllPendingTasks();
+    }
+
+    /**
+     * Advances the inventory view the way a segment sync would. The peon finds out on the next {@link #toHolder()}.
+     */
+    void confirmInventory(boolean nowLoaded)
+    {
+      if (nowLoaded) {
+        druidServer.addDataSegment(segment);
+      } else {
+        druidServer.removeDataSegment(segment.getId());
+      }
+    }
+
+    @Override
+    public void addSegment(DataSegment segment, DataSegmentChangeCallback callback)
+    {
+      segmentsSentToServer.add(segment);
+    }
+
+    @Override
+    public void removeSegment(DataSegment segment, DataSegmentChangeCallback callback)
+    {
+      segmentsSentToServer.add(segment);
+    }
+
+    private class TestHttpClient implements HttpClient
+    {
+      @Override
+      public <Intermediate, Final> ListenableFuture<Final> go(
+          Request request,
+          HttpResponseHandler<Intermediate, Final> handler
+      )
+      {
+        throw new UnsupportedOperationException("Not Implemented.");
+      }
+
+      @Override
+      @SuppressWarnings("unchecked")
+      public <Intermediate, Final> ListenableFuture<Final> go(
+          Request request,
+          HttpResponseHandler<Intermediate, Final> handler,
+          Duration duration
+      )
+      {
+        final HttpResponse httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK);
+        httpResponse.setContent(ChannelBuffers.buffer(0));
+        handler.handleResponse(httpResponse, null);
+
+        try {
+          if (request.getUrl().toString().contains("/loadCapabilities")) {
+            return (ListenableFuture<Final>) Futures.immediateFuture(
+                new ByteArrayInputStream(
+                    MAPPER.writerFor(SegmentLoadingCapabilities.class)
+                          .writeValueAsBytes(new SegmentLoadingCapabilities(1, 3))
+                )
+            );
+          }
+
+          final List<DataSegmentChangeRequest> changeRequests = MAPPER.readValue(
+              request.getContent().array(),
+              HttpLoadQueuePeon.REQUEST_ENTITY_TYPE_REF
+          );
+
+          final List<DataSegmentChangeResponse> statuses = new ArrayList<>(changeRequests.size());
+          for (DataSegmentChangeRequest cr : changeRequests) {
+            cr.go(TestServer.this, null);
+            statuses.add(new DataSegmentChangeResponse(cr, SegmentChangeStatus.success()));
+          }
+
+          return (ListenableFuture<Final>) Futures.immediateFuture(
+              new ByteArrayInputStream(
+                  MAPPER.writerFor(HttpLoadQueuePeon.RESPONSE_ENTITY_TYPE_REF).writeValueAsBytes(statuses)
+              )
+          );
+        }
+        catch (Exception ex) {
+          throw new RE(ex, "Unexpected exception.");
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes #18764.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

During move of a 1x-replicated segment from historical A to historical B, the coordinator can currently race and drop a segment temporarily from the timeline.

This occurs through 2 primary ways:

1. The `SegmentLoadQueueManager.moveSegment` operation calls `unmarkSegmentToDrop` and then `dropSegment` which can race with readers.
2. The coordinator currently receives information about what segments are loaded where through an inventory view (`ServerInventoryView`) and historical node callbacks (`HttpLoadQueuePeon`). Since these historical callbacks typically always arrive first, the code [sums up](https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCountMap.java#L52-L61) load data from both sources and then does a [diff](https://github.com/apache/druid/blob/master/server/src/main/java/org/apache/druid/server/coordinator/loading/SegmentReplicaCount.java#L145). While this works if the HttpLoadQueuePeon is present in the queue (to cancel out the new pending load on historical B), before this fix, the peon deletes the holder the moment the server acks. So the DROP left the queue while the inventory still showed the segment loaded.


#### Changes

1. Ensure we do the mark to drop transition atomically (`SegmentMoveConcurrencyTest::testMarkToDropGraduatesToQueuedDrop`).
2. Make sure we hang on to callbacks until inventory catches up. 

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.