### PR TITLE
test: migrate second extensions-contrib batch to JUnit 5

### DIFF
--- a/extensions-contrib/aliyun-oss-extensions/pom.xml
+++ b/extensions-contrib/aliyun-oss-extensions/pom.xml
@@ -33,6 +33,21 @@
   </parent>
   
     <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
@@ -111,11 +126,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-server</artifactId>
             <version>${project.parent.version}</version>
@@ -129,12 +139,6 @@
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
@@ -71,17 +71,14 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.utils.CompressionUtils;
 import org.easymock.EasyMock;
 import org.easymock.IArgumentMatcher;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
@@ -90,6 +87,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OssInputSourceTest extends InitializedNullHandlingTest
 {
@@ -141,11 +140,8 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     INPUT_DATA_CONFIG.setMaxListingLength(MAX_LISTING_LENGTH);
   }
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void testSerdeWithUris() throws Exception
@@ -161,8 +157,8 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         null
     );
     final OssInputSource serdeWithUris = MAPPER.readValue(MAPPER.writeValueAsString(withUris), OssInputSource.class);
-    Assert.assertEquals(withUris, serdeWithUris);
-    Assert.assertEquals(Collections.emptySet(), serdeWithUris.getConfiguredSystemFields());
+    Assertions.assertEquals(withUris, serdeWithUris);
+    Assertions.assertEquals(Collections.emptySet(), serdeWithUris.getConfiguredSystemFields());
   }
 
   @Test
@@ -179,8 +175,8 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         null
     );
     final OssInputSource serdeWithUris = MAPPER.readValue(MAPPER.writeValueAsString(withUris), OssInputSource.class);
-    Assert.assertEquals(withUris, serdeWithUris);
-    Assert.assertEquals(
+    Assertions.assertEquals(withUris, serdeWithUris);
+    Assertions.assertEquals(
         EnumSet.of(SystemField.URI, SystemField.BUCKET, SystemField.PATH),
         serdeWithUris.getConfiguredSystemFields()
     );
@@ -201,7 +197,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     );
     final OssInputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), OssInputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
   }
 
   @Test
@@ -219,7 +215,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     );
     final OssInputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), OssInputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
   }
 
   @Test
@@ -242,7 +238,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         null,
         mockConfigPropertiesWithoutKeyAndSecret
     );
-    Assert.assertNotNull(withPrefixes);
+    Assertions.assertNotNull(withPrefixes);
 
     withPrefixes.createEntity(new CloudObjectLocation("bucket", "path"));
     EasyMock.verify(mockConfigPropertiesWithoutKeyAndSecret);
@@ -265,7 +261,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     );
     final OssInputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), OssInputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
     EasyMock.verify(clientConfig);
   }
 
@@ -286,7 +282,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     );
     final OssInputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), OssInputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
     EasyMock.verify(clientConfig);
   }
 
@@ -305,58 +301,61 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     );
     final OssInputSource serdeWithPrefixes =
         MAPPER.readValue(MAPPER.writeValueAsString(withPrefixes), OssInputSource.class);
-    Assert.assertEquals(withPrefixes, serdeWithPrefixes);
+    Assertions.assertEquals(withPrefixes, serdeWithPrefixes);
   }
 
   @Test
   public void testSerdeWithInvalidArgs()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new OssInputSource(
-        OSSCLIENT,
-        INPUT_DATA_CONFIG,
-        EXPECTED_URIS,
-        PREFIXES,
-        EXPECTED_LOCATION,
-        null,
-        null,
-        null
-    );
+    assertThrows(IllegalArgumentException.class, () -> {
+      // constructor will explode
+      new OssInputSource(
+          OSSCLIENT,
+          INPUT_DATA_CONFIG,
+          EXPECTED_URIS,
+          PREFIXES,
+          EXPECTED_LOCATION,
+          null,
+          null,
+          null
+      );
+    });
   }
 
   @Test
   public void testSerdeWithOtherInvalidArgs()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new OssInputSource(
-        OSSCLIENT,
-        INPUT_DATA_CONFIG,
-        EXPECTED_URIS,
-        PREFIXES,
-        ImmutableList.of(),
-        null,
-        null,
-        null
-    );
+    assertThrows(IllegalArgumentException.class, () -> {
+      // constructor will explode
+      new OssInputSource(
+          OSSCLIENT,
+          INPUT_DATA_CONFIG,
+          EXPECTED_URIS,
+          PREFIXES,
+          ImmutableList.of(),
+          null,
+          null,
+          null
+      );
+    });
   }
 
   @Test
   public void testSerdeWithOtherOtherInvalidArgs()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    // constructor will explode
-    new OssInputSource(
-        OSSCLIENT,
-        INPUT_DATA_CONFIG,
-        ImmutableList.of(),
-        PREFIXES,
-        EXPECTED_LOCATION,
-        null,
-        null,
-        null
-    );
+    assertThrows(IllegalArgumentException.class, () -> {
+      // constructor will explode
+      new OssInputSource(
+          OSSCLIENT,
+          INPUT_DATA_CONFIG,
+          ImmutableList.of(),
+          PREFIXES,
+          EXPECTED_LOCATION,
+          null,
+          null,
+          null
+      );
+    });
   }
 
   @Test
@@ -385,7 +384,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(10, null)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(OSSCLIENT);
   }
 
@@ -413,7 +412,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(null, 1)
     );
 
-    Assert.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
+    Assertions.assertEquals(EXPECTED_COORDS, splits.map(InputSplit::get).collect(Collectors.toList()));
     EasyMock.verify(OSSCLIENT);
   }
 
@@ -441,7 +440,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         new MaxSizeSplitHintSpec(new HumanReadableBytes(CONTENT.length * 3L), null)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(EXPECTED_URIS.stream().map(CloudObjectLocation::new).collect(Collectors.toList())),
         splits.map(InputSplit::get).collect(Collectors.toList())
     );
@@ -471,7 +470,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         new JsonInputFormat(JSONPathSpec.DEFAULT, null, null, null, null),
         null
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(ImmutableList.of(new CloudObjectLocation(EXPECTED_URIS.get(0)))),
         splits.map(InputSplit::get).collect(Collectors.toList())
     );
@@ -497,15 +496,20 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    expectedException.expectMessage("Failed to get object summaries from aliyun OSS bucket[bar], prefix[foo/file2.csv]");
-    expectedException.expectCause(
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("can't list that bucket"))
+    final RuntimeException exception = Assertions.assertThrows(
+        RuntimeException.class,
+        () -> inputSource.createSplits(
+            new JsonInputFormat(JSONPathSpec.DEFAULT, null, null, null, null),
+            null
+        ).collect(Collectors.toList())
     );
-
-    inputSource.createSplits(
-        new JsonInputFormat(JSONPathSpec.DEFAULT, null, null, null, null),
-        null
-    ).collect(Collectors.toList());
+    Assertions.assertTrue(
+        exception.getMessage().contains(
+            "Failed to get object summaries from aliyun OSS bucket[bar], prefix[foo/file2.csv]"
+        )
+    );
+    Assertions.assertNotNull(exception.getCause());
+    Assertions.assertTrue(exception.getCause().getMessage().contains("can't list that bucket"));
   }
 
   @Test
@@ -538,7 +542,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        temporaryFolder.newFolder()
+        newFolder(temporaryFolder, "junit")
     );
 
     final InputStats inputStats = new InputStatsImpl();
@@ -546,12 +550,12 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
 
     while (iterator.hasNext()) {
       InputRow nextRow = iterator.next();
-      Assert.assertEquals(NOW, nextRow.getTimestamp());
-      Assert.assertEquals("hello", nextRow.getDimension("dim1").get(0));
-      Assert.assertEquals("world", nextRow.getDimension("dim2").get(0));
+      Assertions.assertEquals(NOW, nextRow.getTimestamp());
+      Assertions.assertEquals("hello", nextRow.getDimension("dim1").get(0));
+      Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
 
-    Assert.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
+    Assertions.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
     EasyMock.verify(OSSCLIENT);
   }
 
@@ -585,7 +589,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     InputSourceReader reader = inputSource.reader(
         someSchema,
         new CsvInputFormat(ImmutableList.of("time", "dim1", "dim2"), "|", false, null, 0, null),
-        temporaryFolder.newFolder()
+        newFolder(temporaryFolder, "junit")
     );
 
     final InputStats inputStats = new InputStatsImpl();
@@ -593,12 +597,12 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
 
     while (iterator.hasNext()) {
       InputRow nextRow = iterator.next();
-      Assert.assertEquals(NOW, nextRow.getTimestamp());
-      Assert.assertEquals("hello", nextRow.getDimension("dim1").get(0));
-      Assert.assertEquals("world", nextRow.getDimension("dim2").get(0));
+      Assertions.assertEquals(NOW, nextRow.getTimestamp());
+      Assertions.assertEquals("hello", nextRow.getDimension("dim1").get(0));
+      Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
 
-    Assert.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
+    Assertions.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
     EasyMock.verify(OSSCLIENT);
   }
 
@@ -616,7 +620,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(ImmutableSet.of(OssStorageDruidModule.SCHEME), inputSource.getTypes());
+    Assertions.assertEquals(ImmutableSet.of(OssStorageDruidModule.SCHEME), inputSource.getTypes());
   }
 
   @Test
@@ -633,16 +637,16 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         EnumSet.of(SystemField.URI, SystemField.BUCKET, SystemField.PATH),
         inputSource.getConfiguredSystemFields()
     );
 
     final OssEntity entity = new OssEntity(null, new CloudObjectLocation("foo", "bar"));
 
-    Assert.assertEquals("oss://foo/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
-    Assert.assertEquals("foo", inputSource.getSystemFieldValue(entity, SystemField.BUCKET));
-    Assert.assertEquals("bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
+    Assertions.assertEquals("oss://foo/bar", inputSource.getSystemFieldValue(entity, SystemField.URI));
+    Assertions.assertEquals("foo", inputSource.getSystemFieldValue(entity, SystemField.BUCKET));
+    Assertions.assertEquals("bar", inputSource.getSystemFieldValue(entity, SystemField.PATH));
   }
 
   @Test
@@ -774,6 +778,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     {
       return OSSCLIENT;
     }
+
   }
 
   public static class ItemDeserializer<T> extends StdDeserializer<T>
@@ -793,6 +798,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     {
       throw new UnsupportedOperationException();
     }
+
   }
 
   private static ObjectMetadata objectMetadataWithSize(final long size)
@@ -800,5 +806,15 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
     final ObjectMetadata retVal = new ObjectMetadata();
     retVal.setContentLength(size);
     return retVal;
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
+    final String subFolder = String.join("/", subDirs);
+    final File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 }

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
@@ -556,7 +556,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
       Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
 
-    Assertions.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
+    Assertions.assertEquals(2L * CONTENT.length, inputStats.getProcessedBytes());
     EasyMock.verify(OSSCLIENT);
   }
 
@@ -603,7 +603,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
       Assertions.assertEquals("world", nextRow.getDimension("dim2").get(0));
     }
 
-    Assertions.assertEquals(2 * CONTENT.length, inputStats.getProcessedBytes());
+    Assertions.assertEquals(2L * CONTENT.length, inputStats.getProcessedBytes());
     EasyMock.verify(OSSCLIENT);
   }
 

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/data/input/aliyun/OssInputSourceTest.java
@@ -59,6 +59,7 @@ import org.apache.druid.data.input.impl.systemfield.SystemField;
 import org.apache.druid.data.input.impl.systemfield.SystemFields;
 import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
@@ -812,9 +813,7 @@ public class OssInputSourceTest extends InitializedNullHandlingTest
   {
     final String subFolder = String.join("/", subDirs);
     final File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 }

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentArchiverTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentArchiverTest.java
@@ -34,9 +34,9 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -94,7 +94,7 @@ public class OssDataSegmentArchiverTest
       .size(0)
       .build();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpStatic()
   {
     PUSHER_CONFIG.setPrefix("push_base");
@@ -126,7 +126,7 @@ public class OssDataSegmentArchiverTest
         return archivedSegment;
       }
     };
-    Assert.assertEquals(archivedSegment, archiver.archive(SOURCE_SEGMENT));
+    Assertions.assertEquals(archivedSegment, archiver.archive(SOURCE_SEGMENT));
   }
 
   @Test
@@ -145,7 +145,7 @@ public class OssDataSegmentArchiverTest
         return SOURCE_SEGMENT;
       }
     };
-    Assert.assertNull(archiver.archive(SOURCE_SEGMENT));
+    Assertions.assertNull(archiver.archive(SOURCE_SEGMENT));
   }
 
   @Test
@@ -173,7 +173,7 @@ public class OssDataSegmentArchiverTest
         return archivedSegment;
       }
     };
-    Assert.assertEquals(archivedSegment, archiver.restore(SOURCE_SEGMENT));
+    Assertions.assertEquals(archivedSegment, archiver.restore(SOURCE_SEGMENT));
   }
 
   @Test
@@ -192,6 +192,6 @@ public class OssDataSegmentArchiverTest
         return SOURCE_SEGMENT;
       }
     };
-    Assert.assertNull(archiver.restore(SOURCE_SEGMENT));
+    Assertions.assertNull(archiver.restore(SOURCE_SEGMENT));
   }
 }

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentKillerTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentKillerTest.java
@@ -29,18 +29,18 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockExtension;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 
-@RunWith(EasyMockRunner.class)
+@ExtendWith(EasyMockExtension.class)
 public class OssDataSegmentKillerTest extends EasyMockSupport
 {
   private static final String KEY_1 = "key1";
@@ -83,7 +83,7 @@ public class OssDataSegmentKillerTest extends EasyMockSupport
     catch (ISE e) {
       thrownISEException = true;
     }
-    Assert.assertTrue(thrownISEException);
+    Assertions.assertTrue(thrownISEException);
     EasyMock.verify(client, segmentPusherConfig, inputDataConfig);
   }
 
@@ -200,7 +200,7 @@ public class OssDataSegmentKillerTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
     EasyMock.verify(client, segmentPusherConfig, inputDataConfig);
   }
 }

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentMoverTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentMoverTest.java
@@ -36,14 +36,16 @@ import org.apache.druid.java.util.common.MapUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class OssDataSegmentMoverTest
 {
@@ -81,12 +83,12 @@ public class OssDataSegmentMoverTest
     );
 
     Map<String, Object> targetLoadSpec = movedSegment.getLoadSpec();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "targetBaseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
         MapUtils.getString(targetLoadSpec, "key")
     );
-    Assert.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
-    Assert.assertTrue(mockClient.didMove());
+    Assertions.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
+    Assertions.assertTrue(mockClient.didMove());
   }
 
   @Test
@@ -107,24 +109,26 @@ public class OssDataSegmentMoverTest
 
     Map<String, Object> targetLoadSpec = movedSegment.getLoadSpec();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "targetBaseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
         MapUtils.getString(targetLoadSpec, "key")
     );
-    Assert.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
-    Assert.assertFalse(mockOssClient.didMove());
+    Assertions.assertEquals("archive", MapUtils.getString(targetLoadSpec, "bucket"));
+    Assertions.assertFalse(mockOssClient.didMove());
   }
 
-  @Test(expected = SegmentLoadingException.class)
-  public void testMoveException() throws Exception
+  @Test
+  public void testMoveException()
   {
-    MockClient mockClient = new MockClient();
-    OssDataSegmentMover mover = new OssDataSegmentMover(Suppliers.ofInstance(mockClient), new OssStorageConfig());
+    assertThrows(SegmentLoadingException.class, () -> {
+      MockClient mockClient = new MockClient();
+      OssDataSegmentMover mover = new OssDataSegmentMover(Suppliers.ofInstance(mockClient), new OssStorageConfig());
 
-    mover.move(
-        SOURCE_SEGMENT,
-        ImmutableMap.of("baseKey", "targetBaseKey", "bucket", "archive")
-    );
+      mover.move(
+          SOURCE_SEGMENT,
+          ImmutableMap.of("baseKey", "targetBaseKey", "bucket", "archive")
+      );
+    });
   }
 
   @Test
@@ -150,27 +154,29 @@ public class OssDataSegmentMoverTest
     ), ImmutableMap.of("bucket", "DOES NOT EXIST", "baseKey", "baseKey"));
   }
 
-  @Test(expected = SegmentLoadingException.class)
-  public void testFailsToMoveMissing() throws Exception
+  @Test
+  public void testFailsToMoveMissing()
   {
-    MockClient client = new MockClient();
-    OssDataSegmentMover mover = new OssDataSegmentMover(Suppliers.ofInstance(client), new OssStorageConfig());
-    mover.move(new DataSegment(
-        "test",
-        Intervals.of("2013-01-01/2013-01-02"),
-        "1",
-        ImmutableMap.of(
-            "key",
-            "baseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
-            "bucket",
-            "DOES NOT EXIST"
-        ),
-        ImmutableList.of("dim1", "dim1"),
-        ImmutableList.of("metric1", "metric2"),
-        NoneShardSpec.instance(),
-        0,
-        1
-    ), ImmutableMap.of("bucket", "DOES NOT EXIST", "baseKey", "baseKey2"));
+    assertThrows(SegmentLoadingException.class, () -> {
+      MockClient client = new MockClient();
+      OssDataSegmentMover mover = new OssDataSegmentMover(Suppliers.ofInstance(client), new OssStorageConfig());
+      mover.move(new DataSegment(
+          "test",
+          Intervals.of("2013-01-01/2013-01-02"),
+          "1",
+          ImmutableMap.of(
+              "key",
+              "baseKey/test/2013-01-01T00:00:00.000Z_2013-01-02T00:00:00.000Z/1/0/index.zip",
+              "bucket",
+              "DOES NOT EXIST"
+          ),
+          ImmutableList.of("dim1", "dim1"),
+          ImmutableList.of("metric1", "metric2"),
+          NoneShardSpec.instance(),
+          0,
+          1
+      ), ImmutableMap.of("bucket", "DOES NOT EXIST", "baseKey", "baseKey2"));
+    });
   }
 
   private static class MockClient extends OSSClient

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPullerTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPullerTest.java
@@ -29,10 +29,9 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -50,8 +49,8 @@ import java.util.zip.GZIPOutputStream;
  */
 public class OssDataSegmentPullerTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   @Test
   public void testSimpleGetVersion() throws IOException
@@ -83,7 +82,7 @@ public class OssDataSegmentPullerTest
 
     EasyMock.verify(ossClient);
 
-    Assert.assertEquals(StringUtils.format("%d", new Date(0).getTime()), version);
+    Assertions.assertEquals(StringUtils.format("%d", new Date(0).getTime()), version);
   }
 
   @Test
@@ -94,7 +93,7 @@ public class OssDataSegmentPullerTest
     final OSS ossClient = EasyMock.createStrictMock(OSS.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("gzTest.gz");
+    final File tmpFile = new File(temporaryFolder, "gzTest.gz");
 
     try (final FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
          final OutputStream outputStream = new GZIPOutputStream(fileOutputStream)) {
@@ -114,7 +113,7 @@ public class OssDataSegmentPullerTest
     final ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setLastModified(new Date(1));
 
-    final File tmpDir = temporaryFolder.newFolder("gzTestDir");
+    final File tmpDir = newFolder(temporaryFolder, "gzTestDir");
 
     try (final InputStream objectContent = new FileInputStream(tmpFile)) {
       object0.setObjectContent(objectContent);
@@ -138,10 +137,10 @@ public class OssDataSegmentPullerTest
       );
       EasyMock.verify(ossClient);
 
-      Assert.assertEquals(value.length, result.size());
+      Assertions.assertEquals(value.length, result.size());
       final File expected = new File(tmpDir, "renames-0");
-      Assert.assertTrue(expected.exists());
-      Assert.assertEquals(value.length, expected.length());
+      Assertions.assertTrue(expected.exists());
+      Assertions.assertEquals(value.length, expected.length());
     }
   }
 
@@ -153,7 +152,7 @@ public class OssDataSegmentPullerTest
     final OSS ossClient = EasyMock.createStrictMock(OSS.class);
     final byte[] value = bucket.getBytes(StandardCharsets.UTF_8);
 
-    final File tmpFile = temporaryFolder.newFile("gzTest.gz");
+    final File tmpFile = new File(temporaryFolder, "gzTest.gz");
 
     try (final FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
          final OutputStream outputStream = new GZIPOutputStream(fileOutputStream)) {
@@ -169,7 +168,7 @@ public class OssDataSegmentPullerTest
     final ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setLastModified(new Date(0));
 
-    File tmpDir = temporaryFolder.newFolder("gzTestDir");
+    File tmpDir = newFolder(temporaryFolder, "gzTestDir");
 
     OSSException exception = new OSSException("OssDataSegmentPullerTest", "NoSuchKey", null, null, null, null, null);
     try (final InputStream objectContent = new FileInputStream(tmpFile)) {
@@ -200,11 +199,21 @@ public class OssDataSegmentPullerTest
       );
       EasyMock.verify(ossClient);
 
-      Assert.assertEquals(value.length, result.size());
+      Assertions.assertEquals(value.length, result.size());
       final File expected = new File(tmpDir, "renames-0");
-      Assert.assertTrue(expected.exists());
-      Assert.assertEquals(value.length, expected.length());
+      Assertions.assertTrue(expected.exists());
+      Assertions.assertEquals(value.length, expected.length());
     }
+  }
+
+  private static File newFolder(File root, String... subDirs) throws IOException
+  {
+    final String subFolder = String.join("/", subDirs);
+    final File result = new File(root, subFolder);
+    if (!result.mkdirs()) {
+      throw new IOException("Couldn't create folders " + root);
+    }
+    return result;
   }
 
 }

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPullerTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPullerTest.java
@@ -210,9 +210,7 @@ public class OssDataSegmentPullerTest
   {
     final String subFolder = String.join("/", subDirs);
     final File result = new File(root, subFolder);
-    if (!result.mkdirs()) {
-      throw new IOException("Couldn't create folders " + root);
-    }
+    FileUtils.mkdirp(result);
     return result;
   }
 

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherConfigTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherConfigTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.storage.aliyun;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -36,7 +36,7 @@ public class OssDataSegmentPusherConfigTest
     String jsonConfig = "{\"bucket\":\"bucket1\",\"prefix\":\"dataSource1\"}";
 
     OssStorageConfig config = JSON_MAPPER.readValue(jsonConfig, OssStorageConfig.class);
-    Assert.assertEquals(jsonConfig, JSON_MAPPER.writeValueAsString(config));
+    Assertions.assertEquals(jsonConfig, JSON_MAPPER.writeValueAsString(config));
   }
 
   @Test
@@ -46,6 +46,6 @@ public class OssDataSegmentPusherConfigTest
     String expectedJsonConfig = "{\"bucket\":\"bucket1\",\"prefix\":\"dataSource1\"}";
 
     OssStorageConfig config = JSON_MAPPER.readValue(jsonConfig, OssStorageConfig.class);
-    Assert.assertEquals(expectedJsonConfig, JSON_MAPPER.writeValueAsString(config));
+    Assertions.assertEquals(expectedJsonConfig, JSON_MAPPER.writeValueAsString(config));
   }
 }

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherTest.java
@@ -26,10 +26,9 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -56,8 +55,8 @@ public class OssDataSegmentPusherTest
     }
   }
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   @Test
   public void testPush() throws Exception
@@ -91,7 +90,7 @@ public class OssDataSegmentPusherTest
     OssDataSegmentPusher pusher = new OssDataSegmentPusher(client, config);
 
     // Create a mock segment on disk
-    File tmp = tempFolder.newFile("version.bin");
+    File tmp = new File(tempFolder, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
     Files.write(data, tmp);
@@ -109,16 +108,16 @@ public class OssDataSegmentPusherTest
         size
     );
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, useUniquePath);
+    DataSegment segment = pusher.push(tempFolder, segmentToPush, useUniquePath);
 
-    Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
-    Assert.assertEquals(1, (int) segment.getBinaryVersion());
-    Assert.assertEquals("bucket", segment.getLoadSpec().get("bucket"));
-    Assert.assertTrue(
-        segment.getLoadSpec().get("key").toString(),
-        Pattern.compile(matcher).matcher(segment.getLoadSpec().get("key").toString()).matches()
+    Assertions.assertEquals(segmentToPush.getSize(), segment.getSize());
+    Assertions.assertEquals(1, (int) segment.getBinaryVersion());
+    Assertions.assertEquals("bucket", segment.getLoadSpec().get("bucket"));
+    Assertions.assertTrue(
+        Pattern.compile(matcher).matcher(segment.getLoadSpec().get("key").toString()).matches(),
+        segment.getLoadSpec().get("key").toString()
     );
-    Assert.assertEquals("oss_zip", segment.getLoadSpec().get("type"));
+    Assertions.assertEquals("oss_zip", segment.getLoadSpec().get("type"));
 
     EasyMock.verify(client);
   }

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssDataSegmentPusherTest.java
@@ -90,7 +90,7 @@ public class OssDataSegmentPusherTest
     OssDataSegmentPusher pusher = new OssDataSegmentPusher(client, config);
 
     // Create a mock segment on disk
-    File tmp = new File(tempFolder, "version.bin");
+    final File tmp = new File(tempFolder, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
     Files.write(data, tmp);

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssObjectSummaryIteratorTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssObjectSummaryIteratorTest.java
@@ -26,8 +26,8 @@ import com.aliyun.oss.model.OSSObjectSummary;
 import com.aliyun.oss.model.ObjectListing;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -206,10 +206,10 @@ public class OssObjectSummaryIteratorTest
         )
     );
 
-    Assert.assertEquals(
-        prefixes.toString(),
+    Assertions.assertEquals(
         expectedObjects.stream().map(OssUtils::summaryToUri).collect(Collectors.toList()),
-        actualObjects.stream().map(OssUtils::summaryToUri).collect(Collectors.toList())
+        actualObjects.stream().map(OssUtils::summaryToUri).collect(Collectors.toList()),
+        prefixes.toString()
     );
   }
 

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssStorageDruidModuleTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssStorageDruidModuleTest.java
@@ -28,8 +28,8 @@ import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.segment.loading.OmniDataSegmentArchiver;
 import org.apache.druid.segment.loading.OmniDataSegmentKiller;
 import org.apache.druid.segment.loading.OmniDataSegmentMover;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -40,8 +40,8 @@ public class OssStorageDruidModuleTest
   {
     Injector injector = createInjector();
     OmniDataSegmentKiller killer = injector.getInstance(OmniDataSegmentKiller.class);
-    Assert.assertTrue(killer.getKillers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
-    Assert.assertSame(
+    Assertions.assertTrue(killer.getKillers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
+    Assertions.assertSame(
         killer.getKillers().get(OssStorageDruidModule.SCHEME_ZIP).get(),
         killer.getKillers().get(OssStorageDruidModule.SCHEME_ZIP).get()
     );
@@ -52,8 +52,8 @@ public class OssStorageDruidModuleTest
   {
     Injector injector = createInjector();
     OmniDataSegmentArchiver archiver = injector.getInstance(OmniDataSegmentArchiver.class);
-    Assert.assertTrue(archiver.getArchivers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
-    Assert.assertSame(
+    Assertions.assertTrue(archiver.getArchivers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
+    Assertions.assertSame(
         archiver.getArchivers().get(OssStorageDruidModule.SCHEME_ZIP).get(),
         archiver.getArchivers().get(OssStorageDruidModule.SCHEME_ZIP).get()
     );
@@ -64,8 +64,8 @@ public class OssStorageDruidModuleTest
   {
     Injector injector = createInjector();
     OmniDataSegmentMover mover = injector.getInstance(OmniDataSegmentMover.class);
-    Assert.assertTrue(mover.getMovers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
-    Assert.assertSame(
+    Assertions.assertTrue(mover.getMovers().containsKey(OssStorageDruidModule.SCHEME_ZIP));
+    Assertions.assertSame(
         mover.getMovers().get(OssStorageDruidModule.SCHEME_ZIP).get(),
         mover.getMovers().get(OssStorageDruidModule.SCHEME_ZIP).get()
     );

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssTaskLogsTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssTaskLogsTest.java
@@ -37,14 +37,13 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.common.utils.CurrentTimeMillisSupplier;
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockExtension;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nonnull;
 import java.io.BufferedReader;
@@ -60,7 +59,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@RunWith(EasyMockRunner.class)
+@ExtendWith(EasyMockExtension.class)
 public class OssTaskLogsTest extends EasyMockSupport
 {
 
@@ -85,8 +84,8 @@ public class OssTaskLogsTest extends EasyMockSupport
   @Mock
   private OSS ossClient;
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   @Test
   public void testTaskLogsPushWithAclDisabled() throws Exception
@@ -96,8 +95,8 @@ public class OssTaskLogsTest extends EasyMockSupport
 
     List<Grant> grantList = testPushInternal(true, ownerId, ownerDisplayName);
 
-    Assert.assertNotNull("Grant list should not be null", grantList);
-    Assert.assertEquals("Grant list should be empty as ACL is disabled", 0, grantList.size());
+    Assertions.assertNotNull(grantList, "Grant list should not be null");
+    Assertions.assertEquals(0, grantList.size(), "Grant list should be empty as ACL is disabled");
   }
 
   @Test
@@ -192,7 +191,7 @@ public class OssTaskLogsTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
 
     EasyMock.verify(ossClient, timeSupplier);
   }
@@ -279,7 +278,7 @@ public class OssTaskLogsTest extends EasyMockSupport
       ioExceptionThrown = true;
     }
 
-    Assert.assertTrue(ioExceptionThrown);
+    Assertions.assertTrue(ioExceptionThrown);
 
     EasyMock.verify(ossClient, timeSupplier);
   }
@@ -306,7 +305,7 @@ public class OssTaskLogsTest extends EasyMockSupport
       taskLogs = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(LOG_CONTENTS, taskLogs);
+    Assertions.assertEquals(LOG_CONTENTS, taskLogs);
   }
 
   @Test
@@ -331,7 +330,7 @@ public class OssTaskLogsTest extends EasyMockSupport
       taskLogs = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
+    Assertions.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
   }
 
   @Test
@@ -356,7 +355,7 @@ public class OssTaskLogsTest extends EasyMockSupport
       taskLogs = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
+    Assertions.assertEquals(LOG_CONTENTS.substring(1), taskLogs);
   }
 
 
@@ -382,7 +381,7 @@ public class OssTaskLogsTest extends EasyMockSupport
       report = reader.lines().collect(Collectors.joining("\n"));
     }
 
-    Assert.assertEquals(REPORT_CONTENTS, report);
+    Assertions.assertEquals(REPORT_CONTENTS, report);
   }
 
   @Nonnull
@@ -424,7 +423,8 @@ public class OssTaskLogsTest extends EasyMockSupport
     OssTaskLogs taskLogs = new OssTaskLogs(ossClient, config, inputDataConfig, timeSupplier);
 
     String taskId = "index_test-datasource_2019-06-18T13:30:28.887Z";
-    File logFile = tempFolder.newFile("test_log_file");
+    File logFile = new File(tempFolder, "test_log_file");
+    Assertions.assertTrue(logFile.createNewFile());
 
     taskLogs.pushTaskLog(taskId, logFile);
 

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssTaskLogsTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssTaskLogsTest.java
@@ -422,8 +422,8 @@ public class OssTaskLogsTest extends EasyMockSupport
     OssInputDataConfig inputDataConfig = new OssInputDataConfig();
     OssTaskLogs taskLogs = new OssTaskLogs(ossClient, config, inputDataConfig, timeSupplier);
 
-    String taskId = "index_test-datasource_2019-06-18T13:30:28.887Z";
-    File logFile = new File(tempFolder, "test_log_file");
+    final String taskId = "index_test-datasource_2019-06-18T13:30:28.887Z";
+    final File logFile = new File(tempFolder, "test_log_file");
     Assertions.assertTrue(logFile.createNewFile());
 
     taskLogs.pushTaskLog(taskId, logFile);

--- a/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssTimestampVersionedDataFinderTest.java
+++ b/extensions-contrib/aliyun-oss-extensions/src/test/java/org/apache/druid/storage/aliyun/OssTimestampVersionedDataFinderTest.java
@@ -25,8 +25,8 @@ import com.aliyun.oss.model.OSSObjectSummary;
 import com.aliyun.oss.model.ObjectListing;
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.Date;
@@ -75,7 +75,7 @@ public class OssTimestampVersionedDataFinderTest
 
     URI expected = URI.create(StringUtils.format("%s://%s/%s", OssStorageDruidModule.SCHEME, bucket, object1.getKey()));
 
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 
   @Test
@@ -102,7 +102,7 @@ public class OssTimestampVersionedDataFinderTest
 
     EasyMock.verify(oss);
 
-    Assert.assertEquals(null, latest);
+    Assertions.assertEquals(null, latest);
   }
 
   @Test
@@ -139,7 +139,7 @@ public class OssTimestampVersionedDataFinderTest
 
     URI expected = URI.create(StringUtils.format("%s://%s/%s", OssStorageDruidModule.SCHEME, bucket, object0.getKey()));
 
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 
   @Test
@@ -173,6 +173,6 @@ public class OssTimestampVersionedDataFinderTest
 
     URI expected = URI.create(StringUtils.format("%s://%s/%s", OssStorageDruidModule.SCHEME, bucket, object0.getKey()));
 
-    Assert.assertEquals(expected, latest);
+    Assertions.assertEquals(expected, latest);
   }
 }

--- a/extensions-contrib/moving-average-query/pom.xml
+++ b/extensions-contrib/moving-average-query/pom.xml
@@ -38,6 +38,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -101,23 +116,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageIterableTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageIterableTest.java
@@ -34,12 +34,10 @@ import org.apache.druid.query.movingaverage.averagers.AveragerFactory;
 import org.apache.druid.query.movingaverage.averagers.ConstantAveragerFactory;
 import org.apache.druid.query.movingaverage.averagers.LongMeanAveragerFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -115,54 +113,54 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
 
     Iterator<Row> iter = iterable.iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row r = iter.next();
-    Assert.assertEquals(JAN_1, r.getTimestamp());
-    Assert.assertEquals("m", r.getRaw(GENDER));
+    Assertions.assertEquals(JAN_1, r.getTimestamp());
+    Assertions.assertEquals("m", r.getRaw(GENDER));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
-    Assert.assertEquals(JAN_1, r.getTimestamp());
-    Assert.assertEquals("f", r.getRaw(GENDER));
+    Assertions.assertEquals(JAN_1, r.getTimestamp());
+    Assertions.assertEquals("f", r.getRaw(GENDER));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
-    Assert.assertEquals(JAN_2, r.getTimestamp());
-    Assert.assertEquals("m", r.getRaw(GENDER));
+    Assertions.assertEquals(JAN_2, r.getTimestamp());
+    Assertions.assertEquals("m", r.getRaw(GENDER));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
-    Assert.assertEquals(JAN_2, r.getTimestamp());
-    Assert.assertEquals("f", r.getRaw(GENDER));
+    Assertions.assertEquals(JAN_2, r.getTimestamp());
+    Assertions.assertEquals("f", r.getRaw(GENDER));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
     Row r2 = r;
-    Assert.assertEquals(JAN_3, r.getTimestamp());
-    Assert.assertEquals("US", r.getRaw(COUNTRY));
+    Assertions.assertEquals(JAN_3, r.getTimestamp());
+    Assertions.assertEquals("US", r.getRaw(COUNTRY));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
-    Assert.assertEquals(JAN_3, r.getTimestamp());
-    Assert.assertEquals("US", r.getRaw(COUNTRY));
-    MatcherAssert.assertThat(r.getRaw(AGE), CoreMatchers.not(CoreMatchers.equalTo(r2.getRaw(AGE))));
+    Assertions.assertEquals(JAN_3, r.getTimestamp());
+    Assertions.assertEquals("US", r.getRaw(COUNTRY));
+    Assertions.assertNotEquals(r.getRaw(AGE), r2.getRaw(AGE));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
-    Assert.assertEquals(JAN_4, r.getTimestamp());
-    Assert.assertEquals("f", r.getRaw(GENDER));
+    Assertions.assertEquals(JAN_4, r.getTimestamp());
+    Assertions.assertEquals("f", r.getRaw(GENDER));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
-    Assert.assertEquals(JAN_4, r.getTimestamp());
-    Assert.assertEquals("u", r.getRaw(GENDER));
+    Assertions.assertEquals(JAN_4, r.getTimestamp());
+    Assertions.assertEquals("u", r.getRaw(GENDER));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     r = iter.next();
-    Assert.assertEquals(JAN_4, r.getTimestamp());
-    Assert.assertEquals("m", r.getRaw(GENDER));
+    Assertions.assertEquals(JAN_4, r.getTimestamp());
+    Assertions.assertEquals("m", r.getRaw(GENDER));
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
@@ -212,30 +210,30 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(new LongSumAggregatorFactory("pageViews", "pageViews"))
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row caResult = iter.next();
 
-    Assert.assertEquals(JAN_1, caResult.getTimestamp());
-    Assert.assertEquals("m", (caResult.getDimension("gender")).get(0));
-    Assert.assertEquals(retval, caResult.getMetric("costPageViews").floatValue(), 0.0f);
-    Assert.assertEquals(1.4285715f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals(JAN_1, caResult.getTimestamp());
+    Assertions.assertEquals("m", (caResult.getDimension("gender")).get(0));
+    Assertions.assertEquals(retval, caResult.getMetric("costPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals(1.4285715f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     caResult = iter.next();
-    Assert.assertEquals("m", (caResult.getDimension("gender")).get(0));
-    Assert.assertEquals(4.285714f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (caResult.getDimension("gender")).get(0));
+    Assertions.assertEquals(4.285714f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     caResult = iter.next();
-    Assert.assertEquals("m", (caResult.getDimension("gender")).get(0));
-    Assert.assertEquals(8.571428f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (caResult.getDimension("gender")).get(0));
+    Assertions.assertEquals(8.571428f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     caResult = iter.next();
-    Assert.assertEquals("f", (caResult.getDimension("gender")).get(0));
-    Assert.assertEquals(5.714285850f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("f", (caResult.getDimension("gender")).get(0));
+    Assertions.assertEquals(5.714285850f, caResult.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
 
   }
 
@@ -281,37 +279,37 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(new LongSumAggregatorFactory("pageViews", "pageViews"))
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
 
   }
 
@@ -355,27 +353,27 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(new LongSumAggregatorFactory("pageViews", "pageViews"))
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   // test injection when the data is missing at the end
@@ -417,37 +415,37 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(new LongSumAggregatorFactory("pageViews", "pageViews"))
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   // test injection when the data is missing in the middle
@@ -496,70 +494,70 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
     ).iterator();
 
     // Jan 1
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_1, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_1, (result.getTimestamp()));
 
     // Jan 2
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_2, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_2, (result.getTimestamp()));
 
     // Jan 3
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_3, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_3, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_3, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_3, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_3, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_3, (result.getTimestamp()));
 
     // Jan 4
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_4, (result.getTimestamp()));
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_4, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("u", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_4, (result.getTimestamp()));
+    Assertions.assertEquals("u", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_4, (result.getTimestamp()));
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("f", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(JAN_4, (result.getTimestamp()));
+    Assertions.assertEquals("f", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(JAN_4, (result.getTimestamp()));
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
@@ -597,17 +595,17 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(new LongSumAggregatorFactory("pageViews", "pageViews"))
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
@@ -644,27 +642,27 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(new LongSumAggregatorFactory("pageViews", "pageViews"))
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
@@ -705,27 +703,27 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(filteredAggregatorFactory)
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 
   @Test
@@ -764,37 +762,37 @@ public class MovingAverageIterableTest extends InitializedNullHandlingTest
         Collections.singletonList(new LongSumAggregatorFactory("pageViews", "pageViews"))
     ).iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     Row result = iter.next();
 
-    Assert.assertEquals(JAN_1, result.getTimestamp());
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals(JAN_1, result.getTimestamp());
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(2.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals(JAN_2, result.getTimestamp());
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals(JAN_2, result.getTimestamp());
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals(JAN_3, result.getTimestamp());
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals(JAN_3, result.getTimestamp());
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals(JAN_4, result.getTimestamp());
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals(JAN_4, result.getTimestamp());
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(7.5f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     result = iter.next();
-    Assert.assertEquals(JAN_5, result.getTimestamp());
-    Assert.assertEquals("m", (result.getDimension("gender")).get(0));
-    Assert.assertEquals(5.0f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
+    Assertions.assertEquals(JAN_5, result.getTimestamp());
+    Assertions.assertEquals("m", (result.getDimension("gender")).get(0));
+    Assertions.assertEquals(5.0f, result.getMetric("movingAvgPageViews").floatValue(), 0.0f);
 
-    Assert.assertFalse(iter.hasNext());
+    Assertions.assertFalse(iter.hasNext());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
@@ -70,22 +70,20 @@ import org.apache.druid.query.timeseries.TimeseriesQuery;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
 import org.apache.druid.segment.join.MapJoinableFactory;
 import org.apache.druid.server.ClientQuerySegmentWalker;
-import org.apache.druid.server.QueryStackTests;
+import org.apache.druid.server.QueryScheduler;
 import org.apache.druid.server.SubqueryGuardrailHelper;
 import org.apache.druid.server.initialization.ServerConfig;
 import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.apache.druid.server.metrics.SubqueryCountStatsProvider;
+import org.apache.druid.server.scheduling.ManualQueryPrioritizationStrategy;
+import org.apache.druid.server.scheduling.NoQueryLaningStrategy;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.TimelineLookup;
 import org.apache.druid.utils.JvmUtils;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -102,20 +100,25 @@ import java.util.concurrent.ForkJoinPool;
 /**
  * Base class for implementing MovingAverageQuery tests
  */
-@RunWith(Parameterized.class)
 public class MovingAverageQueryTest extends InitializedNullHandlingTest
 {
-  private final ObjectMapper jsonMapper;
-  private final QueryRunnerFactoryConglomerate conglomerate;
-  private final RetryQueryRunnerConfig retryConfig;
-  private final ServerConfig serverConfig;
+  private static final QueryScheduler NOOP_SCHEDULER = new QueryScheduler(
+      0,
+      ManualQueryPrioritizationStrategy.INSTANCE,
+      NoQueryLaningStrategy.INSTANCE,
+      new ServerConfig()
+  );
+
+  private ObjectMapper jsonMapper;
+  private QueryRunnerFactoryConglomerate conglomerate;
+  private RetryQueryRunnerConfig retryConfig;
+  private ServerConfig serverConfig;
 
   private final List<ResultRow> groupByResults = new ArrayList<>();
   private final List<Result<TimeseriesResultValue>> timeseriesResults = new ArrayList<>();
 
-  private final TestConfig config;
+  private TestConfig config;
 
-  @Parameters(name = "{0}")
   public static Iterable<String[]> data() throws IOException
   {
     List<String[]> tests = new ArrayList<>();
@@ -134,7 +137,7 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
     return tests;
   }
 
-  public MovingAverageQueryTest(String yamlFile) throws IOException
+  public void initMovingAverageQueryTest(String yamlFile) throws IOException
   {
 
     List<Module> modules = getRequiredModules();
@@ -305,16 +308,18 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
   /**
    * Validate that the specified query behaves correctly.
    */
+  @MethodSource("data")
   @SuppressWarnings({"unchecked", "rawtypes"})
-  @Test
-  public void testQuery() throws IOException
+  @ParameterizedTest(name = "{0}")
+  public void testQuery(String yamlFile) throws IOException
   {
+    initMovingAverageQueryTest(yamlFile);
     Query<?> query = jsonMapper.readValue(getQueryString(), Query.class);
-    MatcherAssert.assertThat(query, IsInstanceOf.instanceOf(getExpectedQueryType()));
+    Assertions.assertInstanceOf(getExpectedQueryType(), query);
 
     List<MapBasedRow> expectedResults = jsonMapper.readValue(getExpectedResultString(), getExpectedResultType());
-    Assert.assertNotNull(expectedResults);
-    MatcherAssert.assertThat(expectedResults, IsInstanceOf.instanceOf(List.class));
+    Assertions.assertNotNull(expectedResults);
+    Assertions.assertInstanceOf(List.class, expectedResults);
 
     DruidHttpClientConfig httpClientConfig = new DruidHttpClientConfig()
     {
@@ -371,7 +376,7 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
         httpClientConfig,
         new BrokerParallelMergeConfig(),
         ForkJoinPool.commonPool(),
-        QueryStackTests.DEFAULT_NOOP_SCHEDULER,
+        NOOP_SCHEDULER,
         new NoopServiceEmitter()
     );
 
@@ -402,6 +407,6 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
     expectedResults = consistentTypeCasting(expectedResults);
     actualResults = consistentTypeCasting(actualResults);
 
-    Assert.assertEquals(expectedResults, actualResults);
+    Assertions.assertEquals(expectedResults, actualResults);
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/MovingAverageQueryTest.java
@@ -82,7 +82,8 @@ import org.apache.druid.timeline.TimelineLookup;
 import org.apache.druid.utils.JvmUtils;
 import org.joda.time.Interval;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.BufferedReader;
@@ -100,6 +101,8 @@ import java.util.concurrent.ForkJoinPool;
 /**
  * Base class for implementing MovingAverageQuery tests
  */
+@ParameterizedClass(name = "{0}")
+@MethodSource("data")
 public class MovingAverageQueryTest extends InitializedNullHandlingTest
 {
   private static final QueryScheduler NOOP_SCHEDULER = new QueryScheduler(
@@ -109,15 +112,15 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
       new ServerConfig()
   );
 
-  private ObjectMapper jsonMapper;
-  private QueryRunnerFactoryConglomerate conglomerate;
-  private RetryQueryRunnerConfig retryConfig;
-  private ServerConfig serverConfig;
+  private final ObjectMapper jsonMapper;
+  private final QueryRunnerFactoryConglomerate conglomerate;
+  private final RetryQueryRunnerConfig retryConfig;
+  private final ServerConfig serverConfig;
 
   private final List<ResultRow> groupByResults = new ArrayList<>();
   private final List<Result<TimeseriesResultValue>> timeseriesResults = new ArrayList<>();
 
-  private TestConfig config;
+  private final TestConfig config;
 
   public static Iterable<String[]> data() throws IOException
   {
@@ -137,7 +140,7 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
     return tests;
   }
 
-  public void initMovingAverageQueryTest(String yamlFile) throws IOException
+  public MovingAverageQueryTest(String yamlFile) throws IOException
   {
 
     List<Module> modules = getRequiredModules();
@@ -308,12 +311,10 @@ public class MovingAverageQueryTest extends InitializedNullHandlingTest
   /**
    * Validate that the specified query behaves correctly.
    */
-  @MethodSource("data")
   @SuppressWarnings({"unchecked", "rawtypes"})
-  @ParameterizedTest(name = "{0}")
-  public void testQuery(String yamlFile) throws IOException
+  @Test
+  public void testQuery() throws IOException
   {
-    initMovingAverageQueryTest(yamlFile);
     Query<?> query = jsonMapper.readValue(getQueryString(), Query.class);
     Assertions.assertInstanceOf(getExpectedQueryType(), query);
 

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/PostAveragerAggregatorCalculatorTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/PostAveragerAggregatorCalculatorTest.java
@@ -31,9 +31,9 @@ import org.apache.druid.query.spec.MultipleIntervalSegmentSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -46,7 +46,7 @@ public class PostAveragerAggregatorCalculatorTest
   private Map<String, Object> event;
   private MapBasedRow row;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     MovingAverageQuery query = new MovingAverageQuery(
@@ -87,7 +87,7 @@ public class PostAveragerAggregatorCalculatorTest
 
     Row result = pac.apply(row);
 
-    Assert.assertEquals(10.0f / 12.0f, result.getMetric("avgCountRatio").floatValue(), 0.0);
+    Assertions.assertEquals(10.0f / 12.0f, result.getMetric("avgCountRatio").floatValue(), 0.0);
   }
 
   @Test
@@ -97,7 +97,7 @@ public class PostAveragerAggregatorCalculatorTest
 
     Row result = pac.apply(row);
 
-    Assert.assertNull(result.getMetric("avgCountRatio"));
-    Assert.assertNull(result.getRaw("avgCountRatio"));
+    Assertions.assertNull(result.getMetric("avgCountRatio"));
+    Assertions.assertNull(result.getRaw("avgCountRatio"));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/RowBucketIterableTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/RowBucketIterableTest.java
@@ -27,9 +27,9 @@ import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
 import org.joda.time.chrono.ISOChronology;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,7 +77,7 @@ public class RowBucketIterableTest
   private List<Row> rows = null;
   private List<Interval> intervals = new ArrayList<>();
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     EVENT_M_10.put("gender", "m");
@@ -110,20 +110,20 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_2, actual.getDateTime());
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(JAN_2, actual.getDateTime());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -149,16 +149,16 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -186,16 +186,16 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -214,8 +214,8 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(expectedDay1, actual.getRows());
-    Assert.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
   }
 
   @Test
@@ -236,8 +236,8 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
   }
 
   @Test
@@ -257,12 +257,12 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_2, actual.getDateTime());
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(JAN_2, actual.getDateTime());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
   }
 
   @Test
@@ -286,20 +286,20 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_2, actual.getDateTime());
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(JAN_2, actual.getDateTime());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -322,20 +322,20 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_2, actual.getDateTime());
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(JAN_2, actual.getDateTime());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -358,20 +358,20 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_2, actual.getDateTime());
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(JAN_2, actual.getDateTime());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -396,24 +396,24 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_2, actual.getDateTime());
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(JAN_2, actual.getDateTime());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_5, actual.getDateTime());
-    Assert.assertEquals(expectedDay5, actual.getRows());
+    Assertions.assertEquals(JAN_5, actual.getDateTime());
+    Assertions.assertEquals(expectedDay5, actual.getRows());
   }
 
   @Test
@@ -437,17 +437,17 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -471,20 +471,20 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(JAN_1, actual.getDateTime());
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(JAN_1, actual.getDateTime());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_2, actual.getDateTime());
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(JAN_2, actual.getDateTime());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -509,17 +509,17 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -543,18 +543,18 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_3, actual.getDateTime());
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(JAN_3, actual.getDateTime());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(JAN_4, actual.getDateTime());
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(JAN_4, actual.getDateTime());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
   }
 
   @Test
@@ -589,25 +589,25 @@ public class RowBucketIterableTest
     Iterator<RowBucket> iter = rbi.iterator();
 
     RowBucket actual = iter.next();
-    Assert.assertEquals(expectedDay1, actual.getRows());
+    Assertions.assertEquals(expectedDay1, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay2, actual.getRows());
+    Assertions.assertEquals(expectedDay2, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay3, actual.getRows());
+    Assertions.assertEquals(expectedDay3, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay4, actual.getRows());
+    Assertions.assertEquals(expectedDay4, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay6, actual.getRows());
+    Assertions.assertEquals(expectedDay6, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay7, actual.getRows());
+    Assertions.assertEquals(expectedDay7, actual.getRows());
 
     actual = iter.next();
-    Assert.assertEquals(expectedDay8, actual.getRows());
+    Assertions.assertEquals(expectedDay8, actual.getRows());
   }
 
   @Test
@@ -623,8 +623,8 @@ public class RowBucketIterableTest
     RowBucketIterable rbi = new RowBucketIterable(seq, intervals, ONE_DAY);
     Iterator<RowBucket> iter = rbi.iterator();
 
-    Assert.assertTrue(iter.hasNext());
+    Assertions.assertTrue(iter.hasNext());
     RowBucket actual = iter.next();
-    Assert.assertEquals(Collections.emptyList(), actual.getRows());
+    Assertions.assertEquals(Collections.emptyList(), actual.getRows());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/AveragerFactoryWrapperTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/AveragerFactoryWrapperTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.query.movingaverage.averagers;
 
 import org.apache.druid.query.movingaverage.AveragerFactoryWrapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class AveragerFactoryWrapperTest
 {
@@ -32,7 +32,7 @@ public class AveragerFactoryWrapperTest
         new DoubleMaxAveragerFactory("double", 1, 1, "test"),
         "test"
     );
-    Assert.assertEquals(factoryWrapper, factoryWrapper.withName("test"));
-    Assert.assertEquals("newTestdouble", factoryWrapper.withName("newTest").getName());
+    Assertions.assertEquals(factoryWrapper, factoryWrapper.withName("test"));
+    Assertions.assertEquals("newTestdouble", factoryWrapper.withName("newTest").getName());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/BaseAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/BaseAveragerFactoryTest.java
@@ -19,9 +19,9 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.List;
@@ -30,7 +30,7 @@ public class BaseAveragerFactoryTest
 {
   private AveragerFactory<Long, Long> fac;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     fac = new BaseAveragerFactory<>("test", 5, "field", 1)
@@ -53,14 +53,14 @@ public class BaseAveragerFactoryTest
   public void testGetDependentFields()
   {
     List<String> dependentFields = fac.getDependentFields();
-    Assert.assertEquals(1, dependentFields.size());
-    Assert.assertEquals("field", dependentFields.get(0));
+    Assertions.assertEquals(1, dependentFields.size());
+    Assertions.assertEquals("field", dependentFields.get(0));
   }
 
   @Test
   public void testFinalization()
   {
     Long input = 5L;
-    Assert.assertEquals(input, fac.finalizeComputation(input));
+    Assertions.assertEquals(input, fac.finalizeComputation(input));
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/BaseAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/BaseAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -46,10 +46,10 @@ public class BaseAveragerTest
   {
     BaseAverager<Integer, Integer> avg = new TestAverager(Integer.class, 5, "test", "field", 1);
 
-    Assert.assertEquals("test", avg.getName());
-    Assert.assertEquals(5, avg.getNumBuckets());
-    Assert.assertEquals(5, avg.getBuckets().length);
-    Assert.assertTrue(avg.getBuckets().getClass().isArray());
+    Assertions.assertEquals("test", avg.getName());
+    Assertions.assertEquals(5, avg.getNumBuckets());
+    Assertions.assertEquals(5, avg.getBuckets().length);
+    Assertions.assertTrue(avg.getBuckets().getClass().isArray());
   }
 
   @Test
@@ -59,24 +59,24 @@ public class BaseAveragerTest
     Object[] buckets = avg.getBuckets();
 
     avg.addElement(Collections.singletonMap("field", 1), Collections.emptyMap());
-    Assert.assertEquals(1, buckets[0]);
-    Assert.assertNull(buckets[1]);
-    Assert.assertNull(buckets[2]);
+    Assertions.assertEquals(1, buckets[0]);
+    Assertions.assertNull(buckets[1]);
+    Assertions.assertNull(buckets[2]);
 
     avg.addElement(Collections.singletonMap("field", 2), Collections.emptyMap());
-    Assert.assertEquals(1, buckets[0]);
-    Assert.assertEquals(2, buckets[1]);
-    Assert.assertNull(buckets[2]);
+    Assertions.assertEquals(1, buckets[0]);
+    Assertions.assertEquals(2, buckets[1]);
+    Assertions.assertNull(buckets[2]);
 
     avg.addElement(Collections.singletonMap("field", 3), Collections.emptyMap());
-    Assert.assertEquals(1, buckets[0]);
-    Assert.assertEquals(2, buckets[1]);
-    Assert.assertEquals(3, buckets[2]);
+    Assertions.assertEquals(1, buckets[0]);
+    Assertions.assertEquals(2, buckets[1]);
+    Assertions.assertEquals(3, buckets[2]);
 
     avg.addElement(Collections.singletonMap("field", 4), Collections.emptyMap());
-    Assert.assertEquals(4, buckets[0]);
-    Assert.assertEquals(2, buckets[1]);
-    Assert.assertEquals(3, buckets[2]);
+    Assertions.assertEquals(4, buckets[0]);
+    Assertions.assertEquals(2, buckets[1]);
+    Assertions.assertEquals(3, buckets[2]);
   }
 
   @Test
@@ -89,32 +89,32 @@ public class BaseAveragerTest
     avg.addElement(Collections.singletonMap("field", 1), Collections.emptyMap());
     avg.addElement(Collections.singletonMap("field", 1), Collections.emptyMap());
 
-    Assert.assertEquals(1, buckets[0]);
-    Assert.assertEquals(1, buckets[1]);
-    Assert.assertEquals(1, buckets[2]);
+    Assertions.assertEquals(1, buckets[0]);
+    Assertions.assertEquals(1, buckets[1]);
+    Assertions.assertEquals(1, buckets[2]);
 
     avg.skip();
-    Assert.assertNull(buckets[0]);
-    Assert.assertNotNull(buckets[1]);
-    Assert.assertNotNull(buckets[2]);
+    Assertions.assertNull(buckets[0]);
+    Assertions.assertNotNull(buckets[1]);
+    Assertions.assertNotNull(buckets[2]);
 
     avg.skip();
-    Assert.assertNull(buckets[0]);
-    Assert.assertNull(buckets[1]);
-    Assert.assertNotNull(buckets[2]);
+    Assertions.assertNull(buckets[0]);
+    Assertions.assertNull(buckets[1]);
+    Assertions.assertNotNull(buckets[2]);
 
     avg.skip();
-    Assert.assertNull(buckets[0]);
-    Assert.assertNull(buckets[1]);
-    Assert.assertNull(buckets[2]);
+    Assertions.assertNull(buckets[0]);
+    Assertions.assertNull(buckets[1]);
+    Assertions.assertNull(buckets[2]);
 
     // poke some test data into the array
     buckets[0] = 1;
 
     avg.skip();
-    Assert.assertNull(buckets[0]);
-    Assert.assertNull(buckets[1]);
-    Assert.assertNull(buckets[2]);
+    Assertions.assertNull(buckets[0]);
+    Assertions.assertNull(buckets[1]);
+    Assertions.assertNull(buckets[2]);
   }
 
   @Test
@@ -122,16 +122,16 @@ public class BaseAveragerTest
   {
     BaseAverager<Integer, Integer> avg = new TestAverager(Integer.class, 3, "test", "field", 1);
 
-    Assert.assertFalse(avg.hasData());
+    Assertions.assertFalse(avg.hasData());
 
     avg.addElement(Collections.singletonMap("field", 1), Collections.emptyMap());
-    Assert.assertTrue(avg.hasData());
+    Assertions.assertTrue(avg.hasData());
 
     avg.skip();
     avg.skip();
     avg.skip();
 
-    Assert.assertFalse(avg.hasData());
+    Assertions.assertFalse(avg.hasData());
   }
 
   @Test
@@ -139,9 +139,9 @@ public class BaseAveragerTest
   {
     BaseAverager<Integer, Integer> avg = new TestAverager(Integer.class, 3, "test", "field", 1);
 
-    Assert.assertNull(avg.getResult());
+    Assertions.assertNull(avg.getResult());
 
     avg.addElement(Collections.singletonMap("field", 1), Collections.emptyMap());
-    Assert.assertEquals(Integer.valueOf(1), avg.getResult());
+    Assertions.assertEquals(Integer.valueOf(1), avg.getResult());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMaxAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMaxAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DoubleMaxAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class DoubleMaxAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMaxAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), CoreMatchers.instanceOf(DoubleMaxAverager.class));
+    Assertions.assertInstanceOf(DoubleMaxAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMaxAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMaxAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,23 +32,23 @@ public class DoubleMaxAveragerTest
   {
     BaseAverager<Number, Double> avg = new DoubleMaxAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(Double.NEGATIVE_INFINITY, avg.computeResult(), 0.0);
+    Assertions.assertEquals(Double.NEGATIVE_INFINITY, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", -1.1e100), new HashMap<>());
-    Assert.assertEquals(-1.1e100, avg.computeResult(), 0.0);
+    Assertions.assertEquals(-1.1e100, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 1.0), new HashMap<>());
-    Assert.assertEquals(1.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(1.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 1), new HashMap<>());
-    Assert.assertEquals(1.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(1.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 5.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
-    Assert.assertEquals(5.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(5.0, avg.computeResult(), 0.0);
 
     avg.skip();
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DoubleMeanAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class DoubleMeanAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMeanAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMeanAverager.class));
+    Assertions.assertInstanceOf(DoubleMeanAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,23 +32,23 @@ public class DoubleMeanAveragerTest
   {
     BaseAverager<Number, Double> avg = new DoubleMeanAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(0.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(0.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(1.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(1.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 0), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.skip();
-    Assert.assertEquals(4.0 / 3, avg.computeResult(), 0.0);
+    Assertions.assertEquals(4.0 / 3, avg.computeResult(), 0.0);
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerWithPeriodTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanAveragerWithPeriodTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,10 +47,10 @@ public class DoubleMeanAveragerWithPeriodTest
     averager.addElement(Collections.singletonMap("field", 5.0), new HashMap<>());
     averager.addElement(Collections.singletonMap("field", 6.0), new HashMap<>());
 
-    Assert.assertEquals(7, averager.computeResult(), 0.0); // (7+7)/2
+    Assertions.assertEquals(7, averager.computeResult(), 0.0); // (7+7)/2
 
     averager.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(1, averager.computeResult(), 0.0); // (1+1)/2
+    Assertions.assertEquals(1, averager.computeResult(), 0.0); // (1+1)/2
 
     BaseAverager<Number, Double> averager1 = new DoubleMeanAverager(14, "test", "field", 3);
 
@@ -69,10 +69,10 @@ public class DoubleMeanAveragerWithPeriodTest
     averager1.addElement(Collections.singletonMap("field", 1.0), new HashMap<>());
     averager1.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
 
-    Assert.assertEquals(1, averager1.computeResult(), 0.0); // (1+1+1+1+1)/5
+    Assertions.assertEquals(1, averager1.computeResult(), 0.0); // (1+1+1+1+1)/5
 
-    Assert.assertEquals(2, averager1.computeResult(), 0.0); // (2+2+2+2+2)/5
+    Assertions.assertEquals(2, averager1.computeResult(), 0.0); // (2+2+2+2+2)/5
 
-    Assert.assertEquals(13.0 / 5, averager1.computeResult(), 0.0); // (3+3+3+3+1)/5
+    Assertions.assertEquals(13.0 / 5, averager1.computeResult(), 0.0); // (3+3+3+3+1)/5
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanNoNullAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanNoNullAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DoubleMeanNoNullAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class DoubleMeanNoNullAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMeanNoNullAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMeanNoNullAverager.class));
+    Assertions.assertInstanceOf(DoubleMeanNoNullAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanNoNullAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMeanNoNullAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,30 +32,30 @@ public class DoubleMeanNoNullAveragerTest
   {
     BaseAverager<Number, Double> avg = new DoubleMeanNoNullAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(Double.NaN, avg.computeResult(), 0.0);
+    Assertions.assertEquals(Double.NaN, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 0), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.skip();
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     // testing cycleSize functionality
     BaseAverager<Number, Double> averager = new DoubleMeanNoNullAverager(14, "test", "field", 7);
 
     averager.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
-    Assert.assertEquals(2.0, averager.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, averager.computeResult(), 0.0);
 
     averager.addElement(Collections.singletonMap("field", 4.0), new HashMap<>());
     averager.addElement(Collections.singletonMap("field", 5.0), new HashMap<>());
@@ -71,9 +71,9 @@ public class DoubleMeanNoNullAveragerTest
     averager.addElement(Collections.singletonMap("field", 15.0), new HashMap<>());
     averager.addElement(Collections.singletonMap("field", 16.0), new HashMap<>());
 
-    Assert.assertEquals(7.5, averager.computeResult(), 0.0);
+    Assertions.assertEquals(7.5, averager.computeResult(), 0.0);
 
     averager.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(8.5, averager.computeResult(), 0.0);
+    Assertions.assertEquals(8.5, averager.computeResult(), 0.0);
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMinAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMinAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DoubleMinAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class DoubleMinAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleMinAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleMinAverager.class));
+    Assertions.assertInstanceOf(DoubleMinAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMinAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleMinAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,24 +32,24 @@ public class DoubleMinAveragerTest
   {
     BaseAverager<Number, Double> avg = new DoubleMinAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(Double.POSITIVE_INFINITY, avg.computeResult(), 0.0);
+    Assertions.assertEquals(Double.POSITIVE_INFINITY, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", -1.1e100), new HashMap<>());
-    Assert.assertEquals(-1.1e100, avg.computeResult(), 0.0);
+    Assertions.assertEquals(-1.1e100, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 1.0), new HashMap<>());
-    Assert.assertEquals(-1.1e100, avg.computeResult(), 0.0);
+    Assertions.assertEquals(-1.1e100, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 1), new HashMap<>());
-    Assert.assertEquals(-1.1e100, avg.computeResult(), 0.0);
+    Assertions.assertEquals(-1.1e100, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 5.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.skip();
     avg.skip();
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleSumAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleSumAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DoubleSumAveragerFactoryTest
 {
@@ -30,7 +29,7 @@ public class DoubleSumAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new DoubleSumAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(DoubleSumAverager.class));
+    Assertions.assertInstanceOf(DoubleSumAverager.class, fac.createAverager());
   }
 
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleSumAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/DoubleSumAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,24 +33,24 @@ public class DoubleSumAveragerTest
   {
     BaseAverager<Number, Double> avg = new DoubleSumAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(0.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(0.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3.0), new HashMap<>());
-    Assert.assertEquals(6.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(6.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 0), new HashMap<>());
-    Assert.assertEquals(6.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(6.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 2.5), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2.0), new HashMap<>());
-    Assert.assertEquals(6.5, avg.computeResult(), 0.0);
+    Assertions.assertEquals(6.5, avg.computeResult(), 0.0);
 
     avg.skip();
-    Assert.assertEquals(4.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(4.0, avg.computeResult(), 0.0);
 
   }
 

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMaxAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMaxAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LongMaxAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class LongMaxAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMaxAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMaxAverager.class));
+    Assertions.assertInstanceOf(LongMaxAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMaxAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMaxAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,23 +32,23 @@ public class LongMaxAveragerTest
   {
     BaseAverager<Number, Long> avg = new LongMaxAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(Long.MIN_VALUE, (long) avg.computeResult());
+    Assertions.assertEquals(Long.MIN_VALUE, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", -1000000L), new HashMap<>());
-    Assert.assertEquals(-1000000, (long) avg.computeResult());
+    Assertions.assertEquals(-1000000, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", 1L), new HashMap<>());
-    Assert.assertEquals(1, (long) avg.computeResult());
+    Assertions.assertEquals(1, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", 1), new HashMap<>());
-    Assert.assertEquals(1, (long) avg.computeResult());
+    Assertions.assertEquals(1, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", 5L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
-    Assert.assertEquals(5, (long) avg.computeResult());
+    Assertions.assertEquals(5, (long) avg.computeResult());
 
     avg.skip();
-    Assert.assertEquals(3, (long) avg.computeResult());
+    Assertions.assertEquals(3, (long) avg.computeResult());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LongMeanAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class LongMeanAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMeanAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMeanAverager.class));
+    Assertions.assertInstanceOf(LongMeanAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,23 +32,23 @@ public class LongMeanAveragerTest
   {
     BaseAverager<Number, Double> avg = new LongMeanAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(0.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(0.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
-    Assert.assertEquals(1.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(1.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3), new HashMap<>());
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.skip();
-    Assert.assertEquals(4.0 / 3, avg.computeResult(), 0.0);
+    Assertions.assertEquals(4.0 / 3, avg.computeResult(), 0.0);
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanNoNullAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanNoNullAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LongMeanNoNullAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class LongMeanNoNullAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMeanNoNullAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMeanNoNullAverager.class));
+    Assertions.assertInstanceOf(LongMeanNoNullAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanNoNullAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMeanNoNullAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,24 +32,24 @@ public class LongMeanNoNullAveragerTest
   {
     BaseAverager<Number, Double> avg = new LongMeanNoNullAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(Double.NaN, avg.computeResult(), 0.0);
+    Assertions.assertEquals(Double.NaN, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 0), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
 
     avg.skip();
-    Assert.assertEquals(2.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(2.0, avg.computeResult(), 0.0);
   }
 
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMinAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMinAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LongMinAveragerFactoryTest
 {
@@ -29,6 +28,6 @@ public class LongMinAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongMinAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongMinAverager.class));
+    Assertions.assertInstanceOf(LongMinAverager.class, fac.createAverager());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMinAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongMinAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,24 +32,24 @@ public class LongMinAveragerTest
   {
     BaseAverager<Number, Long> avg = new LongMinAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(Long.MAX_VALUE, (long) avg.computeResult());
+    Assertions.assertEquals(Long.MAX_VALUE, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", -10000L), new HashMap<>());
-    Assert.assertEquals(-10000, (long) avg.computeResult());
+    Assertions.assertEquals(-10000, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", 1L), new HashMap<>());
-    Assert.assertEquals(-10000, (long) avg.computeResult());
+    Assertions.assertEquals(-10000, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", 1000), new HashMap<>());
-    Assert.assertEquals(-10000, (long) avg.computeResult());
+    Assertions.assertEquals(-10000, (long) avg.computeResult());
 
     avg.addElement(Collections.singletonMap("field", 5L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
-    Assert.assertEquals(2, (long) avg.computeResult());
+    Assertions.assertEquals(2, (long) avg.computeResult());
 
     avg.skip();
     avg.skip();
-    Assert.assertEquals(3, (long) avg.computeResult());
+    Assertions.assertEquals(3, (long) avg.computeResult());
   }
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongSumAveragerFactoryTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongSumAveragerFactoryTest.java
@@ -19,9 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class LongSumAveragerFactoryTest
 {
@@ -30,7 +29,7 @@ public class LongSumAveragerFactoryTest
   public void testCreateAverager()
   {
     AveragerFactory<?, ?> fac = new LongSumAveragerFactory("test", 5, 1, "field");
-    MatcherAssert.assertThat(fac.createAverager(), IsInstanceOf.instanceOf(LongSumAverager.class));
+    Assertions.assertInstanceOf(LongSumAverager.class, fac.createAverager());
   }
 
 }

--- a/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongSumAveragerTest.java
+++ b/extensions-contrib/moving-average-query/src/test/java/org/apache/druid/query/movingaverage/averagers/LongSumAveragerTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.query.movingaverage.averagers;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -32,23 +32,23 @@ public class LongSumAveragerTest
   {
     BaseAverager<Number, Long> avg = new LongSumAverager(3, "test", "field", 1);
 
-    Assert.assertEquals(0.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(0.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
-    Assert.assertEquals(3.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(3.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3L), new HashMap<>());
-    Assert.assertEquals(6.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(6.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 3), new HashMap<>());
-    Assert.assertEquals(9.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(9.0, avg.computeResult(), 0.0);
 
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
     avg.addElement(Collections.singletonMap("field", 2L), new HashMap<>());
-    Assert.assertEquals(6.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(6.0, avg.computeResult(), 0.0);
 
     avg.skip();
-    Assert.assertEquals(4.0, avg.computeResult(), 0.0);
+    Assertions.assertEquals(4.0, avg.computeResult(), 0.0);
   }
 }

--- a/extensions-contrib/opentsdb-emitter/pom.xml
+++ b/extensions-contrib/opentsdb-emitter/pom.xml
@@ -35,6 +35,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -86,11 +101,6 @@
     </dependency>
 
     <!-- Tests -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/EventConverterTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/EventConverterTest.java
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +36,7 @@ public class EventConverterTest
   private EventConverter converterWithNamespacePrefixContainingSpace;
   private EventConverter converterWithoutNamespacePrefix;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     converterWithNamespacePrefix = new EventConverter(new ObjectMapper(), null, "druid");
@@ -48,9 +48,9 @@ public class EventConverterTest
   public void testSanitize()
   {
     String metric = " foo bar/baz";
-    Assert.assertEquals("foo_bar.baz", converterWithNamespacePrefix.sanitize(metric));
-    Assert.assertEquals("foo_bar.baz", converterWithNamespacePrefixContainingSpace.sanitize(metric));
-    Assert.assertEquals("foo_bar.baz", converterWithoutNamespacePrefix.sanitize(metric));
+    Assertions.assertEquals("foo_bar.baz", converterWithNamespacePrefix.sanitize(metric));
+    Assertions.assertEquals("foo_bar.baz", converterWithNamespacePrefixContainingSpace.sanitize(metric));
+    Assertions.assertEquals("foo_bar.baz", converterWithoutNamespacePrefix.sanitize(metric));
   }
 
   @Test
@@ -71,10 +71,10 @@ public class EventConverterTest
     expectedTags.put("type", "groupBy");
 
     OpentsdbEvent opentsdbEvent = converterWithNamespacePrefix.convert(configuredEvent);
-    Assert.assertEquals("druid.query.time", opentsdbEvent.getMetric());
-    Assert.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
-    Assert.assertEquals(10, opentsdbEvent.getValue());
-    Assert.assertEquals(expectedTags, opentsdbEvent.getTags());
+    Assertions.assertEquals("druid.query.time", opentsdbEvent.getMetric());
+    Assertions.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
+    Assertions.assertEquals(10, opentsdbEvent.getValue());
+    Assertions.assertEquals(expectedTags, opentsdbEvent.getTags());
 
     ServiceMetricEvent notConfiguredEvent = new ServiceMetricEvent.Builder()
         .setDimension("dataSource", "data-source")
@@ -82,7 +82,7 @@ public class EventConverterTest
         .setCreatedTime(dateTime)
         .setMetric("foo/bar", 10)
         .build("broker", "brokerHost1");
-    Assert.assertNull(converterWithNamespacePrefix.convert(notConfiguredEvent));
+    Assertions.assertNull(converterWithNamespacePrefix.convert(notConfiguredEvent));
   }
 
   @Test
@@ -103,10 +103,10 @@ public class EventConverterTest
     expectedTags.put("type", "groupBy");
 
     OpentsdbEvent opentsdbEvent = converterWithNamespacePrefixContainingSpace.convert(configuredEvent);
-    Assert.assertEquals("legendary_druid.query.time", opentsdbEvent.getMetric());
-    Assert.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
-    Assert.assertEquals(10, opentsdbEvent.getValue());
-    Assert.assertEquals(expectedTags, opentsdbEvent.getTags());
+    Assertions.assertEquals("legendary_druid.query.time", opentsdbEvent.getMetric());
+    Assertions.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
+    Assertions.assertEquals(10, opentsdbEvent.getValue());
+    Assertions.assertEquals(expectedTags, opentsdbEvent.getTags());
 
     ServiceMetricEvent notConfiguredEvent = new ServiceMetricEvent.Builder()
         .setDimension("dataSource", "data-source")
@@ -114,7 +114,7 @@ public class EventConverterTest
         .setCreatedTime(dateTime)
         .setMetric("foo/bar", 10)
         .build("broker", "brokerHost1");
-    Assert.assertNull(converterWithNamespacePrefixContainingSpace.convert(notConfiguredEvent));
+    Assertions.assertNull(converterWithNamespacePrefixContainingSpace.convert(notConfiguredEvent));
   }
 
   @Test
@@ -135,10 +135,10 @@ public class EventConverterTest
     expectedTags.put("type", "groupBy");
 
     OpentsdbEvent opentsdbEvent = converterWithoutNamespacePrefix.convert(configuredEvent);
-    Assert.assertEquals("query.time", opentsdbEvent.getMetric());
-    Assert.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
-    Assert.assertEquals(10, opentsdbEvent.getValue());
-    Assert.assertEquals(expectedTags, opentsdbEvent.getTags());
+    Assertions.assertEquals("query.time", opentsdbEvent.getMetric());
+    Assertions.assertEquals(dateTime.getMillis() / 1000L, opentsdbEvent.getTimestamp());
+    Assertions.assertEquals(10, opentsdbEvent.getValue());
+    Assertions.assertEquals(expectedTags, opentsdbEvent.getTags());
 
     ServiceMetricEvent notConfiguredEvent = new ServiceMetricEvent.Builder()
         .setDimension("dataSource", "data-source")
@@ -146,7 +146,7 @@ public class EventConverterTest
         .setCreatedTime(dateTime)
         .setMetric("foo/bar", 10)
         .build("broker", "brokerHost1");
-    Assert.assertNull(converterWithoutNamespacePrefix.convert(notConfiguredEvent));
+    Assertions.assertNull(converterWithoutNamespacePrefix.convert(notConfiguredEvent));
   }
 
 }

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfigTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEmitterConfigTest.java
@@ -22,15 +22,15 @@ package org.apache.druid.emitter.opentsdb;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class OpentsdbEmitterConfigTest
 {
   private ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper()));
@@ -43,7 +43,7 @@ public class OpentsdbEmitterConfigTest
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
     OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
                                                                 .readValue(opentsdbEmitterConfigString);
-    Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
+    Assertions.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
   }
 
   @Test
@@ -53,7 +53,7 @@ public class OpentsdbEmitterConfigTest
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
     OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
                                                                 .readValue(opentsdbEmitterConfigString);
-    Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
+    Assertions.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
   }
 
   @Test
@@ -63,7 +63,7 @@ public class OpentsdbEmitterConfigTest
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
     OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
         .readValue(opentsdbEmitterConfigString);
-    Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
+    Assertions.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
   }
 
   @Test
@@ -73,12 +73,12 @@ public class OpentsdbEmitterConfigTest
     String opentsdbEmitterConfigString = mapper.writeValueAsString(opentsdbEmitterConfig);
     OpentsdbEmitterConfig expectedOpentsdbEmitterConfig = mapper.readerFor(OpentsdbEmitterConfig.class)
         .readValue(opentsdbEmitterConfigString);
-    Assert.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
+    Assertions.assertEquals(expectedOpentsdbEmitterConfig, opentsdbEmitterConfig);
   }
 
   @Test
   public void testJacksonModules()
   {
-    Assert.assertTrue(new OpentsdbEmitterModule().getJacksonModules().isEmpty());
+    Assertions.assertTrue(new OpentsdbEmitterModule().getJacksonModules().isEmpty());
   }
 }

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEventTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbEventTest.java
@@ -22,9 +22,9 @@ package org.apache.druid.emitter.opentsdb;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,7 +33,7 @@ public class OpentsdbEventTest
 {
   private ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(ObjectMapper.class, new DefaultObjectMapper()));
@@ -49,6 +49,6 @@ public class OpentsdbEventTest
     String opentsdbString = mapper.writeValueAsString(opentsdbEvent);
     OpentsdbEvent expectedOpentsdbEvent = mapper.readerFor(OpentsdbEvent.class)
                                                 .readValue(opentsdbString);
-    Assert.assertEquals(expectedOpentsdbEvent, opentsdbEvent);
+    Assertions.assertEquals(expectedOpentsdbEvent, opentsdbEvent);
   }
 }

--- a/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbSenderTest.java
+++ b/extensions-contrib/opentsdb-emitter/src/test/java/org/apache/druid/emitter/opentsdb/OpentsdbSenderTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.emitter.opentsdb;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class OpentsdbSenderTest
 {
@@ -29,6 +29,6 @@ public class OpentsdbSenderTest
   {
     OpentsdbSender sender = new OpentsdbSender("localhost", 9999, 2000, 2000, 100, 1000, 10000L);
     String expectedUrl = "http://localhost:9999/api/put";
-    Assert.assertEquals(expectedUrl, sender.getWebResource().getURI().toString());
+    Assertions.assertEquals(expectedUrl, sender.getWebResource().getURI().toString());
   }
 }

--- a/extensions-contrib/rabbit-stream-indexing-service/pom.xml
+++ b/extensions-contrib/rabbit-stream-indexing-service/pom.xml
@@ -35,6 +35,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-indexing-service</artifactId>
       <version>${project.parent.version}</version>
@@ -94,16 +109,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
@@ -136,11 +141,6 @@
     </dependency>
 
     <!-- Tests -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskIOConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskIOConfigTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbe
 import org.apache.druid.indexing.seekablestream.supervisor.BoundedStreamConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.indexing.IOConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
@@ -57,27 +57,27 @@ public class RabbitStreamIndexTaskIOConfigTest
         IOConfig.class
     );
 
-    Assert.assertNull(config.getTaskGroupId());
-    Assert.assertEquals("my-sequence-name", config.getBaseSequenceName());
+    Assertions.assertNull(config.getTaskGroupId());
+    Assertions.assertEquals("my-sequence-name", config.getBaseSequenceName());
 
-    Assert.assertEquals("mystream", config.getStartSequenceNumbers().getStream());
+    Assertions.assertEquals("mystream", config.getStartSequenceNumbers().getStream());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of("stream-0", 1L, "stream-1", 10L),
         config.getStartSequenceNumbers().getPartitionSequenceNumberMap()
     );
 
-    Assert.assertEquals("mystream", config.getEndSequenceNumbers().getStream());
+    Assertions.assertEquals("mystream", config.getEndSequenceNumbers().getStream());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of("stream-0", 15L, "stream-1", 200L),
         config.getEndSequenceNumbers().getPartitionSequenceNumberMap()
     );
 
-    Assert.assertTrue(config.isUseTransaction());
-    Assert.assertNull("minimumMessageTime", config.getMinimumMessageTime());
-    Assert.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
-    Assert.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
+    Assertions.assertTrue(config.isUseTransaction());
+    Assertions.assertNull(config.getMinimumMessageTime(), "minimumMessageTime");
+    Assertions.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
+    Assertions.assertEquals(Collections.emptySet(), config.getStartSequenceNumbers().getExclusivePartitions());
   }
 
   @Test
@@ -91,8 +91,8 @@ public class RabbitStreamIndexTaskIOConfigTest
         new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of("q0", 10L), Collections.emptySet());
 
     RabbitStreamDataSourceMetadata metadata = new RabbitStreamDataSourceMetadata(partitions, boundedConfig);
-    Assert.assertNotNull(metadata.getBoundedStreamConfig());
-    Assert.assertEquals(boundedConfig, metadata.getBoundedStreamConfig());
+    Assertions.assertNotNull(metadata.getBoundedStreamConfig());
+    Assertions.assertEquals(boundedConfig, metadata.getBoundedStreamConfig());
   }
 
   @Test
@@ -102,7 +102,7 @@ public class RabbitStreamIndexTaskIOConfigTest
         new SeekableStreamStartSequenceNumbers<>("stream", ImmutableMap.of("q0", 10L), Collections.emptySet());
 
     RabbitStreamDataSourceMetadata metadata = new RabbitStreamDataSourceMetadata(partitions);
-    Assert.assertNull(metadata.getBoundedStreamConfig());
+    Assertions.assertNull(metadata.getBoundedStreamConfig());
   }
 
 }

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskTuningConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamIndexTaskTuningConfigTest.java
@@ -27,10 +27,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.indexing.TuningConfig;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
@@ -43,9 +41,6 @@ public class RabbitStreamIndexTaskTuningConfigTest
     mapper = new DefaultObjectMapper();
     mapper.registerModules((Iterable<Module>) new RabbitStreamIndexTaskModule().getJacksonModules());
   }
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testSerdeWithDefaults() throws Exception
@@ -61,22 +56,22 @@ public class RabbitStreamIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(150000, config.getMaxRowsInMemory());
-    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(0, config.getMaxPendingPersists());
-    // Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
-    Assert.assertEquals(false, config.isReportParseExceptions());
-    Assert.assertEquals(Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(150000, config.getMaxRowsInMemory());
+    Assertions.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(0, config.getMaxPendingPersists());
+    // Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
+    Assertions.assertEquals(false, config.isReportParseExceptions());
+    Assertions.assertEquals(Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
 
-    Assert.assertNull(config.getRecordBufferSizeConfigured());
-    Assert.assertEquals(10000, config.getRecordBufferSizeOrDefault(1_000_000_000));
-    Assert.assertEquals(5000, config.getRecordBufferOfferTimeout());
+    Assertions.assertNull(config.getRecordBufferSizeConfigured());
+    Assertions.assertEquals(10000, config.getRecordBufferSizeOrDefault(1_000_000_000));
+    Assertions.assertEquals(5000, config.getRecordBufferOfferTimeout());
 
-    Assert.assertFalse(config.isSkipSequenceNumberAvailabilityCheck());
-    Assert.assertFalse(config.isResetOffsetAutomatically());
+    Assertions.assertFalse(config.isSkipSequenceNumberAvailabilityCheck());
+    Assertions.assertFalse(config.isResetOffsetAutomatically());
   }
 
   @Test
@@ -106,18 +101,18 @@ public class RabbitStreamIndexTaskTuningConfigTest
         TuningConfig.class
     );
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(100, config.getMaxRowsInMemory());
-    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(100, config.getMaxPendingPersists());
-    Assert.assertTrue(config.isReportParseExceptions());
-    Assert.assertEquals(100, config.getHandoffConditionTimeout());
-    Assert.assertEquals(1000, (int) config.getRecordBufferSizeConfigured());
-    Assert.assertEquals(1000, config.getRecordBufferSizeOrDefault(1_000_000_000));
-    Assert.assertEquals(500, config.getRecordBufferOfferTimeout());
-    Assert.assertFalse(config.isResetOffsetAutomatically());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(100, config.getMaxRowsInMemory());
+    Assertions.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(100, config.getMaxPendingPersists());
+    Assertions.assertTrue(config.isReportParseExceptions());
+    Assertions.assertEquals(100, config.getHandoffConditionTimeout());
+    Assertions.assertEquals(1000, (int) config.getRecordBufferSizeConfigured());
+    Assertions.assertEquals(1000, config.getRecordBufferSizeOrDefault(1_000_000_000));
+    Assertions.assertEquals(500, config.getRecordBufferOfferTimeout());
+    Assertions.assertFalse(config.isResetOffsetAutomatically());
   }
 
 
@@ -189,7 +184,7 @@ public class RabbitStreamIndexTaskTuningConfigTest
                     "maxColumnsToMerge=-1}";
 
 
-    Assert.assertEquals(resStr, config.toString());
+    Assertions.assertEquals(resStr, config.toString());
   }
 
   /**

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamRecordSupplierTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/RabbitStreamRecordSupplierTest.java
@@ -41,9 +41,9 @@ import org.apache.druid.metadata.MapStringDynamicConfigProvider;
 import org.apache.druid.segment.TestHelper;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -175,7 +175,7 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     }
   }
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     environment = createMock(Environment.class);
@@ -190,11 +190,11 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
   {
     String test = "stream-0";
     String res = RabbitStreamRecordSupplier.getStreamFromSubstream(test);
-    Assert.assertEquals("stream", res);
+    Assertions.assertEquals("stream", res);
 
     test = "test-stream-0";
     res = RabbitStreamRecordSupplier.getStreamFromSubstream(test);
-    Assert.assertEquals("test-stream", res);
+    Assertions.assertEquals("test-stream", res);
 
   }
 
@@ -215,7 +215,7 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
 
     res = recordSupplier.getAssignment();
 
-    Assert.assertTrue(res.isEmpty());
+    Assertions.assertTrue(res.isEmpty());
 
     EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
     EasyMock.expect(environmentBuilder.build()).andStubReturn(environment);
@@ -235,7 +235,7 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     replayAll();
 
     recordSupplier.assign(partitions);
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
 
     verifyAll();
   }
@@ -262,7 +262,7 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
 
     res = recordSupplier.getAssignment();
 
-    Assert.assertTrue(res.isEmpty());
+    Assertions.assertTrue(res.isEmpty());
 
     EasyMock.expect(environmentBuilder.uri("rabbitmq-stream://localhost:5552")).andReturn(environmentBuilder).once();
     EasyMock.expect(environmentBuilder.build()).andStubReturn(environment);
@@ -283,7 +283,7 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     replayAll();
 
     recordSupplier.assign(partitions);
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
 
     verifyAll();
 
@@ -292,7 +292,7 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
       recordSupplier.seek(partition1, offset2);
     }
     catch (Exception exc) {
-      Assert.fail("Exception seeking:" + exc.getMessage());
+      Assertions.fail("Exception seeking:" + exc.getMessage());
     }
 
     resetAll();
@@ -304,10 +304,10 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     replayAll();
 
     recordSupplier.assign(ImmutableSet.of(partition0));
-    Assert.assertEquals(ImmutableSet.of(partition0), recordSupplier.getAssignment());
+    Assertions.assertEquals(ImmutableSet.of(partition0), recordSupplier.getAssignment());
   
-    Assert.assertNotNull(recordSupplier.getOffset(partition0));
-    Assert.assertNull(recordSupplier.getOffset(partition1));
+    Assertions.assertNotNull(recordSupplier.getOffset(partition0));
+    Assertions.assertNull(recordSupplier.getOffset(partition1));
 
   }
 
@@ -349,7 +349,7 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     replayAll();
 
     recordSupplier.assign(partitions);
-    Assert.assertEquals(partitions, recordSupplier.getAssignment());
+    Assertions.assertEquals(partitions, recordSupplier.getAssignment());
 
     verifyAll();
 
@@ -358,31 +358,31 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
       recordSupplier.seek(partition1, offset2);
     }
     catch (Exception exc) {
-      Assert.fail("Exception seeking:" + exc.getMessage());
+      Assertions.fail("Exception seeking:" + exc.getMessage());
     }
 
 
-    Assert.assertEquals(recordSupplier.getOffset(partition0).getOffset(), offset1);
-    Assert.assertEquals(recordSupplier.getOffset(partition1).getOffset(), offset2);
+    Assertions.assertEquals(recordSupplier.getOffset(partition0).getOffset(), offset1);
+    Assertions.assertEquals(recordSupplier.getOffset(partition1).getOffset(), offset2);
 
     try {
       recordSupplier.seekToEarliest(partitions);
     }
     catch (Exception exc) {
-      Assert.fail("Exception seeking:" + exc.getMessage());
+      Assertions.fail("Exception seeking:" + exc.getMessage());
     }
-    Assert.assertEquals(recordSupplier.getOffset(partition0), OffsetSpecification.first());
-    Assert.assertEquals(recordSupplier.getOffset(partition1), OffsetSpecification.first());
+    Assertions.assertEquals(recordSupplier.getOffset(partition0), OffsetSpecification.first());
+    Assertions.assertEquals(recordSupplier.getOffset(partition1), OffsetSpecification.first());
 
     try {
       recordSupplier.seekToLatest(partitions);
     }
     catch (Exception exc) {
-      Assert.fail("Exception seeking:" + exc.getMessage());
+      Assertions.fail("Exception seeking:" + exc.getMessage());
     }
 
-    Assert.assertEquals(recordSupplier.getOffset(partition0), OffsetSpecification.last());
-    Assert.assertEquals(recordSupplier.getOffset(partition1), OffsetSpecification.last());
+    Assertions.assertEquals(recordSupplier.getOffset(partition0), OffsetSpecification.last());
+    Assertions.assertEquals(recordSupplier.getOffset(partition1), OffsetSpecification.last());
 
   }
 
@@ -424,8 +424,8 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     recordSupplier.seek(partition0, 10L);
 
     final List<OrderedPartitionableRecord<String, Long, ByteEntity>> messages = recordSupplier.poll(0);
-    Assert.assertEquals(50, messages.size());
-    Assert.assertTrue(messages.stream().allMatch(message -> PARTITION_ID1.equals(message.getPartitionId())));
+    Assertions.assertEquals(50, messages.size());
+    Assertions.assertTrue(messages.stream().allMatch(message -> PARTITION_ID1.equals(message.getPartitionId())));
 
     recordSupplier.close();
     verifyAll();
@@ -512,11 +512,11 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
       recordSupplier.seek(partition2, offset2);
     }
     catch (Exception exc) {
-      Assert.fail("Exception seeking:" + exc.getMessage());
+      Assertions.fail("Exception seeking:" + exc.getMessage());
     }
 
     List<OrderedPartitionableRecord<String, Long, ByteEntity>> messages = recordSupplier.poll(0);
-    Assert.assertEquals(2, messages.size());
+    Assertions.assertEquals(2, messages.size());
 
     recordSupplier.close();
 
@@ -582,10 +582,10 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     Set<String> partitions = supplier.getPartitionIds(STREAM);
     verifyAll();
 
-    Assert.assertTrue(clientParameters == supplier.sentParameters);
+    Assertions.assertTrue(clientParameters == supplier.sentParameters);
 
-    Assert.assertEquals(2, partitions.size());
-    Assert.assertTrue(partitions.containsAll(ALL_PARTITIONS));
+    Assertions.assertEquals(2, partitions.size());
+    Assertions.assertTrue(partitions.containsAll(ALL_PARTITIONS));
    
     supplier.close();
     
@@ -631,10 +631,10 @@ public class RabbitStreamRecordSupplierTest extends EasyMockSupport
     Set<String> partitions = supplier.getPartitionIds(STREAM);
     verifyAll();
 
-    Assert.assertTrue(clientParameters == supplier.sentParameters);
+    Assertions.assertTrue(clientParameters == supplier.sentParameters);
 
-    Assert.assertEquals(2, partitions.size());
-    Assert.assertTrue(partitions.containsAll(ALL_PARTITIONS));
+    Assertions.assertEquals(2, partitions.size());
+    Assertions.assertTrue(partitions.containsAll(ALL_PARTITIONS));
    
     supplier.close();
     

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIOConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorIOConfigTest.java
@@ -30,13 +30,10 @@ import org.apache.druid.indexing.rabbitstream.RabbitStreamIndexTaskModule;
 import org.apache.druid.indexing.seekablestream.supervisor.LagAggregator;
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.easymock.EasyMock.createMock;
 
@@ -49,9 +46,6 @@ public class RabbitStreamSupervisorIOConfigTest
     mapper = new DefaultObjectMapper();
     mapper.registerModules((Iterable<Module>) new RabbitStreamIndexTaskModule().getJacksonModules());
   }
-
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testSerdeWithDefaults() throws Exception
@@ -66,18 +60,18 @@ public class RabbitStreamSupervisorIOConfigTest
         jsonStr,
         RabbitStreamSupervisorIOConfig.class);
 
-    Assert.assertEquals("my-stream", config.getStream());
-    Assert.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
-    Assert.assertEquals(1, (int) config.getReplicas());
-    Assert.assertEquals(1, (int) config.getTaskCount());
-    Assert.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
-    Assert.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());
-    Assert.assertFalse(config.isUseEarliestSequenceNumber());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
-    Assert.assertFalse("lateMessageRejectionPeriod", config.getLateMessageRejectionPeriod().isPresent());
-    Assert.assertFalse("earlyMessageRejectionPeriod", config.getEarlyMessageRejectionPeriod().isPresent());
-    Assert.assertFalse("lateMessageRejectionStartDateTime", config.getLateMessageRejectionStartDateTime().isPresent());
+    Assertions.assertEquals("my-stream", config.getStream());
+    Assertions.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
+    Assertions.assertEquals(1, (int) config.getReplicas());
+    Assertions.assertEquals(1, (int) config.getTaskCount());
+    Assertions.assertEquals(Duration.standardMinutes(60), config.getTaskDuration());
+    Assertions.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(30), config.getPeriod());
+    Assertions.assertFalse(config.isUseEarliestSequenceNumber());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
+    Assertions.assertFalse(config.getLateMessageRejectionPeriod().isPresent(), "lateMessageRejectionPeriod");
+    Assertions.assertFalse(config.getEarlyMessageRejectionPeriod().isPresent(), "earlyMessageRejectionPeriod");
+    Assertions.assertFalse(config.getLateMessageRejectionStartDateTime().isPresent(), "lateMessageRejectionStartDateTime");
   }
 
   @Test
@@ -103,19 +97,19 @@ public class RabbitStreamSupervisorIOConfigTest
         jsonStr,
         RabbitStreamSupervisorIOConfig.class);
 
-    Assert.assertEquals("my-stream", config.getStream());
-    Assert.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
-    Assert.assertEquals(3, (int) config.getReplicas());
-    Assert.assertEquals(9, (int) config.getTaskCount());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
-    Assert.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(10), config.getPeriod());
-    Assert.assertTrue(config.isUseEarliestSequenceNumber());
-    Assert.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
-    Assert.assertEquals(Duration.standardHours(1), config.getLateMessageRejectionPeriod().get());
-    Assert.assertEquals(Duration.standardHours(1), config.getEarlyMessageRejectionPeriod().get());
-    // Assert.assertEquals((Integer) 4000, config.getRecordsPerFetch());
-    // Assert.assertEquals(1000, config.getFetchDelayMillis());
+    Assertions.assertEquals("my-stream", config.getStream());
+    Assertions.assertEquals(config.getUri(), "rabbitmq-stream://localhost:5552");
+    Assertions.assertEquals(3, (int) config.getReplicas());
+    Assertions.assertEquals(9, (int) config.getTaskCount());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getTaskDuration());
+    Assertions.assertEquals(Duration.standardMinutes(1), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(10), config.getPeriod());
+    Assertions.assertTrue(config.isUseEarliestSequenceNumber());
+    Assertions.assertEquals(Duration.standardMinutes(45), config.getCompletionTimeout());
+    Assertions.assertEquals(Duration.standardHours(1), config.getLateMessageRejectionPeriod().get());
+    Assertions.assertEquals(Duration.standardHours(1), config.getEarlyMessageRejectionPeriod().get());
+    // Assertions.assertEquals((Integer) 4000, config.getRecordsPerFetch());
+    // Assertions.assertEquals(1000, config.getFetchDelayMillis());
   }
 
   @Test
@@ -125,10 +119,12 @@ public class RabbitStreamSupervisorIOConfigTest
         + "  \"type\": \"rabbit\"\n"
         + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("stream"));
-    mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
+    final JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class)
+    );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("stream"));
   }
 
   @Test
@@ -139,10 +135,12 @@ public class RabbitStreamSupervisorIOConfigTest
         + "  \"stream\": \"my-stream\"\n"
         + "}";
 
-    exception.expect(JsonMappingException.class);
-    exception.expectCause(CoreMatchers.isA(NullPointerException.class));
-    exception.expectMessage(CoreMatchers.containsString("uri"));
-    mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
+    final JsonMappingException exception = Assertions.assertThrows(
+        JsonMappingException.class,
+        () -> mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class)
+    );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
+    Assertions.assertTrue(exception.getMessage().contains("uri"));
   }
 
   @Test
@@ -160,10 +158,10 @@ public class RabbitStreamSupervisorIOConfigTest
 
     RabbitStreamSupervisorIOConfig config = mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
   }
 
   @Test
@@ -181,10 +179,10 @@ public class RabbitStreamSupervisorIOConfigTest
 
     RabbitStreamSupervisorIOConfig config = mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getBoundedStreamConfig().getEndSequenceNumbers().size());
   }
 
   @Test
@@ -202,8 +200,8 @@ public class RabbitStreamSupervisorIOConfigTest
 
     RabbitStreamSupervisorIOConfig config = mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
   }
 
   @Test
@@ -217,8 +215,8 @@ public class RabbitStreamSupervisorIOConfigTest
 
     RabbitStreamSupervisorIOConfig config = mapper.readValue(jsonStr, RabbitStreamSupervisorIOConfig.class);
 
-    Assert.assertFalse(config.isBounded());
-    Assert.assertNull(config.getBoundedStreamConfig());
+    Assertions.assertFalse(config.isBounded());
+    Assertions.assertNull(config.getBoundedStreamConfig());
   }
 
   private static RabbitStreamIOConfigBuilder ioConfigBuilder()
@@ -235,24 +233,24 @@ public class RabbitStreamSupervisorIOConfigTest
   public void testEqualsAndHashCode()
   {
     final RabbitStreamSupervisorIOConfig config = ioConfigBuilder().build();
-    Assert.assertEquals(config, ioConfigBuilder().build());
-    Assert.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
-    Assert.assertNotEquals(config, null);
-    Assert.assertNotEquals(config, "not an io config");
-    Assert.assertNotEquals(config, ioConfigBuilder().withUri("rabbit://other").build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withPollTimeout(999L).build());
+    Assertions.assertEquals(config, ioConfigBuilder().build());
+    Assertions.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
+    Assertions.assertNotEquals(config, null);
+    Assertions.assertNotEquals(config, "not an io config");
+    Assertions.assertNotEquals(config, ioConfigBuilder().withUri("rabbit://other").build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withPollTimeout(999L).build());
   }
 
   @Test
   public void testTuningConfigEqualsAndHashCode()
   {
     final RabbitStreamSupervisorTuningConfig config = RabbitStreamSupervisorTuningConfig.defaultConfig();
-    Assert.assertEquals(config, RabbitStreamSupervisorTuningConfig.defaultConfig());
-    Assert.assertEquals(config.hashCode(), RabbitStreamSupervisorTuningConfig.defaultConfig().hashCode());
-    Assert.assertNotEquals(config, null);
-    Assert.assertNotEquals(config, "not a tuning config");
+    Assertions.assertEquals(config, RabbitStreamSupervisorTuningConfig.defaultConfig());
+    Assertions.assertEquals(config.hashCode(), RabbitStreamSupervisorTuningConfig.defaultConfig().hashCode());
+    Assertions.assertNotEquals(config, null);
+    Assertions.assertNotEquals(config, "not a tuning config");
   }
 
   /**

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTest.java
@@ -57,11 +57,11 @@ import org.apache.druid.server.metrics.NoopServiceEmitter;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -123,13 +123,13 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
                      .build();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     dataSchema = getDataSchema(DATASOURCE);
   }
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     taskStorage = createMock(TaskStorage.class);
@@ -176,7 +176,7 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
     supervisorConfig = new SupervisorStateManagerConfig();
   }
 
-  @After
+  @AfterEach
   public void tearDownTest()
   {
     supervisor = null;
@@ -300,28 +300,28 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
         rowIngestionMetersFactory);
 
     RabbitStreamRecordSupplier supplier = (RabbitStreamRecordSupplier) supervisor.setupRecordSupplier();
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(0, supplier.bufferSize());
-    Assert.assertEquals(Collections.emptySet(), supplier.getAssignment());
-    Assert.assertEquals(false, supplier.isRunning());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(0, supplier.bufferSize());
+    Assertions.assertEquals(Collections.emptySet(), supplier.getAssignment());
+    Assertions.assertEquals(false, supplier.isRunning());
   }
 
   @Test
   public void testGetters()
   {
     supervisor = getDefaultSupervisor();
-    Assert.assertNull(supervisor.getPartitionTimeLag());
+    Assertions.assertNull(supervisor.getPartitionTimeLag());
 
-    Assert.assertNull(supervisor.getTimeLagPerPartition(null));
-    Assert.assertFalse(supervisor.isEndOfShard(null));
-    Assert.assertFalse(supervisor.isShardExpirationMarker(null));
+    Assertions.assertNull(supervisor.getTimeLagPerPartition(null));
+    Assertions.assertFalse(supervisor.isEndOfShard(null));
+    Assertions.assertFalse(supervisor.isShardExpirationMarker(null));
 
-    Assert.assertEquals(Long.valueOf(Long.MAX_VALUE), supervisor.getEndOfPartitionMarker());
+    Assertions.assertEquals(Long.valueOf(Long.MAX_VALUE), supervisor.getEndOfPartitionMarker());
 
-    Assert.assertEquals("index_rabbit", supervisor.baseTaskName());
+    Assertions.assertEquals("index_rabbit", supervisor.baseTaskName());
 
-    Assert.assertEquals(Long.valueOf(-1L), supervisor.getNotSetMarker());
-    Assert.assertEquals(false, supervisor.useExclusiveStartSequenceNumberForNonFirstSequence());
+    Assertions.assertEquals(Long.valueOf(-1L), supervisor.getNotSetMarker());
+    Assertions.assertEquals(false, supervisor.useExclusiveStartSequenceNumberForNonFirstSequence());
 
   }
 
@@ -344,7 +344,7 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
           RabbitStreamSupervisorTest.dataSchema,
           tuningConfig);
       for (String partition : partitions) {
-        Assert.assertEquals(partition.hashCode() % taskCount, supervisor.getTaskGroupIdForPartition(partition));
+        Assertions.assertEquals(partition.hashCode() % taskCount, supervisor.getTaskGroupIdForPartition(partition));
       }
     }
   }
@@ -364,12 +364,12 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
         tuningConfig);
 
     SeekableStreamSupervisorReportPayload<String, Long> payload = supervisor.createReportPayload(1, false);
-    Assert.assertEquals(STREAM, payload.getStream());
-    Assert.assertEquals(1, payload.getPartitions());
-    Assert.assertEquals(1, payload.getReplicas());
-    Assert.assertEquals(false, payload.isSuspended());
-    Assert.assertEquals(true, payload.isHealthy());
-    Assert.assertEquals(30 * 60, payload.getDurationSeconds());
+    Assertions.assertEquals(STREAM, payload.getStream());
+    Assertions.assertEquals(1, payload.getPartitions());
+    Assertions.assertEquals(1, payload.getReplicas());
+    Assertions.assertEquals(false, payload.isSuspended());
+    Assertions.assertEquals(true, payload.isHealthy());
+    Assertions.assertEquals(30 * 60, payload.getDurationSeconds());
   }
 
   @Test
@@ -411,7 +411,7 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
             .build()
     );
 
-    Assert.assertEquals(30L, ioConfig.getRefreshRejectionPeriodsInMinutes().longValue());
+    Assertions.assertEquals(30L, ioConfig.getRefreshRejectionPeriodsInMinutes().longValue());
   }
 
   @Test
@@ -433,19 +433,19 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
     EasyMock.expect(rabbitTaskMatch.getSupervisorId()).andReturn("supervisorId");
     EasyMock.replay(rabbitTaskMatch);
 
-    Assert.assertTrue(supervisor.doesTaskMatchSupervisor(rabbitTaskMatch));
+    Assertions.assertTrue(supervisor.doesTaskMatchSupervisor(rabbitTaskMatch));
 
     RabbitStreamIndexTask rabbitTaskNoMatch = createMock(RabbitStreamIndexTask.class);
     EasyMock.expect(rabbitTaskNoMatch.getSupervisorId()).andReturn(dataSchema.getDataSource());
     EasyMock.replay(rabbitTaskNoMatch);
 
-    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(rabbitTaskNoMatch));
+    Assertions.assertFalse(supervisor.doesTaskMatchSupervisor(rabbitTaskNoMatch));
 
     SeekableStreamIndexTask differentTaskType = createMock(SeekableStreamIndexTask.class);
     EasyMock.expect(differentTaskType.getSupervisorId()).andReturn("supervisorId");
     EasyMock.replay(differentTaskType);
 
-    Assert.assertFalse(supervisor.doesTaskMatchSupervisor(differentTaskType));
+    Assertions.assertFalse(supervisor.doesTaskMatchSupervisor(differentTaskType));
   }
 
   @Test
@@ -472,7 +472,7 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
         .withBoundedStreamConfig(new BoundedStreamConfig(startOffsets, endOffsets))
         .build();
 
-    Assert.assertTrue(rabbitSupervisorIOConfig.isBounded());
+    Assertions.assertTrue(rabbitSupervisorIOConfig.isBounded());
 
     final RabbitStreamIndexTaskClientFactory taskClientFactory = new RabbitStreamIndexTaskClientFactory(null, OBJECT_MAPPER);
     final RabbitStreamSupervisorSpec spec = new RabbitStreamSupervisorSpec(
@@ -506,18 +506,18 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
 
     // Test type conversion methods
     String queueName = supervisor.createPartitionIdFromString("queue-0");
-    Assert.assertEquals("queue-0", queueName);
+    Assertions.assertEquals("queue-0", queueName);
 
     Long offset = supervisor.createSequenceOffsetFromObject(100);
-    Assert.assertEquals(Long.valueOf(100L), offset);
+    Assertions.assertEquals(Long.valueOf(100L), offset);
 
     offset = supervisor.createSequenceOffsetFromObject("200");
-    Assert.assertEquals(Long.valueOf(200L), offset);
+    Assertions.assertEquals(Long.valueOf(200L), offset);
 
     // Test isOffsetAtOrBeyond
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(500L, 100L));
-    Assert.assertTrue(supervisor.isOffsetAtOrBeyond(100L, 100L));
-    Assert.assertFalse(supervisor.isOffsetAtOrBeyond(50L, 100L));
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(500L, 100L));
+    Assertions.assertTrue(supervisor.isOffsetAtOrBeyond(100L, 100L));
+    Assertions.assertFalse(supervisor.isOffsetAtOrBeyond(50L, 100L));
   }
 
   @Test
@@ -525,10 +525,10 @@ public class RabbitStreamSupervisorTest extends EasyMockSupport
   {
     supervisor = getDefaultSupervisor();
 
-    Exception e = Assert.assertThrows(
+    Exception e = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> supervisor.createSequenceOffsetFromObject(new Object())
     );
-    Assert.assertTrue(e.getMessage().contains("Cannot convert"));
+    Assertions.assertTrue(e.getMessage().contains("Cannot convert"));
   }
 }

--- a/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
+++ b/extensions-contrib/rabbit-stream-indexing-service/src/test/java/org/apache/druid/indexing/rabbitstream/supervisor/RabbitStreamSupervisorTuningConfigTest.java
@@ -34,10 +34,8 @@ import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.indexing.TuningConfig;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -52,24 +50,21 @@ public class RabbitStreamSupervisorTuningConfigTest
     mapper.registerModules((Iterable<Module>) new RabbitStreamIndexTaskModule().getJacksonModules());
   }
 
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
-
   @Test
   public void testRequireRestartWhenRabbitTaskTuningChanges()
   {
     final RabbitStreamSupervisorSpec oldSpec = supervisorSpec(tuningConfig(15, 16, 17));
 
     // getActionOnUpdateTo is invoked on the running (old) spec with the proposed spec as argument.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
         oldSpec.getActionOnUpdateTo(supervisorSpec(tuningConfig(20, 16, 17)))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
         oldSpec.getActionOnUpdateTo(supervisorSpec(tuningConfig(15, 20, 17)))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
         oldSpec.getActionOnUpdateTo(supervisorSpec(tuningConfig(15, 16, 20)))
     );
@@ -87,21 +82,21 @@ public class RabbitStreamSupervisorTuningConfigTest
                 TuningConfig.class)),
         TuningConfig.class);
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(150000, config.getMaxRowsInMemory());
-    Assert.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(0, config.getMaxPendingPersists());
-    // Assert.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
-    Assert.assertEquals(false, config.isReportParseExceptions());
-    Assert.assertEquals(java.time.Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
-    Assert.assertNull(config.getWorkerThreads());
-    Assert.assertEquals(8L, (long) config.getChatRetries());
-    Assert.assertEquals(Duration.standardSeconds(10), config.getHttpTimeout());
-    Assert.assertEquals(Duration.standardSeconds(80), config.getShutdownTimeout());
-    Assert.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
-    Assert.assertEquals(100, config.getMaxRecordsPerPollOrDefault());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(150000, config.getMaxRowsInMemory());
+    Assertions.assertEquals(5_000_000, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT10M"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(0, config.getMaxPendingPersists());
+    // Assertions.assertEquals(IndexSpec.getDefault(), config.getIndexSpec());
+    Assertions.assertEquals(false, config.isReportParseExceptions());
+    Assertions.assertEquals(java.time.Duration.ofMinutes(15).toMillis(), config.getHandoffConditionTimeout());
+    Assertions.assertNull(config.getWorkerThreads());
+    Assertions.assertEquals(8L, (long) config.getChatRetries());
+    Assertions.assertEquals(Duration.standardSeconds(10), config.getHttpTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(80), config.getShutdownTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
+    Assertions.assertEquals(100, config.getMaxRecordsPerPollOrDefault());
   }
 
   @Test
@@ -134,22 +129,22 @@ public class RabbitStreamSupervisorTuningConfigTest
                 TuningConfig.class)),
         TuningConfig.class);
 
-    Assert.assertNull(config.getBasePersistDirectory());
-    Assert.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
-    Assert.assertEquals(100, config.getMaxRowsInMemory());
-    Assert.assertEquals(100, config.getMaxRowsPerSegment().intValue());
-    Assert.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
-    Assert.assertEquals(100, config.getMaxPendingPersists());
-    Assert.assertEquals(true, config.isReportParseExceptions());
-    Assert.assertEquals(100, config.getHandoffConditionTimeout());
-    Assert.assertEquals(12, (int) config.getWorkerThreads());
-    Assert.assertEquals(14L, (long) config.getChatRetries());
-    Assert.assertEquals(15, (int) config.getRecordBufferSizeConfigured());
-    Assert.assertEquals(16, (int) config.getRecordBufferOfferTimeout());
-    Assert.assertEquals(17, (int) config.getMaxRecordsPerPollConfigured());
-    Assert.assertEquals(Duration.standardSeconds(15), config.getHttpTimeout());
-    Assert.assertEquals(Duration.standardSeconds(95), config.getShutdownTimeout());
-    Assert.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
+    Assertions.assertNull(config.getBasePersistDirectory());
+    Assertions.assertEquals(new OnheapIncrementalIndex.Spec(), config.getAppendableIndexSpec());
+    Assertions.assertEquals(100, config.getMaxRowsInMemory());
+    Assertions.assertEquals(100, config.getMaxRowsPerSegment().intValue());
+    Assertions.assertEquals(new Period("PT1H"), config.getIntermediatePersistPeriod());
+    Assertions.assertEquals(100, config.getMaxPendingPersists());
+    Assertions.assertEquals(true, config.isReportParseExceptions());
+    Assertions.assertEquals(100, config.getHandoffConditionTimeout());
+    Assertions.assertEquals(12, (int) config.getWorkerThreads());
+    Assertions.assertEquals(14L, (long) config.getChatRetries());
+    Assertions.assertEquals(15, (int) config.getRecordBufferSizeConfigured());
+    Assertions.assertEquals(16, (int) config.getRecordBufferOfferTimeout());
+    Assertions.assertEquals(17, (int) config.getMaxRecordsPerPollConfigured());
+    Assertions.assertEquals(Duration.standardSeconds(15), config.getHttpTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(95), config.getShutdownTimeout());
+    Assertions.assertEquals(Duration.standardSeconds(120), config.getRepartitionTransitionDuration());
   }
 
   private RabbitStreamSupervisorSpec supervisorSpec(final RabbitStreamSupervisorTuningConfig tuningConfig)


### PR DESCRIPTION
Part of [#13948](https://github.com/apache/druid/issues/13948).

## Summary

This PR migrates the second independent `extensions-contrib` batch from JUnit 4 to JUnit 5:

- `moving-average-query`
- `aliyun-oss-extensions`
- `rabbit-stream-indexing-service`
- `opentsdb-emitter`

The module POMs remove JUnit 4 and Hamcrest test dependencies, and the test sources use Jupiter annotations, assertions, and parameterization. `MovingAverageQueryTest` now owns its small no-op scheduler fixture instead of loading the JUnit-4-based `QueryStackTests` class.

This branch is based directly on `master`; it does not stack on [#19908](https://github.com/apache/druid/pull/19908) and contains no shared SQL/processing fixture changes. It can be merged independently. The shared fixtures are intentionally owned only by #19908.

Related migration PRs: [#19908](https://github.com/apache/druid/pull/19908), [#19875](https://github.com/apache/druid/pull/19875), [#19876](https://github.com/apache/druid/pull/19876), [#19877](https://github.com/apache/druid/pull/19877), [#19878](https://github.com/apache/druid/pull/19878), [#19879](https://github.com/apache/druid/pull/19879), [#19880](https://github.com/apache/druid/pull/19880), [#19881](https://github.com/apache/druid/pull/19881), and [#19882](https://github.com/apache/druid/pull/19882).

## Validation

- `test-compile` passed for all four modules and their required reactor dependencies.
- Focused tests passed: moving-average (65), Aliyun OSS (68), Rabbit stream (39), and OpenTSDB (11).
- Checkstyle passed with 0 violations for all four modules.
- SpotBugs passed with 0 bugs/errors for all four modules.
- No JUnit 4 or Hamcrest source imports or direct POM dependencies remain in these modules.
- `git diff --check` passed.
