### PR TITLE
feat: Add operator access to configure AWS retry policy. Default to STANDARD, recommended by AWS

### DIFF
--- a/cloud/aws-common/pom.xml
+++ b/cloud/aws-common/pom.xml
@@ -82,6 +82,17 @@
           <artifactId>sdk-core</artifactId>
           <version>${aws.sdk.v2.version}</version>
         </dependency>
+        <!-- Retry strategies configured by AWSClientConfig -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries-spi</artifactId>
+            <version>${aws.sdk.v2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>retries</artifactId>
+            <version>${aws.sdk.v2.version}</version>
+        </dependency>
         <!-- WebIdentityTokenProvider requires runtime dependency on sts -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/cloud/aws-common/pom.xml
+++ b/cloud/aws-common/pom.xml
@@ -126,5 +126,10 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
@@ -45,14 +45,6 @@ public class AWSClientConfig
   private static final int DEFAULT_MAX_CONNECTIONS_FLOOR = 50;
 
   /**
-   * Selects the retry behavior AWS documents for {@code standard} and {@code adaptive} rather than the pre-2026
-   * behavior. The no-argument factories default the {@code aws.newRetries2026} opt-in to false, which changes the
-   * backoff base delays and the retry-quota token costs; asking for it explicitly means the modes behave as
-   * documented, and keeps them behaving that way when AWS flips the opt-in default.
-   */
-  private static final Boolean USE_DOCUMENTED_RETRY_BEHAVIOR = Boolean.TRUE;
-
-  /**
    * Retry strategy family. Declared as an enum so an unrecognised value is rejected while the config is bound at
    * startup, rather than when a client is first built.
    */
@@ -62,7 +54,8 @@ public class AWSClientConfig
       @Override
       RetryStrategy createStrategy()
       {
-        return AwsRetryStrategy.standardRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOR);
+        // Pass true to ensure we get the new standard AWS SDKv2 retry behavior and not legacy behavior.
+        return AwsRetryStrategy.standardRetryStrategy(true);
       }
     },
     ADAPTIVE {
@@ -72,7 +65,7 @@ public class AWSClientConfig
         // Standard plus a client-side rate limiter, which unlike standard can delay or block the initial request,
         // not just retries. The limiter belongs to one client instance and covers every request that client makes,
         // so throttling on one key prefix also slows requests to prefixes that are not being throttled.
-        return AwsRetryStrategy.adaptiveRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOR);
+        return AwsRetryStrategy.adaptiveRetryStrategy(true);
       }
     },
     LEGACY {
@@ -152,16 +145,12 @@ public class AWSClientConfig
 
   /**
    * Retry strategy applied to every AWS client built from this config.
-   * <p>
-   * Setting this at all is deliberate: left unset, the SDK picks its own default, and which one it picks depends on
-   * the {@code aws.newRetries2026} migration flag. Naming the mode here keeps retry behavior stable across SDK
-   * upgrades instead of changing under Druid when that flag's default flips.
    */
   @JsonProperty
   private RetryMode retryMode = RetryMode.STANDARD;
 
   /**
-   * Total attempts per request, including the first. Maps directly to the SDK's {@code maxAttempts}, so 1 disables
+   * Total attempts per request, including the first. A value of 1 disables
    * retries. Null leaves the count that {@link #retryMode} defines for itself, which AWS tunes alongside that mode's
    * backoff and retry quota.
    * <p>
@@ -172,7 +161,7 @@ public class AWSClientConfig
   @JsonProperty
   @Nullable
   @Min(1)
-  private Integer maxRetryAttempts = null;
+  private Integer maxAttempts = null;
 
   public String getProtocol()
   {
@@ -246,9 +235,9 @@ public class AWSClientConfig
   }
 
   @Nullable
-  public Integer getMaxRetryAttempts()
+  public Integer getMaxAttempts()
   {
-    return maxRetryAttempts;
+    return maxAttempts;
   }
 
   /**
@@ -262,15 +251,15 @@ public class AWSClientConfig
   }
 
   /**
-   * Overrides the attempt count only when one is configured, so an unset {@link #maxRetryAttempts} leaves whatever
+   * Overrides the attempt count only when one is configured, so an unset {@link #maxAttempts} leaves whatever
    * the chosen mode defines for itself.
    */
   private RetryStrategy withMaxAttempts(RetryStrategy strategy)
   {
-    if (maxRetryAttempts == null) {
+    if (maxAttempts == null) {
       return strategy;
     }
-    return strategy.toBuilder().maxAttempts(maxRetryAttempts).build();
+    return strategy.toBuilder().maxAttempts(maxAttempts).build();
   }
 
   @Override
@@ -285,7 +274,7 @@ public class AWSClientConfig
            ", socketTimeout=" + socketTimeout +
            ", maxConnections=" + getMaxConnections() +
            ", retryMode='" + retryMode + '\'' +
-           ", maxRetryAttempts=" + maxRetryAttempts +
+           ", maxRetryAttempts=" + maxAttempts +
            '}';
   }
 }

--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
@@ -20,10 +20,18 @@
 package org.apache.druid.common.aws;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.druid.java.util.common.IAE;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.utils.RuntimeInfo;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.retries.api.RetryStrategy;
 
 import javax.annotation.Nullable;
+import javax.validation.constraints.Min;
+import java.util.Arrays;
 
 public class AWSClientConfig
 {
@@ -35,6 +43,68 @@ public class AWSClientConfig
   private static final int DEFAULT_SOCKET_TIMEOUT_MILLIS = 50_000;
   /** AWS SDK v2's own default. */
   private static final int DEFAULT_MAX_CONNECTIONS_FLOOR = 50;
+
+  /**
+   * Selects the retry behaviour AWS documents for {@code standard} and {@code adaptive} rather than the pre-2026
+   * behaviour. The no-argument factories default the {@code aws.newRetries2026} opt-in to false, which changes the
+   * backoff base delays and the retry-quota token costs; asking for it explicitly means the modes behave as
+   * documented, and keeps them behaving that way when AWS flips the opt-in default.
+   */
+  private static final Boolean USE_DOCUMENTED_RETRY_BEHAVIOUR = Boolean.TRUE;
+
+  /**
+   * Retry strategy family. Declared as an enum so an unrecognised value is rejected while the config is bound at
+   * startup, rather than when a client is first built.
+   */
+  public enum RetryMode
+  {
+    STANDARD {
+      @Override
+      RetryStrategy createStrategy()
+      {
+        return AwsRetryStrategy.standardRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOUR);
+      }
+    },
+    ADAPTIVE {
+      @Override
+      RetryStrategy createStrategy()
+      {
+        // Standard plus a client-side rate limiter, which unlike standard can delay or block the initial request,
+        // not just retries. The limiter belongs to one client instance and covers every request that client makes,
+        // so throttling on one key prefix also slows requests to prefixes that are not being throttled.
+        return AwsRetryStrategy.adaptiveRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOUR);
+      }
+    },
+    LEGACY {
+      @Override
+      RetryStrategy createStrategy()
+      {
+        // Deliberately left on the pre-standard behaviour: this mode exists so a deployment can get back to what it
+        // had before, which is the opposite of what the opt-in above asks for.
+        return AwsRetryStrategy.legacyRetryStrategy();
+      }
+    };
+
+    abstract RetryStrategy createStrategy();
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+      return StringUtils.toLowerCase(name());
+    }
+
+    @JsonCreator
+    public static RetryMode fromString(String value)
+    {
+      for (RetryMode mode : values()) {
+        if (mode.name().equalsIgnoreCase(value)) {
+          return mode;
+        }
+      }
+      throw new IAE("Invalid druid.s3.retryMode[%s]. Must be one of %s.", value, Arrays.toString(values()));
+    }
+  }
 
   /**
    * Used by {@link #getMaxConnections} to scale the default connection pool with host size so hosts large enough to
@@ -79,6 +149,30 @@ public class AWSClientConfig
   @JsonProperty
   @Nullable
   private Integer maxConnections = null;
+
+  /**
+   * Retry strategy applied to every AWS client built from this config.
+   * <p>
+   * Setting this at all is deliberate: left unset, the SDK picks its own default, and which one it picks depends on
+   * the {@code aws.newRetries2026} migration flag. Naming the mode here keeps retry behaviour stable across SDK
+   * upgrades instead of changing under Druid when that flag's default flips.
+   */
+  @JsonProperty
+  private RetryMode retryMode = RetryMode.STANDARD;
+
+  /**
+   * Total attempts per request, including the first. Maps directly to the SDK's {@code maxAttempts}, so 1 disables
+   * retries. Null leaves the count that {@link #retryMode} defines for itself, which AWS tunes alongside that mode's
+   * backoff and retry quota.
+   * <p>
+   * This counts HTTP requests. Druid layers its own retries on top (see {@code S3Utils#retryS3Operation}) and the two
+   * multiply, but they are not equivalent: an attempt here re-sends a single request, whereas a Druid-level retry
+   * repeats a whole operation, such as re-uploading an entire segment.
+   */
+  @JsonProperty
+  @Nullable
+  @Min(1)
+  private Integer maxRetryAttempts = null;
 
   public String getProtocol()
   {
@@ -146,6 +240,39 @@ public class AWSClientConfig
     return Math.max(DEFAULT_MAX_CONNECTIONS_FLOOR, 4 * runtimeInfo.getAvailableProcessors());
   }
 
+  public RetryMode getRetryMode()
+  {
+    return retryMode;
+  }
+
+  @Nullable
+  public Integer getMaxRetryAttempts()
+  {
+    return maxRetryAttempts;
+  }
+
+  /**
+   * Builds the strategy to hand to {@code ClientOverrideConfiguration.retryStrategy}. Kept as a plain function of the
+   * config because a built AWS client does not expose the strategy it was given, so this is the only place the
+   * mapping can be tested.
+   */
+  public RetryStrategy getRetryStrategy()
+  {
+    return withMaxAttempts(retryMode.createStrategy());
+  }
+
+  /**
+   * Overrides the attempt count only when one is configured, so an unset {@link #maxRetryAttempts} leaves whatever
+   * the chosen mode defines for itself.
+   */
+  private RetryStrategy withMaxAttempts(RetryStrategy strategy)
+  {
+    if (maxRetryAttempts == null) {
+      return strategy;
+    }
+    return strategy.toBuilder().maxAttempts(maxRetryAttempts).build();
+  }
+
   @Override
   public String toString()
   {
@@ -157,6 +284,8 @@ public class AWSClientConfig
            ", connectionTimeout=" + connectionTimeout +
            ", socketTimeout=" + socketTimeout +
            ", maxConnections=" + getMaxConnections() +
+           ", retryMode='" + retryMode + '\'' +
+           ", maxRetryAttempts=" + maxRetryAttempts +
            '}';
   }
 }

--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
@@ -244,6 +244,9 @@ public class AWSClientConfig
    * Builds the strategy to hand to {@code ClientOverrideConfiguration.retryStrategy}. Kept as a plain function of the
    * config because a built AWS client does not expose the strategy it was given, so this is the only place the
    * mapping can be tested.
+   * <p>
+   * Returns a new instance per call; clients must not share one, since the strategies hold their circuit-breaker
+   * quota (and, for adaptive, their rate limiter) on the instance.
    */
   public RetryStrategy getRetryStrategy()
   {

--- a/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
+++ b/cloud/aws-common/src/main/java/org/apache/druid/common/aws/AWSClientConfig.java
@@ -45,12 +45,12 @@ public class AWSClientConfig
   private static final int DEFAULT_MAX_CONNECTIONS_FLOOR = 50;
 
   /**
-   * Selects the retry behaviour AWS documents for {@code standard} and {@code adaptive} rather than the pre-2026
-   * behaviour. The no-argument factories default the {@code aws.newRetries2026} opt-in to false, which changes the
+   * Selects the retry behavior AWS documents for {@code standard} and {@code adaptive} rather than the pre-2026
+   * behavior. The no-argument factories default the {@code aws.newRetries2026} opt-in to false, which changes the
    * backoff base delays and the retry-quota token costs; asking for it explicitly means the modes behave as
    * documented, and keeps them behaving that way when AWS flips the opt-in default.
    */
-  private static final Boolean USE_DOCUMENTED_RETRY_BEHAVIOUR = Boolean.TRUE;
+  private static final Boolean USE_DOCUMENTED_RETRY_BEHAVIOR = Boolean.TRUE;
 
   /**
    * Retry strategy family. Declared as an enum so an unrecognised value is rejected while the config is bound at
@@ -62,7 +62,7 @@ public class AWSClientConfig
       @Override
       RetryStrategy createStrategy()
       {
-        return AwsRetryStrategy.standardRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOUR);
+        return AwsRetryStrategy.standardRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOR);
       }
     },
     ADAPTIVE {
@@ -72,14 +72,14 @@ public class AWSClientConfig
         // Standard plus a client-side rate limiter, which unlike standard can delay or block the initial request,
         // not just retries. The limiter belongs to one client instance and covers every request that client makes,
         // so throttling on one key prefix also slows requests to prefixes that are not being throttled.
-        return AwsRetryStrategy.adaptiveRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOUR);
+        return AwsRetryStrategy.adaptiveRetryStrategy(USE_DOCUMENTED_RETRY_BEHAVIOR);
       }
     },
     LEGACY {
       @Override
       RetryStrategy createStrategy()
       {
-        // Deliberately left on the pre-standard behaviour: this mode exists so a deployment can get back to what it
+        // Deliberately left on the pre-standard behavior: this mode exists so a deployment can get back to what it
         // had before, which is the opposite of what the opt-in above asks for.
         return AwsRetryStrategy.legacyRetryStrategy();
       }
@@ -154,7 +154,7 @@ public class AWSClientConfig
    * Retry strategy applied to every AWS client built from this config.
    * <p>
    * Setting this at all is deliberate: left unset, the SDK picks its own default, and which one it picks depends on
-   * the {@code aws.newRetries2026} migration flag. Naming the mode here keeps retry behaviour stable across SDK
+   * the {@code aws.newRetries2026} migration flag. Naming the mode here keeps retry behavior stable across SDK
    * upgrades instead of changing under Druid when that flag's default flips.
    */
   @JsonProperty

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
@@ -146,7 +146,7 @@ public class AWSClientConfigTest
   {
     final AWSClientConfig config = new AWSClientConfig();
 
-    Assertions.assertNull(config.getMaxRetryAttempts());
+    Assertions.assertNull(config.getMaxAttempts());
     Assertions.assertEquals(
         AWSClientConfig.RetryMode.STANDARD.createStrategy().maxAttempts(),
         config.getRetryStrategy().maxAttempts()

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
@@ -20,22 +20,43 @@
 package org.apache.druid.common.aws;
 
 import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.utils.RuntimeInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.retries.AdaptiveRetryStrategy;
 import software.amazon.awssdk.retries.LegacyRetryStrategy;
 import software.amazon.awssdk.retries.StandardRetryStrategy;
+import software.amazon.awssdk.retries.api.RetryStrategy;
+
+import java.util.Map;
+import java.util.stream.Stream;
 
 public class AWSClientConfigTest
 {
-  private static final ObjectMapper MAPPER = new ObjectMapper().setInjectableValues(
-      new InjectableValues.Std().addValue(RuntimeInfo.class, new RuntimeInfo())
-  );
+  private static final ObjectMapper MAPPER = mapperWithRuntimeInfo(new RuntimeInfo());
+
+  /**
+   * Binds a property map the way {@code JsonConfigurator} binds {@code druid.s3.*} at startup, so behaviour that only
+   * exists during binding - defaults, unset versus explicitly set, rejection of bad values - is exercised here the
+   * same way it happens in a running process.
+   */
+  private static AWSClientConfig bind(Map<String, Object> properties)
+  {
+    return MAPPER.convertValue(properties, AWSClientConfig.class);
+  }
+
+  private static AWSClientConfig bind(Map<String, Object> properties, RuntimeInfo runtimeInfo)
+  {
+    return mapperWithRuntimeInfo(runtimeInfo).convertValue(properties, AWSClientConfig.class);
+  }
 
   private static ObjectMapper mapperWithRuntimeInfo(RuntimeInfo runtimeInfo)
   {
@@ -49,51 +70,58 @@ public class AWSClientConfigTest
   {
     final AWSClientConfig config = new AWSClientConfig();
 
+    Assertions.assertEquals(AWSClientConfig.RetryMode.STANDARD, config.getRetryMode());
     Assertions.assertInstanceOf(StandardRetryStrategy.class, config.getRetryStrategy());
   }
 
-  @Test
-  public void testDefaultLeavesAttemptCountToTheSdk()
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("retryModeStrategies")
+  public void testEachRetryModeBuildsItsStrategy(
+      AWSClientConfig.RetryMode mode,
+      Class<? extends RetryStrategy> expected
+  )
   {
-    final AWSClientConfig config = new AWSClientConfig();
+    Assertions.assertInstanceOf(expected, mode.createStrategy());
+  }
 
-    Assertions.assertNull(config.getMaxRetryAttempts());
+  /**
+   * Guards {@link #retryModeStrategies} against a mode being added without a strategy expectation.
+   */
+  @Test
+  public void testEveryRetryModeHasAStrategyExpectation()
+  {
+    Assertions.assertEquals(AWSClientConfig.RetryMode.values().length, retryModeStrategies().count());
+  }
+
+  private static Stream<Arguments> retryModeStrategies()
+  {
+    return Stream.of(
+        Arguments.of(AWSClientConfig.RetryMode.STANDARD, StandardRetryStrategy.class),
+        Arguments.of(AWSClientConfig.RetryMode.ADAPTIVE, AdaptiveRetryStrategy.class),
+        Arguments.of(AWSClientConfig.RetryMode.LEGACY, LegacyRetryStrategy.class)
+    );
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"adaptive", "ADAPTIVE", "Adaptive"})
+  public void testRetryModeParsingIsCaseInsensitive(String value)
+  {
+    Assertions.assertEquals(AWSClientConfig.RetryMode.ADAPTIVE, AWSClientConfig.RetryMode.fromString(value));
+  }
+
+  @Test
+  public void testRetryModeBindsFromItsProperty()
+  {
     Assertions.assertEquals(
-        AwsRetryStrategy.standardRetryStrategy().maxAttempts(),
-        config.getRetryStrategy().maxAttempts()
+        AWSClientConfig.RetryMode.ADAPTIVE,
+        bind(Map.of("retryMode", "adaptive")).getRetryMode()
     );
   }
 
   @Test
-  public void testAdaptiveRetryModeIsSelectable() throws Exception
+  public void testRetryModeSerializesToItsPropertyValue()
   {
-    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"adaptive\"}", AWSClientConfig.class);
-
-    Assertions.assertInstanceOf(AdaptiveRetryStrategy.class, config.getRetryStrategy());
-  }
-
-  @Test
-  public void testLegacyRetryModeIsSelectable() throws Exception
-  {
-    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"legacy\"}", AWSClientConfig.class);
-
-    Assertions.assertInstanceOf(LegacyRetryStrategy.class, config.getRetryStrategy());
-  }
-
-  @Test
-  public void testRetryModeIsCaseInsensitive() throws Exception
-  {
-    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"ADAPTIVE\"}", AWSClientConfig.class);
-
-    Assertions.assertInstanceOf(AdaptiveRetryStrategy.class, config.getRetryStrategy());
-  }
-
-  @Test
-  public void testConfiguredAttemptCountIsApplied() throws Exception
-  {
-    final AWSClientConfig config = MAPPER.readValue("{\"maxRetryAttempts\": 8}", AWSClientConfig.class);
-
-    Assertions.assertEquals(8, config.getRetryStrategy().maxAttempts());
+    Assertions.assertEquals("adaptive", MAPPER.convertValue(AWSClientConfig.RetryMode.ADAPTIVE, String.class));
   }
 
   /**
@@ -103,102 +131,79 @@ public class AWSClientConfigTest
   @Test
   public void testUnrecognizedRetryModeIsRejectedWhenConfigIsBound()
   {
-    final JsonMappingException e = Assertions.assertThrows(
-        JsonMappingException.class,
-        () -> MAPPER.readValue("{\"retryMode\": \"aggressive\"}", AWSClientConfig.class)
+    final IllegalArgumentException e = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> bind(Map.of("retryMode", "aggressive"))
     );
 
-    Assertions.assertInstanceOf(IAE.class, e.getCause());
-    Assertions.assertTrue(e.getCause().getMessage().contains("aggressive"));
+    final Throwable rootCause = Throwables.getRootCause(e);
+    Assertions.assertInstanceOf(IAE.class, rootCause);
+    Assertions.assertTrue(rootCause.getMessage().contains("aggressive"));
   }
 
   @Test
-  public void testRetryModeSerializesToItsPropertyValue() throws Exception
+  public void testUnsetAttemptCountLeavesTheCountTheModeDefines()
   {
-    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"adaptive\"}", AWSClientConfig.class);
+    final AWSClientConfig config = new AWSClientConfig();
 
-    Assertions.assertEquals("adaptive", MAPPER.convertValue(config.getRetryMode(), String.class));
-  }
-
-  @Test
-  public void testDefaultCrossRegionAccessEnabled() throws Exception
-  {
-    AWSClientConfig config = MAPPER.readValue("{}", AWSClientConfig.class);
-    Assertions.assertNull(config.isForceGlobalBucketAccessEnabled());
-    Assertions.assertFalse(config.isCrossRegionAccessEnabled());
-  }
-
-  @Test
-  public void testCrossRegionAccessEnabledExplicitlySet() throws Exception
-  {
-    AWSClientConfig config = MAPPER.readValue("{\"crossRegionAccessEnabled\": true}", AWSClientConfig.class);
-    Assertions.assertNull(config.isForceGlobalBucketAccessEnabled());
-    Assertions.assertTrue(config.isCrossRegionAccessEnabled());
-  }
-
-  @Test
-  public void testNewConfigTakesPrecedenceOverDeprecatedWhenBothSet() throws Exception
-  {
-    AWSClientConfig config = MAPPER.readValue(
-        "{\"forceGlobalBucketAccessEnabled\": true, \"crossRegionAccessEnabled\": false}",
-        AWSClientConfig.class
+    Assertions.assertNull(config.getMaxRetryAttempts());
+    Assertions.assertEquals(
+        AWSClientConfig.RetryMode.STANDARD.createStrategy().maxAttempts(),
+        config.getRetryStrategy().maxAttempts()
     );
-    Assertions.assertFalse(config.isCrossRegionAccessEnabled());
   }
 
   @Test
-  public void testNewConfigTrueWinsOverDeprecatedFalse() throws Exception
+  public void testConfiguredAttemptCountIsApplied()
   {
-    AWSClientConfig config = MAPPER.readValue(
-        "{\"forceGlobalBucketAccessEnabled\": false, \"crossRegionAccessEnabled\": true}",
-        AWSClientConfig.class
+    Assertions.assertEquals(8, bind(Map.of("maxRetryAttempts", 8)).getRetryStrategy().maxAttempts());
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("crossRegionAccessBindings")
+  public void testCrossRegionAccessResolution(Map<String, Object> properties, boolean expected)
+  {
+    Assertions.assertEquals(expected, bind(properties).isCrossRegionAccessEnabled());
+  }
+
+  private static Stream<Arguments> crossRegionAccessBindings()
+  {
+    return Stream.of(
+        Arguments.of(Map.of(), false),
+        Arguments.of(Map.of("crossRegionAccessEnabled", true), true),
+        Arguments.of(Map.of("forceGlobalBucketAccessEnabled", true), true),
+        // the new property wins whichever way the two disagree
+        Arguments.of(Map.of("forceGlobalBucketAccessEnabled", true, "crossRegionAccessEnabled", false), false),
+        Arguments.of(Map.of("forceGlobalBucketAccessEnabled", false, "crossRegionAccessEnabled", true), true)
     );
-    Assertions.assertTrue(config.isCrossRegionAccessEnabled());
+  }
+
+  /**
+   * The deprecated property is only ever populated by its own key, so code still reading it cannot be misled by the
+   * replacement being set.
+   */
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testDeprecatedPropertyStaysUnsetWhenOnlyItsReplacementIsBound()
+  {
+    Assertions.assertNull(bind(Map.of()).isForceGlobalBucketAccessEnabled());
+    Assertions.assertNull(bind(Map.of("crossRegionAccessEnabled", true)).isForceGlobalBucketAccessEnabled());
+  }
+
+  @ParameterizedTest(name = "{0} processors -> {1} connections")
+  @CsvSource({"8, 50", "32, 128"})
+  public void testDefaultMaxConnectionsTakesTheSdkFloorOrFourPerCore(int processors, int expected)
+  {
+    Assertions.assertEquals(expected, bind(Map.of(), new FixedProcessorsRuntimeInfo(processors)).getMaxConnections());
   }
 
   @Test
-  public void testDeprecatedForceGlobalBucketAccessAloneTrue() throws Exception
+  public void testExplicitMaxConnectionsOverridesDefault()
   {
-    AWSClientConfig config = MAPPER.readValue(
-        "{\"forceGlobalBucketAccessEnabled\": true}",
-        AWSClientConfig.class
+    Assertions.assertEquals(
+        200,
+        bind(Map.of("maxConnections", 200), new FixedProcessorsRuntimeInfo(64)).getMaxConnections()
     );
-    Assertions.assertTrue(config.isCrossRegionAccessEnabled());
-  }
-
-  @Test
-  public void testDeprecatedNotSetFallsThroughToCrossRegion() throws Exception
-  {
-    AWSClientConfig config = MAPPER.readValue(
-        "{\"crossRegionAccessEnabled\": true}",
-        AWSClientConfig.class
-    );
-    Assertions.assertNull(config.isForceGlobalBucketAccessEnabled());
-    Assertions.assertTrue(config.isCrossRegionAccessEnabled());
-  }
-
-  @Test
-  public void testDefaultMaxConnectionsKeepsAwsSdkFloorOnSmallHost() throws Exception
-  {
-    AWSClientConfig config = mapperWithRuntimeInfo(new FixedProcessorsRuntimeInfo(8))
-        .readValue("{}", AWSClientConfig.class);
-    Assertions.assertEquals(50, config.getMaxConnections());
-  }
-
-  @Test
-  public void testDefaultMaxConnectionsScalesWithCoresOnLargeHost() throws Exception
-  {
-    AWSClientConfig config = mapperWithRuntimeInfo(new FixedProcessorsRuntimeInfo(32))
-        .readValue("{}", AWSClientConfig.class);
-    Assertions.assertEquals(128, config.getMaxConnections());
-  }
-
-  @Test
-  public void testExplicitMaxConnectionsOverridesDefault() throws Exception
-  {
-    AWSClientConfig config = mapperWithRuntimeInfo(new FixedProcessorsRuntimeInfo(64))
-        .readValue("{\"maxConnections\": 200}", AWSClientConfig.class);
-    Assertions.assertEquals(200, config.getMaxConnections());
   }
 
   private static final class FixedProcessorsRuntimeInfo extends RuntimeInfo

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
@@ -20,10 +20,16 @@
 package org.apache.druid.common.aws;
 
 import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.utils.RuntimeInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.retries.AdaptiveRetryStrategy;
+import software.amazon.awssdk.retries.LegacyRetryStrategy;
+import software.amazon.awssdk.retries.StandardRetryStrategy;
 
 public class AWSClientConfigTest
 {
@@ -36,6 +42,82 @@ public class AWSClientConfigTest
     return new ObjectMapper().setInjectableValues(
         new InjectableValues.Std().addValue(RuntimeInfo.class, runtimeInfo)
     );
+  }
+
+  @Test
+  public void testDefaultRetryModeIsStandard()
+  {
+    final AWSClientConfig config = new AWSClientConfig();
+
+    Assertions.assertInstanceOf(StandardRetryStrategy.class, config.getRetryStrategy());
+  }
+
+  @Test
+  public void testDefaultLeavesAttemptCountToTheSdk()
+  {
+    final AWSClientConfig config = new AWSClientConfig();
+
+    Assertions.assertNull(config.getMaxRetryAttempts());
+    Assertions.assertEquals(
+        AwsRetryStrategy.standardRetryStrategy().maxAttempts(),
+        config.getRetryStrategy().maxAttempts()
+    );
+  }
+
+  @Test
+  public void testAdaptiveRetryModeIsSelectable() throws Exception
+  {
+    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"adaptive\"}", AWSClientConfig.class);
+
+    Assertions.assertInstanceOf(AdaptiveRetryStrategy.class, config.getRetryStrategy());
+  }
+
+  @Test
+  public void testLegacyRetryModeIsSelectable() throws Exception
+  {
+    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"legacy\"}", AWSClientConfig.class);
+
+    Assertions.assertInstanceOf(LegacyRetryStrategy.class, config.getRetryStrategy());
+  }
+
+  @Test
+  public void testRetryModeIsCaseInsensitive() throws Exception
+  {
+    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"ADAPTIVE\"}", AWSClientConfig.class);
+
+    Assertions.assertInstanceOf(AdaptiveRetryStrategy.class, config.getRetryStrategy());
+  }
+
+  @Test
+  public void testConfiguredAttemptCountIsApplied() throws Exception
+  {
+    final AWSClientConfig config = MAPPER.readValue("{\"maxRetryAttempts\": 8}", AWSClientConfig.class);
+
+    Assertions.assertEquals(8, config.getRetryStrategy().maxAttempts());
+  }
+
+  /**
+   * Binding the config is the last point at which a bad mode can be reported against the property that set it, so it
+   * has to fail here rather than when some client is first built.
+   */
+  @Test
+  public void testUnrecognizedRetryModeIsRejectedWhenConfigIsBound()
+  {
+    final JsonMappingException e = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> MAPPER.readValue("{\"retryMode\": \"aggressive\"}", AWSClientConfig.class)
+    );
+
+    Assertions.assertInstanceOf(IAE.class, e.getCause());
+    Assertions.assertTrue(e.getCause().getMessage().contains("aggressive"));
+  }
+
+  @Test
+  public void testRetryModeSerializesToItsPropertyValue() throws Exception
+  {
+    final AWSClientConfig config = MAPPER.readValue("{\"retryMode\": \"adaptive\"}", AWSClientConfig.class);
+
+    Assertions.assertEquals("adaptive", MAPPER.convertValue(config.getRetryMode(), String.class));
   }
 
   @Test

--- a/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
+++ b/cloud/aws-common/src/test/java/org/apache/druid/common/aws/AWSClientConfigTest.java
@@ -156,7 +156,7 @@ public class AWSClientConfigTest
   @Test
   public void testConfiguredAttemptCountIsApplied()
   {
-    Assertions.assertEquals(8, bind(Map.of("maxRetryAttempts", 8)).getRetryStrategy().maxAttempts());
+    Assertions.assertEquals(8, bind(Map.of("maxAttempts", 8)).getRetryStrategy().maxAttempts());
   }
 
   @ParameterizedTest(name = "{0}")

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -131,8 +131,8 @@ For example, to set the region to 'us-east-1' through system properties:
 |`druid.s3.disableChunkedEncoding`|Disables chunked encoding. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--) for details.|false|
 |`druid.s3.enablePathStyleAccess`|Enables path style access. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#enablePathStyleAccess--) for details.|false|
 |`druid.s3.crossRegionAccessEnabled`|Enables cross-region access for S3 requests. When enabled, the S3 client automatically detects the correct region for a bucket on first access and caches it for subsequent requests.|false|
-|`druid.s3.retryMode`|Retry strategy used by every AWS client Druid builds. One of `standard`, `adaptive` or `legacy`. See [Retry behavior](#retry-behavior).|`standard`|
-|`druid.s3.maxRetryAttempts`|Total attempts per HTTP request, including the first, so `1` disables SDK retries. When unset, the count defined by `druid.s3.retryMode` applies. See [Retry behavior](#retry-behavior).|null (the retry mode's own default)|
+|`druid.s3.retryMode`|Retry strategy used by every AWS client Druid builds. One of `standard`, `adaptive` or `legacy`. See [AWS document](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html) for details about each mode.|`standard`|
+|`druid.s3.maxAttempts`|Total attempts per HTTP request, including the first, so `1` disables SDK retries. When unset, the SDK default count defined by `druid.s3.retryMode` applies.|null (the retry mode's own default)|
 |`druid.s3.forceGlobalBucketAccessEnabled`|**Deprecated.** Use `druid.s3.crossRegionAccessEnabled` instead. Only used as a fallback if `crossRegionAccessEnabled` is not explicitly set.|null|
 |`druid.s3.endpoint.url`|Service endpoint either with or without the protocol.|None|
 |`druid.s3.endpoint.signingRegion`|Region to use for SigV4 signing of requests (e.g. us-west-1).|None|
@@ -143,61 +143,6 @@ For example, to set the region to 'us-east-1' through system properties:
 |`druid.storage.sse.type`|Server-side encryption type. Should be one of `s3`, `kms`, and `custom`. See the below [Server-side encryption section](#server-side-encryption) for more details.|None|
 |`druid.storage.sse.kms.keyId`|AWS KMS key ID. This is used only when `druid.storage.sse.type` is `kms` and can be empty to use the default key ID.|None|
 |`druid.storage.sse.custom.base64EncodedKey`|Base64-encoded key. Should be specified if `druid.storage.sse.type` is `custom`.|None|
-
-## Retry behavior
-
-Druid names the AWS SDK retry strategy explicitly rather than accepting the SDK's default. The SDK's own default
-depends on the `aws.newRetries2026` migration flag, so leaving it unset would let retry behavior change underneath
-Druid when that flag's default flips. For `standard` and `adaptive`, Druid also opts in to the behavior AWS
-documents for those modes, rather than quietly falling back to any legacy behavior the SDK may have.
-
-|Mode|Behavior|
-|----|--------|
-|`standard`|Error classification consistent with the other AWS SDK implementations, and the mode AWS recommends for all workloads.|
-|`adaptive`|`standard` plus a client-side rate limiter that slows requests down when S3 reports throttling. Unlike `standard`, it can delay or block the **initial** request, not only retries. The limiter covers every request made by one client instance, so throttling on one key prefix also slows requests to prefixes that are not being throttled.|
-|`legacy`|The SDK's legacy behavior, retained so a deployment can revert without a rollback. AWS recommends moving off it.|
-
-### Choosing a mode
-
-AWS recommends `standard` as the default and `adaptive` only for workloads that are *single-resource,
-throttling-heavy, and latency-tolerant*. S3 applies its request-rate limits per key prefix, so "single-resource"
-means a process that concentrates its requests on one prefix.
-
-That maps onto Druid roughly as follows. Because a peon runs one task, you can select a mode per task type — through
-a Kubernetes pod template, or `druid.indexer.fork.property.druid.s3.retryMode` in a task's context when using the
-MiddleManager task runner.
-
-|Process|Suggested mode|Reasoning|
-|-------|--------------|---------|
-|MSQ and compaction peons|`adaptive`|Segment output goes to one new version prefix and shuffle output to one prefix per query, which is exactly the concentration that provokes throttling. Batch work tolerates the added latency.|
-|Batch ingestion peons|`standard`, or `adaptive` if throttled|Same shape as above at lower request rates.|
-|Historicals|`standard`|One client loads segments for every datasource the process serves, so a rate limiter tripped by one prefix would slow loads for unrelated ones. Segment loads can also sit on the query path.|
-|Brokers, Coordinator, Overlord|`standard`|Low request volume, and delaying an initial request costs query latency for no benefit.|
-
-### Retry quota
-
-Every mode carries a retry quota: a token bucket, held per client instance and never shared across processes, that
-stops retries once it is exhausted so the client fails fast instead of adding load a struggling service cannot
-absorb. It only engages under sustained failure — roughly a 32% failure rate for throttling errors — and is inert
-otherwise. Choosing between the modes does not change whether it is present.
-
-S3 reports throttling as `SlowDown` and `503`, which the SDK classifies as throttling rather than transient errors.
-Those get a longer base backoff than transient failures, and they are what `adaptive`'s rate limiter reacts to.
-
-### Retries are layered
-
-`druid.s3.maxRetryAttempts` applies per HTTP request. Druid retries again on top of it, and the two multiply:
-
-|Layer|Scope of one attempt|Attempts|Backoff cap|
-|-----|--------------------|--------|-----------|
-|`druid.s3.maxRetryAttempts`|A single HTTP request, such as one `UploadPart`|Set by the retry mode|`~20s`|
-|`S3Utils.retryS3Operation`|A whole logical operation, such as re-uploading an entire segment|10|`60s`|
-|`druid.msq.intermediate.storage.maxRetry`|A durable storage operation|10|`60s`|
-
-The layers are not equivalent, and the difference matters more than the totals: an attempt at the first layer
-re-sends one part, whereas a retry at the layers below it repeats the whole transfer. A workload that keeps losing
-uploads to throttling is usually better served by raising `druid.s3.maxRetryAttempts`, which absorbs failures before
-they reach a layer that re-uploads everything, than by raising the Druid-level counts.
 
 ## Server-side encryption
 

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -131,6 +131,8 @@ For example, to set the region to 'us-east-1' through system properties:
 |`druid.s3.disableChunkedEncoding`|Disables chunked encoding. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--) for details.|false|
 |`druid.s3.enablePathStyleAccess`|Enables path style access. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#enablePathStyleAccess--) for details.|false|
 |`druid.s3.crossRegionAccessEnabled`|Enables cross-region access for S3 requests. When enabled, the S3 client automatically detects the correct region for a bucket on first access and caches it for subsequent requests.|false|
+|`druid.s3.retryMode`|Retry strategy used by every AWS client Druid builds. One of `standard`, `adaptive` or `legacy`. See [Retry behavior](#retry-behavior).|`standard`|
+|`druid.s3.maxRetryAttempts`|Total attempts per HTTP request, including the first, so `1` disables SDK retries. When unset, the count defined by `druid.s3.retryMode` applies. See [Retry behavior](#retry-behavior).|null (the retry mode's own default)|
 |`druid.s3.forceGlobalBucketAccessEnabled`|**Deprecated.** Use `druid.s3.crossRegionAccessEnabled` instead. Only used as a fallback if `crossRegionAccessEnabled` is not explicitly set.|null|
 |`druid.s3.endpoint.url`|Service endpoint either with or without the protocol.|None|
 |`druid.s3.endpoint.signingRegion`|Region to use for SigV4 signing of requests (e.g. us-west-1).|None|
@@ -141,6 +143,61 @@ For example, to set the region to 'us-east-1' through system properties:
 |`druid.storage.sse.type`|Server-side encryption type. Should be one of `s3`, `kms`, and `custom`. See the below [Server-side encryption section](#server-side-encryption) for more details.|None|
 |`druid.storage.sse.kms.keyId`|AWS KMS key ID. This is used only when `druid.storage.sse.type` is `kms` and can be empty to use the default key ID.|None|
 |`druid.storage.sse.custom.base64EncodedKey`|Base64-encoded key. Should be specified if `druid.storage.sse.type` is `custom`.|None|
+
+## Retry behavior
+
+Druid names the AWS SDK retry strategy explicitly rather than accepting the SDK's default. The SDK's own default
+depends on the `aws.newRetries2026` migration flag, so leaving it unset would let retry behavior change underneath
+Druid when that flag's default flips. For `standard` and `adaptive`, Druid also opts in to the behavior AWS
+documents for those modes, rather than quietly falling back to any legacy behavior the SDK may have.
+
+|Mode|Behavior|
+|----|--------|
+|`standard`|Error classification consistent with the other AWS SDK implementations, and the mode AWS recommends for all workloads.|
+|`adaptive`|`standard` plus a client-side rate limiter that slows requests down when S3 reports throttling. Unlike `standard`, it can delay or block the **initial** request, not only retries. The limiter covers every request made by one client instance, so throttling on one key prefix also slows requests to prefixes that are not being throttled.|
+|`legacy`|The SDK's legacy behavior, retained so a deployment can revert without a rollback. AWS recommends moving off it.|
+
+### Choosing a mode
+
+AWS recommends `standard` as the default and `adaptive` only for workloads that are *single-resource,
+throttling-heavy, and latency-tolerant*. S3 applies its request-rate limits per key prefix, so "single-resource"
+means a process that concentrates its requests on one prefix.
+
+That maps onto Druid roughly as follows. Because a peon runs one task, you can select a mode per task type — through
+a Kubernetes pod template, or `druid.indexer.fork.property.druid.s3.retryMode` in a task's context when using the
+MiddleManager task runner.
+
+|Process|Suggested mode|Reasoning|
+|-------|--------------|---------|
+|MSQ and compaction peons|`adaptive`|Segment output goes to one new version prefix and shuffle output to one prefix per query, which is exactly the concentration that provokes throttling. Batch work tolerates the added latency.|
+|Batch ingestion peons|`standard`, or `adaptive` if throttled|Same shape as above at lower request rates.|
+|Historicals|`standard`|One client loads segments for every datasource the process serves, so a rate limiter tripped by one prefix would slow loads for unrelated ones. Segment loads can also sit on the query path.|
+|Brokers, Coordinator, Overlord|`standard`|Low request volume, and delaying an initial request costs query latency for no benefit.|
+
+### Retry quota
+
+Every mode carries a retry quota: a token bucket, held per client instance and never shared across processes, that
+stops retries once it is exhausted so the client fails fast instead of adding load a struggling service cannot
+absorb. It only engages under sustained failure — roughly a 32% failure rate for throttling errors — and is inert
+otherwise. Choosing between the modes does not change whether it is present.
+
+S3 reports throttling as `SlowDown` and `503`, which the SDK classifies as throttling rather than transient errors.
+Those get a longer base backoff than transient failures, and they are what `adaptive`'s rate limiter reacts to.
+
+### Retries are layered
+
+`druid.s3.maxRetryAttempts` applies per HTTP request. Druid retries again on top of it, and the two multiply:
+
+|Layer|Scope of one attempt|Attempts|Backoff cap|
+|-----|--------------------|--------|-----------|
+|`druid.s3.maxRetryAttempts`|A single HTTP request, such as one `UploadPart`|Set by the retry mode|`~20s`|
+|`S3Utils.retryS3Operation`|A whole logical operation, such as re-uploading an entire segment|10|`60s`|
+|`druid.msq.intermediate.storage.maxRetry`|A durable storage operation|10|`60s`|
+
+The layers are not equivalent, and the difference matters more than the totals: an attempt at the first layer
+re-sends one part, whereas a retry at the layers below it repeats the whole transfer. A workload that keeps losing
+uploads to throttling is usually better served by raising `druid.s3.maxRetryAttempts`, which absorbs failures before
+they reach a layer that re-uploads everything, than by raising the Druid-level counts.
 
 ## Server-side encryption
 

--- a/docs/development/extensions-core/s3.md
+++ b/docs/development/extensions-core/s3.md
@@ -131,7 +131,7 @@ For example, to set the region to 'us-east-1' through system properties:
 |`druid.s3.disableChunkedEncoding`|Disables chunked encoding. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#disableChunkedEncoding--) for details.|false|
 |`druid.s3.enablePathStyleAccess`|Enables path style access. See [AWS document](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Builder.html#enablePathStyleAccess--) for details.|false|
 |`druid.s3.crossRegionAccessEnabled`|Enables cross-region access for S3 requests. When enabled, the S3 client automatically detects the correct region for a bucket on first access and caches it for subsequent requests.|false|
-|`druid.s3.retryMode`|Retry strategy used by every AWS client Druid builds. One of `standard`, `adaptive` or `legacy`. See [AWS document](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html) for details about each mode.|`standard`|
+|`druid.s3.retryMode`|Retry strategy for AWS clients built from this configuration. One of `standard`, `adaptive` or `legacy`. See [AWS document](https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html) for details about each mode.|`standard`|
 |`druid.s3.maxAttempts`|Total attempts per HTTP request, including the first, so `1` disables SDK retries. When unset, the SDK default count defined by `druid.s3.retryMode` applies.|null (the retry mode's own default)|
 |`druid.s3.forceGlobalBucketAccessEnabled`|**Deprecated.** Use `druid.s3.crossRegionAccessEnabled` instead. Only used as a fallback if `crossRegionAccessEnabled` is not explicitly set.|null|
 |`druid.s3.endpoint.url`|Service endpoint either with or without the protocol.|None|

--- a/extensions-core/s3-extensions/pom.xml
+++ b/extensions-core/s3-extensions/pom.xml
@@ -164,6 +164,11 @@
       <version>${aws.sdk.v2.version}</version>
     </dependency>
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>retries-spi</artifactId>
+      <version>${aws.sdk.v2.version}</version>
+    </dependency>
+    <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil-core</artifactId>
       <scope>provided</scope>

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
@@ -127,7 +127,7 @@ public class S3InputSource extends CloudObjectInputSource
           s3ClientBuilder.getS3StorageConfig(),
           awsProxyConfig,
           awsEndpointConfig,
-          awsClientConfig,
+          awsClientConfig != null ? awsClientConfig : s3ClientBuilder.getAwsClientConfig(),
           s3InputSourceConfig,
           null
       ).build();

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/data/input/s3/S3InputSource.java
@@ -127,7 +127,7 @@ public class S3InputSource extends CloudObjectInputSource
           s3ClientBuilder.getS3StorageConfig(),
           awsProxyConfig,
           awsEndpointConfig,
-          awsClientConfig != null ? awsClientConfig : s3ClientBuilder.getAwsClientConfig(),
+          awsClientConfig,
           s3InputSourceConfig,
           null
       ).build();

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -373,10 +374,16 @@ public class ServerSideEncryptingAmazonS3
       S3Configuration s3Config = S3Configuration.builder()
                                                 .chunkedEncodingEnabled(!awsClientConfig.isDisableChunkedEncoding())
                                                 .build();
+      final ClientOverrideConfiguration retryOverrides =
+          ClientOverrideConfiguration.builder()
+                                     .retryStrategy(awsClientConfig.getRetryStrategy())
+                                     .build();
       clientBuilder.serviceConfiguration(s3Config)
                    .forcePathStyle(awsClientConfig.isEnablePathStyleAccess())
-                   .crossRegionAccessEnabled(awsClientConfig.isCrossRegionAccessEnabled());
-      asyncClientBuilder.forcePathStyle(awsClientConfig.isEnablePathStyleAccess())
+                   .crossRegionAccessEnabled(awsClientConfig.isCrossRegionAccessEnabled())
+                   .overrideConfiguration(retryOverrides);
+      asyncClientBuilder.overrideConfiguration(retryOverrides)
+                        .forcePathStyle(awsClientConfig.isEnablePathStyleAccess())
                         .crossRegionAccessEnabled(awsClientConfig.isCrossRegionAccessEnabled())
                         .httpClientBuilder(AsyncHttpClientType.fromString(s3StorageConfig.getS3TransferConfig().getAsyncHttpClientType()).buildBuilder(awsClientConfig))
                         .multipartEnabled(true);
@@ -405,7 +412,8 @@ public class ServerSideEncryptingAmazonS3
           assumeRoleArn,
           assumeRoleExternalId,
           awsEndpointConfig,
-          credentialsProvider
+          credentialsProvider,
+          awsClientConfig
       );
     }
 
@@ -443,7 +451,8 @@ public class ServerSideEncryptingAmazonS3
       String assumeRoleArn,
       @Nullable String assumeRoleExternalId,
       @Nullable AWSEndpointConfig awsEndpointConfig,
-      AwsCredentialsProvider baseCredentialsProvider
+      AwsCredentialsProvider baseCredentialsProvider,
+      @Nullable AWSClientConfig awsClientConfig
   )
   {
     String roleSessionName = StringUtils.format("druid-s3-%s", UUID.randomUUID().toString());
@@ -452,6 +461,11 @@ public class ServerSideEncryptingAmazonS3
     // If we have endpoint config, use its region for STS too
     if (awsEndpointConfig != null && awsEndpointConfig.getSigningRegion() != null) {
       stsBuilder.region(Region.of(awsEndpointConfig.getSigningRegion()));
+    }
+    if (awsClientConfig != null) {
+      stsBuilder.overrideConfiguration(
+          ClientOverrideConfiguration.builder().retryStrategy(awsClientConfig.getRetryStrategy()).build()
+      );
     }
 
     AssumeRoleRequest.Builder assumeRoleRequestBuilder =

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
@@ -375,16 +375,12 @@ public class ServerSideEncryptingAmazonS3
       S3Configuration s3Config = S3Configuration.builder()
                                                 .chunkedEncodingEnabled(!awsClientConfig.isDisableChunkedEncoding())
                                                 .build();
-      final ClientOverrideConfiguration retryOverrides =
-          ClientOverrideConfiguration.builder()
-                                     .retryStrategy(awsClientConfig.getRetryStrategy())
-                                     .build();
       clientBuilder.serviceConfiguration(s3Config)
                    .forcePathStyle(awsClientConfig.isEnablePathStyleAccess())
                    .crossRegionAccessEnabled(awsClientConfig.isCrossRegionAccessEnabled())
-                   .overrideConfiguration(retryOverrides);
+                   .overrideConfiguration(retryOverride(awsClientConfig));
       final S3TransferConfig transferConfig = s3StorageConfig.getS3TransferConfig();
-      asyncClientBuilder.overrideConfiguration(retryOverrides)
+      asyncClientBuilder.overrideConfiguration(retryOverride(awsClientConfig))
                         .forcePathStyle(awsClientConfig.isEnablePathStyleAccess())
                         .crossRegionAccessEnabled(awsClientConfig.isCrossRegionAccessEnabled())
                         .httpClientBuilder(AsyncHttpClientType.fromString(transferConfig.getAsyncHttpClientType()).buildBuilder(awsClientConfig))
@@ -430,7 +426,19 @@ public class ServerSideEncryptingAmazonS3
     return ServerSideEncryptingAmazonS3.builder()
                                        .setS3ClientSupplier(clientBuilder::build)
                                        .setS3AsyncClientSupplier(asyncClientBuilder::build)
-                                       .setS3StorageConfig(s3StorageConfig);
+                                       .setS3StorageConfig(s3StorageConfig)
+                                       .setAwsClientConfig(awsClientConfig);
+  }
+
+  /**
+   * Builds the retry override for a single client. Every client needs its own {@code RetryStrategy} instance: the
+   * standard strategy holds its circuit-breaker token bucket on the instance, and the adaptive strategy additionally
+   * holds its client-side rate limiter there. Sharing one instance would let throttled TransferManager uploads drain
+   * the quota of, or throttle, synchronous reads and listings.
+   */
+  private static ClientOverrideConfiguration retryOverride(AWSClientConfig awsClientConfig)
+  {
+    return ClientOverrideConfiguration.builder().retryStrategy(awsClientConfig.getRetryStrategy()).build();
   }
 
   @Nonnull
@@ -468,10 +476,10 @@ public class ServerSideEncryptingAmazonS3
     if (awsEndpointConfig != null && awsEndpointConfig.getSigningRegion() != null) {
       stsBuilder.region(Region.of(awsEndpointConfig.getSigningRegion()));
     }
+    // A null config leaves the SDK defaults in place, so callers should pass the process configuration rather than
+    // null when a spec supplies no override of its own.
     if (awsClientConfig != null) {
-      stsBuilder.overrideConfiguration(
-          ClientOverrideConfiguration.builder().retryStrategy(awsClientConfig.getRetryStrategy()).build()
-      );
+      stsBuilder.overrideConfiguration(retryOverride(awsClientConfig));
     }
 
     AssumeRoleRequest.Builder assumeRoleRequestBuilder =
@@ -494,6 +502,8 @@ public class ServerSideEncryptingAmazonS3
     @Nullable
     private Supplier<S3AsyncClient> s3AsyncClientSupplier;
     private S3StorageConfig s3StorageConfig = new S3StorageConfig(new NoopServerSideEncryption(), null);
+    @Nullable
+    private AWSClientConfig awsClientConfig;
 
     public Builder setS3ClientSupplier(Supplier<S3Client> s3ClientSupplier)
     {
@@ -516,6 +526,24 @@ public class ServerSideEncryptingAmazonS3
     public S3StorageConfig getS3StorageConfig()
     {
       return this.s3StorageConfig;
+    }
+
+    public Builder setAwsClientConfig(@Nullable AWSClientConfig awsClientConfig)
+    {
+      this.awsClientConfig = awsClientConfig;
+      return this;
+    }
+
+    /**
+     * The client configuration the clients of this builder are configured with. Exposed, like
+     * {@link #getS3StorageConfig()}, so a caller that rebuilds a client for a per-spec override can fall back to it
+     * instead of dropping process-level settings. Null when the builder was not
+     * created from an {@link AWSClientConfig}, in which case the clients keep the SDK defaults.
+     */
+    @Nullable
+    public AWSClientConfig getAwsClientConfig()
+    {
+      return this.awsClientConfig;
     }
 
     /**

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3.java
@@ -426,8 +426,7 @@ public class ServerSideEncryptingAmazonS3
     return ServerSideEncryptingAmazonS3.builder()
                                        .setS3ClientSupplier(clientBuilder::build)
                                        .setS3AsyncClientSupplier(asyncClientBuilder::build)
-                                       .setS3StorageConfig(s3StorageConfig)
-                                       .setAwsClientConfig(awsClientConfig);
+                                       .setS3StorageConfig(s3StorageConfig);
   }
 
   /**
@@ -476,8 +475,6 @@ public class ServerSideEncryptingAmazonS3
     if (awsEndpointConfig != null && awsEndpointConfig.getSigningRegion() != null) {
       stsBuilder.region(Region.of(awsEndpointConfig.getSigningRegion()));
     }
-    // A null config leaves the SDK defaults in place, so callers should pass the process configuration rather than
-    // null when a spec supplies no override of its own.
     if (awsClientConfig != null) {
       stsBuilder.overrideConfiguration(retryOverride(awsClientConfig));
     }
@@ -502,8 +499,6 @@ public class ServerSideEncryptingAmazonS3
     @Nullable
     private Supplier<S3AsyncClient> s3AsyncClientSupplier;
     private S3StorageConfig s3StorageConfig = new S3StorageConfig(new NoopServerSideEncryption(), null);
-    @Nullable
-    private AWSClientConfig awsClientConfig;
 
     public Builder setS3ClientSupplier(Supplier<S3Client> s3ClientSupplier)
     {
@@ -526,24 +521,6 @@ public class ServerSideEncryptingAmazonS3
     public S3StorageConfig getS3StorageConfig()
     {
       return this.s3StorageConfig;
-    }
-
-    public Builder setAwsClientConfig(@Nullable AWSClientConfig awsClientConfig)
-    {
-      this.awsClientConfig = awsClientConfig;
-      return this;
-    }
-
-    /**
-     * The client configuration the clients of this builder are configured with. Exposed, like
-     * {@link #getS3StorageConfig()}, so a caller that rebuilds a client for a per-spec override can fall back to it
-     * instead of dropping process-level settings. Null when the builder was not
-     * created from an {@link AWSClientConfig}, in which case the clients keep the SDK defaults.
-     */
-    @Nullable
-    public AWSClientConfig getAwsClientConfig()
-    {
-      return this.awsClientConfig;
     }
 
     /**

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -100,7 +100,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -349,7 +348,6 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
   {
     EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig()).andStubReturn(S3_STORAGE_CONFIG);
-    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig()).andStubReturn(null);
     EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     final S3InputSource withPrefixes = new S3InputSource(
         SERVICE,
@@ -377,7 +375,6 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
   {
     EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig()).andStubReturn(S3_STORAGE_CONFIG);
-    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig()).andStubReturn(null);
     EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     final S3InputSource withSessionToken = new S3InputSource(
         SERVICE,
@@ -410,7 +407,6 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig())
             .andStubReturn(S3_STORAGE_CONFIG);
-    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig()).andStubReturn(null);
     EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
 
     final AWSEndpointConfig schemelessEndpoint = MAPPER.readValue(
@@ -435,49 +431,6 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     // Forces s3ClientSupplier evaluation, which hits S3Utils.useHttps and confirms a null client config does not blow up.
     inputSource.createEntity(new CloudObjectLocation("bucket", "path"));
 
-    EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
-  }
-
-  @Test
-  public void testClientConfigOmittedFromSpecFallsBackToProcessConfig()
-  {
-    // A spec that overrides credentials but not the client config must still get the process-wide client settings
-    final AtomicInteger strategiesRequested = new AtomicInteger();
-    final AWSClientConfig processClientConfig = new AWSClientConfig()
-    {
-      @Override
-      public RetryStrategy getRetryStrategy()
-      {
-        strategiesRequested.incrementAndGet();
-        return super.getRetryStrategy();
-      }
-    };
-
-    EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
-    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig()).andStubReturn(S3_STORAGE_CONFIG);
-    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig())
-            .andStubReturn(processClientConfig);
-    EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
-
-    final S3InputSource inputSource = new S3InputSource(
-        SERVICE,
-        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
-        INPUT_DATA_CONFIG,
-        null,
-        null,
-        EXPECTED_LOCATION,
-        null,
-        CLOUD_CONFIG_PROPERTIES,
-        null,
-        ENDPOINT_CONFIG,
-        null
-    );
-
-    // Forces s3ClientSupplier evaluation, which is where the clients are configured.
-    inputSource.createEntity(new CloudObjectLocation("bucket", "path"));
-
-    // One per client, sync and async.
-    Assertions.assertEquals(2, strategiesRequested.get());
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
   }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -100,6 +100,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -348,6 +349,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
   {
     EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig()).andStubReturn(S3_STORAGE_CONFIG);
+    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig()).andStubReturn(null);
     EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     final S3InputSource withPrefixes = new S3InputSource(
         SERVICE,
@@ -375,6 +377,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
   {
     EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig()).andStubReturn(S3_STORAGE_CONFIG);
+    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig()).andStubReturn(null);
     EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     final S3InputSource withSessionToken = new S3InputSource(
         SERVICE,
@@ -407,6 +410,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
     EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig())
             .andStubReturn(S3_STORAGE_CONFIG);
+    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig()).andStubReturn(null);
     EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
 
     final AWSEndpointConfig schemelessEndpoint = MAPPER.readValue(
@@ -431,6 +435,49 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     // Forces s3ClientSupplier evaluation, which hits S3Utils.useHttps and confirms a null client config does not blow up.
     inputSource.createEntity(new CloudObjectLocation("bucket", "path"));
 
+    EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
+  }
+
+  @Test
+  public void testClientConfigOmittedFromSpecFallsBackToProcessConfig()
+  {
+    // A spec that overrides credentials but not the client config must still get the process-wide client settings
+    final AtomicInteger strategiesRequested = new AtomicInteger();
+    final AWSClientConfig processClientConfig = new AWSClientConfig()
+    {
+      @Override
+      public RetryStrategy getRetryStrategy()
+      {
+        strategiesRequested.incrementAndGet();
+        return super.getRetryStrategy();
+      }
+    };
+
+    EasyMock.reset(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
+    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getS3StorageConfig()).andStubReturn(S3_STORAGE_CONFIG);
+    EasyMock.expect(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER.getAwsClientConfig())
+            .andStubReturn(processClientConfig);
+    EasyMock.replay(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
+
+    final S3InputSource inputSource = new S3InputSource(
+        SERVICE,
+        SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER,
+        INPUT_DATA_CONFIG,
+        null,
+        null,
+        EXPECTED_LOCATION,
+        null,
+        CLOUD_CONFIG_PROPERTIES,
+        null,
+        ENDPOINT_CONFIG,
+        null
+    );
+
+    // Forces s3ClientSupplier evaluation, which is where the clients are configured.
+    inputSource.createEntity(new CloudObjectLocation("bucket", "path"));
+
+    // One per client, sync and async.
+    Assertions.assertEquals(2, strategiesRequested.get());
     EasyMock.verify(SERVER_SIDE_ENCRYPTING_AMAZON_S3_BUILDER);
   }
 
@@ -520,7 +567,10 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     EasyMock.expect(mockAwsClientConfig.getConnectionTimeoutMillis()).andStubReturn(10_000);
     EasyMock.expect(mockAwsClientConfig.getSocketTimeoutMillis()).andStubReturn(50_000);
     EasyMock.expect(mockAwsClientConfig.getMaxConnections()).andStubReturn(50);
-    EasyMock.expect(mockAwsClientConfig.getRetryStrategy()).andReturn(EasyMock.createMock(RetryStrategy.class));
+    // Once for the sync client and once for the async one, since the two must not share a strategy instance.
+    EasyMock.expect(mockAwsClientConfig.getRetryStrategy())
+            .andReturn(EasyMock.createMock(RetryStrategy.class))
+            .times(2);
 
     EasyMock.expect(mockAwsProxyConfig.getHost()).andStubReturn("");
     EasyMock.expect(mockAwsProxyConfig.getPort()).andStubReturn(-1);

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/data/input/s3/S3InputSourceTest.java
@@ -78,6 +78,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -519,6 +520,7 @@ public class S3InputSourceTest extends InitializedNullHandlingTest
     EasyMock.expect(mockAwsClientConfig.getConnectionTimeoutMillis()).andStubReturn(10_000);
     EasyMock.expect(mockAwsClientConfig.getSocketTimeoutMillis()).andStubReturn(50_000);
     EasyMock.expect(mockAwsClientConfig.getMaxConnections()).andStubReturn(50);
+    EasyMock.expect(mockAwsClientConfig.getRetryStrategy()).andReturn(EasyMock.createMock(RetryStrategy.class));
 
     EasyMock.expect(mockAwsProxyConfig.getHost()).andStubReturn("");
     EasyMock.expect(mockAwsProxyConfig.getPort()).andStubReturn(-1);

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3Test.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/ServerSideEncryptingAmazonS3Test.java
@@ -19,13 +19,16 @@
 
 package org.apache.druid.storage.s3;
 
+import org.apache.druid.common.aws.AWSClientConfig;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Grant;
@@ -40,6 +43,8 @@ import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 
@@ -253,6 +258,35 @@ public class ServerSideEncryptingAmazonS3Test
 
     Assertions.assertNotNull(s3);
     Assertions.assertEquals(builtClient, s3.getS3Client());
+  }
+
+  @Test
+  public void testEachClientGetsItsOwnRetryStrategy()
+  {
+    final List<RetryStrategy> issued = new ArrayList<>();
+    final AWSClientConfig clientConfig = new AWSClientConfig()
+    {
+      @Override
+      public RetryStrategy getRetryStrategy()
+      {
+        final RetryStrategy strategy = super.getRetryStrategy();
+        issued.add(strategy);
+        return strategy;
+      }
+    };
+
+    ServerSideEncryptingAmazonS3.builder(
+        AnonymousCredentialsProvider.create(),
+        new S3StorageConfig(new NoopServerSideEncryption(), new S3TransferConfig()),
+        null,
+        null,
+        clientConfig,
+        null,
+        null
+    );
+
+    Assertions.assertEquals(2, issued.size(), "one strategy per client, sync and async");
+    Assertions.assertNotSame(issued.get(0), issued.get(1));
   }
 
   @Test


### PR DESCRIPTION
### Description

AWS sdk has made changes to how s3 retries are handled by the client. There are multiple policy decisions available. https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html can be referenced for more information. The biggest change in this PR is ensuring that we are operating with STANDARD which is the general recommendation for policy going forward. ADAPTIVE is the special case policy that I want to expose to operators. ~We do update docs to suggest that ingestion tasks may be good fits for adaptive but we do not go as far as changing the policy for anything to use adaptive by default. If we find that it is far and away better, perhaps future releases will create clients with policies tailored to the job of the service.~

Edit: Previously the PR gave guidance on retry mode selection per druid service type. On advice of review, we have scaled the docs way back to simply expose the new runtime property and link to the AWS docs on choosing a retry mode. I was overselling confidence in what mode is good for what service. If, in the future, we determine adaptive is better than standard for anything we will opt into that by default.

#### Release note

Explicitly change to the AWS Standard retry policy for the s3 client. The retry mode used by s3 client is configurable now in case operators want to customize. One such customization that may be useful is moving `druid.s3.retryMode` to adaptive for ingestion tasks. Operators should use caution when making changes the the retry mode, and consult https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html  before making any decisions for critical service configuration.


<hr>

##### Key changed/added classes in this PR
 * `AWSClientConfig`
 * `ServerSideEncryptingAmazonS3`

<hr>

This PR has:

- [x] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.