### PR TITLE
test: migrate third extensions-contrib batch to JUnit 5

### DIFF
--- a/extensions-contrib/cassandra-storage/pom.xml
+++ b/extensions-contrib/cassandra-storage/pom.xml
@@ -166,12 +166,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Tests -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions-contrib/consul-extensions/pom.xml
+++ b/extensions-contrib/consul-extensions/pom.xml
@@ -41,6 +41,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-server</artifactId>
       <version>${project.parent.version}</version>
@@ -112,11 +127,6 @@
     </dependency>
 
     <!-- Test dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>

--- a/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulClientsSecurityTest.java
+++ b/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulClientsSecurityTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.consul.discovery;
 
 import com.ecwid.consul.v1.ConsulClient;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for Consul client security validation, especially around basic auth over HTTP.
@@ -38,22 +38,22 @@ public class ConsulClientsSecurityTest
         // No TLS configured
         .build();
 
-    IllegalStateException exception = Assert.assertThrows(
+    IllegalStateException exception = Assertions.assertThrows(
         IllegalStateException.class,
         () -> ConsulClients.create(config)
     );
 
-    Assert.assertTrue(
-        "Exception should mention TLS not enabled",
-        exception.getMessage().contains("TLS is not enabled")
+    Assertions.assertTrue(
+        exception.getMessage().contains("TLS is not enabled"),
+        "Exception should mention TLS not enabled"
     );
-    Assert.assertTrue(
-        "Exception should mention cleartext transmission",
-        exception.getMessage().contains("cleartext")
+    Assertions.assertTrue(
+        exception.getMessage().contains("cleartext"),
+        "Exception should mention cleartext transmission"
     );
-    Assert.assertTrue(
-        "Exception should mention allowBasicAuthOverHttp flag",
-        exception.getMessage().contains("allowBasicAuthOverHttp")
+    Assertions.assertTrue(
+        exception.getMessage().contains("allowBasicAuthOverHttp"),
+        "Exception should mention allowBasicAuthOverHttp flag"
     );
   }
 
@@ -70,7 +70,7 @@ public class ConsulClientsSecurityTest
 
     // Should not throw with the flag enabled
     ConsulClient client = ConsulClients.create(config);
-    Assert.assertNotNull(client);
+    Assertions.assertNotNull(client);
   }
 
   @Test
@@ -84,14 +84,14 @@ public class ConsulClientsSecurityTest
         // No TLS configured
         .build();
 
-    IllegalStateException exception = Assert.assertThrows(
+    IllegalStateException exception = Assertions.assertThrows(
         IllegalStateException.class,
         () -> ConsulClients.create(config)
     );
 
-    Assert.assertTrue(
-        "Exception should mention TLS not enabled",
-        exception.getMessage().contains("TLS is not enabled")
+    Assertions.assertTrue(
+        exception.getMessage().contains("TLS is not enabled"),
+        "Exception should mention TLS not enabled"
     );
   }
 
@@ -105,7 +105,7 @@ public class ConsulClientsSecurityTest
 
     // Should succeed without basic auth even without TLS
     ConsulClient client = ConsulClients.create(config);
-    Assert.assertNotNull(client);
+    Assertions.assertNotNull(client);
   }
 
   @Test
@@ -119,7 +119,7 @@ public class ConsulClientsSecurityTest
 
     // Should succeed - validation only applies when both user and password are set
     ConsulClient client = ConsulClients.create(config);
-    Assert.assertNotNull(client);
+    Assertions.assertNotNull(client);
   }
 
   @Test
@@ -133,7 +133,7 @@ public class ConsulClientsSecurityTest
 
     // Should succeed - validation only applies when both user and password are set
     ConsulClient client = ConsulClients.create(config);
-    Assert.assertNotNull(client);
+    Assertions.assertNotNull(client);
   }
 
   @Test
@@ -143,9 +143,9 @@ public class ConsulClientsSecurityTest
         .servicePrefix("druid")
         .build();
 
-    Assert.assertFalse(
-        "allowBasicAuthOverHttp should default to false",
-        config.getAuth().getAllowBasicAuthOverHttp()
+    Assertions.assertFalse(
+        config.getAuth().getAllowBasicAuthOverHttp(),
+        "allowBasicAuthOverHttp should default to false"
     );
   }
 }

--- a/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulDiscoveryConfigTest.java
+++ b/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulDiscoveryConfigTest.java
@@ -22,8 +22,10 @@ package org.apache.druid.consul.discovery;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ConsulDiscoveryConfigTest
 {
@@ -80,7 +82,7 @@ public class ConsulDiscoveryConfigTest
         + "  \"service\": { \"servicePrefix\": \"druid\" }\n"
         + "}\n"
     );
-    Assert.assertFalse(config.getAuth().getAllowBasicAuthOverHttp());
+    Assertions.assertFalse(config.getAuth().getAllowBasicAuthOverHttp());
   }
 
   @Test
@@ -92,7 +94,7 @@ public class ConsulDiscoveryConfigTest
         + "  \"service\": { \"servicePrefix\": \"druid\" }\n"
         + "}\n"
     );
-    Assert.assertTrue(config.getAuth().getAllowBasicAuthOverHttp());
+    Assertions.assertTrue(config.getAuth().getAllowBasicAuthOverHttp());
   }
 
   @Test
@@ -104,19 +106,21 @@ public class ConsulDiscoveryConfigTest
         + "  \"watch\": { \"maxWatchRetries\": -1 }\n"
         + "}\n"
     );
-    Assert.assertEquals(Long.MAX_VALUE, config.getWatch().getMaxWatchRetries());
+    Assertions.assertEquals(Long.MAX_VALUE, config.getWatch().getMaxWatchRetries());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullServicePrefixThrows()
   {
-    TestUtils.builder().servicePrefix(null).build();
+    assertThrows(IllegalArgumentException.class, () ->
+      TestUtils.builder().servicePrefix(null).build());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyServicePrefixThrows()
   {
-    TestUtils.builder().servicePrefix("").build();
+    assertThrows(IllegalArgumentException.class, () ->
+      TestUtils.builder().servicePrefix("").build());
   }
 
   @Test
@@ -128,8 +132,8 @@ public class ConsulDiscoveryConfigTest
         + "  \"leader\": { \"leaderMaxErrorRetries\": 5, \"leaderRetryBackoffMax\": \"PT30S\" }\n"
         + "}\n"
     );
-    Assert.assertEquals(5L, config.getLeader().getLeaderMaxErrorRetries());
-    Assert.assertEquals(Duration.millis(30000), config.getLeader().getLeaderRetryBackoffMax());
+    Assertions.assertEquals(5L, config.getLeader().getLeaderMaxErrorRetries());
+    Assertions.assertEquals(Duration.millis(30000), config.getLeader().getLeaderRetryBackoffMax());
   }
 
   @Test
@@ -141,7 +145,7 @@ public class ConsulDiscoveryConfigTest
           .socketTimeout(Duration.millis(5000))
           .watchSeconds(Duration.millis(60000))
           .build();
-      Assert.fail("Expected IllegalArgumentException for socketTimeout <= watchSeconds");
+      Assertions.fail("Expected IllegalArgumentException for socketTimeout <= watchSeconds");
     }
     catch (IllegalArgumentException expected) {
       // expected
@@ -156,7 +160,7 @@ public class ConsulDiscoveryConfigTest
         .watchSeconds(Duration.millis(60000))
         .build();
 
-    Assert.assertTrue(config.getConnection().getSocketTimeout().isLongerThan(config.getWatch().getWatchSeconds()));
+    Assertions.assertTrue(config.getConnection().getSocketTimeout().isLongerThan(config.getWatch().getWatchSeconds()));
   }
 
   @Test
@@ -175,12 +179,12 @@ public class ConsulDiscoveryConfigTest
 
     String toString = config.toString();
 
-    Assert.assertFalse(toString.contains("secret-acl-token"));
-    Assert.assertFalse(toString.contains("password"));
-    Assert.assertFalse(toString.contains("admin"));
-    Assert.assertTrue(toString.contains("*****"));
-    Assert.assertTrue(toString.contains("localhost"));
-    Assert.assertTrue(toString.contains("druid"));
+    Assertions.assertFalse(toString.contains("secret-acl-token"));
+    Assertions.assertFalse(toString.contains("password"));
+    Assertions.assertFalse(toString.contains("admin"));
+    Assertions.assertTrue(toString.contains("*****"));
+    Assertions.assertTrue(toString.contains("localhost"));
+    Assertions.assertTrue(toString.contains("druid"));
   }
 
   @Test
@@ -192,7 +196,7 @@ public class ConsulDiscoveryConfigTest
         .build();
 
     // Default should be max(45s, 3 * healthCheckInterval)
-    Assert.assertEquals(Duration.standardSeconds(45), config.getLeader().getLeaderSessionTtl());
+    Assertions.assertEquals(Duration.standardSeconds(45), config.getLeader().getLeaderSessionTtl());
   }
 
   @Test
@@ -205,16 +209,17 @@ public class ConsulDiscoveryConfigTest
         + "}\n"
     );
 
-    Assert.assertEquals(Duration.standardSeconds(60), config.getLeader().getLeaderSessionTtl());
+    Assertions.assertEquals(Duration.standardSeconds(60), config.getLeader().getLeaderSessionTtl());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testLeaderSessionTtlTooLow()
   {
-    TestUtils.builder()
-        .servicePrefix("druid")
-        .leaderSessionTtl(Duration.standardSeconds(5))
-        .build();
+    assertThrows(IllegalArgumentException.class, () ->
+      TestUtils.builder()
+          .servicePrefix("druid")
+          .leaderSessionTtl(Duration.standardSeconds(5))
+          .build());
   }
 
   @Test
@@ -238,7 +243,7 @@ public class ConsulDiscoveryConfigTest
         .build();
 
     // Should be 3 * healthCheckInterval = 60s (greater than minimum 45s)
-    Assert.assertEquals(Duration.standardSeconds(60), config.getLeader().getLeaderSessionTtl());
+    Assertions.assertEquals(Duration.standardSeconds(60), config.getLeader().getLeaderSessionTtl());
   }
 
   @Test
@@ -258,11 +263,11 @@ public class ConsulDiscoveryConfigTest
     // Original map modifications should not affect stored map
     originalTags.put("key1", "mutated");
 
-    Assert.assertEquals("value1", serviceConfig.getServiceTags().get("key1"));
+    Assertions.assertEquals("value1", serviceConfig.getServiceTags().get("key1"));
 
     try {
       serviceConfig.getServiceTags().put("key2", "value2");
-      Assert.fail("Expected UnsupportedOperationException when mutating serviceTags");
+      Assertions.fail("Expected UnsupportedOperationException when mutating serviceTags");
     }
     catch (UnsupportedOperationException expected) {
       // expected
@@ -276,7 +281,7 @@ public class ConsulDiscoveryConfigTest
         jsonMapper.writeValueAsString(config),
         ConsulDiscoveryConfig.class
     );
-    Assert.assertEquals(config, roundTrip);
+    Assertions.assertEquals(config, roundTrip);
   }
 
   private ConsulDiscoveryConfig testSerdeAndReturn(String jsonStr) throws Exception
@@ -286,7 +291,7 @@ public class ConsulDiscoveryConfigTest
         jsonMapper.writeValueAsString(config),
         ConsulDiscoveryConfig.class
     );
-    Assert.assertEquals(config, roundTrip);
+    Assertions.assertEquals(config, roundTrip);
     return config;
   }
 }

--- a/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulDruidNodeAnnouncerTest.java
+++ b/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulDruidNodeAnnouncerTest.java
@@ -26,17 +26,14 @@ import org.apache.http.NoHttpResponseException;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.joda.time.Duration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(JUnit4.class)
 public class ConsulDruidNodeAnnouncerTest
 {
   private final DiscoveryDruidNode testNode = new DiscoveryDruidNode(
@@ -56,13 +53,13 @@ public class ConsulDruidNodeAnnouncerTest
   private ConsulApiClient mockConsulApiClient;
   private ConsulDruidNodeAnnouncer announcer;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mockConsulApiClient = EasyMock.createMock(ConsulApiClient.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     // Don't call stop() here - each test will handle its own lifecycle
@@ -88,7 +85,7 @@ public class ConsulDruidNodeAnnouncerTest
     announcer = new ConsulDruidNodeAnnouncer(mockConsulApiClient, config);
     announcer.start();
     announcer.announce(testNode);
-    Assert.assertEquals(testNode, nodeCapture.getValue());
+    Assertions.assertEquals(testNode, nodeCapture.getValue());
 
     // Explicitly stop to trigger cleanup
     announcer.stop();
@@ -149,7 +146,7 @@ public class ConsulDruidNodeAnnouncerTest
 
     // Verify service ID format
     String expectedServiceId = "druid-broker-test-host-8082";
-    Assert.assertEquals(expectedServiceId, deregisterCapture.getValue());
+    Assertions.assertEquals(expectedServiceId, deregisterCapture.getValue());
   }
 
   @Test
@@ -173,10 +170,10 @@ public class ConsulDruidNodeAnnouncerTest
 
     try {
       announcer.announce(testNode);
-      Assert.fail("Expected RuntimeException");
+      Assertions.fail("Expected RuntimeException");
     }
     catch (RuntimeException e) {
-      Assert.assertTrue(e.getMessage().contains("Failed to announce"));
+      Assertions.assertTrue(e.getMessage().contains("Failed to announce"));
     }
 
     // Don't need to stop since no nodes were announced
@@ -238,10 +235,10 @@ public class ConsulDruidNodeAnnouncerTest
 
     try {
       announcer.announce(testNode);
-      Assert.fail("Expected failure on first announce");
+      Assertions.fail("Expected failure on first announce");
     }
     catch (RuntimeException expected) {
-      Assert.assertTrue(expected.getMessage().contains("Failed to announce"));
+      Assertions.assertTrue(expected.getMessage().contains("Failed to announce"));
     }
 
     announcer.announce(testNode); // succeeds
@@ -285,7 +282,7 @@ public class ConsulDruidNodeAnnouncerTest
     t1.start();
     t2.start();
 
-    Assert.assertTrue("Announce tasks did not finish", latch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(latch.await(5, TimeUnit.SECONDS), "Announce tasks did not finish");
 
     announcer.stop();
 

--- a/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulDruidNodeDiscoveryProviderTest.java
+++ b/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulDruidNodeDiscoveryProviderTest.java
@@ -26,10 +26,10 @@ import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.server.DruidNode;
 import org.easymock.EasyMock;
 import org.joda.time.Duration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.List;
@@ -61,14 +61,14 @@ public class ConsulDruidNodeDiscoveryProviderTest
   private ConsulApiClient mockConsulApiClient;
   private ConsulDruidNodeDiscoveryProvider provider;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mockConsulApiClient = EasyMock.createMock(ConsulApiClient.class);
     provider = new ConsulDruidNodeDiscoveryProvider(mockConsulApiClient, config);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (provider != null) {
@@ -90,7 +90,7 @@ public class ConsulDruidNodeDiscoveryProviderTest
     provider.start();
 
     boolean found = provider.getForNode(node1.getDruidNode(), NodeRole.BROKER).getAsBoolean();
-    Assert.assertTrue(found);
+    Assertions.assertTrue(found);
 
     EasyMock.verify(mockConsulApiClient);
   }
@@ -127,14 +127,14 @@ public class ConsulDruidNodeDiscoveryProviderTest
     provider.start();
 
     DruidNodeDiscovery discovery = provider.getForNodeRole(NodeRole.BROKER);
-    Assert.assertNotNull(discovery);
+    Assertions.assertNotNull(discovery);
 
     // Wait a bit for cache to initialize
     Thread.sleep(500);
 
     Collection<DiscoveryDruidNode> nodes = discovery.getAllNodes();
-    Assert.assertEquals(1, nodes.size());
-    Assert.assertTrue(nodes.contains(node1));
+    Assertions.assertEquals(1, nodes.size());
+    Assertions.assertTrue(nodes.contains(node1));
 
     EasyMock.verify(mockConsulApiClient);
   }
@@ -208,8 +208,8 @@ public class ConsulDruidNodeDiscoveryProviderTest
       }
     });
 
-    Assert.assertTrue("Initialization timed out", initLatch.await(5, TimeUnit.SECONDS));
-    Assert.assertTrue("Node addition not detected", addedLatch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(initLatch.await(5, TimeUnit.SECONDS), "Initialization timed out");
+    Assertions.assertTrue(addedLatch.await(5, TimeUnit.SECONDS), "Node addition not detected");
 
     EasyMock.verify(mockConsulApiClient);
   }

--- a/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulLeaderSelectorTest.java
+++ b/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulLeaderSelectorTest.java
@@ -30,10 +30,10 @@ import org.apache.druid.discovery.DruidLeaderSelector;
 import org.apache.druid.server.DruidNode;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -51,7 +51,7 @@ public class ConsulLeaderSelectorTest
   private ConsulDiscoveryConfig testConfig;
   private DruidNode selfNode;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     selfNode = new DruidNode(
@@ -70,7 +70,7 @@ public class ConsulLeaderSelectorTest
     leaderSelector = new ConsulLeaderSelector(selfNode, LOCK_KEY, testConfig, mockConsulClient);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     // Only unregister if we actually registered a listener
@@ -96,7 +96,7 @@ public class ConsulLeaderSelectorTest
     EasyMock.replay(mockConsulClient);
 
     String currentLeader = leaderSelector.getCurrentLeader();
-    Assert.assertEquals(leaderValue, currentLeader);
+    Assertions.assertEquals(leaderValue, currentLeader);
 
     EasyMock.verify(mockConsulClient);
   }
@@ -117,7 +117,7 @@ public class ConsulLeaderSelectorTest
     EasyMock.replay(mockConsulClient);
 
     String currentLeader = leaderSelector.getCurrentLeader();
-    Assert.assertNull(currentLeader);
+    Assertions.assertNull(currentLeader);
 
     EasyMock.verify(mockConsulClient);
   }
@@ -125,13 +125,13 @@ public class ConsulLeaderSelectorTest
   @Test
   public void testIsLeaderInitiallyFalse()
   {
-    Assert.assertFalse(leaderSelector.isLeader());
+    Assertions.assertFalse(leaderSelector.isLeader());
   }
 
   @Test
   public void testLocalTermInitiallyZero()
   {
-    Assert.assertEquals(0, leaderSelector.localTerm());
+    Assertions.assertEquals(0, leaderSelector.localTerm());
   }
 
   @Test
@@ -200,22 +200,22 @@ public class ConsulLeaderSelectorTest
     leaderSelector.registerListener(listener);
 
     // Wait for session creation and leader election
-    Assert.assertTrue("Session not created", sessionCreatedLatch.await(5, TimeUnit.SECONDS));
-    Assert.assertTrue("Did not become leader", becameLeaderLatch.await(5, TimeUnit.SECONDS));
+    Assertions.assertTrue(sessionCreatedLatch.await(5, TimeUnit.SECONDS), "Session not created");
+    Assertions.assertTrue(becameLeaderLatch.await(5, TimeUnit.SECONDS), "Did not become leader");
 
     // Verify we became leader
-    Assert.assertTrue(leaderSelector.isLeader());
-    Assert.assertEquals(1, leaderSelector.localTerm());
+    Assertions.assertTrue(leaderSelector.isLeader());
+    Assertions.assertEquals(1, leaderSelector.localTerm());
 
     // Verify session was created correctly
     NewSession createdSession = sessionCapture.getValue();
-    Assert.assertNotNull(createdSession);
-    Assert.assertEquals(Session.Behavior.DELETE, createdSession.getBehavior());
-    Assert.assertEquals(5L, createdSession.getLockDelay());
+    Assertions.assertNotNull(createdSession);
+    Assertions.assertEquals(Session.Behavior.DELETE, createdSession.getBehavior());
+    Assertions.assertEquals(5L, createdSession.getLockDelay());
 
     // Verify lock acquisition used the session
     PutParams putParams = putParamsCapture.getValue();
-    Assert.assertEquals(SESSION_ID, putParams.getAcquireSession());
+    Assertions.assertEquals(SESSION_ID, putParams.getAcquireSession());
 
     EasyMock.verify(mockConsulClient);
   }
@@ -293,7 +293,7 @@ public class ConsulLeaderSelectorTest
     leaderSelector.unregisterListener();
 
     // Verify session was destroyed
-    Assert.assertEquals(SESSION_ID, sessionIdCapture.getValue());
+    Assertions.assertEquals(SESSION_ID, sessionIdCapture.getValue());
 
     EasyMock.verify(mockConsulClient);
   }

--- a/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulServiceIdsTest.java
+++ b/extensions-contrib/consul-extensions/src/test/java/org/apache/druid/consul/discovery/ConsulServiceIdsTest.java
@@ -23,8 +23,8 @@ import org.apache.druid.discovery.DiscoveryDruidNode;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.server.DruidNode;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ConsulServiceIdsTest
 {
@@ -49,15 +49,15 @@ public class ConsulServiceIdsTest
 
     NodeRole role = NodeRole.PEON;
     String serviceName = ConsulServiceIds.serviceName(config, role);
-    Assert.assertEquals("druid-peon", serviceName);
+    Assertions.assertEquals("druid-peon", serviceName);
 
     DruidNode druidNode = new DruidNode("service", "host", false, 8080, null, true, false);
     DiscoveryDruidNode discoveryNode = new DiscoveryDruidNode(druidNode, role, null);
 
     String serviceId = ConsulServiceIds.serviceId(config, discoveryNode);
-    Assert.assertEquals("druid-peon-host-8080", serviceId);
+    Assertions.assertEquals("druid-peon-host-8080", serviceId);
 
     String kvKey = ConsulServiceIds.nodeKvKey(config, serviceId);
-    Assert.assertEquals("druid/nodes/druid-peon-host-8080", kvKey);
+    Assertions.assertEquals("druid/nodes/druid-peon-host-8080", kvKey);
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/pom.xml
+++ b/extensions-contrib/druid-deltalake-extensions/pom.xml
@@ -40,6 +40,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.delta</groupId>
       <artifactId>delta-kernel-api</artifactId>
       <version>${delta-kernel.version}</version>
@@ -119,50 +134,10 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-migrationsupport</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/DeltaAssertions.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/DeltaAssertions.java
@@ -17,20 +17,22 @@
  * under the License.
  */
 
-package org.apache.druid.iceberg.filter;
+package org.apache.druid.delta;
 
-import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.Expressions;
+import org.apache.druid.error.DruidException;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 
-public class IcebergEqualsFilterTest
+public class DeltaAssertions
 {
-  @Test
-  public void testFilter()
+  private DeltaAssertions()
   {
-    IcebergEqualsFilter testFilter = new IcebergEqualsFilter("column1", "value1");
-    Expression expectedExpression = Expressions.equal("column1", "value1");
-    Assertions.assertEquals(expectedExpression.toString(), testFilter.getFilterExpression().toString());
+  }
+
+  public static void assertInvalidInput(final DruidException exception, final String expectedMessage)
+  {
+    Assertions.assertAll(
+        () -> Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory()),
+        () -> Assertions.assertEquals(expectedMessage, exception.getMessage())
+    );
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/DeltaAssertions.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/DeltaAssertions.java
@@ -31,7 +31,9 @@ public class DeltaAssertions
   public static void assertInvalidInput(final DruidException exception, final String expectedMessage)
   {
     Assertions.assertAll(
+        () -> Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona()),
         () -> Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory()),
+        () -> Assertions.assertEquals("invalidInput", exception.getErrorCode()),
         () -> Assertions.assertEquals(expectedMessage, exception.getMessage())
     );
   }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaAndFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaAndFilterTest.java
@@ -25,12 +25,11 @@ import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
+import org.apache.druid.delta.DeltaAssertions;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.StringUtils;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,8 +53,8 @@ public class DeltaAndFilterTest
 
     Predicate predicate = andFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertTrue(predicate instanceof And);
-    Assert.assertEquals(2, predicate.getChildren().size());
+    Assertions.assertTrue(predicate instanceof And);
+    Assertions.assertEquals(2, predicate.getChildren().size());
   }
 
   @Test
@@ -68,33 +67,29 @@ public class DeltaAndFilterTest
         )
     );
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () -> andFilter.getFilterPredicate(SCHEMA)),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format("column[name2] doesn't exist in schema[%s]", SCHEMA)
-        )
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(DruidException.class, () -> andFilter.getFilterPredicate(SCHEMA)),
+        StringUtils.format("column[name2] doesn't exist in schema[%s]", SCHEMA)
     );
   }
 
   @Test
   public void testAndFilterWithNoFilterPredicates()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new DeltaAndFilter(null)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Delta and filter requires 2 filter predicates and must be non-empty. None provided."
-        )
+        "Delta and filter requires 2 filter predicates and must be non-empty. None provided."
     );
   }
 
   @Test
   public void testAndFilterWithOneFilterPredicate()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new DeltaAndFilter(
                 Collections.singletonList(
@@ -102,9 +97,7 @@ public class DeltaAndFilterTest
                 )
             )
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Delta and filter requires 2 filter predicates, but provided [1]."
-        )
+        "Delta and filter requires 2 filter predicates, but provided [1]."
     );
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaEqualsFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaEqualsFilterTest.java
@@ -29,11 +29,10 @@ import io.delta.kernel.types.ShortType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
+import org.apache.druid.delta.DeltaAssertions;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DeltaEqualsFilterTest
 {
@@ -53,35 +52,31 @@ public class DeltaEqualsFilterTest
 
     Predicate predicate = eqFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertEquals("=", predicate.getName());
-    Assert.assertEquals(2, predicate.getChildren().size());
+    Assertions.assertEquals("=", predicate.getName());
+    Assertions.assertEquals(2, predicate.getChildren().size());
   }
 
   @Test
   public void testFilterWithNullColumn()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new DeltaEqualsFilter(null, "Employee1")
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "column is a required field for = filter."
-        )
+        "column is a required field for = filter."
     );
   }
 
   @Test
   public void testFilterWithNullValue()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new DeltaEqualsFilter("str_col", null)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "value is a required field for = filter. None provided for column[str_col]."
-        )
+        "value is a required field for = filter. None provided for column[str_col]."
     );
   }
 
@@ -90,14 +85,12 @@ public class DeltaEqualsFilterTest
   {
     DeltaEqualsFilter eqFilter = new DeltaEqualsFilter("long_col", "twentyOne");
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> eqFilter.getFilterPredicate(SCHEMA)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "column[long_col] has an invalid value[twentyOne]. The value must be a number, as the column's data type is [long]."
-        )
+        "column[long_col] has an invalid value[twentyOne]. The value must be a number, as the column's data type is [long]."
     );
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaGreaterThanFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaGreaterThanFilterTest.java
@@ -29,8 +29,8 @@ import io.delta.kernel.types.ShortType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DeltaGreaterThanFilterTest
 {
@@ -50,7 +50,7 @@ public class DeltaGreaterThanFilterTest
 
     Predicate predicate = gtFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertEquals(">", predicate.getName());
-    Assert.assertEquals(2, predicate.getChildren().size());
+    Assertions.assertEquals(">", predicate.getName());
+    Assertions.assertEquals(2, predicate.getChildren().size());
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaGreaterThanOrEqualsFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaGreaterThanOrEqualsFilterTest.java
@@ -29,8 +29,8 @@ import io.delta.kernel.types.ShortType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DeltaGreaterThanOrEqualsFilterTest
 {
@@ -51,7 +51,7 @@ public class DeltaGreaterThanOrEqualsFilterTest
 
     Predicate predicate = gteFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertEquals(">=", predicate.getName());
-    Assert.assertEquals(2, predicate.getChildren().size());
+    Assertions.assertEquals(">=", predicate.getName());
+    Assertions.assertEquals(2, predicate.getChildren().size());
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaLessThanFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaLessThanFilterTest.java
@@ -29,8 +29,8 @@ import io.delta.kernel.types.ShortType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DeltaLessThanFilterTest
 {
@@ -50,7 +50,7 @@ public class DeltaLessThanFilterTest
 
     Predicate predicate = ltFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertEquals("<", predicate.getName());
-    Assert.assertEquals(2, predicate.getChildren().size());
+    Assertions.assertEquals("<", predicate.getName());
+    Assertions.assertEquals(2, predicate.getChildren().size());
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaLessThanOrEqualsFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaLessThanOrEqualsFilterTest.java
@@ -29,11 +29,10 @@ import io.delta.kernel.types.ShortType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
+import org.apache.druid.delta.DeltaAssertions;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DeltaLessThanOrEqualsFilterTest
 {
@@ -53,8 +52,8 @@ public class DeltaLessThanOrEqualsFilterTest
 
     Predicate predicate = lteFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertEquals("<=", predicate.getName());
-    Assert.assertEquals(2, predicate.getChildren().size());
+    Assertions.assertEquals("<=", predicate.getName());
+    Assertions.assertEquals(2, predicate.getChildren().size());
   }
 
   @Test
@@ -62,14 +61,12 @@ public class DeltaLessThanOrEqualsFilterTest
   {
     DeltaLessThanOrEqualsFilter lteFilter = new DeltaLessThanOrEqualsFilter("long_col", "twentyOne");
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> lteFilter.getFilterPredicate(SCHEMA)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "column[long_col] has an invalid value[twentyOne]. The value must be a number, as the column's data type is [long]."
-        )
+        "column[long_col] has an invalid value[twentyOne]. The value must be a number, as the column's data type is [long]."
     );
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaNotFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaNotFilterTest.java
@@ -24,12 +24,11 @@ import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
+import org.apache.druid.delta.DeltaAssertions;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.StringUtils;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -51,8 +50,8 @@ public class DeltaNotFilterTest
 
     Predicate predicate = notFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertEquals(predicate.getName(), "NOT");
-    Assert.assertEquals(1, predicate.getChildren().size());
+    Assertions.assertEquals(predicate.getName(), "NOT");
+    Assertions.assertEquals(1, predicate.getChildren().size());
   }
 
   @Test
@@ -74,8 +73,8 @@ public class DeltaNotFilterTest
 
     Predicate predicate = notFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertEquals(predicate.getName(), "NOT");
-    Assert.assertEquals(1, predicate.getChildren().size());
+    Assertions.assertEquals(predicate.getName(), "NOT");
+    Assertions.assertEquals(1, predicate.getChildren().size());
   }
 
   @Test
@@ -87,25 +86,21 @@ public class DeltaNotFilterTest
     );
     DeltaNotFilter notFilter = new DeltaNotFilter(equalsFilter);
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () -> notFilter.getFilterPredicate(SCHEMA)),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format("column[name2] doesn't exist in schema[%s]", SCHEMA)
-        )
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(DruidException.class, () -> notFilter.getFilterPredicate(SCHEMA)),
+        StringUtils.format("column[name2] doesn't exist in schema[%s]", SCHEMA)
     );
   }
 
   @Test
   public void testNotFilterWithNoFilterPredicates()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new DeltaNotFilter(null)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Delta not filter requiers 1 filter predicate and must be non-empty. None provided."
-        )
+        "Delta not filter requiers 1 filter predicate and must be non-empty. None provided."
     );
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaOrFilterTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/filter/DeltaOrFilterTest.java
@@ -25,12 +25,11 @@ import io.delta.kernel.types.LongType;
 import io.delta.kernel.types.StringType;
 import io.delta.kernel.types.StructField;
 import io.delta.kernel.types.StructType;
+import org.apache.druid.delta.DeltaAssertions;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.StringUtils;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,8 +53,8 @@ public class DeltaOrFilterTest
 
     Predicate predicate = orFilter.getFilterPredicate(SCHEMA);
 
-    Assert.assertTrue(predicate instanceof Or);
-    Assert.assertEquals(2, predicate.getChildren().size());
+    Assertions.assertTrue(predicate instanceof Or);
+    Assertions.assertEquals(2, predicate.getChildren().size());
   }
 
   @Test
@@ -68,33 +67,29 @@ public class DeltaOrFilterTest
         )
     );
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () -> orFilter.getFilterPredicate(SCHEMA)),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format("column[name2] doesn't exist in schema[%s]", SCHEMA)
-        )
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(DruidException.class, () -> orFilter.getFilterPredicate(SCHEMA)),
+        StringUtils.format("column[name2] doesn't exist in schema[%s]", SCHEMA)
     );
   }
 
   @Test
   public void testOrFilterWithNoFilterPredicates()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new DeltaOrFilter(null)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Delta or filter requires 2 filter predicates and must be non-empty. None provided."
-        )
+        "Delta or filter requires 2 filter predicates and must be non-empty. None provided."
     );
   }
 
   @Test
   public void testOrFilterWithOneFilterPredicate()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new DeltaOrFilter(
                 Collections.singletonList(
@@ -102,9 +97,7 @@ public class DeltaOrFilterTest
                 )
             )
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Delta or filter requires 2 filter predicates, but provided [1]."
-        )
+        "Delta or filter requires 2 filter predicates, but provided [1]."
     );
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaInputRowTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaInputRowTest.java
@@ -33,11 +33,10 @@ import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
 import io.delta.kernel.utils.FileStatus;
 import org.apache.druid.data.input.InputRowSchema;
+import org.apache.druid.delta.DeltaAssertions;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.hadoop.conf.Configuration;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -102,23 +101,23 @@ public class DeltaInputRowTest
           FilteredColumnarBatch dataReadResult = dataIter.next();
           Row next = dataReadResult.getRows().next();
           DeltaInputRow deltaInputRow = new DeltaInputRow(next, schema);
-          Assert.assertNotNull(deltaInputRow);
-          Assert.assertEquals(dimensions, deltaInputRow.getDimensions());
+          Assertions.assertNotNull(deltaInputRow);
+          Assertions.assertEquals(dimensions, deltaInputRow.getDimensions());
 
           Map<String, Object> expectedRow = expectedRows.get(totalRecordCount);
           for (String key : expectedRow.keySet()) {
             if (schema.getTimestampSpec().getTimestampColumn().equals(key)) {
               final long expectedMillis = ((Long) expectedRow.get(key)) * 1000;
-              Assert.assertEquals(expectedMillis, deltaInputRow.getTimestampFromEpoch());
+              Assertions.assertEquals(expectedMillis, deltaInputRow.getTimestampFromEpoch());
             } else {
-              Assert.assertEquals(expectedRow.get(key), deltaInputRow.getRaw(key));
+              Assertions.assertEquals(expectedRow.get(key), deltaInputRow.getRaw(key));
             }
           }
           totalRecordCount += 1;
         }
       }
     }
-    Assert.assertEquals(expectedRows.size(), totalRecordCount);
+    Assertions.assertEquals(expectedRows.size(), totalRecordCount);
   }
 
   @MethodSource("data")
@@ -127,14 +126,12 @@ public class DeltaInputRowTest
   {
     final DeltaInputSource deltaInputSource = new DeltaInputSource("non-existent-table", null, null, null);
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    DeltaAssertions.assertInvalidInput(
+        Assertions.assertThrows(
             DruidException.class,
             () -> deltaInputSource.reader(null, null, null)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "tablePath[non-existent-table] not found."
-        )
+        "tablePath[non-existent-table] not found."
     );
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaInputSourceSerdeTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaInputSourceSerdeTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.delta.common.DeltaLakeDruidModule;
 import org.apache.druid.delta.filter.DeltaAndFilter;
 import org.apache.druid.delta.filter.DeltaLessThanFilter;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DeltaInputSourceSerdeTest
 {
@@ -43,8 +43,8 @@ public class DeltaInputSourceSerdeTest
                            + "    }";
 
     final DeltaInputSource deltaInputSource = OBJECT_MAPPER.readValue(payload, DeltaInputSource.class);
-    Assert.assertEquals("foo/bar", deltaInputSource.getTablePath());
-    Assert.assertNull(deltaInputSource.getFilter());
+    Assertions.assertEquals("foo/bar", deltaInputSource.getTablePath());
+    Assertions.assertNull(deltaInputSource.getFilter());
   }
 
   @Test
@@ -61,8 +61,8 @@ public class DeltaInputSourceSerdeTest
                            + "    }";
 
     final DeltaInputSource deltaInputSource = OBJECT_MAPPER.readValue(payload, DeltaInputSource.class);
-    Assert.assertEquals("foo/bar", deltaInputSource.getTablePath());
-    Assert.assertTrue(deltaInputSource.getFilter() instanceof DeltaLessThanFilter);
+    Assertions.assertEquals("foo/bar", deltaInputSource.getTablePath());
+    Assertions.assertTrue(deltaInputSource.getFilter() instanceof DeltaLessThanFilter);
   }
 
   @Test
@@ -89,8 +89,8 @@ public class DeltaInputSourceSerdeTest
                      + "    }";
 
     final DeltaInputSource deltaInputSource = OBJECT_MAPPER.readValue(payload, DeltaInputSource.class);
-    Assert.assertEquals("s3://foo/bar/baz", deltaInputSource.getTablePath());
-    Assert.assertTrue(deltaInputSource.getFilter() instanceof DeltaAndFilter);
+    Assertions.assertEquals("s3://foo/bar/baz", deltaInputSource.getTablePath());
+    Assertions.assertTrue(deltaInputSource.getFilter() instanceof DeltaAndFilter);
   }
 
   @Test
@@ -105,12 +105,12 @@ public class DeltaInputSourceSerdeTest
                            + "      }\n"
                            + "    }";
 
-    final ValueInstantiationException exception = Assert.assertThrows(
+    final ValueInstantiationException exception = Assertions.assertThrows(
         ValueInstantiationException.class,
         () -> OBJECT_MAPPER.readValue(payload, DeltaInputSource.class)
     );
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         exception.getCause().getMessage().contains(
             "tablePath cannot be null."
         )
@@ -129,12 +129,12 @@ public class DeltaInputSourceSerdeTest
                            + "      }\n"
                            + "    }";
 
-    final ValueInstantiationException exception = Assert.assertThrows(
+    final ValueInstantiationException exception = Assertions.assertThrows(
         ValueInstantiationException.class,
         () -> OBJECT_MAPPER.readValue(payload, DeltaInputSource.class)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "column is a required field for >= filter.",
         exception.getCause().getMessage()
     );
@@ -150,7 +150,7 @@ public class DeltaInputSourceSerdeTest
                            + "    }";
 
     final DeltaInputSource deltaInputSource = OBJECT_MAPPER.readValue(payload, DeltaInputSource.class);
-    Assert.assertEquals("foo/bar", deltaInputSource.getTablePath());
-    Assert.assertEquals((Long) 56L, deltaInputSource.getSnapshotVersion());
+    Assertions.assertEquals("foo/bar", deltaInputSource.getTablePath());
+    Assertions.assertEquals((Long) 56L, deltaInputSource.getSnapshotVersion());
   }
 }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaInputSourceTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaInputSourceTest.java
@@ -24,6 +24,7 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.InputRowListPlusRawValues;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.InputSourceReader;
+import org.apache.druid.delta.DeltaAssertions;
 import org.apache.druid.delta.filter.DeltaAndFilter;
 import org.apache.druid.delta.filter.DeltaEqualsFilter;
 import org.apache.druid.delta.filter.DeltaFilter;
@@ -33,15 +34,14 @@ import org.apache.druid.delta.filter.DeltaLessThanOrEqualsFilter;
 import org.apache.druid.delta.filter.DeltaNotFilter;
 import org.apache.druid.delta.filter.DeltaOrFilter;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,16 +53,15 @@ import java.util.stream.Collectors;
 
 public class DeltaInputSourceTest
 {
-  @Before
+  @BeforeEach
   public void setUp()
   {
     System.setProperty("user.timezone", "UTC");
   }
 
-  @RunWith(Parameterized.class)
-  public static class TablePathParameterTests
+  @Nested
+  public class TablePathParameterTests
   {
-    @Parameterized.Parameters
     public static Object[][] data()
     {
       return new Object[][]{
@@ -128,64 +127,66 @@ public class DeltaInputSourceTest
           }
       };
     }
-
-    @Parameterized.Parameter(0)
-    public String deltaTablePath;
-    @Parameterized.Parameter(1)
-    public InputRowSchema schema;
-    @Parameterized.Parameter(2)
-    public Long snapshotVersion;
-    @Parameterized.Parameter(3)
-    public List<Map<String, Object>> expectedRows;
-
-    @Test
-    public void testSampleDeltaTable() throws IOException
+    @MethodSource("data")
+    @ParameterizedTest
+    public void testSampleDeltaTable(
+        String deltaTablePath,
+        InputRowSchema schema,
+        Long snapshotVersion,
+        List<Map<String, Object>> expectedRows
+    ) throws IOException
     {
       final DeltaInputSource deltaInputSource = new DeltaInputSource(deltaTablePath, null, null, snapshotVersion);
       final InputSourceReader inputSourceReader = deltaInputSource.reader(schema, null, null);
 
       List<InputRowListPlusRawValues> actualSampledRows = sampleAllRows(inputSourceReader);
-      Assert.assertEquals(expectedRows.size(), actualSampledRows.size());
+      Assertions.assertEquals(expectedRows.size(), actualSampledRows.size());
 
       for (int idx = 0; idx < expectedRows.size(); idx++) {
         Map<String, Object> expectedRow = expectedRows.get(idx);
         InputRowListPlusRawValues actualSampledRow = actualSampledRows.get(idx);
-        Assert.assertNull(actualSampledRow.getParseException());
+        Assertions.assertNull(actualSampledRow.getParseException());
 
         Map<String, Object> actualSampledRawVals = actualSampledRow.getRawValues();
-        Assert.assertNotNull(actualSampledRawVals);
-        Assert.assertNotNull(actualSampledRow.getRawValuesList());
-        Assert.assertEquals(1, actualSampledRow.getRawValuesList().size());
+        Assertions.assertNotNull(actualSampledRawVals);
+        Assertions.assertNotNull(actualSampledRow.getRawValuesList());
+        Assertions.assertEquals(1, actualSampledRow.getRawValuesList().size());
 
         for (String key : expectedRow.keySet()) {
           if (!schema.getColumnsFilter().apply(key)) {
-            Assert.assertNull(actualSampledRawVals.get(key));
+            Assertions.assertNull(actualSampledRawVals.get(key));
           } else {
             if (schema.getTimestampSpec().getTimestampColumn().equals(key)) {
               final long expectedMillis = (Long) expectedRow.get(key);
-              Assert.assertEquals(expectedMillis, actualSampledRawVals.get(key));
+              Assertions.assertEquals(expectedMillis, actualSampledRawVals.get(key));
             } else {
-              Assert.assertEquals(expectedRow.get(key), actualSampledRawVals.get(key));
+              Assertions.assertEquals(expectedRow.get(key), actualSampledRawVals.get(key));
             }
           }
         }
       }
     }
 
-    @Test
-    public void testReadDeltaTable() throws IOException
+    @MethodSource("data")
+    @ParameterizedTest
+    public void testReadDeltaTable(
+        String deltaTablePath,
+        InputRowSchema schema,
+        Long snapshotVersion,
+        List<Map<String, Object>> expectedRows
+    ) throws IOException
     {
       final DeltaInputSource deltaInputSource = new DeltaInputSource(deltaTablePath, null, null, snapshotVersion);
       final InputSourceReader inputSourceReader = deltaInputSource.reader(schema, null, null);
       final List<InputRow> actualReadRows = readAllRows(inputSourceReader);
       validateRows(expectedRows, actualReadRows, schema);
     }
+
   }
 
-  @RunWith(Parameterized.class)
-  public static class FilterParameterTests
+  @Nested
+  public class FilterParameterTests
   {
-    @Parameterized.Parameters
     public static Object[][] data()
     {
       return new Object[][]{
@@ -295,43 +296,40 @@ public class DeltaInputSourceTest
       };
     }
 
-    @Parameterized.Parameter(0)
-    public String deltaTablePath;
-    @Parameterized.Parameter(1)
-    public DeltaFilter filter;
-    @Parameterized.Parameter(2)
-    public InputRowSchema schema;
-    @Parameterized.Parameter(3)
-    public List<Map<String, Object>> expectedRows;
-
-    @Test
-    public void testSampleDeltaTable() throws IOException
+    @MethodSource("data")
+    @ParameterizedTest
+    public void testSampleDeltaTable(
+        String deltaTablePath,
+        DeltaFilter filter,
+        InputRowSchema schema,
+        List<Map<String, Object>> expectedRows
+    ) throws IOException
     {
       final DeltaInputSource deltaInputSource = new DeltaInputSource(deltaTablePath, null, filter, null);
       final InputSourceReader inputSourceReader = deltaInputSource.reader(schema, null, null);
 
       List<InputRowListPlusRawValues> actualSampledRows = sampleAllRows(inputSourceReader);
-      Assert.assertEquals(expectedRows.size(), actualSampledRows.size());
+      Assertions.assertEquals(expectedRows.size(), actualSampledRows.size());
 
       for (int idx = 0; idx < expectedRows.size(); idx++) {
         Map<String, Object> expectedRow = expectedRows.get(idx);
         InputRowListPlusRawValues actualSampledRow = actualSampledRows.get(idx);
-        Assert.assertNull(actualSampledRow.getParseException());
+        Assertions.assertNull(actualSampledRow.getParseException());
 
         Map<String, Object> actualSampledRawVals = actualSampledRow.getRawValues();
-        Assert.assertNotNull(actualSampledRawVals);
-        Assert.assertNotNull(actualSampledRow.getRawValuesList());
-        Assert.assertEquals(1, actualSampledRow.getRawValuesList().size());
+        Assertions.assertNotNull(actualSampledRawVals);
+        Assertions.assertNotNull(actualSampledRow.getRawValuesList());
+        Assertions.assertEquals(1, actualSampledRow.getRawValuesList().size());
 
         for (String key : expectedRow.keySet()) {
           if (!schema.getColumnsFilter().apply(key)) {
-            Assert.assertNull(actualSampledRawVals.get(key));
+            Assertions.assertNull(actualSampledRawVals.get(key));
           } else {
             if (schema.getTimestampSpec().getTimestampColumn().equals(key)) {
               final long expectedMillis = (Long) expectedRow.get(key);
-              Assert.assertEquals(expectedMillis, actualSampledRawVals.get(key));
+              Assertions.assertEquals(expectedMillis, actualSampledRawVals.get(key));
             } else {
-              Assert.assertEquals(expectedRow.get(key), actualSampledRawVals.get(key));
+              Assertions.assertEquals(expectedRow.get(key), actualSampledRawVals.get(key));
             }
           }
         }
@@ -346,29 +344,35 @@ public class DeltaInputSourceTest
       return rows.stream().filter(filter).collect(Collectors.toList());
     }
 
-    @Test
-    public void testReadDeltaTable() throws IOException
+    @MethodSource("data")
+    @ParameterizedTest
+    public void testReadDeltaTable(
+        String deltaTablePath,
+        DeltaFilter filter,
+        InputRowSchema schema,
+        List<Map<String, Object>> expectedRows
+    ) throws IOException
     {
       final DeltaInputSource deltaInputSource = new DeltaInputSource(deltaTablePath, null, filter, null);
       final InputSourceReader inputSourceReader = deltaInputSource.reader(schema, null, null);
       final List<InputRow> actualReadRows = readAllRows(inputSourceReader);
       validateRows(expectedRows, actualReadRows, schema);
     }
+
   }
 
-  public static class InvalidInputTests
+  @Nested
+  public class InvalidInputTests
   {
     @Test
     public void testNullTable()
     {
-      MatcherAssert.assertThat(
-          Assert.assertThrows(
+      DeltaAssertions.assertInvalidInput(
+          Assertions.assertThrows(
               DruidException.class,
               () -> new DeltaInputSource(null, null, null, null)
           ),
-          DruidExceptionMatcher.invalidInput().expectMessageIs(
-              "tablePath cannot be null."
-          )
+          "tablePath cannot be null."
       );
     }
 
@@ -377,14 +381,12 @@ public class DeltaInputSourceTest
     {
       final DeltaInputSource deltaInputSource = new DeltaInputSource("non-existent-table", null, null, null);
 
-      MatcherAssert.assertThat(
-          Assert.assertThrows(
+      DeltaAssertions.assertInvalidInput(
+          Assertions.assertThrows(
               DruidException.class,
               () -> deltaInputSource.createSplits(null, null)
           ),
-          DruidExceptionMatcher.invalidInput().expectMessageIs(
-              "tablePath[non-existent-table] not found."
-          )
+          "tablePath[non-existent-table] not found."
       );
     }
 
@@ -393,14 +395,12 @@ public class DeltaInputSourceTest
     {
       final DeltaInputSource deltaInputSource = new DeltaInputSource("non-existent-table", null, null, null);
 
-      MatcherAssert.assertThat(
-          Assert.assertThrows(
+      DeltaAssertions.assertInvalidInput(
+          Assertions.assertThrows(
               DruidException.class,
               () -> deltaInputSource.reader(null, null, null)
           ),
-          DruidExceptionMatcher.invalidInput().expectMessageIs(
-              "tablePath[non-existent-table] not found."
-          )
+          "tablePath[non-existent-table] not found."
       );
     }
 
@@ -414,7 +414,7 @@ public class DeltaInputSourceTest
           100L
       );
 
-      Assert.assertThrows(
+      Assertions.assertThrows(
           KernelException.class,
           () -> deltaInputSource.reader(null, null, null)
       );
@@ -453,7 +453,8 @@ public class DeltaInputSourceTest
    * Without the fix: 1024 x 2 = 2048 rows.
    * With the fix:    4000 rows.
    */
-  public static class BatchDrainRegressionTests
+  @Nested
+  public class BatchDrainRegressionTests
   {
     @Test
     public void testAllRowsReturnedWhenFileExceedsOneBatch() throws IOException
@@ -470,11 +471,11 @@ public class DeltaInputSourceTest
           null
       );
       final List<InputRow> rows = readAllRows(inputSourceReader);
-      Assert.assertEquals(
-          "Expected all rows to be read. "
-          + "If this fails with " + (1024 * 2) + " rows, the per-file batch drain bug (GH-18606) has regressed.",
+      Assertions.assertEquals(
           LargeRowGroupDeltaTable.EXPECTED_ROW_COUNT,
-          rows.size()
+          rows.size(),
+          "Expected all rows to be read. "
+          + "If this fails with " + (1024 * 2) + " rows, the per-file batch drain bug (GH-18606) has regressed."
       );
     }
   }
@@ -485,21 +486,21 @@ public class DeltaInputSourceTest
       final InputRowSchema schema
   )
   {
-    Assert.assertEquals(expectedRows.size(), actualReadRows.size());
+    Assertions.assertEquals(expectedRows.size(), actualReadRows.size());
 
     for (int idx = 0; idx < expectedRows.size(); idx++) {
       final Map<String, Object> expectedRow = expectedRows.get(idx);
       final InputRow actualInputRow = actualReadRows.get(idx);
       for (String key : expectedRow.keySet()) {
         if (!schema.getColumnsFilter().apply(key)) {
-          Assert.assertNull(actualInputRow.getRaw(key));
+          Assertions.assertNull(actualInputRow.getRaw(key));
         } else {
           if (schema.getTimestampSpec().getTimestampColumn().equals(key)) {
             final long expectedMillis = (Long) expectedRow.get(key) * 1000;
-            Assert.assertEquals(expectedMillis, actualInputRow.getTimestampFromEpoch());
-            Assert.assertEquals(DateTimes.utc(expectedMillis), actualInputRow.getTimestamp());
+            Assertions.assertEquals(expectedMillis, actualInputRow.getTimestampFromEpoch());
+            Assertions.assertEquals(DateTimes.utc(expectedMillis), actualInputRow.getTimestamp());
           } else {
-            Assert.assertEquals(expectedRow.get(key), actualInputRow.getRaw(key));
+            Assertions.assertEquals(expectedRow.get(key), actualInputRow.getRaw(key));
           }
         }
       }

--- a/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaTimeUtilsTest.java
+++ b/extensions-contrib/druid-deltalake-extensions/src/test/java/org/apache/druid/delta/input/DeltaTimeUtilsTest.java
@@ -20,15 +20,15 @@
 package org.apache.druid.delta.input;
 
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
 public class DeltaTimeUtilsTest
 {
-  @Before
+  @BeforeEach
   public void setUp()
   {
     System.setProperty("user.timezone", "UTC");
@@ -37,7 +37,7 @@ public class DeltaTimeUtilsTest
   @Test
   public void testTimestampValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Instant.parse("2018-02-02T00:28:02.000Z"),
         Instant.ofEpochMilli(
             DeltaTimeUtils.getMillisFromTimestamp(
@@ -46,7 +46,7 @@ public class DeltaTimeUtilsTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Instant.parse("2024-01-31T00:58:03.000Z"),
         Instant.ofEpochMilli(
             DeltaTimeUtils.getMillisFromTimestamp(
@@ -59,7 +59,7 @@ public class DeltaTimeUtilsTest
   @Test
   public void testDateTimeValue()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Instant.parse("2020-02-01T00:00:00.000Z"),
         Instant.ofEpochSecond(
             DeltaTimeUtils.getSecondsFromDate(
@@ -68,7 +68,7 @@ public class DeltaTimeUtilsTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Instant.parse("2024-01-01T00:00:00.000Z"),
         Instant.ofEpochSecond(
             DeltaTimeUtils.getSecondsFromDate(

--- a/extensions-contrib/druid-iceberg-extensions/pom.xml
+++ b/extensions-contrib/druid-iceberg-extensions/pom.xml
@@ -39,6 +39,21 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <scope>compile</scope>
@@ -780,11 +795,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergAndFilterTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergAndFilterTest.java
@@ -24,8 +24,8 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,14 +61,14 @@ public class IcebergAndFilterTest
         new IcebergEqualsFilter(COLUMN2, "value2")
     ));
     Expression expectedExpression = Expressions.and(equalExpression1, equalExpression2);
-    Assert.assertEquals(expectedExpression.toString(), andFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), andFilter.getFilterExpression().toString());
   }
 
   @Test
   public void testEmptyFilter()
   {
-    Assert.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(null));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(Collections.emptyList()));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(null));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(Collections.emptyList()));
   }
 
   @Test
@@ -91,6 +91,6 @@ public class IcebergAndFilterTest
         Expressions.and(equalExpression1, equalExpression2),
         intervalExpression
     );
-    Assert.assertEquals(expectedExpression.toString(), andFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), andFilter.getFilterExpression().toString());
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergIntervalFilterTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergIntervalFilterTest.java
@@ -25,8 +25,8 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Types;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -73,6 +73,6 @@ public class IcebergIntervalFilterTest
             )
         )
     );
-    Assert.assertEquals(expectedExpression.toString(), intervalFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), intervalFilter.getFilterExpression().toString());
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergNotFilterTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergNotFilterTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.iceberg.filter;
 
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -33,7 +33,7 @@ public class IcebergNotFilterTest
   {
     IcebergNotFilter testFilter = new IcebergNotFilter(new IcebergEqualsFilter("column1", "value1"));
     Expression expectedExpression = Expressions.not(Expressions.equal("column1", "value1"));
-    Assert.assertEquals(expectedExpression.toString(), testFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), testFilter.getFilterExpression().toString());
   }
 
   @Test
@@ -76,7 +76,7 @@ public class IcebergNotFilterTest
         Expressions.equal(column2, "value2")
     ));
 
-    Assert.assertEquals(expressionNotAnd.toString(), filterNotAnd.getFilterExpression().toString());
-    Assert.assertEquals(expressionNotOr.toString(), filterNotOr.getFilterExpression().toString());
+    Assertions.assertEquals(expressionNotAnd.toString(), filterNotAnd.getFilterExpression().toString());
+    Assertions.assertEquals(expressionNotOr.toString(), filterNotOr.getFilterExpression().toString());
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergOrFilterTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergOrFilterTest.java
@@ -24,8 +24,8 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,14 +61,14 @@ public class IcebergOrFilterTest
         new IcebergEqualsFilter(COLUMN2, "value2")
     ));
     Expression expectedExpression = Expressions.or(equalExpression1, equalExpression2);
-    Assert.assertEquals(expectedExpression.toString(), orFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), orFilter.getFilterExpression().toString());
   }
 
   @Test
   public void testEmptyFilter()
   {
-    Assert.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(null));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(Collections.emptyList()));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(null));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> new IcebergAndFilter(Collections.emptyList()));
   }
 
   @Test
@@ -110,7 +110,7 @@ public class IcebergOrFilterTest
         intervalExpression
     );
 
-    Assert.assertEquals(expectedExpressionOrOr.toString(), filterOrOr.getFilterExpression().toString());
-    Assert.assertEquals(expectedExpressionOrAnd.toString(), filterOrAnd.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpressionOrOr.toString(), filterOrOr.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpressionOrAnd.toString(), filterOrAnd.getFilterExpression().toString());
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergRangeFilterTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergRangeFilterTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.iceberg.filter;
 
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class IcebergRangeFilterTest
 {
@@ -36,7 +36,7 @@ public class IcebergRangeFilterTest
         Expressions.lessThan(TEST_COLUMN, 50)
     );
     IcebergRangeFilter rangeFilter = new IcebergRangeFilter(TEST_COLUMN, 45, 50, false, true);
-    Assert.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
   }
 
   @Test
@@ -47,7 +47,7 @@ public class IcebergRangeFilterTest
         Expressions.lessThanOrEqual(TEST_COLUMN, 50)
     );
     IcebergRangeFilter rangeFilter = new IcebergRangeFilter(TEST_COLUMN, 45, 50, true, false);
-    Assert.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
   }
 
   @Test
@@ -55,7 +55,7 @@ public class IcebergRangeFilterTest
   {
     Expression expectedExpression = Expressions.lessThanOrEqual(TEST_COLUMN, 50);
     IcebergRangeFilter rangeFilter = new IcebergRangeFilter(TEST_COLUMN, null, 50, null, false);
-    Assert.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
   }
 
   @Test
@@ -63,6 +63,6 @@ public class IcebergRangeFilterTest
   {
     Expression expectedExpression = Expressions.greaterThanOrEqual(TEST_COLUMN, 100);
     IcebergRangeFilter rangeFilter = new IcebergRangeFilter(TEST_COLUMN, 100, null, null, null);
-    Assert.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), rangeFilter.getFilterExpression().toString());
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergTimeWindowFilterTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/filter/IcebergTimeWindowFilterTest.java
@@ -27,8 +27,8 @@ import org.apache.iceberg.types.Types;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class IcebergTimeWindowFilterTest
 {
@@ -57,6 +57,6 @@ public class IcebergTimeWindowFilterTest
                    .value()
         )
     );
-    Assert.assertEquals(expectedExpression.toString(), intervalFilter.getFilterExpression().toString());
+    Assertions.assertEquals(expectedExpression.toString(), intervalFilter.getFilterExpression().toString());
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/GlueIcebergCatalogTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/GlueIcebergCatalogTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.iceberg.input;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 
@@ -42,7 +42,7 @@ public class GlueIcebergCatalogTest
         true,
         mapper
     );
-    Assert.assertEquals("glue", glueCatalog.retrieveCatalog().name());
+    Assertions.assertEquals("glue", glueCatalog.retrieveCatalog().name());
   }
 
   @Test
@@ -53,6 +53,6 @@ public class GlueIcebergCatalogTest
         true,
         mapper
     );
-    Assert.assertEquals(true, glueCatalog.isCaseSensitive());
+    Assertions.assertEquals(true, glueCatalog.isCaseSensitive());
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/HiveIcebergCatalogTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/HiveIcebergCatalogTest.java
@@ -24,8 +24,8 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashMap;
@@ -54,8 +54,8 @@ public class HiveIcebergCatalogTest
         mapper,
         new Configuration()
     );
-    Assert.assertEquals("hive", hiveCatalog.retrieveCatalog().name());
-    Assert.assertEquals(2, hiveCatalogNullProps.getCatalogProperties().size());
+    Assertions.assertEquals("hive", hiveCatalog.retrieveCatalog().name());
+    Assertions.assertEquals(2, hiveCatalogNullProps.getCatalogProperties().size());
   }
 
   @Test
@@ -74,7 +74,7 @@ public class HiveIcebergCatalogTest
         mapper,
         new Configuration()
     );
-    Assert.assertEquals("hdfs://testuri", hiveCatalog.getCatalogUri());
+    Assertions.assertEquals("hdfs://testuri", hiveCatalog.getCatalogUri());
 
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/IcebergInputSourceTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/IcebergInputSourceTest.java
@@ -46,12 +46,11 @@ import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.types.Types;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -64,8 +63,8 @@ import java.util.stream.Stream;
 
 public class IcebergInputSourceTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @TempDir
+  public File temporaryFolder;
 
   private IcebergCatalog testCatalog;
   private TableIdentifier tableIdentifier;
@@ -80,7 +79,7 @@ public class IcebergInputSourceTest
   private static final String NAMESPACE = "default";
   private static final String TABLENAME = "foosTable";
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     warehouseDir = FileUtils.createTempDir();
@@ -109,8 +108,8 @@ public class IcebergInputSourceTest
                                             .flatMap(List::stream)
                                             .collect(Collectors.toList());
 
-    Assert.assertEquals(1, inputSource.estimateNumSplits(null, new MaxSizeSplitHintSpec(1L, null)));
-    Assert.assertEquals(1, localInputSourceList.size());
+    Assertions.assertEquals(1, inputSource.estimateNumSplits(null, new MaxSizeSplitHintSpec(1L, null)));
+    Assertions.assertEquals(1, localInputSourceList.size());
     CloseableIterable<Record> datafileReader = Parquet.read(Files.localInput(localInputSourceList.get(0)))
                                                       .project(tableSchema)
                                                       .createReaderFunc(fileSchema -> GenericParquetReaders.buildReader(
@@ -121,8 +120,8 @@ public class IcebergInputSourceTest
 
 
     for (Record record : datafileReader) {
-      Assert.assertEquals(tableData.get("id"), record.get(0));
-      Assert.assertEquals(tableData.get("name"), record.get(1));
+      Assertions.assertEquals(tableData.get("id"), record.get(0));
+      Assertions.assertEquals(tableData.get("name"), record.get(1));
     }
   }
 
@@ -139,7 +138,7 @@ public class IcebergInputSourceTest
         null
     );
     Stream<InputSplit<List<String>>> splits = inputSource.createSplits(null, new MaxSizeSplitHintSpec(null, null));
-    Assert.assertEquals(0, splits.count());
+    Assertions.assertEquals(0, splits.count());
   }
 
   @Test
@@ -161,8 +160,8 @@ public class IcebergInputSourceTest
                                             .flatMap(List::stream)
                                             .collect(Collectors.toList());
 
-    Assert.assertEquals(1, inputSource.estimateNumSplits(null, new MaxSizeSplitHintSpec(1L, null)));
-    Assert.assertEquals(1, localInputSourceList.size());
+    Assertions.assertEquals(1, inputSource.estimateNumSplits(null, new MaxSizeSplitHintSpec(1L, null)));
+    Assertions.assertEquals(1, localInputSourceList.size());
     CloseableIterable<Record> datafileReader = Parquet.read(Files.localInput(localInputSourceList.get(0)))
                                                       .project(tableSchema)
                                                       .createReaderFunc(fileSchema -> GenericParquetReaders.buildReader(
@@ -173,8 +172,8 @@ public class IcebergInputSourceTest
 
 
     for (Record record : datafileReader) {
-      Assert.assertEquals(tableData.get("id"), record.get(0));
-      Assert.assertEquals(tableData.get("name"), record.get(1));
+      Assertions.assertEquals(tableData.get("id"), record.get(0));
+      Assertions.assertEquals(tableData.get("name"), record.get(1));
     }
   }
 
@@ -191,7 +190,7 @@ public class IcebergInputSourceTest
         null
     );
     Stream<InputSplit<List<String>>> splits = inputSource.createSplits(null, new MaxSizeSplitHintSpec(null, null));
-    Assert.assertEquals(1, splits.count());
+    Assertions.assertEquals(1, splits.count());
   }
 
   @Test
@@ -218,8 +217,8 @@ public class IcebergInputSourceTest
                                             .flatMap(List::stream)
                                             .collect(Collectors.toList());
 
-    Assert.assertEquals(1, inputSource.estimateNumSplits(null, new MaxSizeSplitHintSpec(1L, null)));
-    Assert.assertEquals(1, localInputSourceList.size());
+    Assertions.assertEquals(1, inputSource.estimateNumSplits(null, new MaxSizeSplitHintSpec(1L, null)));
+    Assertions.assertEquals(1, localInputSourceList.size());
   }
 
   @Test
@@ -236,7 +235,7 @@ public class IcebergInputSourceTest
         ResidualFilterMode.IGNORE
     );
     Stream<InputSplit<List<String>>> splits = inputSource.createSplits(null, new MaxSizeSplitHintSpec(null, null));
-    Assert.assertEquals(1, splits.count());
+    Assertions.assertEquals(1, splits.count());
   }
 
   @Test
@@ -252,13 +251,13 @@ public class IcebergInputSourceTest
         null,
         ResidualFilterMode.FAIL
     );
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> inputSource.createSplits(null, new MaxSizeSplitHintSpec(null, null))
     );
-    Assert.assertTrue(
-        "Expect residual error to be thrown",
-        exception.getMessage().contains("residual")
+    Assertions.assertTrue(
+        exception.getMessage().contains("residual"),
+        "Expect residual error to be thrown"
     );
   }
 
@@ -281,7 +280,7 @@ public class IcebergInputSourceTest
         ResidualFilterMode.FAIL
     );
     Stream<InputSplit<List<String>>> splits = inputSource.createSplits(null, new MaxSizeSplitHintSpec(null, null));
-    Assert.assertEquals(1, splits.count());
+    Assertions.assertEquals(1, splits.count());
   }
 
   @Test
@@ -303,17 +302,17 @@ public class IcebergInputSourceTest
         null,
         ResidualFilterMode.FAIL
     );
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> inputSource.createSplits(null, new MaxSizeSplitHintSpec(null, null))
     );
-    Assert.assertTrue(
-        "Expect residual error to be thrown",
-        exception.getMessage().contains("residual")
+    Assertions.assertTrue(
+        exception.getMessage().contains("residual"),
+        "Expect residual error to be thrown"
     );
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     dropTableFromCatalog(tableIdentifier);

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/LocalCatalogTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/LocalCatalogTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.FileUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashMap;
@@ -39,9 +39,9 @@ public class LocalCatalogTest
     LocalCatalog before = new LocalCatalog(warehouseDir.getPath(), new HashMap<>(), true);
     LocalCatalog after = mapper.readValue(
         mapper.writeValueAsString(before), LocalCatalog.class);
-    Assert.assertEquals(before, after);
-    Assert.assertEquals("hadoop", before.retrieveCatalog().name());
-    Assert.assertEquals("hadoop", after.retrieveCatalog().name());
+    Assertions.assertEquals(before, after);
+    Assertions.assertEquals("hadoop", before.retrieveCatalog().name());
+    Assertions.assertEquals("hadoop", after.retrieveCatalog().name());
   }
 
   @Test

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/ResidualFilterModeTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/ResidualFilterModeTest.java
@@ -20,26 +20,26 @@
 package org.apache.druid.iceberg.input;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ResidualFilterModeTest
 {
   @Test
   public void testFromString()
   {
-    Assert.assertEquals(ResidualFilterMode.IGNORE, ResidualFilterMode.fromString("ignore"));
-    Assert.assertEquals(ResidualFilterMode.FAIL, ResidualFilterMode.fromString("fail"));
+    Assertions.assertEquals(ResidualFilterMode.IGNORE, ResidualFilterMode.fromString("ignore"));
+    Assertions.assertEquals(ResidualFilterMode.FAIL, ResidualFilterMode.fromString("fail"));
 
     // Test case insensitivity
-    Assert.assertEquals(ResidualFilterMode.IGNORE, ResidualFilterMode.fromString("IGNORE"));
-    Assert.assertEquals(ResidualFilterMode.FAIL, ResidualFilterMode.fromString("FAIL"));
+    Assertions.assertEquals(ResidualFilterMode.IGNORE, ResidualFilterMode.fromString("IGNORE"));
+    Assertions.assertEquals(ResidualFilterMode.FAIL, ResidualFilterMode.fromString("FAIL"));
   }
 
   @Test
   public void testFromStringInvalid()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ResidualFilterMode.fromString("invalid")
     );
@@ -48,8 +48,8 @@ public class ResidualFilterModeTest
   @Test
   public void testGetValue()
   {
-    Assert.assertEquals("ignore", ResidualFilterMode.IGNORE.getValue());
-    Assert.assertEquals("fail", ResidualFilterMode.FAIL.getValue());
+    Assertions.assertEquals("ignore", ResidualFilterMode.IGNORE.getValue());
+    Assertions.assertEquals("fail", ResidualFilterMode.FAIL.getValue());
   }
 
   @Test
@@ -58,11 +58,11 @@ public class ResidualFilterModeTest
     ObjectMapper mapper = new ObjectMapper();
 
     // Test serialization
-    Assert.assertEquals("\"ignore\"", mapper.writeValueAsString(ResidualFilterMode.IGNORE));
-    Assert.assertEquals("\"fail\"", mapper.writeValueAsString(ResidualFilterMode.FAIL));
+    Assertions.assertEquals("\"ignore\"", mapper.writeValueAsString(ResidualFilterMode.IGNORE));
+    Assertions.assertEquals("\"fail\"", mapper.writeValueAsString(ResidualFilterMode.FAIL));
 
     // Test deserialization
-    Assert.assertEquals(ResidualFilterMode.IGNORE, mapper.readValue("\"ignore\"", ResidualFilterMode.class));
-    Assert.assertEquals(ResidualFilterMode.FAIL, mapper.readValue("\"fail\"", ResidualFilterMode.class));
+    Assertions.assertEquals(ResidualFilterMode.IGNORE, mapper.readValue("\"ignore\"", ResidualFilterMode.class));
+    Assertions.assertEquals(ResidualFilterMode.FAIL, mapper.readValue("\"fail\"", ResidualFilterMode.class));
   }
 }

--- a/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
+++ b/extensions-contrib/druid-iceberg-extensions/src/test/java/org/apache/druid/iceberg/input/RestCatalogTest.java
@@ -25,10 +25,10 @@ import com.sun.net.httpserver.HttpServer;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.rest.RESTCatalog;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -44,7 +44,7 @@ public class RestCatalogTest
   private HttpServer server = null;
   private ServerSocket serverSocket = null;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception
   {
     serverSocket = new ServerSocket(0);
@@ -81,12 +81,12 @@ public class RestCatalogTest
     );
     RESTCatalog innerCatalog = (RESTCatalog) testRestCatalog.retrieveCatalog();
 
-    Assert.assertEquals("rest", innerCatalog.name());
-    Assert.assertNotNull(innerCatalog.properties());
-    Assert.assertNotNull(testRestCatalog.getCatalogProperties());
-    Assert.assertEquals(testRestCatalog.getCatalogUri(), innerCatalog.properties().get("uri"));
+    Assertions.assertEquals("rest", innerCatalog.name());
+    Assertions.assertNotNull(innerCatalog.properties());
+    Assertions.assertNotNull(testRestCatalog.getCatalogProperties());
+    Assertions.assertEquals(testRestCatalog.getCatalogUri(), innerCatalog.properties().get("uri"));
   }
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     if (server != null) {


### PR DESCRIPTION
Part of [#13948](https://github.com/apache/druid/issues/13948).

## Summary

This PR migrates an independent `extensions-contrib` batch to JUnit 5:

- `druid-iceberg-extensions`
- `druid-deltalake-extensions`
- `consul-extensions`
- `cassandra-storage` (POM cleanup; no test sources)

The migrated module POMs remove direct JUnit 4/Hamcrest usage and use Jupiter where tests are present. This batch deliberately does not change the shared SQL/processing test fixtures and does not depend on #19908 or #19915. The modules that require the shared `AggregationTestHelper` fixture are owned by #19908 instead.

This branch is based directly on `master`; it is independent of the other migration PRs.

Related migration PRs: [#19908](https://github.com/apache/druid/pull/19908), [#19915](https://github.com/apache/druid/pull/19915), [#19875](https://github.com/apache/druid/pull/19875), [#19876](https://github.com/apache/druid/pull/19876), [#19877](https://github.com/apache/druid/pull/19877), [#19878](https://github.com/apache/druid/pull/19878), [#19879](https://github.com/apache/druid/pull/19879), [#19880](https://github.com/apache/druid/pull/19880), [#19881](https://github.com/apache/druid/pull/19881), and [#19882](https://github.com/apache/druid/pull/19882).

## Validation

- `test-compile` passed for all four modules and their reactor dependencies.
- Focused tests passed: Iceberg (35), Delta Lake (82), and Consul (43); Cassandra has no tests.
- Checkstyle passed with 0 violations for all four modules.
- SpotBugs passed with 0 bugs/errors for all four modules.
- No JUnit 4/Hamcrest source imports or direct POM dependencies remain in these modules.
- `git diff --check` passed.
