### PR TITLE
test: migrate final extensions-contrib batch to JUnit 5

### DIFF
--- a/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -35,6 +35,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -108,16 +123,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.jackson</groupId>

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterConfigTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterConfigTest.java
@@ -22,9 +22,9 @@ package org.apache.druid.emitter.ambari.metrics;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -33,7 +33,7 @@ public class AmbariMetricsEmitterConfigTest
 {
   private final ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(
@@ -63,7 +63,7 @@ public class AmbariMetricsEmitterConfigTest
     AmbariMetricsEmitterConfig serde = mapper.readerFor(AmbariMetricsEmitterConfig.class).readValue(
         mapper.writeValueAsBytes(config)
     );
-    Assert.assertEquals(config, serde);
+    Assertions.assertEquals(config, serde);
   }
 
   @Test
@@ -72,7 +72,7 @@ public class AmbariMetricsEmitterConfigTest
     SendAllTimelineEventConverter sendAllConverter = new SendAllTimelineEventConverter("prefix", "druid");
     DruidToTimelineMetricConverter serde = mapper.readerFor(DruidToTimelineMetricConverter.class)
                                                  .readValue(mapper.writeValueAsBytes(sendAllConverter));
-    Assert.assertEquals(sendAllConverter, serde);
+    Assertions.assertEquals(sendAllConverter, serde);
 
     WhiteListBasedDruidToTimelineEventConverter whiteListBasedDruidToTimelineEventConverter = new WhiteListBasedDruidToTimelineEventConverter(
         "prefix",
@@ -83,6 +83,6 @@ public class AmbariMetricsEmitterConfigTest
     serde = mapper.readerFor(DruidToTimelineMetricConverter.class)
                   .readValue(mapper.writeValueAsBytes(
                       whiteListBasedDruidToTimelineEventConverter));
-    Assert.assertEquals(whiteListBasedDruidToTimelineEventConverter, serde);
+    Assertions.assertEquals(whiteListBasedDruidToTimelineEventConverter, serde);
   }
 }

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/AmbariMetricsEmitterTest.java
@@ -22,9 +22,9 @@ package org.apache.druid.emitter.ambari.metrics;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -32,7 +32,7 @@ public class AmbariMetricsEmitterTest
 {
   private final ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(
@@ -60,15 +60,15 @@ public class AmbariMetricsEmitterTest
         400L
     );
     AmbariMetricsEmitter emitter = new AmbariMetricsEmitter(config, Collections.emptyList());
-    Assert.assertEquals("8080", emitter.getCollectorPort());
-    Assert.assertEquals("http", emitter.getCollectorProtocol());
-    Assert.assertEquals("http://myHost:8080/ws/v1/timeline/metrics", emitter.getCollectorUri("myHost"));
-    Assert.assertEquals("hostname", emitter.getHostname());
-    Assert.assertNull(emitter.getZookeeperQuorum());
-    Assert.assertEquals(Collections.singleton("hostname"), emitter.getConfiguredCollectorHosts());
+    Assertions.assertEquals("8080", emitter.getCollectorPort());
+    Assertions.assertEquals("http", emitter.getCollectorProtocol());
+    Assertions.assertEquals("http://myHost:8080/ws/v1/timeline/metrics", emitter.getCollectorUri("myHost"));
+    Assertions.assertEquals("hostname", emitter.getHostname());
+    Assertions.assertNull(emitter.getZookeeperQuorum());
+    Assertions.assertEquals(Collections.singleton("hostname"), emitter.getConfiguredCollectorHosts());
 
-    Assert.assertFalse(emitter.isHostInMemoryAggregationEnabled());
-    Assert.assertEquals(0, emitter.getHostInMemoryAggregationPort());
-    Assert.assertEquals("", emitter.getHostInMemoryAggregationProtocol());
+    Assertions.assertFalse(emitter.isHostInMemoryAggregationEnabled());
+    Assertions.assertEquals(0, emitter.getHostInMemoryAggregationPort());
+    Assertions.assertEquals("", emitter.getHostInMemoryAggregationProtocol());
   }
 }

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/DruidToWhiteListBasedConverterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/DruidToWhiteListBasedConverterTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.emitter.ambari.metrics;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DruidToWhiteListBasedConverterTest
 {
@@ -29,6 +29,6 @@ public class DruidToWhiteListBasedConverterTest
   public void testSanitize()
   {
     String test = "host name.yahoo.com:8080";
-    Assert.assertEquals("host_name_yahoo_com:8080", AmbariMetricsEmitter.sanitize(test));
+    Assertions.assertEquals("host_name_yahoo_com:8080", AmbariMetricsEmitter.sanitize(test));
   }
 }

--- a/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/WhiteListBasedDruidToTimelineEventConverterTest.java
+++ b/extensions-contrib/ambari-metrics-emitter/src/test/java/org/apache/druid/emitter/ambari/metrics/WhiteListBasedDruidToTimelineEventConverterTest.java
@@ -19,34 +19,33 @@
 
 package org.apache.druid.emitter.ambari.metrics;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.apache.commons.io.IOUtils;
-import org.apache.druid.annotations.UsedByJUnitParamsRunner;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.hadoop.metrics2.sink.timeline.TimelineMetric;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-@RunWith(JUnitParamsRunner.class)
 public class WhiteListBasedDruidToTimelineEventConverterTest
 {
-  private final String prefix = "druid";
-  private final WhiteListBasedDruidToTimelineEventConverter defaultWhiteListBasedDruidToTimelineEventConverter =
-      new WhiteListBasedDruidToTimelineEventConverter(prefix, "druid", null, new DefaultObjectMapper());
-  private final String hostname = "testHost:8080";
-  private final String serviceName = "historical";
-  private final String defaultNamespace = prefix + "." + serviceName;
+  private static final String PREFIX = "druid";
+  private static final String HOSTNAME = "testHost:8080";
+  private static final String SERVICE_NAME = "historical";
+  private static final String DEFAULT_NAMESPACE = PREFIX + "." + SERVICE_NAME;
 
-  @Test
-  @Parameters({
+  private final WhiteListBasedDruidToTimelineEventConverter defaultWhiteListBasedDruidToTimelineEventConverter =
+      new WhiteListBasedDruidToTimelineEventConverter(PREFIX, "druid", null, new DefaultObjectMapper());
+
+  @ParameterizedTest
+  @CsvSource({
       "query/time, true",
       "query/node/ttfb, true",
       "query/segmentAndCache/time, true",
@@ -58,7 +57,7 @@ public class WhiteListBasedDruidToTimelineEventConverterTest
       "segment/cost/raw, false",
       "coordinator/TIER_1 /cost/raw, false",
       "segment/Kost/raw, false",
-      ", false",
+      "'', false",
       "word, false",
       "coordinator, false",
       "server/, false",
@@ -72,14 +71,14 @@ public class WhiteListBasedDruidToTimelineEventConverterTest
         .builder()
         .setFeed("metrics")
         .setMetric(key, 10)
-        .build(serviceName, hostname);
+        .build(SERVICE_NAME, HOSTNAME);
 
     boolean isIn = defaultWhiteListBasedDruidToTimelineEventConverter.druidEventToTimelineMetric(event) != null;
-    Assert.assertEquals(expectedValue, isIn);
+    Assertions.assertEquals(expectedValue, isIn);
   }
 
-  @Test
-  @Parameters
+  @ParameterizedTest
+  @MethodSource("parametersForTestGetName")
   public void testGetName(ServiceMetricEvent serviceMetricEvent, String expectedPath)
   {
     TimelineMetric metric = defaultWhiteListBasedDruidToTimelineEventConverter.druidEventToTimelineMetric(serviceMetricEvent);
@@ -87,7 +86,7 @@ public class WhiteListBasedDruidToTimelineEventConverterTest
     if (metric != null) {
       path = metric.getMetricName();
     }
-    Assert.assertEquals(expectedPath, path);
+    Assertions.assertEquals(expectedPath, path);
   }
 
   @Test
@@ -104,7 +103,7 @@ public class WhiteListBasedDruidToTimelineEventConverterTest
     }
 
     WhiteListBasedDruidToTimelineEventConverter converter = new WhiteListBasedDruidToTimelineEventConverter(
-        prefix,
+        PREFIX,
         "druid",
         mapFile.getAbsolutePath(),
         new DefaultObjectMapper()
@@ -113,63 +112,62 @@ public class WhiteListBasedDruidToTimelineEventConverterTest
     ServiceMetricEvent event = new ServiceMetricEvent.Builder()
         .setDimension("gcName", new String[] {"g1"})
         .setMetric("jvm/gc/cpu", 10)
-        .build(serviceName, hostname);
+        .build(SERVICE_NAME, HOSTNAME);
 
     TimelineMetric metric = converter.druidEventToTimelineMetric(event);
 
-    Assert.assertNotNull(metric);
-    Assert.assertEquals(defaultNamespace + ".g1.jvm/gc/cpu", metric.getMetricName());
+    Assertions.assertNotNull(metric);
+    Assertions.assertEquals(DEFAULT_NAMESPACE + ".g1.jvm/gc/cpu", metric.getMetricName());
   }
 
-  @UsedByJUnitParamsRunner
-  private Object[] parametersForTestGetName()
+  private static Object[] parametersForTestGetName()
   {
     return new Object[]{
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("id", "dummy_id")
-                                            .setDimension("status", "some_status")
-                                            .setDimension("numDimensions", "1")
-                                            .setDimension("segment", "dummy_segment")
-                                            .setMetric("query/segment/time/balabla/more", 10)
-                .build(serviceName, hostname),
-            defaultNamespace + ".query/segment/time/balabla/more"
+                .setDimension("status", "some_status")
+                .setDimension("numDimensions", "1")
+                .setDimension("segment", "dummy_segment")
+                .setMetric("query/segment/time/balabla/more", 10)
+                .build(SERVICE_NAME, HOSTNAME),
+            DEFAULT_NAMESPACE + ".query/segment/time/balabla/more"
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("dataSource", "some_data_source")
-                                            .setDimension("tier", "_default_tier")
-                                            .setMetric("segment/max", 10)
-                .build(serviceName, hostname),
+                .setDimension("tier", "_default_tier")
+                .setMetric("segment/max", 10)
+                .build(SERVICE_NAME, HOSTNAME),
             null
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("dataSource", "data-source")
-                                            .setDimension("type", "groupBy")
-                                            .setDimension("interval", "2013/2015")
-                                            .setDimension("some_random_dim1", "random_dim_value1")
-                                            .setDimension("some_random_dim2", "random_dim_value2")
-                                            .setDimension("hasFilters", "no")
-                                            .setDimension("duration", "P1D")
-                                            .setDimension("remoteAddress", "194.0.90.2")
-                                            .setDimension("id", "ID")
-                                            .setDimension("context", "{context}")
-                                            .setMetric("query/time", 10)
-                .build(serviceName, hostname),
-            defaultNamespace + ".data-source.groupBy.query/time"
+                .setDimension("type", "groupBy")
+                .setDimension("interval", "2013/2015")
+                .setDimension("some_random_dim1", "random_dim_value1")
+                .setDimension("some_random_dim2", "random_dim_value2")
+                .setDimension("hasFilters", "no")
+                .setDimension("duration", "P1D")
+                .setDimension("remoteAddress", "194.0.90.2")
+                .setDimension("id", "ID")
+                .setDimension("context", "{context}")
+                .setMetric("query/time", 10)
+                .build(SERVICE_NAME, HOSTNAME),
+            DEFAULT_NAMESPACE + ".data-source.groupBy.query/time"
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("dataSource", "data-source")
-                                            .setDimension("type", "groupBy")
-                                            .setDimension("some_random_dim1", "random_dim_value1")
-                                            .setMetric("ingest/persists/count", 10)
-                .build(serviceName, hostname),
-            defaultNamespace + ".data-source.ingest/persists/count"
+                .setDimension("type", "groupBy")
+                .setDimension("some_random_dim1", "random_dim_value1")
+                .setMetric("ingest/persists/count", 10)
+                .build(SERVICE_NAME, HOSTNAME),
+            DEFAULT_NAMESPACE + ".data-source.ingest/persists/count"
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("bufferpoolName", "BufferPool")
-                                            .setDimension("type", "groupBy")
-                                            .setDimension("some_random_dim1", "random_dim_value1")
-                                            .setMetric("jvm/bufferpool/capacity", 10)
-                .build(serviceName, hostname),
+                .setDimension("type", "groupBy")
+                .setDimension("some_random_dim1", "random_dim_value1")
+                .setMetric("jvm/bufferpool/capacity", 10)
+                .build(SERVICE_NAME, HOSTNAME),
             null
         }
     };

--- a/extensions-contrib/cloudfiles-extensions/pom.xml
+++ b/extensions-contrib/cloudfiles-extensions/pom.xml
@@ -39,6 +39,21 @@
     </properties>
 
     <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
@@ -156,11 +171,6 @@
         </dependency>
 
         <!-- Tests -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesByteSourceTest.java
+++ b/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesByteSourceTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.storage.cloudfiles;
 
 import org.jclouds.io.Payload;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,7 +49,7 @@ public class CloudFilesByteSourceTest
     payload.close();
 
     CloudFilesByteSource byteSource = new CloudFilesByteSource(objectApi, path);
-    Assert.assertEquals(stream, byteSource.openStream());
+    Assertions.assertEquals(stream, byteSource.openStream());
     byteSource.closeStream();
 
     verify(objectApi).get(path, 0);
@@ -57,7 +57,7 @@ public class CloudFilesByteSourceTest
     verify(payload).openStream();
   }
 
-  @Test()
+  @Test
   public void openStreamWithRecoverableErrorTest() throws IOException
   {
     final String path = "path";
@@ -74,14 +74,10 @@ public class CloudFilesByteSourceTest
     payload.close();
 
     CloudFilesByteSource byteSource = new CloudFilesByteSource(objectApi, path);
-    try {
-      byteSource.openStream();
-    }
-    catch (Exception e) {
-      Assert.assertEquals("Recoverable exception", e.getMessage());
-    }
+    final IOException exception = Assertions.assertThrows(IOException.class, byteSource::openStream);
+    Assertions.assertEquals("Recoverable exception", exception.getMessage());
 
-    Assert.assertEquals(stream, byteSource.openStream());
+    Assertions.assertEquals(stream, byteSource.openStream());
     byteSource.closeStream();
 
     verify(objectApi).get(path, 0);

--- a/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPusherTest.java
+++ b/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesDataSegmentPusherTest.java
@@ -26,10 +26,9 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.NoneShardSpec;
 import org.jclouds.openstack.swift.v1.features.ObjectApi;
 import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -45,8 +44,8 @@ import static org.mockito.Mockito.when;
  */
 public class CloudFilesDataSegmentPusherTest
 {
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public File tempFolder;
 
   @Test
   public void testPush() throws Exception
@@ -66,7 +65,7 @@ public class CloudFilesDataSegmentPusherTest
     CloudFilesDataSegmentPusher pusher = new CloudFilesDataSegmentPusher(api, config, new DefaultObjectMapper());
 
     // Create a mock segment on disk
-    File tmp = tempFolder.newFile("version.bin");
+    final File tmp = new File(tempFolder, "version.bin");
 
     final byte[] data = new byte[]{0x0, 0x0, 0x0, 0x1};
     Files.write(data, tmp);
@@ -84,9 +83,9 @@ public class CloudFilesDataSegmentPusherTest
         size
     );
 
-    DataSegment segment = pusher.push(tempFolder.getRoot(), segmentToPush, false);
+    DataSegment segment = pusher.push(tempFolder, segmentToPush, false);
 
-    Assert.assertEquals(segmentToPush.getSize(), segment.getSize());
+    Assertions.assertEquals(segmentToPush.getSize(), segment.getSize());
 
     verify(objectApi, atLeastOnce()).put(any(), any());
     verify(api, atLeastOnce()).getObjectApi(any(), any());

--- a/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesObjectApiProxyTest.java
+++ b/extensions-contrib/cloudfiles-extensions/src/test/java/org/apache/druid/storage/cloudfiles/CloudFilesObjectApiProxyTest.java
@@ -23,8 +23,8 @@ import org.jclouds.io.Payload;
 import org.jclouds.openstack.swift.v1.domain.SwiftObject;
 import org.jclouds.openstack.swift.v1.features.ObjectApi;
 import org.jclouds.rackspace.cloudfiles.v1.CloudFilesApi;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -51,10 +51,10 @@ public class CloudFilesObjectApiProxyTest
     CloudFilesObjectApiProxy cfoApiProxy = new CloudFilesObjectApiProxy(cloudFilesApi, region, container);
     CloudFilesObject cloudFilesObject = cfoApiProxy.get(path, 0);
 
-    Assert.assertEquals(cloudFilesObject.getPayload(), payload);
-    Assert.assertEquals(cloudFilesObject.getRegion(), region);
-    Assert.assertEquals(cloudFilesObject.getContainer(), container);
-    Assert.assertEquals(cloudFilesObject.getPath(), path);
+    Assertions.assertEquals(payload, cloudFilesObject.getPayload());
+    Assertions.assertEquals(region, cloudFilesObject.getRegion());
+    Assertions.assertEquals(container, cloudFilesObject.getContainer());
+    Assertions.assertEquals(path, cloudFilesObject.getPath());
 
     verify(cloudFilesApi).getObjectApi(region, container);
     verify(objectApi).get(path);

--- a/extensions-contrib/dropwizard-emitter/pom.xml
+++ b/extensions-contrib/dropwizard-emitter/pom.xml
@@ -35,6 +35,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -61,11 +76,6 @@
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jmx</artifactId>
       <version>${dropwizard.metrics.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>

--- a/extensions-contrib/dropwizard-emitter/src/test/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfigTest.java
+++ b/extensions-contrib/dropwizard-emitter/src/test/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfigTest.java
@@ -26,9 +26,9 @@ import org.apache.druid.emitter.dropwizard.reporters.DropwizardConsoleReporter;
 import org.apache.druid.emitter.dropwizard.reporters.DropwizardJMXReporter;
 import org.apache.druid.guice.JsonConfigTesterBase;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -36,9 +36,10 @@ public class DropwizardEmitterConfigTest extends JsonConfigTesterBase<Dropwizard
 {
   private ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
-  public void setUp()
+  @BeforeEach
+  public void setUp() throws IllegalAccessException
   {
+    super.setup();
     testProperties.put(getPropertyKey("reporters"), "[{\"type\":\"jmx\", \"domain\" : \"mydomain\"}]");
     propertyValues.put(getPropertyKey("reporters"), "[DropwizardJMXReporter{domain='mydomain'}]");
     propertyValues.put(getPropertyKey("includeHost"), "true");
@@ -63,7 +64,7 @@ public class DropwizardEmitterConfigTest extends JsonConfigTesterBase<Dropwizard
     DropwizardEmitterConfig dropwizardEmitterConfigExpected = mapper.readerFor(DropwizardEmitterConfig.class).readValue(
         dropwizardEmitterConfigString
     );
-    Assert.assertEquals(dropwizardEmitterConfigExpected, dropwizardEmitterConfig);
+    Assertions.assertEquals(dropwizardEmitterConfigExpected, dropwizardEmitterConfig);
   }
 
   @Test
@@ -75,12 +76,11 @@ public class DropwizardEmitterConfigTest extends JsonConfigTesterBase<Dropwizard
     testProperties.putAll(propertyValues);
     configProvider.inject(testProperties, configurator);
     DropwizardEmitterConfig config = configProvider.get();
-    Assert.assertTrue("IncludeHost", config.getIncludeHost());
-    Assert.assertEquals("test-prefix", config.getPrefix());
-    Assert.assertEquals(1, config.getReporters().size());
-    Assert.assertTrue("jmx reporter", config.getReporters().get(0) instanceof DropwizardJMXReporter);
+    Assertions.assertTrue(config.getIncludeHost(), "IncludeHost");
+    Assertions.assertEquals("test-prefix", config.getPrefix());
+    Assertions.assertEquals(1, config.getReporters().size());
+    Assertions.assertTrue(config.getReporters().get(0) instanceof DropwizardJMXReporter, "jmx reporter");
   }
 
 }
-
 

--- a/extensions-contrib/dropwizard-emitter/src/test/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfigTest.java
+++ b/extensions-contrib/dropwizard-emitter/src/test/java/org/apache/druid/emitter/dropwizard/DropwizardEmitterConfigTest.java
@@ -50,6 +50,25 @@ public class DropwizardEmitterConfigTest extends JsonConfigTesterBase<Dropwizard
   }
 
   @Test
+  public void testSimpleInjection()
+  {
+    configProvider.inject(testProperties, configurator);
+    DropwizardEmitterConfig config = configProvider.get();
+    Assertions.assertEquals(propertyValues.get(getPropertyKey("reporters")), config.getReporters().toString());
+    Assertions.assertEquals(propertyValues.get(getPropertyKey("prefix")), config.getPrefix());
+    Assertions.assertEquals(propertyValues.get(getPropertyKey("includeHost")), String.valueOf(config.getIncludeHost()));
+    Assertions.assertEquals(
+        propertyValues.get(getPropertyKey("dimensionMapPath")),
+        String.valueOf(config.getDimensionMapPath())
+    );
+    Assertions.assertEquals(propertyValues.get(getPropertyKey("alertEmitters")), config.getAlertEmitters().toString());
+    Assertions.assertEquals(
+        propertyValues.get(getPropertyKey("maxMetricsRegistrySize")),
+        String.valueOf(config.getMaxMetricsRegistrySize())
+    );
+  }
+
+  @Test
   public void testSerDeserDropwizardEmitterConfig() throws IOException
   {
     DropwizardEmitterConfig dropwizardEmitterConfig = new DropwizardEmitterConfig(
@@ -83,4 +102,3 @@ public class DropwizardEmitterConfigTest extends JsonConfigTesterBase<Dropwizard
   }
 
 }
-

--- a/extensions-contrib/druid-ranger-security/pom.xml
+++ b/extensions-contrib/druid-ranger-security/pom.xml
@@ -46,6 +46,21 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <version>${project.parent.version}</version>
@@ -239,11 +254,6 @@
         </dependency>
 
         <!-- Tests -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-server</artifactId>

--- a/extensions-contrib/druid-ranger-security/src/test/java/org/apache/druid/security/ranger/authorizer/RangerAuthorizerTest.java
+++ b/extensions-contrib/druid-ranger-security/src/test/java/org/apache/druid/security/ranger/authorizer/RangerAuthorizerTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.server.security.AuthenticationResult;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceType;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class RangerAuthorizerTest
 {
@@ -39,7 +39,7 @@ public class RangerAuthorizerTest
   private static final Resource aliceConfig = new Resource("config", ResourceType.CONFIG);
   private static final Resource aliceState = new Resource("state", ResourceType.STATE);
 
-  @BeforeClass
+  @BeforeAll
   public static void setupBeforeClass()
   {
     rangerAuthorizer = new RangerAuthorizer(null, null, false, new Configuration());
@@ -48,13 +48,13 @@ public class RangerAuthorizerTest
   @Test
   public void testOperations()
   {
-    Assert.assertTrue(rangerAuthorizer.authorize(alice, aliceDatasource, Action.READ).isAllowed());
-    Assert.assertTrue(rangerAuthorizer.authorize(alice, aliceDatasource, Action.READ).isAllowed());
-    Assert.assertTrue(rangerAuthorizer.authorize(alice, aliceConfig, Action.READ).isAllowed());
-    Assert.assertTrue(rangerAuthorizer.authorize(alice, aliceConfig, Action.WRITE).isAllowed());
-    Assert.assertTrue(rangerAuthorizer.authorize(alice, aliceState, Action.READ).isAllowed());
-    Assert.assertTrue(rangerAuthorizer.authorize(alice, aliceState, Action.WRITE).isAllowed());
+    Assertions.assertTrue(rangerAuthorizer.authorize(alice, aliceDatasource, Action.READ).isAllowed());
+    Assertions.assertTrue(rangerAuthorizer.authorize(alice, aliceDatasource, Action.READ).isAllowed());
+    Assertions.assertTrue(rangerAuthorizer.authorize(alice, aliceConfig, Action.READ).isAllowed());
+    Assertions.assertTrue(rangerAuthorizer.authorize(alice, aliceConfig, Action.WRITE).isAllowed());
+    Assertions.assertTrue(rangerAuthorizer.authorize(alice, aliceState, Action.READ).isAllowed());
+    Assertions.assertTrue(rangerAuthorizer.authorize(alice, aliceState, Action.WRITE).isAllowed());
 
-    Assert.assertFalse(rangerAuthorizer.authorize(bob, aliceDatasource, Action.READ).isAllowed());
+    Assertions.assertFalse(rangerAuthorizer.authorize(bob, aliceDatasource, Action.READ).isAllowed());
   }
 }

--- a/extensions-contrib/gce-extensions/pom.xml
+++ b/extensions-contrib/gce-extensions/pom.xml
@@ -36,6 +36,21 @@
   </properties>
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -104,11 +119,6 @@
       <scope>provided</scope>
     </dependency>
     <!-- Tests -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>

--- a/extensions-contrib/gce-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/gce/GceAutoScalerTest.java
+++ b/extensions-contrib/gce-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/gce/GceAutoScalerTest.java
@@ -38,10 +38,10 @@ import org.apache.druid.indexing.overlord.autoscaling.AutoScalingData;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -67,7 +67,7 @@ public class GceAutoScalerTest
   //provision
   private Compute.InstanceGroupManagers.Resize mockResizeRequest = null;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     // for every test let's create all (only a subset needed for each test tho)
@@ -88,7 +88,7 @@ public class GceAutoScalerTest
     mockResizeRequest = EasyMock.createMock(Compute.InstanceGroupManagers.Resize.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     // not calling verify here as we use different bits and pieces in each test
@@ -96,12 +96,12 @@ public class GceAutoScalerTest
 
   private static void verifyAutoScaler(final GceAutoScaler autoScaler)
   {
-    Assert.assertEquals(1, autoScaler.getEnvConfig().getNumInstances());
-    Assert.assertEquals(4, autoScaler.getMaxNumWorkers());
-    Assert.assertEquals(2, autoScaler.getMinNumWorkers());
-    Assert.assertEquals("winkie-country", autoScaler.getEnvConfig().getZoneName());
-    Assert.assertEquals("super-project", autoScaler.getEnvConfig().getProjectId());
-    Assert.assertEquals("druid-mig", autoScaler.getEnvConfig().getManagedInstanceGroupName());
+    Assertions.assertEquals(1, autoScaler.getEnvConfig().getNumInstances());
+    Assertions.assertEquals(4, autoScaler.getMaxNumWorkers());
+    Assertions.assertEquals(2, autoScaler.getMinNumWorkers());
+    Assertions.assertEquals("winkie-country", autoScaler.getEnvConfig().getZoneName());
+    Assertions.assertEquals("super-project", autoScaler.getEnvConfig().getProjectId());
+    Assertions.assertEquals("druid-mig", autoScaler.getEnvConfig().getManagedInstanceGroupName());
   }
 
   @Test
@@ -148,10 +148,10 @@ public class GceAutoScalerTest
       );
       verifyAutoScaler(roundTripAutoScaler);
 
-      Assert.assertEquals("Round trip equals", autoScaler, roundTripAutoScaler);
+      Assertions.assertEquals(autoScaler, roundTripAutoScaler, "Round trip equals");
     }
     catch (Exception e) {
-      Assert.fail(StringUtils.format("Got exception in test %s", e.getMessage()));
+      Assertions.fail(StringUtils.format("Got exception in test %s", e.getMessage()));
     }
   }
 
@@ -196,12 +196,12 @@ public class GceAutoScalerTest
     // empty IPs
     List<String> ips1 = Collections.emptyList();
     List<String> ids1 = autoScaler.ipToIdLookup(ips1);
-    Assert.assertEquals(0, ids1.size());
+    Assertions.assertEquals(0, ids1.size());
 
     // actually not IPs
     List<String> ips2 = Collections.singletonList("foo-bar-baz");
     List<String> ids2 = autoScaler.ipToIdLookup(ips2);
-    Assert.assertEquals(ips2, ids2);
+    Assertions.assertEquals(ips2, ids2);
 
     // actually IPs
     Instance i1 = makeInstance("foo", "1.2.3.5"); // not the one we look for
@@ -224,8 +224,8 @@ public class GceAutoScalerTest
 
     List<String> ips3 = Collections.singletonList("1.2.3.4");
     List<String> ids3 = autoScaler.ipToIdLookup(ips3);
-    Assert.assertEquals(1, ids3.size());
-    Assert.assertEquals("bar", ids3.get(0));
+    Assertions.assertEquals(1, ids3.size());
+    Assertions.assertEquals("bar", ids3.get(0));
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockInstances);
@@ -255,7 +255,7 @@ public class GceAutoScalerTest
     // empty IPs
     List<String> ids1 = Collections.emptyList();
     List<String> ips1 = autoScaler.idToIpLookup(ids1);
-    Assert.assertEquals(0, ips1.size());
+    Assertions.assertEquals(0, ips1.size());
 
     // actually IDs
     Instance i1 = makeInstance("foo", "null");    // invalid ip, not returned
@@ -281,8 +281,8 @@ public class GceAutoScalerTest
 
     List<String> ids3 = Arrays.asList("foo", "bar");
     List<String> ips3 = autoScaler.idToIpLookup(ids3);
-    Assert.assertEquals(1, ips3.size());
-    Assert.assertEquals("1.2.3.4", ips3.get(0));
+    Assertions.assertEquals(1, ips3.size());
+    Assertions.assertEquals("1.2.3.4", ips3.get(0));
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockInstances);
@@ -382,8 +382,8 @@ public class GceAutoScalerTest
 
     AutoScalingData autoScalingData =
             autoScaler.terminateWithIds(Collections.singletonList("baz"));
-    Assert.assertEquals(1, autoScalingData.getNodeIds().size());
-    Assert.assertEquals("baz", autoScalingData.getNodeIds().get(0));
+    Assertions.assertEquals(1, autoScalingData.getNodeIds().size());
+    Assertions.assertEquals("baz", autoScalingData.getNodeIds().get(0));
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockInstanceGroupManagers);
@@ -485,8 +485,8 @@ public class GceAutoScalerTest
 
     AutoScalingData autoScalingData =
         autoScaler.terminate(Collections.singletonList("1.2.3.6"));
-    Assert.assertEquals(1, autoScalingData.getNodeIds().size());
-    Assert.assertEquals("baz", autoScalingData.getNodeIds().get(0));
+    Assertions.assertEquals(1, autoScalingData.getNodeIds().size());
+    Assertions.assertEquals("baz", autoScalingData.getNodeIds().get(0));
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockIpToIdRequest);
@@ -582,8 +582,8 @@ public class GceAutoScalerTest
 
     AutoScalingData autoScalingData =
         autoScaler.terminateWithIds(Collections.singletonList("baz"));
-    Assert.assertEquals(1, autoScalingData.getNodeIds().size());
-    Assert.assertEquals("baz", autoScalingData.getNodeIds().get(0));
+    Assertions.assertEquals(1, autoScalingData.getNodeIds().size());
+    Assertions.assertEquals("baz", autoScalingData.getNodeIds().get(0));
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockInstanceGroupManagers);
@@ -663,8 +663,8 @@ public class GceAutoScalerTest
     EasyMock.replay(mockCompute);
 
     AutoScalingData autoScalingData = autoScaler.provision();
-    Assert.assertEquals(1, autoScalingData.getNodeIds().size());
-    Assert.assertEquals("baz", autoScalingData.getNodeIds().get(0));
+    Assertions.assertEquals(1, autoScalingData.getNodeIds().size());
+    Assertions.assertEquals("baz", autoScalingData.getNodeIds().get(0));
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockInstanceGroupManagers);
@@ -718,7 +718,7 @@ public class GceAutoScalerTest
     EasyMock.replay(mockCompute);
 
     AutoScalingData autoScalingData = autoScaler.provision();
-    Assert.assertEquals(0, autoScalingData.getNodeIds().size());
+    Assertions.assertEquals(0, autoScalingData.getNodeIds().size());
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockInstancesRequest);
@@ -805,8 +805,8 @@ public class GceAutoScalerTest
     EasyMock.replay(mockCompute);
 
     AutoScalingData autoScalingData = autoScaler.provision();
-    Assert.assertEquals(1, autoScalingData.getNodeIds().size());
-    Assert.assertEquals("baz", autoScalingData.getNodeIds().get(0));
+    Assertions.assertEquals(1, autoScalingData.getNodeIds().size());
+    Assertions.assertEquals("baz", autoScalingData.getNodeIds().get(0));
 
     EasyMock.verify(mockCompute);
     EasyMock.verify(mockInstanceGroupManagers);
@@ -847,7 +847,7 @@ public class GceAutoScalerTest
 
     List<String> ips = Collections.singletonList("1.2.3.4");
     List<String> ids = autoScaler.ipToIdLookup(ips);
-    Assert.assertEquals(0, ids.size());  // Exception caught in execution results in empty result
+    Assertions.assertEquals(0, ids.size());  // Exception caught in execution results in empty result
   }
 
 }

--- a/extensions-contrib/gce-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/gce/GceUtilsTest.java
+++ b/extensions-contrib/gce-extensions/src/test/java/org/apache/druid/indexing/overlord/autoscaling/gce/GceUtilsTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.indexing.overlord.autoscaling.gce;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,19 +34,19 @@ public class GceUtilsTest
   {
     String instance0 =
         "https://www.googleapis.com/compute/v1/projects/X/zones/Y/instances/name-of-the-thing";
-    Assert.assertEquals("name-of-the-thing", GceUtils.extractNameFromInstance(instance0));
+    Assertions.assertEquals("name-of-the-thing", GceUtils.extractNameFromInstance(instance0));
 
     String instance1 = "https://www.googleapis.com/compute/v1/projects/X/zones/Y/instances/";
-    Assert.assertEquals("", GceUtils.extractNameFromInstance(instance1));
+    Assertions.assertEquals("", GceUtils.extractNameFromInstance(instance1));
 
     String instance2 = "name-of-the-thing";
-    Assert.assertEquals("name-of-the-thing", GceUtils.extractNameFromInstance(instance2));
+    Assertions.assertEquals("name-of-the-thing", GceUtils.extractNameFromInstance(instance2));
 
     String instance3 = null;
-    Assert.assertEquals(null, GceUtils.extractNameFromInstance(instance3));
+    Assertions.assertEquals(null, GceUtils.extractNameFromInstance(instance3));
 
     String instance4 = "";
-    Assert.assertEquals("", GceUtils.extractNameFromInstance(instance4));
+    Assertions.assertEquals("", GceUtils.extractNameFromInstance(instance4));
   }
 
   @Test
@@ -55,7 +55,7 @@ public class GceUtilsTest
     List<String> list0 = null;
     try {
       String x = GceUtils.buildFilter(list0, "name");
-      Assert.fail("Exception should have been thrown!");
+      Assertions.fail("Exception should have been thrown!");
     }
     catch (IllegalArgumentException e) {
       // ok to be here!
@@ -64,7 +64,7 @@ public class GceUtilsTest
     List<String> list1 = new ArrayList<>();
     try {
       String x = GceUtils.buildFilter(list1, "name");
-      Assert.fail("Exception should have been thrown!");
+      Assertions.fail("Exception should have been thrown!");
     }
     catch (IllegalArgumentException e) {
       // ok to be here!
@@ -74,7 +74,7 @@ public class GceUtilsTest
     list2.add("foo");
     try {
       String x = GceUtils.buildFilter(list2, null);
-      Assert.fail("Exception should have been thrown!");
+      Assertions.fail("Exception should have been thrown!");
     }
     catch (IllegalArgumentException e) {
       // ok to be here!
@@ -82,12 +82,12 @@ public class GceUtilsTest
 
     List<String> list3 = new ArrayList<>();
     list3.add("foo");
-    Assert.assertEquals("(name = \"foo\")", GceUtils.buildFilter(list3, "name"));
+    Assertions.assertEquals("(name = \"foo\")", GceUtils.buildFilter(list3, "name"));
 
     List<String> list4 = new ArrayList<>();
     list4.add("foo");
     list4.add("bar");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "(name = \"foo\") OR (name = \"bar\")",
         GceUtils.buildFilter(list4, "name")
     );

--- a/extensions-contrib/graphite-emitter/pom.xml
+++ b/extensions-contrib/graphite-emitter/pom.xml
@@ -35,6 +35,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -92,16 +107,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>

--- a/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/DruidToWhiteListBasedConverterTest.java
+++ b/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/DruidToWhiteListBasedConverterTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.emitter.graphite;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DruidToWhiteListBasedConverterTest
 {
@@ -29,13 +29,13 @@ public class DruidToWhiteListBasedConverterTest
   public void testSanitize()
   {
     String test = "host name.yahoo.com:8080";
-    Assert.assertEquals("host_name_yahoo_com:8080", GraphiteEmitter.sanitize(test));
+    Assertions.assertEquals("host_name_yahoo_com:8080", GraphiteEmitter.sanitize(test));
   }
 
   @Test
   public void testSanitizeAndReplaceSlashWithDot()
   {
     String test = "query/cache/delta/hitRate";
-    Assert.assertEquals("query.cache.delta.hitRate", GraphiteEmitter.sanitize(test, true));
+    Assertions.assertEquals("query.cache.delta.hitRate", GraphiteEmitter.sanitize(test, true));
   }
 }

--- a/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/GraphiteEmitterConfigTest.java
+++ b/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/GraphiteEmitterConfigTest.java
@@ -22,9 +22,9 @@ package org.apache.druid.emitter.graphite;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -33,7 +33,7 @@ public class GraphiteEmitterConfigTest
 {
   private ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(
@@ -62,7 +62,7 @@ public class GraphiteEmitterConfigTest
     GraphiteEmitterConfig graphiteEmitterConfigExpected = mapper.readerFor(GraphiteEmitterConfig.class).readValue(
         graphiteEmitterConfigString
     );
-    Assert.assertEquals(graphiteEmitterConfigExpected, graphiteEmitterConfig);
+    Assertions.assertEquals(graphiteEmitterConfigExpected, graphiteEmitterConfig);
   }
 
   @Test
@@ -77,7 +77,7 @@ public class GraphiteEmitterConfigTest
     String noopGraphiteEventConverterString = mapper.writeValueAsString(sendAllGraphiteEventConverter);
     DruidToGraphiteEventConverter druidToGraphiteEventConverter = mapper.readerFor(DruidToGraphiteEventConverter.class)
                                                                         .readValue(noopGraphiteEventConverterString);
-    Assert.assertEquals(druidToGraphiteEventConverter, sendAllGraphiteEventConverter);
+    Assertions.assertEquals(druidToGraphiteEventConverter, sendAllGraphiteEventConverter);
 
     WhiteListBasedConverter whiteListBasedConverter = new WhiteListBasedConverter(
         "prefix",
@@ -90,12 +90,12 @@ public class GraphiteEmitterConfigTest
     String whiteListBasedConverterString = mapper.writeValueAsString(whiteListBasedConverter);
     druidToGraphiteEventConverter = mapper.readerFor(DruidToGraphiteEventConverter.class)
                                           .readValue(whiteListBasedConverterString);
-    Assert.assertEquals(druidToGraphiteEventConverter, whiteListBasedConverter);
+    Assertions.assertEquals(druidToGraphiteEventConverter, whiteListBasedConverter);
   }
 
   @Test
   public void testJacksonModules()
   {
-    Assert.assertTrue(new GraphiteEmitterModule().getJacksonModules().isEmpty());
+    Assertions.assertTrue(new GraphiteEmitterModule().getJacksonModules().isEmpty());
   }
 }

--- a/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/WhiteListBasedConverterTest.java
+++ b/extensions-contrib/graphite-emitter/src/test/java/org/apache/druid/emitter/graphite/WhiteListBasedConverterTest.java
@@ -19,15 +19,14 @@
 
 package org.apache.druid.emitter.graphite;
 
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.apache.commons.io.IOUtils;
-import org.apache.druid.annotations.UsedByJUnitParamsRunner;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,24 +34,25 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 
-@RunWith(JUnitParamsRunner.class)
 public class WhiteListBasedConverterTest
 {
-  private final String prefix = "druid";
+  private static final String PREFIX = "druid";
+  private static final String HOSTNAME = "testHost.yahoo.com:8080";
+  private static final String SERVICE_NAME = "historical";
+  private static final String DEFAULT_NAMESPACE =
+      PREFIX + "." + SERVICE_NAME + "." + GraphiteEmitter.sanitize(HOSTNAME);
+
   private final WhiteListBasedConverter defaultWhiteListBasedConverter = new WhiteListBasedConverter(
-      prefix,
+      PREFIX,
       false,
       false,
       false,
       null,
       new DefaultObjectMapper()
   );
-  private final String hostname = "testHost.yahoo.com:8080";
-  private final String serviceName = "historical";
-  private final String defaultNamespace = prefix + "." + serviceName + "." + GraphiteEmitter.sanitize(hostname);
 
-  @Test
-  @Parameters({
+  @ParameterizedTest
+  @CsvSource({
       "query/time, true",
       "query/node/ttfb, true",
       "query/segmentAndCache/time, true",
@@ -64,7 +64,7 @@ public class WhiteListBasedConverterTest
       "segment/cost/raw, false",
       "coordinator/TIER_1 /cost/raw, false",
       "segment/Kost/raw, false",
-      ", false",
+      "'', false",
       "word, false",
       "coordinator, false",
       "server/, false",
@@ -77,14 +77,14 @@ public class WhiteListBasedConverterTest
     ServiceMetricEvent event = ServiceMetricEvent
         .builder()
         .setMetric(key, 10)
-        .build(serviceName, hostname);
+        .build(SERVICE_NAME, HOSTNAME);
 
     boolean isIn = defaultWhiteListBasedConverter.druidEventToGraphite(event) != null;
-    Assert.assertEquals(expectedValue, isIn);
+    Assertions.assertEquals(expectedValue, isIn);
   }
 
-  @Test
-  @Parameters
+  @ParameterizedTest
+  @MethodSource("parametersForTestGetPath")
   public void testGetPath(ServiceMetricEvent serviceMetricEvent, String expectedPath)
   {
     GraphiteEvent graphiteEvent = defaultWhiteListBasedConverter.druidEventToGraphite(serviceMetricEvent);
@@ -92,7 +92,7 @@ public class WhiteListBasedConverterTest
     if (graphiteEvent != null) {
       path = graphiteEvent.getEventPath();
     }
-    Assert.assertEquals(expectedPath, path);
+    Assertions.assertEquals(expectedPath, path);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class WhiteListBasedConverterTest
     }
 
     WhiteListBasedConverter converter = new WhiteListBasedConverter(
-        prefix,
+        PREFIX,
         false,
         false,
         false,
@@ -120,63 +120,62 @@ public class WhiteListBasedConverterTest
     ServiceMetricEvent event = new ServiceMetricEvent.Builder()
         .setDimension("gcName", new String[]{"g1"})
         .setMetric("jvm/gc/cpu", 10)
-        .build(serviceName, hostname);
+        .build(SERVICE_NAME, HOSTNAME);
 
     GraphiteEvent graphiteEvent = converter.druidEventToGraphite(event);
 
-    Assert.assertNotNull(graphiteEvent);
-    Assert.assertEquals(defaultNamespace + ".g1.jvm/gc/cpu", graphiteEvent.getEventPath());
+    Assertions.assertNotNull(graphiteEvent);
+    Assertions.assertEquals(DEFAULT_NAMESPACE + ".g1.jvm/gc/cpu", graphiteEvent.getEventPath());
   }
 
-  @UsedByJUnitParamsRunner
-  private Object[] parametersForTestGetPath()
+  private static Object[] parametersForTestGetPath()
   {
     return new Object[]{
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("id", "dummy_id")
-                                            .setDimension("status", "some_status")
-                                            .setDimension("numDimensions", "1")
-                                            .setDimension("segment", "dummy_segment")
-                                            .setMetric("query/segment/time/balabla/more", 10)
-                .build(serviceName, hostname),
-            defaultNamespace + ".query/segment/time/balabla/more"
+                .setDimension("status", "some_status")
+                .setDimension("numDimensions", "1")
+                .setDimension("segment", "dummy_segment")
+                .setMetric("query/segment/time/balabla/more", 10)
+                .build(SERVICE_NAME, HOSTNAME),
+            DEFAULT_NAMESPACE + ".query/segment/time/balabla/more"
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("dataSource", "some_data_source")
-                                            .setDimension("tier", "_default_tier")
-                                            .setMetric("segment/max", 10)
-                .build(serviceName, hostname),
+                .setDimension("tier", "_default_tier")
+                .setMetric("segment/max", 10)
+                .build(SERVICE_NAME, HOSTNAME),
             null
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("dataSource", "data-source")
-                                            .setDimension("type", "groupBy")
-                                            .setDimension("interval", "2013/2015")
-                                            .setDimension("some_random_dim1", "random_dim_value1")
-                                            .setDimension("some_random_dim2", "random_dim_value2")
-                                            .setDimension("hasFilters", "no")
-                                            .setDimension("duration", "P1D")
-                                            .setDimension("remoteAddress", "194.0.90.2")
-                                            .setDimension("id", "ID")
-                                            .setDimension("context", "{context}")
-                                            .setMetric("query/time", 10)
-                .build(serviceName, hostname),
-            defaultNamespace + ".data-source.groupBy.query/time"
+                .setDimension("type", "groupBy")
+                .setDimension("interval", "2013/2015")
+                .setDimension("some_random_dim1", "random_dim_value1")
+                .setDimension("some_random_dim2", "random_dim_value2")
+                .setDimension("hasFilters", "no")
+                .setDimension("duration", "P1D")
+                .setDimension("remoteAddress", "194.0.90.2")
+                .setDimension("id", "ID")
+                .setDimension("context", "{context}")
+                .setMetric("query/time", 10)
+                .build(SERVICE_NAME, HOSTNAME),
+            DEFAULT_NAMESPACE + ".data-source.groupBy.query/time"
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("dataSource", "data-source")
-                                            .setDimension("type", "groupBy")
-                                            .setDimension("some_random_dim1", "random_dim_value1")
-                                            .setMetric("ingest/persists/count", 10)
-                .build(serviceName, hostname),
-            defaultNamespace + ".ingest/persists/count"
+                .setDimension("type", "groupBy")
+                .setDimension("some_random_dim1", "random_dim_value1")
+                .setMetric("ingest/persists/count", 10)
+                .build(SERVICE_NAME, HOSTNAME),
+            DEFAULT_NAMESPACE + ".ingest/persists/count"
         },
         new Object[]{
             new ServiceMetricEvent.Builder().setDimension("bufferpoolName", "BufferPool")
-                                            .setDimension("type", "groupBy")
-                                            .setDimension("some_random_dim1", "random_dim_value1")
-                                            .setMetric("jvm/bufferpool/capacity", 10)
-                .build(serviceName, hostname),
+                .setDimension("type", "groupBy")
+                .setDimension("some_random_dim1", "random_dim_value1")
+                .setMetric("jvm/bufferpool/capacity", 10)
+                .build(SERVICE_NAME, HOSTNAME),
             null
         }
     };

--- a/extensions-contrib/influx-extensions/pom.xml
+++ b/extensions-contrib/influx-extensions/pom.xml
@@ -41,6 +41,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -83,28 +98,8 @@
 
     <!-- Tests -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>nl.jqno.equalsverifier</groupId>
       <artifactId>equalsverifier</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>pl.pragmatists</groupId>
-      <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-contrib/influx-extensions/src/test/java/org/apache/druid/data/input/influx/InfluxInputFormatTest.java
+++ b/extensions-contrib/influx-extensions/src/test/java/org/apache/druid/data/input/influx/InfluxInputFormatTest.java
@@ -35,9 +35,9 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,7 +47,7 @@ public class InfluxInputFormatTest
 {
   private InputRowSchema schema;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     schema = new InputRowSchema(
@@ -64,14 +64,14 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(null),
         "cpu,host=foo.bar.baz,region=us-east-1,application=echo pct_idle=99.3,pct_user=88.8,m1_load=2i 1465839830100400200"
     );
-    Assert.assertEquals("cpu", row.getDimension("measurement").get(0));
-    Assert.assertEquals(1465839830100L, row.getTimestampFromEpoch());
-    Assert.assertEquals("foo.bar.baz", row.getDimension("host").get(0));
-    Assert.assertEquals("us-east-1", row.getDimension("region").get(0));
-    Assert.assertEquals("echo", row.getDimension("application").get(0));
-    Assert.assertEquals(99.3, row.getMetric("pct_idle").doubleValue(), 0.0);
-    Assert.assertEquals(88.8, row.getMetric("pct_user").doubleValue(), 0.0);
-    Assert.assertEquals(2L, row.getMetric("m1_load").longValue());
+    Assertions.assertEquals("cpu", row.getDimension("measurement").get(0));
+    Assertions.assertEquals(1465839830100L, row.getTimestampFromEpoch());
+    Assertions.assertEquals("foo.bar.baz", row.getDimension("host").get(0));
+    Assertions.assertEquals("us-east-1", row.getDimension("region").get(0));
+    Assertions.assertEquals("echo", row.getDimension("application").get(0));
+    Assertions.assertEquals(99.3, row.getMetric("pct_idle").doubleValue(), 0.0);
+    Assertions.assertEquals(88.8, row.getMetric("pct_user").doubleValue(), 0.0);
+    Assertions.assertEquals(2L, row.getMetric("m1_load").longValue());
   }
 
   @Test
@@ -81,13 +81,13 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(null),
         "foo,region=us-east-1,host=127.0.0.1 m=1.0,n=3.0,o=500i -123456789"
     );
-    Assert.assertEquals("foo", row.getDimension("measurement").get(0));
-    Assert.assertEquals(-123L, row.getTimestampFromEpoch());
-    Assert.assertEquals("us-east-1", row.getDimension("region").get(0));
-    Assert.assertEquals("127.0.0.1", row.getDimension("host").get(0));
-    Assert.assertEquals(1.0, row.getMetric("m").doubleValue(), 0.0);
-    Assert.assertEquals(3.0, row.getMetric("n").doubleValue(), 0.0);
-    Assert.assertEquals(500L, row.getMetric("o").longValue());
+    Assertions.assertEquals("foo", row.getDimension("measurement").get(0));
+    Assertions.assertEquals(-123L, row.getTimestampFromEpoch());
+    Assertions.assertEquals("us-east-1", row.getDimension("region").get(0));
+    Assertions.assertEquals("127.0.0.1", row.getDimension("host").get(0));
+    Assertions.assertEquals(1.0, row.getMetric("m").doubleValue(), 0.0);
+    Assertions.assertEquals(3.0, row.getMetric("n").doubleValue(), 0.0);
+    Assertions.assertEquals(500L, row.getMetric("o").longValue());
   }
 
   @Test
@@ -97,8 +97,8 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(null),
         "foo,region=us-east-1,host=127.0.0.1 m=1.0,n=3.0,o=500i 123"
     );
-    Assert.assertEquals("foo", row.getDimension("measurement").get(0));
-    Assert.assertEquals(0L, row.getTimestampFromEpoch());
+    Assertions.assertEquals("foo", row.getDimension("measurement").get(0));
+    Assertions.assertEquals(0L, row.getTimestampFromEpoch());
   }
 
   @Test
@@ -108,10 +108,10 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(null),
         "foo m=1.0,n=3.0 123456789"
     );
-    Assert.assertEquals("foo", row.getDimension("measurement").get(0));
-    Assert.assertEquals(123L, row.getTimestampFromEpoch());
-    Assert.assertEquals(1.0, row.getMetric("m").doubleValue(), 0.0);
-    Assert.assertEquals(3.0, row.getMetric("n").doubleValue(), 0.0);
+    Assertions.assertEquals("foo", row.getDimension("measurement").get(0));
+    Assertions.assertEquals(123L, row.getTimestampFromEpoch());
+    Assertions.assertEquals(1.0, row.getMetric("m").doubleValue(), 0.0);
+    Assertions.assertEquals(3.0, row.getMetric("n").doubleValue(), 0.0);
   }
 
   @Test
@@ -121,9 +121,9 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(null),
         "foo,region=us-east-1,host=127.0.0.1 m=1.0,n=3.0,o=\"something \\\"cool\\\" \" 123456789"
     );
-    Assert.assertEquals("foo", row.getDimension("measurement").get(0));
-    Assert.assertEquals(123L, row.getTimestampFromEpoch());
-    Assert.assertEquals("something \"cool\" ", row.getDimension("o").get(0));
+    Assertions.assertEquals("foo", row.getDimension("measurement").get(0));
+    Assertions.assertEquals(123L, row.getTimestampFromEpoch());
+    Assertions.assertEquals("something \"cool\" ", row.getDimension("o").get(0));
   }
 
   @Test
@@ -133,11 +133,11 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(null),
         "\uD83D\uDE00,\uD83D\uDE05=\uD83D\uDE06 \uD83D\uDE0B=100i,b=\"\uD83D\uDE42\" 123456789"
     );
-    Assert.assertEquals("\uD83D\uDE00", row.getDimension("measurement").get(0));
-    Assert.assertEquals(123L, row.getTimestampFromEpoch());
-    Assert.assertEquals("\uD83D\uDE06", row.getDimension("\uD83D\uDE05").get(0));
-    Assert.assertEquals(100L, row.getMetric("\uD83D\uDE0B").longValue());
-    Assert.assertEquals("\uD83D\uDE42", row.getDimension("b").get(0));
+    Assertions.assertEquals("\uD83D\uDE00", row.getDimension("measurement").get(0));
+    Assertions.assertEquals(123L, row.getTimestampFromEpoch());
+    Assertions.assertEquals("\uD83D\uDE06", row.getDimension("\uD83D\uDE05").get(0));
+    Assertions.assertEquals(100L, row.getMetric("\uD83D\uDE0B").longValue());
+    Assertions.assertEquals("\uD83D\uDE42", row.getDimension("b").get(0));
   }
 
   @Test
@@ -147,11 +147,11 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(null),
         "f\\,oo\\ \\=,bar=baz m=1.0,n=3.0 123456789"
     );
-    Assert.assertEquals("f,oo =", row.getDimension("measurement").get(0));
-    Assert.assertEquals(123L, row.getTimestampFromEpoch());
-    Assert.assertEquals("baz", row.getDimension("bar").get(0));
-    Assert.assertEquals(1.0, row.getMetric("m").doubleValue(), 0.0);
-    Assert.assertEquals(3.0, row.getMetric("n").doubleValue(), 0.0);
+    Assertions.assertEquals("f,oo =", row.getDimension("measurement").get(0));
+    Assertions.assertEquals(123L, row.getTimestampFromEpoch());
+    Assertions.assertEquals("baz", row.getDimension("bar").get(0));
+    Assertions.assertEquals(1.0, row.getMetric("m").doubleValue(), 0.0);
+    Assertions.assertEquals(3.0, row.getMetric("n").doubleValue(), 0.0);
   }
 
   @Test
@@ -161,13 +161,13 @@ public class InfluxInputFormatTest
         new InfluxInputFormat(ImmutableList.of("cpu")),
         "cpu,host=foo.bar.baz,region=us-east pct_idle=99.3,pct_user=88.8,m1_load=2 1465839830100400200"
     );
-    Assert.assertEquals("cpu", row.getDimension("measurement").get(0));
+    Assertions.assertEquals("cpu", row.getDimension("measurement").get(0));
   }
 
   @Test
   public void testWhitelistFail()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ParseException.class,
         () -> readSingleRow(
             new InfluxInputFormat(ImmutableList.of("mem")),
@@ -181,13 +181,13 @@ public class InfluxInputFormatTest
   {
     // empty line is skipped (this was a parse exception in old InfluxParser)
     List<InputRow> rows = readAllRows(new InfluxInputFormat(null), "");
-    Assert.assertTrue(rows.isEmpty());
+    Assertions.assertTrue(rows.isEmpty());
   }
 
   @Test
   public void testParseInvalidMeasurement()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ParseException.class,
         () -> readSingleRow(new InfluxInputFormat(null), "invalid measurement")
     );
@@ -196,7 +196,7 @@ public class InfluxInputFormatTest
   @Test
   public void testParseInvalidTimestamp()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ParseException.class,
         () -> readSingleRow(new InfluxInputFormat(null), "foo i=123 123x")
     );
@@ -209,11 +209,11 @@ public class InfluxInputFormatTest
                    + "mem,host=b used=1024i 1465839831100400200";
     InfluxInputFormat format = new InfluxInputFormat(null);
     List<InputRow> rows = readAllRows(format, input);
-    Assert.assertEquals(2, rows.size());
-    Assert.assertEquals("cpu", rows.get(0).getDimension("measurement").get(0));
-    Assert.assertEquals("a", rows.get(0).getDimension("host").get(0));
-    Assert.assertEquals("mem", rows.get(1).getDimension("measurement").get(0));
-    Assert.assertEquals("b", rows.get(1).getDimension("host").get(0));
+    Assertions.assertEquals(2, rows.size());
+    Assertions.assertEquals("cpu", rows.get(0).getDimension("measurement").get(0));
+    Assertions.assertEquals("a", rows.get(0).getDimension("host").get(0));
+    Assertions.assertEquals("mem", rows.get(1).getDimension("measurement").get(0));
+    Assertions.assertEquals("b", rows.get(1).getDimension("host").get(0));
   }
 
   @Test
@@ -228,8 +228,8 @@ public class InfluxInputFormatTest
     String json = mapper.writeValueAsString(format);
     InfluxInputFormat deserialized = (InfluxInputFormat) mapper.readValue(json, InputFormat.class);
 
-    Assert.assertEquals(format, deserialized);
-    Assert.assertEquals(format.getWhitelistMeasurements(), deserialized.getWhitelistMeasurements());
+    Assertions.assertEquals(format, deserialized);
+    Assertions.assertEquals(format.getWhitelistMeasurements(), deserialized.getWhitelistMeasurements());
   }
 
   @Test
@@ -244,14 +244,14 @@ public class InfluxInputFormatTest
     String json = mapper.writeValueAsString(format);
     InfluxInputFormat deserialized = (InfluxInputFormat) mapper.readValue(json, InputFormat.class);
 
-    Assert.assertEquals(format, deserialized);
-    Assert.assertNull(deserialized.getWhitelistMeasurements());
+    Assertions.assertEquals(format, deserialized);
+    Assertions.assertNull(deserialized.getWhitelistMeasurements());
   }
 
   @Test
   public void testIsSplittable()
   {
-    Assert.assertFalse(new InfluxInputFormat(null).isSplittable());
+    Assertions.assertFalse(new InfluxInputFormat(null).isSplittable());
   }
 
   @Test
@@ -264,9 +264,9 @@ public class InfluxInputFormatTest
   {
     InputEntityReader reader = format.createReader(schema, new ByteEntity(StringUtils.toUtf8(line)), null);
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       InputRow row = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(iterator.hasNext());
       return row;
     }
   }

--- a/extensions-contrib/influxdb-emitter/pom.xml
+++ b/extensions-contrib/influxdb-emitter/pom.xml
@@ -35,6 +35,21 @@
     <modelVersion>4.0.0</modelVersion>
 
     <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
@@ -71,11 +86,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>

--- a/extensions-contrib/influxdb-emitter/src/test/java/org/apache/druid/emitter/influxdb/InfluxdbEmitterConfigTest.java
+++ b/extensions-contrib/influxdb-emitter/src/test/java/org/apache/druid/emitter/influxdb/InfluxdbEmitterConfigTest.java
@@ -24,19 +24,21 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.security.KeyStore;
 import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InfluxdbEmitterConfigTest
 {
   private ObjectMapper mapper = new DefaultObjectMapper();
   private InfluxdbEmitterConfig influxdbEmitterConfig;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper.setInjectableValues(new InjectableValues.Std().addValue(
@@ -79,27 +81,29 @@ public class InfluxdbEmitterConfigTest
         "password",
         null
     );
-    Assert.assertNotEquals(influxdbEmitterConfig, influxdbEmitterConfigComparison);
+    Assertions.assertNotEquals(influxdbEmitterConfig, influxdbEmitterConfigComparison);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testConfigWithNullHostname()
   {
-    InfluxdbEmitterConfig influxdbEmitterConfigWithNullHostname = new InfluxdbEmitterConfig(
-        null,
-        8080,
-        null,
-        null,
-        null,
-        null,
-        "dbname",
-        10000,
-        15000,
-        30000,
-        "adam",
-        "password",
-        null
-    );
+    assertThrows(NullPointerException.class, () -> {
+      InfluxdbEmitterConfig influxdbEmitterConfigWithNullHostname = new InfluxdbEmitterConfig(
+          null,
+          8080,
+          null,
+          null,
+          null,
+          null,
+          "dbname",
+          10000,
+          15000,
+          30000,
+          "adam",
+          "password",
+          null
+      );
+    });
   }
 
   @Test
@@ -121,7 +125,7 @@ public class InfluxdbEmitterConfigTest
         null
     );
     int expectedPort = 8086;
-    Assert.assertEquals(expectedPort, influxdbEmitterConfig.getPort());
+    Assertions.assertEquals(expectedPort, influxdbEmitterConfig.getPort());
   }
 
   @Test
@@ -142,7 +146,7 @@ public class InfluxdbEmitterConfigTest
         "password",
         null
     );
-    Assert.assertTrue(influxdbEmitterConfig.equals(influxdbEmitterConfigComparison));
+    Assertions.assertTrue(influxdbEmitterConfig.equals(influxdbEmitterConfigComparison));
   }
 
   @Test
@@ -163,47 +167,51 @@ public class InfluxdbEmitterConfigTest
         "password",
         null
     );
-    Assert.assertFalse(influxdbEmitterConfig.equals(influxdbEmitterConfigComparison));
+    Assertions.assertFalse(influxdbEmitterConfig.equals(influxdbEmitterConfigComparison));
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testConfigWithNullInfluxdbUserName()
   {
-    InfluxdbEmitterConfig influxdbEmitterConfigWithNullHostname = new InfluxdbEmitterConfig(
-        "localhost",
-        8086,
-        null,
-        null,
-        null,
-        null,
-        "dbname",
-        10000,
-        15000,
-        30000,
-        null,
-        "password",
-        null
-    );
+    assertThrows(NullPointerException.class, () -> {
+      InfluxdbEmitterConfig influxdbEmitterConfigWithNullHostname = new InfluxdbEmitterConfig(
+          "localhost",
+          8086,
+          null,
+          null,
+          null,
+          null,
+          "dbname",
+          10000,
+          15000,
+          30000,
+          null,
+          "password",
+          null
+      );
+    });
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void testConfigWithNullInfluxdbPassword()
   {
-    InfluxdbEmitterConfig influxdbEmitterConfigWithNullHostname = new InfluxdbEmitterConfig(
-        "localhost",
-        8086,
-        null,
-        null,
-        null,
-        null,
-        "dbname",
-        10000,
-        15000,
-        30000,
-        "adam",
-        null,
-        null
-    );
+    assertThrows(NullPointerException.class, () -> {
+      InfluxdbEmitterConfig influxdbEmitterConfigWithNullHostname = new InfluxdbEmitterConfig(
+          "localhost",
+          8086,
+          null,
+          null,
+          null,
+          null,
+          "dbname",
+          10000,
+          15000,
+          30000,
+          "adam",
+          null,
+          null
+      );
+    });
   }
 
   @Test
@@ -225,7 +233,7 @@ public class InfluxdbEmitterConfigTest
         null
     );
     ImmutableSet<String> expected = ImmutableSet.copyOf(Arrays.asList("dataSource", "type", "numMetrics", "numDimensions", "threshold", "dimension", "taskType", "taskStatus", "tier"));
-    Assert.assertEquals(expected, influxdbEmitterConfig.getDimensionWhitelist());
+    Assertions.assertEquals(expected, influxdbEmitterConfig.getDimensionWhitelist());
   }
 
   @Test
@@ -247,7 +255,7 @@ public class InfluxdbEmitterConfigTest
         ImmutableSet.of("dataSource", "taskType")
     );
     ImmutableSet<String> expected = ImmutableSet.copyOf(Arrays.asList("dataSource", "taskType"));
-    Assert.assertEquals(expected, influxdbEmitterConfig.getDimensionWhitelist());
+    Assertions.assertEquals(expected, influxdbEmitterConfig.getDimensionWhitelist());
   }
 
   @Test
@@ -269,7 +277,7 @@ public class InfluxdbEmitterConfigTest
         null
     );
     String expectedProtocol = "http";
-    Assert.assertEquals(expectedProtocol, influxdbEmitterConfigWithNullProtocol.getProtocol());
+    Assertions.assertEquals(expectedProtocol, influxdbEmitterConfigWithNullProtocol.getProtocol());
   }
 
   @Test
@@ -305,7 +313,7 @@ public class InfluxdbEmitterConfigTest
         null
     );
     String expectedTrustStoreType = KeyStore.getDefaultType();
-    Assert.assertEquals(expectedTrustStoreType, influxdbEmitterConfigWithNullTrustStoreType.getTrustStoreType());
+    Assertions.assertEquals(expectedTrustStoreType, influxdbEmitterConfigWithNullTrustStoreType.getTrustStoreType());
   }
 
 }

--- a/extensions-contrib/influxdb-emitter/src/test/java/org/apache/druid/emitter/influxdb/InfluxdbEmitterTest.java
+++ b/extensions-contrib/influxdb-emitter/src/test/java/org/apache/druid/emitter/influxdb/InfluxdbEmitterTest.java
@@ -25,16 +25,18 @@ import org.apache.druid.java.util.emitter.service.ServiceEventBuilder;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class InfluxdbEmitterTest
 {
 
   private ServiceMetricEvent event;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     DateTime date = new DateTime(2017,
@@ -83,7 +85,7 @@ public class InfluxdbEmitterTest
         "druid_metric,service=druid/historical,metric=druid_te_st,hostname=localhost,dataSource=test_datasource druid_value=1234 1509357600000000000"
         + "\n";
     String actual = influxdbEmitter.transformForInfluxSystems(event);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -127,7 +129,7 @@ public class InfluxdbEmitterTest
     String expected = "druid_metric,service=druid/historical,hostname=localhost druid_time=1234 1509357600000000000"
                       + "\n";
     String actual = influxdbEmitter.transformForInfluxSystems(event);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -173,7 +175,7 @@ public class InfluxdbEmitterTest
     String expected = "druid_metric,service=druid/historical,hostname=localhost,dataSource=wikipedia druid_time=1234 1509357600000000000"
                       + "\n";
     String actual = influxdbEmitter.transformForInfluxSystems(event);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -219,97 +221,105 @@ public class InfluxdbEmitterTest
     String expected = "druid_metric,service=druid/historical,hostname=localhost,dataSource=wikipedia,taskType=index druid_time=1234 1509357600000000000"
                       + "\n";
     String actual = influxdbEmitter.transformForInfluxSystems(event);
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
   public void testJacksonModules()
   {
-    Assert.assertTrue(new InfluxdbEmitterModule().getJacksonModules().isEmpty());
+    Assertions.assertTrue(new InfluxdbEmitterModule().getJacksonModules().isEmpty());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testBuildInfluxdbClientWithHttpsProtocolAndNoTrustStore()
   {
-    InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
-        "localhost",
-        8086,
-        "https",
-        null,
-        null,
-        null,
-        "dbname",
-        10000,
-        15000,
-        30000,
-        "adam",
-        "password",
-        null
-    );
-    InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    assertThrows(IllegalStateException.class, () -> {
+      InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
+          "localhost",
+          8086,
+          "https",
+          null,
+          null,
+          null,
+          "dbname",
+          10000,
+          15000,
+          30000,
+          "adam",
+          "password",
+          null
+      );
+      InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testBuildInfluxdbClientWithHttpsProtocolAndNullTrustStorePath()
   {
-    InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
-        "localhost",
-        8086,
-        "https",
-        null,
-        null,
-        "pass",
-        "dbname",
-        10000,
-        15000,
-        30000,
-        "adam",
-        "password",
-        null
-    );
-    InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    assertThrows(IllegalStateException.class, () -> {
+      InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
+          "localhost",
+          8086,
+          "https",
+          null,
+          null,
+          "pass",
+          "dbname",
+          10000,
+          15000,
+          30000,
+          "adam",
+          "password",
+          null
+      );
+      InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testBuildInfluxdbClientWithHttpsProtocolAndNullTrustStorePassword()
   {
-    InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
-        "localhost",
-        8086,
-        "https",
-        "path",
-        null,
-        null,
-        "dbname",
-        10000,
-        15000,
-        30000,
-        "adam",
-        "password",
-        null
-    );
-    InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    assertThrows(IllegalStateException.class, () -> {
+      InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
+          "localhost",
+          8086,
+          "https",
+          "path",
+          null,
+          null,
+          "dbname",
+          10000,
+          15000,
+          30000,
+          "adam",
+          "password",
+          null
+      );
+      InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testUnableToLoadTrustStore()
   {
-    InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
-        "localhost",
-        8086,
-        "https",
-        "path",
-        null,
-        "pass",
-        "dbname",
-        10000,
-        15000,
-        30000,
-        "adam",
-        "password",
-        null
-    );
-    InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    assertThrows(IllegalStateException.class, () -> {
+      InfluxdbEmitterConfig config = new InfluxdbEmitterConfig(
+          "localhost",
+          8086,
+          "https",
+          "path",
+          null,
+          "pass",
+          "dbname",
+          10000,
+          15000,
+          30000,
+          "adam",
+          "password",
+          null
+      );
+      InfluxdbEmitter influxdbEmitter = new InfluxdbEmitter(config);
+    });
   }
 
 }

--- a/extensions-contrib/kafka-emitter/pom.xml
+++ b/extensions-contrib/kafka-emitter/pom.xml
@@ -35,6 +35,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>${apache.kafka.version}</version>
@@ -98,11 +113,6 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -119,16 +129,6 @@
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
       <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterConfigTest.java
@@ -24,13 +24,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.metadata.DynamicConfigProvider;
 import org.apache.druid.metadata.MapStringDynamicConfigProvider;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -64,7 +62,7 @@ public class KafkaEmitterConfigTest
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);
-    Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
+    Assertions.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
   }
 
   @Test
@@ -87,7 +85,7 @@ public class KafkaEmitterConfigTest
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);
-    Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
+    Assertions.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
   }
 
   @Test
@@ -112,7 +110,7 @@ public class KafkaEmitterConfigTest
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);
-    Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
+    Assertions.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
   }
 
   @Test
@@ -134,28 +132,28 @@ public class KafkaEmitterConfigTest
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);
-    Assert.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
+    Assertions.assertEquals(kafkaEmitterConfigExpected, kafkaEmitterConfig);
     try {
       @SuppressWarnings("unused")
       KafkaEmitter emitter = new KafkaEmitter(kafkaEmitterConfig, MAPPER);
     }
     catch (NullPointerException e) {
-      Assert.fail();
+      Assertions.fail();
     }
   }
 
   @Test
   public void testDeserializeEventTypesWithDifferentCase() throws JsonProcessingException
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KafkaEmitterConfig.EventType.SEGMENT_METADATA,
         MAPPER.readValue("\"segment_metadata\"", KafkaEmitterConfig.EventType.class)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         KafkaEmitterConfig.EventType.ALERTS,
         MAPPER.readValue("\"alerts\"", KafkaEmitterConfig.EventType.class)
     );
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ValueInstantiationException.class,
         () -> MAPPER.readValue("\"segmentMetadata\"", KafkaEmitterConfig.EventType.class)
     );
@@ -164,14 +162,14 @@ public class KafkaEmitterConfigTest
   @Test
   public void testJacksonModules()
   {
-    Assert.assertTrue(new KafkaEmitterModule().getJacksonModules().isEmpty());
+    Assertions.assertTrue(new KafkaEmitterModule().getJacksonModules().isEmpty());
   }
 
   @Test
   public void testNullBootstrapServers()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    assertOperatorException(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new KafkaEmitterConfig(
                 null,
@@ -187,16 +185,15 @@ public class KafkaEmitterConfigTest
                 null
             )
         ),
-        operatorExceptionMatcher()
-            .expectMessageIs("druid.emitter.kafka.bootstrap.servers must be specified.")
+        "druid.emitter.kafka.bootstrap.servers must be specified."
     );
   }
 
   @Test
   public void testNullMetricTopic()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    assertOperatorException(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new KafkaEmitterConfig(
                 "foo",
@@ -212,16 +209,15 @@ public class KafkaEmitterConfigTest
                 null
             )
         ),
-        operatorExceptionMatcher()
-            .expectMessageIs("druid.emitter.kafka.metric.topic must be specified if druid.emitter.kafka.event.types contains metrics.")
+        "druid.emitter.kafka.metric.topic must be specified if druid.emitter.kafka.event.types contains metrics."
     );
   }
 
   @Test
   public void testNullAlertTopic()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    assertOperatorException(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new KafkaEmitterConfig(
                 "foo",
@@ -237,18 +233,15 @@ public class KafkaEmitterConfigTest
                 null
             )
         ),
-        operatorExceptionMatcher()
-            .expectMessageIs(
-                "druid.emitter.kafka.alert.topic must be specified if druid.emitter.kafka.event.types contains alerts."
-            )
+        "druid.emitter.kafka.alert.topic must be specified if druid.emitter.kafka.event.types contains alerts."
     );
   }
 
   @Test
   public void testNullRequestTopic()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    assertOperatorException(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new KafkaEmitterConfig(
                 "foo",
@@ -264,18 +257,15 @@ public class KafkaEmitterConfigTest
                 null
             )
         ),
-        operatorExceptionMatcher()
-            .expectMessageIs(
-                "druid.emitter.kafka.request.topic must be specified if druid.emitter.kafka.event.types contains requests."
-            )
+        "druid.emitter.kafka.request.topic must be specified if druid.emitter.kafka.event.types contains requests."
     );
   }
 
   @Test
   public void testNullSegmentMetadataTopic()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    assertOperatorException(
+        Assertions.assertThrows(
             DruidException.class,
             () -> new KafkaEmitterConfig(
                 "foo",
@@ -291,10 +281,7 @@ public class KafkaEmitterConfigTest
                 null
             )
         ),
-        operatorExceptionMatcher()
-            .expectMessageIs(
-                "druid.emitter.kafka.segmentMetadata.topic must be specified if druid.emitter.kafka.event.types contains segment_metadata."
-            )
+        "druid.emitter.kafka.segmentMetadata.topic must be specified if druid.emitter.kafka.event.types contains segment_metadata."
     );
   }
 
@@ -320,15 +307,16 @@ public class KafkaEmitterConfigTest
     String kafkaEmitterConfigString = MAPPER.writeValueAsString(kafkaEmitterConfig);
     KafkaEmitterConfig kafkaEmitterConfigExpected = MAPPER.readerFor(KafkaEmitterConfig.class)
                                                           .readValue(kafkaEmitterConfigString);
-    Assert.assertEquals(Long.MAX_VALUE, (long) kafkaEmitterConfigExpected.getShutdownTimeout());
+    Assertions.assertEquals(Long.MAX_VALUE, (long) kafkaEmitterConfigExpected.getShutdownTimeout());
   }
 
-  private DruidExceptionMatcher operatorExceptionMatcher()
+  private void assertOperatorException(final DruidException exception, final String expectedMessage)
   {
-    return new DruidExceptionMatcher(
-        DruidException.Persona.OPERATOR,
-        DruidException.Category.NOT_FOUND,
-        "general"
+    Assertions.assertAll(
+        () -> Assertions.assertEquals(DruidException.Persona.OPERATOR, exception.getTargetPersona()),
+        () -> Assertions.assertEquals(DruidException.Category.NOT_FOUND, exception.getCategory()),
+        () -> Assertions.assertEquals("general", exception.getErrorCode()),
+        () -> Assertions.assertEquals(expectedMessage, exception.getMessage())
     );
   }
 }

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -38,10 +38,11 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -53,9 +54,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -64,13 +64,13 @@ public class KafkaEmitterTest
 {
   private KafkaProducer<String, String> producer;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     producer = mock(KafkaProducer.class);
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     producer.close();
@@ -136,7 +136,8 @@ public class KafkaEmitterTest
    * Only {@link KafkaEmitterConfig.EventType}s is subscribed in the config, so the expectation is that the
    * events are emitted without any drops.
    */
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testServiceMetricEvents() throws InterruptedException, JsonProcessingException
   {
     final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
@@ -169,19 +170,19 @@ public class KafkaEmitterTest
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
-    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getInvalidLostCount());
 
     kafkaEmitter.logLostMessagesStatus();
 
-    Assert.assertEquals(0, kafkaEmitter.getPreviousMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousSegmentMetadataLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousSegmentMetadataLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousInvalidLostCount());
   }
 
   /**
@@ -190,7 +191,8 @@ public class KafkaEmitterTest
    * All {@link KafkaEmitterConfig.EventType}s are subscribed in the config, so the expectation is that all the
    * events are emitted without any drops.
    */
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testAllEvents() throws InterruptedException, JsonProcessingException
   {
     final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
@@ -228,11 +230,11 @@ public class KafkaEmitterTest
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
-    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getInvalidLostCount());
   }
 
   /**
@@ -240,7 +242,8 @@ public class KafkaEmitterTest
    * The default event types (alerts and metrics) are subscribed in the config, so the expectation is that both input
    * event types should be emitted without any drops.
    */
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultEvents() throws InterruptedException, JsonProcessingException
   {
     final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
@@ -276,11 +279,11 @@ public class KafkaEmitterTest
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
-    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getInvalidLostCount());
   }
 
   /**
@@ -289,7 +292,8 @@ public class KafkaEmitterTest
    * Only alerts are subscribed in the config, so the expectation is that only alert events
    * should be emitted, and everything else should be dropped.
    */
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testAlertsPlusUnsubscribedEvents() throws InterruptedException, JsonProcessingException
   {
     final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
@@ -329,30 +333,30 @@ public class KafkaEmitterTest
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getInvalidLostCount());
 
-    Assert.assertEquals(0, kafkaEmitter.getPreviousAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousInvalidLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousSegmentMetadataLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getPreviousRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousSegmentMetadataLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getPreviousRequestLostCount());
 
     // Others would be dropped as we've only subscribed to alert events.
-    Assert.assertEquals(SERVICE_METRIC_EVENTS.size(), kafkaEmitter.getMetricLostCount());
-    Assert.assertNotEquals(kafkaEmitter.getMetricLostCount(), kafkaEmitter.getPreviousMetricLostCount());
-    Assert.assertEquals(SEGMENT_METADATA_EVENTS.size(), kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertNotEquals(kafkaEmitter.getSegmentMetadataLostCount(), kafkaEmitter.getPreviousSegmentMetadataLostCount());
-    Assert.assertEquals(REQUEST_LOG_EVENTS.size(), kafkaEmitter.getRequestLostCount());
-    Assert.assertNotEquals(kafkaEmitter.getRequestLostCount(), kafkaEmitter.getPreviousRequestLostCount());
+    Assertions.assertEquals(SERVICE_METRIC_EVENTS.size(), kafkaEmitter.getMetricLostCount());
+    Assertions.assertNotEquals(kafkaEmitter.getMetricLostCount(), kafkaEmitter.getPreviousMetricLostCount());
+    Assertions.assertEquals(SEGMENT_METADATA_EVENTS.size(), kafkaEmitter.getSegmentMetadataLostCount());
+    Assertions.assertNotEquals(kafkaEmitter.getSegmentMetadataLostCount(), kafkaEmitter.getPreviousSegmentMetadataLostCount());
+    Assertions.assertEquals(REQUEST_LOG_EVENTS.size(), kafkaEmitter.getRequestLostCount());
+    Assertions.assertNotEquals(kafkaEmitter.getRequestLostCount(), kafkaEmitter.getPreviousRequestLostCount());
 
     kafkaEmitter.logLostMessagesStatus();
 
-    Assert.assertEquals(kafkaEmitter.getMetricLostCount(), kafkaEmitter.getPreviousMetricLostCount());
-    Assert.assertEquals(kafkaEmitter.getAlertLostCount(), kafkaEmitter.getPreviousAlertLostCount());
-    Assert.assertEquals(kafkaEmitter.getRequestLostCount(), kafkaEmitter.getPreviousRequestLostCount());
-    Assert.assertEquals(kafkaEmitter.getSegmentMetadataLostCount(), kafkaEmitter.getPreviousSegmentMetadataLostCount());
-    Assert.assertEquals(kafkaEmitter.getInvalidLostCount(), kafkaEmitter.getPreviousInvalidLostCount());
+    Assertions.assertEquals(kafkaEmitter.getMetricLostCount(), kafkaEmitter.getPreviousMetricLostCount());
+    Assertions.assertEquals(kafkaEmitter.getAlertLostCount(), kafkaEmitter.getPreviousAlertLostCount());
+    Assertions.assertEquals(kafkaEmitter.getRequestLostCount(), kafkaEmitter.getPreviousRequestLostCount());
+    Assertions.assertEquals(kafkaEmitter.getSegmentMetadataLostCount(), kafkaEmitter.getPreviousSegmentMetadataLostCount());
+    Assertions.assertEquals(kafkaEmitter.getInvalidLostCount(), kafkaEmitter.getPreviousInvalidLostCount());
   }
 
   /**
@@ -364,7 +368,8 @@ public class KafkaEmitterTest
    * is that all input events are emitted without any drops.
    * </p>
    */
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testAllEventsWithCommonTopic() throws InterruptedException, JsonProcessingException
   {
     final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
@@ -403,11 +408,11 @@ public class KafkaEmitterTest
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
-    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getInvalidLostCount());
   }
 
   /**
@@ -416,7 +421,8 @@ public class KafkaEmitterTest
    * {@link ServiceMetricEvent} is expected to be emitted, while dropping all unknown {@link TestEvent}s.
    * </p>
    */
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testUnknownEvents() throws InterruptedException, JsonProcessingException
   {
     final KafkaEmitterConfig kafkaEmitterConfig = new KafkaEmitterConfig(
@@ -453,11 +459,11 @@ public class KafkaEmitterTest
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
-    Assert.assertEquals(0, kafkaEmitter.getMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertEquals(UNKNOWN_EVENTS.size(), kafkaEmitter.getInvalidLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assertions.assertEquals(UNKNOWN_EVENTS.size(), kafkaEmitter.getInvalidLostCount());
   }
 
   /**
@@ -467,7 +473,8 @@ public class KafkaEmitterTest
    * the config, so the expectation is that all {@link ServiceMetricEvent}s up to {@code n - bufferEventsDrop} will be
    * emitted, {@code n} being the total number of input events, while dropping the last {@code bufferEventsDrop} events.
    */
-  @Test(timeout = 10_000)
+  @Test
+  @Timeout(value = 10_000, unit = TimeUnit.MILLISECONDS)
   public void testDropEventsWhenQueueFull() throws JsonProcessingException, InterruptedException
   {
     final List<Event> inputEvents = flattenEvents(
@@ -482,19 +489,19 @@ public class KafkaEmitterTest
     );
 
     final int bufferEventsDrop = 3;
-    Assert.assertTrue(
+    Assertions.assertTrue(
+        inputEvents.size() - bufferEventsDrop > 0,
         StringUtils.format(
             "Total events to emit: %d. There must at least be %d events to drop.",
             inputEvents.size(),
             bufferEventsDrop
-        ),
-        inputEvents.size() - bufferEventsDrop > 0
+        )
     );
 
-    Assert.assertEquals(
-        "Currently the test only supports having 1 feed",
+    Assertions.assertEquals(
         1,
-        feedToAllEventsBeforeDrop.size()
+        feedToAllEventsBeforeDrop.size(),
+        "Currently the test only supports having 1 feed"
     );
 
     // Note: this only accounts for one feed currently. If we want to test the queuing behavior across all feeds,
@@ -536,11 +543,11 @@ public class KafkaEmitterTest
 
     validateEvents(feedToExpectedEvents, feedToActualEvents);
 
-    Assert.assertEquals(bufferEventsDrop, kafkaEmitter.getMetricLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getAlertLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getRequestLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
-    Assert.assertEquals(0, kafkaEmitter.getInvalidLostCount());
+    Assertions.assertEquals(bufferEventsDrop, kafkaEmitter.getMetricLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getAlertLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getRequestLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getSegmentMetadataLostCount());
+    Assertions.assertEquals(0, kafkaEmitter.getInvalidLostCount());
   }
 
   private KafkaEmitter initKafkaEmitter(
@@ -632,13 +639,19 @@ public class KafkaEmitterTest
       final Map<String, List<EventMap>> feedToActualEvents
   )
   {
-    Assert.assertEquals(feedToExpectedEvents.size(), feedToActualEvents.size());
+    Assertions.assertEquals(feedToExpectedEvents.size(), feedToActualEvents.size());
 
     for (final Map.Entry<String, List<EventMap>> actualEntry : feedToActualEvents.entrySet()) {
       final String feed = actualEntry.getKey();
       final List<EventMap> actualEvents = actualEntry.getValue();
       final List<EventMap> expectedEvents = feedToExpectedEvents.get(feed);
-      assertThat(actualEvents, containsInAnyOrder(expectedEvents.toArray(new Map[0])));
+      Assertions.assertEquals(expectedEvents.size(), actualEvents.size());
+      Assertions.assertTrue(
+          expectedEvents.stream().allMatch(
+              expectedEvent -> Collections.frequency(expectedEvents, expectedEvent)
+                               == Collections.frequency(actualEvents, expectedEvent)
+          )
+      );
     }
   }
 

--- a/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
+++ b/extensions-contrib/kafka-emitter/src/test/java/org/apache/druid/emitter/kafka/KafkaEmitterTest.java
@@ -639,7 +639,7 @@ public class KafkaEmitterTest
       final Map<String, List<EventMap>> feedToActualEvents
   )
   {
-    Assertions.assertEquals(feedToExpectedEvents.size(), feedToActualEvents.size());
+    Assertions.assertEquals(feedToExpectedEvents.keySet(), feedToActualEvents.keySet());
 
     for (final Map.Entry<String, List<EventMap>> actualEntry : feedToActualEvents.entrySet()) {
       final String feed = actualEntry.getKey();

--- a/extensions-contrib/opentelemetry-emitter/pom.xml
+++ b/extensions-contrib/opentelemetry-emitter/pom.xml
@@ -68,6 +68,21 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -140,11 +155,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
+++ b/extensions-contrib/opentelemetry-emitter/src/test/java/org/apache/druid/emitter/opentelemetry/OpenTelemetryEmitterTest.java
@@ -35,9 +35,9 @@ import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.core.EventMap;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -75,7 +75,7 @@ public class OpenTelemetryEmitterTest
   private NoopExporter noopExporter;
   private OpenTelemetryEmitter emitter;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     noopExporter = new NoopExporter();
@@ -110,7 +110,7 @@ public class OpenTelemetryEmitterTest
         };
 
     emitter.emit(notServiceMetricEvent);
-    Assert.assertNull(noopExporter.spanDataCollection);
+    Assertions.assertNull(noopExporter.spanDataCollection);
   }
 
   // Check that we don't call "emitQueryTimeEvent" method for ServiceMetricEvent that is not "query/time" type
@@ -122,7 +122,7 @@ public class OpenTelemetryEmitterTest
                                         .build("broker", "brokerHost1");
 
     emitter.emit(notQueryTimeMetric);
-    Assert.assertNull(noopExporter.spanDataCollection);
+    Assertions.assertNull(noopExporter.spanDataCollection);
   }
 
   @Test
@@ -146,13 +146,13 @@ public class OpenTelemetryEmitterTest
 
     emitter.emit(queryTimeMetric);
 
-    Assert.assertEquals(1, noopExporter.spanDataCollection.size());
+    Assertions.assertEquals(1, noopExporter.spanDataCollection.size());
 
     SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
-    Assert.assertEquals(serviceName, actualSpanData.getName());
-    Assert.assertEquals((createdTime.getMillis() - metricValue) * 1_000_000, actualSpanData.getStartEpochNanos());
-    Assert.assertEquals(expectedParentTraceId, actualSpanData.getParentSpanContext().getTraceId());
-    Assert.assertEquals(expectedParentSpanId, actualSpanData.getParentSpanContext().getSpanId());
+    Assertions.assertEquals(serviceName, actualSpanData.getName());
+    Assertions.assertEquals((createdTime.getMillis() - metricValue) * 1_000_000, actualSpanData.getStartEpochNanos());
+    Assertions.assertEquals(expectedParentTraceId, actualSpanData.getParentSpanContext().getTraceId());
+    Assertions.assertEquals(expectedParentSpanId, actualSpanData.getParentSpanContext().getSpanId());
   }
 
   @Test
@@ -171,8 +171,8 @@ public class OpenTelemetryEmitterTest
     emitter.emit(queryTimeMetricWithAttributes);
 
     SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
-    Assert.assertEquals(1, actualSpanData.getAttributes().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, actualSpanData.getAttributes().size());
+    Assertions.assertEquals(
         expectedAttributeValue,
         actualSpanData.getAttributes().get(AttributeKey.stringKey(expectedAttributeKey))
     );
@@ -192,7 +192,7 @@ public class OpenTelemetryEmitterTest
     emitter.emit(queryTimeMetric);
 
     SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
-    Assert.assertEquals(0, actualSpanData.getAttributes().size());
+    Assertions.assertEquals(0, actualSpanData.getAttributes().size());
   }
 
   @Test
@@ -206,7 +206,7 @@ public class OpenTelemetryEmitterTest
     emitter.emit(queryTimeMetric);
 
     SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
-    Assert.assertEquals(StatusCode.OK, actualSpanData.getStatus().getStatusCode());
+    Assertions.assertEquals(StatusCode.OK, actualSpanData.getStatus().getStatusCode());
   }
 
   @Test
@@ -220,6 +220,6 @@ public class OpenTelemetryEmitterTest
     emitter.emit(queryTimeMetric);
 
     SpanData actualSpanData = noopExporter.spanDataCollection.iterator().next();
-    Assert.assertEquals(StatusCode.ERROR, actualSpanData.getStatus().getStatusCode());
+    Assertions.assertEquals(StatusCode.ERROR, actualSpanData.getStatus().getStatusCode());
   }
 }

--- a/extensions-contrib/prometheus-emitter/pom.xml
+++ b/extensions-contrib/prometheus-emitter/pom.xml
@@ -35,6 +35,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -89,11 +104,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/MetricsTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.emitter.prometheus;
 import io.prometheus.client.Histogram;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.ISE;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -36,23 +36,23 @@ public class MetricsTest
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(null, "test", null, null, null, true, true, null, null, null, null);
     Metrics metrics = new Metrics(config);
     DimensionsAndCollector dimensionsAndCollector = metrics.getByName("query/time", "historical");
-    Assert.assertNotNull(dimensionsAndCollector);
+    Assertions.assertNotNull(dimensionsAndCollector);
     String[] dimensions = dimensionsAndCollector.getDimensions();
-    Assert.assertEquals("dataSource", dimensions[0]);
-    Assert.assertEquals("druid_service", dimensions[1]);
-    Assert.assertEquals("host_name", dimensions[2]);
-    Assert.assertEquals("type", dimensions[3]);
-    Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
+    Assertions.assertEquals("dataSource", dimensions[0]);
+    Assertions.assertEquals("druid_service", dimensions[1]);
+    Assertions.assertEquals("host_name", dimensions[2]);
+    Assertions.assertEquals("type", dimensions[3]);
+    Assertions.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     double[] defaultHistogramBuckets = {0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 30.0, 60.0, 120.0, 300.0};
-    Assert.assertArrayEquals(defaultHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);
-    Assert.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
+    Assertions.assertArrayEquals(defaultHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);
+    Assertions.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
 
     DimensionsAndCollector d = metrics.getByName("segment/loadQueue/count", "historical");
-    Assert.assertNotNull(d);
+    Assertions.assertNotNull(d);
     String[] dims = d.getDimensions();
-    Assert.assertEquals("druid_service", dims[0]);
-    Assert.assertEquals("host_name", dims[1]);
-    Assert.assertEquals("server", dims[2]);
+    Assertions.assertEquals("druid_service", dims[0]);
+    Assertions.assertEquals("host_name", dims[1]);
+    Assertions.assertEquals("server", dims[2]);
   }
 
   @Test
@@ -64,25 +64,25 @@ public class MetricsTest
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(null, "test_2", null, null, null, true, true, null, extraLabels, null, null);
     Metrics metrics = new Metrics(config);
     DimensionsAndCollector dimensionsAndCollector = metrics.getByName("query/time", "historical");
-    Assert.assertNotNull(dimensionsAndCollector);
+    Assertions.assertNotNull(dimensionsAndCollector);
     String[] dimensions = dimensionsAndCollector.getDimensions();
-    Assert.assertEquals("dataSource", dimensions[0]);
-    Assert.assertEquals("druid_service", dimensions[1]);
-    Assert.assertEquals("extra_label", dimensions[2]);
-    Assert.assertEquals("host_name", dimensions[3]);
-    Assert.assertEquals("type", dimensions[4]);
-    Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
+    Assertions.assertEquals("dataSource", dimensions[0]);
+    Assertions.assertEquals("druid_service", dimensions[1]);
+    Assertions.assertEquals("extra_label", dimensions[2]);
+    Assertions.assertEquals("host_name", dimensions[3]);
+    Assertions.assertEquals("type", dimensions[4]);
+    Assertions.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     double[] defaultHistogramBuckets = {0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, 30.0, 60.0, 120.0, 300.0};
-    Assert.assertArrayEquals(defaultHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);
-    Assert.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
+    Assertions.assertArrayEquals(defaultHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);
+    Assertions.assertTrue(dimensionsAndCollector.getCollector() instanceof Histogram);
 
     DimensionsAndCollector d = metrics.getByName("segment/loadQueue/count", "historical");
-    Assert.assertNotNull(d);
+    Assertions.assertNotNull(d);
     String[] dims = d.getDimensions();
-    Assert.assertEquals("druid_service", dims[0]);
-    Assert.assertEquals("extra_label", dims[1]);
-    Assert.assertEquals("host_name", dims[2]);
-    Assert.assertEquals("server", dims[3]);
+    Assertions.assertEquals("druid_service", dims[0]);
+    Assertions.assertEquals("extra_label", dims[1]);
+    Assertions.assertEquals("host_name", dims[2]);
+    Assertions.assertEquals("server", dims[3]);
   }
   
   @Test
@@ -92,14 +92,14 @@ public class MetricsTest
     extraLabels.put("extra label", "value");
 
     // Expect an exception thrown by Prometheus code due to invalid metric label
-    Exception exception = Assert.assertThrows(DruidException.class, () -> {
+    Exception exception = Assertions.assertThrows(DruidException.class, () -> {
       new Metrics(new PrometheusEmitterConfig(null, "test_3", null, null, null, true, true, null, extraLabels, null, null));
     });
 
     String expectedMessage = "Invalid metric label name [extra label]. Label names must conform to the pattern [[a-zA-Z_:][a-zA-Z0-9_:]*].";
     String actualMessage = exception.getMessage();
 
-    Assert.assertTrue(actualMessage.contains(expectedMessage));
+    Assertions.assertTrue(actualMessage.contains(expectedMessage));
   }
 
   @Test
@@ -108,17 +108,17 @@ public class MetricsTest
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(null, "test_4", null, null, null, true, true, null, null, null, null);
     Metrics metrics = new Metrics(config);
     DimensionsAndCollector nonExistentDimsCollector = metrics.getByName("non/existent", "historical");
-    Assert.assertNull(nonExistentDimsCollector);
+    Assertions.assertNull(nonExistentDimsCollector);
   }
 
   @Test
   public void testMetricsConfigurationWithUnSupportedType()
   {
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(null, "test_5", "src/test/resources/defaultInvalidMetricsTest.json", null, null, true, true, null, null, null, null);
-    ISE iseException = Assert.assertThrows(ISE.class, () -> {
+    ISE iseException = Assertions.assertThrows(ISE.class, () -> {
       new Metrics(config);
     });
-    Assert.assertEquals("Failed to parse metric configuration", iseException.getMessage());
+    Assertions.assertEquals("Failed to parse metric configuration", iseException.getMessage());
   }
 
   @Test
@@ -127,15 +127,15 @@ public class MetricsTest
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(null, "test_6", "src/test/resources/defaultMetricsTest.json", null, null, true, true, null, null, null, null);
     Metrics metrics = new Metrics(config);
     DimensionsAndCollector dimensionsAndCollector = metrics.getByName("query/time", "historical");
-    Assert.assertNotNull(dimensionsAndCollector);
+    Assertions.assertNotNull(dimensionsAndCollector);
     String[] dimensions = dimensionsAndCollector.getDimensions();
-    Assert.assertEquals("dataSource", dimensions[0]);
-    Assert.assertEquals("druid_service", dimensions[1]);
-    Assert.assertEquals("host_name", dimensions[2]);
-    Assert.assertEquals("type", dimensions[3]);
-    Assert.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
+    Assertions.assertEquals("dataSource", dimensions[0]);
+    Assertions.assertEquals("druid_service", dimensions[1]);
+    Assertions.assertEquals("host_name", dimensions[2]);
+    Assertions.assertEquals("type", dimensions[3]);
+    Assertions.assertEquals(1000.0, dimensionsAndCollector.getConversionFactor(), 0.0);
     double[] expectedHistogramBuckets = {10.0, 30.0, 60.0, 120.0, 200.0, 300.0};
-    Assert.assertArrayEquals(expectedHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);
+    Assertions.assertArrayEquals(expectedHistogramBuckets, dimensionsAndCollector.getHistogramBuckets(), 0.0);
   }
 
 }

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfigTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterConfigTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.emitter.prometheus;
 
 import io.prometheus.client.CollectorRegistry;
 import org.apache.druid.error.DruidException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,36 +38,36 @@ public class PrometheusEmitterConfigTest
     extraLabels.put("label Name", "label Value");
 
     // Expect an exception thrown by our own PrometheusEmitterConfig due to invalid label key
-    Exception exception = Assert.assertThrows(DruidException.class, () -> {
+    Exception exception = Assertions.assertThrows(DruidException.class, () -> {
       new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, null, null, 0, null, false, true, 60, extraLabels, false, null);
     });
 
     String expectedMessage = "Invalid metric label name [label Name]. Label names must conform to the pattern [[a-zA-Z_:][a-zA-Z0-9_:]*]";
     String actualMessage = exception.getMessage();
 
-    Assert.assertTrue(actualMessage.contains(expectedMessage));
+    Assertions.assertTrue(actualMessage.contains(expectedMessage));
   }
 
   @Test
   public void testDefaultConstructor()
   {
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(null, null, null, null, null, false, false, null, null, null, null);
-    Assert.assertEquals(PrometheusEmitterConfig.Strategy.exporter, config.getStrategy());
-    Assert.assertEquals("druid", config.getNamespace());
-    Assert.assertNull(config.getDimensionMapPath());
+    Assertions.assertEquals(PrometheusEmitterConfig.Strategy.exporter, config.getStrategy());
+    Assertions.assertEquals("druid", config.getNamespace());
+    Assertions.assertNull(config.getDimensionMapPath());
   }
 
   @Test
   public void testExporterStrategy()
   {
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, "druid", null, 8080, null, true, true, null, null, null, null);
-    Assert.assertEquals(PrometheusEmitterConfig.Strategy.exporter, config.getStrategy());
-    Assert.assertEquals("druid", config.getNamespace());
-    Assert.assertEquals(8080, config.getPort());
-    Assert.assertTrue(config.isAddHostAsLabel());
-    Assert.assertTrue(config.isAddHostAsLabel());
+    Assertions.assertEquals(PrometheusEmitterConfig.Strategy.exporter, config.getStrategy());
+    Assertions.assertEquals("druid", config.getNamespace());
+    Assertions.assertEquals(8080, config.getPort());
+    Assertions.assertTrue(config.isAddHostAsLabel());
+    Assertions.assertTrue(config.isAddHostAsLabel());
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
       new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, null, null, null, null, false, false, null, null, null, null);
     });
   }
@@ -76,13 +76,13 @@ public class PrometheusEmitterConfigTest
   public void testPushgatewayStrategy()
   {
     PrometheusEmitterConfig config = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "druid", null, null, "localhost:9091", false, false, 30, null, true, 5000L);
-    Assert.assertEquals(PrometheusEmitterConfig.Strategy.pushgateway, config.getStrategy());
-    Assert.assertEquals("druid", config.getNamespace());
-    Assert.assertEquals("localhost:9091", config.getPushGatewayAddress());
-    Assert.assertEquals(Integer.valueOf(30), config.getFlushPeriod());
-    Assert.assertFalse(config.isAddHostAsLabel());
+    Assertions.assertEquals(PrometheusEmitterConfig.Strategy.pushgateway, config.getStrategy());
+    Assertions.assertEquals("druid", config.getNamespace());
+    Assertions.assertEquals("localhost:9091", config.getPushGatewayAddress());
+    Assertions.assertEquals(Integer.valueOf(30), config.getFlushPeriod());
+    Assertions.assertFalse(config.isAddHostAsLabel());
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
       new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, null, null, null, null, false, false, null, null, null, null);
     });
   }
@@ -90,34 +90,34 @@ public class PrometheusEmitterConfigTest
   @Test
   public void testInvalidFlushPeriod()
   {
-    DruidException druidException = Assert.assertThrows(DruidException.class, () -> {
+    DruidException druidException = Assertions.assertThrows(DruidException.class, () -> {
       new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, null, null, null, "localhost:9091", false, false, -1, null, null, null);
     });
-    Assert.assertEquals("Invalid value for flushPeriod[-1] specified, flushPeriod must be > 0.", druidException.getMessage());
+    Assertions.assertEquals("Invalid value for flushPeriod[-1] specified, flushPeriod must be > 0.", druidException.getMessage());
 
-    druidException = Assert.assertThrows(DruidException.class, () -> {
+    druidException = Assertions.assertThrows(DruidException.class, () -> {
       new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, null, null, 0, null, false, false, 0, null, null, null);
     });
-    Assert.assertEquals("Invalid value for flushPeriod[0] specified, flushPeriod must be > 0.", druidException.getMessage());
+    Assertions.assertEquals("Invalid value for flushPeriod[0] specified, flushPeriod must be > 0.", druidException.getMessage());
   }
 
   @Test
   public void testInvalidExtraLabelName()
   {
-    DruidException druidException = Assert.assertThrows(DruidException.class, () -> {
+    DruidException druidException = Assertions.assertThrows(DruidException.class, () -> {
       Map<String, String> extraLabels = new HashMap<>();
       extraLabels.put("invalid label", "value");
       new PrometheusEmitterConfig(null, null, null, null, null, false, false, null, extraLabels, null, null);
     });
-    Assert.assertEquals("Invalid metric label name [invalid label]. Label names must conform to the pattern [[a-zA-Z_:][a-zA-Z0-9_:]*].", druidException.getMessage());
+    Assertions.assertEquals("Invalid metric label name [invalid label]. Label names must conform to the pattern [[a-zA-Z_:][a-zA-Z0-9_:]*].", druidException.getMessage());
   }
 
   @Test
   public void testNegativeWaitForShutdownDelay()
   {
-    DruidException druidException = Assert.assertThrows(DruidException.class, () -> {
+    DruidException druidException = Assertions.assertThrows(DruidException.class, () -> {
       new PrometheusEmitterConfig(null, null, null, null, null, false, false, null, null, null, -1L);
     });
-    Assert.assertEquals("Invalid value for waitForShutdownDelay[-1] specified, waitForShutdownDelay must be >= 0.", druidException.getMessage());
+    Assertions.assertEquals("Invalid value for waitForShutdownDelay[-1] specified, waitForShutdownDelay must be >= 0.", druidException.getMessage());
   }
 }

--- a/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
+++ b/extensions-contrib/prometheus-emitter/src/test/java/org/apache/druid/emitter/prometheus/PrometheusEmitterTest.java
@@ -28,9 +28,9 @@ import org.apache.druid.java.util.common.concurrent.ScheduledExecutors;
 import org.apache.druid.java.util.emitter.core.Emitter;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.easymock.EasyMock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -57,14 +57,14 @@ public class PrometheusEmitterTest
                                                  .setDimension("server", "druid-data01.vpc.region")
                                                  .setMetric("segment/loadQueue/count", 10)
                                                  .build(ImmutableMap.of("service", "historical", "host", "druid.test.cn"));
-    Assert.assertEquals("historical", build.getService());
-    Assert.assertEquals("druid.test.cn", build.getHost());
-    Assert.assertFalse(build.getUserDims().isEmpty());
+    Assertions.assertEquals("historical", build.getService());
+    Assertions.assertEquals("druid.test.cn", build.getHost());
+    Assertions.assertFalse(build.getUserDims().isEmpty());
     emitter.emit(build);
     Double count = CollectorRegistry.defaultRegistry.getSampleValue(
         "druid_segment_loadqueue_count", new String[]{"druid_service", "server"}, new String[]{"historical", "druid_data01_vpc_region"}
     );
-    Assert.assertEquals(10, count.intValue());
+    Assertions.assertEquals(10, count.intValue());
   }
 
   @Test
@@ -77,14 +77,14 @@ public class PrometheusEmitterTest
             .setDimension("server", "druid-data01.vpc.region")
             .setMetric("segment/loadQueue/count", 10)
             .build(ImmutableMap.of("service", "historical", "host", "druid.test.cn"));
-    Assert.assertEquals("historical", build.getService());
-    Assert.assertEquals("druid.test.cn", build.getHost());
-    Assert.assertFalse(build.getUserDims().isEmpty());
+    Assertions.assertEquals("historical", build.getService());
+    Assertions.assertEquals("druid.test.cn", build.getHost());
+    Assertions.assertFalse(build.getUserDims().isEmpty());
     emitter.emit(build);
     Double count = CollectorRegistry.defaultRegistry.getSampleValue(
             "druid_segment_loadqueue_count", new String[]{"druid_service", "host_name", "server"}, new String[]{"historical", "druid.test.cn", "druid_data01_vpc_region"}
     );
-    Assert.assertEquals(10, count.intValue());
+    Assertions.assertEquals(10, count.intValue());
   }
 
   @Test
@@ -105,7 +105,7 @@ public class PrometheusEmitterTest
         new String[]{"labelName", "server"},
         new String[]{"labelValue", "druid_data01_vpc_region"}
     );
-    Assert.assertEquals(10, count.intValue());
+    Assertions.assertEquals(10, count.intValue());
   }
 
   @Test
@@ -126,7 +126,7 @@ public class PrometheusEmitterTest
         new String[]{"druid_service", "labelName", "server"},
         new String[]{"historical", "labelValue", "druid_data01_vpc_region"}
     );
-    Assert.assertEquals(10, count.intValue());
+    Assertions.assertEquals(10, count.intValue());
   }
 
   @Test
@@ -146,7 +146,7 @@ public class PrometheusEmitterTest
         new String[]{"druid_service", "server"},
         new String[]{"historical", "druid_data01_vpc_region"}
     );
-    Assert.assertEquals(10, count.intValue());
+    Assertions.assertEquals(10, count.intValue());
   }
 
   @Test
@@ -168,7 +168,7 @@ public class PrometheusEmitterTest
         new String[]{"druid_service", "labelName1", "labelName2", "server"},
         new String[]{"historical", "labelValue1", "labelValue2", "druid_data01_vpc_region"}
     );
-    Assert.assertEquals(10, count.intValue());
+    Assertions.assertEquals(10, count.intValue());
   }
 
   @Test
@@ -191,9 +191,9 @@ public class PrometheusEmitterTest
         new String[]{"historical", "druid_data01_vpc_region"}
     );
     // Check that the extraLabel did not override the service label
-    Assert.assertEquals(10, count.intValue());
+    Assertions.assertEquals(10, count.intValue());
     // Check that the extraLabel is not present in the CollectorRegistry
-    Assert.assertNull(CollectorRegistry.defaultRegistry.getSampleValue(
+    Assertions.assertNull(CollectorRegistry.defaultRegistry.getSampleValue(
         "druid_segment_loadqueue_count",
         new String[]{"druid_service", "server"},
         new String[]{"historical", "collisionLabelValue"}
@@ -213,10 +213,10 @@ public class PrometheusEmitterTest
             .build(ImmutableMap.of("service", "overlord", "host", "druid.test.cn"));
     emitter.emit(build);
     double assertEpsilon = 0.0001;
-    Assert.assertEquals(0.0, CollectorRegistry.defaultRegistry.getSampleValue(
+    Assertions.assertEquals(0.0, CollectorRegistry.defaultRegistry.getSampleValue(
             "namespace_task_run_time_bucket", new String[]{"dataSource", "druid_service", "host_name", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.1"}
     ), assertEpsilon);
-    Assert.assertEquals(1.0, CollectorRegistry.defaultRegistry.getSampleValue(
+    Assertions.assertEquals(1.0, CollectorRegistry.defaultRegistry.getSampleValue(
             "namespace_task_run_time_bucket", new String[]{"dataSource", "druid_service", "host_name", "taskType", "le"}, new String[]{"test", "overlord", "druid.test.cn", "index_parallel", "0.5"}
     ), assertEpsilon);
   }
@@ -227,15 +227,15 @@ public class PrometheusEmitterTest
     PrometheusEmitterConfig exportEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.exporter, "namespace1", null, 0, null, true, true, 60, null, false, null);
     PrometheusEmitter exportEmitter = new PrometheusEmitter(exportEmitterConfig);
     exportEmitter.start();
-    Assert.assertNotNull(exportEmitter.getServer());
-    Assert.assertTrue(exportEmitter.getServer() instanceof HTTPServer);
+    Assertions.assertNotNull(exportEmitter.getServer());
+    Assertions.assertTrue(exportEmitter.getServer() instanceof HTTPServer);
     exportEmitter.close();
 
     PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace2", null, 0, "pushgateway", true, true, 60, null, false, null);
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
     pushEmitter.start();
-    Assert.assertNotNull(pushEmitter.getPushGateway());
-    Assert.assertTrue(pushEmitter.getPushGateway() instanceof PushGateway);
+    Assertions.assertNotNull(pushEmitter.getPushGateway());
+    Assertions.assertTrue(pushEmitter.getPushGateway() instanceof PushGateway);
     pushEmitter.close();
   }
 
@@ -276,8 +276,7 @@ public class PrometheusEmitterTest
         null
     );
 
-    Assert.assertThrows(
-        "For `pushgateway` strategy, pushGatewayAddress must be specified.",
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new PrometheusEmitterConfig(
             PrometheusEmitterConfig.Strategy.pushgateway,
@@ -291,7 +290,8 @@ public class PrometheusEmitterTest
             null,
             false,
             null
-        )
+        ),
+        "For `pushgateway` strategy, pushGatewayAddress must be specified."
     );
   }
 
@@ -301,7 +301,7 @@ public class PrometheusEmitterTest
     PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace4", null, 0, "http://pushgateway", true, true, 60, null, false, null);
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
     pushEmitter.start();
-    Assert.assertNotNull(pushEmitter.getPushGateway());
+    Assertions.assertNotNull(pushEmitter.getPushGateway());
   }
 
   @Test
@@ -310,14 +310,13 @@ public class PrometheusEmitterTest
     PrometheusEmitterConfig pushEmitterConfig = new PrometheusEmitterConfig(PrometheusEmitterConfig.Strategy.pushgateway, "namespace5", null, 0, "https://pushgateway", true, true, 60, null, false, null);
     PrometheusEmitter pushEmitter = new PrometheusEmitter(pushEmitterConfig);
     pushEmitter.start();
-    Assert.assertNotNull(pushEmitter.getPushGateway());
+    Assertions.assertNotNull(pushEmitter.getPushGateway());
   }
 
   @Test
   public void testEmitterConfig()
   {
-    Assert.assertThrows(
-        "For `exporter` strategy, port must be specified.",
+    Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new PrometheusEmitterConfig(
             PrometheusEmitterConfig.Strategy.exporter,
@@ -331,7 +330,8 @@ public class PrometheusEmitterTest
             null,
             false,
             null
-        )
+        ),
+        "For `exporter` strategy, port must be specified."
     );
 
     // For pushgateway strategy, port can be null
@@ -448,17 +448,17 @@ public class PrometheusEmitterTest
     Map<String, DimensionsAndCollector> registeredMetrics = emitter.getMetrics().getRegisteredMetrics();
     DimensionsAndCollector testMetric = registeredMetrics.get("segment/loadQueue/count");
 
-    Assert.assertNotNull("Test metric should be registered", testMetric);
-    Assert.assertFalse(
-        "Metric should not be expired initially",
-        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1"))
+    Assertions.assertNotNull(testMetric, "Test metric should be registered");
+    Assertions.assertFalse(
+        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1")),
+        "Metric should not be expired initially"
     );
-    Assert.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
+    Assertions.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
 
     // Wait for the metric to expire (ttl + 1 second buffer)
     Thread.sleep(TimeUnit.SECONDS.toMillis(flushPeriod) + 1000);
     exec.submit(emitter::cleanUpStaleMetrics).get();
-    Assert.assertEquals(0, testMetric.getCollector().collect().get(0).samples.size());
+    Assertions.assertEquals(0, testMetric.getCollector().collect().get(0).samples.size());
     emitter.close();
   }
 
@@ -481,26 +481,26 @@ public class PrometheusEmitterTest
     Map<String, DimensionsAndCollector> registeredMetrics = emitter.getMetrics().getRegisteredMetrics();
     DimensionsAndCollector testMetric = registeredMetrics.get("segment/loadQueue/count");
 
-    Assert.assertNotNull(
-        "Test metric should be registered",
-        testMetric
+    Assertions.assertNotNull(
+        testMetric,
+        "Test metric should be registered"
     );
-    Assert.assertFalse(
-        "Metric should not be expired initially",
-        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1"))
+    Assertions.assertFalse(
+        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1")),
+        "Metric should not be expired initially"
     );
-    Assert.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
+    Assertions.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
 
     // Wait for a little, but not long enough for the metric to expire
     long waitTime = TimeUnit.SECONDS.toMillis(flushPeriod) / 5;
     Thread.sleep(waitTime);
 
-    Assert.assertFalse(
-        "Metric should not be expired",
-        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1"))
+    Assertions.assertFalse(
+        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1")),
+        "Metric should not be expired"
     );
     exec.submit(emitter::cleanUpStaleMetrics).get();
-    Assert.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
+    Assertions.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
     emitter.close();
   }
 
@@ -528,35 +528,35 @@ public class PrometheusEmitterTest
     Map<String, DimensionsAndCollector> registeredMetrics = emitter.getMetrics().getRegisteredMetrics();
     DimensionsAndCollector testMetric = registeredMetrics.get("segment/loadQueue/count");
 
-    Assert.assertNotNull(
-        "Test metric should be registered",
-        testMetric
+    Assertions.assertNotNull(
+        testMetric,
+        "Test metric should be registered"
     );
-    Assert.assertFalse(
-        "Metric should not be expired initially",
-        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1"))
+    Assertions.assertFalse(
+        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1")),
+        "Metric should not be expired initially"
     );
-    Assert.assertFalse(
-        "Metric should not be expired initially",
-        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical2"))
+    Assertions.assertFalse(
+        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical2")),
+        "Metric should not be expired initially"
     );
     exec.submit(emitter::cleanUpStaleMetrics).get();
-    Assert.assertEquals(2, testMetric.getCollector().collect().get(0).samples.size());
+    Assertions.assertEquals(2, testMetric.getCollector().collect().get(0).samples.size());
 
     // Wait for a little, but not long enough for the metric to expire
     long waitTime = TimeUnit.SECONDS.toMillis(flushPeriod) / 5;
     Thread.sleep(waitTime);
 
-    Assert.assertFalse(
-        "Metric should not be expired",
-        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1"))
+    Assertions.assertFalse(
+        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical1")),
+        "Metric should not be expired"
     );
-    Assert.assertFalse(
-        "Metric should not be expired",
-        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical2"))
+    Assertions.assertFalse(
+        testMetric.shouldRemoveIfExpired(Arrays.asList("historical", "druid.test.cn", "historical2")),
+        "Metric should not be expired"
     );
     exec.submit(emitter::cleanUpStaleMetrics).get();
-    Assert.assertEquals(2, testMetric.getCollector().collect().get(0).samples.size());
+    Assertions.assertEquals(2, testMetric.getCollector().collect().get(0).samples.size());
     // Reset update time only for event2
     emitter.emit(event2);
 
@@ -564,7 +564,7 @@ public class PrometheusEmitterTest
     Thread.sleep(waitTime * 4);
 
     exec.submit(emitter::cleanUpStaleMetrics).get();
-    Assert.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
+    Assertions.assertEquals(1, testMetric.getCollector().collect().get(0).samples.size());
     emitter.close();
   }
 
@@ -581,14 +581,14 @@ public class PrometheusEmitterTest
             .build(ImmutableMap.of("service", "historical", "host", "druid.test.cn"));
     emitter.emit(event);
     DimensionsAndCollector metric = emitter.getMetrics().getRegisteredMetrics().get("segment/loadQueue/count");
-    Assert.assertEquals(0, metric.getLabelValuesToStopwatch().size());
+    Assertions.assertEquals(0, metric.getLabelValuesToStopwatch().size());
     emitter.close();
     CollectorRegistry.defaultRegistry.clear();
 
     emitter = new PrometheusEmitter(flushPeriodSet);
     emitter.emit(event);
     metric = emitter.getMetrics().getRegisteredMetrics().get("segment/loadQueue/count");
-    Assert.assertEquals(1, metric.getLabelValuesToStopwatch().size());
+    Assertions.assertEquals(1, metric.getLabelValuesToStopwatch().size());
     emitter.close();
   }
 
@@ -605,7 +605,7 @@ public class PrometheusEmitterTest
     emitter.close();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     CollectorRegistry.defaultRegistry.clear();

--- a/extensions-contrib/redis-cache/pom.xml
+++ b/extensions-contrib/redis-cache/pom.xml
@@ -34,6 +34,21 @@
     </parent>
 
     <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
@@ -103,19 +118,8 @@
 
         <!-- Tests -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.fppt</groupId>
             <artifactId>jedis-mock</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisCacheConfigTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisCacheConfigTest.java
@@ -25,12 +25,8 @@ import com.github.fppt.jedismock.RedisServer;
 import com.github.fppt.jedismock.server.ServiceOptions;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.metadata.PasswordProvider;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.JedisClientConfig;
 import redis.clients.jedis.SslVerifyMode;
 
@@ -38,84 +34,6 @@ import java.io.IOException;
 
 public class RedisCacheConfigTest
 {
-  @FunctionalInterface
-  interface MessageMatcher
-  {
-    boolean match(String input);
-  }
-
-  static class StartWithMatcher implements MessageMatcher
-  {
-    private String expected;
-
-    public StartWithMatcher(String expected)
-    {
-      this.expected = expected;
-    }
-
-    @Override
-    public boolean match(String input)
-    {
-      return input.startsWith(expected);
-    }
-  }
-
-  static class ContainsMatcher implements MessageMatcher
-  {
-    private String expected;
-
-    public ContainsMatcher(String expected)
-    {
-      this.expected = expected;
-    }
-
-    @Override
-    public boolean match(String input)
-    {
-      return input.contains(expected);
-    }
-  }
-
-  static class ExceptionMatcher implements Matcher
-  {
-    private MessageMatcher messageMatcher;
-    private Class<? extends Throwable> exceptionClass;
-
-    public ExceptionMatcher(Class<? extends Throwable> exceptionClass, MessageMatcher exceptionMessageMatcher)
-    {
-      this.exceptionClass = exceptionClass;
-      this.messageMatcher = exceptionMessageMatcher;
-    }
-
-    @Override
-    public boolean matches(Object item)
-    {
-      if (!(item.getClass().equals(exceptionClass))) {
-        return false;
-      }
-
-      return this.messageMatcher.match(((Throwable) item).getMessage());
-    }
-
-    @Override
-    public void describeMismatch(Object item, Description mismatchDescription)
-    {
-    }
-
-    @Override
-    public void _dont_implement_Matcher___instead_extend_BaseMatcher_()
-    {
-    }
-
-    @Override
-    public void describeTo(Description description)
-    {
-    }
-  }
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testClusterPriority() throws IOException
   {
@@ -132,7 +50,7 @@ public class RedisCacheConfigTest
                                                  + "}", RedisCacheConfig.class);
 
     try (Cache cache = RedisCacheFactory.create(fromJson)) {
-      Assert.assertTrue(cache instanceof RedisClusterCache);
+      Assertions.assertTrue(cache instanceof RedisClusterCache);
     }
     finally {
       server.stop();
@@ -152,11 +70,8 @@ public class RedisCacheConfigTest
         RedisCacheConfig.class
     );
 
-    expectedException.expect(new ExceptionMatcher(
-        IAE.class,
-        new StartWithMatcher("Invalid redis cluster")
-    ));
-    RedisCacheFactory.create(fromJson);
+    final IAE exception = Assertions.assertThrows(IAE.class, () -> RedisCacheFactory.create(fromJson));
+    Assertions.assertTrue(exception.getMessage().startsWith("Invalid redis cluster"));
   }
 
   @Test
@@ -172,11 +87,8 @@ public class RedisCacheConfigTest
         RedisCacheConfig.class
     );
 
-    expectedException.expect(new ExceptionMatcher(
-        IAE.class,
-        new StartWithMatcher("Invalid port")
-    ));
-    RedisCacheFactory.create(fromJson);
+    final IAE exception = Assertions.assertThrows(IAE.class, () -> RedisCacheFactory.create(fromJson));
+    Assertions.assertTrue(exception.getMessage().startsWith("Invalid port"));
   }
 
   @Test
@@ -192,11 +104,8 @@ public class RedisCacheConfigTest
         RedisCacheConfig.class
     );
 
-    expectedException.expect(new ExceptionMatcher(
-        IAE.class,
-        new ContainsMatcher("Invalid port")
-    ));
-    RedisCacheFactory.create(fromJson);
+    final IAE exception = Assertions.assertThrows(IAE.class, () -> RedisCacheFactory.create(fromJson));
+    Assertions.assertTrue(exception.getMessage().contains("Invalid port"));
   }
 
   @Test
@@ -212,11 +121,8 @@ public class RedisCacheConfigTest
         RedisCacheConfig.class
     );
 
-    expectedException.expect(new ExceptionMatcher(
-        IAE.class,
-        new ContainsMatcher("Invalid port")
-    ));
-    RedisCacheFactory.create(fromJson);
+    final IAE exception = Assertions.assertThrows(IAE.class, () -> RedisCacheFactory.create(fromJson));
+    Assertions.assertTrue(exception.getMessage().contains("Invalid port"));
   }
 
   @Test
@@ -229,11 +135,8 @@ public class RedisCacheConfigTest
         RedisCacheConfig.class
     );
 
-    expectedException.expect(new ExceptionMatcher(
-        IAE.class,
-        new ContainsMatcher("no redis server")
-    ));
-    RedisCacheFactory.create(fromJson);
+    final IAE exception = Assertions.assertThrows(IAE.class, () -> RedisCacheFactory.create(fromJson));
+    Assertions.assertTrue(exception.getMessage().contains("no redis server"));
   }
 
   @Test
@@ -245,13 +148,13 @@ public class RedisCacheConfigTest
         "{\"host\": \"localhost\", \"port\": 6379}",
         RedisCacheConfig.class
     );
-    Assert.assertFalse(defaultConfig.getEnableTls());
+    Assertions.assertFalse(defaultConfig.getEnableTls());
 
     RedisCacheConfig tlsConfig = mapper.readValue(
         "{\"host\": \"localhost\", \"port\": 6379, \"enableTls\": true}",
         RedisCacheConfig.class
     );
-    Assert.assertTrue(tlsConfig.getEnableTls());
+    Assertions.assertTrue(tlsConfig.getEnableTls());
   }
 
   @Test
@@ -263,13 +166,13 @@ public class RedisCacheConfigTest
         "{\"host\": \"localhost\", \"port\": 6379}",
         RedisCacheConfig.class
     );
-    Assert.assertFalse(defaultConfig.getSkipTlsHostnameVerification());
+    Assertions.assertFalse(defaultConfig.getSkipTlsHostnameVerification());
 
     RedisCacheConfig skipConfig = mapper.readValue(
         "{\"host\": \"localhost\", \"port\": 6379, \"skipTlsHostnameVerification\": true}",
         RedisCacheConfig.class
     );
-    Assert.assertTrue(skipConfig.getSkipTlsHostnameVerification());
+    Assertions.assertTrue(skipConfig.getSkipTlsHostnameVerification());
   }
 
   @Test
@@ -277,10 +180,10 @@ public class RedisCacheConfigTest
   {
     // TLS disabled: not SSL, no SSL options, database argument passed through, null password.
     JedisClientConfig plain = RedisCacheFactory.buildClientConfig(new RedisCacheConfig(), 3);
-    Assert.assertFalse(plain.isSsl());
-    Assert.assertNull(plain.getSslOptions());
-    Assert.assertEquals(3, plain.getDatabase());
-    Assert.assertNull(plain.getPassword());
+    Assertions.assertFalse(plain.isSsl());
+    Assertions.assertNull(plain.getSslOptions());
+    Assertions.assertEquals(3, plain.getDatabase());
+    Assertions.assertNull(plain.getPassword());
 
     // TLS enabled with hostname verification (default) maps to SslVerifyMode.FULL, and a
     // non-null password is forwarded.
@@ -299,9 +202,9 @@ public class RedisCacheConfigTest
       }
     };
     JedisClientConfig verify = RedisCacheFactory.buildClientConfig(verifyConfig, 0);
-    Assert.assertTrue(verify.isSsl());
-    Assert.assertEquals(SslVerifyMode.FULL, verify.getSslOptions().getSslVerifyMode());
-    Assert.assertEquals("secret", verify.getPassword());
+    Assertions.assertTrue(verify.isSsl());
+    Assertions.assertEquals(SslVerifyMode.FULL, verify.getSslOptions().getSslVerifyMode());
+    Assertions.assertEquals("secret", verify.getPassword());
 
     // skipTlsHostnameVerification maps to SslVerifyMode.CA (chain verified, hostname skipped).
     RedisCacheConfig skipConfig = new RedisCacheConfig()
@@ -318,7 +221,7 @@ public class RedisCacheConfigTest
         return true;
       }
     };
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SslVerifyMode.CA,
         RedisCacheFactory.buildClientConfig(skipConfig, 0).getSslOptions().getSslVerifyMode()
     );

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
@@ -26,10 +26,10 @@ import com.github.fppt.jedismock.server.ServiceOptions;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 
@@ -58,7 +58,7 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
 
   private RedisServer server;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     ServiceOptions options = ServiceOptions.defaultOptions().withClusterModeEnabled();
@@ -68,7 +68,7 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
     cache = new RedisClusterCache(cluster, cacheConfig);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     server.stop();
@@ -79,16 +79,16 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
   {
     ObjectMapper mapper = new ObjectMapper();
     RedisCacheConfig fromJson = mapper.readValue("{\"expiration\": 1000}", RedisCacheConfig.class);
-    Assert.assertEquals(1, fromJson.getExpiration().getSeconds());
+    Assertions.assertEquals(1, fromJson.getExpiration().getSeconds());
 
     fromJson = mapper.readValue("{\"expiration\": \"PT1H\"}", RedisCacheConfig.class);
-    Assert.assertEquals(3600, fromJson.getExpiration().getSeconds());
+    Assertions.assertEquals(3600, fromJson.getExpiration().getSeconds());
   }
 
   @Test
   public void testCache()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     Cache.NamedKey key1 = new Cache.NamedKey("the", HI);
     Cache.NamedKey key2 = new Cache.NamedKey("the", HO);
@@ -99,11 +99,11 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
     cache.put(key1, new byte[]{1, 2, 3, 4});
     cache.put(key2, new byte[]{2, 3, 4, 5});
     cache.put(key3, new byte[]{3, 4, 5, 6});
-    Assert.assertEquals(0x01020304, Ints.fromByteArray(cache.get(key1)));
-    Assert.assertEquals(0x02030405, Ints.fromByteArray(cache.get(key2)));
-    Assert.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
-    Assert.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
-    Assert.assertNull(cache.get(notExist));
+    Assertions.assertEquals(0x01020304, Ints.fromByteArray(cache.get(key1)));
+    Assertions.assertEquals(0x02030405, Ints.fromByteArray(cache.get(key2)));
+    Assertions.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
+    Assertions.assertEquals(0x03040506, Ints.fromByteArray(cache.get(key3)));
+    Assertions.assertNull(cache.get(notExist));
 
     //test multi get
     Map<Cache.NamedKey, byte[]> result = cache.getBulk(
@@ -115,9 +115,9 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
         )
     );
 
-    Assert.assertEquals(3, result.size());
-    Assert.assertEquals(0x01020304, Ints.fromByteArray(result.get(key1)));
-    Assert.assertEquals(0x02030405, Ints.fromByteArray(result.get(key2)));
-    Assert.assertEquals(0x03040506, Ints.fromByteArray(result.get(key3)));
+    Assertions.assertEquals(3, result.size());
+    Assertions.assertEquals(0x01020304, Ints.fromByteArray(result.get(key1)));
+    Assertions.assertEquals(0x02030405, Ints.fromByteArray(result.get(key2)));
+    Assertions.assertEquals(0x03040506, Ints.fromByteArray(result.get(key3)));
   }
 }

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
@@ -60,7 +60,7 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
   private RedisServer server;
 
   @BeforeEach
-  public void setUp() throws IOException
+  public void initializeCache() throws IOException
   {
     ServiceOptions options = ServiceOptions.defaultOptions().withClusterModeEnabled();
     server = RedisServer.newRedisServer().setOptions(options).start();
@@ -70,7 +70,7 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
   }
 
   @AfterEach
-  public void tearDown() throws IOException
+  public void closeCache() throws IOException
   {
     server.stop();
   }

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisClusterCacheTest.java
@@ -25,6 +25,7 @@ import com.github.fppt.jedismock.RedisServer;
 import com.github.fppt.jedismock.server.ServiceOptions;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
+import org.apache.druid.client.CacheUtil;
 import org.apache.druid.java.util.common.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -72,6 +73,16 @@ public class RedisClusterCacheTest extends CacheTestBase<RedisClusterCache>
   public void tearDown() throws IOException
   {
     server.stop();
+  }
+
+  @Override
+  @Test
+  public void testKeyContainingNegativeBytes()
+  {
+    byte[] value = new byte[] {1, 0, -10, -55, 111};
+    Cache.NamedKey key = CacheUtil.computeResultLevelCacheKey(new byte[] {1, 0, -10, 0});
+    cache.put(key, value);
+    Assertions.assertArrayEquals(value, cache.get(key));
   }
 
   @Test

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisStandaloneCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisStandaloneCacheTest.java
@@ -33,10 +33,10 @@ import org.apache.druid.guice.ManageLifecycle;
 import org.apache.druid.initialization.Initialization;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import redis.clients.jedis.JedisPool;
 
 import java.io.IOException;
@@ -64,7 +64,7 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
     }
   };
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     server = RedisServer.newRedisServer().start();
@@ -72,7 +72,7 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
     cache = new RedisStandaloneCache(pool, cacheConfig);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     server.stop();
@@ -103,7 +103,7 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
     lifecycle.start();
     try {
       Cache cache = injector.getInstance(Cache.class);
-      Assert.assertEquals(RedisStandaloneCache.class, cache.getClass());
+      Assertions.assertEquals(RedisStandaloneCache.class, cache.getClass());
     }
     finally {
       lifecycle.stop();
@@ -128,37 +128,37 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
         )
     );
     final CacheProvider cacheProvider = injector.getInstance(CacheProvider.class);
-    Assert.assertNotNull(cacheProvider);
-    Assert.assertEquals(RedisCacheProvider.class, cacheProvider.getClass());
+    Assertions.assertNotNull(cacheProvider);
+    Assertions.assertEquals(RedisCacheProvider.class, cacheProvider.getClass());
   }
 
   @Test
   public void testSanity()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HI)));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HI)));
     put(cache, "a", HI, 0);
-    Assert.assertEquals(0, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    Assertions.assertEquals(0, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     put(cache, "the", HI, 1);
-    Assert.assertEquals(0, get(cache, "a", HI));
-    Assert.assertEquals(1, get(cache, "the", HI));
+    Assertions.assertEquals(0, get(cache, "a", HI));
+    Assertions.assertEquals(1, get(cache, "the", HI));
 
     put(cache, "the", HO, 10);
-    Assert.assertEquals(0, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
-    Assert.assertEquals(1, get(cache, "the", HI));
-    Assert.assertEquals(10, get(cache, "the", HO));
+    Assertions.assertEquals(0, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    Assertions.assertEquals(1, get(cache, "the", HI));
+    Assertions.assertEquals(10, get(cache, "the", HO));
 
     cache.close("the");
-    Assert.assertEquals(0, get(cache, "a", HI));
-    Assert.assertNull(cache.get(new Cache.NamedKey("a", HO)));
+    Assertions.assertEquals(0, get(cache, "a", HI));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("a", HO)));
   }
 
   @Test
   public void testGetBulk()
   {
-    Assert.assertNull(cache.get(new Cache.NamedKey("the", HI)));
+    Assertions.assertNull(cache.get(new Cache.NamedKey("the", HI)));
 
     put(cache, "the", HI, 1);
     put(cache, "the", HO, 10);
@@ -175,9 +175,9 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
         )
     );
 
-    Assert.assertEquals(1, Ints.fromByteArray(result.get(key1)));
-    Assert.assertEquals(10, Ints.fromByteArray(result.get(key2)));
-    Assert.assertEquals(null, result.get(key3));
+    Assertions.assertEquals(1, Ints.fromByteArray(result.get(key1)));
+    Assertions.assertEquals(10, Ints.fromByteArray(result.get(key2)));
+    Assertions.assertEquals(null, result.get(key3));
   }
 
   public void put(Cache cache, String namespace, byte[] key, Integer value)

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisStandaloneCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisStandaloneCacheTest.java
@@ -27,6 +27,7 @@ import com.google.common.primitives.Ints;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.name.Names;
+import org.apache.druid.client.CacheUtil;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.guice.JsonConfigProvider;
 import org.apache.druid.guice.ManageLifecycle;
@@ -76,6 +77,16 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
   public void tearDown() throws IOException
   {
     server.stop();
+  }
+
+  @Override
+  @Test
+  public void testKeyContainingNegativeBytes()
+  {
+    byte[] value = new byte[] {1, 0, -10, -55, 111};
+    Cache.NamedKey key = CacheUtil.computeResultLevelCacheKey(new byte[] {1, 0, -10, 0});
+    cache.put(key, value);
+    Assertions.assertArrayEquals(value, cache.get(key));
   }
 
   @Test
@@ -207,4 +218,3 @@ class RedisCacheProviderWithConfig extends RedisCacheProvider
     return RedisCacheFactory.create(config);
   }
 }
-

--- a/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisStandaloneCacheTest.java
+++ b/extensions-contrib/redis-cache/src/test/java/org/apache/druid/client/cache/RedisStandaloneCacheTest.java
@@ -66,7 +66,7 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
   };
 
   @BeforeEach
-  public void setUp() throws IOException
+  public void initializeCache() throws IOException
   {
     server = RedisServer.newRedisServer().start();
     JedisPool pool = new JedisPool(server.getHost(), server.getBindPort());
@@ -74,7 +74,7 @@ public class RedisStandaloneCacheTest extends CacheTestBase<RedisStandaloneCache
   }
 
   @AfterEach
-  public void tearDown() throws IOException
+  public void closeCache() throws IOException
   {
     server.stop();
   }

--- a/extensions-contrib/sqlserver-metadata-storage/pom.xml
+++ b/extensions-contrib/sqlserver-metadata-storage/pom.xml
@@ -33,7 +33,21 @@
     </parent>
 
     <dependencies>
-
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
@@ -79,11 +93,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/CustomStatementRewriterTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/CustomStatementRewriterTest.java
@@ -19,15 +19,17 @@
 
 package org.apache.druid.metadata.storage.sqlserver;
 
-import junit.framework.Assert;
 import org.apache.druid.metadata.MetadataStorageActionHandler;
 import org.apache.druid.metadata.storage.sqlserver.SQLServerConnector.CustomStatementRewriter;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.skife.jdbi.v2.Binding;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.exceptions.UnableToCreateStatementException;
 import org.skife.jdbi.v2.tweak.RewrittenStatement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 @SuppressWarnings("nls")
 public class CustomStatementRewriterTest
@@ -37,7 +39,7 @@ public class CustomStatementRewriterTest
   private Binding params;
   private StatementContext ctx;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     customStatementRewriter = new CustomStatementRewriter();
@@ -56,13 +58,13 @@ public class CustomStatementRewriterTest
   public void testExactPatternReplacement()
   {
 
-    Assert.assertEquals("BIT NOT NULL DEFAULT (0)", rewrite("BOOLEAN NOT NULL DEFAULT FALSE"));
-    Assert.assertEquals("BIT NOT NULL DEFAULT (1)", rewrite("BOOLEAN NOT NULL DEFAULT TRUE"));
-    Assert.assertEquals("BIT NOT NULL DEFAULT (0)", rewrite("BOOLEAN DEFAULT FALSE"));
-    Assert.assertEquals("BIT NOT NULL DEFAULT (1)", rewrite("BOOLEAN DEFAULT TRUE"));
-    Assert.assertEquals("BIT", rewrite("BOOLEAN"));
-    Assert.assertEquals("1", rewrite("TRUE"));
-    Assert.assertEquals("0", rewrite("FALSE"));
+    assertEquals("BIT NOT NULL DEFAULT (0)", rewrite("BOOLEAN NOT NULL DEFAULT FALSE"));
+    assertEquals("BIT NOT NULL DEFAULT (1)", rewrite("BOOLEAN NOT NULL DEFAULT TRUE"));
+    assertEquals("BIT NOT NULL DEFAULT (0)", rewrite("BOOLEAN DEFAULT FALSE"));
+    assertEquals("BIT NOT NULL DEFAULT (1)", rewrite("BOOLEAN DEFAULT TRUE"));
+    assertEquals("BIT", rewrite("BOOLEAN"));
+    assertEquals("1", rewrite("TRUE"));
+    assertEquals("0", rewrite("FALSE"));
   }
 
   /**
@@ -72,16 +74,16 @@ public class CustomStatementRewriterTest
   public void testCustomStatementRewriter()
   {
 
-    Assert.assertEquals("select column# from table1 where id = ?",
+    assertEquals("select column# from table1 where id = ?",
         rewrite("select column# from table1 where id = :id"));
 
-    Assert.assertEquals("select * from table2\n where id = ?", rewrite("select * from table2\n where id = :id"));
+    assertEquals("select * from table2\n where id = ?", rewrite("select * from table2\n where id = :id"));
 
     try {
       rewrite("select * from table3 where id = :\u0091\u009c"); // Control codes
                                                                 // -
                                                                 // https://en.wikipedia.org/wiki/List_of_Unicode_characters
-      Assert.fail("Expected 'UnableToCreateStatementException'");
+      fail("Expected 'UnableToCreateStatementException'");
     }
     catch (UnableToCreateStatementException e) {
       // expected
@@ -123,7 +125,7 @@ public class CustomStatementRewriterTest
         "  PRIMARY KEY (id)\n" +
         ")";
 
-    Assert.assertEquals(sqlOut, rewrite(sqlIn));
+    assertEquals(sqlOut, rewrite(sqlIn));
 
   }
 
@@ -135,7 +137,7 @@ public class CustomStatementRewriterTest
   @Test
   public void testSQLMetadataStorageActionHandlerSetStatus()
   {
-    Assert.assertEquals("UPDATE %s SET active = ?, status_payload = ? WHERE id = ? AND active = 1",
+    assertEquals("UPDATE %s SET active = ?, status_payload = ? WHERE id = ? AND active = 1",
         rewrite("UPDATE %s SET active = :active, status_payload = :status_payload WHERE id = :id AND active = TRUE"));
 
   }

--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/org/apache/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
@@ -23,8 +23,8 @@ import com.google.common.base.Suppliers;
 import org.apache.druid.metadata.MetadataStorageConnectorConfig;
 import org.apache.druid.metadata.MetadataStorageTablesConfig;
 import org.apache.druid.segment.metadata.CentralizedDatasourceSchemaConfig;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
 
@@ -43,15 +43,15 @@ public class SQLServerConnectorTest
         CentralizedDatasourceSchemaConfig.create()
     );
 
-    Assert.assertTrue(connector.isTransientException(new SQLException("Resource Failure!", "08DIE")));
-    Assert.assertTrue(connector.isTransientException(new SQLException("Resource Failure as well!", "53RES")));
-    Assert.assertTrue(connector.isTransientException(new SQLException("Transient Failures", "JW001")));
-    Assert.assertTrue(connector.isTransientException(new SQLException("Transient Rollback", "40001")));
+    Assertions.assertTrue(connector.isTransientException(new SQLException("Resource Failure!", "08DIE")));
+    Assertions.assertTrue(connector.isTransientException(new SQLException("Resource Failure as well!", "53RES")));
+    Assertions.assertTrue(connector.isTransientException(new SQLException("Transient Failures", "JW001")));
+    Assertions.assertTrue(connector.isTransientException(new SQLException("Transient Rollback", "40001")));
 
-    Assert.assertFalse(connector.isTransientException(new SQLException("SQLException with reason only")));
-    Assert.assertFalse(connector.isTransientException(new SQLException()));
-    Assert.assertFalse(connector.isTransientException(new Exception("Exception with reason only")));
-    Assert.assertFalse(connector.isTransientException(new Throwable("Throwable with reason only")));
+    Assertions.assertFalse(connector.isTransientException(new SQLException("SQLException with reason only")));
+    Assertions.assertFalse(connector.isTransientException(new SQLException()));
+    Assertions.assertFalse(connector.isTransientException(new Exception("Exception with reason only")));
+    Assertions.assertFalse(connector.isTransientException(new Throwable("Throwable with reason only")));
   }
 
   @Test
@@ -66,22 +66,22 @@ public class SQLServerConnectorTest
     );
 
     // SQL Server integrity_constraint_violation SQL state (23000)
-    Assert.assertTrue(connector.isUniqueConstraintViolation(
+    Assertions.assertTrue(connector.isUniqueConstraintViolation(
         new SQLException("Violation of UNIQUE KEY constraint", "23000")
     ));
 
     // Different SQL state should return false
-    Assert.assertFalse(connector.isUniqueConstraintViolation(
+    Assertions.assertFalse(connector.isUniqueConstraintViolation(
         new SQLException("some other error", "42000")
     ));
 
     // SQLException wrapped in another exception (tests cause chain traversal)
-    Assert.assertTrue(connector.isUniqueConstraintViolation(
+    Assertions.assertTrue(connector.isUniqueConstraintViolation(
         new RuntimeException(new SQLException("Duplicate key", "23000"))
     ));
 
     // Non-SQLException exception
-    Assert.assertFalse(connector.isUniqueConstraintViolation(new Exception("not a SQLException")));
+    Assertions.assertFalse(connector.isUniqueConstraintViolation(new Exception("not a SQLException")));
   }
 
   @Test
@@ -94,6 +94,6 @@ public class SQLServerConnectorTest
         ),
         CentralizedDatasourceSchemaConfig.create()
     );
-    Assert.assertEquals("FETCH NEXT 100 ROWS ONLY", connector.limitClause(100));
+    Assertions.assertEquals("FETCH NEXT 100 ROWS ONLY", connector.limitClause(100));
   }
 }

--- a/extensions-contrib/statsd-emitter/pom.xml
+++ b/extensions-contrib/statsd-emitter/pom.xml
@@ -33,6 +33,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -77,11 +92,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/DimensionConverterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/DimensionConverterTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.emitter.statsd;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class DimensionConverterTest
 {
@@ -52,10 +52,10 @@ public class DimensionConverterTest
         event.getUserDims(),
         actual
     );
-    Assert.assertEquals("correct StatsDMetric.Type", StatsDMetric.Type.timer, statsDMetric.type);
+    Assertions.assertEquals(StatsDMetric.Type.timer, statsDMetric.type, "correct StatsDMetric.Type");
     ImmutableMap.Builder<String, String> expected = new ImmutableMap.Builder<>();
     expected.put("dataSource", "data-source");
     expected.put("type", "groupBy");
-    Assert.assertEquals("correct Dimensions", expected.build(), actual.build());
+    Assertions.assertEquals(expected.build(), actual.build(), "correct Dimensions");
   }
 }

--- a/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
+++ b/extensions-contrib/statsd-emitter/src/test/java/org/apache/druid/emitter/statsd/StatsDEmitterTest.java
@@ -27,8 +27,8 @@ import com.timgroup.statsd.StatsDClient;
 import org.apache.druid.java.util.emitter.service.AlertBuilder;
 import org.apache.druid.java.util.emitter.service.AlertEvent;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.mockito.ArgumentMatchers.eq;
@@ -218,11 +218,11 @@ public class StatsDEmitterTest
     );
 
     Event actualEvent = eventArgumentCaptor.getValue();
-    Assert.assertTrue(actualEvent.getMillisSinceEpoch() > 0);
-    Assert.assertEquals(expectedEvent.getPriority(), actualEvent.getPriority());
-    Assert.assertEquals(expectedEvent.getAlertType(), actualEvent.getAlertType());
-    Assert.assertEquals(expectedEvent.getTitle(), actualEvent.getTitle());
-    Assert.assertEquals(expectedEvent.getText(), actualEvent.getText());
+    Assertions.assertTrue(actualEvent.getMillisSinceEpoch() > 0);
+    Assertions.assertEquals(expectedEvent.getPriority(), actualEvent.getPriority());
+    Assertions.assertEquals(expectedEvent.getAlertType(), actualEvent.getAlertType());
+    Assertions.assertEquals(expectedEvent.getTitle(), actualEvent.getTitle());
+    Assertions.assertEquals(expectedEvent.getText(), actualEvent.getText());
   }
 
   @Test
@@ -254,6 +254,6 @@ public class StatsDEmitterTest
   @Test
   public void testJacksonModules()
   {
-    Assert.assertTrue(new StatsDEmitterModule().getJacksonModules().isEmpty());
+    Assertions.assertTrue(new StatsDEmitterModule().getJacksonModules().isEmpty());
   }
 }

--- a/extensions-contrib/thrift-extensions/pom.xml
+++ b/extensions-contrib/thrift-extensions/pom.xml
@@ -41,6 +41,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
@@ -107,21 +122,6 @@
       <groupId>com.twitter</groupId>
       <artifactId>scrooge-core_2.11</artifactId>
       <version>${scrooge.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftInputFormatTest.java
+++ b/extensions-contrib/thrift-extensions/src/test/java/org/apache/druid/data/input/thrift/ThriftInputFormatTest.java
@@ -41,9 +41,9 @@ import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TJSONProtocol;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -55,7 +55,7 @@ public class ThriftInputFormatTest
   private InputRowSchema schema;
   private JSONPathSpec flattenSpec;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     book = new Book()
@@ -114,8 +114,8 @@ public class ThriftInputFormatTest
 
     ThriftInputFormat format = new ThriftInputFormat(flattenSpec, "example/book.jar", THRIFT_CLASS);
     InputRow row = readSingleRow(format, bytes);
-    Assert.assertEquals("title", row.getDimension("title").get(0));
-    Assert.assertEquals("last", row.getDimension("lastName").get(0));
+    Assertions.assertEquals("title", row.getDimension("title").get(0));
+    Assertions.assertEquals("last", row.getDimension("lastName").get(0));
   }
 
   @Test
@@ -130,14 +130,14 @@ public class ThriftInputFormatTest
     String json = mapper.writeValueAsString(format);
     ThriftInputFormat deserialized = (ThriftInputFormat) mapper.readValue(json, org.apache.druid.data.input.InputFormat.class);
 
-    Assert.assertEquals(format, deserialized);
+    Assertions.assertEquals(format, deserialized);
   }
 
   @Test
   public void testIsSplittable()
   {
     ThriftInputFormat format = new ThriftInputFormat(null, null, THRIFT_CLASS);
-    Assert.assertFalse(format.isSplittable());
+    Assertions.assertFalse(format.isSplittable());
   }
 
   @Test
@@ -150,17 +150,17 @@ public class ThriftInputFormatTest
   {
     ThriftInputFormat format = new ThriftInputFormat(flattenSpec, null, THRIFT_CLASS);
     InputRow row = readSingleRow(format, bytes);
-    Assert.assertEquals("title", row.getDimension("title").get(0));
-    Assert.assertEquals("last", row.getDimension("lastName").get(0));
+    Assertions.assertEquals("title", row.getDimension("title").get(0));
+    Assertions.assertEquals("last", row.getDimension("lastName").get(0));
   }
 
   private InputRow readSingleRow(ThriftInputFormat format, byte[] bytes) throws IOException
   {
     InputEntityReader reader = format.createReader(schema, new ByteEntity(bytes), null);
     try (CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(iterator.hasNext());
       InputRow row = iterator.next();
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(iterator.hasNext());
       return row;
     }
   }

--- a/extensions-contrib/virtual-columns/pom.xml
+++ b/extensions-contrib/virtual-columns/pom.xml
@@ -34,6 +34,21 @@
     </parent>
 
     <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <scope>test</scope>
+      </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
@@ -72,11 +87,6 @@
         </dependency>
 
         <!-- Tests -->
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>

--- a/extensions-contrib/virtual-columns/src/test/java/org/apache/druid/segment/MapVirtualColumnGroupByTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/org/apache/druid/segment/MapVirtualColumnGroupByTest.java
@@ -52,9 +52,9 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -66,7 +66,7 @@ public class MapVirtualColumnGroupByTest extends InitializedNullHandlingTest
 {
   private QueryRunner<ResultRow> runner;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     final IncrementalIndex incrementalIndex = MapVirtualColumnTestBase.generateIndex();
@@ -146,11 +146,11 @@ public class MapVirtualColumnGroupByTest extends InitializedNullHandlingTest
         null
     );
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> runner.run(QueryPlus.wrap(query)).toList()
     );
-    Assert.assertEquals("Unable to group on the column[params]", t.getMessage());
+    Assertions.assertEquals("Unable to group on the column[params]", t.getMessage());
   }
 
 
@@ -181,7 +181,7 @@ public class MapVirtualColumnGroupByTest extends InitializedNullHandlingTest
         new MapBasedRow(DateTimes.of("2011-01-12T00:00:00.000Z"), MapVirtualColumnTestBase.mapOf("count", 2L))
     ).stream().map(row -> ResultRow.fromLegacyRow(row, query)).collect(Collectors.toList());
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -210,7 +210,7 @@ public class MapVirtualColumnGroupByTest extends InitializedNullHandlingTest
         )
     ).stream().map(row -> ResultRow.fromLegacyRow(row, query)).collect(Collectors.toList());
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class MapVirtualColumnGroupByTest extends InitializedNullHandlingTest
         )
     ).stream().map(row -> ResultRow.fromLegacyRow(row, query)).collect(Collectors.toList());
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -263,7 +263,7 @@ public class MapVirtualColumnGroupByTest extends InitializedNullHandlingTest
     final List<ResultRow> result = runner.run(QueryPlus.wrap(query)).toList();
     final List<ResultRow> expected = Collections.emptyList();
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 
   @Test
@@ -287,6 +287,6 @@ public class MapVirtualColumnGroupByTest extends InitializedNullHandlingTest
     final List<ResultRow> result = runner.run(QueryPlus.wrap(query)).toList();
     final List<ResultRow> expected = Collections.emptyList();
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 }

--- a/extensions-contrib/virtual-columns/src/test/java/org/apache/druid/segment/MapVirtualColumnTopNTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/org/apache/druid/segment/MapVirtualColumnTopNTest.java
@@ -42,25 +42,24 @@ import org.apache.druid.query.topn.TopNResultValue;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 public class MapVirtualColumnTopNTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
 
   private QueryRunner<Result<TopNResultValue>> runner;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     final IncrementalIndex incrementalIndex = MapVirtualColumnTestBase.generateIndex();
@@ -82,25 +81,25 @@ public class MapVirtualColumnTopNTest extends InitializedNullHandlingTest
   @Test
   public void testWithMapColumn()
   {
-    final TopNQuery query = new TopNQuery(
-        new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
-        VirtualColumns.create(
-            new MapVirtualColumn("keys", "values", "params")
-        ),
-        new DefaultDimensionSpec("params", "params"), // params is the map type
-        new NumericTopNMetricSpec("count"),
-        1,
-        new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2011/2012"))),
-        null,
-        Granularities.ALL,
-        ImmutableList.of(new CountAggregatorFactory("count")),
-        null,
-        null
-    );
-
-    expectedException.expect(UnsupportedOperationException.class);
-    expectedException.expectMessage("Map column doesn't support getRow()");
-    runner.run(QueryPlus.wrap(query)).toList();
+    Throwable exception = assertThrows(UnsupportedOperationException.class, () -> {
+      final TopNQuery query = new TopNQuery(
+          new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
+          VirtualColumns.create(
+              new MapVirtualColumn("keys", "values", "params")
+          ),
+          new DefaultDimensionSpec("params", "params"), // params is the map type
+          new NumericTopNMetricSpec("count"),
+          1,
+          new MultipleIntervalSegmentSpec(ImmutableList.of(Intervals.of("2011/2012"))),
+          null,
+          Granularities.ALL,
+          ImmutableList.of(new CountAggregatorFactory("count")),
+          null,
+          null
+      );
+      runner.run(QueryPlus.wrap(query)).toList();
+    });
+    assertTrue(exception.getMessage().contains("Map column doesn't support getRow()"));
   }
 
   @Test
@@ -135,6 +134,6 @@ public class MapVirtualColumnTopNTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(expected, result);
+    Assertions.assertEquals(expected, result);
   }
 }

--- a/extensions-contrib/virtual-columns/src/test/java/org/apache/druid/segment/MapVirtualColumnTopNTest.java
+++ b/extensions-contrib/virtual-columns/src/test/java/org/apache/druid/segment/MapVirtualColumnTopNTest.java
@@ -81,7 +81,7 @@ public class MapVirtualColumnTopNTest extends InitializedNullHandlingTest
   @Test
   public void testWithMapColumn()
   {
-    Throwable exception = assertThrows(UnsupportedOperationException.class, () -> {
+    final Throwable exception = assertThrows(UnsupportedOperationException.class, () -> {
       final TopNQuery query = new TopNQuery(
           new TableDataSource(QueryRunnerTestHelper.DATA_SOURCE),
           VirtualColumns.create(


### PR DESCRIPTION
Part of [#13948](https://github.com/apache/druid/issues/13948).

## Summary

This PR migrates the final independent `extensions-contrib` batch to JUnit 5.

Migrated modules:

- `ambari-metrics-emitter`
- `cloudfiles-extensions`
- `druid-ranger-security`
- `graphite-emitter`
- `gce-extensions`
- `influx-extensions`
- `influxdb-emitter`
- `kafka-emitter`
- `opentelemetry-emitter`
- `prometheus-emitter`
- `redis-cache`
- `sqlserver-metadata-storage`
- `statsd-emitter`
- `thrift-extensions`
- `virtual-columns`
- `dropwizard-emitter`

The migrated module POMs remove their direct JUnit 4, JUnit Vintage, and Hamcrest dependencies. No production code changes are included.

This branch is based directly on `master` and is intentionally independent of the shared-fixture PR [#19908](https://github.com/apache/druid/pull/19908) and the other contrib batches. The `distinctcount` module is owned by #19908 because its migrated tests use processing's shared `TestHelper`, which is converted there; this batch contains no dependency on that shared fixture change.

## Validation

- `test-compile` passed for all 16 migrated modules and their reactor dependencies.
- Focused migrated tests passed: 225 executions, 0 failures, and 0 errors.
- Checkstyle passed with 0 violations for all changed modules.
- SpotBugs passed with 0 bugs and 0 errors for all changed modules.
- No JUnit 4, Hamcrest, `TemporaryFolder`, or legacy query-stack imports remain in the migrated module sources/POMs.
- `git diff --check` passed.
