### PR TITLE
test(indexing-service): migrate task actions and compaction tests to JUnit 5

### DIFF
--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -199,6 +199,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-migrationsupport</artifactId>
             <scope>test</scope>
         </dependency>
@@ -259,6 +264,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/LocalTaskActionClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/LocalTaskActionClientTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common.actions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -34,6 +34,6 @@ public class LocalTaskActionClientTest
   public void testGetActionType()
   {
     final TaskAction<?> action = SegmentTransactionalInsertAction.appendAction(Collections.emptySet(), null, null, null, null, null);
-    Assert.assertEquals("segmentTransactionalInsert", LocalTaskActionClient.getActionType(objectMapper, action));
+    Assertions.assertEquals("segmentTransactionalInsert", LocalTaskActionClient.getActionType(objectMapper, action));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClientFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClientFactoryTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing.common.actions;
 import org.apache.druid.indexing.common.RetryPolicyConfig;
 import org.apache.druid.rpc.StandardRetryPolicy;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RemoteTaskActionClientFactoryTest
 {
@@ -34,13 +34,13 @@ public class RemoteTaskActionClientFactoryTest
     final StandardRetryPolicy retryPolicy = RemoteTaskActionClientFactory.buildRetryPolicy(config);
 
     // Default maxRetryCount is 13, so maxAttempts should be 14 (13 retries + 1 initial attempt)
-    Assert.assertEquals(14, retryPolicy.maxAttempts());
+    Assertions.assertEquals(14, retryPolicy.maxAttempts());
 
     // Default minWait is PT5S (5 seconds)
-    Assert.assertEquals(5000, retryPolicy.minWaitMillis());
+    Assertions.assertEquals(5000, retryPolicy.minWaitMillis());
 
     // Default maxWait is PT1M (1 minute)
-    Assert.assertEquals(60000, retryPolicy.maxWaitMillis());
+    Assertions.assertEquals(60000, retryPolicy.maxWaitMillis());
   }
 
   @Test
@@ -54,13 +54,13 @@ public class RemoteTaskActionClientFactoryTest
     final StandardRetryPolicy retryPolicy = RemoteTaskActionClientFactory.buildRetryPolicy(config);
 
     // maxRetryCount is 5, so maxAttempts should be 6 (5 retries + 1 initial attempt)
-    Assert.assertEquals(6, retryPolicy.maxAttempts());
+    Assertions.assertEquals(6, retryPolicy.maxAttempts());
 
     // minWait is PT10S (10 seconds)
-    Assert.assertEquals(10000, retryPolicy.minWaitMillis());
+    Assertions.assertEquals(10000, retryPolicy.minWaitMillis());
 
     // maxWait is PT2M (2 minutes)
-    Assert.assertEquals(120000, retryPolicy.maxWaitMillis());
+    Assertions.assertEquals(120000, retryPolicy.maxWaitMillis());
   }
 
   @Test
@@ -74,12 +74,12 @@ public class RemoteTaskActionClientFactoryTest
     final StandardRetryPolicy retryPolicy = RemoteTaskActionClientFactory.buildRetryPolicy(config);
 
     // maxRetryCount is 0, so maxAttempts should be 1 (0 retries + 1 initial attempt)
-    Assert.assertEquals(1, retryPolicy.maxAttempts());
+    Assertions.assertEquals(1, retryPolicy.maxAttempts());
 
     // minWait is PT1S (1 second)
-    Assert.assertEquals(1000, retryPolicy.minWaitMillis());
+    Assertions.assertEquals(1000, retryPolicy.minWaitMillis());
 
     // maxWait is PT30S (30 seconds)
-    Assert.assertEquals(30000, retryPolicy.maxWaitMillis());
+    Assertions.assertEquals(30000, retryPolicy.maxWaitMillis());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RemoteTaskActionClientTest.java
@@ -43,11 +43,9 @@ import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -59,13 +57,10 @@ import java.util.concurrent.ExecutionException;
 
 public class RemoteTaskActionClientTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private ServiceClient directOverlordClient;
   private final ObjectMapper objectMapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     directOverlordClient = EasyMock.createMock(ServiceClient.class);
@@ -108,7 +103,7 @@ public class RemoteTaskActionClientTest
     RemoteTaskActionClient client = new RemoteTaskActionClient(task, directOverlordClient, objectMapper);
     final List<TaskLock> locks = client.submit(action);
 
-    Assert.assertEquals(expectedLocks, locks);
+    Assertions.assertEquals(expectedLocks, locks);
     EasyMock.verify(directOverlordClient);
   }
 
@@ -142,12 +137,15 @@ public class RemoteTaskActionClientTest
     EasyMock.replay(directOverlordClient);
 
     RemoteTaskActionClient client = new RemoteTaskActionClient(task, directOverlordClient, objectMapper);
-    expectedException.expect(IOException.class);
-    expectedException.expectMessage(
-        "Error with status[400 Bad Request] and message[testSubmitWithIllegalStatusCode]. "
-        + "Check overlord logs for details."
+    final IOException exception = Assertions.assertThrows(
+        IOException.class,
+        () -> client.submit(action)
     );
-    client.submit(action);
+    Assertions.assertEquals(
+        "Error with status[400 Bad Request] and message[testSubmitWithIllegalStatusCode]. "
+        + "Check overlord logs for details.",
+        exception.getMessage()
+    );
 
     EasyMock.verify(directOverlordClient, response);
   }
@@ -173,6 +171,6 @@ public class RemoteTaskActionClientTest
       totalWaitTimeMillis += ServiceClientImpl.computeBackoffMs(retryPolicy, attempt);
     }
 
-    Assert.assertEquals(13, defaultRetryConfig.getMaxRetryCount());
+    Assertions.assertEquals(13, defaultRetryConfig.getMaxRetryCount());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RetrieveSegmentsActionsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RetrieveSegmentsActionsTest.java
@@ -28,10 +28,10 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -42,14 +42,14 @@ public class RetrieveSegmentsActionsTest
   private static final String UNUSED_V0 = "v0";
   private static final String UNUSED_V1 = "v1";
 
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit actionTestKit = new TaskActionTestKit();
 
   private static Task task;
   private static Set<DataSegment> expectedUnusedSegments;
   private static Set<DataSegment> expectedUsedSegments;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     task = NoopTask.create();
@@ -102,7 +102,7 @@ public class RetrieveSegmentsActionsTest
     final RetrieveUsedSegmentsAction action =
         new RetrieveUsedSegmentsAction(task.getDataSource(), ImmutableList.of(INTERVAL));
     final Set<DataSegment> observedUsedSegments = new HashSet<>(action.perform(task, actionTestKit.getTaskActionToolbox()));
-    Assert.assertEquals(expectedUsedSegments, observedUsedSegments);
+    Assertions.assertEquals(expectedUsedSegments, observedUsedSegments);
   }
 
   @Test
@@ -116,7 +116,7 @@ public class RetrieveSegmentsActionsTest
         null
     );
     final Set<DataSegment> observedUnusedSegments = new HashSet<>(action.perform(task, actionTestKit.getTaskActionToolbox()));
-    Assert.assertEquals(expectedUnusedSegments, observedUnusedSegments);
+    Assertions.assertEquals(expectedUnusedSegments, observedUnusedSegments);
   }
 
   @Test
@@ -130,7 +130,7 @@ public class RetrieveSegmentsActionsTest
         null
     );
     final Set<DataSegment> observedUnusedSegments = new HashSet<>(action.perform(task, actionTestKit.getTaskActionToolbox()));
-    Assert.assertEquals(ImmutableSet.of(), observedUnusedSegments);
+    Assertions.assertEquals(ImmutableSet.of(), observedUnusedSegments);
   }
 
   @Test
@@ -138,7 +138,7 @@ public class RetrieveSegmentsActionsTest
   {
     final RetrieveUnusedSegmentsAction action = new RetrieveUnusedSegmentsAction(task.getDataSource(), INTERVAL, null, null, DateTimes.MIN);
     final Set<DataSegment> observedUnusedSegments = new HashSet<>(action.perform(task, actionTestKit.getTaskActionToolbox()));
-    Assert.assertEquals(ImmutableSet.of(), observedUnusedSegments);
+    Assertions.assertEquals(ImmutableSet.of(), observedUnusedSegments);
   }
 
   @Test
@@ -146,6 +146,6 @@ public class RetrieveSegmentsActionsTest
   {
     final RetrieveUnusedSegmentsAction action = new RetrieveUnusedSegmentsAction(task.getDataSource(), INTERVAL, null, null, DateTimes.nowUtc());
     final Set<DataSegment> observedUnusedSegments = new HashSet<>(action.perform(task, actionTestKit.getTaskActionToolbox()));
-    Assert.assertEquals(expectedUnusedSegments, observedUnusedSegments);
+    Assertions.assertEquals(expectedUnusedSegments, observedUnusedSegments);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RetrieveUsedSegmentsActionSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/RetrieveUsedSegmentsActionSerdeTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.indexing.overlord.Segments;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.TestHelper;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -47,8 +47,8 @@ public class RetrieveUsedSegmentsActionSerdeTest
 
     RetrieveUsedSegmentsAction actual =
         MAPPER.readValue(MAPPER.writeValueAsString(expected), RetrieveUsedSegmentsAction.class);
-    Assert.assertEquals(ImmutableList.of(interval), actual.getIntervals());
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(ImmutableList.of(interval), actual.getIntervals());
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -62,8 +62,8 @@ public class RetrieveUsedSegmentsActionSerdeTest
 
     RetrieveUsedSegmentsAction actual =
         MAPPER.readValue(MAPPER.writeValueAsString(expected), RetrieveUsedSegmentsAction.class);
-    Assert.assertEquals(intervals, actual.getIntervals());
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(intervals, actual.getIntervals());
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -72,7 +72,7 @@ public class RetrieveUsedSegmentsActionSerdeTest
     String jsonStr = "{\"type\": \"segmentListUsed\", \"dataSource\": \"test\", \"intervals\": [\"2014/2015\"]}";
     RetrieveUsedSegmentsAction actual = (RetrieveUsedSegmentsAction) MAPPER.readValue(jsonStr, TaskAction.class);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new RetrieveUsedSegmentsAction(
             "test",
             Collections.singletonList(Intervals.of("2014/2015")),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionSerdeTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.timeline.partition.NumberedPartialShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Map;
@@ -66,14 +66,14 @@ public class SegmentAllocateActionSerdeTest
         TaskAction.class
     );
 
-    Assert.assertEquals(target.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(target.getTimestamp(), fromJson.getTimestamp());
-    Assert.assertEquals(target.getQueryGranularity(), fromJson.getQueryGranularity());
-    Assert.assertEquals(target.getPreferredSegmentGranularity(), fromJson.getPreferredSegmentGranularity());
-    Assert.assertEquals(target.getSequenceName(), fromJson.getSequenceName());
-    Assert.assertEquals(target.getPreviousSegmentId(), fromJson.getPreviousSegmentId());
-    Assert.assertEquals(target.isSkipSegmentLineageCheck(), fromJson.isSkipSegmentLineageCheck());
-    Assert.assertEquals(TaskLockType.EXCLUSIVE, target.getTaskLockType());
+    Assertions.assertEquals(target.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(target.getTimestamp(), fromJson.getTimestamp());
+    Assertions.assertEquals(target.getQueryGranularity(), fromJson.getQueryGranularity());
+    Assertions.assertEquals(target.getPreferredSegmentGranularity(), fromJson.getPreferredSegmentGranularity());
+    Assertions.assertEquals(target.getSequenceName(), fromJson.getSequenceName());
+    Assertions.assertEquals(target.getPreviousSegmentId(), fromJson.getPreviousSegmentId());
+    Assertions.assertEquals(target.isSkipSegmentLineageCheck(), fromJson.isSkipSegmentLineageCheck());
+    Assertions.assertEquals(TaskLockType.EXCLUSIVE, target.getTaskLockType());
   }
 
   @Test
@@ -84,23 +84,23 @@ public class SegmentAllocateActionSerdeTest
         Map.class
     );
 
-    Assert.assertEquals(11, fromJson.size());
-    Assert.assertEquals(SegmentAllocateAction.TYPE, fromJson.get("type"));
-    Assert.assertEquals(target.getDataSource(), fromJson.get("dataSource"));
-    Assert.assertEquals(target.getTimestamp(), DateTimes.of((String) fromJson.get("timestamp")));
-    Assert.assertEquals(
+    Assertions.assertEquals(11, fromJson.size());
+    Assertions.assertEquals(SegmentAllocateAction.TYPE, fromJson.get("type"));
+    Assertions.assertEquals(target.getDataSource(), fromJson.get("dataSource"));
+    Assertions.assertEquals(target.getTimestamp(), DateTimes.of((String) fromJson.get("timestamp")));
+    Assertions.assertEquals(
         target.getQueryGranularity(),
         Granularity.fromString((String) fromJson.get("queryGranularity"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         target.getPreferredSegmentGranularity(),
         Granularity.fromString((String) fromJson.get("preferredSegmentGranularity"))
     );
-    Assert.assertEquals(target.getSequenceName(), fromJson.get("sequenceName"));
-    Assert.assertEquals(target.getPreviousSegmentId(), fromJson.get("previousSegmentId"));
-    Assert.assertEquals(target.isSkipSegmentLineageCheck(), fromJson.get("skipSegmentLineageCheck"));
-    Assert.assertEquals(ImmutableMap.of("type", "numbered"), fromJson.get("shardSpecFactory"));
-    Assert.assertEquals(target.getLockGranularity(), LockGranularity.valueOf((String) fromJson.get("lockGranularity")));
-    Assert.assertEquals(target.getTaskLockType(), TaskLockType.valueOf((String) fromJson.get("taskLockType")));
+    Assertions.assertEquals(target.getSequenceName(), fromJson.get("sequenceName"));
+    Assertions.assertEquals(target.getPreviousSegmentId(), fromJson.get("previousSegmentId"));
+    Assertions.assertEquals(target.isSkipSegmentLineageCheck(), fromJson.get("skipSegmentLineageCheck"));
+    Assertions.assertEquals(ImmutableMap.of("type", "numbered"), fromJson.get("shardSpecFactory"));
+    Assertions.assertEquals(target.getLockGranularity(), LockGranularity.valueOf((String) fromJson.get("lockGranularity")));
+    Assertions.assertEquals(target.getTaskLockType(), TaskLockType.valueOf((String) fromJson.get("taskLockType")));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocateActionTest.java
@@ -54,14 +54,14 @@ import org.apache.druid.timeline.partition.ShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -79,10 +79,11 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class SegmentAllocateActionTest
 {
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit taskActionTestKit = new TaskActionTestKit();
 
   private static final String DATA_SOURCE = "none";
@@ -94,7 +95,6 @@ public class SegmentAllocateActionTest
 
   private SegmentAllocationQueue allocationQueue;
 
-  @Parameterized.Parameters(name = "lock={0}, useBatch={1}, useSegmentCache={2}, reduceMetadataIO={3}")
   public static Iterable<Object[]> constructorFeeder()
   {
     // reduceMetadataIO is applicable only with batch allocation
@@ -122,7 +122,7 @@ public class SegmentAllocateActionTest
     this.taskActionTestKit.setUseSegmentMetadataCache(useSegmentMetadataCache);
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     ServiceEmitter emitter = EasyMock.createMock(ServiceEmitter.class);
@@ -135,7 +135,7 @@ public class SegmentAllocateActionTest
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (allocationQueue != null) {
@@ -146,7 +146,7 @@ public class SegmentAllocateActionTest
   @Test
   public void testManySegmentsSameInterval_noLineageCheck() throws Exception
   {
-    Assume.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
+    Assumptions.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
 
     final Task task = NoopTask.create();
     final int numTasks = 2;
@@ -195,7 +195,7 @@ public class SegmentAllocateActionTest
           )
       );
     }
-    Assert.assertEquals(expectedIds, allocatedIds);
+    Assertions.assertEquals(expectedIds, allocatedIds);
   }
 
   @Test
@@ -270,7 +270,7 @@ public class SegmentAllocateActionTest
                                                              .filter(input -> input.getInterval().contains(PARTY_TIME))
                                                              .collect(Collectors.toList());
 
-      Assert.assertEquals(3, partyTimeLocks.size());
+      Assertions.assertEquals(3, partyTimeLocks.size());
 
       assertSameIdentifier(
           new SegmentIdWithShardSpec(
@@ -319,7 +319,7 @@ public class SegmentAllocateActionTest
         "s1",
         null
     );
-    Assert.assertNotNull(id1);
+    Assertions.assertNotNull(id1);
     allocatedPartyTimeIds.put(id1.getShardSpec().getPartitionNum(), id1);
     final SegmentIdWithShardSpec id2 = allocate(
         task,
@@ -329,7 +329,7 @@ public class SegmentAllocateActionTest
         "s1",
         id1.toString()
     );
-    Assert.assertNotNull(id2);
+    Assertions.assertNotNull(id2);
     allocatedFutureIds.put(id2.getShardSpec().getPartitionNum(), id2);
     final SegmentIdWithShardSpec id3 = allocate(
         task,
@@ -339,7 +339,7 @@ public class SegmentAllocateActionTest
         "s1",
         id2.toString()
     );
-    Assert.assertNotNull(id3);
+    Assertions.assertNotNull(id3);
     allocatedPartyTimeIds.put(id3.getShardSpec().getPartitionNum(), id3);
     final SegmentIdWithShardSpec id4 = allocate(
         task,
@@ -349,7 +349,7 @@ public class SegmentAllocateActionTest
         "s1",
         id1.toString()
     );
-    Assert.assertNull(id4);
+    Assertions.assertNull(id4);
     final SegmentIdWithShardSpec id5 = allocate(
         task,
         THE_DISTANT_FUTURE,
@@ -358,7 +358,7 @@ public class SegmentAllocateActionTest
         "s1",
         id1.toString()
     );
-    Assert.assertNotNull(id5);
+    Assertions.assertNotNull(id5);
     allocatedFutureIds.put(id5.getShardSpec().getPartitionNum(), id5);
     final SegmentIdWithShardSpec id6 = allocate(
         task,
@@ -368,7 +368,7 @@ public class SegmentAllocateActionTest
         "s1",
         id1.toString()
     );
-    Assert.assertNull(id6);
+    Assertions.assertNull(id6);
     final SegmentIdWithShardSpec id7 = allocate(
         task,
         THE_DISTANT_FUTURE,
@@ -377,7 +377,7 @@ public class SegmentAllocateActionTest
         "s1",
         id1.toString()
     );
-    Assert.assertNotNull(id7);
+    Assertions.assertNotNull(id7);
     allocatedFutureIds.put(id7.getShardSpec().getPartitionNum(), id7);
 
     if (lockGranularity == LockGranularity.TIME_CHUNK) {
@@ -424,10 +424,10 @@ public class SegmentAllocateActionTest
                                                          .filter(input -> input.getInterval().contains(PARTY_TIME))
                                                          .collect(Collectors.toList());
 
-      Assert.assertEquals(2, partyLocks.size());
+      Assertions.assertEquals(2, partyLocks.size());
       final Map<Integer, SegmentLock> partitionIdToLock = new HashMap<>();
       partyLocks.forEach(lock -> {
-        Assert.assertEquals(LockGranularity.SEGMENT, lock.getGranularity());
+        Assertions.assertEquals(LockGranularity.SEGMENT, lock.getGranularity());
         final SegmentLock segmentLock = (SegmentLock) lock;
         partitionIdToLock.put(segmentLock.getPartitionId(), segmentLock);
       });
@@ -451,10 +451,10 @@ public class SegmentAllocateActionTest
           .filter(input -> input.getInterval().contains(THE_DISTANT_FUTURE))
           .collect(Collectors.toList());
 
-      Assert.assertEquals(1, futureLocks.size());
+      Assertions.assertEquals(1, futureLocks.size());
       partitionIdToLock.clear();
       futureLocks.forEach(lock -> {
-        Assert.assertEquals(LockGranularity.SEGMENT, lock.getGranularity());
+        Assertions.assertEquals(LockGranularity.SEGMENT, lock.getGranularity());
         final SegmentLock segmentLock = (SegmentLock) lock;
         partitionIdToLock.put(segmentLock.getPartitionId(), segmentLock);
       });
@@ -472,9 +472,9 @@ public class SegmentAllocateActionTest
       }
     }
 
-    Assert.assertNull(id4);
+    Assertions.assertNull(id4);
     assertSameIdentifier(id2, id5);
-    Assert.assertNull(id6);
+    Assertions.assertNull(id6);
     assertSameIdentifier(id2, id7);
   }
 
@@ -514,9 +514,9 @@ public class SegmentAllocateActionTest
         allocate(task, PARTY_TIME, Granularities.NONE, Granularities.HOUR, sequenceName, null);
 
     assertSameIdentifier(pendingSegmentV11, pendingSegmentV12);
-    Assert.assertEquals(segmentV1.getVersion(), pendingSegmentV11.getVersion());
+    Assertions.assertEquals(segmentV1.getVersion(), pendingSegmentV11.getVersion());
 
-    Assert.assertNotEquals(pendingSegmentV01, pendingSegmentV11);
+    Assertions.assertNotEquals(pendingSegmentV01, pendingSegmentV11);
 
     // Commit a segment for version V2 to overshadow V1
     final DataSegment segmentV2
@@ -530,7 +530,7 @@ public class SegmentAllocateActionTest
     taskActionTestKit.getMetadataStorageCoordinator().commitSegments(
         Collections.singleton(segmentV2), null
     );
-    Assert.assertTrue(segmentV2.getVersion().compareTo(segmentV1.getVersion()) > 0);
+    Assertions.assertTrue(segmentV2.getVersion().compareTo(segmentV1.getVersion()) > 0);
 
     // Verify that new segment allocations use version V2
     final SegmentIdWithShardSpec pendingSegmentV21 =
@@ -538,10 +538,10 @@ public class SegmentAllocateActionTest
     final SegmentIdWithShardSpec pendingSegmentV22 =
         allocate(task, PARTY_TIME, Granularities.NONE, Granularities.HOUR, sequenceName, null);
     assertSameIdentifier(pendingSegmentV21, pendingSegmentV22);
-    Assert.assertEquals(segmentV2.getVersion(), pendingSegmentV21.getVersion());
+    Assertions.assertEquals(segmentV2.getVersion(), pendingSegmentV21.getVersion());
 
-    Assert.assertNotEquals(pendingSegmentV21, pendingSegmentV01);
-    Assert.assertNotEquals(pendingSegmentV21, pendingSegmentV11);
+    Assertions.assertNotEquals(pendingSegmentV21, pendingSegmentV01);
+    Assertions.assertNotEquals(pendingSegmentV21, pendingSegmentV11);
   }
 
   @Test
@@ -648,7 +648,7 @@ public class SegmentAllocateActionTest
                                                          .filter(input -> input.getInterval().contains(PARTY_TIME))
                                                          .collect(Collectors.toList());
 
-      Assert.assertEquals(3, partyLocks.size());
+      Assertions.assertEquals(3, partyLocks.size());
 
       assertSameIdentifier(
           new SegmentIdWithShardSpec(
@@ -685,7 +685,7 @@ public class SegmentAllocateActionTest
           .filter(input -> input.getInterval().contains(THE_DISTANT_FUTURE))
           .collect(Collectors.toList());
 
-      Assert.assertEquals(2, futureLocks.size());
+      Assertions.assertEquals(2, futureLocks.size());
 
       assertSameIdentifier(
           new SegmentIdWithShardSpec(
@@ -949,7 +949,7 @@ public class SegmentAllocateActionTest
 
     final SegmentIdWithShardSpec id1 = allocate(task, PARTY_TIME, Granularities.DAY, Granularities.DAY, "s1", null);
 
-    Assert.assertNull(id1);
+    Assertions.assertNull(id1);
   }
 
   @Test
@@ -960,7 +960,7 @@ public class SegmentAllocateActionTest
 
     final SegmentIdWithShardSpec id1 = allocate(task, PARTY_TIME, Granularities.DAY, Granularities.HOUR, "s1", null);
 
-    Assert.assertNull(id1);
+    Assertions.assertNull(id1);
   }
 
   @Test
@@ -1008,15 +1008,15 @@ public class SegmentAllocateActionTest
         null
     );
     final SegmentIdWithShardSpec segmentIdentifier = action.perform(task, taskActionTestKit.getTaskActionToolbox());
-    Assert.assertNotNull(segmentIdentifier);
+    Assertions.assertNotNull(segmentIdentifier);
 
     final ShardSpec shardSpec = segmentIdentifier.getShardSpec();
-    Assert.assertEquals(2, shardSpec.getPartitionNum());
+    Assertions.assertEquals(2, shardSpec.getPartitionNum());
 
-    Assert.assertTrue(shardSpec instanceof HashBasedNumberedShardSpec);
+    Assertions.assertTrue(shardSpec instanceof HashBasedNumberedShardSpec);
     final HashBasedNumberedShardSpec hashBasedNumberedShardSpec = (HashBasedNumberedShardSpec) shardSpec;
-    Assert.assertEquals(2, hashBasedNumberedShardSpec.getNumCorePartitions());
-    Assert.assertEquals(ImmutableList.of("dim1"), hashBasedNumberedShardSpec.getPartitionDimensions());
+    Assertions.assertEquals(2, hashBasedNumberedShardSpec.getNumCorePartitions());
+    Assertions.assertEquals(ImmutableList.of("dim1"), hashBasedNumberedShardSpec.getPartitionDimensions());
   }
 
   @Test
@@ -1046,8 +1046,8 @@ public class SegmentAllocateActionTest
         "s2",
         null
     );
-    Assert.assertNotNull(id1);
-    Assert.assertNotNull(id2);
+    Assertions.assertNotNull(id1);
+    Assertions.assertNotNull(id2);
   }
 
   @Test
@@ -1073,10 +1073,10 @@ public class SegmentAllocateActionTest
         null
     );
 
-    Assert.assertNotNull(id1);
-    Assert.assertNotNull(id2);
-    Assert.assertEquals(Intervals.ETERNITY, id1.getInterval());
-    Assert.assertEquals(Intervals.ETERNITY, id2.getInterval());
+    Assertions.assertNotNull(id1);
+    Assertions.assertNotNull(id2);
+    Assertions.assertEquals(Intervals.ETERNITY, id1.getInterval());
+    Assertions.assertEquals(Intervals.ETERNITY, id2.getInterval());
   }
 
   @Test
@@ -1103,10 +1103,10 @@ public class SegmentAllocateActionTest
         null
     );
 
-    Assert.assertNotNull(id1);
-    Assert.assertNotNull(id2);
-    Assert.assertEquals(Duration.ofHours(1).toMillis(), id1.getInterval().toDurationMillis());
-    Assert.assertEquals(Duration.ofDays(7).toMillis(), id2.getInterval().toDurationMillis());
+    Assertions.assertNotNull(id1);
+    Assertions.assertNotNull(id2);
+    Assertions.assertEquals(Duration.ofHours(1).toMillis(), id1.getInterval().toDurationMillis());
+    Assertions.assertEquals(Duration.ofDays(7).toMillis(), id2.getInterval().toDurationMillis());
   }
 
   @Test
@@ -1133,10 +1133,10 @@ public class SegmentAllocateActionTest
         null
     );
 
-    Assert.assertNotNull(id1);
-    Assert.assertNotNull(id2);
-    Assert.assertEquals(Duration.ofHours(1).toMillis(), id1.getInterval().toDurationMillis());
-    Assert.assertEquals(Duration.ofDays(1).toMillis(), id2.getInterval().toDurationMillis());
+    Assertions.assertNotNull(id1);
+    Assertions.assertNotNull(id2);
+    Assertions.assertEquals(Duration.ofHours(1).toMillis(), id1.getInterval().toDurationMillis());
+    Assertions.assertEquals(Duration.ofDays(1).toMillis(), id2.getInterval().toDurationMillis());
   }
 
   @Test
@@ -1173,7 +1173,7 @@ public class SegmentAllocateActionTest
     // Allocate another id and ensure that it doesn't exist in the druid_segments table
     final SegmentIdWithShardSpec theId =
         allocate(task1, DateTimes.nowUtc(), Granularities.NONE, Granularities.ALL, "seq", "3");
-    Assert.assertNull(coordinator.retrieveSegmentForId(theId.asSegmentId()));
+    Assertions.assertNull(coordinator.retrieveSegmentForId(theId.asSegmentId()));
 
     lockbox.unlock(task1, Intervals.ETERNITY);
   }
@@ -1271,8 +1271,8 @@ public class SegmentAllocateActionTest
 
   private void assertSameIdentifier(final SegmentIdWithShardSpec expected, final SegmentIdWithShardSpec actual)
   {
-    Assert.assertEquals(expected, actual);
-    Assert.assertEquals(expected.getShardSpec(), actual.getShardSpec());
+    Assertions.assertEquals(expected, actual);
+    Assertions.assertEquals(expected.getShardSpec(), actual.getShardSpec());
   }
 
   private DataSegment getSegmentForIdentifier(SegmentIdWithShardSpec identifier)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentAllocationQueueTest.java
@@ -31,13 +31,13 @@ import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
 import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorService;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,10 +46,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("getTestParameters")
 public class SegmentAllocationQueueTest
 {
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit taskActionTestKit = new TaskActionTestKit();
 
   private SegmentAllocationQueue allocationQueue;
@@ -60,7 +61,6 @@ public class SegmentAllocationQueueTest
 
   private final boolean reduceMetadataIO;
 
-  @Parameterized.Parameters(name = "reduceMetadataIO = {0}, useSegmentCache = {1}")
   public static Object[][] getTestParameters()
   {
     return new Object[][]{
@@ -78,7 +78,7 @@ public class SegmentAllocationQueueTest
     taskActionTestKit.setUseSegmentMetadataCache(useSegmentMetadataCache);
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     managerExec = new BlockingExecutorService("test-manager-exec");
@@ -127,7 +127,7 @@ public class SegmentAllocationQueueTest
     allocationQueue.becomeLeader();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (allocationQueue != null) {
@@ -261,8 +261,8 @@ public class SegmentAllocationQueueTest
     processDistinctDatasourceBatches();
     processDistinctDatasourceBatches();
 
-    Assert.assertNotNull(getSegmentId(hourSegmentFuture));
-    Assert.assertNull(getSegmentId(halfHourSegmentFuture));
+    Assertions.assertNotNull(getSegmentId(hourSegmentFuture));
+    Assertions.assertNull(getSegmentId(halfHourSegmentFuture));
   }
 
   @Test
@@ -279,8 +279,8 @@ public class SegmentAllocationQueueTest
     Future<SegmentIdWithShardSpec> future = allocationQueue.add(request);
 
     // Verify that the future is already complete and segment allocation has failed
-    Throwable t = Assert.assertThrows(ISE.class, () -> getSegmentId(future));
-    Assert.assertEquals(
+    Throwable t = Assertions.assertThrows(ISE.class, () -> getSegmentId(future));
+    Assertions.assertEquals(
         "Segment allocation queue is full. Check the metric `task/action/batch/runTime` "
         + "to determine if metadata operations are slow.",
         t.getMessage()
@@ -297,11 +297,11 @@ public class SegmentAllocationQueueTest
     }
 
     // Verify that next request is added to a new batch
-    Assert.assertEquals(1, allocationQueue.size());
+    Assertions.assertEquals(1, allocationQueue.size());
     SegmentAllocateRequest request =
         allocateRequest().forTask(createTask(TestDataSource.WIKI, "group_1")).build();
     allocationQueue.add(request);
-    Assert.assertEquals(2, allocationQueue.size());
+    Assertions.assertEquals(2, allocationQueue.size());
   }
 
   @Test
@@ -324,7 +324,7 @@ public class SegmentAllocationQueueTest
     SegmentIdWithShardSpec segmentId1 = getSegmentId(segmentFutures.get(0));
 
     for (Future<SegmentIdWithShardSpec> future : segmentFutures) {
-      Assert.assertEquals(getSegmentId(future), segmentId1);
+      Assertions.assertEquals(getSegmentId(future), segmentId1);
     }
 
     // Verify each datasource batch is marked skipped just once
@@ -351,8 +351,8 @@ public class SegmentAllocationQueueTest
     processDistinctDatasourceBatches();
 
     for (Future<SegmentIdWithShardSpec> future : segmentFutures) {
-      Throwable t = Assert.assertThrows(ISE.class, () -> getSegmentId(future));
-      Assert.assertEquals("Not leader anymore", t.getMessage());
+      Throwable t = Assertions.assertThrows(ISE.class, () -> getSegmentId(future));
+      Assertions.assertEquals("Not leader anymore", t.getMessage());
     }
   }
 
@@ -362,12 +362,12 @@ public class SegmentAllocationQueueTest
       boolean canBatch
   )
   {
-    Assert.assertEquals(0, allocationQueue.size());
+    Assertions.assertEquals(0, allocationQueue.size());
     final Future<SegmentIdWithShardSpec> futureA = allocationQueue.add(a);
     final Future<SegmentIdWithShardSpec> futureB = allocationQueue.add(b);
 
     final int expectedCount = canBatch ? 1 : 2;
-    Assert.assertEquals(expectedCount, allocationQueue.size());
+    Assertions.assertEquals(expectedCount, allocationQueue.size());
 
     // Process both the jobs
     processDistinctDatasourceBatches();
@@ -375,8 +375,8 @@ public class SegmentAllocationQueueTest
     emitter.verifyEmitted("task/action/batch/size", expectedCount);
     emitter.verifySum("task/action/batch/submitted", expectedCount);
 
-    Assert.assertNotNull(getSegmentId(futureA));
-    Assert.assertNotNull(getSegmentId(futureB));
+    Assertions.assertNotNull(getSegmentId(futureA));
+    Assertions.assertNotNull(getSegmentId(futureB));
   }
 
   private SegmentIdWithShardSpec getSegmentId(Future<SegmentIdWithShardSpec> future)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalInsertActionTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
@@ -36,18 +35,18 @@ import org.apache.druid.indexing.overlord.supervisor.NoopSupervisorSpec;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.assertj.core.api.Assertions;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class SegmentTransactionalInsertActionTest
 {
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit actionTestKit = new TaskActionTestKit();
 
   private static final String DATA_SOURCE = "none";
@@ -116,7 +115,7 @@ public class SegmentTransactionalInsertActionTest
         task,
         actionTestKit.getTaskActionToolbox()
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT1)), result1);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT1)), result1);
 
     SegmentPublishResult result2 = SegmentTransactionalInsertAction.appendAction(
         ImmutableSet.of(SEGMENT2),
@@ -129,14 +128,14 @@ public class SegmentTransactionalInsertActionTest
         task,
         actionTestKit.getTaskActionToolbox()
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT2)), result2);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT2)), result2);
 
-    Assertions.assertThat(
+    assertThat(
         actionTestKit.getMetadataStorageCoordinator()
                      .retrieveUsedSegmentsForInterval(DATA_SOURCE, INTERVAL, Segments.ONLY_VISIBLE)
     ).containsExactlyInAnyOrder(SEGMENT1, SEGMENT2);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableList.of(2)),
         actionTestKit.getMetadataStorageCoordinator().retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
@@ -160,7 +159,7 @@ public class SegmentTransactionalInsertActionTest
         task,
         actionTestKit.getTaskActionToolbox()
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT1)), result1);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT1)), result1);
 
     SegmentPublishResult result2 = SegmentTransactionalInsertAction.appendAction(
         ImmutableSet.of(SEGMENT2),
@@ -173,14 +172,14 @@ public class SegmentTransactionalInsertActionTest
         task,
         actionTestKit.getTaskActionToolbox()
     );
-    Assert.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT2)), result2);
+    Assertions.assertEquals(SegmentPublishResult.ok(ImmutableSet.of(SEGMENT2)), result2);
 
-    Assertions.assertThat(
+    assertThat(
         actionTestKit.getMetadataStorageCoordinator()
                      .retrieveUsedSegmentsForInterval(DATA_SOURCE, INTERVAL, Segments.ONLY_VISIBLE)
     ).containsExactlyInAnyOrder(SEGMENT1, SEGMENT2);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new ObjectMetadata(ImmutableList.of(2)),
         actionTestKit.getMetadataStorageCoordinator().retrieveDataSourceMetadata(SUPERVISOR_ID)
     );
@@ -208,7 +207,7 @@ public class SegmentTransactionalInsertActionTest
         actionTestKit.getTaskActionToolbox()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SegmentPublishResult.fail(
             "The new start metadata state[ObjectMetadata{theObject=[1]}] is"
             + " ahead of the last committed end state[null]. Try resetting the supervisor."
@@ -226,12 +225,13 @@ public class SegmentTransactionalInsertActionTest
     actionTestKit.getTaskLockbox().add(task);
     acquireTimeChunkLock(TaskLockType.EXCLUSIVE, task, INTERVAL, 5000);
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            DruidException.class,
-            () -> action.perform(task, actionTestKit.getTaskActionToolbox())
-        ),
-        DruidExceptionMatcher.conflict().expectMessageContains("are not covered by locks")
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () -> action.perform(task, actionTestKit.getTaskActionToolbox())
     );
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.CONFLICT, exception.getCategory());
+    Assertions.assertEquals("general", exception.getErrorCode());
+    assertThat(exception.getMessage()).contains("are not covered by locks");
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalReplaceActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SegmentTransactionalReplaceActionTest.java
@@ -33,9 +33,9 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -57,7 +57,7 @@ public class SegmentTransactionalReplaceActionTest
   private TaskActionToolbox toolbox;
   private Task task;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     emitter = new StubServiceEmitter("test", "localhost");
@@ -79,7 +79,7 @@ public class SegmentTransactionalReplaceActionTest
 
     action.registerUpgradedPendingSegmentsOnSupervisor(task, toolbox, records(2));
 
-    Assert.assertEquals(2, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
+    Assertions.assertEquals(2, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
     EasyMock.verify(supervisorManager);
   }
 
@@ -95,7 +95,7 @@ public class SegmentTransactionalReplaceActionTest
 
     action.registerUpgradedPendingSegmentsOnSupervisor(task, toolbox, records(3));
 
-    Assert.assertEquals(3, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
+    Assertions.assertEquals(3, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
     EasyMock.verify(supervisorManager);
   }
 
@@ -111,7 +111,7 @@ public class SegmentTransactionalReplaceActionTest
 
     action.registerUpgradedPendingSegmentsOnSupervisor(task, toolbox, records(MORE_THAN_SAMPLE_SIZE));
 
-    Assert.assertEquals(MORE_THAN_SAMPLE_SIZE, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
+    Assertions.assertEquals(MORE_THAN_SAMPLE_SIZE, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
     EasyMock.verify(supervisorManager);
   }
 
@@ -129,7 +129,7 @@ public class SegmentTransactionalReplaceActionTest
 
     action.registerUpgradedPendingSegmentsOnSupervisor(task, toolbox, records(2));
 
-    Assert.assertEquals(2, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
+    Assertions.assertEquals(2, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
     EasyMock.verify(supervisorManager);
   }
 
@@ -148,7 +148,7 @@ public class SegmentTransactionalReplaceActionTest
 
       action.registerUpgradedPendingSegmentsOnSupervisor(task, toolbox, records(MORE_THAN_SAMPLE_SIZE));
 
-      Assert.assertEquals(MORE_THAN_SAMPLE_SIZE, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
+      Assertions.assertEquals(MORE_THAN_SAMPLE_SIZE, emitter.getMetricEventCount(SegmentUpgradeMetrics.PERSISTED));
       EasyMock.verify(supervisorManager);
     }
     finally {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SurrogateActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/SurrogateActionTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.TaskLockType;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -41,6 +41,6 @@ public class SurrogateActionTest
     );
 
     final String json = objectMapper.writeValueAsString(surrogateAction);
-    Assert.assertEquals(surrogateAction.toString(), objectMapper.readValue(json, TaskAction.class).toString());
+    Assertions.assertEquals(surrogateAction.toString(), objectMapper.readValue(json, TaskAction.class).toString());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
@@ -55,13 +55,14 @@ import org.joda.time.Period;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.ExternalResource;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-public class TaskActionTestKit implements BeforeEachCallback, AfterEachCallback
+public class TaskActionTestKit extends ExternalResource implements BeforeEachCallback, AfterEachCallback
 {
   private final MetadataStorageTablesConfig metadataStorageTablesConfig = MetadataStorageTablesConfig.fromBase("druid");
 
@@ -193,6 +194,7 @@ public class TaskActionTestKit implements BeforeEachCallback, AfterEachCallback
     taskActionDelegate.put(actionType, function);
   }
 
+  @Override
   public void before()
   {
     Preconditions.checkState(configFinalized.compareAndSet(false, true));
@@ -331,6 +333,7 @@ public class TaskActionTestKit implements BeforeEachCallback, AfterEachCallback
     };
   }
 
+  @Override
   public void after()
   {
     testDerbyConnector.tearDown();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionTestKit.java
@@ -52,14 +52,16 @@ import org.apache.druid.server.coordinator.simulate.BlockingExecutorService;
 import org.apache.druid.server.coordinator.simulate.TestDruidLeaderSelector;
 import org.apache.druid.server.coordinator.simulate.WrappingScheduledExecutorService;
 import org.joda.time.Period;
-import org.junit.rules.ExternalResource;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-public class TaskActionTestKit extends ExternalResource
+public class TaskActionTestKit implements BeforeEachCallback, AfterEachCallback
 {
   private final MetadataStorageTablesConfig metadataStorageTablesConfig = MetadataStorageTablesConfig.fromBase("druid");
 
@@ -191,7 +193,6 @@ public class TaskActionTestKit extends ExternalResource
     taskActionDelegate.put(actionType, function);
   }
 
-  @Override
   public void before()
   {
     Preconditions.checkState(configFinalized.compareAndSet(false, true));
@@ -330,7 +331,6 @@ public class TaskActionTestKit extends ExternalResource
     };
   }
 
-  @Override
   public void after()
   {
     testDerbyConnector.tearDown();
@@ -343,5 +343,17 @@ public class TaskActionTestKit extends ExternalResource
     segmentMetadataCache.stop();
     supervisorManager.stop();
     useSegmentMetadataCache = false;
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext context)
+  {
+    before();
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context)
+  {
+    after();
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionToolboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskActionToolboxTest.java
@@ -21,10 +21,10 @@ package org.apache.druid.indexing.common.actions;
 
 import org.apache.druid.indexing.overlord.ForkingTaskRunner;
 import org.apache.druid.indexing.overlord.ForkingTaskRunnerFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskLocksTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TaskLocksTest.java
@@ -46,9 +46,9 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -62,7 +62,7 @@ public class TaskLocksTest
   private GlobalTaskLockbox lockbox;
   private Task task;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     final TaskStorage taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
@@ -119,7 +119,7 @@ public class TaskLocksTest
     final TaskLock taskLock = lockbox
         .tryLock(task, new TimeChunkLockRequest(lockType, task, interval, null))
         .getTaskLock();
-    Assert.assertNotNull(taskLock);
+    Assertions.assertNotNull(taskLock);
     return taskLock;
   }
 
@@ -148,8 +148,8 @@ public class TaskLocksTest
         )
     );
 
-    Assert.assertEquals(3, locks.size());
-    Assert.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
+    Assertions.assertEquals(3, locks.size());
+    Assertions.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
   }
 
   @Test
@@ -164,13 +164,13 @@ public class TaskLocksTest
         .mapToObj(
             partitionId -> {
               final TaskLock lock = trySegmentLock(task, interval, version, partitionId).getTaskLock();
-              Assert.assertNotNull(lock);
+              Assertions.assertNotNull(lock);
               return lock;
             }
         ).collect(Collectors.toList());
 
-    Assert.assertEquals(5, locks.size());
-    Assert.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
+    Assertions.assertEquals(5, locks.size());
+    Assertions.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
   }
 
   @Test
@@ -188,8 +188,8 @@ public class TaskLocksTest
         )
     );
 
-    Assert.assertEquals(1, locks.size());
-    Assert.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
+    Assertions.assertEquals(1, locks.size());
+    Assertions.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
   }
 
   @Test
@@ -209,8 +209,8 @@ public class TaskLocksTest
         )
     );
 
-    Assert.assertEquals(3, locks.size());
-    Assert.assertFalse(TaskLocks.isLockCoversSegments(task, lockbox, segments));
+    Assertions.assertEquals(3, locks.size());
+    Assertions.assertFalse(TaskLocks.isLockCoversSegments(task, lockbox, segments));
   }
 
   @Test
@@ -230,8 +230,8 @@ public class TaskLocksTest
         )
     );
 
-    Assert.assertEquals(3, locks.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(3, locks.size());
+    Assertions.assertEquals(
         ImmutableList.of(
             newTimeChunkLock(intervals.get(0), locks.get(intervals.get(0)).getVersion()),
             newTimeChunkLock(intervals.get(1), locks.get(intervals.get(1)).getVersion()),
@@ -253,13 +253,13 @@ public class TaskLocksTest
         .mapToObj(
             partitionId -> {
               final TaskLock lock = trySegmentLock(task, interval, version, partitionId).getTaskLock();
-              Assert.assertNotNull(lock);
+              Assertions.assertNotNull(lock);
               return lock;
             }
         ).collect(Collectors.toList());
 
-    Assert.assertEquals(5, locks.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(5, locks.size());
+    Assertions.assertEquals(
         ImmutableList.of(
             newSegmentLock(interval, locks.get(0).getVersion(), 0),
             newSegmentLock(interval, locks.get(0).getVersion(), 1),
@@ -278,10 +278,10 @@ public class TaskLocksTest
     final Interval interval = Intervals.of("2017-01-01/2017-01-02");
 
     final TaskLock lock = tryTimeChunkLock(task, interval, TaskLockType.EXCLUSIVE);
-    Assert.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
+    Assertions.assertTrue(TaskLocks.isLockCoversSegments(task, lockbox, segments));
 
     lockbox.revokeLock(task.getId(), lock);
-    Assert.assertFalse(TaskLocks.isLockCoversSegments(task, lockbox, segments));
+    Assertions.assertFalse(TaskLocks.isLockCoversSegments(task, lockbox, segments));
   }
 
   @Test
@@ -298,10 +298,10 @@ public class TaskLocksTest
 
     final Map<DataSegment, ReplaceTaskLock> observedLocks
         = TaskLocks.findReplaceLocksCoveringSegments(task.getDataSource(), lockbox, segments);
-    Assert.assertEquals(segments.size(), observedLocks.size());
+    Assertions.assertEquals(segments.size(), observedLocks.size());
     for (DataSegment segment : segments) {
       TaskLock lockFromResult = lockResults.get(segment);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           new ReplaceTaskLock(task.getId(), lockFromResult.getInterval(), lockFromResult.getVersion()),
           observedLocks.get(segment)
       );
@@ -311,7 +311,7 @@ public class TaskLocksTest
   @Test
   public void testLockTypeForAppendUsingConcurrentLocks()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.APPEND,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of(Tasks.USE_CONCURRENT_LOCKS, true)
@@ -322,25 +322,25 @@ public class TaskLocksTest
   @Test
   public void testLockTypeForAppendWithLockTypeInContext()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.REPLACE,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of(Tasks.TASK_LOCK_TYPE, "REPLACE")
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.APPEND,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of(Tasks.TASK_LOCK_TYPE, "APPEND")
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.SHARED,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of(Tasks.TASK_LOCK_TYPE, "SHARED")
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.EXCLUSIVE,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of(Tasks.TASK_LOCK_TYPE, "EXCLUSIVE", Tasks.USE_SHARED_LOCK, true)
@@ -351,19 +351,19 @@ public class TaskLocksTest
   @Test
   public void testLockTypeForAppendWithNoLockTypeInContext()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.EXCLUSIVE,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of()
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.EXCLUSIVE,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of(Tasks.USE_SHARED_LOCK, false)
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskLockType.SHARED,
         TaskLocks.determineLockTypeForAppend(
             ImmutableMap.of(Tasks.USE_SHARED_LOCK, true)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TimeChunkLockAcquireActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TimeChunkLockAcquireActionTest.java
@@ -26,15 +26,17 @@ import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 public class TimeChunkLockAcquireActionTest
 {
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit actionTestKit = new TaskActionTestKit();
 
   private final ObjectMapper mapper = new DefaultObjectMapper();
@@ -50,9 +52,9 @@ public class TimeChunkLockAcquireActionTest
 
     final byte[] bytes = mapper.writeValueAsBytes(expected);
     final TimeChunkLockAcquireAction actual = mapper.readValue(bytes, TimeChunkLockAcquireAction.class);
-    Assert.assertEquals(expected.getType(), actual.getType());
-    Assert.assertEquals(expected.getInterval(), actual.getInterval());
-    Assert.assertEquals(expected.getTimeoutMs(), actual.getTimeoutMs());
+    Assertions.assertEquals(expected.getType(), actual.getType());
+    Assertions.assertEquals(expected.getInterval(), actual.getInterval());
+    Assertions.assertEquals(expected.getTimeoutMs(), actual.getTimeoutMs());
   }
 
   @Test
@@ -66,12 +68,13 @@ public class TimeChunkLockAcquireActionTest
         Intervals.of("2017-01-01/2017-01-02"),
         0
     );
-    Assert.assertEquals(expected.getType(), actual.getType());
-    Assert.assertEquals(expected.getInterval(), actual.getInterval());
-    Assert.assertEquals(expected.getTimeoutMs(), actual.getTimeoutMs());
+    Assertions.assertEquals(expected.getType(), actual.getType());
+    Assertions.assertEquals(expected.getInterval(), actual.getInterval());
+    Assertions.assertEquals(expected.getTimeoutMs(), actual.getTimeoutMs());
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testWithLockType()
   {
     final Task task = NoopTask.create();
@@ -83,10 +86,11 @@ public class TimeChunkLockAcquireActionTest
 
     actionTestKit.getTaskLockbox().add(task);
     final TaskLock lock = action.perform(task, actionTestKit.getTaskActionToolbox());
-    Assert.assertNotNull(lock);
+    Assertions.assertNotNull(lock);
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testWithoutLockType()
   {
     final Task task = NoopTask.create();
@@ -98,6 +102,6 @@ public class TimeChunkLockAcquireActionTest
 
     actionTestKit.getTaskLockbox().add(task);
     final TaskLock lock = action.perform(task, actionTestKit.getTaskActionToolbox());
-    Assert.assertNotNull(lock);
+    Assertions.assertNotNull(lock);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TimeChunkLockTryAcquireActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/TimeChunkLockTryAcquireActionTest.java
@@ -26,15 +26,17 @@ import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 public class TimeChunkLockTryAcquireActionTest
 {
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit actionTestKit = new TaskActionTestKit();
 
   private final ObjectMapper mapper = new DefaultObjectMapper();
@@ -49,8 +51,8 @@ public class TimeChunkLockTryAcquireActionTest
 
     final byte[] bytes = mapper.writeValueAsBytes(expected);
     final TimeChunkLockTryAcquireAction actual = mapper.readValue(bytes, TimeChunkLockTryAcquireAction.class);
-    Assert.assertEquals(expected.getType(), actual.getType());
-    Assert.assertEquals(expected.getInterval(), actual.getInterval());
+    Assertions.assertEquals(expected.getType(), actual.getType());
+    Assertions.assertEquals(expected.getInterval(), actual.getInterval());
   }
 
   @Test
@@ -63,11 +65,12 @@ public class TimeChunkLockTryAcquireActionTest
         TaskLockType.EXCLUSIVE,
         Intervals.of("2017-01-01/2017-01-02")
     );
-    Assert.assertEquals(expected.getType(), actual.getType());
-    Assert.assertEquals(expected.getInterval(), actual.getInterval());
+    Assertions.assertEquals(expected.getType(), actual.getType());
+    Assertions.assertEquals(expected.getInterval(), actual.getInterval());
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testWithLockType()
   {
     final Task task = NoopTask.create();
@@ -78,10 +81,11 @@ public class TimeChunkLockTryAcquireActionTest
 
     actionTestKit.getTaskLockbox().add(task);
     final TaskLock lock = action.perform(task, actionTestKit.getTaskActionToolbox());
-    Assert.assertNotNull(lock);
+    Assertions.assertNotNull(lock);
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testWithoutLockType()
   {
     final Task task = NoopTask.create();
@@ -92,6 +96,6 @@ public class TimeChunkLockTryAcquireActionTest
 
     actionTestKit.getTaskLockbox().add(task);
     final TaskLock lock = action.perform(task, actionTestKit.getTaskActionToolbox());
-    Assert.assertNotNull(lock);
+    Assertions.assertNotNull(lock);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateLocationActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateLocationActionTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -81,13 +81,13 @@ public class UpdateLocationActionTest
     );
     final String json = TestHelper.JSON_MAPPER.writeValueAsString(original);
     final TaskAction<?> deserialized = TestHelper.JSON_MAPPER.readValue(json, TaskAction.class);
-    Assert.assertEquals(original, deserialized);
+    Assertions.assertEquals(original, deserialized);
   }
 
   @Test
   public void test_actionWithNullLocation_throwsException()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> new UpdateLocationAction(null)
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/actions/UpdateStatusActionTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.overlord.TaskRunner;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -95,6 +95,6 @@ public class UpdateStatusActionTest
   {
     UpdateStatusAction one = new UpdateStatusAction("", TaskStatus.failure(ID, "error"));
     UpdateStatusAction two = new UpdateStatusAction("", TaskStatus.failure(ID, "error"));
-    Assert.assertEquals(one, two);
+    Assertions.assertEquals(one, two);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientCompactionTaskQuerySerdeTest.java
@@ -70,8 +70,8 @@ import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.server.security.AuthorizerMapper;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -123,7 +123,7 @@ public class ClientCompactionTaskQuerySerdeTest
     final CompactionTask task = (CompactionTask) MAPPER.readValue(json, Task.class);
 
     // Verify that CompactionTask has added new parameters into the context because transformSpec was null.
-    Assert.assertNotEquals(query.getContext(), task.getContext());
+    Assertions.assertNotEquals(query.getContext(), task.getContext());
     query.getContext().put(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE.toString());
     assertQueryToTask(query, task);
   }
@@ -138,7 +138,7 @@ public class ClientCompactionTaskQuerySerdeTest
     final byte[] json = MAPPER.writeValueAsBytes(task);
     final ClientCompactionTaskQuery actual = (ClientCompactionTaskQuery) MAPPER.readValue(json, ClientTaskQuery.class);
 
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -152,10 +152,10 @@ public class ClientCompactionTaskQuerySerdeTest
     final ClientCompactionTaskQuery actual = (ClientCompactionTaskQuery) MAPPER.readValue(json, ClientTaskQuery.class);
 
     // Verify that CompactionTask has added new parameters into the context
-    Assert.assertNotEquals(expected, actual);
+    Assertions.assertNotEquals(expected, actual);
 
     expected.getContext().put(LookupLoadingSpec.CTX_LOOKUP_LOADING_MODE, LookupLoadingSpec.Mode.NONE.toString());
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -190,8 +190,8 @@ public class ClientCompactionTaskQuerySerdeTest
     final byte[] json = MAPPER.writeValueAsBytes(query);
     final ClientCompactionTaskQuery actual = (ClientCompactionTaskQuery) MAPPER.readValue(json, ClientTaskQuery.class);
 
-    Assert.assertEquals(baseTable, actual.getBaseTable());
-    Assert.assertEquals(query, actual);
+    Assertions.assertEquals(baseTable, actual.getBaseTable());
+    Assertions.assertEquals(query, actual);
   }
 
   private static ObjectMapper setupInjectablesInObjectMapper(ObjectMapper objectMapper)
@@ -229,104 +229,104 @@ public class ClientCompactionTaskQuerySerdeTest
 
   private void assertQueryToTask(ClientCompactionTaskQuery query, CompactionTask task)
   {
-    Assert.assertEquals(query.getId(), task.getId());
-    Assert.assertEquals(query.getDataSource(), task.getDataSource());
-    Assert.assertTrue(query.getIoConfig().getInputSpec() instanceof ClientCompactionIntervalSpec);
-    Assert.assertTrue(task.getIoConfig().getInputSpec() instanceof CompactionIntervalSpec);
-    Assert.assertEquals(
+    Assertions.assertEquals(query.getId(), task.getId());
+    Assertions.assertEquals(query.getDataSource(), task.getDataSource());
+    Assertions.assertTrue(query.getIoConfig().getInputSpec() instanceof ClientCompactionIntervalSpec);
+    Assertions.assertTrue(task.getIoConfig().getInputSpec() instanceof CompactionIntervalSpec);
+    Assertions.assertEquals(
         query.getIoConfig().getInputSpec().getInterval(),
         ((CompactionIntervalSpec) task.getIoConfig().getInputSpec()).getInterval()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ((ClientCompactionIntervalSpec) query.getIoConfig().getInputSpec()).getSha256OfSortedSegmentIds(),
         ((CompactionIntervalSpec) task.getIoConfig().getInputSpec()).getSha256OfSortedSegmentIds()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getMaxRowsInMemory().intValue(),
         task.getTuningConfig().getMaxRowsInMemory()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getMaxBytesInMemory().longValue(),
         task.getTuningConfig().getMaxBytesInMemory()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getSplitHintSpec(),
         task.getTuningConfig().getSplitHintSpec()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getPartitionsSpec(),
         task.getTuningConfig().getPartitionsSpec()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getIndexSpec(),
         task.getTuningConfig().getIndexSpec()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getIndexSpecForIntermediatePersists(),
         task.getTuningConfig().getIndexSpecForIntermediatePersists()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getPushTimeout().longValue(),
         task.getTuningConfig().getPushTimeout()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getSegmentWriteOutMediumFactory(),
         task.getTuningConfig().getSegmentWriteOutMediumFactory()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getMaxNumConcurrentSubTasks().intValue(),
         task.getTuningConfig().getMaxNumConcurrentSubTasks()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getMaxRetry().intValue(),
         task.getTuningConfig().getMaxRetry()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getTaskStatusCheckPeriodMs().longValue(),
         task.getTuningConfig().getTaskStatusCheckPeriodMs()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getChatHandlerTimeout(),
         task.getTuningConfig().getChatHandlerTimeout()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getMaxNumSegmentsToMerge().intValue(),
         task.getTuningConfig().getMaxNumSegmentsToMerge()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTuningConfig().getTotalNumMergeTasks().intValue(),
         task.getTuningConfig().getTotalNumMergeTasks()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getGranularitySpec(),
         task.getGranularitySpec()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getGranularitySpec().getQueryGranularity(),
         task.getGranularitySpec().getQueryGranularity()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getGranularitySpec().getSegmentGranularity(),
         task.getGranularitySpec().getSegmentGranularity()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getGranularitySpec().isRollup(),
         task.getGranularitySpec().isRollup()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getIoConfig().isDropExisting(),
         task.getIoConfig().isDropExisting()
     );
-    Assert.assertEquals(query.getContext(), task.getContext());
-    Assert.assertEquals(
+    Assertions.assertEquals(query.getContext(), task.getContext());
+    Assertions.assertEquals(
         query.getDimensionsSpec().getDimensions(),
         task.getDimensionsSpec().getDimensions()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         query.getTransformSpec(),
         task.getTransformSpec()
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         query.getMetricsSpec(),
         task.getMetricsSpec()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionInputSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionInputSpecTest.java
@@ -26,18 +26,18 @@ import org.apache.druid.java.util.common.JodaUtils;
 import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class CompactionInputSpecTest
 {
   private static final String DATASOURCE = "datasource";
@@ -46,7 +46,6 @@ public class CompactionInputSpecTest
       SEGMENTS.stream().map(DataSegment::getInterval).collect(Collectors.toList())
   );
 
-  @Parameters
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -96,15 +95,15 @@ public class CompactionInputSpecTest
   @Test
   public void testFindInterval()
   {
-    Assert.assertEquals(INTERVAL, inputSpec.findInterval(DATASOURCE));
+    Assertions.assertEquals(INTERVAL, inputSpec.findInterval(DATASOURCE));
   }
 
   @Test
   public void testValidateSegments()
   {
-    Assert.assertTrue(inputSpec.validateSegments(LockGranularity.TIME_CHUNK, SEGMENTS));
-    Assert.assertTrue(inputSpec.validateSegments(LockGranularity.SEGMENT, SEGMENTS));
-    Assert.assertFalse(inputSpec.validateSegments(LockGranularity.SEGMENT, SEGMENTS.subList(0, SEGMENTS.size() - 1)));
+    Assertions.assertTrue(inputSpec.validateSegments(LockGranularity.TIME_CHUNK, SEGMENTS));
+    Assertions.assertTrue(inputSpec.validateSegments(LockGranularity.SEGMENT, SEGMENTS));
+    Assertions.assertFalse(inputSpec.validateSegments(LockGranularity.SEGMENT, SEGMENTS.subList(0, SEGMENTS.size() - 1)));
   }
 
   @Test
@@ -112,10 +111,10 @@ public class CompactionInputSpecTest
   {
     final List<DataSegment> someSegmentIsMissing = new ArrayList<>(SEGMENTS);
     someSegmentIsMissing.remove(0);
-    Assert.assertFalse(inputSpec.validateSegments(LockGranularity.TIME_CHUNK, someSegmentIsMissing));
+    Assertions.assertFalse(inputSpec.validateSegments(LockGranularity.TIME_CHUNK, someSegmentIsMissing));
 
     final List<DataSegment> someSegmentIsUnknown = new ArrayList<>(SEGMENTS);
     someSegmentIsUnknown.add(newSegment(Intervals.of("2018-01-01/2018-01-02")));
-    Assert.assertFalse(inputSpec.validateSegments(LockGranularity.TIME_CHUNK, someSegmentIsUnknown));
+    Assertions.assertFalse(inputSpec.validateSegments(LockGranularity.TIME_CHUNK, someSegmentIsUnknown));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
@@ -59,6 +59,7 @@ import org.apache.druid.indexing.common.actions.TaskActionTestKit;
 import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.common.task.CompactionTask.Builder;
 import org.apache.druid.indexing.overlord.Segments;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
@@ -119,15 +120,15 @@ import org.apache.druid.timeline.partition.NumberedOverwriteShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.PartitionIds;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.annotation.Nullable;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -187,10 +188,9 @@ public abstract class CompactionTaskRunBase
   );
   protected static final int TOTAL_TEST_ROWS = 10;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  protected final File temporaryFolder = FileUtils.createTempDir("compaction-task-run-test");
 
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit taskActionTestKit = new TaskActionTestKit();
 
   protected ObjectMapper objectMapper;
@@ -230,8 +230,7 @@ public abstract class CompactionTaskRunBase
     this.inputInterval = inputInterval;
     this.segmentGranularity = segmentGranularity;
 
-    temporaryFolder.create();
-    reportsFile = temporaryFolder.newFile();
+    reportsFile = new File(temporaryFolder, "reports.json");
     testUtils = new TestUtils();
     segmentCacheManagerFactory = SegmentCacheManagerFactory.createWithOwnedPool(TestIndex.INDEX_IO, testUtils.getTestObjectMapper());
 
@@ -278,18 +277,23 @@ public abstract class CompactionTaskRunBase
     };
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     exec = Execs.multiThreaded(2, "compaction-task-run-test-%d");
-    localDeepStorage = temporaryFolder.newFolder();
+    localDeepStorage = newTempFolder();
   }
 
-  @After
-  public void teardown()
+  @AfterEach
+  public void teardown() throws IOException
   {
     exec.shutdownNow();
-    temporaryFolder.delete();
+    FileUtils.deleteDirectory(temporaryFolder);
+  }
+
+  protected File newTempFolder()
+  {
+    return FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "tmp");
   }
 
   @Test
@@ -306,7 +310,7 @@ public abstract class CompactionTaskRunBase
     final DataSegmentsWithSchemas dataSegmentsWithSchemas = resultPair.rhs;
     final List<DataSegment> segments = new ArrayList<>(dataSegmentsWithSchemas.getSegments());
     List<String> rowsFromSegment = getCSVFormatRowsFromSegments(segments);
-    Assert.assertEquals(TEST_ROWS, rowsFromSegment);
+    Assertions.assertEquals(TEST_ROWS, rowsFromSegment);
     verifyCompactedSegment(
         compactionTask.getCompactionRunner(),
         segments,
@@ -320,11 +324,8 @@ public abstract class CompactionTaskRunBase
   public void testRunWithHashPartitioning() throws Exception
   {
     // Hash partitioning is not supported with segment lock yet
-    Assume.assumeTrue(
-        "Hash partitioning is not supported with segment lock yet",
-        lockGranularity != LockGranularity.SEGMENT
-    );
-    Assume.assumeTrue("Test null segment granularity is sufficient", segmentGranularity == null);
+    Assumptions.assumeTrue(lockGranularity != LockGranularity.SEGMENT, "Hash partitioning is not supported with segment lock yet");
+    Assumptions.assumeTrue(segmentGranularity == null, "Test null segment granularity is sufficient");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask =
@@ -342,22 +343,22 @@ public abstract class CompactionTaskRunBase
     final List<DataSegment> segments = List.copyOf(resultPair.rhs.getSegments());
     List<String> rowsFromSegment = getCSVFormatRowsFromSegments(segments);
     rowsFromSegment.sort(Ordering.natural());
-    Assert.assertEquals(TEST_ROWS, rowsFromSegment);
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(TEST_ROWS, rowsFromSegment);
+    Assertions.assertEquals(6, segments.size());
 
     for (int i = 0; i < 3; i++) {
       final Interval interval = Intervals.of("2014-01-01T0%d:00:00/2014-01-01T0%d:00:00", i, i + 1);
       for (int j = 0; j < 2; j++) {
         final int segmentIdx = i * 2 + j;
-        Assert.assertEquals(interval, segments.get(segmentIdx).getInterval());
+        Assertions.assertEquals(interval, segments.get(segmentIdx).getInterval());
         CompactionState expectedState =
             getDefaultCompactionState(Granularities.HOUR, Granularities.MINUTE, List.of(interval))
                 .toBuilder()
                 .partitionsSpec(new HashedPartitionsSpec(null, 3, null))
                 .indexSpec(compactionTask.getTuningConfig().getIndexSpec().getEffectiveSpec())
                 .build();
-        Assert.assertEquals(expectedState, segments.get(segmentIdx).getLastCompactionState());
-        Assert.assertSame(HashBasedNumberedShardSpec.class, segments.get(segmentIdx).getShardSpec().getClass());
+        Assertions.assertEquals(expectedState, segments.get(segmentIdx).getLastCompactionState());
+        Assertions.assertSame(HashBasedNumberedShardSpec.class, segments.get(segmentIdx).getShardSpec().getClass());
       }
     }
   }
@@ -365,7 +366,7 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testRunCompactionTwice() throws Exception
   {
-    Assume.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
+    Assumptions.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask1 =
@@ -396,17 +397,17 @@ public abstract class CompactionTaskRunBase
       );
     } else if (segmentGranularity.equals(Granularities.SIX_HOUR)) {
       Set<DataSegment> compactedSegments = resultPair2.rhs.getSegments();
-      Assert.assertEquals(1, compactedSegments.size());
+      Assertions.assertEquals(1, compactedSegments.size());
 
       DataSegment compactedSegment = Iterables.getOnlyElement(compactedSegments);
-      Assert.assertEquals(TEST_INTERVAL, compactedSegment.getInterval());
+      Assertions.assertEquals(TEST_INTERVAL, compactedSegment.getInterval());
 
       // compact interval is always the SIX_HOUR interval, since the previous compaction has generated a new SIX_HOUR segment, this means the compaction state in the second compaction is different from the first one.
-      Assert.assertEquals(
+      Assertions.assertEquals(
           getDefaultCompactionState(segmentGranularity, DEFAULT_QUERY_GRAN, List.of(TEST_INTERVAL)),
           compactedSegment.getLastCompactionState()
       );
-      Assert.assertEquals(new NumberedShardSpec(0, 1), compactedSegment.getShardSpec());
+      Assertions.assertEquals(new NumberedShardSpec(0, 1), compactedSegment.getShardSpec());
 
     } else {
       throw new RE("Gran[%s] is not supported", segmentGranularity);
@@ -416,7 +417,7 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testRunCompactionTwiceWithSegmentLock() throws Exception
   {
-    Assume.assumeTrue(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeTrue(lockGranularity == LockGranularity.SEGMENT);
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask1 =
@@ -439,18 +440,18 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair2, TOTAL_TEST_ROWS);
     List<DataSegment> segments = List.copyOf(resultPair2.rhs.getSegments());
     if (segmentGranularity == null || segmentGranularity.equals(Granularities.HOUR)) {
-      Assert.assertEquals(3, segments.size());
+      Assertions.assertEquals(3, segments.size());
 
       for (int i = 0; i < 3; i++) {
         Interval interval = Intervals.of("2014-01-01T0%d:00:00/2014-01-01T0%d:00:00", i, i + 1);
-        Assert.assertEquals(interval, segments.get(i).getInterval());
+        Assertions.assertEquals(interval, segments.get(i).getInterval());
         Interval compactInterval = segmentGranularity == null ? interval : TEST_ACTUAL_INTERVAL;
-        Assert.assertEquals(
+        Assertions.assertEquals(
             getDefaultCompactionState(DEFAULT_SEGMENT_GRAN, DEFAULT_QUERY_GRAN, List.of(compactInterval)),
             segments.get(i).getLastCompactionState()
         );
         // overwrite shard starts at NON_ROOT_GEN_START_PARTITION_ID + 1, and minor version 2 for the second compaction
-        Assert.assertEquals(new NumberedOverwriteShardSpec(
+        Assertions.assertEquals(new NumberedOverwriteShardSpec(
             PartitionIds.NON_ROOT_GEN_START_PARTITION_ID + 1,
             0,
             2,
@@ -459,15 +460,15 @@ public abstract class CompactionTaskRunBase
         ), segments.get(i).getShardSpec());
       }
     } else if (segmentGranularity.equals(Granularities.SIX_HOUR)) {
-      Assert.assertEquals(1, segments.size());
-      Assert.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
+      Assertions.assertEquals(1, segments.size());
+      Assertions.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
       // compact interval is always the SIX_HOUR interval, since the previous compaction has generated a new SIX_HOUR segment, this means the compaction state in the second compaction is different from the first one.
-      Assert.assertEquals(
+      Assertions.assertEquals(
           getDefaultCompactionState(segmentGranularity, DEFAULT_QUERY_GRAN, List.of(TEST_INTERVAL)),
           segments.get(0).getLastCompactionState()
       );
       // use overwrite shard for the second compaction
-      Assert.assertEquals(new NumberedOverwriteShardSpec(
+      Assertions.assertEquals(new NumberedOverwriteShardSpec(
           PartitionIds.NON_ROOT_GEN_START_PARTITION_ID,
           0,
           1,
@@ -482,11 +483,8 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testRunIndexAndCompactAtTheSameTimeForDifferentInterval() throws Exception
   {
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-        && lockGranularity != LockGranularity.SEGMENT
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
+        && lockGranularity != LockGranularity.SEGMENT, "test with defined segment granularity and interval in this test");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask =
@@ -522,17 +520,17 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(indexResult, 9);
 
     List<DataSegment> segments = new ArrayList<>(indexResult.rhs.getSegments());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
 
     for (int i = 0; i < 6; i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Intervals.of("2014-01-01T0%d:00:00/2014-01-01T0%d:00:00", 6 + i / 2, 6 + i / 2 + 1),
           segments.get(i).getInterval()
       );
       if (lockGranularity == LockGranularity.SEGMENT) {
-        Assert.assertEquals(new NumberedShardSpec(i % 2, 0), segments.get(i).getShardSpec());
+        Assertions.assertEquals(new NumberedShardSpec(i % 2, 0), segments.get(i).getShardSpec());
       } else {
-        Assert.assertEquals(new NumberedShardSpec(i % 2, 2), segments.get(i).getShardSpec());
+        Assertions.assertEquals(new NumberedShardSpec(i % 2, 2), segments.get(i).getShardSpec());
       }
     }
 
@@ -550,10 +548,7 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testWithSegmentGranularityMisalignedInterval() throws Exception
   {
-    Assume.assumeTrue(
-        "use Granularities.WEEK segment granularity in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity), "use Granularities.WEEK segment granularity in this test");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
     // Test when inputInterval is less than Granularities.WEEK is not allowed
     final CompactionTask compactionTask1 =
@@ -561,22 +556,19 @@ public abstract class CompactionTaskRunBase
             .ioConfig(new CompactionIOConfig(new CompactionIntervalSpec(inputInterval, null), false, true))
             .build();
 
-    final IllegalArgumentException e = Assert.assertThrows(
+    final IllegalArgumentException e = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> runTask(compactionTask1)
     );
-    Assert.assertTrue(e.getMessage().contains(inputInterval.toString()));
-    Assert.assertTrue(e.getMessage().contains("is not aligned with segmentGranularity"));
-    Assert.assertTrue(e.getMessage().contains(Granularities.WEEK.toString()));
+    Assertions.assertTrue(e.getMessage().contains(inputInterval.toString()));
+    Assertions.assertTrue(e.getMessage().contains("is not aligned with segmentGranularity"));
+    Assertions.assertTrue(e.getMessage().contains(Granularities.WEEK.toString()));
   }
 
   @Test
   public void testWithSegmentGranularityMisalignedIntervalAllowed() throws Exception
   {
-    Assume.assumeTrue(
-        "use Granularities.WEEK segment granularity in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity), "use Granularities.WEEK segment granularity in this test");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
     // Test when inputInterval is less than Granularities.WEEK is allowed
     final CompactionTask compactionTask1 =
@@ -588,10 +580,10 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, TOTAL_TEST_ROWS);
 
     List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
-    Assert.assertEquals(Intervals.of("2013-12-30/2014-01-06"), segments.get(0).getInterval());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, segments.size());
+    Assertions.assertEquals(Intervals.of("2013-12-30/2014-01-06"), segments.get(0).getInterval());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(
         getDefaultCompactionState(Granularities.WEEK, DEFAULT_QUERY_GRAN, List.of(TEST_ACTUAL_INTERVAL)),
         segments.get(0).getLastCompactionState()
     );
@@ -600,11 +592,8 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testWithSegmentGranularityMisalignedIntervalAllowed2() throws Exception
   {
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-        && lockGranularity != LockGranularity.SEGMENT
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
+        && lockGranularity != LockGranularity.SEGMENT, "test with defined segment granularity and interval in this test");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
     // Test when inputInterval doesn't align with segment granularity
     final Interval interval = Intervals.of("2014-01-01T00:30:00Z/2014-01-01T01:30:00Z");
@@ -617,10 +606,10 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, 3);
 
     List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
-    Assert.assertEquals(Intervals.of("2014-01-01T01:00:00Z/2014-01-01T02:00:00Z"), segments.get(0).getInterval());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, segments.size());
+    Assertions.assertEquals(Intervals.of("2014-01-01T01:00:00Z/2014-01-01T02:00:00Z"), segments.get(0).getInterval());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(
         getDefaultCompactionState(
             Granularities.HOUR,
             DEFAULT_QUERY_GRAN,
@@ -633,10 +622,7 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testCompactionWithFilterInTransformSpec() throws Exception
   {
-    Assume.assumeTrue(
-        "test with six hour granularity is enough",
-        Granularities.SIX_HOUR.equals(segmentGranularity)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity), "test with six hour granularity is enough");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask = compactionTaskBuilder(segmentGranularity)
@@ -649,9 +635,9 @@ public abstract class CompactionTaskRunBase
 
     List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
 
-    Assert.assertEquals(1, segments.size());
-    Assert.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(1, segments.size());
+    Assertions.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
 
     // native runner use interval from actual seen segments, while msq runner use interval from input
     Interval compactInterval = compactionTask.getCompactionRunner() instanceof NativeCompactionRunner
@@ -662,12 +648,12 @@ public abstract class CompactionTaskRunBase
         DEFAULT_QUERY_GRAN,
         List.of(compactInterval)
     ).toBuilder().transformSpec(new CompactionTransformSpec(new SelectorDimFilter("dim", "a", null), null)).build();
-    Assert.assertEquals(expectedCompactionState, segments.get(0).getLastCompactionState());
+    Assertions.assertEquals(expectedCompactionState, segments.get(0).getLastCompactionState());
   }
 
   public void validateCompactionState(CompactionState expected, CompactionState actual)
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CompactionState.builder()
                        .partitionsSpec(expected.getPartitionsSpec())
                        .dimensionsSpec(expected.getDimensionsSpec()
@@ -693,10 +679,7 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testCompactionWithNewMetricInMetricsSpec() throws Exception
   {
-    Assume.assumeTrue(
-        "test with six hour granularity is enough",
-        Granularities.SIX_HOUR.equals(segmentGranularity)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity), "test with six hour granularity is enough");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask =
@@ -712,10 +695,10 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, TOTAL_TEST_ROWS);
 
     List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
-    Assert.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
 
     AggregatorFactory expectedCountMetric = new CountAggregatorFactory("cnt");
     AggregatorFactory expectedLongSumMetric = new LongSumAggregatorFactory("val", "val");
@@ -724,7 +707,7 @@ public abstract class CompactionTaskRunBase
             .toBuilder()
             .metricsSpec(List.of(expectedCountMetric, expectedLongSumMetric))
             .build();
-    Assert.assertEquals(expectedCompactionState, segments.get(0).getLastCompactionState());
+    Assertions.assertEquals(expectedCompactionState, segments.get(0).getLastCompactionState());
   }
 
   @Test
@@ -754,10 +737,7 @@ public abstract class CompactionTaskRunBase
   @Test
   public void testWithGranularitySpecNonNullQueryGranularityAndCoarseSegmentGranularity() throws Exception
   {
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval), "test with defined segment granularity and interval in this test");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     // day segmentGranularity and day queryGranularity
@@ -770,26 +750,23 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, TOTAL_TEST_ROWS);
 
     List<DataSegment> segments = List.copyOf(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
-    Assert.assertEquals(TEST_INTERVAL_DAY, segments.get(0).getInterval());
+    Assertions.assertEquals(1, segments.size());
+    Assertions.assertEquals(TEST_INTERVAL_DAY, segments.get(0).getInterval());
     // native runner use interval from actual seen segments, while msq runner use interval from input
     Interval interval = compactionTask1.getCompactionRunner() instanceof NativeCompactionRunner
                         ? TEST_ACTUAL_INTERVAL
                         : TEST_INTERVAL_DAY;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         getDefaultCompactionState(Granularities.DAY, Granularities.DAY, List.of(interval)),
         segments.get(0).getLastCompactionState()
     );
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
   }
 
   @Test
   public void testCompactThenAppend() throws Exception
   {
-    Assume.assumeTrue(
-        "test three hour segment granularity is enough",
-        Granularities.SIX_HOUR.equals(segmentGranularity)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity), "test three hour segment granularity is enough");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask =
@@ -809,7 +786,7 @@ public abstract class CompactionTaskRunBase
     final Set<DataSegment> usedSegments = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(Intervals.of("2014-01-01/2014-01-02"))).get());
 
-    Assert.assertEquals(expectedSegments, usedSegments);
+    Assertions.assertEquals(expectedSegments, usedSegments);
   }
 
   @Test
@@ -817,11 +794,8 @@ public abstract class CompactionTaskRunBase
       throws Exception
   {
     // This test fails with segment lock because of the bug reported in https://github.com/apache/druid/issues/10911.
-    Assume.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-    );
+    Assumptions.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval), "test with defined segment granularity and interval in this test");
 
     // The following task creates (several, more than three, last time I checked, six) HOUR segments with intervals of
     // - 2014-01-01T00:00:00/2014-01-01T01:00:00
@@ -842,7 +816,7 @@ public abstract class CompactionTaskRunBase
     // maxRowsPerSegment is set to 2 inside the runIndexTask methods
     Pair<TaskStatus, DataSegmentsWithSchemas> result = runIndexTask();
     verifyTaskSuccessRowsAndSchemaMatch(result, TOTAL_TEST_ROWS);
-    Assert.assertEquals(6, result.rhs.getSegments().size());
+    Assertions.assertEquals(6, result.rhs.getSegments().size());
 
     // Setup partial compaction:
     // Change the granularity from HOUR to MINUTE through compaction for hour 01, there are three rows in the compaction interval,
@@ -876,20 +850,20 @@ public abstract class CompactionTaskRunBase
             List.of(Intervals.of("2014-01-01T02:00:00/2014-01-01T03:00:00"))
         ).get());
     expectedSegments.addAll(partialCompactionResult.rhs.getSegments());
-    Assert.assertEquals(64, expectedSegments.size());
+    Assertions.assertEquals(64, expectedSegments.size());
 
     // New segments that were compacted are expected. However, old segments of the compacted interval should be
     // overshadowed by the new tombstones (59) being created for all minutes other than 01:01
     final Set<DataSegment> segmentsAfterPartialCompaction = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(Intervals.of("2014-01-01/2014-01-02"))).get());
-    Assert.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
+    Assertions.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
     final List<DataSegment> realSegmentsAfterPartialCompaction =
         segmentsAfterPartialCompaction.stream().filter(s -> !s.isTombstone()).collect(Collectors.toList());
     final List<DataSegment> tombstonesAfterPartialCompaction =
         segmentsAfterPartialCompaction.stream().filter(s -> s.isTombstone()).collect(Collectors.toList());
-    Assert.assertEquals(59, tombstonesAfterPartialCompaction.size());
-    Assert.assertEquals(5, realSegmentsAfterPartialCompaction.size());
-    Assert.assertEquals(64, segmentsAfterPartialCompaction.size());
+    Assertions.assertEquals(59, tombstonesAfterPartialCompaction.size());
+    Assertions.assertEquals(5, realSegmentsAfterPartialCompaction.size());
+    Assertions.assertEquals(64, segmentsAfterPartialCompaction.size());
 
     // Setup full compaction:
     // Full Compaction with null segmentGranularity meaning that the original segmentGranularity is preserved.
@@ -916,25 +890,25 @@ public abstract class CompactionTaskRunBase
     segmentsAfterFullCompaction.sort(
         (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(s1.getInterval(), s2.getInterval())
     );
-    Assert.assertEquals(62, segmentsAfterFullCompaction.size());
+    Assertions.assertEquals(62, segmentsAfterFullCompaction.size());
 
     final List<DataSegment> tombstonesAfterFullCompaction =
         segmentsAfterFullCompaction.stream().filter(s -> s.isTombstone()).collect(Collectors.toList());
-    Assert.assertEquals(59, tombstonesAfterFullCompaction.size());
+    Assertions.assertEquals(59, tombstonesAfterFullCompaction.size());
 
     final List<DataSegment> realSegmentsAfterFullCompaction =
         segmentsAfterFullCompaction.stream().filter(s -> !s.isTombstone()).collect(Collectors.toList());
-    Assert.assertEquals(3, realSegmentsAfterFullCompaction.size());
+    Assertions.assertEquals(3, realSegmentsAfterFullCompaction.size());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2014-01-01T00:00:00.000Z/2014-01-01T01:00:00.000Z"),
         realSegmentsAfterFullCompaction.get(0).getInterval()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2014-01-01T01:00:00.000Z/2014-01-01T01:01:00.000Z"),
         realSegmentsAfterFullCompaction.get(1).getInterval()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2014-01-01T02:00:00.000Z/2014-01-01T03:00:00.000Z"),
         realSegmentsAfterFullCompaction.get(2).getInterval()
     );
@@ -944,11 +918,8 @@ public abstract class CompactionTaskRunBase
   public void testCompactDatasourceOverIntervalWithOnlyTombstones() throws Exception
   {
     // This test fails with segment lock because of the bug reported in https://github.com/apache/druid/issues/10911.
-    Assume.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-    );
+    Assumptions.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval), "test with defined segment granularity and interval in this test");
 
     // The following task creates (several, more than three, last time I checked, six) HOUR segments with intervals of
     // - 2014-01-01T00:00:00/2014-01-01T01:00:00
@@ -969,7 +940,7 @@ public abstract class CompactionTaskRunBase
     // maxRowsPerSegment is set to 2 inside the runIndexTask methods
     Pair<TaskStatus, DataSegmentsWithSchemas> result = runIndexTask();
     verifyTaskSuccessRowsAndSchemaMatch(result, TOTAL_TEST_ROWS);
-    Assert.assertEquals(6, result.rhs.getSegments().size());
+    Assertions.assertEquals(6, result.rhs.getSegments().size());
 
     // Setup partial interval compaction:
     // Change the granularity from HOUR to MINUTE through compaction for hour 01, there are three rows in the compaction
@@ -1004,20 +975,20 @@ public abstract class CompactionTaskRunBase
             List.of(Intervals.of("2014-01-01T02:00:00/2014-01-01T03:00:00"))
         ).get());
     expectedSegments.addAll(partialCompactionResult.rhs.getSegments());
-    Assert.assertEquals(64, expectedSegments.size());
+    Assertions.assertEquals(64, expectedSegments.size());
 
     // New segments that were compacted are expected. However, old segments of the compacted interval should be
     // overshadowed by the new tombstones (59) being created for all minutes other than 01:01
     final Set<DataSegment> segmentsAfterPartialCompaction = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(TEST_INTERVAL)).get());
-    Assert.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
+    Assertions.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
     final List<DataSegment> realSegmentsAfterPartialCompaction =
         segmentsAfterPartialCompaction.stream().filter(s -> !s.isTombstone()).collect(Collectors.toList());
     final List<DataSegment> tombstonesAfterPartialCompaction =
         segmentsAfterPartialCompaction.stream().filter(s -> s.isTombstone()).collect(Collectors.toList());
-    Assert.assertEquals(59, tombstonesAfterPartialCompaction.size());
-    Assert.assertEquals(5, realSegmentsAfterPartialCompaction.size());
-    Assert.assertEquals(64, segmentsAfterPartialCompaction.size());
+    Assertions.assertEquals(59, tombstonesAfterPartialCompaction.size());
+    Assertions.assertEquals(5, realSegmentsAfterPartialCompaction.size());
+    Assertions.assertEquals(64, segmentsAfterPartialCompaction.size());
 
     // Now setup compaction over an interval with only tombstones, keeping same, minute granularity
     final CompactionTask compactionTaskOverOnlyTombstones =
@@ -1033,8 +1004,8 @@ public abstract class CompactionTaskRunBase
 
     // compaction should not fail but since it is over the same granularity it should leave
     // the tombstones unchanged
-    Assert.assertEquals(59, resultOverOnlyTombstones.rhs.getSegments().size());
-    resultOverOnlyTombstones.rhs.getSegments().forEach(t -> Assert.assertTrue(t.isTombstone()));
+    Assertions.assertEquals(59, resultOverOnlyTombstones.rhs.getSegments().size());
+    resultOverOnlyTombstones.rhs.getSegments().forEach(t -> Assertions.assertTrue(t.isTombstone()));
   }
 
   @Test
@@ -1042,16 +1013,13 @@ public abstract class CompactionTaskRunBase
       throws Exception
   {
     // This test fails with segment lock because of the bug reported in https://github.com/apache/druid/issues/10911.
-    Assume.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-    );
+    Assumptions.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval), "test with defined segment granularity and interval in this test");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final Set<DataSegment> expectedSegments = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(Intervals.of("2014-01-01/2014-01-02"))).get());
-    Assert.assertEquals(6, expectedSegments.size());
+    Assertions.assertEquals(6, expectedSegments.size());
 
     final Interval partialInterval = Intervals.of("2014-01-01T01:00:00/2014-01-01T02:00:00");
     final CompactionTask partialCompactionTask = compactionTaskBuilder(Granularities.MINUTE)
@@ -1063,13 +1031,13 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(partialCompactionResult, 3);
     // All segments in the previous expectedSegments should still appear as they have larger segment granularity.
     expectedSegments.addAll(partialCompactionResult.rhs.getSegments());
-    Assert.assertEquals(7, expectedSegments.size());
+    Assertions.assertEquals(7, expectedSegments.size());
 
     final Set<DataSegment> segmentsAfterPartialCompaction = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(TEST_INTERVAL)).get());
-    Assert.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
+    Assertions.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
     // the lower version of hour01 segment is visible, but the 3 rows is not because hour01minite00 is overshadowed by a higher version segment.
-    Assert.assertEquals(13, expectedSegments.stream().mapToInt(DataSegment::getTotalRows).sum());
+    Assertions.assertEquals(13, expectedSegments.stream().mapToInt(DataSegment::getTotalRows).sum());
 
     final CompactionTask fullCompactionTask = compactionTaskBuilder(Granularities.HOUR)
         // Set dropExisting to false
@@ -1085,9 +1053,9 @@ public abstract class CompactionTaskRunBase
         (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(s1.getInterval(), s2.getInterval())
     );
 
-    Assert.assertEquals(3, segmentsAfterFullCompaction.size());
+    Assertions.assertEquals(3, segmentsAfterFullCompaction.size());
     for (int i = 0; i < segmentsAfterFullCompaction.size(); i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Intervals.of(StringUtils.format("2014-01-01T%02d/2014-01-01T%02d", i, i + 1)),
           segmentsAfterFullCompaction.get(i).getInterval()
       );
@@ -1118,14 +1086,14 @@ public abstract class CompactionTaskRunBase
 
     verifyTaskSuccessRowsAndSchemaMatch(indexFuture.get(), TOTAL_TEST_ROWS);
     List<DataSegment> segments = new ArrayList<>(indexFuture.get().rhs.getSegments());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
     for (int i = 0; i < 6; i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Intervals.of("2014-01-01T0%d:00:00/2014-01-01T0%d:00:00", i / 2, i / 2 + 1),
           segments.get(i).getInterval()
       );
       if (lockGranularity == LockGranularity.SEGMENT) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             new NumberedOverwriteShardSpec(
                 PartitionIds.NON_ROOT_GEN_START_PARTITION_ID + i % 2,
                 0,
@@ -1136,12 +1104,12 @@ public abstract class CompactionTaskRunBase
             segments.get(i).getShardSpec()
         );
       } else {
-        Assert.assertEquals(new NumberedShardSpec(i % 2, 2), segments.get(i).getShardSpec());
+        Assertions.assertEquals(new NumberedShardSpec(i % 2, 2), segments.get(i).getShardSpec());
       }
     }
 
-    Exception e = Assert.assertThrows(Exception.class, () -> compactionFuture.get());
-    Assert.assertTrue(e.getMessage().contains("not ready"));
+    Exception e = Assertions.assertThrows(Exception.class, () -> compactionFuture.get());
+    Assertions.assertTrue(e.getMessage().contains("not ready"));
   }
 
   @Test
@@ -1175,15 +1143,15 @@ public abstract class CompactionTaskRunBase
 
     verifyTaskSuccessRowsAndSchemaMatch(indexFuture.get(), TOTAL_TEST_ROWS);
     List<DataSegment> segments = new ArrayList<>(indexFuture.get().rhs.getSegments());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
 
     for (int i = 0; i < 6; i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Intervals.of("2014-01-01T0%d:00:00/2014-01-01T0%d:00:00", i / 2, i / 2 + 1),
           segments.get(i).getInterval()
       );
       if (lockGranularity == LockGranularity.SEGMENT) {
-        Assert.assertEquals(
+        Assertions.assertEquals(
             new NumberedOverwriteShardSpec(
                 PartitionIds.NON_ROOT_GEN_START_PARTITION_ID + i % 2,
                 0,
@@ -1194,21 +1162,18 @@ public abstract class CompactionTaskRunBase
             segments.get(i).getShardSpec()
         );
       } else {
-        Assert.assertEquals(new NumberedShardSpec(i % 2, 2), segments.get(i).getShardSpec());
+        Assertions.assertEquals(new NumberedShardSpec(i % 2, 2), segments.get(i).getShardSpec());
       }
     }
 
     final Pair<TaskStatus, DataSegmentsWithSchemas> compactionResult = compactionFuture.get();
-    Assert.assertEquals(TaskState.FAILED, compactionResult.lhs.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, compactionResult.lhs.getStatusCode());
   }
 
   @Test
   public void testRunWithSpatialDimensions() throws Exception
   {
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval), "test with defined segment granularity and interval in this test");
     final List<String> spatialrows = ImmutableList.of(
         "2014-01-01T00:00:10Z,a,10,100,1\n",
         "2014-01-01T00:00:10Z,b,20,110,2\n",
@@ -1242,9 +1207,9 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, 6);
 
     final List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
-    Assert.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
+    Assertions.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
     // native runner use interval from actual seen segments, while msq runner use interval from input
     Interval compactInterval = compactionTask.getCompactionRunner() instanceof NativeCompactionRunner
                                ? Intervals.of("2014-01-01T00:00:00Z/2014-01-01T02:00:00Z")
@@ -1264,10 +1229,10 @@ public abstract class CompactionTaskRunBase
                                       new NewSpatialDimensionSchema("spatial", Collections.singletonList("spatial"))
                                   ))
                                   .build()).build();
-    Assert.assertEquals(newCompactionState, segments.get(0).getLastCompactionState());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(newCompactionState, segments.get(0).getLastCompactionState());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
 
-    final File cacheDir = temporaryFolder.newFolder();
+    final File cacheDir = newTempFolder();
     final SegmentCacheManager segmentCacheManager = segmentCacheManagerFactory.manufacturate(
         cacheDir,
         null,
@@ -1286,10 +1251,10 @@ public abstract class CompactionTaskRunBase
       );
       try (final CursorHolder cursorHolder = windowed.getCursorFactory().makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {
         final Cursor cursor = cursorHolder.asCursor();
-        Assert.assertNotNull(cursor);
+        Assertions.assertNotNull(cursor);
         cursor.reset();
         final ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
-        Assert.assertTrue(factory.getColumnCapabilities("spatial").hasSpatialIndexes());
+        Assertions.assertTrue(factory.getColumnCapabilities("spatial").hasSpatialIndexes());
         while (!cursor.isDone()) {
           final ColumnValueSelector<?> selector1 = factory.makeColumnValueSelector("ts");
           final DimensionSelector selector2 = factory.makeDimensionSelector(new DefaultDimensionSpec("dim", "dim"));
@@ -1311,16 +1276,13 @@ public abstract class CompactionTaskRunBase
         }
       }
     }
-    Assert.assertEquals(spatialrows, rowsFromSegment);
+    Assertions.assertEquals(spatialrows, rowsFromSegment);
   }
 
   @Test
   public void testRunWithAutoCastDimensions() throws Exception
   {
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval), "test with defined segment granularity and interval in this test");
     final List<String> rows = ImmutableList.of(
         "2014-01-01T00:00:10Z,a,10,100,1\n",
         "2014-01-01T00:00:10Z,b,20,110,2\n",
@@ -1358,8 +1320,8 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, 6);
 
     final List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
-    Assert.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
+    Assertions.assertEquals(1, segments.size());
+    Assertions.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
 
     final List<String> dimensionExclusions =
         compactionTask.getCompactionRunner() instanceof NativeCompactionRunner ? List.of() : List.of("__time", "val");
@@ -1381,10 +1343,10 @@ public abstract class CompactionTaskRunBase
                  new AutoTypeColumnSchema("y", ColumnType.LONG, DEFAULT_NESTED_SPEC)
              )).toBuilder().setDimensionExclusions(dimensionExclusions).build())
          .build();
-    Assert.assertEquals(expectedState, segments.get(0).getLastCompactionState());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(expectedState, segments.get(0).getLastCompactionState());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
 
-    final File cacheDir = temporaryFolder.newFolder();
+    final File cacheDir = newTempFolder();
     final SegmentCacheManager segmentCacheManager = segmentCacheManagerFactory.manufacturate(
         cacheDir,
         null,
@@ -1403,13 +1365,13 @@ public abstract class CompactionTaskRunBase
       );
       try (final CursorHolder cursorHolder = windowed.getCursorFactory().makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {
         final Cursor cursor = cursorHolder.asCursor();
-        Assert.assertNotNull(cursor);
+        Assertions.assertNotNull(cursor);
         cursor.reset();
         final ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
-        Assert.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("ts").toColumnType());
-        Assert.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("dim").toColumnType());
-        Assert.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("x").toColumnType());
-        Assert.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("y").toColumnType());
+        Assertions.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("ts").toColumnType());
+        Assertions.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("dim").toColumnType());
+        Assertions.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("x").toColumnType());
+        Assertions.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("y").toColumnType());
         while (!cursor.isDone()) {
           final ColumnValueSelector<?> selector1 = factory.makeColumnValueSelector("ts");
           final DimensionSelector selector2 = factory.makeDimensionSelector(new DefaultDimensionSpec("dim", "dim"));
@@ -1432,16 +1394,13 @@ public abstract class CompactionTaskRunBase
         }
       }
     }
-    Assert.assertEquals(rows, rowsFromSegment);
+    Assertions.assertEquals(rows, rowsFromSegment);
   }
 
   @Test
   public void testRunWithAutoCastDimensionsSortByDimension() throws Exception
   {
-    Assume.assumeTrue(
-        "test with defined segment granularity and interval in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval)
-    );
+    Assumptions.assumeTrue(Granularities.SIX_HOUR.equals(segmentGranularity) && TEST_INTERVAL.equals(inputInterval), "test with defined segment granularity and interval in this test");
     // Compaction will produce one segment sorted by [x, __time], even though input rows are sorted by __time.
     final List<String> rows = ImmutableList.of(
         "2014-01-01T00:00:10Z,a,10,100,1\n",
@@ -1482,10 +1441,10 @@ public abstract class CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, 6);
 
     final List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
     final DataSegment compactSegment = Iterables.getOnlyElement(segments);
-    Assert.assertEquals(interval, compactSegment.getInterval());
+    Assertions.assertEquals(interval, compactSegment.getInterval());
     final List<String> dimensionExclusions =
         compactionTask.getCompactionRunner() instanceof NativeCompactionRunner ? List.of() : List.of("val");
     CompactionState expectedState =
@@ -1503,10 +1462,10 @@ public abstract class CompactionTaskRunBase
                  new AutoTypeColumnSchema("y", ColumnType.LONG, DEFAULT_NESTED_SPEC)
              )).toBuilder().setDimensionExclusions(dimensionExclusions).setForceSegmentSortByTime(false).build())
          .build();
-    Assert.assertEquals(expectedState, compactSegment.getLastCompactionState());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), compactSegment.getShardSpec());
+    Assertions.assertEquals(expectedState, compactSegment.getLastCompactionState());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), compactSegment.getShardSpec());
 
-    final File cacheDir = temporaryFolder.newFolder();
+    final File cacheDir = newTempFolder();
     final SegmentCacheManager segmentCacheManager = segmentCacheManagerFactory.manufacturate(
         cacheDir,
         null,
@@ -1523,7 +1482,7 @@ public abstract class CompactionTaskRunBase
         new QueryableIndexCursorFactory(queryableIndex),
         compactSegment.getInterval()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             OrderBy.ascending("x"),
             OrderBy.ascending("__time"),
@@ -1540,10 +1499,10 @@ public abstract class CompactionTaskRunBase
       final Cursor cursor = cursorHolder.asCursor();
       cursor.reset();
       final ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
-      Assert.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("ts").toColumnType());
-      Assert.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("dim").toColumnType());
-      Assert.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("x").toColumnType());
-      Assert.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("y").toColumnType());
+      Assertions.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("ts").toColumnType());
+      Assertions.assertEquals(ColumnType.STRING, factory.getColumnCapabilities("dim").toColumnType());
+      Assertions.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("x").toColumnType());
+      Assertions.assertEquals(ColumnType.LONG, factory.getColumnCapabilities("y").toColumnType());
       while (!cursor.isDone()) {
         final ColumnValueSelector<?> selector1 = factory.makeColumnValueSelector("ts");
         final DimensionSelector selector2 = factory.makeDimensionSelector(new DefaultDimensionSpec("dim", "dim"));
@@ -1566,7 +1525,7 @@ public abstract class CompactionTaskRunBase
       }
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "2014-01-01T00:00:10Z,a,10,100,1",
             "2014-01-01T00:01:20Z,a,10,100,1",
@@ -1624,7 +1583,7 @@ public abstract class CompactionTaskRunBase
       boolean appendToExisting
   ) throws Exception
   {
-    File tmpDir = temporaryFolder.newFolder();
+    File tmpDir = newTempFolder();
     File tmpFile = File.createTempFile("druid", "index", tmpDir);
 
     try (BufferedWriter writer = Files.newWriter(tmpFile, StandardCharsets.UTF_8)) {
@@ -1734,7 +1693,7 @@ public abstract class CompactionTaskRunBase
         .joinableFactory(NoopJoinableFactory.INSTANCE)
         .segmentCacheManager(cacheManager)
         .jsonMapper(objectMapper)
-        .taskWorkDir(temporaryFolder.newFolder())
+        .taskWorkDir(newTempFolder())
         .indexIO(testUtils.getTestIndexIO())
         .handoffNotifierFactory(new NoopSegmentHandoffNotifierFactory())
         .indexMerger(testUtils.getIndexMergerV9Factory().create(true))
@@ -1753,7 +1712,7 @@ public abstract class CompactionTaskRunBase
 
   protected List<String> getCSVFormatRowsFromSegments(List<DataSegment> segments) throws Exception
   {
-    final File cacheDir = temporaryFolder.newFolder();
+    final File cacheDir = newTempFolder();
     final SegmentCacheManager segmentCacheManager = segmentCacheManagerFactory.manufacturate(
         cacheDir,
         null,
@@ -1772,7 +1731,7 @@ public abstract class CompactionTaskRunBase
       );
       try (final CursorHolder cursorHolder = windowed.getCursorFactory().makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {
         final Cursor cursor = cursorHolder.asCursor();
-        Assert.assertNotNull(cursor);
+        Assertions.assertNotNull(cursor);
         cursor.reset();
         while (!cursor.isDone()) {
           final DimensionSelector selector1 = cursor.getColumnSelectorFactory()
@@ -1808,12 +1767,12 @@ public abstract class CompactionTaskRunBase
 
   public void verifyTaskSuccessRowsAndSchemaMatch(Pair<TaskStatus, DataSegmentsWithSchemas> resultPair, int totalRows)
   {
-    Assert.assertTrue(resultPair.lhs.isSuccess());
+    Assertions.assertTrue(resultPair.lhs.isSuccess());
     DataSegmentsWithSchemas dataSegmentsWithSchemas = resultPair.rhs;
     if (useCentralizedDatasourceSchema) {
       verifySchema(dataSegmentsWithSchemas.getSegments(), dataSegmentsWithSchemas.getSegmentSchemaMapping());
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         totalRows,
         dataSegmentsWithSchemas.getSegments().stream().mapToInt(DataSegment::getTotalRows).sum()
     );
@@ -1828,38 +1787,38 @@ public abstract class CompactionTaskRunBase
   )
   {
     if (gran == null || gran.equals(Granularities.HOUR)) {
-      Assert.assertEquals(3, segments.size());
+      Assertions.assertEquals(3, segments.size());
 
       for (int i = 0; i < 3; i++) {
         Interval interval = Intervals.of("2014-01-01T0%d:00:00/2014-01-01T0%d:00:00", i, i + 1);
-        Assert.assertEquals(interval, segments.get(i).getInterval());
+        Assertions.assertEquals(interval, segments.get(i).getInterval());
         // native runner use interval from actual seen segments, while msq runner use never use this gran
         Interval compactInterval = gran == null ? interval : TEST_ACTUAL_INTERVAL;
-        Assert.assertEquals(
+        Assertions.assertEquals(
             getDefaultCompactionState(DEFAULT_SEGMENT_GRAN, queryGran, List.of(compactInterval)),
             segments.get(i).getLastCompactionState()
         );
         if (useOverwriteShard) {
-          Assert.assertEquals(
+          Assertions.assertEquals(
               new NumberedOverwriteShardSpec(PartitionIds.NON_ROOT_GEN_START_PARTITION_ID, 0, 2, (short) 1, (short) 1),
               segments.get(i).getShardSpec()
           );
         } else {
-          Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(i).getShardSpec());
+          Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(i).getShardSpec());
         }
       }
     } else if (gran.equals(Granularities.SIX_HOUR)) {
-      Assert.assertEquals(1, segments.size());
-      Assert.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
+      Assertions.assertEquals(1, segments.size());
+      Assertions.assertEquals(TEST_INTERVAL, segments.get(0).getInterval());
       // native runner use interval from actual seen segments, while msq runner use interval from input
       Interval compactInterval = compactionRunner instanceof NativeCompactionRunner
                                  ? TEST_ACTUAL_INTERVAL
                                  : inputInterval;
-      Assert.assertEquals(
+      Assertions.assertEquals(
           getDefaultCompactionState(gran, queryGran, List.of(compactInterval)),
           segments.get(0).getLastCompactionState()
       );
-      Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+      Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
     } else {
       throw new RE("Gran[%s] is not supported", gran);
     }
@@ -1911,9 +1870,9 @@ public abstract class CompactionTaskRunBase
         continue;
       }
       nonTombstoneSegments++;
-      Assert.assertTrue(segmentSchemaMapping.getSegmentIdToMetadataMap().containsKey(segment.getId().toString()));
+      Assertions.assertTrue(segmentSchemaMapping.getSegmentIdToMetadataMap().containsKey(segment.getId().toString()));
     }
-    Assert.assertEquals(nonTombstoneSegments, segmentSchemaMapping.getSegmentIdToMetadataMap().size());
+    Assertions.assertEquals(nonTombstoneSegments, segmentSchemaMapping.getSegmentIdToMetadataMap().size());
   }
 
   private static String makeCSVFormatRow(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
@@ -219,7 +219,7 @@ public abstract class CompactionTaskRunBase
       boolean useConcurrentLocks,
       Interval inputInterval,
       Granularity segmentGranularity
-  ) throws IOException
+  )
   {
     this.lockGranularity = lockGranularity;
     this.useCentralizedDatasourceSchema = useCentralizedDatasourceSchema;
@@ -1667,7 +1667,7 @@ public abstract class CompactionTaskRunBase
 
   protected abstract Builder compactionTaskBuilder(ClientCompactionTaskGranularitySpec granularitySpec);
 
-  private TaskToolbox createTaskToolbox(ObjectMapper objectMapper, TaskActionClient taskActionClient) throws IOException
+  private TaskToolbox createTaskToolbox(ObjectMapper objectMapper, TaskActionClient taskActionClient)
   {
     final SegmentLoaderConfig loaderConfig = SegmentLoaderConfig.builder()
         .locations(new StorageLocationConfig(localDeepStorage, null, null))

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskRunBase.java
@@ -126,6 +126,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 
@@ -188,7 +189,8 @@ public abstract class CompactionTaskRunBase
   );
   protected static final int TOTAL_TEST_ROWS = 10;
 
-  protected final File temporaryFolder = FileUtils.createTempDir("compaction-task-run-test");
+  @TempDir
+  protected static File temporaryFolder;
 
   @RegisterExtension
   public TaskActionTestKit taskActionTestKit = new TaskActionTestKit();
@@ -288,7 +290,6 @@ public abstract class CompactionTaskRunBase
   public void teardown() throws IOException
   {
     exec.shutdownNow();
-    FileUtils.deleteDirectory(temporaryFolder);
   }
 
   protected File newTempFolder()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskTest.java
@@ -151,20 +151,19 @@ import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -180,7 +179,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class CompactionTaskTest
 {
   private static final long SEGMENT_SIZE_BYTES = 100;
@@ -221,7 +220,7 @@ public class CompactionTaskTest
   private TaskToolbox toolbox;
   private SegmentCacheManagerFactory segmentCacheManagerFactory;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     MIXED_TYPE_COLUMN_MAP.put(Intervals.of("2017-01-01/2017-02-01"), new StringDimensionSchema(MIXED_TYPE_COLUMN));
@@ -359,15 +358,12 @@ public class CompactionTaskTest
         .build();
   }
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Rule
+  @RegisterExtension
   public TaskActionTestKit taskActionTestKit = new TaskActionTestKit();
 
   private StubServiceEmitter emitter;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     final TestIndexIO testIndexIO = new TestIndexIO(OBJECT_MAPPER, SEGMENT_MAP);
@@ -400,13 +396,13 @@ public class CompactionTaskTest
     builder2.tuningConfig(createTuningConfig());
     builder2.granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.HOUR, Granularities.DAY, null));
     final CompactionTask taskCreatedWithGranularitySpec = builder2.build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         taskCreatedWithGranularitySpec.getSegmentGranularity(),
         taskCreatedWithSegmentGranularity.getSegmentGranularity()
     );
   }
 
-  @Test(expected = IAE.class)
+  @Test
   public void testCreateCompactionTaskWithConflictingGranularitySpecAndSegmentGranularityShouldThrowIAE()
   {
     final Builder builder = new Builder(
@@ -417,21 +413,15 @@ public class CompactionTaskTest
     builder.tuningConfig(createTuningConfig());
     builder.segmentGranularity(Granularities.HOUR);
     builder.granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.MINUTE, Granularities.DAY, null));
-    try {
-      builder.build();
-    }
-    catch (IAE iae) {
-      Assert.assertEquals(
-          StringUtils.format(
-              CONFLICTING_SEGMENT_GRANULARITY_FORMAT,
-              Granularities.HOUR,
-              Granularities.MINUTE
-          ),
-          iae.getMessage()
-      );
-      throw iae;
-    }
-    Assert.fail("Should not have reached here!");
+    final IAE exception = Assertions.assertThrows(IAE.class, builder::build);
+    Assertions.assertEquals(
+        StringUtils.format(
+            CONFLICTING_SEGMENT_GRANULARITY_FORMAT,
+            Granularities.HOUR,
+            Granularities.MINUTE
+        ),
+        exception.getMessage()
+    );
   }
 
   @Test
@@ -447,7 +437,7 @@ public class CompactionTaskTest
     builder.tuningConfig(createTuningConfig());
     builder.transformSpec(transformSpec);
     final CompactionTask taskCreatedWithTransformSpec = builder.build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         transformSpec,
         taskCreatedWithTransformSpec.getTransformSpec()
     );
@@ -465,13 +455,13 @@ public class CompactionTaskTest
     builder.tuningConfig(createTuningConfig());
     builder.metricsSpec(aggregatorFactories);
     final CompactionTask taskCreatedWithTransformSpec = builder.build();
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         aggregatorFactories,
         taskCreatedWithTransformSpec.getMetricsSpec()
     );
   }
 
-  @Test(expected = IAE.class)
+  @Test
   public void testCreateCompactionTaskWithNullSegmentGranularityInGranularitySpecAndSegmentGranularityShouldSucceed()
   {
     final Builder builder = new Builder(
@@ -482,21 +472,15 @@ public class CompactionTaskTest
     builder.tuningConfig(createTuningConfig());
     builder.segmentGranularity(Granularities.HOUR);
     builder.granularitySpec(new ClientCompactionTaskGranularitySpec(null, Granularities.DAY, null));
-    try {
-      builder.build();
-    }
-    catch (IAE iae) {
-      Assert.assertEquals(
-          StringUtils.format(
-              CONFLICTING_SEGMENT_GRANULARITY_FORMAT,
-              Granularities.HOUR,
-              null
-          ),
-          iae.getMessage()
-      );
-      throw iae;
-    }
-    Assert.fail("Should not have reached here!");
+    final IAE exception = Assertions.assertThrows(IAE.class, builder::build);
+    Assertions.assertEquals(
+        StringUtils.format(
+            CONFLICTING_SEGMENT_GRANULARITY_FORMAT,
+            Granularities.HOUR,
+            null
+        ),
+        exception.getMessage()
+    );
   }
 
   @Test
@@ -511,7 +495,7 @@ public class CompactionTaskTest
     builder.segmentGranularity(Granularities.HOUR);
     builder.granularitySpec(new ClientCompactionTaskGranularitySpec(Granularities.HOUR, Granularities.DAY, null));
     final CompactionTask taskCreatedWithSegmentGranularity = builder.build();
-    Assert.assertEquals(Granularities.HOUR, taskCreatedWithSegmentGranularity.getSegmentGranularity());
+    Assertions.assertEquals(Granularities.HOUR, taskCreatedWithSegmentGranularity.getSegmentGranularity());
   }
 
   @Test
@@ -609,7 +593,7 @@ public class CompactionTaskTest
 
     final byte[] bytes = OBJECT_MAPPER.writeValueAsBytes(task);
     final CompactionTask fromJson = OBJECT_MAPPER.readValue(bytes, CompactionTask.class);
-    Assert.assertEquals(projections, fromJson.getProjections());
+    Assertions.assertEquals(projections, fromJson.getProjections());
     assertEquals(task, fromJson);
   }
 
@@ -684,7 +668,7 @@ public class CompactionTaskTest
         .context(Map.of("testKey", "testContext"))
         .build();
 
-    Assert.assertTrue(task.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(task.getInputSourceResources().isEmpty());
   }
 
   @Test
@@ -722,7 +706,7 @@ public class CompactionTaskTest
         .withReportParseExceptions(false)
         .build();
 
-    Assert.assertEquals(compactionTuningConfig, CompactionTask.getTuningConfig(indexTuningConfig));
+    Assertions.assertEquals(compactionTuningConfig, CompactionTask.getTuningConfig(indexTuningConfig));
 
   }
 
@@ -763,18 +747,18 @@ public class CompactionTaskTest
         .withPushTimeout(5000L)
         .build();
 
-    Assert.assertEquals(compactionTuningConfig, CompactionTask.getTuningConfig(parallelIndexTuningConfig));
+    Assertions.assertEquals(compactionTuningConfig, CompactionTask.getTuningConfig(parallelIndexTuningConfig));
   }
 
   private static void assertEquals(CompactionTask expected, CompactionTask actual)
   {
-    Assert.assertEquals(expected.getType(), actual.getType());
-    Assert.assertEquals(expected.getDataSource(), actual.getDataSource());
-    Assert.assertEquals(expected.getIoConfig(), actual.getIoConfig());
-    Assert.assertEquals(expected.getDimensionsSpec(), actual.getDimensionsSpec());
-    Assert.assertArrayEquals(expected.getMetricsSpec(), actual.getMetricsSpec());
-    Assert.assertEquals(expected.getTuningConfig(), actual.getTuningConfig());
-    Assert.assertEquals(expected.getContext(), actual.getContext());
+    Assertions.assertEquals(expected.getType(), actual.getType());
+    Assertions.assertEquals(expected.getDataSource(), actual.getDataSource());
+    Assertions.assertEquals(expected.getIoConfig(), actual.getIoConfig());
+    Assertions.assertEquals(expected.getDimensionsSpec(), actual.getDimensionsSpec());
+    Assertions.assertArrayEquals(expected.getMetricsSpec(), actual.getMetricsSpec());
+    Assertions.assertEquals(expected.getTuningConfig(), actual.getTuningConfig());
+    Assertions.assertEquals(expected.getContext(), actual.getContext());
   }
 
   @Test
@@ -785,11 +769,14 @@ public class CompactionTaskTest
         new CompactionIntervalSpec(Intervals.of("2021-01-01/P1D"), null)
     );
 
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage(
-        "No segments found for compaction. Please check that datasource name and interval are correct."
+    final IllegalStateException exception = Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> provider.checkSegments(LockGranularity.TIME_CHUNK, List.of())
     );
-    provider.checkSegments(LockGranularity.TIME_CHUNK, List.of());
+    Assertions.assertEquals(
+        "No segments found for compaction. Please check that datasource name and interval are correct.",
+        exception.getMessage()
+    );
   }
 
   @Test
@@ -826,7 +813,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -890,7 +877,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -955,7 +942,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1020,7 +1007,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1092,7 +1079,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     final List<DimensionsSpec> dimensionsSpecs = new ArrayList<>(6);
     IntStream.range(0, 6).forEach(i -> dimensionsSpecs.add(customSpec));
     assertIngestionSchema(
@@ -1147,7 +1134,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1193,7 +1180,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1208,84 +1195,88 @@ public class CompactionTaskTest
   @Test
   public void testCreateIngestionSchemaWithDifferentSegmentSet() throws IOException
   {
-    expectedException.expect(CoreMatchers.instanceOf(IllegalStateException.class));
-    expectedException.expectMessage(CoreMatchers.containsString("are different from the current used segments"));
-
     final List<DataSegment> segments = new ArrayList<>(SEGMENTS);
     Collections.sort(segments);
     // Remove one segment in the middle
     segments.remove(segments.size() / 2);
-    final Map<QuerySegmentSpec, DataSchema> inputSchemas = CompactionTask.createInputDataSchemas(
-        toolbox,
-        LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, SpecificSegmentsSpec.fromSegments(segments)),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        METRIC_BUILDER,
-        false
-    );
+    final IllegalStateException exception = Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> {
+          final Map<QuerySegmentSpec, DataSchema> inputSchemas = CompactionTask.createInputDataSchemas(
+              toolbox,
+              LockGranularity.TIME_CHUNK,
+              new SegmentProvider(DATA_SOURCE, SpecificSegmentsSpec.fromSegments(segments)),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              METRIC_BUILDER,
+              false
+          );
 
-    NativeCompactionRunner.createIngestionSpecs(
-        inputSchemas,
-        toolbox,
-        new CompactionIOConfig(null, false, null),
-        new PartitionConfigurationManager(TUNING_CONFIG),
-        COORDINATOR_CLIENT,
-        segmentCacheManagerFactory
+          NativeCompactionRunner.createIngestionSpecs(
+              inputSchemas,
+              toolbox,
+              new CompactionIOConfig(null, false, null),
+              new PartitionConfigurationManager(TUNING_CONFIG),
+              COORDINATOR_CLIENT,
+              segmentCacheManagerFactory
+          );
+        }
     );
+    Assertions.assertTrue(exception.getMessage().contains("are different from the current used segments"));
   }
 
   @Test
   public void testMissingMetadata() throws IOException
   {
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage(CoreMatchers.startsWith("Index metadata doesn't exist for segment"));
-
     final TestIndexIO indexIO = (TestIndexIO) toolbox.getIndexIO();
     indexIO.removeMetadata(Iterables.getFirst(indexIO.getQueryableIndexMap().keySet(), null));
-    final Map<QuerySegmentSpec, DataSchema> inputSchemas = CompactionTask.createInputDataSchemas(
-        toolbox,
-        LockGranularity.TIME_CHUNK,
-        new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        METRIC_BUILDER,
-        false
-    );
+    final RuntimeException exception = Assertions.assertThrows(
+        RuntimeException.class,
+        () -> {
+          final Map<QuerySegmentSpec, DataSchema> inputSchemas = CompactionTask.createInputDataSchemas(
+              toolbox,
+              LockGranularity.TIME_CHUNK,
+              new SegmentProvider(DATA_SOURCE, new CompactionIntervalSpec(COMPACTION_INTERVAL, null)),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              METRIC_BUILDER,
+              false
+          );
 
-    NativeCompactionRunner.createIngestionSpecs(
-        inputSchemas,
-        toolbox,
-        new CompactionIOConfig(null, false, null),
-        new PartitionConfigurationManager(TUNING_CONFIG),
-        COORDINATOR_CLIENT,
-        segmentCacheManagerFactory
+          NativeCompactionRunner.createIngestionSpecs(
+              inputSchemas,
+              toolbox,
+              new CompactionIOConfig(null, false, null),
+              new PartitionConfigurationManager(TUNING_CONFIG),
+              COORDINATOR_CLIENT,
+              segmentCacheManagerFactory
+          );
+        }
     );
+    Assertions.assertTrue(exception.getMessage().startsWith("Index metadata doesn't exist for segment"));
   }
 
   @Test
   public void testEmptyInterval()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(CoreMatchers.containsString("must specify a nonempty interval"));
-
     final Builder builder = new Builder(
         DATA_SOURCE,
         segmentCacheManagerFactory
     );
 
-    @SuppressWarnings("unused")
-    final CompactionTask task = builder
-        .interval(Intervals.of("2000-01-01/2000-01-01"))
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> builder.interval(Intervals.of("2000-01-01/2000-01-01")).build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("must specify a nonempty interval"));
   }
 
   @Test
@@ -1323,7 +1314,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(1, ingestionSpecs.size());
+    Assertions.assertEquals(1, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1367,7 +1358,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1420,7 +1411,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(1, ingestionSpecs.size());
+    Assertions.assertEquals(1, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1468,7 +1459,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1516,7 +1507,7 @@ public class CompactionTaskTest
             s2.getDataSchema().getGranularitySpec().inputIntervals().get(0)
         )
     );
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     assertIngestionSchema(
         ingestionSpecs,
         expectedDimensionsSpec,
@@ -1555,9 +1546,9 @@ public class CompactionTaskTest
         segmentCacheManagerFactory
     );
 
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     for (ParallelIndexIngestionSpec indexIngestionSpec : ingestionSpecs) {
-      Assert.assertTrue(indexIngestionSpec.getDataSchema().getGranularitySpec().isRollup());
+      Assertions.assertTrue(indexIngestionSpec.getDataSchema().getGranularitySpec().isRollup());
     }
   }
 
@@ -1589,10 +1580,10 @@ public class CompactionTaskTest
     );
 
 
-    Assert.assertEquals(6, ingestionSpecs.size());
+    Assertions.assertEquals(6, ingestionSpecs.size());
     for (ParallelIndexIngestionSpec indexIngestionSpec : ingestionSpecs) {
       //Expect false since rollup value in metadata of existing segments are null
-      Assert.assertFalse(indexIngestionSpec.getDataSchema().getGranularitySpec().isRollup());
+      Assertions.assertFalse(indexIngestionSpec.getDataSchema().getGranularitySpec().isRollup());
     }
   }
 
@@ -1614,8 +1605,8 @@ public class CompactionTaskTest
         true
     );
     for (DataSchema dataSchema : inputSchemas.values()) {
-      Assert.assertTrue(dataSchema instanceof CombinedDataSchema);
-      Assert.assertTrue(((CombinedDataSchema) dataSchema).getMultiValuedDimensions().isEmpty());
+      Assertions.assertTrue(dataSchema instanceof CombinedDataSchema);
+      Assertions.assertTrue(((CombinedDataSchema) dataSchema).getMultiValuedDimensions().isEmpty());
     }
   }
 
@@ -1630,7 +1621,7 @@ public class CompactionTaskTest
     builder.compactionRunner(new TestMSQCompactionRunner());
     final CompactionTask compactionTask = builder.build();
     // granularitySpec=null should assume a possible rollup
-    Assert.assertTrue(compactionTask.identifyMultiValuedDimensions());
+    Assertions.assertTrue(compactionTask.identifyMultiValuedDimensions());
   }
 
   @Test
@@ -1654,7 +1645,7 @@ public class CompactionTaskTest
                                                 ))
                                             .build());
     final CompactionTask compactionTask = builder.build();
-    Assert.assertTrue(compactionTask.identifyMultiValuedDimensions());
+    Assertions.assertTrue(compactionTask.identifyMultiValuedDimensions());
   }
 
   @Test
@@ -1672,7 +1663,7 @@ public class CompactionTaskTest
     builder.dimensionsSpec(new DimensionsSpec(List.of(stringDim)));
     final CompactionTask compactionTask = builder.build();
     // A string dimension with rollup=true should need MVD info
-    Assert.assertTrue(compactionTask.identifyMultiValuedDimensions());
+    Assertions.assertTrue(compactionTask.identifyMultiValuedDimensions());
   }
 
   @Test
@@ -1699,7 +1690,7 @@ public class CompactionTaskTest
                                             .build());
     builder.dimensionsSpec(new DimensionsSpec(List.of(stringDim)));
     CompactionTask compactionTask = builder.build();
-    Assert.assertTrue(compactionTask.identifyMultiValuedDimensions());
+    Assertions.assertTrue(compactionTask.identifyMultiValuedDimensions());
   }
 
   @Test
@@ -1726,7 +1717,7 @@ public class CompactionTaskTest
                                             .build());
     builder.dimensionsSpec(new DimensionsSpec(List.of(stringDim)));
     CompactionTask compactionTask = builder.build();
-    Assert.assertFalse(compactionTask.identifyMultiValuedDimensions());
+    Assertions.assertFalse(compactionTask.identifyMultiValuedDimensions());
   }
 
   @Test
@@ -1743,7 +1734,7 @@ public class CompactionTaskTest
         Granularities.ALL,
         Granularities.MINUTE
     );
-    Assert.assertEquals(Granularities.SECOND, chooseFinestGranularityHelper(input));
+    Assertions.assertEquals(Granularities.SECOND, chooseFinestGranularityHelper(input));
   }
 
   @Test
@@ -1760,7 +1751,7 @@ public class CompactionTaskTest
         Granularities.NONE,
         Granularities.MINUTE
     );
-    Assert.assertEquals(Granularities.NONE, chooseFinestGranularityHelper(input));
+    Assertions.assertEquals(Granularities.NONE, chooseFinestGranularityHelper(input));
   }
 
   @Test
@@ -1772,7 +1763,7 @@ public class CompactionTaskTest
         null,
         null
     );
-    Assert.assertNull(chooseFinestGranularityHelper(input));
+    Assertions.assertNull(chooseFinestGranularityHelper(input));
   }
 
   @Test
@@ -1785,7 +1776,7 @@ public class CompactionTaskTest
     final CompactionTask task = builder
         .interval(Intervals.of("2000-01-01/2000-01-02"))
         .build();
-    Assert.assertEquals(LookupLoadingSpec.NONE, task.getLookupLoadingSpec());
+    Assertions.assertEquals(LookupLoadingSpec.NONE, task.getLookupLoadingSpec());
   }
 
   @Test
@@ -1799,7 +1790,7 @@ public class CompactionTaskTest
         .interval(Intervals.of("2000-01-01/2000-01-02"))
         .transformSpec(new CompactionTransformSpec(new SelectorDimFilter("dim1", "foo", null), null))
         .build();
-    Assert.assertEquals(LookupLoadingSpec.ALL, task.getLookupLoadingSpec());
+    Assertions.assertEquals(LookupLoadingSpec.ALL, task.getLookupLoadingSpec());
   }
 
   private Granularity chooseFinestGranularityHelper(List<Granularity> granularities)
@@ -1919,21 +1910,21 @@ public class CompactionTaskTest
 
       // assert dataSchema
       final DataSchema dataSchema = ingestionSchema.getDataSchema();
-      Assert.assertEquals(DATA_SOURCE, dataSchema.getDataSource());
+      Assertions.assertEquals(DATA_SOURCE, dataSchema.getDataSource());
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           new TimestampSpec(ColumnHolder.TIME_COLUMN_NAME, "millis", null),
           dataSchema.getTimestampSpec()
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           new HashSet<>(expectedDimensionsSpec.getDimensions()),
           new HashSet<>(dataSchema.getDimensionsSpec().getDimensions())
       );
 
       // metrics
-      Assert.assertEquals(expectedMetricsSpec, Arrays.asList(dataSchema.getAggregators()));
-      Assert.assertEquals(
+      Assertions.assertEquals(expectedMetricsSpec, Arrays.asList(dataSchema.getAggregators()));
+      Assertions.assertEquals(
           new UniformGranularitySpec(
               expectedSegmentGranularity,
               expectedQueryGranularity,
@@ -1945,20 +1936,20 @@ public class CompactionTaskTest
 
       // assert ioConfig
       final ParallelIndexIOConfig ioConfig = ingestionSchema.getIOConfig();
-      Assert.assertFalse(ioConfig.isAppendToExisting());
-      Assert.assertEquals(
+      Assertions.assertFalse(ioConfig.isAppendToExisting());
+      Assertions.assertEquals(
           expectedDropExisting,
           ioConfig.isDropExisting()
       );
       final InputSource inputSource = ioConfig.getInputSource();
-      Assert.assertTrue(inputSource instanceof DruidInputSource);
+      Assertions.assertTrue(inputSource instanceof DruidInputSource);
       final DruidInputSource druidInputSource = (DruidInputSource) inputSource;
-      Assert.assertEquals(DATA_SOURCE, druidInputSource.getDataSource());
-      Assert.assertEquals(expectedSegmentIntervals.get(i), druidInputSource.getInterval());
-      Assert.assertNull(druidInputSource.getDimFilter());
+      Assertions.assertEquals(DATA_SOURCE, druidInputSource.getDataSource());
+      Assertions.assertEquals(expectedSegmentIntervals.get(i), druidInputSource.getInterval());
+      Assertions.assertNull(druidInputSource.getDimFilter());
 
       // assert tuningConfig
-      Assert.assertEquals(expectedTuningConfig, ingestionSchema.getTuningConfig());
+      Assertions.assertEquals(expectedTuningConfig, ingestionSchema.getTuningConfig());
     }
   }
 
@@ -2057,7 +2048,7 @@ public class CompactionTaskTest
   @Test
   public void testMinorCompactionChecksIfSegmentsToCompactIsEmpty()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> new MinorCompactionInputSpec(COMPACTION_INTERVAL, List.of())
     );
@@ -2075,7 +2066,7 @@ public class CompactionTaskTest
         List.of(segment.toDescriptor())
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         // Setting dropExisting == false disables REPLACE mode.
         () -> new Builder(DATA_SOURCE, segmentCacheManagerFactory)
@@ -2123,7 +2114,7 @@ public class CompactionTaskTest
     };
 
     task.determineLockGranularityAndTryLock(segmentAwareClient, List.of(testInterval));
-    Assert.assertEquals(LockGranularity.TIME_CHUNK, task.getTaskLockHelper().getLockGranularityToUse());
+    Assertions.assertEquals(LockGranularity.TIME_CHUNK, task.getTaskLockHelper().getLockGranularityToUse());
   }
 
   @Test
@@ -2197,7 +2188,7 @@ public class CompactionTaskTest
     };
     subtask.determineLockGranularityAndTryLock(segmentAwareClient, List.of(testInterval));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         LockGranularity.TIME_CHUNK,
         subtask.getTaskLockHelper().getLockGranularityToUse()
     );
@@ -2268,12 +2259,12 @@ public class CompactionTaskTest
         segmentCacheManagerFactory
     );
 
-    Assert.assertEquals(1, ingestionSpecs.size());
+    Assertions.assertEquals(1, ingestionSpecs.size());
     final InputSource inputSource = ingestionSpecs.get(0).getIOConfig().getInputSource();
-    Assert.assertTrue(inputSource instanceof DruidInputSource);
+    Assertions.assertTrue(inputSource instanceof DruidInputSource);
     final DruidInputSource druidInputSource = (DruidInputSource) inputSource;
-    Assert.assertNotNull(druidInputSource.getSegmentIds());
-    Assert.assertEquals(2, druidInputSource.getSegmentIds().size());
+    Assertions.assertNotNull(druidInputSource.getSegmentIds());
+    Assertions.assertEquals(2, druidInputSource.getSegmentIds().size());
   }
 
   private DataSegment createSegmentWithPartition(Interval interval, String version, int partitionNum)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTuningConfigTest.java
@@ -27,9 +27,9 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.indexing.TuningConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -37,7 +37,7 @@ public class CompactionTuningConfigTest
 {
   private final ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     mapper.registerSubtypes(new NamedType(CompactionTask.CompactionTuningConfig.class, "compcation"));
@@ -51,22 +51,19 @@ public class CompactionTuningConfigTest
     final byte[] json = mapper.writeValueAsBytes(tuningConfig);
     final ParallelIndexTuningConfig fromJson =
         (CompactionTask.CompactionTuningConfig) mapper.readValue(json, TuningConfig.class);
-    Assert.assertEquals(fromJson, tuningConfig);
+    Assertions.assertEquals(fromJson, tuningConfig);
   }
 
   @Test
   public void testConfigWithNonZeroAwaitSegmentAvailabilityTimeoutThrowsException()
   {
-    final Exception e = Assert.assertThrows(
+    final Exception e = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> TuningConfigBuilder.forCompactionTask()
                                  .withAwaitSegmentAvailabilityTimeoutMillis(5L)
                                  .build()
     );
-    Assert.assertEquals(
-        "awaitSegmentAvailabilityTimeoutMillis is not supported for Compcation Task",
-        e.getMessage()
-    );
+    Assertions.assertEquals("awaitSegmentAvailabilityTimeoutMillis is not supported for Compcation Task", e.getMessage());
   }
 
   @Test
@@ -76,7 +73,7 @@ public class CompactionTuningConfigTest
         .forCompactionTask()
         .withAwaitSegmentAvailabilityTimeoutMillis(0L)
         .build();
-    Assert.assertEquals(0L, tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
+    Assertions.assertEquals(0L, tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }
 
   @Test
@@ -84,7 +81,7 @@ public class CompactionTuningConfigTest
   {
     final CompactionTask.CompactionTuningConfig tuningConfig =
         TuningConfigBuilder.forCompactionTask().build();
-    Assert.assertEquals(0L, tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
+    Assertions.assertEquals(0L, tuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/MinorCompactionInputSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/MinorCompactionInputSpecTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.query.SegmentDescriptor;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -45,9 +45,9 @@ public class MinorCompactionInputSpecTest
     String json = mapper.writeValueAsString(spec);
     MinorCompactionInputSpec deserialized = mapper.readValue(json, MinorCompactionInputSpec.class);
 
-    Assert.assertEquals(spec, deserialized);
-    Assert.assertEquals(interval, deserialized.getInterval());
-    Assert.assertEquals(segments, deserialized.getSegments());
+    Assertions.assertEquals(spec, deserialized);
+    Assertions.assertEquals(interval, deserialized.getInterval());
+    Assertions.assertEquals(segments, deserialized.getSegments());
   }
 
   @Test
@@ -62,9 +62,9 @@ public class MinorCompactionInputSpecTest
 
     MinorCompactionInputSpec deserialized = mapper.readValue(clientJson, MinorCompactionInputSpec.class);
 
-    Assert.assertEquals(Intervals.of("2015-04-11/2015-04-12"), deserialized.getInterval());
-    Assert.assertEquals(1, deserialized.getSegments().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(Intervals.of("2015-04-11/2015-04-12"), deserialized.getInterval());
+    Assertions.assertEquals(1, deserialized.getSegments().size());
+    Assertions.assertEquals(
         new SegmentDescriptor(Intervals.of("2015-04-11/2015-04-12"), "v1", 0),
         deserialized.getSegments().get(0)
     );
@@ -77,18 +77,18 @@ public class MinorCompactionInputSpecTest
         new SegmentDescriptor(Intervals.of("2015-04-11/2015-04-12"), "v1", 0)
     );
 
-    Assert.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(null, segments));
+    Assertions.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(null, segments));
 
     Interval emptyInterval = Intervals.of("2015-04-11/2015-04-11");
-    Assert.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(emptyInterval, segments));
+    Assertions.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(emptyInterval, segments));
   }
 
   @Test
   public void testThrowsExceptionWhenInvalidSegments()
   {
     Interval interval = Intervals.of("2015-04-11/2015-04-12");
-    Assert.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(interval, null));
-    Assert.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(interval, List.of()));
+    Assertions.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(interval, null));
+    Assertions.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(interval, List.of()));
   }
 
   @Test
@@ -99,6 +99,6 @@ public class MinorCompactionInputSpecTest
         new SegmentDescriptor(Intervals.of("2015-05-11/2015-05-12"), "v1", 0)
     );
 
-    Assert.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(interval, segments));
+    Assertions.assertThrows(DruidException.class, () -> new MinorCompactionInputSpec(interval, segments));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NativeCompactionRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NativeCompactionRunnerTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.transform.CompactionTransformSpec;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.server.coordinator.CompactionConfigValidationResult;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
@@ -64,8 +64,8 @@ public class NativeCompactionRunnerTest
         inputSchemas
     );
 
-    Assert.assertFalse(validationResult.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(validationResult.isValid());
+    Assertions.assertEquals(
         "Virtual columns in filter rules are not supported by the Native compaction engine. Use MSQ compaction engine instead.",
         validationResult.getReason()
     );
@@ -82,7 +82,7 @@ public class NativeCompactionRunnerTest
         inputSchemas
     );
 
-    Assert.assertTrue(validationResult.isValid());
+    Assertions.assertTrue(validationResult.isValid());
   }
 
   @Test
@@ -98,7 +98,7 @@ public class NativeCompactionRunnerTest
         inputSchemas
     );
 
-    Assert.assertTrue(validationResult.isValid());
+    Assertions.assertTrue(validationResult.isValid());
   }
 
   private CompactionTask createCompactionTask(CompactionTransformSpec transformSpec)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NativeCompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NativeCompactionTaskRunTest.java
@@ -25,17 +25,18 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.joda.time.Interval;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class NativeCompactionTaskRunTest extends CompactionTaskRunBase
 {
-  @Parameterized.Parameters(name = "name={0}, inputInterval={6}, segmentGran={7}")
+
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NativeCompactionTaskRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NativeCompactionTaskRunTest.java
@@ -28,7 +28,6 @@ import org.joda.time.Interval;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -86,7 +85,7 @@ public class NativeCompactionTaskRunTest extends CompactionTaskRunBase
       boolean useConcurrentLocks,
       Interval inputInterval,
       Granularity compactionGranularity
-  ) throws IOException
+  )
   {
     super(
         name,

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
@@ -104,13 +104,13 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -133,13 +133,13 @@ import static org.mockito.Mockito.when;
  * Tests for CompactionTask using MSQCompactionRunner.
  * Extends CompactionTaskRunTest to reuse all test infrastructure.
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
 {
   private final ConcurrentHashMap<String, TaskActionClient> taskActionClients = new ConcurrentHashMap<>();
   private Injector injector;
 
-  @Parameterized.Parameters(name = "name: {0}, inputInterval={6}, segmentGran={7}")
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -208,7 +208,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
     Preconditions.checkState(taskActionClients.put(taskId, taskActionClient) == null);
   }
 
-  @Before
+  @BeforeEach
   public void setUpMSQ()
   {
     objectMapper.registerModules(new MSQIndexingModule().getJacksonModules());
@@ -295,28 +295,28 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
   }
 
   @Override
-  @Ignore("Hash paritioning is not supported in MSQ")
+  @Disabled("Hash paritioning is not supported in MSQ")
   @Test
   public void testRunWithHashPartitioning()
   {
   }
 
   @Override
-  @Ignore("dropExisting must set to true in MSQ")
+  @Disabled("dropExisting must set to true in MSQ")
   @Test
   public void testPartialIntervalCompactWithFinerSegmentGranularityThenFullIntervalCompactWithDropExistingFalse()
   {
   }
 
   @Override
-  @Ignore("allowNonAlignedInterval is not supported in MSQ")
+  @Disabled("allowNonAlignedInterval is not supported in MSQ")
   @Test
   public void testWithSegmentGranularityMisalignedIntervalAllowed()
   {
   }
 
   @Override
-  @Ignore("allowNonAlignedInterval is not supported in MSQ")
+  @Disabled("allowNonAlignedInterval is not supported in MSQ")
   @Test
   public void testWithSegmentGranularityMisalignedIntervalAllowed2()
   {
@@ -327,7 +327,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
   public void testCompactionWithNewMetricInMetricsSpec() throws Exception
   {
     // MSQ doesn't support count aggregator
-    Assume.assumeTrue(segmentGranularity != null && !segmentGranularity.isFinerThan(Granularities.SIX_HOUR));
+    Assumptions.assumeTrue(segmentGranularity != null && !segmentGranularity.isFinerThan(Granularities.SIX_HOUR));
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask =
@@ -340,10 +340,10 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
     verifyTaskSuccessRowsAndSchemaMatch(resultPair, TOTAL_TEST_ROWS);
 
     List<DataSegment> segments = new ArrayList<>(resultPair.rhs.getSegments());
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
-    Assert.assertEquals(inputInterval, segments.get(0).getInterval());
-    Assert.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
+    Assertions.assertEquals(inputInterval, segments.get(0).getInterval());
+    Assertions.assertEquals(new NumberedShardSpec(0, 1), segments.get(0).getShardSpec());
 
     CompactionState expectedCompactionState =
         getDefaultCompactionState(segmentGranularity, Granularities.MINUTE, List.of(TEST_INTERVAL))
@@ -360,10 +360,10 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
   {
     // This test is almost identical to base, except for fullCompactionTask, since MSQ doesn't allow disjoint intervals.
     // This test fails with segment lock because of the bug reported in https://github.com/apache/druid/issues/10911.
-    Assume.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
-    Assume.assumeTrue(
-        "test with defined segment granularity in this test",
-        Granularities.SIX_HOUR.equals(segmentGranularity)
+    Assumptions.assumeTrue(lockGranularity != LockGranularity.SEGMENT);
+    Assumptions.assumeTrue(
+        Granularities.SIX_HOUR.equals(segmentGranularity),
+        "test with defined segment granularity in this test"
     );
 
     // The following task creates (several, more than three, last time I checked, six) HOUR segments with intervals of
@@ -385,7 +385,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
     // maxRowsPerSegment is set to 2 inside the runIndexTask methods
     Pair<TaskStatus, DataSegmentsWithSchemas> result = runIndexTask();
     verifyTaskSuccessRowsAndSchemaMatch(result, TOTAL_TEST_ROWS);
-    Assert.assertEquals(6, result.rhs.getSegments().size());
+    Assertions.assertEquals(6, result.rhs.getSegments().size());
 
     // Setup partial compaction:
     // Change the granularity from HOUR to MINUTE through compaction for hour 01, there are three rows in the compaction interval,
@@ -419,20 +419,20 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
             List.of(Intervals.of("2014-01-01T02:00:00/2014-01-01T03:00:00"))
         ).get());
     expectedSegments.addAll(partialCompactionResult.rhs.getSegments());
-    Assert.assertEquals(64, expectedSegments.size());
+    Assertions.assertEquals(64, expectedSegments.size());
 
     // New segments that were compacted are expected. However, old segments of the compacted interval should be
     // overshadowed by the new tombstones (59) being created for all minutes other than 01:01
     final Set<DataSegment> segmentsAfterPartialCompaction = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(Intervals.of("2014-01-01/2014-01-02"))).get());
-    Assert.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
+    Assertions.assertEquals(expectedSegments, segmentsAfterPartialCompaction);
     final List<DataSegment> realSegmentsAfterPartialCompaction =
         segmentsAfterPartialCompaction.stream().filter(s -> !s.isTombstone()).collect(Collectors.toList());
     final List<DataSegment> tombstonesAfterPartialCompaction =
         segmentsAfterPartialCompaction.stream().filter(s -> s.isTombstone()).collect(Collectors.toList());
-    Assert.assertEquals(59, tombstonesAfterPartialCompaction.size());
-    Assert.assertEquals(5, realSegmentsAfterPartialCompaction.size());
-    Assert.assertEquals(64, segmentsAfterPartialCompaction.size());
+    Assertions.assertEquals(59, tombstonesAfterPartialCompaction.size());
+    Assertions.assertEquals(5, realSegmentsAfterPartialCompaction.size());
+    Assertions.assertEquals(64, segmentsAfterPartialCompaction.size());
 
     // Setup full compaction:
     // Reindex with new MINUTE segment granularity. MSQ engine doesn't support disjoint intervals.
@@ -449,25 +449,25 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
     segmentsAfterFullCompaction.sort(
         (s1, s2) -> Comparators.intervalsByStartThenEnd().compare(s1.getInterval(), s2.getInterval())
     );
-    Assert.assertEquals(180, segmentsAfterFullCompaction.size());
+    Assertions.assertEquals(180, segmentsAfterFullCompaction.size());
 
     final List<DataSegment> tombstonesAfterFullCompaction =
         segmentsAfterFullCompaction.stream().filter(s -> s.isTombstone()).collect(Collectors.toList());
-    Assert.assertEquals(177, tombstonesAfterFullCompaction.size());
+    Assertions.assertEquals(177, tombstonesAfterFullCompaction.size());
 
     final List<DataSegment> realSegmentsAfterFullCompaction =
         segmentsAfterFullCompaction.stream().filter(s -> !s.isTombstone()).collect(Collectors.toList());
-    Assert.assertEquals(3, realSegmentsAfterFullCompaction.size());
+    Assertions.assertEquals(3, realSegmentsAfterFullCompaction.size());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2014-01-01T00:00:00.000Z/2014-01-01T00:01:00.000Z"),
         realSegmentsAfterFullCompaction.get(0).getInterval()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2014-01-01T01:00:00.000Z/2014-01-01T01:01:00.000Z"),
         realSegmentsAfterFullCompaction.get(1).getInterval()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2014-01-01T02:00:00.000Z/2014-01-01T02:01:00.000Z"),
         realSegmentsAfterFullCompaction.get(2).getInterval()
     );
@@ -476,7 +476,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
   @Test
   public void testMSQCompactionWithConcurrentAppendCompactionLocksFirst() throws Exception
   {
-    Assume.assumeTrue(useConcurrentLocks);
+    Assumptions.assumeTrue(useConcurrentLocks);
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask =
@@ -516,17 +516,17 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
 
     verifyTaskSuccessRowsAndSchemaMatch(appendFuture.get(), 9);
     List<DataSegment> segments = new ArrayList<>(appendFuture.get().rhs.getSegments());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
 
     final Pair<TaskStatus, DataSegmentsWithSchemas> compactionResult = compactionFuture.get();
     verifyTaskSuccessRowsAndSchemaMatch(compactionResult, TOTAL_TEST_ROWS);
-    Assert.assertEquals(1, compactionResult.rhs.getSegments().size());
+    Assertions.assertEquals(1, compactionResult.rhs.getSegments().size());
 
     final Set<DataSegment> usedSegments = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(Intervals.of("2014-01-01/2014-01-02"))).get());
-    Assert.assertEquals(7, usedSegments.size());
+    Assertions.assertEquals(7, usedSegments.size());
     final String version = Iterables.getOnlyElement(compactionResult.rhs.getSegments()).getVersion();
-    Assert.assertTrue(usedSegments.stream().allMatch(segment -> segment.getVersion().equals(version)));
+    Assertions.assertTrue(usedSegments.stream().allMatch(segment -> segment.getVersion().equals(version)));
 
     CompactionTask finalTask = compactionTaskBuilder(segmentGranularity).interval(inputInterval, true).build();
     Pair<TaskStatus, DataSegmentsWithSchemas> finalResult = runTask(finalTask);
@@ -537,7 +537,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
   @Test
   public void testMSQCompactionWithConcurrentAppendAppendLocksFirst() throws Exception
   {
-    Assume.assumeTrue(useConcurrentLocks);
+    Assumptions.assumeTrue(useConcurrentLocks);
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask =
@@ -577,17 +577,17 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
 
     verifyTaskSuccessRowsAndSchemaMatch(appendFuture.get(), 9);
     List<DataSegment> segments = new ArrayList<>(appendFuture.get().rhs.getSegments());
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
 
     final Pair<TaskStatus, DataSegmentsWithSchemas> compactionResult = compactionFuture.get();
     verifyTaskSuccessRowsAndSchemaMatch(compactionResult, TOTAL_TEST_ROWS);
-    Assert.assertEquals(1, compactionResult.rhs.getSegments().size());
+    Assertions.assertEquals(1, compactionResult.rhs.getSegments().size());
 
     final Set<DataSegment> usedSegments = new HashSet<>(
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(Intervals.of("2014-01-01/2014-01-02"))).get());
-    Assert.assertEquals(7, usedSegments.size());
+    Assertions.assertEquals(7, usedSegments.size());
     final String version = Iterables.getOnlyElement(compactionResult.rhs.getSegments()).getVersion();
-    Assert.assertTrue(usedSegments.stream().allMatch(segment -> segment.getVersion().equals(version)));
+    Assertions.assertTrue(usedSegments.stream().allMatch(segment -> segment.getVersion().equals(version)));
 
     CompactionTask finalTask = compactionTaskBuilder(segmentGranularity).interval(inputInterval, true).build();
     Pair<TaskStatus, DataSegmentsWithSchemas> finalResult = runTask(finalTask);
@@ -597,8 +597,8 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
   @Test
   public void testMinorCompaction() throws Exception
   {
-    Assume.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
-    Assume.assumeTrue("Minor compaction depends on concurrent lock", useConcurrentLocks);
+    Assumptions.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
+    Assumptions.assumeTrue(useConcurrentLocks, "Minor compaction depends on concurrent lock");
     verifyTaskSuccessRowsAndSchemaMatch(runIndexTask(), TOTAL_TEST_ROWS);
 
     final CompactionTask compactionTask1 =
@@ -613,7 +613,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
         DEFAULT_QUERY_GRAN,
         false
     );
-    Assert.assertEquals(1, resultPair1.rhs.getSegments().size());
+    Assertions.assertEquals(1, resultPair1.rhs.getSegments().size());
     final DataSegment compactedSegment1 = Iterables.getOnlyElement(resultPair1.rhs.getSegments());
 
     Pair<TaskStatus, DataSegmentsWithSchemas> appendTask = runAppendTask();
@@ -629,7 +629,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
             .build();
     final Pair<TaskStatus, DataSegmentsWithSchemas> resultPair2 = runTask(compactionTask2);
     verifyTaskSuccessRowsAndSchemaMatch(resultPair2, TOTAL_TEST_ROWS);
-    Assert.assertEquals(1, resultPair2.rhs.getSegments().size());
+    Assertions.assertEquals(1, resultPair2.rhs.getSegments().size());
     final DataSegment compactedSegment2 = Iterables.getOnlyElement(resultPair2.rhs.getSegments());
 
     final List<String> usedSegments =
@@ -638,7 +638,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
                          .stream()
                          .map(DataSegment::toString)
                          .collect(Collectors.toList());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(
             compactedSegment2.withShardSpec(new NumberedShardSpec(0, 2)).toString(),
             // shard spec in compactedSegment2 has been updated
@@ -664,8 +664,8 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
         "2014-01-01T02:00:30Z,b,2\n",
         "2014-01-01T02:00:30Z,c,3\n"
     );
-    Assume.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
-    Assume.assumeTrue("Minor compaction depends on concurrent lock", useConcurrentLocks);
+    Assumptions.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
+    Assumptions.assumeTrue(useConcurrentLocks, "Minor compaction depends on concurrent lock");
     verifyTaskSuccessRowsAndSchemaMatch(
         runTask(buildIndexTask(DEFAULT_TIMESTAMP_SPEC, DEFAULT_DIMENSIONS_SPEC, DEFAULT_INPUT_FORMAT, rows, inputInterval, false)),
         9
@@ -682,7 +682,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
 
     final Pair<TaskStatus, DataSegmentsWithSchemas> resultPair1 = runTask(compactionTask1);
     verifyTaskSuccessRowsAndSchemaMatch(resultPair1, 9);
-    Assert.assertEquals(3, resultPair1.rhs.getSegments().size());
+    Assertions.assertEquals(3, resultPair1.rhs.getSegments().size());
 
     Pair<TaskStatus, DataSegmentsWithSchemas> appendTask =
         runTask(buildIndexTask(DEFAULT_TIMESTAMP_SPEC, DEFAULT_DIMENSIONS_SPEC, DEFAULT_INPUT_FORMAT, rows, inputInterval, true));
@@ -699,20 +699,20 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
             .build();
     final Pair<TaskStatus, DataSegmentsWithSchemas> resultPair2 = runTask(compactionTask2);
     verifyTaskSuccessRowsAndSchemaMatch(resultPair2, 9);
-    Assert.assertEquals(3, resultPair2.rhs.getSegments().size());
+    Assertions.assertEquals(3, resultPair2.rhs.getSegments().size());
 
     final List<DataSegment> usedSegments =
         coordinatorClient.fetchUsedSegments(DATA_SOURCE, List.of(Intervals.of("2014-01-01/2014-01-02"))).get();
-    Assert.assertEquals(6, usedSegments.size());
+    Assertions.assertEquals(6, usedSegments.size());
     final List<ShardSpec> shards = usedSegments.stream().map(DataSegment::getShardSpec).collect(Collectors.toList());
-    Assert.assertEquals(Set.of("range"), shards.stream().map(ShardSpec::getType).collect(Collectors.toSet()));
+    Assertions.assertEquals(Set.of("range"), shards.stream().map(ShardSpec::getType).collect(Collectors.toSet()));
   }
 
   @Test
   public void testMinorCompactionOverlappingInterval() throws Exception
   {
-    Assume.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
-    Assume.assumeTrue("Minor compaction depends on concurrent lock", useConcurrentLocks);
+    Assumptions.assumeTrue(lockGranularity == LockGranularity.TIME_CHUNK);
+    Assumptions.assumeTrue(useConcurrentLocks, "Minor compaction depends on concurrent lock");
 
     List<String> rows = new ArrayList<>();
     rows.add("2014-01-01T00:00:10Z,a1,11\n");
@@ -736,7 +736,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
     );
     Pair<TaskStatus, DataSegmentsWithSchemas> indexTaskResult = runTask(indexTask);
     // created 2 segments in HOUR 0 -> HOUR 6, and 4 segments in HOUR 6 -> HOUR12
-    Assert.assertEquals(6, indexTaskResult.rhs.getSegments().size());
+    Assertions.assertEquals(6, indexTaskResult.rhs.getSegments().size());
     verifyTaskSuccessRowsAndSchemaMatch(indexTaskResult, 10);
 
     // First compaction task to only compact 6 segments from indexTask.
@@ -752,8 +752,8 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
         compactionTaskBuilder(Granularities.EIGHT_HOUR)
             .inputSpec(new MinorCompactionInputSpec(compactionInterval, uncompactedFromIndexTask), true)
             .build();
-    DruidException e = Assert.assertThrows(DruidException.class, () -> runTask(compactionTask1));
-    Assert.assertEquals(
+    DruidException e = Assertions.assertThrows(DruidException.class, () -> runTask(compactionTask1));
+    Assertions.assertEquals(
         "Minor compaction doesn't allow segments not completely within interval[2014-01-01T00:00:00.000Z/2014-01-01T08:00:00.000Z]",
         e.getMessage()
     );

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/exec/MSQCompactionTaskRunTest.java
@@ -113,7 +113,6 @@ import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -188,7 +187,7 @@ public class MSQCompactionTaskRunTest extends CompactionTaskRunBase
       boolean useConcurrentLocks,
       Interval inputInterval,
       Granularity compactionGranularities
-  ) throws IOException
+  )
   {
     super(
         name,


### PR DESCRIPTION
## Summary

- Migrate the indexing-service Task Action tests to JUnit 5.
- Migrate the indexing-service compaction tests and their shared `CompactionTaskRunBase` fixture to JUnit 5.
- Migrate `MSQCompactionTaskRunTest`, which consumes the shared compaction fixture from the multi-stage-query module.
- Use native Jupiter assertions, assumptions, parameterized tests, and extensions; use Druid `FileUtils` for the compaction test temporary-directory lifecycle.
- Reuse the existing `TestDerbyConnector` lifecycle instead of introducing a duplicate JUnit 5 connector helper.
- Add only the Jupiter parameterized-test and Mockito Jupiter integration dependencies needed by this batch.
- Retain `TaskActionTestKit`'s `ExternalResource` compatibility bridge for the still-JUnit-4 `UnusedSegmentsKillerTest`; the Overlord batch removes that remaining consumer.

This PR is now limited to Part 1 of the indexing-service migration: Task Actions and Compaction. The remaining indexing-service tests are being migrated in five independent follow-up PRs: ingestion/parallel indexing, common support, Overlord core/API, seekable streams, and workers.

The broad assertion, matcher, expected-failure, temporary-directory, and Derby connector helper layer from the earlier version was removed. This batch does not remove the shared JUnit 4, Vintage, Hamcrest, system-rules, or migration-support dependencies from `indexing-service/pom.xml`, because later batches still use them; those dependencies will be removed after the source migrations are complete.

## Validation

- Clean reactor `verify` passed for `indexing-service` and `multi-stage-query` with static checks enabled.
- The updated six-module reactor compile/test-compile/static gate passed with `BUILD SUCCESS`; Checkstyle, PMD, Enforcer, forbidden APIs, compilation, and packaging passed.
- Migrated indexing-service tests passed: 1,061 tests, 0 failures, 0 errors, 0 skips.
- `MSQCompactionTaskRunTest` passed: 153 tests, 0 failures, 0 errors, 5 existing skips.
- The compatibility consumer `UnusedSegmentsKillerTest` passed: 17 tests, 0 failures, 0 errors, 0 skips.
- `git diff --check` passed.

## Tracking

Part of [#13948](https://github.com/apache/druid/issues/13948).

Related migration PRs: [#19920](https://github.com/apache/druid/pull/19920), [#19922](https://github.com/apache/druid/pull/19922), [#19923](https://github.com/apache/druid/pull/19923), and the remaining split batches.
