### PR TITLE
fix: correct WEEK interval literal duration in calciteLiteralToDruidLiteral (#18665)

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/expression/Expressions.java
@@ -33,7 +33,9 @@ import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.sql.SqlIntervalQualifier;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -371,7 +373,14 @@ public class Expressions
       retVal = new DruidLiteral(ExpressionType.DOUBLE, number == null ? null : number.doubleValue());
     } else if (SqlTypeFamily.INTERVAL_DAY_TIME == sqlTypeName.getFamily()) {
       // Calcite represents DAY-TIME intervals in milliseconds.
-      final long milliseconds = ((Number) RexLiteral.value(rexNode)).longValue();
+      long milliseconds = ((Number) RexLiteral.value(rexNode)).longValue();
+      // Calcite has a known quirk where WEEK interval literals are stored as 1 hour in the
+      // INTERVAL_DAY_TIME family (see https://github.com/apache/druid/issues/18665).
+      // Detect the WEEK qualifier and convert the value to 7 days.
+      final SqlIntervalQualifier intervalQualifier = rexNode.getType().getIntervalQualifier();
+      if (intervalQualifier != null && intervalQualifier.getStartUnit() == TimeUnit.WEEK) {
+        milliseconds = milliseconds * 7 * 24;
+      }
       retVal = new DruidLiteral(ExpressionType.LONG, milliseconds);
     } else if (SqlTypeFamily.INTERVAL_YEAR_MONTH == sqlTypeName.getFamily()) {
       // Calcite represents YEAR-MONTH intervals in months.


### PR DESCRIPTION
### Description

Fixes #18665

`INTERVAL 1 WEEK` in SQL resolves to `PT1H` (1 hour) instead of `P7D` (7 days).

```sql
SELECT MILLIS_TO_TIMESTAMP(0) + INTERVAL 1 WEEK
```
Returns `1970-01-01T01:00:00.000Z` instead of `1970-01-08T00:00:00.000Z`.

### Root Cause

Calcite has a known quirk where WEEK interval literals are stored as 1 hour in the `INTERVAL_DAY_TIME` family. The `INTERVAL 1 WEEK` literal's `RexLiteral.value()` returns `3600000` (1 hour in ms) instead of `604800000` (7 days in ms).

### Fix

In `calciteLiteralToDruidLiteral`, detect the `WEEK` qualifier on the `SqlIntervalQualifier` and multiply the stored millisecond value by 7 × 24 to convert from the incorrect 1-hour representation to the correct 7-day duration.

### Impact

All `INTERVAL N WEEK` expressions now correctly resolve to N weeks instead of N hours.
The fix applies to all contexts where `INTERVAL_DAY_TIME` literals are converted to Druid expressions: timestamp arithmetic (`+`/`-`), `TIMESTAMPDIFF`, and other interval-using operations.
### Verification

```sql
SELECT MILLIS_TO_TIMESTAMP(0) + INTERVAL 1 WEEK
-- Before: 1970-01-01T01:00:00.000Z
-- After:  1970-01-08T00:00:00.000Z
```