### PR TITLE
test: fix flaky test EmbeddedDartReportApiTest

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
@@ -610,37 +610,24 @@ public class EmbeddedDartReportApiTest extends EmbeddedClusterTestBase
   )
   {
     final long timeout = 30_000;
-    final long deadline = System.currentTimeMillis() + timeout;
-
-    while (System.currentTimeMillis() < deadline) {
-      final List<GetQueryReportResponse> reports = new ArrayList<>(targetBrokers.length);
-      boolean allReportsCompleted = true;
-
-      for (final EmbeddedBroker targetBroker : targetBrokers) {
-        final GetQueryReportResponse report = msqApis.getDartQueryReport(sqlQueryId, targetBroker);
-        if (report == null
-            || !(report.getQueryInfo() instanceof DartQueryInfo queryInfo)
-            || queryInfo.getDurationMs() == null) {
-          allReportsCompleted = false;
-          break;
-        }
-        reports.add(report);
-      }
-
-      if (allReportsCompleted) {
-        return reports;
-      }
-
-      try {
-        Thread.sleep(100);
-      }
-      catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
-      }
-    }
-
-    throw new ISE("Timed out after[%,d] ms waiting for completed reports", timeout);
+    return cluster.callApi()
+                  .waitForResult(
+                      () -> {
+                        final List<GetQueryReportResponse> reports = new ArrayList<>(targetBrokers.length);
+                        for (final EmbeddedBroker targetBroker : targetBrokers) {
+                          reports.add(msqApis.getDartQueryReport(sqlQueryId, targetBroker));
+                        }
+                        return reports;
+                      },
+                      reports -> reports.stream().allMatch(
+                          report -> report != null
+                                    && report.getQueryInfo() instanceof DartQueryInfo queryInfo
+                                    && queryInfo.getDurationMs() != null
+                      )
+                  )
+                  .withTimeoutMillis(timeout)
+                  .withRetryMillis(100)
+                  .go();
   }
 
   /**

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/EmbeddedDartReportApiTest.java
@@ -72,7 +72,6 @@ import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -227,7 +226,7 @@ public class EmbeddedDartReportApiTest extends EmbeddedClusterTestBase
     Assertions.assertEquals("10", result);
 
     // Now fetch the report using the SQL query ID
-    final GetQueryReportResponse reportResponse = msqApis.getDartQueryReport(sqlQueryId, broker1);
+    final GetQueryReportResponse reportResponse = waitForCompletedReports(sqlQueryId, broker1).get(0);
 
     // Verify the report response
     Assertions.assertNotNull(reportResponse, "Report response should not be null");
@@ -332,12 +331,12 @@ public class EmbeddedDartReportApiTest extends EmbeddedClusterTestBase
     Assertions.assertEquals(1, sqlClients1.getAllClients().size(), "Broker1 should have 1 client (broker2)");
     Assertions.assertEquals(1, sqlClients2.getAllClients().size(), "Broker2 should have 1 client (broker1)");
 
-    // Fetch the report from both brokers, to verify cross-broker lookup is working
-    final GetQueryReportResponse reportFromBroker1 = msqApis.getDartQueryReport(sqlQueryId, broker1);
-    final GetQueryReportResponse reportFromBroker2 = msqApis.getDartQueryReport(sqlQueryId, broker2);
+    // Wait for the completed report to be available from both brokers. The SQL result can be returned
+    // before the controller is deregistered and its completed report is published.
+    final List<GetQueryReportResponse> completedReports = waitForCompletedReports(sqlQueryId, broker1, broker2);
 
     // Verify the report content
-    for (GetQueryReportResponse report : Arrays.asList(reportFromBroker1, reportFromBroker2)) {
+    for (GetQueryReportResponse report : completedReports) {
       Assertions.assertNotNull(report);
       final DartQueryInfo queryInfo = (DartQueryInfo) report.getQueryInfo();
       Assertions.assertEquals(sqlQueryId, queryInfo.getSqlQueryId());
@@ -600,6 +599,48 @@ public class EmbeddedDartReportApiTest extends EmbeddedClusterTestBase
       }
     }
     throw new ISE("Timed out after[%,d] ms waiting for query to be in RUNNING state", timeout);
+  }
+
+  /**
+   * Polls the report API on the specified brokers until completed reports are available from all of them.
+   */
+  private List<GetQueryReportResponse> waitForCompletedReports(
+      final String sqlQueryId,
+      final EmbeddedBroker... targetBrokers
+  )
+  {
+    final long timeout = 30_000;
+    final long deadline = System.currentTimeMillis() + timeout;
+
+    while (System.currentTimeMillis() < deadline) {
+      final List<GetQueryReportResponse> reports = new ArrayList<>(targetBrokers.length);
+      boolean allReportsCompleted = true;
+
+      for (final EmbeddedBroker targetBroker : targetBrokers) {
+        final GetQueryReportResponse report = msqApis.getDartQueryReport(sqlQueryId, targetBroker);
+        if (report == null
+            || !(report.getQueryInfo() instanceof DartQueryInfo queryInfo)
+            || queryInfo.getDurationMs() == null) {
+          allReportsCompleted = false;
+          break;
+        }
+        reports.add(report);
+      }
+
+      if (allReportsCompleted) {
+        return reports;
+      }
+
+      try {
+        Thread.sleep(100);
+      }
+      catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new ISE("Timed out after[%,d] ms waiting for completed reports", timeout);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Wait for completed Dart query reports before asserting completion metadata.
- Apply the same synchronization to the single-broker completed-report test and the cross-broker test.

## Root cause

The master CI failure was reported as `expected: not <null>` at `EmbeddedDartReportApiTest.java:348`, which is the assertion that `DartQueryInfo.getDurationMs()` is non-null. The report response itself was present.

The SQL result can be returned before `ControllerHolder.runAsync` finishes deregistration and `DartControllerRegistry` publishes the retained completed report. During that window, the report API can return the running-query snapshot, whose `durationMs` is explicitly null. Cross-broker forwarding can observe the same intermediate state.

Evidence:

- [Failed master job](https://github.com/apache/druid/actions/runs/31102715850/job/92620026819)
- [Same test passed on the immediate parent run](https://github.com/apache/druid/actions/runs/31102703521/job/92619984800)
- [Report metadata is documented as null until known](https://github.com/apache/druid/blob/master/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/http/DartQueryInfo.java#L162-L170)
- [Controller deregistration publishes the completed report after query execution](https://github.com/apache/druid/blob/master/multi-stage-query/src/main/java/org/apache/druid/msq/exec/ControllerHolder.java#L205-L220)

## Fix

Poll the report API until each requested broker returns a report with non-null `durationMs`, using one shared timeout for the multi-broker check. This synchronizes the test with the API's completed-report state without adding a fixed sleep.

## Validation

```
mvn -ntp test -pl embedded-tests -am \
  -Dtest="org.apache.druid.testing.embedded.msq.EmbeddedDartReportApiTest" \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Pskip-static-checks -Dweb.console.skip=true -T1C
```

Result: 7 tests passed, 0 failures, 0 errors.
