### PR TITLE
test(indexing-service): migrate common support tests to JUnit 5

### DIFF
--- a/indexing-service/src/test/java/org/apache/druid/indexing/appenderator/ActionBasedPublishedSegmentRetrieverTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/appenderator/ActionBasedPublishedSegmentRetrieverTest.java
@@ -33,9 +33,9 @@ import org.apache.druid.server.coordinator.CreateDataSegments;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -49,7 +49,7 @@ public class ActionBasedPublishedSegmentRetrieverTest
   private TaskActionClient taskActionClient;
   private ActionBasedPublishedSegmentRetriever segmentRetriever;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     taskActionClient = EasyMock.createMock(TaskActionClient.class);
@@ -78,7 +78,7 @@ public class ActionBasedPublishedSegmentRetrieverTest
     final Set<SegmentId> searchSegmentIds = segments.stream()
                                                     .map(DataSegment::getId)
                                                     .collect(Collectors.toSet());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new HashSet<>(segments),
         segmentRetriever.findPublishedSegments(searchSegmentIds)
     );
@@ -114,7 +114,7 @@ public class ActionBasedPublishedSegmentRetrieverTest
     final Set<SegmentId> searchSegmentIds = segments.stream()
                                                     .map(DataSegment::getId)
                                                     .collect(Collectors.toSet());
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new HashSet<>(segments),
         segmentRetriever.findPublishedSegments(searchSegmentIds)
     );
@@ -125,7 +125,7 @@ public class ActionBasedPublishedSegmentRetrieverTest
   @Test
   public void testSegmentsForMultipleDatasourcesThrowsException()
   {
-    DruidException exception = Assert.assertThrows(
+    DruidException exception = Assertions.assertThrows(
         DruidException.class,
         () -> segmentRetriever.findPublishedSegments(
             ImmutableSet.of(
@@ -134,7 +134,7 @@ public class ActionBasedPublishedSegmentRetrieverTest
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Published segment IDs to find cannot belong to multiple datasources[wiki, koala].",
         exception.getMessage()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriterTest.java
@@ -23,10 +23,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexer.report.IngestionStatsAndErrorsTaskReport;
 import org.apache.druid.indexer.report.TaskReport;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.segment.TestHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,11 +37,14 @@ public class MultipleFileTaskReportFileWriterTest
 {
   private static final String TASK_ID = "mytask";
 
+  @TempDir
+  private File temporaryFolder;
+
   @Test
   public void testReport() throws IOException
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File file = new File(FileUtils.createTempDir(), "report.json");
+    final File file = new File(temporaryFolder, "report.json");
     final MultipleFileTaskReportFileWriter writer = new MultipleFileTaskReportFileWriter();
     writer.setObjectMapper(mapper);
     writer.add(TASK_ID, file);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/MultipleFileTaskReportFileWriterTest.java
@@ -23,11 +23,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexer.report.IngestionStatsAndErrorsTaskReport;
 import org.apache.druid.indexer.report.TaskReport;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,14 +37,11 @@ public class MultipleFileTaskReportFileWriterTest
 {
   private static final String TASK_ID = "mytask";
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
-
   @Test
   public void testReport() throws IOException
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File file = tempFolder.newFile();
+    final File file = new File(FileUtils.createTempDir(), "report.json");
     final MultipleFileTaskReportFileWriter writer = new MultipleFileTaskReportFileWriter();
     writer.setObjectMapper(mapper);
     writer.add(TASK_ID, file);
@@ -56,11 +52,11 @@ public class MultipleFileTaskReportFileWriterTest
 
     writer.write(TASK_ID, reportsMap);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         reportsMap,
         mapper.readValue(Files.readAllBytes(file.toPath()), new TypeReference<Map<String, TaskReport>>() {})
     );
 
-    Assert.assertEquals(file.getAbsolutePath(), writer.getReportsFile(TASK_ID).getAbsolutePath());
+    Assertions.assertEquals(file.getAbsolutePath(), writer.getReportsFile(TASK_ID).getAbsolutePath());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/RetryPolicyFactoryTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/RetryPolicyFactoryTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common;
 
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RetryPolicyFactoryTest
 {
@@ -35,7 +35,7 @@ public class RetryPolicyFactoryTest
         .setMaxRetryCount(1);
     RetryPolicyFactory retryPolicyFactory = new RetryPolicyFactory(config);
     RetryPolicy retryPolicy = retryPolicyFactory.makeRetryPolicy();
-    Assert.assertEquals(new Duration("PT1S"), retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertTrue(retryPolicy.hasExceededRetryThreshold());
+    Assertions.assertEquals(new Duration("PT1S"), retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertTrue(retryPolicy.hasExceededRetryThreshold());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/RetryPolicyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/RetryPolicyTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common;
 
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -38,13 +38,13 @@ public class RetryPolicyTest
             .setMaxRetryCount(6)
     );
 
-    Assert.assertEquals(new Duration("PT1S"), retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertEquals(new Duration("PT2S"), retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertEquals(new Duration("PT4S"), retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertEquals(new Duration("PT8S"), retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertEquals(new Duration("PT10S"), retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertEquals(new Duration("PT10S"), retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertEquals(null, retryPolicy.getAndIncrementRetryDelay());
-    Assert.assertTrue(retryPolicy.hasExceededRetryThreshold());
+    Assertions.assertEquals(new Duration("PT1S"), retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertEquals(new Duration("PT2S"), retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertEquals(new Duration("PT4S"), retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertEquals(new Duration("PT8S"), retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertEquals(new Duration("PT10S"), retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertEquals(new Duration("PT10S"), retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertNull(retryPolicy.getAndIncrementRetryDelay());
+    Assertions.assertTrue(retryPolicy.hasExceededRetryThreshold());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriterTest.java
@@ -24,11 +24,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexer.report.IngestionStatsAndErrorsTaskReport;
 import org.apache.druid.indexer.report.SingleFileTaskReportFileWriter;
 import org.apache.druid.indexer.report.TaskReport;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,25 +38,22 @@ public class SingleFileTaskReportFileWriterTest
 {
   private static final String TASK_ID = "mytask";
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
-
   @Test
   public void testReport() throws IOException
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File file = tempFolder.newFile();
+    final File file = new File(FileUtils.createTempDir(), "report.json");
     final SingleFileTaskReportFileWriter writer = new SingleFileTaskReportFileWriter(file);
     writer.setObjectMapper(mapper);
     final TaskReport.ReportMap reportsMap = TaskReport.buildTaskReports(
         new IngestionStatsAndErrorsTaskReport(TASK_ID, null)
     );
     writer.write(TASK_ID, reportsMap);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         reportsMap,
         mapper.readValue(Files.readAllBytes(file.toPath()), new TypeReference<Map<String, TaskReport>>() {})
     );
 
-    Assert.assertEquals(file.getAbsolutePath(), writer.getReportsFile(TASK_ID).getAbsolutePath());
+    Assertions.assertEquals(file.getAbsolutePath(), writer.getReportsFile(TASK_ID).getAbsolutePath());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/SingleFileTaskReportFileWriterTest.java
@@ -24,10 +24,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.indexer.report.IngestionStatsAndErrorsTaskReport;
 import org.apache.druid.indexer.report.SingleFileTaskReportFileWriter;
 import org.apache.druid.indexer.report.TaskReport;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.segment.TestHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,11 +38,14 @@ public class SingleFileTaskReportFileWriterTest
 {
   private static final String TASK_ID = "mytask";
 
+  @TempDir
+  private File temporaryFolder;
+
   @Test
   public void testReport() throws IOException
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File file = new File(FileUtils.createTempDir(), "report.json");
+    final File file = new File(temporaryFolder, "report.json");
     final SingleFileTaskReportFileWriter writer = new SingleFileTaskReportFileWriter(file);
     writer.setObjectMapper(mapper);
     final TaskReport.ReportMap reportsMap = TaskReport.buildTaskReports(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskLockTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskLockTest.java
@@ -26,8 +26,8 @@ import com.google.common.base.Preconditions;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -50,7 +50,7 @@ public class TaskLockTest
     final String json = objectMapper.writeValueAsString(lock);
     final TaskLock fromJson = objectMapper.readValue(json, TaskLock.class);
 
-    Assert.assertEquals(lock, fromJson);
+    Assertions.assertEquals(lock, fromJson);
   }
 
   @Test
@@ -75,7 +75,7 @@ public class TaskLockTest
                         + "  \"revoked\" : false\n"
                         + "}";
 
-    Assert.assertEquals(expected, objectMapper.readValue(json, TaskLock.class));
+    Assertions.assertEquals(expected, objectMapper.readValue(json, TaskLock.class));
   }
 
   @Test
@@ -93,7 +93,7 @@ public class TaskLockTest
     final String json = objectMapper.writeValueAsString(lock);
     final TaskLock fromJson = objectMapper.readValue(json, TaskLock.class);
 
-    Assert.assertEquals(lock, fromJson);
+    Assertions.assertEquals(lock, fromJson);
   }
 
   @Test
@@ -110,14 +110,14 @@ public class TaskLockTest
     );
     final byte[] json = objectMapper.writeValueAsBytes(oldTaskLock);
     final TaskLock fromJson = objectMapper.readValue(json, TaskLock.class);
-    Assert.assertEquals(LockGranularity.TIME_CHUNK, fromJson.getGranularity());
-    Assert.assertEquals(TaskLockType.EXCLUSIVE, fromJson.getType());
-    Assert.assertEquals("groupId", fromJson.getGroupId());
-    Assert.assertEquals("dataSource", fromJson.getDataSource());
-    Assert.assertEquals(Intervals.of("2019/2020"), fromJson.getInterval());
-    Assert.assertEquals("version", fromJson.getVersion());
-    Assert.assertEquals(10, fromJson.getPriority().intValue());
-    Assert.assertTrue(fromJson.isRevoked());
+    Assertions.assertEquals(LockGranularity.TIME_CHUNK, fromJson.getGranularity());
+    Assertions.assertEquals(TaskLockType.EXCLUSIVE, fromJson.getType());
+    Assertions.assertEquals("groupId", fromJson.getGroupId());
+    Assertions.assertEquals("dataSource", fromJson.getDataSource());
+    Assertions.assertEquals(Intervals.of("2019/2020"), fromJson.getInterval());
+    Assertions.assertEquals("version", fromJson.getVersion());
+    Assertions.assertEquals(10, fromJson.getPriority().intValue());
+    Assertions.assertTrue(fromJson.isRevoked());
   }
 
   private static class OldTaskLock

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskRealtimeMetricsMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskRealtimeMetricsMonitorTest.java
@@ -29,9 +29,9 @@ import org.apache.druid.segment.incremental.InputRowFilterResult;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.incremental.SimpleRowIngestionMeters;
 import org.apache.druid.segment.realtime.SegmentGenerationMetrics;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -53,7 +53,7 @@ public class TaskRealtimeMetricsMonitorTest
   private StubServiceEmitter emitter;
   private TaskRealtimeMetricsMonitor target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     segmentGenerationMetrics = new SegmentGenerationMetrics();
@@ -72,9 +72,9 @@ public class TaskRealtimeMetricsMonitorTest
     target.doMonitor(emitter);
 
     List<ServiceMetricEvent> events = emitter.getMetricEvents("ingest/events/unparseable");
-    Assert.assertFalse(events.isEmpty());
+    Assertions.assertFalse(events.isEmpty());
     for (ServiceMetricEvent sme : events) {
-      Assert.assertEquals(TAGS, sme.getUserDims().get(DruidMetrics.TAGS));
+      Assertions.assertEquals(TAGS, sme.getUserDims().get(DruidMetrics.TAGS));
     }
   }
 
@@ -92,9 +92,9 @@ public class TaskRealtimeMetricsMonitorTest
     target.doMonitor(emitter);
 
     List<ServiceMetricEvent> events = emitter.getMetricEvents("ingest/events/unparseable");
-    Assert.assertFalse(events.isEmpty());
+    Assertions.assertFalse(events.isEmpty());
     for (ServiceMetricEvent sme : events) {
-      Assert.assertFalse(sme.getUserDims().containsKey(DruidMetrics.TAGS));
+      Assertions.assertFalse(sme.getUserDims().containsKey(DruidMetrics.TAGS));
     }
   }
 
@@ -102,17 +102,17 @@ public class TaskRealtimeMetricsMonitorTest
   public void testMessageGapAggStats()
   {
     target.doMonitor(emitter);
-    Assert.assertTrue(emitter.getMetricEvents("ingest/events/minMessageGap").isEmpty());
-    Assert.assertTrue(emitter.getMetricEvents("ingest/events/maxMessageGap").isEmpty());
-    Assert.assertTrue(emitter.getMetricEvents("ingest/events/avgMessageGap").isEmpty());
+    Assertions.assertTrue(emitter.getMetricEvents("ingest/events/minMessageGap").isEmpty());
+    Assertions.assertTrue(emitter.getMetricEvents("ingest/events/maxMessageGap").isEmpty());
+    Assertions.assertTrue(emitter.getMetricEvents("ingest/events/avgMessageGap").isEmpty());
 
     emitter.flush();
     segmentGenerationMetrics.reportMessageGap(1);
     target.doMonitor(emitter);
 
-    Assert.assertFalse(emitter.getMetricEvents("ingest/events/minMessageGap").isEmpty());
-    Assert.assertFalse(emitter.getMetricEvents("ingest/events/maxMessageGap").isEmpty());
-    Assert.assertFalse(emitter.getMetricEvents("ingest/events/avgMessageGap").isEmpty());
+    Assertions.assertFalse(emitter.getMetricEvents("ingest/events/minMessageGap").isEmpty());
+    Assertions.assertFalse(emitter.getMetricEvents("ingest/events/maxMessageGap").isEmpty());
+    Assertions.assertFalse(emitter.getMetricEvents("ingest/events/avgMessageGap").isEmpty());
   }
 
   @Test
@@ -144,10 +144,10 @@ public class TaskRealtimeMetricsMonitorTest
       thrownAwayByReason.put(reason.toString(), event.getValue().longValue());
     }
 
-    Assert.assertEquals(Long.valueOf(2), thrownAwayByReason.get("null"));
-    Assert.assertEquals(Long.valueOf(3), thrownAwayByReason.get("beforeMinimumMessageTime"));
-    Assert.assertEquals(Long.valueOf(1), thrownAwayByReason.get("afterMaximumMessageTime"));
-    Assert.assertEquals(Long.valueOf(4), thrownAwayByReason.get("filtered"));
+    Assertions.assertEquals(Long.valueOf(2), thrownAwayByReason.get("null"));
+    Assertions.assertEquals(Long.valueOf(3), thrownAwayByReason.get("beforeMinimumMessageTime"));
+    Assertions.assertEquals(Long.valueOf(1), thrownAwayByReason.get("afterMaximumMessageTime"));
+    Assertions.assertEquals(Long.valueOf(4), thrownAwayByReason.get("filtered"));
   }
 
   @Test
@@ -172,11 +172,11 @@ public class TaskRealtimeMetricsMonitorTest
     }
 
     // Only reasons with non-zero counts should be emitted
-    Assert.assertEquals(2, thrownAwayByReason.size());
-    Assert.assertTrue(thrownAwayByReason.containsKey("null"));
-    Assert.assertTrue(thrownAwayByReason.containsKey("filtered"));
-    Assert.assertFalse(thrownAwayByReason.containsKey("beforeMinimumMessageTime"));
-    Assert.assertFalse(thrownAwayByReason.containsKey("afterMaximumMessageTime"));
+    Assertions.assertEquals(2, thrownAwayByReason.size());
+    Assertions.assertTrue(thrownAwayByReason.containsKey("null"));
+    Assertions.assertTrue(thrownAwayByReason.containsKey("filtered"));
+    Assertions.assertFalse(thrownAwayByReason.containsKey("beforeMinimumMessageTime"));
+    Assertions.assertFalse(thrownAwayByReason.containsKey("afterMaximumMessageTime"));
   }
 
   @Test
@@ -200,7 +200,7 @@ public class TaskRealtimeMetricsMonitorTest
         firstCallNullCount = event.getValue().longValue();
       }
     }
-    Assert.assertEquals(2, firstCallNullCount);
+    Assertions.assertEquals(2, firstCallNullCount);
 
     emitter.flush();
     realMeters.incrementThrownAway(InputRowFilterResult.NULL_OR_EMPTY_RECORD);
@@ -216,8 +216,8 @@ public class TaskRealtimeMetricsMonitorTest
     }
 
     // Should emit only the delta (1 more NULL, 2 new FILTERED)
-    Assert.assertEquals(Long.valueOf(1), secondCallCounts.get("null"));
-    Assert.assertEquals(Long.valueOf(2), secondCallCounts.get("filtered"));
+    Assertions.assertEquals(Long.valueOf(1), secondCallCounts.get("null"));
+    Assertions.assertEquals(Long.valueOf(2), secondCallCounts.get("filtered"));
   }
 
   private ServiceMetricEvent.Builder createMetricEventBuilder()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
@@ -27,6 +27,7 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,10 +38,13 @@ import java.util.stream.Collectors;
 
 public class TaskStorageDirTrackerTest
 {
+  @TempDir
+  private File temporaryFolder;
+
   @Test
   public void testGetOrSelectTaskDir() throws IOException
   {
-    File tmpFolder = FileUtils.createTempDir();
+    final File tmpFolder = temporaryFolder;
     List<File> files = ImmutableList.of(
         new File(tmpFolder, "A"),
         new File(tmpFolder, "B"),
@@ -112,7 +116,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testFallBackToTaskConfig() throws IOException
   {
-    final File baseDir = new File(FileUtils.createTempDir(), "A");
+    final File baseDir = new File(temporaryFolder, "A");
     final TaskStorageDirTracker tracker = TaskStorageDirTracker.fromConfigs(
         new WorkerConfig()
         {
@@ -151,7 +155,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testMoreDirectoriesThanSlots() throws IOException
   {
-    File tmpFolder = FileUtils.createTempDir();
+    final File tmpFolder = temporaryFolder;
     List<File> files = ImmutableList.of(
         new File(tmpFolder, "A"),
         new File(tmpFolder, "B"),
@@ -181,7 +185,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testMigration() throws IOException
   {
-    File tmpFolder = FileUtils.createTempDir();
+    final File tmpFolder = temporaryFolder;
     List<File> files = ImmutableList.of(new File(tmpFolder, "A"), new File(tmpFolder, "B"));
 
     TaskStorageDirTracker tracker = TaskStorageDirTracker.fromBaseDirs(files, 4, 100_000_000L);
@@ -237,7 +241,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testGetNumUsedSlots() throws IOException
   {
-    File tmpFolder = FileUtils.createTempDir();
+    final File tmpFolder = temporaryFolder;
     List<File> files = ImmutableList.of(
         new File(tmpFolder, "A"),
         new File(tmpFolder, "B"),
@@ -268,7 +272,6 @@ public class TaskStorageDirTrackerTest
 
     Assertions.assertEquals(6, tracker.getNumUsedSlots());
 
-    FileUtils.deleteDirectory(tmpFolder);
   }
 
   public static class StorageSlotVerifier

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskStorageDirTrackerTest.java
@@ -25,10 +25,8 @@ import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,13 +37,10 @@ import java.util.stream.Collectors;
 
 public class TaskStorageDirTrackerTest
 {
-  @ClassRule
-  public static final TemporaryFolder TMP = new TemporaryFolder();
-
   @Test
   public void testGetOrSelectTaskDir() throws IOException
   {
-    File tmpFolder = TMP.newFolder();
+    File tmpFolder = FileUtils.createTempDir();
     List<File> files = ImmutableList.of(
         new File(tmpFolder, "A"),
         new File(tmpFolder, "B"),
@@ -80,11 +75,11 @@ public class TaskStorageDirTrackerTest
     otherTracker.returnStorageSlot(otherTracker.pickStorageSlot("task3"));
     verifier.validate(otherTracker.pickStorageSlot("eighth-task"), "A", "slot2");
 
-    final IAE iae = Assert.assertThrows(
+    final IAE iae = Assertions.assertThrows(
         IAE.class,
         () -> tracker.returnStorageSlot(otherTracker.pickStorageSlot("eighth-task"))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot return storage slot for task [eighth-task] that I don't own.",
         iae.getMessage()
     );
@@ -117,7 +112,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testFallBackToTaskConfig() throws IOException
   {
-    final File baseDir = new File(TMP.newFolder(), "A");
+    final File baseDir = new File(FileUtils.createTempDir(), "A");
     final TaskStorageDirTracker tracker = TaskStorageDirTracker.fromConfigs(
         new WorkerConfig()
         {
@@ -147,7 +142,7 @@ public class TaskStorageDirTrackerTest
     verifier.validate(tracker.pickStorageSlot("task4"), "slot4");
     verifier.validate(tracker.pickStorageSlot("task10293721"), "slot3");
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ISE.class,
         () -> tracker.pickStorageSlot("seventh-task")
     );
@@ -156,7 +151,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testMoreDirectoriesThanSlots() throws IOException
   {
-    File tmpFolder = TMP.newFolder();
+    File tmpFolder = FileUtils.createTempDir();
     List<File> files = ImmutableList.of(
         new File(tmpFolder, "A"),
         new File(tmpFolder, "B"),
@@ -177,7 +172,7 @@ public class TaskStorageDirTrackerTest
     StorageSlotVerifier verifier = new StorageSlotVerifier(tmpFolder).setExpectedSize(100_000_000L);
     verifier.validate(tracker.pickStorageSlot("task1"), "A", "slot0");
     verifier.validate(tracker.pickStorageSlot("task2"), "B", "slot0");
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ISE.class,
         () -> tracker.pickStorageSlot("third-task")
     );
@@ -186,7 +181,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testMigration() throws IOException
   {
-    File tmpFolder = TMP.newFolder();
+    File tmpFolder = FileUtils.createTempDir();
     List<File> files = ImmutableList.of(new File(tmpFolder, "A"), new File(tmpFolder, "B"));
 
     TaskStorageDirTracker tracker = TaskStorageDirTracker.fromBaseDirs(files, 4, 100_000_000L);
@@ -219,10 +214,10 @@ public class TaskStorageDirTrackerTest
     );
 
     // Ensure that task count is correctly updated
-    Assert.assertEquals(2, tracker.getNumUsedSlots());
+    Assertions.assertEquals(2, tracker.getNumUsedSlots());
 
-    Assert.assertNull(dirs.get("task3"));
-    Assert.assertNull(dirs.get("task4"));
+    Assertions.assertNull(dirs.get("task3"));
+    Assertions.assertNull(dirs.get("task4"));
 
     // Re-create the dirs so that we can actually pick stuff again.
     tracker.ensureDirectories();
@@ -242,7 +237,7 @@ public class TaskStorageDirTrackerTest
   @Test
   public void testGetNumUsedSlots() throws IOException
   {
-    File tmpFolder = TMP.newFolder();
+    File tmpFolder = FileUtils.createTempDir();
     List<File> files = ImmutableList.of(
         new File(tmpFolder, "A"),
         new File(tmpFolder, "B"),
@@ -254,24 +249,24 @@ public class TaskStorageDirTrackerTest
     final TaskStorageDirTracker tracker = TaskStorageDirTracker.fromBaseDirs(files, workerCapacity, baseTaskDirSize);
     tracker.ensureDirectories();
 
-    Assert.assertEquals(0, tracker.getNumUsedSlots());
+    Assertions.assertEquals(0, tracker.getNumUsedSlots());
 
     tracker.pickStorageSlot("task0");
     tracker.pickStorageSlot("task1");
     tracker.pickStorageSlot("task2");
 
-    Assert.assertEquals(3, tracker.getNumUsedSlots());
+    Assertions.assertEquals(3, tracker.getNumUsedSlots());
 
     tracker.returnStorageSlot(tracker.pickStorageSlot("task0"));
 
-    Assert.assertEquals(2, tracker.getNumUsedSlots());
+    Assertions.assertEquals(2, tracker.getNumUsedSlots());
 
     tracker.pickStorageSlot("task3");
     tracker.pickStorageSlot("task4");
     tracker.pickStorageSlot("task5");
     tracker.pickStorageSlot("task6");
 
-    Assert.assertEquals(6, tracker.getNumUsedSlots());
+    Assertions.assertEquals(6, tracker.getNumUsedSlots());
 
     FileUtils.deleteDirectory(tmpFolder);
   }
@@ -298,16 +293,16 @@ public class TaskStorageDirTrackerTest
       for (String dir : dirs) {
         theFile = new File(theFile, dir);
       }
-      Assert.assertEquals(theFile, slot.getDirectory());
+      Assertions.assertEquals(theFile, slot.getDirectory());
       if (expectedSize != null) {
-        Assert.assertEquals(expectedSize.longValue(), slot.getNumBytes());
+        Assertions.assertEquals(expectedSize.longValue(), slot.getNumBytes());
       }
       return slot;
     }
 
     public void validateException(TaskStorageDirTracker tracker, String taskId)
     {
-      Assert.assertThrows(
+      Assertions.assertThrows(
           ISE.class,
           () -> tracker.pickStorageSlot(taskId)
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
@@ -34,7 +34,6 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.common.task.TestAppenderatorsManager;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.metrics.MonitorScheduler;
 import org.apache.druid.query.DruidProcessingConfig;
@@ -64,10 +63,10 @@ import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.utils.JvmUtils;
 import org.apache.druid.utils.RuntimeInfo;
 import org.easymock.EasyMock;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -78,7 +77,8 @@ public class TaskToolboxTest
 {
 
   private TaskToolboxFactory taskToolbox = null;
-  private final File baseDir = FileUtils.createTempDir();
+  @TempDir
+  private File baseDir;
   private TaskActionClientFactory mockTaskActionClientFactory = EasyMock.createMock(TaskActionClientFactory.class);
   private ServiceEmitter mockEmitter = EasyMock.createMock(ServiceEmitter.class);
   private DataSegmentPusher mockSegmentPusher = EasyMock.createMock(DataSegmentPusher.class);
@@ -165,12 +165,6 @@ public class TaskToolboxTest
         CentralizedDatasourceSchemaConfig.create(),
         JvmUtils.getRuntimeInfo()
     );
-  }
-
-  @AfterEach
-  public void tearDown() throws IOException
-  {
-    FileUtils.deleteDirectory(baseDir);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.Tasks;
 import org.apache.druid.indexing.common.task.TestAppenderatorsManager;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.java.util.metrics.MonitorScheduler;
 import org.apache.druid.query.DruidProcessingConfig;
@@ -63,11 +64,9 @@ import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.utils.JvmUtils;
 import org.apache.druid.utils.RuntimeInfo;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -101,10 +100,7 @@ public class TaskToolboxTest
   private CacheConfig mockCacheConfig = EasyMock.createMock(CacheConfig.class);
   private SegmentLoaderConfig segmentLoaderConfig = EasyMock.createMock(SegmentLoaderConfig.class);
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     EasyMock.expect(task.getId()).andReturn("task_id").anyTimes();
@@ -118,7 +114,7 @@ public class TaskToolboxTest
     EasyMock.replay(task, mockHandoffNotifierFactory, mockIndexMergerV9);
 
     TaskConfig taskConfig = new TaskConfigBuilder()
-        .setBaseDir(temporaryFolder.newFile().toString())
+        .setBaseDir(FileUtils.createTempDir().toString())
         .build();
 
     taskToolbox = new TaskToolboxFactory(
@@ -171,25 +167,25 @@ public class TaskToolboxTest
   @Test
   public void testGetDataSegmentArchiver()
   {
-    Assert.assertEquals(mockDataSegmentArchiver, taskToolbox.build(task).getDataSegmentArchiver());
+    Assertions.assertEquals(mockDataSegmentArchiver, taskToolbox.build(task).getDataSegmentArchiver());
   }
 
   @Test
   public void testGetSegmentLoaderConfig()
   {
-    Assert.assertEquals(segmentLoaderConfig, taskToolbox.build(task).getSegmentLoaderConfig());
+    Assertions.assertEquals(segmentLoaderConfig, taskToolbox.build(task).getSegmentLoaderConfig());
   }
 
   @Test
   public void testGetSegmentAnnouncer()
   {
-    Assert.assertEquals(mockSegmentAnnouncer, taskToolbox.build(task).getSegmentAnnouncer());
+    Assertions.assertEquals(mockSegmentAnnouncer, taskToolbox.build(task).getSegmentAnnouncer());
   }
 
   @Test
   public void testGetQueryRunnerFactoryConglomerate()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         mockQueryRunnerFactoryConglomerate,
         taskToolbox.build(task).getQueryRunnerFactoryConglomerate()
     );
@@ -198,49 +194,49 @@ public class TaskToolboxTest
   @Test
   public void testGetQueryProcessingPool()
   {
-    Assert.assertEquals(mockQueryProcessingPool, taskToolbox.build(task).getQueryProcessingPool());
+    Assertions.assertEquals(mockQueryProcessingPool, taskToolbox.build(task).getQueryProcessingPool());
   }
 
   @Test
   public void testGetMonitorScheduler()
   {
-    Assert.assertEquals(mockMonitorScheduler, taskToolbox.build(task).getMonitorScheduler());
+    Assertions.assertEquals(mockMonitorScheduler, taskToolbox.build(task).getMonitorScheduler());
   }
 
   @Test
   public void testGetObjectMapper()
   {
-    Assert.assertEquals(ObjectMapper, taskToolbox.build(task).getJsonMapper());
+    Assertions.assertEquals(ObjectMapper, taskToolbox.build(task).getJsonMapper());
   }
 
   @Test
   public void testGetEmitter()
   {
-    Assert.assertEquals(mockEmitter, taskToolbox.build(task).getEmitter());
+    Assertions.assertEquals(mockEmitter, taskToolbox.build(task).getEmitter());
   }
 
   @Test
   public void testGetDataSegmentKiller()
   {
-    Assert.assertEquals(mockDataSegmentKiller, taskToolbox.build(task).getDataSegmentKiller());
+    Assertions.assertEquals(mockDataSegmentKiller, taskToolbox.build(task).getDataSegmentKiller());
   }
 
   @Test
   public void testGetDataSegmentMover()
   {
-    Assert.assertEquals(mockDataSegmentMover, taskToolbox.build(task).getDataSegmentMover());
+    Assertions.assertEquals(mockDataSegmentMover, taskToolbox.build(task).getDataSegmentMover());
   }
 
   @Test
   public void testGetCache()
   {
-    Assert.assertEquals(mockCache, taskToolbox.build(task).getCache());
+    Assertions.assertEquals(mockCache, taskToolbox.build(task).getCache());
   }
 
   @Test
   public void testGetCacheConfig()
   {
-    Assert.assertEquals(mockCacheConfig, taskToolbox.build(task).getCacheConfig());
+    Assertions.assertEquals(mockCacheConfig, taskToolbox.build(task).getCacheConfig());
   }
 
   @Test
@@ -252,17 +248,17 @@ public class TaskToolboxTest
         new DruidProcessingConfigTest.MockRuntimeInfo(12, 1_000_000, 2_000_000);
     final RuntimeInfo adjustedRuntimeInfo = TaskToolbox.createAdjustedRuntimeInfo(runtimeInfo, appenderatorsManager);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         runtimeInfo.getAvailableProcessors(),
         adjustedRuntimeInfo.getAvailableProcessors()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         runtimeInfo.getMaxHeapSizeBytes(),
         adjustedRuntimeInfo.getMaxHeapSizeBytes()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         runtimeInfo.getDirectMemorySizeBytes(),
         adjustedRuntimeInfo.getDirectMemorySizeBytes()
     );
@@ -292,17 +288,17 @@ public class TaskToolboxTest
 
     final RuntimeInfo adjustedRuntimeInfo = TaskToolbox.createAdjustedRuntimeInfo(runtimeInfo, appenderatorsManager);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         runtimeInfo.getAvailableProcessors() / numWorkers,
         adjustedRuntimeInfo.getAvailableProcessors()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         runtimeInfo.getMaxHeapSizeBytes() / numWorkers,
         adjustedRuntimeInfo.getMaxHeapSizeBytes()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         runtimeInfo.getDirectMemorySizeBytes() / numWorkers,
         adjustedRuntimeInfo.getDirectMemorySizeBytes()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/TaskToolboxTest.java
@@ -64,11 +64,13 @@ import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.utils.JvmUtils;
 import org.apache.druid.utils.RuntimeInfo;
 import org.easymock.EasyMock;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.io.File;
 import java.io.IOException;
 
 @SuppressWarnings("DoNotMock")
@@ -76,6 +78,7 @@ public class TaskToolboxTest
 {
 
   private TaskToolboxFactory taskToolbox = null;
+  private final File baseDir = FileUtils.createTempDir();
   private TaskActionClientFactory mockTaskActionClientFactory = EasyMock.createMock(TaskActionClientFactory.class);
   private ServiceEmitter mockEmitter = EasyMock.createMock(ServiceEmitter.class);
   private DataSegmentPusher mockSegmentPusher = EasyMock.createMock(DataSegmentPusher.class);
@@ -114,7 +117,7 @@ public class TaskToolboxTest
     EasyMock.replay(task, mockHandoffNotifierFactory, mockIndexMergerV9);
 
     TaskConfig taskConfig = new TaskConfigBuilder()
-        .setBaseDir(FileUtils.createTempDir().toString())
+        .setBaseDir(baseDir.toString())
         .build();
 
     taskToolbox = new TaskToolboxFactory(
@@ -162,6 +165,12 @@ public class TaskToolboxTest
         CentralizedDatasourceSchemaConfig.create(),
         JvmUtils.getRuntimeInfo()
     );
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(baseDir);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/config/TaskStorageConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/config/TaskStorageConfigTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing.common.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TaskStorageConfigTest
 {
@@ -36,7 +36,7 @@ public class TaskStorageConfigTest
         "{\"recentlyFinishedThreshold\": \"PT12H\" }",
         TaskStorageConfig.class);
     
-    Assert.assertEquals(Period.parse("PT12H").toStandardDuration(), config.getRecentlyFinishedThreshold());
+    Assertions.assertEquals(Period.parse("PT12H").toStandardDuration(), config.getRecentlyFinishedThreshold());
   }
 
   @Test
@@ -46,6 +46,6 @@ public class TaskStorageConfigTest
         "{}",
         TaskStorageConfig.class);
     
-    Assert.assertEquals(Period.parse("PT24H").toStandardDuration(), config.getRecentlyFinishedThreshold());
+    Assertions.assertEquals(Period.parse("PT24H").toStandardDuration(), config.getRecentlyFinishedThreshold());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/stats/DropwizardRowIngestionMetersTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/stats/DropwizardRowIngestionMetersTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common.stats;
 
 import org.apache.druid.segment.incremental.InputRowFilterResult;
 import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -38,18 +38,18 @@ public class DropwizardRowIngestionMetersTest
     meters.incrementUnparseable();
     meters.incrementThrownAway(InputRowFilterResult.NULL_OR_EMPTY_RECORD);
 
-    Assert.assertEquals(1, meters.getProcessed());
-    Assert.assertEquals(100, meters.getProcessedBytes());
-    Assert.assertEquals(1, meters.getProcessedWithError());
-    Assert.assertEquals(1, meters.getUnparseable());
-    Assert.assertEquals(1, meters.getThrownAway());
+    Assertions.assertEquals(1, meters.getProcessed());
+    Assertions.assertEquals(100, meters.getProcessedBytes());
+    Assertions.assertEquals(1, meters.getProcessedWithError());
+    Assertions.assertEquals(1, meters.getUnparseable());
+    Assertions.assertEquals(1, meters.getThrownAway());
 
     RowIngestionMetersTotals totals = meters.getTotals();
-    Assert.assertEquals(1, totals.getProcessed());
-    Assert.assertEquals(100, totals.getProcessedBytes());
-    Assert.assertEquals(1, totals.getProcessedWithError());
-    Assert.assertEquals(1, totals.getUnparseable());
-    Assert.assertEquals(1, totals.getThrownAway());
+    Assertions.assertEquals(1, totals.getProcessed());
+    Assertions.assertEquals(100, totals.getProcessedBytes());
+    Assertions.assertEquals(1, totals.getProcessedWithError());
+    Assertions.assertEquals(1, totals.getUnparseable());
+    Assertions.assertEquals(1, totals.getThrownAway());
   }
 
   @Test
@@ -66,14 +66,14 @@ public class DropwizardRowIngestionMetersTest
     meters.incrementThrownAway(InputRowFilterResult.CUSTOM_FILTER);
 
     // Total thrownAway should be sum of all reasons
-    Assert.assertEquals(7, meters.getThrownAway());
+    Assertions.assertEquals(7, meters.getThrownAway());
 
     // Check per-reason counts
     Map<String, Long> byReason = meters.getThrownAwayByReason();
-    Assert.assertEquals(Long.valueOf(2), byReason.get(InputRowFilterResult.NULL_OR_EMPTY_RECORD.getReason()));
-    Assert.assertEquals(Long.valueOf(1), byReason.get(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME.getReason()));
-    Assert.assertEquals(Long.valueOf(1), byReason.get(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME.getReason()));
-    Assert.assertEquals(Long.valueOf(3), byReason.get(InputRowFilterResult.CUSTOM_FILTER.getReason()));
+    Assertions.assertEquals(Long.valueOf(2), byReason.get(InputRowFilterResult.NULL_OR_EMPTY_RECORD.getReason()));
+    Assertions.assertEquals(Long.valueOf(1), byReason.get(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME.getReason()));
+    Assertions.assertEquals(Long.valueOf(1), byReason.get(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME.getReason()));
+    Assertions.assertEquals(Long.valueOf(3), byReason.get(InputRowFilterResult.CUSTOM_FILTER.getReason()));
   }
 
   @Test
@@ -83,7 +83,7 @@ public class DropwizardRowIngestionMetersTest
 
     // With no increments, all reasons should be present with 0 counts
     Map<String, Long> byReason = meters.getThrownAwayByReason();
-    Assert.assertTrue(byReason.isEmpty());
+    Assertions.assertTrue(byReason.isEmpty());
   }
 
   @Test
@@ -95,10 +95,9 @@ public class DropwizardRowIngestionMetersTest
     meters.incrementThrownAway(InputRowFilterResult.CUSTOM_FILTER);
 
     Map<String, Object> movingAverages = meters.getMovingAverages();
-    Assert.assertNotNull(movingAverages);
-    Assert.assertTrue(movingAverages.containsKey(DropwizardRowIngestionMeters.ONE_MINUTE_NAME));
-    Assert.assertTrue(movingAverages.containsKey(DropwizardRowIngestionMeters.FIVE_MINUTE_NAME));
-    Assert.assertTrue(movingAverages.containsKey(DropwizardRowIngestionMeters.FIFTEEN_MINUTE_NAME));
+    Assertions.assertNotNull(movingAverages);
+    Assertions.assertTrue(movingAverages.containsKey(DropwizardRowIngestionMeters.ONE_MINUTE_NAME));
+    Assertions.assertTrue(movingAverages.containsKey(DropwizardRowIngestionMeters.FIVE_MINUTE_NAME));
+    Assertions.assertTrue(movingAverages.containsKey(DropwizardRowIngestionMeters.FIFTEEN_MINUTE_NAME));
   }
 }
-

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -32,6 +32,7 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.tasklogs.TaskLogPusher;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 
@@ -52,6 +54,7 @@ import static org.mockito.Mockito.when;
 
 public class AbstractTaskTest
 {
+  private final File tempReportDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
   private ObjectMapper objectMapper;
 
   @BeforeEach
@@ -60,11 +63,17 @@ public class AbstractTaskTest
     objectMapper = new TestUtils().getTestObjectMapper();
   }
 
-  private static File createTempReportFile() throws Exception
+  private File createTempReportFile() throws Exception
   {
-    final File reportsFile = new File(org.apache.druid.java.util.common.FileUtils.createTempDir(), "report.json");
+    final File reportsFile = new File(tempReportDir, "report.json");
     FileUtils.write(reportsFile, "", StandardCharsets.UTF_8);
     return reportsFile;
+  }
+
+  @AfterEach
+  public void tearDown() throws IOException
+  {
+    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempReportDir);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -32,11 +32,9 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.tasklogs.TaskLogPusher;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
@@ -56,13 +54,17 @@ public class AbstractTaskTest
 {
   private ObjectMapper objectMapper;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Before
+  @BeforeEach
   public void setup()
   {
     objectMapper = new TestUtils().getTestObjectMapper();
+  }
+
+  private static File createTempReportFile() throws Exception
+  {
+    final File reportsFile = new File(org.apache.druid.java.util.common.FileUtils.createTempDir(), "report.json");
+    FileUtils.write(reportsFile, "", StandardCharsets.UTF_8);
+    return reportsFile;
   }
 
   @Test
@@ -83,7 +85,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = temporaryFolder.newFolder();
+    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -91,7 +93,11 @@ public class AbstractTaskTest
     TaskActionClient taskActionClient = mock(TaskActionClient.class);
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
     when(toolbox.getTaskActionClient()).thenReturn(taskActionClient);
-    when(toolbox.getTaskReportFileWriter()).thenReturn(new SingleFileTaskReportFileWriter(temporaryFolder.newFile()));
+    when(toolbox.getTaskReportFileWriter()).thenReturn(
+        new SingleFileTaskReportFileWriter(
+            createTempReportFile()
+        )
+    );
 
 
     AbstractTask task = new NoopTask("myID", null, null, 1, 0, null)
@@ -132,7 +138,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(false);
-    File folder = temporaryFolder.newFolder();
+    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -177,7 +183,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = temporaryFolder.newFolder();
+    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -185,7 +191,11 @@ public class AbstractTaskTest
     TaskActionClient taskActionClient = mock(TaskActionClient.class);
     when(taskActionClient.submit(any())).thenReturn(TaskConfig.class);
     when(toolbox.getTaskActionClient()).thenReturn(taskActionClient);
-    when(toolbox.getTaskReportFileWriter()).thenReturn(new SingleFileTaskReportFileWriter(temporaryFolder.newFile()));
+    when(toolbox.getTaskReportFileWriter()).thenReturn(
+        new SingleFileTaskReportFileWriter(
+            createTempReportFile()
+        )
+    );
 
     TaskStatus taskStatus = TaskStatus.failure("myId", "failed");
     AbstractTask task = new NoopTask("myID", null, null, 1, 0, null)
@@ -206,7 +216,11 @@ public class AbstractTaskTest
   {
     TaskToolbox toolbox = mock(TaskToolbox.class);
     when(toolbox.getAttemptId()).thenReturn("1");
-    when(toolbox.getTaskReportFileWriter()).thenReturn(new SingleFileTaskReportFileWriter(temporaryFolder.newFile()));
+    when(toolbox.getTaskReportFileWriter()).thenReturn(
+        new SingleFileTaskReportFileWriter(
+            createTempReportFile()
+        )
+    );
 
     DruidNode node = new DruidNode("foo", "foo", false, 1, 2, true, true);
     when(toolbox.getTaskExecutorNode()).thenReturn(node);
@@ -216,7 +230,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = temporaryFolder.newFolder();
+    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -253,7 +267,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = temporaryFolder.newFolder();
+    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -280,28 +294,28 @@ public class AbstractTaskTest
   public void testBatchIOConfigAppend()
   {
     AbstractTask.IngestionMode ingestionMode = AbstractTask.IngestionMode.fromString("APPEND");
-    Assert.assertEquals(AbstractTask.IngestionMode.APPEND, ingestionMode);
+    Assertions.assertEquals(AbstractTask.IngestionMode.APPEND, ingestionMode);
   }
 
   @Test
   public void testBatchIOConfigReplace()
   {
     AbstractTask.IngestionMode ingestionMode = AbstractTask.IngestionMode.fromString("REPLACE");
-    Assert.assertEquals(AbstractTask.IngestionMode.REPLACE, ingestionMode);
+    Assertions.assertEquals(AbstractTask.IngestionMode.REPLACE, ingestionMode);
   }
 
   @Test
   public void testBatchIOConfigOverwrite()
   {
     AbstractTask.IngestionMode ingestionMode = AbstractTask.IngestionMode.fromString("REPLACE_LEGACY");
-    Assert.assertEquals(AbstractTask.IngestionMode.REPLACE_LEGACY, ingestionMode);
+    Assertions.assertEquals(AbstractTask.IngestionMode.REPLACE_LEGACY, ingestionMode);
   }
 
   @Test
   public void testBatchIOConfigNone()
   {
     AbstractTask.IngestionMode ingestionMode = AbstractTask.IngestionMode.fromString("NONE");
-    Assert.assertEquals(AbstractTask.IngestionMode.NONE, ingestionMode);
+    Assertions.assertEquals(AbstractTask.IngestionMode.NONE, ingestionMode);
   }
 
   @Test
@@ -309,10 +323,10 @@ public class AbstractTaskTest
   {
     final AbstractTask task = NoopTask.create();
     final ServiceMetricEvent.Builder builder = task.getMetricBuilder();
-    Assert.assertEquals(task.getId(), builder.getDimension(DruidMetrics.TASK_ID));
-    Assert.assertEquals(task.getGroupId(), builder.getDimension(DruidMetrics.GROUP_ID));
-    Assert.assertEquals(task.getDataSource(), builder.getDimension(DruidMetrics.DATASOURCE));
-    Assert.assertEquals(task.getType(), builder.getDimension(DruidMetrics.TASK_TYPE));
+    Assertions.assertEquals(task.getId(), builder.getDimension(DruidMetrics.TASK_ID));
+    Assertions.assertEquals(task.getGroupId(), builder.getDimension(DruidMetrics.GROUP_ID));
+    Assertions.assertEquals(task.getDataSource(), builder.getDimension(DruidMetrics.DATASOURCE));
+    Assertions.assertEquals(task.getType(), builder.getDimension(DruidMetrics.TASK_TYPE));
   }
 
   @Test
@@ -322,6 +336,6 @@ public class AbstractTaskTest
     final ServiceMetricEvent.Builder builder1 = task.getMetricBuilder();
     final ServiceMetricEvent.Builder builder2 = task.getMetricBuilder();
 
-    Assert.assertNotSame(builder1, builder2);
+    Assertions.assertNotSame(builder1, builder2);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -75,7 +75,7 @@ public class AbstractTaskTest
 
   private File createTempDir() throws IOException
   {
-    return Files.createTempDirectory(temporaryFolder.toPath(), "task").toFile();
+    return org.apache.druid.java.util.common.FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "task");
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -40,7 +40,6 @@ import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -73,7 +72,7 @@ public class AbstractTaskTest
     return reportsFile;
   }
 
-  private File createTempDir() throws IOException
+  private File createTempDir()
   {
     return org.apache.druid.java.util.common.FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "task");
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/AbstractTaskTest.java
@@ -32,16 +32,17 @@ import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.server.DruidNode;
 import org.apache.druid.tasklogs.TaskLogPusher;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -54,7 +55,9 @@ import static org.mockito.Mockito.when;
 
 public class AbstractTaskTest
 {
-  private final File tempReportDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
+  @TempDir
+  private File temporaryFolder;
+
   private ObjectMapper objectMapper;
 
   @BeforeEach
@@ -65,15 +68,14 @@ public class AbstractTaskTest
 
   private File createTempReportFile() throws Exception
   {
-    final File reportsFile = new File(tempReportDir, "report.json");
+    final File reportsFile = Files.createTempFile(temporaryFolder.toPath(), "report", ".json").toFile();
     FileUtils.write(reportsFile, "", StandardCharsets.UTF_8);
     return reportsFile;
   }
 
-  @AfterEach
-  public void tearDown() throws IOException
+  private File createTempDir() throws IOException
   {
-    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempReportDir);
+    return Files.createTempDirectory(temporaryFolder.toPath(), "task").toFile();
   }
 
   @Test
@@ -94,7 +96,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
+    final File folder = createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -147,7 +149,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(false);
-    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
+    final File folder = createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -192,7 +194,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
+    final File folder = createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -239,7 +241,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
+    final File folder = createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);
@@ -276,7 +278,7 @@ public class AbstractTaskTest
 
     TaskConfig config = mock(TaskConfig.class);
     when(config.isEncapsulatedTask()).thenReturn(true);
-    File folder = org.apache.druid.java.util.common.FileUtils.createTempDir();
+    final File folder = createTempDir();
     when(config.getTaskDir(eq("myID"))).thenReturn(folder);
     when(toolbox.getConfig()).thenReturn(config);
     when(toolbox.getJsonMapper()).thenReturn(objectMapper);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTaskTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.indexing.common.task;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class NoopTaskTest
 {
@@ -28,6 +28,6 @@ public class NoopTaskTest
   public void testNullInputSources()
   {
     NoopTask task = NoopTask.create();
-    Assert.assertTrue(task.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(task.getInputSourceResources().isEmpty());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/SpecificSegmentsSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/SpecificSegmentsSpecTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing.common.task;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -46,7 +46,7 @@ public class SpecificSegmentsSpecTest
         .collect(Collectors.toList());
     Collections.shuffle(segments, ThreadLocalRandom.current());
     final SpecificSegmentsSpec spec = SpecificSegmentsSpec.fromSegments(segments);
-    Assert.assertEquals(expectedSegmentIds, spec.getSegments());
+    Assertions.assertEquals(expectedSegmentIds, spec.getSegments());
   }
 
   private static DataSegment newSegment(Interval interval)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -40,12 +40,9 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.DoubleSumAggregatorFactory;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.hamcrest.CoreMatchers;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
@@ -53,9 +50,6 @@ public class TaskSerdeTest
 {
   private final ObjectMapper jsonMapper;
   private final IndexSpec indexSpec = IndexSpec.getDefault();
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   public TaskSerdeTest()
   {
@@ -75,8 +69,8 @@ public class TaskSerdeTest
         IndexTask.IndexIOConfig.class
     );
 
-    Assert.assertEquals(false, ioConfig.isAppendToExisting());
-    Assert.assertEquals(false, ioConfig.isDropExisting());
+    Assertions.assertEquals(false, ioConfig.isAppendToExisting());
+    Assertions.assertEquals(false, ioConfig.isDropExisting());
   }
 
   @Test
@@ -87,13 +81,13 @@ public class TaskSerdeTest
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertFalse(tuningConfig.isReportParseExceptions());
-    Assert.assertEquals(IndexSpec.getDefault(), tuningConfig.getIndexSpec());
-    Assert.assertEquals(new Period(Integer.MAX_VALUE), tuningConfig.getIntermediatePersistPeriod());
-    Assert.assertEquals(0, tuningConfig.getMaxPendingPersists());
-    Assert.assertEquals(1000000, tuningConfig.getMaxRowsInMemory());
-    Assert.assertNull(tuningConfig.getNumShards());
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertFalse(tuningConfig.isReportParseExceptions());
+    Assertions.assertEquals(IndexSpec.getDefault(), tuningConfig.getIndexSpec());
+    Assertions.assertEquals(new Period(Integer.MAX_VALUE), tuningConfig.getIntermediatePersistPeriod());
+    Assertions.assertEquals(0, tuningConfig.getMaxPendingPersists());
+    Assertions.assertEquals(1000000, tuningConfig.getMaxRowsInMemory());
+    Assertions.assertNull(tuningConfig.getNumShards());
+    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
   }
 
   @Test
@@ -104,67 +98,69 @@ public class TaskSerdeTest
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
-    Assert.assertNull(tuningConfig.getNumShards());
+    Assertions.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertNull(tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\"}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"maxRowsPerSegment\":10}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
-    Assert.assertNull(tuningConfig.getNumShards());
+    Assertions.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertNull(tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"numShards\":10, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(10, (int) tuningConfig.getNumShards());
+    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertEquals(10, (int) tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":-1, \"numShards\":10, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(10, (int) tuningConfig.getNumShards());
+    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertEquals(10, (int) tuningConfig.getNumShards());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":10, \"numShards\":-1}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getNumShards());
-    Assert.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertNull(tuningConfig.getNumShards());
+    Assertions.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":-1, \"numShards\":-1, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assert.assertNull(tuningConfig.getNumShards());
-    Assert.assertNotNull(tuningConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, tuningConfig.getMaxRowsPerSegment().intValue());
+    Assertions.assertNull(tuningConfig.getNumShards());
+    Assertions.assertNotNull(tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, tuningConfig.getMaxRowsPerSegment().intValue());
   }
 
   @Test
   public void testIndexTaskTuningConfigTargetPartitionSizeAndNumShards() throws Exception
   {
-    thrown.expectCause(CoreMatchers.isA(IllegalArgumentException.class));
-
-    jsonMapper.readValue(
-        "{\"type\":\"index\", \"targetPartitionSize\":10, \"numShards\":10, \"forceGuaranteedRollup\": true}",
-        IndexTask.IndexTuningConfig.class
+    final Exception exception = Assertions.assertThrows(
+        Exception.class,
+        () -> jsonMapper.readValue(
+            "{\"type\":\"index\", \"targetPartitionSize\":10, \"numShards\":10, \"forceGuaranteedRollup\": true}",
+            IndexTask.IndexTuningConfig.class
+        )
     );
+    Assertions.assertInstanceOf(IllegalArgumentException.class, exception.getCause());
   }
 
   @Test
@@ -174,39 +170,48 @@ public class TaskSerdeTest
         "{\"availabilityGroup\":\"index_xxx_mmm\", \"requiredCapacity\":1}",
         TaskResource.class
     );
-    Assert.assertNotNull(actual);
-    Assert.assertNotNull(actual.getAvailabilityGroup());
-    Assert.assertTrue(actual.getRequiredCapacity() > 0);
+    Assertions.assertNotNull(actual);
+    Assertions.assertNotNull(actual.getAvailabilityGroup());
+    Assertions.assertTrue(actual.getRequiredCapacity() > 0);
   }
 
   @Test
   public void testTaskResourceWithNullAvailabilityGroupShouldFail() throws Exception
   {
-    thrown.expectCause(CoreMatchers.isA(NullPointerException.class));
-    jsonMapper.readValue(
-        "{\"availabilityGroup\":null, \"requiredCapacity\":10}",
-        TaskResource.class
+    final Exception exception = Assertions.assertThrows(
+        Exception.class,
+        () -> jsonMapper.readValue(
+            "{\"availabilityGroup\":null, \"requiredCapacity\":10}",
+            TaskResource.class
+        )
     );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
   }
 
   @Test
   public void testTaskResourceWithZeroRequiredCapacityShouldFail() throws Exception
   {
-    thrown.expectCause(CoreMatchers.isA(NullPointerException.class));
-    jsonMapper.readValue(
-        "{\"availabilityGroup\":null, \"requiredCapacity\":0}",
-        TaskResource.class
+    final Exception exception = Assertions.assertThrows(
+        Exception.class,
+        () -> jsonMapper.readValue(
+            "{\"availabilityGroup\":null, \"requiredCapacity\":0}",
+            TaskResource.class
+        )
     );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
   }
 
   @Test
   public void testTaskResourceWithNegativeRequiredCapacityShouldFail() throws Exception
   {
-    thrown.expectCause(CoreMatchers.isA(NullPointerException.class));
-    jsonMapper.readValue(
-        "{\"availabilityGroup\":null, \"requiredCapacity\":-1}",
-        TaskResource.class
+    final Exception exception = Assertions.assertThrows(
+        Exception.class,
+        () -> jsonMapper.readValue(
+            "{\"availabilityGroup\":null, \"requiredCapacity\":-1}",
+            TaskResource.class
+        )
     );
+    Assertions.assertInstanceOf(NullPointerException.class, exception.getCause());
   }
 
   @Test
@@ -247,35 +252,35 @@ public class TaskSerdeTest
     Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
     final IndexTask task2 = (IndexTask) jsonMapper.readValue(json, Task.class);
 
-    Assert.assertEquals("foo", task.getDataSource());
+    Assertions.assertEquals("foo", task.getDataSource());
 
-    Assert.assertEquals(task.getId(), task2.getId());
-    Assert.assertEquals(task.getGroupId(), task2.getGroupId());
-    Assert.assertEquals(task.getDataSource(), task2.getDataSource());
+    Assertions.assertEquals(task.getId(), task2.getId());
+    Assertions.assertEquals(task.getGroupId(), task2.getGroupId());
+    Assertions.assertEquals(task.getDataSource(), task2.getDataSource());
 
     IndexTask.IndexIOConfig taskIoConfig = task.getIngestionSchema().getIOConfig();
     IndexTask.IndexIOConfig task2IoConfig = task2.getIngestionSchema().getIOConfig();
 
-    Assert.assertTrue(taskIoConfig.getInputSource() instanceof LocalInputSource);
-    Assert.assertTrue(task2IoConfig.getInputSource() instanceof LocalInputSource);
-    Assert.assertEquals(taskIoConfig.isAppendToExisting(), task2IoConfig.isAppendToExisting());
-    Assert.assertEquals(taskIoConfig.isDropExisting(), task2IoConfig.isDropExisting());
+    Assertions.assertTrue(taskIoConfig.getInputSource() instanceof LocalInputSource);
+    Assertions.assertTrue(task2IoConfig.getInputSource() instanceof LocalInputSource);
+    Assertions.assertEquals(taskIoConfig.isAppendToExisting(), task2IoConfig.isAppendToExisting());
+    Assertions.assertEquals(taskIoConfig.isDropExisting(), task2IoConfig.isDropExisting());
 
     IndexTask.IndexTuningConfig taskTuningConfig = task.getIngestionSchema().getTuningConfig();
     IndexTask.IndexTuningConfig task2TuningConfig = task2.getIngestionSchema().getTuningConfig();
 
-    Assert.assertEquals(taskTuningConfig.getBasePersistDirectory(), task2TuningConfig.getBasePersistDirectory());
-    Assert.assertEquals(taskTuningConfig.getIndexSpec(), task2TuningConfig.getIndexSpec());
-    Assert.assertEquals(
+    Assertions.assertEquals(taskTuningConfig.getBasePersistDirectory(), task2TuningConfig.getBasePersistDirectory());
+    Assertions.assertEquals(taskTuningConfig.getIndexSpec(), task2TuningConfig.getIndexSpec());
+    Assertions.assertEquals(
         taskTuningConfig.getIntermediatePersistPeriod(),
         task2TuningConfig.getIntermediatePersistPeriod()
     );
-    Assert.assertEquals(taskTuningConfig.getMaxPendingPersists(), task2TuningConfig.getMaxPendingPersists());
-    Assert.assertEquals(taskTuningConfig.getMaxRowsInMemory(), task2TuningConfig.getMaxRowsInMemory());
-    Assert.assertEquals(taskTuningConfig.getNumShards(), task2TuningConfig.getNumShards());
-    Assert.assertEquals(taskTuningConfig.getMaxRowsPerSegment(), task2TuningConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(taskTuningConfig.isReportParseExceptions(), task2TuningConfig.isReportParseExceptions());
-    Assert.assertEquals(taskTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(), task2TuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
+    Assertions.assertEquals(taskTuningConfig.getMaxPendingPersists(), task2TuningConfig.getMaxPendingPersists());
+    Assertions.assertEquals(taskTuningConfig.getMaxRowsInMemory(), task2TuningConfig.getMaxRowsInMemory());
+    Assertions.assertEquals(taskTuningConfig.getNumShards(), task2TuningConfig.getNumShards());
+    Assertions.assertEquals(taskTuningConfig.getMaxRowsPerSegment(), task2TuningConfig.getMaxRowsPerSegment());
+    Assertions.assertEquals(taskTuningConfig.isReportParseExceptions(), task2TuningConfig.isReportParseExceptions());
+    Assertions.assertEquals(taskTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(), task2TuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }
 
   @Test
@@ -315,17 +320,17 @@ public class TaskSerdeTest
     Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
     final IndexTask task2 = (IndexTask) jsonMapper.readValue(json, Task.class);
 
-    Assert.assertEquals("foo", task.getDataSource());
+    Assertions.assertEquals("foo", task.getDataSource());
 
-    Assert.assertEquals(task.getId(), task2.getId());
-    Assert.assertEquals(2, task.getTaskResource().getRequiredCapacity());
-    Assert.assertEquals("rofl", task.getTaskResource().getAvailabilityGroup());
-    Assert.assertEquals(task.getTaskResource().getRequiredCapacity(), task2.getTaskResource().getRequiredCapacity());
-    Assert.assertEquals(task.getTaskResource().getAvailabilityGroup(), task2.getTaskResource().getAvailabilityGroup());
-    Assert.assertEquals(task.getGroupId(), task2.getGroupId());
-    Assert.assertEquals(task.getDataSource(), task2.getDataSource());
-    Assert.assertTrue(task.getIngestionSchema().getIOConfig().getInputSource() instanceof LocalInputSource);
-    Assert.assertTrue(task2.getIngestionSchema().getIOConfig().getInputSource() instanceof LocalInputSource);
+    Assertions.assertEquals(task.getId(), task2.getId());
+    Assertions.assertEquals(2, task.getTaskResource().getRequiredCapacity());
+    Assertions.assertEquals("rofl", task.getTaskResource().getAvailabilityGroup());
+    Assertions.assertEquals(task.getTaskResource().getRequiredCapacity(), task2.getTaskResource().getRequiredCapacity());
+    Assertions.assertEquals(task.getTaskResource().getAvailabilityGroup(), task2.getTaskResource().getAvailabilityGroup());
+    Assertions.assertEquals(task.getGroupId(), task2.getGroupId());
+    Assertions.assertEquals(task.getDataSource(), task2.getDataSource());
+    Assertions.assertTrue(task.getIngestionSchema().getIOConfig().getInputSource() instanceof LocalInputSource);
+    Assertions.assertTrue(task2.getIngestionSchema().getIOConfig().getInputSource() instanceof LocalInputSource);
   }
 
   @Test
@@ -343,13 +348,13 @@ public class TaskSerdeTest
     Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
     final ArchiveTask task2 = (ArchiveTask) jsonMapper.readValue(json, Task.class);
 
-    Assert.assertEquals("foo", task.getDataSource());
-    Assert.assertEquals(Intervals.of("2010-01-01/P1D"), task.getInterval());
+    Assertions.assertEquals("foo", task.getDataSource());
+    Assertions.assertEquals(Intervals.of("2010-01-01/P1D"), task.getInterval());
 
-    Assert.assertEquals(task.getId(), task2.getId());
-    Assert.assertEquals(task.getGroupId(), task2.getGroupId());
-    Assert.assertEquals(task.getDataSource(), task2.getDataSource());
-    Assert.assertEquals(task.getInterval(), task2.getInterval());
+    Assertions.assertEquals(task.getId(), task2.getId());
+    Assertions.assertEquals(task.getGroupId(), task2.getGroupId());
+    Assertions.assertEquals(task.getDataSource(), task2.getDataSource());
+    Assertions.assertEquals(task.getInterval(), task2.getInterval());
   }
 
   @Test
@@ -367,13 +372,13 @@ public class TaskSerdeTest
     Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
     final RestoreTask task2 = (RestoreTask) jsonMapper.readValue(json, Task.class);
 
-    Assert.assertEquals("foo", task.getDataSource());
-    Assert.assertEquals(Intervals.of("2010-01-01/P1D"), task.getInterval());
+    Assertions.assertEquals("foo", task.getDataSource());
+    Assertions.assertEquals(Intervals.of("2010-01-01/P1D"), task.getInterval());
 
-    Assert.assertEquals(task.getId(), task2.getId());
-    Assert.assertEquals(task.getGroupId(), task2.getGroupId());
-    Assert.assertEquals(task.getDataSource(), task2.getDataSource());
-    Assert.assertEquals(task.getInterval(), task2.getInterval());
+    Assertions.assertEquals(task.getId(), task2.getId());
+    Assertions.assertEquals(task.getGroupId(), task2.getGroupId());
+    Assertions.assertEquals(task.getDataSource(), task2.getDataSource());
+    Assertions.assertEquals(task.getInterval(), task2.getInterval());
   }
 
   @Test
@@ -393,14 +398,14 @@ public class TaskSerdeTest
     Thread.sleep(100); // Just want to run the clock a bit to make sure the task id doesn't change
     final MoveTask task2 = (MoveTask) jsonMapper.readValue(json, Task.class);
 
-    Assert.assertEquals("foo", task.getDataSource());
-    Assert.assertEquals(Intervals.of("2010-01-01/P1D"), task.getInterval());
-    Assert.assertEquals(ImmutableMap.<String, Object>of("bucket", "hey", "baseKey", "what"), task.getTargetLoadSpec());
+    Assertions.assertEquals("foo", task.getDataSource());
+    Assertions.assertEquals(Intervals.of("2010-01-01/P1D"), task.getInterval());
+    Assertions.assertEquals(ImmutableMap.<String, Object>of("bucket", "hey", "baseKey", "what"), task.getTargetLoadSpec());
 
-    Assert.assertEquals(task.getId(), task2.getId());
-    Assert.assertEquals(task.getGroupId(), task2.getGroupId());
-    Assert.assertEquals(task.getDataSource(), task2.getDataSource());
-    Assert.assertEquals(task.getInterval(), task2.getInterval());
-    Assert.assertEquals(task.getTargetLoadSpec(), task2.getTargetLoadSpec());
+    Assertions.assertEquals(task.getId(), task2.getId());
+    Assertions.assertEquals(task.getGroupId(), task2.getGroupId());
+    Assertions.assertEquals(task.getDataSource(), task2.getDataSource());
+    Assertions.assertEquals(task.getInterval(), task2.getInterval());
+    Assertions.assertEquals(task.getTargetLoadSpec(), task2.getTargetLoadSpec());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -29,6 +29,7 @@ import org.apache.druid.data.input.impl.NoopInputFormat;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexer.partitions.DynamicPartitionsSpec;
+import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexer.partitions.PartitionsSpec;
 import org.apache.druid.indexing.common.TestUtils;
 import org.apache.druid.indexing.common.task.IndexTask.IndexIOConfig;
@@ -86,8 +87,8 @@ public class TaskSerdeTest
     Assertions.assertEquals(new Period(Integer.MAX_VALUE), tuningConfig.getIntermediatePersistPeriod());
     Assertions.assertEquals(0, tuningConfig.getMaxPendingPersists());
     Assertions.assertEquals(1000000, tuningConfig.getMaxRowsInMemory());
-    Assertions.assertNull(tuningConfig.getNumShards());
-    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertNull(getNumShards(tuningConfig));
+    Assertions.assertNull(getMaxRowsPerSegment(tuningConfig));
   }
 
   @Test
@@ -98,56 +99,56 @@ public class TaskSerdeTest
         IndexTask.IndexTuningConfig.class
     );
 
-    Assertions.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
-    Assertions.assertNull(tuningConfig.getNumShards());
+    Assertions.assertEquals(10, (int) getMaxRowsPerSegment(tuningConfig));
+    Assertions.assertNull(getNumShards(tuningConfig));
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\"}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertNull(getMaxRowsPerSegment(tuningConfig));
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"maxRowsPerSegment\":10}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assertions.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
-    Assertions.assertNull(tuningConfig.getNumShards());
+    Assertions.assertEquals(10, (int) getMaxRowsPerSegment(tuningConfig));
+    Assertions.assertNull(getNumShards(tuningConfig));
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"numShards\":10, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
-    Assertions.assertEquals(10, (int) tuningConfig.getNumShards());
+    Assertions.assertNull(getMaxRowsPerSegment(tuningConfig));
+    Assertions.assertEquals(10, (int) getNumShards(tuningConfig));
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":-1, \"numShards\":10, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assertions.assertNull(tuningConfig.getMaxRowsPerSegment());
-    Assertions.assertEquals(10, (int) tuningConfig.getNumShards());
+    Assertions.assertNull(getMaxRowsPerSegment(tuningConfig));
+    Assertions.assertEquals(10, (int) getNumShards(tuningConfig));
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":10, \"numShards\":-1}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assertions.assertNull(tuningConfig.getNumShards());
-    Assertions.assertEquals(10, (int) tuningConfig.getMaxRowsPerSegment());
+    Assertions.assertNull(getNumShards(tuningConfig));
+    Assertions.assertEquals(10, (int) getMaxRowsPerSegment(tuningConfig));
 
     tuningConfig = jsonMapper.readValue(
         "{\"type\":\"index\", \"targetPartitionSize\":-1, \"numShards\":-1, \"forceGuaranteedRollup\": true}",
         IndexTask.IndexTuningConfig.class
     );
 
-    Assertions.assertNull(tuningConfig.getNumShards());
-    Assertions.assertNotNull(tuningConfig.getMaxRowsPerSegment());
-    Assertions.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, tuningConfig.getMaxRowsPerSegment().intValue());
+    Assertions.assertNull(getNumShards(tuningConfig));
+    Assertions.assertNotNull(getMaxRowsPerSegment(tuningConfig));
+    Assertions.assertEquals(PartitionsSpec.DEFAULT_MAX_ROWS_PER_SEGMENT, getMaxRowsPerSegment(tuningConfig).intValue());
   }
 
   @Test
@@ -277,8 +278,8 @@ public class TaskSerdeTest
     );
     Assertions.assertEquals(taskTuningConfig.getMaxPendingPersists(), task2TuningConfig.getMaxPendingPersists());
     Assertions.assertEquals(taskTuningConfig.getMaxRowsInMemory(), task2TuningConfig.getMaxRowsInMemory());
-    Assertions.assertEquals(taskTuningConfig.getNumShards(), task2TuningConfig.getNumShards());
-    Assertions.assertEquals(taskTuningConfig.getMaxRowsPerSegment(), task2TuningConfig.getMaxRowsPerSegment());
+    Assertions.assertEquals(getNumShards(taskTuningConfig), getNumShards(task2TuningConfig));
+    Assertions.assertEquals(getMaxRowsPerSegment(taskTuningConfig), getMaxRowsPerSegment(task2TuningConfig));
     Assertions.assertEquals(taskTuningConfig.isReportParseExceptions(), task2TuningConfig.isReportParseExceptions());
     Assertions.assertEquals(taskTuningConfig.getAwaitSegmentAvailabilityTimeoutMillis(), task2TuningConfig.getAwaitSegmentAvailabilityTimeoutMillis());
   }
@@ -407,5 +408,19 @@ public class TaskSerdeTest
     Assertions.assertEquals(task.getDataSource(), task2.getDataSource());
     Assertions.assertEquals(task.getInterval(), task2.getInterval());
     Assertions.assertEquals(task.getTargetLoadSpec(), task2.getTargetLoadSpec());
+  }
+
+  private static Integer getMaxRowsPerSegment(final IndexTask.IndexTuningConfig tuningConfig)
+  {
+    final PartitionsSpec partitionsSpec = tuningConfig.getPartitionsSpec();
+    return partitionsSpec == null ? null : partitionsSpec.getMaxRowsPerSegment();
+  }
+
+  private static Integer getNumShards(final IndexTask.IndexTuningConfig tuningConfig)
+  {
+    final PartitionsSpec partitionsSpec = tuningConfig.getPartitionsSpec();
+    return partitionsSpec instanceof HashedPartitionsSpec
+           ? ((HashedPartitionsSpec) partitionsSpec).getNumShards()
+           : null;
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskTest.java
@@ -27,8 +27,8 @@ import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.Query;
 import org.apache.druid.query.QueryRunner;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -118,7 +118,7 @@ public class TaskTest
   @Test
   public void testGetInputSourceResources()
   {
-    Assert.assertThrows(
+    Assertions.assertThrows(
         UOE.class,
         TASK::getInputSourceResources
     );
@@ -127,6 +127,6 @@ public class TaskTest
   @Test
   public void testGetLookupLoadingSpec()
   {
-    Assert.assertEquals(LookupLoadingSpec.ALL, TASK.getLookupLoadingSpec());
+    Assertions.assertEquals(LookupLoadingSpec.ALL, TASK.getLookupLoadingSpec());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/ConsoleLoggingEnforcementTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/ConsoleLoggingEnforcementTest.java
@@ -27,8 +27,8 @@ import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.appender.HttpAppender;
 import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -71,7 +71,7 @@ public class ConsoleLoggingEnforcementTest
                                                                          .findFirst()
                                                                          .get()
                                                                          .getLayout();
-    Assert.assertEquals("%m", layout.getConversionPattern());
+    Assertions.assertEquals("%m", layout.getConversionPattern());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class ConsoleLoggingEnforcementTest
                                                                          .findFirst()
                                                                          .get()
                                                                          .getLayout();
-    Assert.assertEquals(defaultPattern, layout.getConversionPattern());
+    Assertions.assertEquals(defaultPattern, layout.getConversionPattern());
   }
 
   @Test
@@ -141,7 +141,7 @@ public class ConsoleLoggingEnforcementTest
                                                                          .findFirst()
                                                                          .get()
                                                                          .getLayout();
-    Assert.assertEquals("%m", layout.getConversionPattern());
+    Assertions.assertEquals("%m", layout.getConversionPattern());
   }
 
   @Test
@@ -184,7 +184,7 @@ public class ConsoleLoggingEnforcementTest
                                                                          .findFirst()
                                                                          .get()
                                                                          .getLayout();
-    Assert.assertEquals("%m", layout.getConversionPattern());
+    Assertions.assertEquals("%m", layout.getConversionPattern());
   }
 
   @Test
@@ -225,7 +225,7 @@ public class ConsoleLoggingEnforcementTest
                                                                          .findFirst()
                                                                          .get()
                                                                          .getLayout();
-    Assert.assertEquals("%m", layout.getConversionPattern());
+    Assertions.assertEquals("%m", layout.getConversionPattern());
   }
 
   @Test
@@ -292,7 +292,7 @@ public class ConsoleLoggingEnforcementTest
                                                                          .findFirst()
                                                                          .get()
                                                                          .getLayout();
-    Assert.assertEquals("%m", layout.getConversionPattern());
+    Assertions.assertEquals("%m", layout.getConversionPattern());
   }
 
   private LoggerContext enforceConsoleLogger(String configuration) throws IOException
@@ -318,14 +318,14 @@ public class ConsoleLoggingEnforcementTest
   )
   {
     // there's two appenders
-    Assert.assertEquals(2, logger.getAppenders().size());
+    Assertions.assertEquals(2, logger.getAppenders().size());
 
     // and the appenders must be ConsoleAppender and HttpAppender
-    Assert.assertEquals(ConsoleAppender.class, logger.getAppenders().get(consoleName).getClass());
-    Assert.assertEquals(HttpAppender.class, logger.getAppenders().get(httpName).getClass());
+    Assertions.assertEquals(ConsoleAppender.class, logger.getAppenders().get(consoleName).getClass());
+    Assertions.assertEquals(HttpAppender.class, logger.getAppenders().get(httpName).getClass());
 
     if (level != null) {
-      Assert.assertEquals(level, logger.getLevel());
+      Assertions.assertEquals(level, logger.getLevel());
     }
   }
 
@@ -333,17 +333,17 @@ public class ConsoleLoggingEnforcementTest
   private void assertHasOnlyOneConsoleAppender(Logger logger, Level level)
   {
     // there's only one appender
-    Assert.assertEquals(1, logger.getAppenders().size());
+    Assertions.assertEquals(1, logger.getAppenders().size());
 
     // and this appender must be ConsoleAppender
-    Assert.assertEquals(ConsoleAppender.class, logger.getAppenders()
+    Assertions.assertEquals(ConsoleAppender.class, logger.getAppenders()
                                                      .values()
                                                      .stream()
                                                      .findFirst()
                                                      .get()
                                                      .getClass());
     if (level != null) {
-      Assert.assertEquals(level, logger.getLevel());
+      Assertions.assertEquals(level, logger.getLevel());
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
@@ -128,7 +128,9 @@ public class FileTaskLogsTest
       Assertions.assertTrue(exception.getMessage().contains("Cannot create directory"));
     }
     finally {
-      tmpDir.setWritable(true);
+      if (!tmpDir.setWritable(true)) {
+        throw new RuntimeException("failed to restore tmp dir write permissions");
+      }
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
@@ -31,11 +31,8 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.tasklogs.TaskLogs;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -45,16 +42,10 @@ import java.util.Map;
 public class FileTaskLogsTest
 {
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testSimple() throws Exception
   {
-    final File tmpDir = temporaryFolder.newFolder();
+    final File tmpDir = FileUtils.createTempDir();
     try {
       final File logDir = new File(tmpDir, "druid/logs");
       final File logFile = new File(tmpDir, "log");
@@ -66,7 +57,7 @@ public class FileTaskLogsTest
       for (Map.Entry<Long, String> entry : expected.entrySet()) {
         final byte[] bytes = ByteStreams.toByteArray(taskLogs.streamTaskLog("foo", entry.getKey()).get());
         final String string = StringUtils.fromUtf8(bytes);
-        Assert.assertEquals(StringUtils.format("Read with offset %,d", entry.getKey()), string, entry.getValue());
+        Assertions.assertEquals(string, entry.getValue(), StringUtils.format("Read with offset %,d", entry.getKey()));
       }
     }
     finally {
@@ -78,7 +69,7 @@ public class FileTaskLogsTest
   public void testSimpleReport() throws Exception
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File tmpDir = temporaryFolder.newFolder();
+    final File tmpDir = FileUtils.createTempDir();
     final File logDir = new File(tmpDir, "druid/logs");
     final File reportFile = new File(tmpDir, "report.json");
 
@@ -90,7 +81,7 @@ public class FileTaskLogsTest
     final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
     taskLogs.pushTaskReports("foo", reportFile);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         testReportString,
         StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskReports("foo").get()))
     );
@@ -100,7 +91,7 @@ public class FileTaskLogsTest
   public void testSimpleStatus() throws Exception
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File tmpDir = temporaryFolder.newFolder();
+    final File tmpDir = FileUtils.createTempDir();
     final File logDir = new File(tmpDir, "druid/myTask");
     final File statusFile = new File(tmpDir, "status.json");
 
@@ -112,7 +103,7 @@ public class FileTaskLogsTest
     final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
     taskLogs.pushTaskStatus(taskId, statusFile);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         taskStatusString,
         StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskStatus(taskId).get()))
     );
@@ -121,7 +112,7 @@ public class FileTaskLogsTest
   @Test
   public void testPushTaskLogDirCreationFails() throws Exception
   {
-    final File tmpDir = temporaryFolder.newFolder();
+    final File tmpDir = FileUtils.createTempDir();
     final File logDir = new File(tmpDir, "druid/logs");
     final File logFile = new File(tmpDir, "log");
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
@@ -132,39 +123,41 @@ public class FileTaskLogsTest
 
     final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
 
-    expectedException.expect(IOException.class);
-    expectedException.expectMessage("Cannot create directory");
-    taskLogs.pushTaskLog("foo", logFile);
+    final IOException exception = Assertions.assertThrows(
+        IOException.class,
+        () -> taskLogs.pushTaskLog("foo", logFile)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Cannot create directory"));
   }
 
   @Test
   public void testKill() throws Exception
   {
-    final File tmpDir = temporaryFolder.newFolder();
+    final File tmpDir = FileUtils.createTempDir();
     final File logDir = new File(tmpDir, "logs");
     final File logFile = new File(tmpDir, "log");
     final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
 
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log1content");
     taskLogs.pushTaskLog("log1", logFile);
-    Assert.assertEquals("log1content", readLog(taskLogs, "log1", 0));
+    Assertions.assertEquals("log1content", readLog(taskLogs, "log1", 0));
 
     //File modification timestamp is only maintained to seconds resolution, so artificial delay
     //is necessary to separate 2 file creations by a timestamp that would result in only one
     //of them getting deleted
     Thread.sleep(1500);
     long time = (System.currentTimeMillis() / 1000) * 1000;
-    Assert.assertTrue(new File(logDir, "log1.log").lastModified() < time);
+    Assertions.assertTrue(new File(logDir, "log1.log").lastModified() < time);
 
     Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log2content");
     taskLogs.pushTaskLog("log2", logFile);
-    Assert.assertEquals("log2content", readLog(taskLogs, "log2", 0));
-    Assert.assertTrue(new File(logDir, "log2.log").lastModified() >= time);
+    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+    Assertions.assertTrue(new File(logDir, "log2.log").lastModified() >= time);
 
     taskLogs.killOlderThan(time);
 
-    Assert.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
-    Assert.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+    Assertions.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
+    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
 
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
@@ -27,12 +27,12 @@ import com.google.common.io.Files;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.report.TaskReport;
 import org.apache.druid.indexing.common.config.FileTaskLogsConfig;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.tasklogs.TaskLogs;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,27 +41,24 @@ import java.util.Map;
 
 public class FileTaskLogsTest
 {
+  @TempDir
+  private File temporaryFolder;
 
   @Test
   public void testSimple() throws Exception
   {
-    final File tmpDir = FileUtils.createTempDir();
-    try {
-      final File logDir = new File(tmpDir, "druid/logs");
-      final File logFile = new File(tmpDir, "log");
-      Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
-      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
-      taskLogs.pushTaskLog("foo", logFile);
+    final File tmpDir = temporaryFolder;
+    final File logDir = new File(tmpDir, "druid/logs");
+    final File logFile = new File(tmpDir, "log");
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
+    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+    taskLogs.pushTaskLog("foo", logFile);
 
-      final Map<Long, String> expected = ImmutableMap.of(0L, "blah", 1L, "lah", -2L, "ah", -5L, "blah");
-      for (Map.Entry<Long, String> entry : expected.entrySet()) {
-        final byte[] bytes = ByteStreams.toByteArray(taskLogs.streamTaskLog("foo", entry.getKey()).get());
-        final String string = StringUtils.fromUtf8(bytes);
-        Assertions.assertEquals(entry.getValue(), string, StringUtils.format("Read with offset %,d", entry.getKey()));
-      }
-    }
-    finally {
-      FileUtils.deleteDirectory(tmpDir);
+    final Map<Long, String> expected = ImmutableMap.of(0L, "blah", 1L, "lah", -2L, "ah", -5L, "blah");
+    for (Map.Entry<Long, String> entry : expected.entrySet()) {
+      final byte[] bytes = ByteStreams.toByteArray(taskLogs.streamTaskLog("foo", entry.getKey()).get());
+      final String string = StringUtils.fromUtf8(bytes);
+      Assertions.assertEquals(entry.getValue(), string, StringUtils.format("Read with offset %,d", entry.getKey()));
     }
   }
 
@@ -69,60 +66,50 @@ public class FileTaskLogsTest
   public void testSimpleReport() throws Exception
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File tmpDir = FileUtils.createTempDir();
-    try {
-      final File logDir = new File(tmpDir, "druid/logs");
-      final File reportFile = new File(tmpDir, "report.json");
+    final File tmpDir = temporaryFolder;
+    final File logDir = new File(tmpDir, "druid/logs");
+    final File reportFile = new File(tmpDir, "report.json");
 
-      final String taskId = "myTask";
-      final TestTaskReport testReport = new TestTaskReport(taskId);
-      final String testReportString = mapper.writeValueAsString(TaskReport.buildTaskReports(testReport));
-      Files.asCharSink(reportFile, StandardCharsets.UTF_8).write(testReportString);
+    final String taskId = "myTask";
+    final TestTaskReport testReport = new TestTaskReport(taskId);
+    final String testReportString = mapper.writeValueAsString(TaskReport.buildTaskReports(testReport));
+    Files.asCharSink(reportFile, StandardCharsets.UTF_8).write(testReportString);
 
-      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
-      taskLogs.pushTaskReports("foo", reportFile);
+    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+    taskLogs.pushTaskReports("foo", reportFile);
 
-      Assertions.assertEquals(
-          testReportString,
-          StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskReports("foo").get()))
-      );
-    }
-    finally {
-      FileUtils.deleteDirectory(tmpDir);
-    }
+    Assertions.assertEquals(
+        testReportString,
+        StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskReports("foo").get()))
+    );
   }
 
   @Test
   public void testSimpleStatus() throws Exception
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
-    final File tmpDir = FileUtils.createTempDir();
-    try {
-      final File logDir = new File(tmpDir, "druid/myTask");
-      final File statusFile = new File(tmpDir, "status.json");
+    final File tmpDir = temporaryFolder;
+    final File logDir = new File(tmpDir, "druid/myTask");
+    final File statusFile = new File(tmpDir, "status.json");
 
-      final String taskId = "myTask";
-      final TaskStatus taskStatus = TaskStatus.success(taskId);
-      final String taskStatusString = mapper.writeValueAsString(taskStatus);
-      Files.asCharSink(statusFile, StandardCharsets.UTF_8).write(taskStatusString);
+    final String taskId = "myTask";
+    final TaskStatus taskStatus = TaskStatus.success(taskId);
+    final String taskStatusString = mapper.writeValueAsString(taskStatus);
+    Files.asCharSink(statusFile, StandardCharsets.UTF_8).write(taskStatusString);
 
-      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
-      taskLogs.pushTaskStatus(taskId, statusFile);
+    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+    taskLogs.pushTaskStatus(taskId, statusFile);
 
-      Assertions.assertEquals(
-          taskStatusString,
-          StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskStatus(taskId).get()))
-      );
-    }
-    finally {
-      FileUtils.deleteDirectory(tmpDir);
-    }
+    Assertions.assertEquals(
+        taskStatusString,
+        StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskStatus(taskId).get()))
+    );
   }
 
   @Test
   public void testPushTaskLogDirCreationFails() throws Exception
   {
-    final File tmpDir = FileUtils.createTempDir();
+    final File tmpDir = temporaryFolder;
     try {
       final File logDir = new File(tmpDir, "druid/logs");
       final File logFile = new File(tmpDir, "log");
@@ -142,43 +129,37 @@ public class FileTaskLogsTest
     }
     finally {
       tmpDir.setWritable(true);
-      FileUtils.deleteDirectory(tmpDir);
     }
   }
 
   @Test
   public void testKill() throws Exception
   {
-    final File tmpDir = FileUtils.createTempDir();
-    try {
-      final File logDir = new File(tmpDir, "logs");
-      final File logFile = new File(tmpDir, "log");
-      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+    final File tmpDir = temporaryFolder;
+    final File logDir = new File(tmpDir, "logs");
+    final File logFile = new File(tmpDir, "log");
+    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
 
-      Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log1content");
-      taskLogs.pushTaskLog("log1", logFile);
-      Assertions.assertEquals("log1content", readLog(taskLogs, "log1", 0));
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log1content");
+    taskLogs.pushTaskLog("log1", logFile);
+    Assertions.assertEquals("log1content", readLog(taskLogs, "log1", 0));
 
-      //File modification timestamp is only maintained to seconds resolution, so artificial delay
-      //is necessary to separate 2 file creations by a timestamp that would result in only one
-      //of them getting deleted
-      Thread.sleep(1500);
-      final long time = (System.currentTimeMillis() / 1000) * 1000;
-      Assertions.assertTrue(new File(logDir, "log1.log").lastModified() < time);
+    //File modification timestamp is only maintained to seconds resolution, so artificial delay
+    //is necessary to separate 2 file creations by a timestamp that would result in only one
+    //of them getting deleted
+    Thread.sleep(1500);
+    final long time = (System.currentTimeMillis() / 1000) * 1000;
+    Assertions.assertTrue(new File(logDir, "log1.log").lastModified() < time);
 
-      Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log2content");
-      taskLogs.pushTaskLog("log2", logFile);
-      Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
-      Assertions.assertTrue(new File(logDir, "log2.log").lastModified() >= time);
+    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log2content");
+    taskLogs.pushTaskLog("log2", logFile);
+    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+    Assertions.assertTrue(new File(logDir, "log2.log").lastModified() >= time);
 
-      taskLogs.killOlderThan(time);
+    taskLogs.killOlderThan(time);
 
-      Assertions.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
-      Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
-    }
-    finally {
-      FileUtils.deleteDirectory(tmpDir);
-    }
+    Assertions.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
+    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
 
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/FileTaskLogsTest.java
@@ -57,7 +57,7 @@ public class FileTaskLogsTest
       for (Map.Entry<Long, String> entry : expected.entrySet()) {
         final byte[] bytes = ByteStreams.toByteArray(taskLogs.streamTaskLog("foo", entry.getKey()).get());
         final String string = StringUtils.fromUtf8(bytes);
-        Assertions.assertEquals(string, entry.getValue(), StringUtils.format("Read with offset %,d", entry.getKey()));
+        Assertions.assertEquals(entry.getValue(), string, StringUtils.format("Read with offset %,d", entry.getKey()));
       }
     }
     finally {
@@ -70,21 +70,26 @@ public class FileTaskLogsTest
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final File tmpDir = FileUtils.createTempDir();
-    final File logDir = new File(tmpDir, "druid/logs");
-    final File reportFile = new File(tmpDir, "report.json");
+    try {
+      final File logDir = new File(tmpDir, "druid/logs");
+      final File reportFile = new File(tmpDir, "report.json");
 
-    final String taskId = "myTask";
-    final TestTaskReport testReport = new TestTaskReport(taskId);
-    final String testReportString = mapper.writeValueAsString(TaskReport.buildTaskReports(testReport));
-    Files.asCharSink(reportFile, StandardCharsets.UTF_8).write(testReportString);
+      final String taskId = "myTask";
+      final TestTaskReport testReport = new TestTaskReport(taskId);
+      final String testReportString = mapper.writeValueAsString(TaskReport.buildTaskReports(testReport));
+      Files.asCharSink(reportFile, StandardCharsets.UTF_8).write(testReportString);
 
-    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
-    taskLogs.pushTaskReports("foo", reportFile);
+      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+      taskLogs.pushTaskReports("foo", reportFile);
 
-    Assertions.assertEquals(
-        testReportString,
-        StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskReports("foo").get()))
-    );
+      Assertions.assertEquals(
+          testReportString,
+          StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskReports("foo").get()))
+      );
+    }
+    finally {
+      FileUtils.deleteDirectory(tmpDir);
+    }
   }
 
   @Test
@@ -92,72 +97,88 @@ public class FileTaskLogsTest
   {
     final ObjectMapper mapper = TestHelper.makeJsonMapper();
     final File tmpDir = FileUtils.createTempDir();
-    final File logDir = new File(tmpDir, "druid/myTask");
-    final File statusFile = new File(tmpDir, "status.json");
+    try {
+      final File logDir = new File(tmpDir, "druid/myTask");
+      final File statusFile = new File(tmpDir, "status.json");
 
-    final String taskId = "myTask";
-    final TaskStatus taskStatus = TaskStatus.success(taskId);
-    final String taskStatusString = mapper.writeValueAsString(taskStatus);
-    Files.asCharSink(statusFile, StandardCharsets.UTF_8).write(taskStatusString);
+      final String taskId = "myTask";
+      final TaskStatus taskStatus = TaskStatus.success(taskId);
+      final String taskStatusString = mapper.writeValueAsString(taskStatus);
+      Files.asCharSink(statusFile, StandardCharsets.UTF_8).write(taskStatusString);
 
-    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
-    taskLogs.pushTaskStatus(taskId, statusFile);
+      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+      taskLogs.pushTaskStatus(taskId, statusFile);
 
-    Assertions.assertEquals(
-        taskStatusString,
-        StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskStatus(taskId).get()))
-    );
+      Assertions.assertEquals(
+          taskStatusString,
+          StringUtils.fromUtf8(ByteStreams.toByteArray(taskLogs.streamTaskStatus(taskId).get()))
+      );
+    }
+    finally {
+      FileUtils.deleteDirectory(tmpDir);
+    }
   }
 
   @Test
   public void testPushTaskLogDirCreationFails() throws Exception
   {
     final File tmpDir = FileUtils.createTempDir();
-    final File logDir = new File(tmpDir, "druid/logs");
-    final File logFile = new File(tmpDir, "log");
-    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
+    try {
+      final File logDir = new File(tmpDir, "druid/logs");
+      final File logFile = new File(tmpDir, "log");
+      Files.asCharSink(logFile, StandardCharsets.UTF_8).write("blah");
 
-    if (!tmpDir.setWritable(false)) {
-      throw new RuntimeException("failed to make tmp dir read-only");
+      if (!tmpDir.setWritable(false)) {
+        throw new RuntimeException("failed to make tmp dir read-only");
+      }
+
+      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+
+      final IOException exception = Assertions.assertThrows(
+          IOException.class,
+          () -> taskLogs.pushTaskLog("foo", logFile)
+      );
+      Assertions.assertTrue(exception.getMessage().contains("Cannot create directory"));
     }
-
-    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
-
-    final IOException exception = Assertions.assertThrows(
-        IOException.class,
-        () -> taskLogs.pushTaskLog("foo", logFile)
-    );
-    Assertions.assertTrue(exception.getMessage().contains("Cannot create directory"));
+    finally {
+      tmpDir.setWritable(true);
+      FileUtils.deleteDirectory(tmpDir);
+    }
   }
 
   @Test
   public void testKill() throws Exception
   {
     final File tmpDir = FileUtils.createTempDir();
-    final File logDir = new File(tmpDir, "logs");
-    final File logFile = new File(tmpDir, "log");
-    final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
+    try {
+      final File logDir = new File(tmpDir, "logs");
+      final File logFile = new File(tmpDir, "log");
+      final TaskLogs taskLogs = new FileTaskLogs(new FileTaskLogsConfig(logDir));
 
-    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log1content");
-    taskLogs.pushTaskLog("log1", logFile);
-    Assertions.assertEquals("log1content", readLog(taskLogs, "log1", 0));
+      Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log1content");
+      taskLogs.pushTaskLog("log1", logFile);
+      Assertions.assertEquals("log1content", readLog(taskLogs, "log1", 0));
 
-    //File modification timestamp is only maintained to seconds resolution, so artificial delay
-    //is necessary to separate 2 file creations by a timestamp that would result in only one
-    //of them getting deleted
-    Thread.sleep(1500);
-    long time = (System.currentTimeMillis() / 1000) * 1000;
-    Assertions.assertTrue(new File(logDir, "log1.log").lastModified() < time);
+      //File modification timestamp is only maintained to seconds resolution, so artificial delay
+      //is necessary to separate 2 file creations by a timestamp that would result in only one
+      //of them getting deleted
+      Thread.sleep(1500);
+      final long time = (System.currentTimeMillis() / 1000) * 1000;
+      Assertions.assertTrue(new File(logDir, "log1.log").lastModified() < time);
 
-    Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log2content");
-    taskLogs.pushTaskLog("log2", logFile);
-    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
-    Assertions.assertTrue(new File(logDir, "log2.log").lastModified() >= time);
+      Files.asCharSink(logFile, StandardCharsets.UTF_8).write("log2content");
+      taskLogs.pushTaskLog("log2", logFile);
+      Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+      Assertions.assertTrue(new File(logDir, "log2.log").lastModified() >= time);
 
-    taskLogs.killOlderThan(time);
+      taskLogs.killOlderThan(time);
 
-    Assertions.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
-    Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+      Assertions.assertFalse(taskLogs.streamTaskLog("log1", 0).isPresent());
+      Assertions.assertEquals("log2content", readLog(taskLogs, "log2", 0));
+    }
+    finally {
+      FileUtils.deleteDirectory(tmpDir);
+    }
 
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/SwitchingTaskLogStreamerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/tasklogs/SwitchingTaskLogStreamerTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.tasklogs.NoopTaskLogs;
 import org.apache.druid.tasklogs.TaskLogStreamer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -69,12 +69,12 @@ public class SwitchingTaskLogStreamerTest
             emptyStreamer
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         getLogString(1, TASK_ID, 1),
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).get()))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         getReportString(1, TASK_ID),
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskReports(TASK_ID).get()))
     );
@@ -91,12 +91,12 @@ public class SwitchingTaskLogStreamerTest
             emptyStreamer
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         getLogString(2, TASK_ID, 1),
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).get()))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         getReportString(2, TASK_ID),
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskReports(TASK_ID).get()))
     );
@@ -112,12 +112,12 @@ public class SwitchingTaskLogStreamerTest
             emptyStreamer
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         getLogString(2, TASK_ID, 1),
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).get()))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         getReportString(2, TASK_ID),
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskReports(TASK_ID).get()))
     );
@@ -134,11 +134,11 @@ public class SwitchingTaskLogStreamerTest
             streamer2
         )
     );
-    Assert.assertThrows("expected log exception", IOException.class, () ->
+    Assertions.assertThrows(IOException.class, () ->
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).get()))
     );
 
-    Assert.assertThrows("expected report exception", IOException.class, () ->
+    Assertions.assertThrows(IOException.class, () ->
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskReports(TASK_ID).get()))
     );
   }
@@ -152,11 +152,11 @@ public class SwitchingTaskLogStreamerTest
             emptyStreamer
         )
     );
-    Assert.assertThrows("expected log exception", IOException.class, () ->
+    Assertions.assertThrows(IOException.class, () ->
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).get()))
     );
 
-    Assert.assertThrows("expected report exception", IOException.class, () ->
+    Assertions.assertThrows(IOException.class, () ->
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskReports(TASK_ID).get()))
     );
 
@@ -171,11 +171,11 @@ public class SwitchingTaskLogStreamerTest
             ioExceptionStreamer
         )
     );
-    Assert.assertThrows("expected log exception", IOException.class, () ->
+    Assertions.assertThrows(IOException.class, () ->
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).get()))
     );
 
-    Assert.assertThrows("expected report exception", IOException.class, () ->
+    Assertions.assertThrows(IOException.class, () ->
         StringUtils.fromUtf8(ByteStreams.toByteArray(switchingTaskLogStreamer.streamTaskReports(TASK_ID).get()))
     );
   }
@@ -189,8 +189,8 @@ public class SwitchingTaskLogStreamerTest
             emptyStreamer
         )
     );
-    Assert.assertFalse(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).isPresent());
-    Assert.assertFalse(switchingTaskLogStreamer.streamTaskReports(TASK_ID).isPresent());
+    Assertions.assertFalse(switchingTaskLogStreamer.streamTaskLog(TASK_ID, 1).isPresent());
+    Assertions.assertFalse(switchingTaskLogStreamer.streamTaskReports(TASK_ID).isPresent());
   }
 
   private static String getLogString(int id, String taskid, long offset)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/CompactionSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/CompactionSupervisorSpecTest.java
@@ -29,9 +29,9 @@ import org.apache.druid.segment.TestDataSource;
 import org.apache.druid.server.coordinator.CompactionConfigValidationResult;
 import org.apache.druid.server.coordinator.DataSourceCompactionConfig;
 import org.apache.druid.server.coordinator.InlineSchemaDataSourceCompactionConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -42,7 +42,7 @@ public class CompactionSupervisorSpecTest
   private static final ObjectMapper OBJECT_MAPPER = new DefaultObjectMapper();
   private CompactionScheduler scheduler;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     scheduler = Mockito.mock(CompactionScheduler.class);
@@ -87,7 +87,7 @@ public class CompactionSupervisorSpecTest
   {
     Mockito.when(scheduler.validateCompactionConfig(ArgumentMatchers.any()))
            .thenReturn(CompactionConfigValidationResult.failure("bad spec"));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Compaction supervisor spec is invalid. Reason[bad spec].", new CompactionSupervisorSpec(
             new InlineSchemaDataSourceCompactionConfig.Builder().forDataSource("datasource").build(),
             false,
@@ -106,12 +106,12 @@ public class CompactionSupervisorSpecTest
         false,
         scheduler
     );
-    final DruidException thrown = Assert.assertThrows(
+    final DruidException thrown = Assertions.assertThrows(
         DruidException.class,
         invalidSpec::validateSpec
     );
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, thrown.getCategory());
-    Assert.assertEquals("Invalid compaction supervisor spec: bad spec", thrown.getMessage());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, thrown.getCategory());
+    Assertions.assertEquals("Invalid compaction supervisor spec: bad spec", thrown.getMessage());
   }
 
   @Test
@@ -133,9 +133,9 @@ public class CompactionSupervisorSpecTest
         false,
         scheduler
     );
-    Assert.assertEquals("autocompact__wiki", activeSpec.getId());
-    Assert.assertEquals(Collections.singletonList(TestDataSource.WIKI), activeSpec.getDataSources());
-    Assert.assertFalse(activeSpec.isSuspended());
+    Assertions.assertEquals("autocompact__wiki", activeSpec.getId());
+    Assertions.assertEquals(Collections.singletonList(TestDataSource.WIKI), activeSpec.getDataSources());
+    Assertions.assertFalse(activeSpec.isSuspended());
   }
 
   @Test
@@ -151,7 +151,7 @@ public class CompactionSupervisorSpecTest
         = new CompactionSupervisorSpec(spec, false, scheduler);
 
     final CompactionSupervisor supervisor = activeSpec.createSupervisor();
-    Assert.assertEquals(CompactionSupervisor.State.RUNNING, supervisor.getState());
+    Assertions.assertEquals(CompactionSupervisor.State.RUNNING, supervisor.getState());
 
     supervisor.start();
     supervisor.stop(false);
@@ -171,7 +171,7 @@ public class CompactionSupervisorSpecTest
         = new CompactionSupervisorSpec(spec, false, scheduler);
 
     final CompactionSupervisor supervisor = activeSpec.createSupervisor();
-    Assert.assertEquals(CompactionSupervisor.State.SCHEDULER_STOPPED, supervisor.getState());
+    Assertions.assertEquals(CompactionSupervisor.State.SCHEDULER_STOPPED, supervisor.getState());
 
     supervisor.start();
     supervisor.stop(false);
@@ -193,7 +193,7 @@ public class CompactionSupervisorSpecTest
         = new CompactionSupervisorSpec(spec, true, scheduler);
 
     final CompactionSupervisor supervisor = suspendedSpec.createSupervisor();
-    Assert.assertEquals(CompactionSupervisor.State.SUSPENDED, supervisor.getState());
+    Assertions.assertEquals(CompactionSupervisor.State.SUSPENDED, supervisor.getState());
 
     supervisor.start();
     supervisor.stop(false);
@@ -209,13 +209,13 @@ public class CompactionSupervisorSpecTest
         false,
         scheduler
     );
-    Assert.assertFalse(activeSpec.isSuspended());
+    Assertions.assertFalse(activeSpec.isSuspended());
 
     final CompactionSupervisorSpec suspendedSpec = activeSpec.createSuspendedSpec();
-    Assert.assertTrue(suspendedSpec.isSuspended());
-    Assert.assertEquals(activeSpec.getId(), suspendedSpec.getId());
-    Assert.assertEquals(activeSpec.getSpec(), suspendedSpec.getSpec());
-    Assert.assertEquals(activeSpec.getDataSources(), suspendedSpec.getDataSources());
+    Assertions.assertTrue(suspendedSpec.isSuspended());
+    Assertions.assertEquals(activeSpec.getId(), suspendedSpec.getId());
+    Assertions.assertEquals(activeSpec.getSpec(), suspendedSpec.getSpec());
+    Assertions.assertEquals(activeSpec.getDataSources(), suspendedSpec.getDataSources());
   }
 
   @Test
@@ -226,13 +226,13 @@ public class CompactionSupervisorSpecTest
         true,
         scheduler
     );
-    Assert.assertTrue(suspendedSpec.isSuspended());
+    Assertions.assertTrue(suspendedSpec.isSuspended());
 
     final CompactionSupervisorSpec activeSpec = suspendedSpec.createRunningSpec();
-    Assert.assertFalse(activeSpec.isSuspended());
-    Assert.assertEquals(activeSpec.getId(), suspendedSpec.getId());
-    Assert.assertEquals(activeSpec.getSpec(), suspendedSpec.getSpec());
-    Assert.assertEquals(activeSpec.getDataSources(), suspendedSpec.getDataSources());
+    Assertions.assertFalse(activeSpec.isSuspended());
+    Assertions.assertEquals(activeSpec.getId(), suspendedSpec.getId());
+    Assertions.assertEquals(activeSpec.getSpec(), suspendedSpec.getSpec());
+    Assertions.assertEquals(activeSpec.getDataSources(), suspendedSpec.getDataSources());
   }
 
   @Test
@@ -243,7 +243,7 @@ public class CompactionSupervisorSpecTest
         true,
         scheduler
     );
-    Assert.assertTrue(supervisorSpec.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(supervisorSpec.getInputSourceResources().isEmpty());
   }
 
   private void testSerde(CompactionSupervisorSpec spec)
@@ -251,13 +251,13 @@ public class CompactionSupervisorSpecTest
     try {
       String json = OBJECT_MAPPER.writeValueAsString(spec);
       SupervisorSpec deserialized = OBJECT_MAPPER.readValue(json, SupervisorSpec.class);
-      Assert.assertTrue(deserialized instanceof CompactionSupervisorSpec);
+      Assertions.assertTrue(deserialized instanceof CompactionSupervisorSpec);
 
       final CompactionSupervisorSpec observedSpec = (CompactionSupervisorSpec) deserialized;
-      Assert.assertEquals(spec.isSuspended(), observedSpec.isSuspended());
-      Assert.assertEquals(spec.getSpec(), observedSpec.getSpec());
-      Assert.assertEquals(spec.getId(), observedSpec.getId());
-      Assert.assertEquals(spec.getDataSources(), observedSpec.getDataSources());
+      Assertions.assertEquals(spec.isSuspended(), observedSpec.isSuspended());
+      Assertions.assertEquals(spec.getSpec(), observedSpec.getSpec());
+      Assertions.assertEquals(spec.getId(), observedSpec.getId());
+      Assertions.assertEquals(spec.getDataSources(), observedSpec.getDataSources());
     }
     catch (Exception e) {
       throw DruidException.defensive(e, "Error while performing serde");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
@@ -313,7 +313,7 @@ public class OverlordCompactionSchedulerTest
     runScheduledJob();
     Assertions.assertFalse(scheduler.isRunning());
 
-    // Enable the schduler to trigger start
+    // Enable the scheduler to trigger start
     enableScheduler();
     Assertions.assertFalse(scheduler.isRunning());
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/compact/OverlordCompactionSchedulerTest.java
@@ -88,9 +88,9 @@ import org.apache.druid.timeline.DataSegment;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
@@ -139,7 +139,7 @@ public class OverlordCompactionSchedulerTest
   private String dataSource;
   private OverlordCompactionScheduler scheduler;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     dataSource = "wiki_" + IdUtils.getRandomId();
@@ -159,16 +159,16 @@ public class OverlordCompactionSchedulerTest
     );
 
     taskMaster = new TaskMaster(null, null);
-    Assert.assertFalse(taskMaster.isHalfOrFullLeader());
-    Assert.assertFalse(taskMaster.isFullLeader());
+    Assertions.assertFalse(taskMaster.isHalfOrFullLeader());
+    Assertions.assertFalse(taskMaster.isFullLeader());
 
     taskMaster.becomeHalfLeader(taskRunner, taskQueue);
-    Assert.assertTrue(taskMaster.isHalfOrFullLeader());
-    Assert.assertFalse(taskMaster.isFullLeader());
+    Assertions.assertTrue(taskMaster.isHalfOrFullLeader());
+    Assertions.assertFalse(taskMaster.isFullLeader());
 
     taskMaster.becomeFullLeader();
-    Assert.assertTrue(taskMaster.isHalfOrFullLeader());
-    Assert.assertTrue(taskMaster.isFullLeader());
+    Assertions.assertTrue(taskMaster.isHalfOrFullLeader());
+    Assertions.assertTrue(taskMaster.isFullLeader());
 
     taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
 
@@ -244,45 +244,45 @@ public class OverlordCompactionSchedulerTest
   @Test
   public void test_becomeLeader_triggersStart_ifEnabled()
   {
-    Assert.assertTrue(scheduler.isEnabled());
+    Assertions.assertTrue(scheduler.isEnabled());
 
-    Assert.assertFalse(scheduler.isRunning());
-    Assert.assertFalse(executor.hasPendingTasks());
+    Assertions.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(executor.hasPendingTasks());
 
     scheduler.becomeLeader();
     runScheduledJob();
 
-    Assert.assertTrue(scheduler.isRunning());
+    Assertions.assertTrue(scheduler.isRunning());
   }
 
   @Test
   public void test_becomeLeader_doesNotTriggerStart_ifDisabled()
   {
     disableScheduler();
-    Assert.assertFalse(scheduler.isEnabled());
+    Assertions.assertFalse(scheduler.isEnabled());
 
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isRunning());
 
     scheduler.becomeLeader();
     runScheduledJob();
 
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isRunning());
   }
 
   @Test
   public void test_stopBeingLeader_triggersStop()
   {
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isRunning());
 
     scheduler.becomeLeader();
     runScheduledJob();
-    Assert.assertTrue(scheduler.isRunning());
+    Assertions.assertTrue(scheduler.isRunning());
 
     scheduler.stopBeingLeader();
-    Assert.assertTrue(scheduler.isRunning());
+    Assertions.assertTrue(scheduler.isRunning());
 
     runScheduledJob();
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isRunning());
   }
 
   @Test
@@ -291,16 +291,16 @@ public class OverlordCompactionSchedulerTest
     // Start scheduler
     scheduler.becomeLeader();
     runScheduledJob();
-    Assert.assertTrue(scheduler.isRunning());
+    Assertions.assertTrue(scheduler.isRunning());
 
     // Disable scheduler to trigger stop
     disableScheduler();
-    Assert.assertFalse(scheduler.isEnabled());
-    Assert.assertTrue(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isEnabled());
+    Assertions.assertTrue(scheduler.isRunning());
 
     // Scheduler finally stops in the next schedule cycle
     runScheduledJob();
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isRunning());
   }
 
   @Test
@@ -311,15 +311,15 @@ public class OverlordCompactionSchedulerTest
     // Becoming leader does not trigger start since scheduler is disabled
     scheduler.becomeLeader();
     runScheduledJob();
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isRunning());
 
     // Enable the schduler to trigger start
     enableScheduler();
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertFalse(scheduler.isRunning());
 
     // Scheduler finally starts in the next schedule cycle
     runScheduledJob();
-    Assert.assertTrue(scheduler.isRunning());
+    Assertions.assertTrue(scheduler.isRunning());
   }
 
   @Test
@@ -352,19 +352,19 @@ public class OverlordCompactionSchedulerTest
   {
     scheduler.becomeLeader();
     runScheduledJob();
-    Assert.assertEquals(enabled, segmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertEquals(enabled, segmentsMetadataManager.isPollingDatabasePeriodically());
 
     scheduler.stopBeingLeader();
     runScheduledJob();
-    Assert.assertFalse(segmentsMetadataManager.isPollingDatabasePeriodically());
+    Assertions.assertFalse(segmentsMetadataManager.isPollingDatabasePeriodically());
   }
 
   @Test
   public void test_validateCompactionConfig_returnsInvalid_forNullConfig()
   {
     final CompactionConfigValidationResult result = scheduler.validateCompactionConfig(null);
-    Assert.assertFalse(result.isValid());
-    Assert.assertEquals("Cannot be null", result.getReason());
+    Assertions.assertFalse(result.isValid());
+    Assertions.assertEquals("Cannot be null", result.getReason());
   }
 
   @Test
@@ -378,8 +378,8 @@ public class OverlordCompactionSchedulerTest
         .build();
 
     final CompactionConfigValidationResult result = scheduler.validateCompactionConfig(datasourceConfig);
-    Assert.assertFalse(result.isValid());
-    Assert.assertEquals(
+    Assertions.assertFalse(result.isValid());
+    Assertions.assertEquals(
         "MSQ: Context maxNumTasks[1] must be at least 2 (1 controller + 1 worker)",
         result.getReason()
     );
@@ -403,7 +403,7 @@ public class OverlordCompactionSchedulerTest
     );
 
     final CompactionConfigValidationResult result = scheduler.validateCompactionConfig(template);
-    Assert.assertTrue(result.isValid());
+    Assertions.assertTrue(result.isValid());
   }
 
   @Test
@@ -419,11 +419,11 @@ public class OverlordCompactionSchedulerTest
     final AutoCompactionSnapshot.Builder expectedSnapshot = AutoCompactionSnapshot.builder(dataSource);
     expectedSnapshot.incrementWaitingStats(CompactionStatistics.create(100_000_000, null, 1, 1));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedSnapshot.build(),
         scheduler.getCompactionSnapshot(dataSource)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Map.of(dataSource, expectedSnapshot.build()),
         scheduler.getAllCompactionSnapshots()
     );
@@ -446,13 +446,13 @@ public class OverlordCompactionSchedulerTest
     runScheduledJob();
     Mockito.verify(taskQueue, Mockito.never()).add(ArgumentMatchers.any());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         AutoCompactionSnapshot.builder(dataSource)
                               .withStatus(AutoCompactionSnapshot.ScheduleStatus.NOT_ENABLED)
                               .build(),
         scheduler.getCompactionSnapshot(dataSource)
     );
-    Assert.assertTrue(scheduler.getAllCompactionSnapshots().isEmpty());
+    Assertions.assertTrue(scheduler.getAllCompactionSnapshots().isEmpty());
 
     serviceEmitter.verifyNotEmitted(Stats.Compaction.SUBMITTED_TASKS.getMetricName());
     serviceEmitter.verifyNotEmitted(Stats.Compaction.COMPACTED_BYTES.getMetricName());
@@ -473,13 +473,13 @@ public class OverlordCompactionSchedulerTest
     final CompactionSimulateResult simulateResult = scheduler.simulateRunWithConfigUpdate(
         new ClusterCompactionConfig(null, null, null, null, null, null)
     );
-    Assert.assertEquals(1, simulateResult.getCompactionStates().size());
+    Assertions.assertEquals(1, simulateResult.getCompactionStates().size());
     final Table pendingCompactionTable = simulateResult.getCompactionStates().get(CompactionStatus.State.PENDING);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("dataSource", "interval", "numSegments", "bytes", "maxTaskSlots", "reasonToCompact"),
         pendingCompactionTable.getColumnNames()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(
             Arrays.asList(
                 dataSource,
@@ -498,7 +498,7 @@ public class OverlordCompactionSchedulerTest
     final CompactionSimulateResult simulateResultWhenDisabled = scheduler.simulateRunWithConfigUpdate(
         new ClusterCompactionConfig(null, null, null, null, null, null)
     );
-    Assert.assertTrue(simulateResultWhenDisabled.getCompactionStates().isEmpty());
+    Assertions.assertTrue(simulateResultWhenDisabled.getCompactionStates().isEmpty());
 
     scheduler.stopBeingLeader();
   }
@@ -506,10 +506,10 @@ public class OverlordCompactionSchedulerTest
   @Test
   public void test_getAllCompactionSnapshots_returnsEmpty_beforeFirstRun()
   {
-    Assert.assertTrue(scheduler.isEnabled());
-    Assert.assertFalse(scheduler.isRunning());
+    Assertions.assertTrue(scheduler.isEnabled());
+    Assertions.assertFalse(scheduler.isRunning());
 
-    Assert.assertTrue(scheduler.getAllCompactionSnapshots().isEmpty());
+    Assertions.assertTrue(scheduler.getAllCompactionSnapshots().isEmpty());
   }
 
   @Test
@@ -518,7 +518,7 @@ public class OverlordCompactionSchedulerTest
     scheduler.startCompaction(dataSource, createSupervisorWithInlineSpec());
 
     AutoCompactionSnapshot snapshot = scheduler.getCompactionSnapshot(dataSource);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         AutoCompactionSnapshot.ScheduleStatus.AWAITING_FIRST_RUN,
         snapshot.getScheduleStatus()
     );
@@ -543,8 +543,8 @@ public class OverlordCompactionSchedulerTest
     Mockito.verify(taskQueue, Mockito.times(expectedCount)).add(taskArgumentCaptor.capture());
 
     for (Task task : taskArgumentCaptor.getAllValues()) {
-      Assert.assertTrue(task instanceof CompactionTask);
-      Assert.assertEquals(dataSource, task.getDataSource());
+      Assertions.assertTrue(task instanceof CompactionTask);
+      Assertions.assertEquals(dataSource, task.getDataSource());
 
       final CompactionTask compactionTask = (CompactionTask) task;
       runCompactionTask(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidInputSourceTest.java
@@ -38,14 +38,10 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.IndexIO;
 import org.apache.druid.segment.TestHelper;
 import org.easymock.EasyMock;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -59,10 +55,7 @@ public class DruidInputSourceTest
 
   private ObjectMapper mapper = null;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mapper = TestHelper.makeJsonMapper();
@@ -87,8 +80,8 @@ public class DruidInputSourceTest
 
     final InputSource inputSource = mapper.readValue(json, InputSource.class);
 
-    MatcherAssert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
-    Assert.assertEquals(
+    Assertions.assertInstanceOf(DruidInputSource.class, inputSource);
+    Assertions.assertEquals(
         new DruidInputSource(
             "foo",
             Intervals.of("2000/2001"),
@@ -104,7 +97,7 @@ public class DruidInputSourceTest
         inputSource
     );
 
-    Assert.assertEquals(json, mapper.writeValueAsString(inputSource));
+    Assertions.assertEquals(json, mapper.writeValueAsString(inputSource));
   }
 
   @Test
@@ -120,8 +113,8 @@ public class DruidInputSourceTest
 
     final InputSource inputSource = mapper.readValue(json, InputSource.class);
 
-    MatcherAssert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
-    Assert.assertEquals(
+    Assertions.assertInstanceOf(DruidInputSource.class, inputSource);
+    Assertions.assertEquals(
         new DruidInputSource(
             "foo",
             Intervals.of("2000/2001"),
@@ -137,7 +130,7 @@ public class DruidInputSourceTest
         inputSource
     );
 
-    Assert.assertEquals(json, mapper.writeValueAsString(inputSource));
+    Assertions.assertEquals(json, mapper.writeValueAsString(inputSource));
   }
 
   @Test
@@ -154,8 +147,8 @@ public class DruidInputSourceTest
 
     final InputSource inputSource = mapper.readValue(json, InputSource.class);
 
-    MatcherAssert.assertThat(inputSource, CoreMatchers.instanceOf(DruidInputSource.class));
-    Assert.assertEquals(
+    Assertions.assertInstanceOf(DruidInputSource.class, inputSource);
+    Assertions.assertEquals(
         new DruidInputSource(
             "foo",
             null,
@@ -176,7 +169,7 @@ public class DruidInputSourceTest
         inputSource
     );
 
-    Assert.assertEquals(json, mapper.writeValueAsString(inputSource));
+    Assertions.assertEquals(json, mapper.writeValueAsString(inputSource));
   }
 
   @Test
@@ -193,10 +186,11 @@ public class DruidInputSourceTest
                         + "}";
 
 
-    expectedException.expect(JsonProcessingException.class);
-    expectedException.expectMessage("Specify exactly one of 'interval' and 'segments'");
-
-    mapper.readValue(json, InputSource.class);
+    final JsonProcessingException exception = Assertions.assertThrows(
+        JsonProcessingException.class,
+        () -> mapper.readValue(json, InputSource.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Specify exactly one of 'interval' and 'segments'"));
   }
 
   @Test
@@ -207,10 +201,11 @@ public class DruidInputSourceTest
                         + "\"dataSource\":\"foo\""
                         + "}";
 
-    expectedException.expect(JsonProcessingException.class);
-    expectedException.expectMessage("Specify exactly one of 'interval' and 'segments'");
-
-    mapper.readValue(json, InputSource.class);
+    final JsonProcessingException exception = Assertions.assertThrows(
+        JsonProcessingException.class,
+        () -> mapper.readValue(json, InputSource.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Specify exactly one of 'interval' and 'segments'"));
   }
 
   @Test
@@ -221,10 +216,11 @@ public class DruidInputSourceTest
                         + "\"interval\":\"2000-01-01T00:00:00.000Z/2001-01-01T00:00:00.000Z\""
                         + "}";
 
-    expectedException.expect(JsonProcessingException.class);
-    expectedException.expectMessage("dataSource");
-
-    mapper.readValue(json, InputSource.class);
+    final JsonProcessingException exception = Assertions.assertThrows(
+        JsonProcessingException.class,
+        () -> mapper.readValue(json, InputSource.class)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("dataSource"));
   }
 
   @Test
@@ -257,8 +253,8 @@ public class DruidInputSourceTest
     );
     InputRowSchema inputSourceReader = druidInputSource.getInputRowSchemaToUse(inputRowSchema);
     ColumnsFilter columnsFilter = inputSourceReader.getColumnsFilter();
-    Assert.assertTrue(columnsFilter.apply(column));
-    Assert.assertTrue(columnsFilter.apply(metricName));
+    Assertions.assertTrue(columnsFilter.apply(column));
+    Assertions.assertTrue(columnsFilter.apply(metricName));
   }
 
   @Test
@@ -291,8 +287,8 @@ public class DruidInputSourceTest
     );
     InputRowSchema inputSourceReader = druidInputSource.getInputRowSchemaToUse(inputRowSchema);
     ColumnsFilter columnsFilter = inputSourceReader.getColumnsFilter();
-    Assert.assertTrue(columnsFilter.apply(column));
-    Assert.assertFalse(columnsFilter.apply(metricName));
+    Assertions.assertTrue(columnsFilter.apply(column));
+    Assertions.assertFalse(columnsFilter.apply(metricName));
   }
 
   @Test
@@ -312,6 +308,6 @@ public class DruidInputSourceTest
         segmentCacheManagerFactory,
         taskConfig
     );
-    Assert.assertEquals(ImmutableSet.of(DruidInputSource.TYPE_KEY), druidInputSource.getTypes());
+    Assertions.assertEquals(ImmutableSet.of(DruidInputSource.TYPE_KEY), druidInputSource.getTypes());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentInputFormatTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentInputFormatTest.java
@@ -27,12 +27,12 @@ import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.FileEntity;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 
 public class DruidSegmentInputFormatTest
@@ -54,7 +54,7 @@ public class DruidSegmentInputFormatTest
         DruidSegmentReaderTest.makeInputEntity(Intervals.of("2000/P1D"), null, ImmutableList.of("s", "d"), ImmutableList.of("cnt", "met_s")),
         null
     );
-    Assert.assertTrue(reader instanceof DruidSegmentReader);
+    Assertions.assertTrue(reader instanceof DruidSegmentReader);
   }
 
 
@@ -67,7 +67,7 @@ public class DruidSegmentInputFormatTest
         DruidSegmentReaderTest.makeTombstoneInputEntity(Intervals.of("2000/P1D")),
         null
     );
-    Assert.assertTrue(reader instanceof DruidTombstoneSegmentReader);
+    Assertions.assertTrue(reader instanceof DruidTombstoneSegmentReader);
   }
 
   @Test
@@ -84,6 +84,6 @@ public class DruidSegmentInputFormatTest
     String expectedMessage =
         "org.apache.druid.indexing.input.DruidSegmentInputEntity required, but org.apache.druid.data.input.impl.FileEntity provided.";
     String actualMessage = exception.getMessage();
-    Assert.assertEquals(expectedMessage, actualMessage);
+    Assertions.assertEquals(expectedMessage, actualMessage);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
@@ -65,11 +65,9 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,13 +78,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DruidSegmentReaderTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
   private File segmentDirectory;
   private long segmentSize;
 
@@ -96,7 +91,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
 
   private InputStats inputStats;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     // Write a segment with two rows in it, with columns: s (string), d (double), cnt (long), met_s (complex).
@@ -148,10 +143,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("2000"),
@@ -178,7 +173,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -244,11 +239,11 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
             new NotDimFilter(new SelectorDimFilter("a", "foo1", null)),
             new NotDimFilter(new SelectorDimFilter("b", "bar1", null))
         ),
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(Arrays.asList(rows.get(2), rows.get(1)), readRows(reader));
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(Arrays.asList(rows.get(2), rows.get(1)), readRows(reader));
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -258,8 +253,8 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         makeTombstoneInputEntity(Intervals.of("2000/P1D"))
     );
 
-    Assert.assertFalse(reader.intermediateRowIterator().hasNext());
-    Assert.assertTrue(readRows(reader).isEmpty());
+    Assertions.assertFalse(reader.intermediateRowIterator().hasNext());
+    Assertions.assertTrue(readRows(reader).isEmpty());
   }
 
   @Test
@@ -276,7 +271,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "DruidSegmentInputEntity must be created from a tombstone.",
         exception.getMessage()
     );
@@ -297,10 +292,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("2000"),
@@ -327,7 +322,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -340,10 +335,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         DimensionsSpec.builder().setDimensionExclusions(ImmutableList.of("__time", "strCol", "cnt", "met_s")).build(),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("2000"),
@@ -370,7 +365,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -388,10 +383,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.inclusionBased(ImmutableSet.of("__time", "strCol", "dblCol")),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("2000"),
@@ -414,7 +409,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -432,10 +427,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.inclusionBased(ImmutableSet.of("strCol", "dblCol")),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("1971"),
@@ -456,7 +451,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -474,10 +469,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         new SelectorDimFilter("dblCol", "1.23", null),
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("2000"),
@@ -493,7 +488,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -511,10 +506,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("1970-01-01T00:00:01.000Z"),
@@ -541,7 +536,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -559,10 +554,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("31969-04-01T00:00:00.000Z"),
@@ -589,7 +584,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -607,10 +602,10 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             new MapBasedInputRow(
                 DateTimes.of("1971"),
@@ -637,7 +632,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         readRows(reader)
     );
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   @Test
@@ -681,8 +676,8 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         iterator.next();
       }
     }
-    Assert.assertTrue("File is not closed", isFileClosed.booleanValue());
-    Assert.assertTrue("Sequence is not closed", isSequenceClosed.booleanValue());
+    Assertions.assertTrue(isFileClosed.booleanValue(), "File is not closed");
+    Assertions.assertTrue(isSequenceClosed.booleanValue(), "Sequence is not closed");
   }
 
   @Test
@@ -735,7 +730,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
                     .rows(rows)
                     .buildIncrementalIndex();
 
-    File segmentDirectory = temporaryFolder.newFolder();
+    File segmentDirectory = FileUtils.createTempDir();
     long segmentSize;
     try {
       TestHelper.getTestIndexMergerV9(
@@ -773,27 +768,27 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
     List<InputRow> readRows = readRows(reader);
 
-    Assert.assertEquals(ImmutableList.of("strCol", "dblCol", "arrayCol"), readRows.get(0).getDimensions());
-    Assert.assertEquals(DateTimes.of("2000T").getMillis(), readRows.get(0).getTimestampFromEpoch());
-    Assert.assertEquals("foo", readRows.get(0).getRaw("strCol"));
-    Assert.assertEquals(1.23, readRows.get(0).getRaw("dblCol"));
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) readRows.get(0).getRaw("arrayCol"));
-    Assert.assertEquals(1L, readRows.get(0).getRaw("cnt"));
-    Assert.assertEquals(makeHLLC("foo"), readRows.get(0).getRaw("met_s"));
+    Assertions.assertEquals(ImmutableList.of("strCol", "dblCol", "arrayCol"), readRows.get(0).getDimensions());
+    Assertions.assertEquals(DateTimes.of("2000T").getMillis(), readRows.get(0).getTimestampFromEpoch());
+    Assertions.assertEquals("foo", readRows.get(0).getRaw("strCol"));
+    Assertions.assertEquals(1.23, readRows.get(0).getRaw("dblCol"));
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) readRows.get(0).getRaw("arrayCol"));
+    Assertions.assertEquals(1L, readRows.get(0).getRaw("cnt"));
+    Assertions.assertEquals(makeHLLC("foo"), readRows.get(0).getRaw("met_s"));
 
-    Assert.assertEquals(DateTimes.of("2000T1").getMillis(), readRows.get(1).getTimestampFromEpoch());
-    Assert.assertEquals("bar", readRows.get(1).getRaw("strCol"));
-    Assert.assertEquals(4.56, readRows.get(1).getRaw("dblCol"));
-    Assert.assertArrayEquals(new Object[]{"x", "y", "z"}, (Object[]) readRows.get(1).getRaw("arrayCol"));
-    Assert.assertEquals(1L, readRows.get(1).getRaw("cnt"));
-    Assert.assertEquals(makeHLLC("bar"), readRows.get(1).getRaw("met_s"));
+    Assertions.assertEquals(DateTimes.of("2000T1").getMillis(), readRows.get(1).getTimestampFromEpoch());
+    Assertions.assertEquals("bar", readRows.get(1).getRaw("strCol"));
+    Assertions.assertEquals(4.56, readRows.get(1).getRaw("dblCol"));
+    Assertions.assertArrayEquals(new Object[]{"x", "y", "z"}, (Object[]) readRows.get(1).getRaw("arrayCol"));
+    Assertions.assertEquals(1L, readRows.get(1).getRaw("cnt"));
+    Assertions.assertEquals(makeHLLC("bar"), readRows.get(1).getRaw("met_s"));
 
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
 
   }
 
@@ -847,7 +842,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
                     .rows(rows)
                     .buildIncrementalIndex();
 
-    File segmentDirectory = temporaryFolder.newFolder();
+    File segmentDirectory = FileUtils.createTempDir();
     long segmentSize;
     try {
       TestHelper.getTestIndexMergerV9(
@@ -885,27 +880,27 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDir()
     );
 
     List<InputRow> readRows = readRows(reader);
 
-    Assert.assertEquals(ImmutableList.of("strCol", "dblCol", "arrayCol"), readRows.get(0).getDimensions());
-    Assert.assertEquals(DateTimes.of("2000T").getMillis(), readRows.get(0).getTimestampFromEpoch());
-    Assert.assertEquals("foo", readRows.get(0).getRaw("strCol"));
-    Assert.assertEquals(1.23, readRows.get(0).getRaw("dblCol"));
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) readRows.get(0).getRaw("arrayCol"));
-    Assert.assertEquals(1L, readRows.get(0).getRaw("cnt"));
-    Assert.assertEquals(makeHLLC("foo"), readRows.get(0).getRaw("met_s"));
+    Assertions.assertEquals(ImmutableList.of("strCol", "dblCol", "arrayCol"), readRows.get(0).getDimensions());
+    Assertions.assertEquals(DateTimes.of("2000T").getMillis(), readRows.get(0).getTimestampFromEpoch());
+    Assertions.assertEquals("foo", readRows.get(0).getRaw("strCol"));
+    Assertions.assertEquals(1.23, readRows.get(0).getRaw("dblCol"));
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) readRows.get(0).getRaw("arrayCol"));
+    Assertions.assertEquals(1L, readRows.get(0).getRaw("cnt"));
+    Assertions.assertEquals(makeHLLC("foo"), readRows.get(0).getRaw("met_s"));
 
-    Assert.assertEquals(DateTimes.of("2000T1").getMillis(), readRows.get(1).getTimestampFromEpoch());
-    Assert.assertEquals("bar", readRows.get(1).getRaw("strCol"));
-    Assert.assertEquals(4.56, readRows.get(1).getRaw("dblCol"));
-    Assert.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) readRows.get(1).getRaw("arrayCol"));
-    Assert.assertEquals(1L, readRows.get(1).getRaw("cnt"));
-    Assert.assertEquals(makeHLLC("bar"), readRows.get(1).getRaw("met_s"));
+    Assertions.assertEquals(DateTimes.of("2000T1").getMillis(), readRows.get(1).getTimestampFromEpoch());
+    Assertions.assertEquals("bar", readRows.get(1).getRaw("strCol"));
+    Assertions.assertEquals(4.56, readRows.get(1).getRaw("dblCol"));
+    Assertions.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) readRows.get(1).getRaw("arrayCol"));
+    Assertions.assertEquals(1L, readRows.get(1).getRaw("cnt"));
+    Assertions.assertEquals(makeHLLC("bar"), readRows.get(1).getRaw("met_s"));
 
-    Assert.assertEquals(segmentSize, inputStats.getProcessedBytes());
+    Assertions.assertEquals(segmentSize, inputStats.getProcessedBytes());
   }
 
   private InputEntity makeInputEntity(final Interval interval)
@@ -1022,7 +1017,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
                     .rows(rows)
                     .buildIncrementalIndex();
 
-    segmentDirectory = temporaryFolder.newFolder();
+    segmentDirectory = FileUtils.createTempDir();
 
     try {
       TestHelper.getTestIndexMergerV9(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
@@ -65,13 +65,14 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -83,6 +84,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DruidSegmentReaderTest extends InitializedNullHandlingTest
 {
+  @TempDir
+  private File temporaryFolder;
+
   private File segmentDirectory;
   private long segmentSize;
 
@@ -91,14 +95,6 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
   private List<AggregatorFactory> metrics;
 
   private InputStats inputStats;
-
-  @AfterEach
-  public void tearDown() throws IOException
-  {
-    if (segmentDirectory != null) {
-      FileUtils.deleteDirectory(segmentDirectory);
-    }
-  }
 
   @BeforeEach
   public void setUp() throws IOException
@@ -152,7 +148,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -248,7 +244,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
             new NotDimFilter(new SelectorDimFilter("a", "foo1", null)),
             new NotDimFilter(new SelectorDimFilter("b", "bar1", null))
         ),
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(Arrays.asList(rows.get(2), rows.get(1)), readRows(reader));
@@ -301,7 +297,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -344,7 +340,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         DimensionsSpec.builder().setDimensionExclusions(ImmutableList.of("__time", "strCol", "cnt", "met_s")).build(),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -392,7 +388,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.inclusionBased(ImmutableSet.of("__time", "strCol", "dblCol")),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -436,7 +432,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.inclusionBased(ImmutableSet.of("strCol", "dblCol")),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -478,7 +474,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         new SelectorDimFilter("dblCol", "1.23", null),
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -515,7 +511,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -563,7 +559,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -611,7 +607,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     Assertions.assertEquals(
@@ -739,7 +735,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
                     .rows(rows)
                     .buildIncrementalIndex();
 
-    File segmentDirectory = FileUtils.createTempDir();
+    File segmentDirectory = createTempDir();
     long segmentSize;
     try {
       TestHelper.getTestIndexMergerV9(
@@ -777,7 +773,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     List<InputRow> readRows = readRows(reader);
@@ -851,7 +847,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
                     .rows(rows)
                     .buildIncrementalIndex();
 
-    File segmentDirectory = FileUtils.createTempDir();
+    File segmentDirectory = createTempDir();
     long segmentSize;
     try {
       TestHelper.getTestIndexMergerV9(
@@ -889,7 +885,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
         ),
         ColumnsFilter.all(),
         null,
-        FileUtils.createTempDir()
+        createTempDir()
     );
 
     List<InputRow> readRows = readRows(reader);
@@ -1026,7 +1022,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
                     .rows(rows)
                     .buildIncrementalIndex();
 
-    segmentDirectory = FileUtils.createTempDir();
+    segmentDirectory = createTempDir();
 
     try {
       TestHelper.getTestIndexMergerV9(
@@ -1042,6 +1038,11 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
     finally {
       incrementalIndex.close();
     }
+  }
+
+  private File createTempDir() throws IOException
+  {
+    return Files.createTempDirectory(temporaryFolder.toPath(), "segment").toFile();
   }
 
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
@@ -65,6 +65,7 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,6 +91,14 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
   private List<AggregatorFactory> metrics;
 
   private InputStats inputStats;
+
+  @AfterEach
+  public void tearDown() throws IOException
+  {
+    if (segmentDirectory != null) {
+      FileUtils.deleteDirectory(segmentDirectory);
+    }
+  }
 
   @BeforeEach
   public void setUp() throws IOException

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
@@ -1039,7 +1039,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
     }
   }
 
-  private File createTempDir() throws IOException
+  private File createTempDir()
   {
     return FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "segment");
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/DruidSegmentReaderTest.java
@@ -72,7 +72,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1042,7 +1041,7 @@ public class DruidSegmentReaderTest extends InitializedNullHandlingTest
 
   private File createTempDir() throws IOException
   {
-    return Files.createTempDirectory(temporaryFolder.toPath(), "segment").toFile();
+    return FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "segment");
   }
 
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/GeneratorInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/GeneratorInputSourceTest.java
@@ -39,8 +39,8 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.generator.DataGenerator;
 import org.apache.druid.segment.generator.GeneratorBasicSchemas;
 import org.apache.druid.segment.generator.GeneratorColumnSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -65,7 +65,7 @@ public class GeneratorInputSourceTest
     String serialized = MAPPER.writeValueAsString(inputSource);
     GeneratorInputSource sauce = MAPPER.readValue(serialized, GeneratorInputSource.class);
 
-    Assert.assertEquals(inputSource, sauce);
+    Assertions.assertEquals(inputSource, sauce);
   }
 
   @Test
@@ -96,7 +96,7 @@ public class GeneratorInputSourceTest
     String serialized = MAPPER.writeValueAsString(inputSource);
     GeneratorInputSource sauce = MAPPER.readValue(serialized, GeneratorInputSource.class);
 
-    Assert.assertEquals(inputSource, sauce);
+    Assertions.assertEquals(inputSource, sauce);
   }
 
   @Test
@@ -146,13 +146,13 @@ public class GeneratorInputSourceTest
 
     InputRow first = iterator.next();
     InputRow generatorFirst = MapInputRowParser.parse(rowSchema, generator.nextRaw(rowSchema.getTimestampSpec().getTimestampColumn()));
-    Assert.assertEquals(generatorFirst, first);
-    Assert.assertTrue(iterator.hasNext());
+    Assertions.assertEquals(generatorFirst, first);
+    Assertions.assertTrue(iterator.hasNext());
     int i;
     for (i = 1; iterator.hasNext(); i++) {
       iterator.next();
     }
-    Assert.assertEquals(numRows, i);
+    Assertions.assertEquals(numRows, i);
   }
 
   @Test
@@ -169,10 +169,10 @@ public class GeneratorInputSourceTest
         1.0
     );
 
-    Assert.assertEquals(2, inputSource.estimateNumSplits(null, null));
-    Assert.assertFalse(inputSource.needsFormat());
-    Assert.assertEquals(2, inputSource.createSplits(null, null).count());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, inputSource.estimateNumSplits(null, null));
+    Assertions.assertFalse(inputSource.needsFormat());
+    Assertions.assertEquals(2, inputSource.createSplits(null, null).count());
+    Assertions.assertEquals(
         Long.valueOf(2048L),
         ((GeneratorInputSource) inputSource.withSplit(new InputSplit<>(2048L))).getSeed()
     );
@@ -192,6 +192,6 @@ public class GeneratorInputSourceTest
         1.0
     );
 
-    Assert.assertEquals(ImmutableSet.of(IndexingServiceInputSourceModule.GENERATOR_SCHEME), inputSource.getTypes());
+    Assertions.assertEquals(ImmutableSet.of(IndexingServiceInputSourceModule.GENERATOR_SCHEME), inputSource.getTypes());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/InputRowSchemasTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/InputRowSchemasTest.java
@@ -40,8 +40,8 @@ import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.segment.transform.ExpressionTransform;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -66,7 +66,7 @@ public class InputRowSchemasTest extends InitializedNullHandlingTest
         }
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ColumnsFilter.inclusionBased(
             ImmutableSet.of(
                 "ts",
@@ -99,7 +99,7 @@ public class InputRowSchemasTest extends InitializedNullHandlingTest
         }
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ColumnsFilter.exclusionBased(
             ImmutableSet.of(
                 "foo"
@@ -137,10 +137,10 @@ public class InputRowSchemasTest extends InitializedNullHandlingTest
                   .build();
 
     InputRowSchema inputRowSchema = InputRowSchemas.fromDataSchema(schema);
-    Assert.assertEquals(timestampSpec, inputRowSchema.getTimestampSpec());
-    Assert.assertEquals(dimensionsSpec.getDimensions(), inputRowSchema.getDimensionsSpec().getDimensions());
-    Assert.assertEquals(dimensionsSpec.getDimensionNames(), inputRowSchema.getDimensionsSpec().getDimensionNames());
-    Assert.assertEquals(ImmutableSet.of("count", "met"), inputRowSchema.getMetricNames());
+    Assertions.assertEquals(timestampSpec, inputRowSchema.getTimestampSpec());
+    Assertions.assertEquals(dimensionsSpec.getDimensions(), inputRowSchema.getDimensionsSpec().getDimensions());
+    Assertions.assertEquals(dimensionsSpec.getDimensionNames(), inputRowSchema.getDimensionsSpec().getDimensionNames());
+    Assertions.assertEquals(ImmutableSet.of("count", "met"), inputRowSchema.getMetricNames());
   }
 
   @Test
@@ -164,9 +164,9 @@ public class InputRowSchemasTest extends InitializedNullHandlingTest
                                   .build();
 
     InputRowSchema inputRowSchema = InputRowSchemas.fromDataSchema(schema);
-    Assert.assertEquals(timestampSpec, inputRowSchema.getTimestampSpec());
-    Assert.assertEquals(dimensionsSpec.getDimensions(), inputRowSchema.getDimensionsSpec().getDimensions());
-    Assert.assertEquals(dimensionsSpec.getDimensionNames(), inputRowSchema.getDimensionsSpec().getDimensionNames());
-    Assert.assertEquals(ImmutableSet.of(), inputRowSchema.getMetricNames());
+    Assertions.assertEquals(timestampSpec, inputRowSchema.getTimestampSpec());
+    Assertions.assertEquals(dimensionsSpec.getDimensions(), inputRowSchema.getDimensionsSpec().getDimensions());
+    Assertions.assertEquals(dimensionsSpec.getDimensionNames(), inputRowSchema.getDimensionsSpec().getDimensionNames());
+    Assertions.assertEquals(ImmutableSet.of(), inputRowSchema.getMetricNames());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/input/WindowedSegmentIdTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/input/WindowedSegmentIdTest.java
@@ -20,7 +20,7 @@
 package org.apache.druid.indexing.input;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class WindowedSegmentIdTest
 {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/QuartzCronSchedulerConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/QuartzCronSchedulerConfigTest.java
@@ -22,19 +22,16 @@ package org.apache.druid.indexing.scheduledbatch;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class QuartzCronSchedulerConfigTest
 {
@@ -107,19 +104,19 @@ public class QuartzCronSchedulerConfigTest
   @Test
   public void testInvalidCronExpression()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            DruidException.class,
-            () -> new QuartzCronSchedulerConfig("0 15 10 * *")
-        ),
-        // Expected parts order varies due to non-deterministic Set iteration.
-        Matchers.anyOf(
-            DruidExceptionMatcher.invalidInput().expectMessageIs(
-                "Quartz schedule[0 15 10 * *] is invalid: [Cron expression contains 5 parts but we expect one of [6, 7]]"
-            ),
-            DruidExceptionMatcher.invalidInput().expectMessageIs(
-                "Quartz schedule[0 15 10 * *] is invalid: [Cron expression contains 5 parts but we expect one of [7, 6]]"
-            )
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () -> new QuartzCronSchedulerConfig("0 15 10 * *")
+    );
+    assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    assertEquals("invalidInput", exception.getErrorCode());
+    // Expected parts order varies due to non-deterministic Set iteration.
+    Assertions.assertTrue(
+        exception.getMessage().equals(
+            "Quartz schedule[0 15 10 * *] is invalid: [Cron expression contains 5 parts but we expect one of [6, 7]]"
+        ) || exception.getMessage().equals(
+            "Quartz schedule[0 15 10 * *] is invalid: [Cron expression contains 5 parts but we expect one of [7, 6]]"
         )
     );
   }
@@ -127,14 +124,16 @@ public class QuartzCronSchedulerConfigTest
   @Test
   public void testMacroExpressionsNotSupported()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            DruidException.class,
-            () -> new QuartzCronSchedulerConfig("@daily")
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Quartz schedule[@daily] is invalid: [Nicknames not supported!]"
-        )
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () -> new QuartzCronSchedulerConfig("@daily")
+    );
+    assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    assertEquals("invalidInput", exception.getErrorCode());
+    assertEquals(
+        "Quartz schedule[@daily] is invalid: [Nicknames not supported!]",
+        exception.getMessage()
     );
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchStatusTrackerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchStatusTrackerTest.java
@@ -23,17 +23,16 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.query.http.SqlTaskStatus;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ScheduledBatchStatusTrackerTest
 {
@@ -46,7 +45,7 @@ public class ScheduledBatchStatusTrackerTest
 
   private ScheduledBatchStatusTracker statusTracker;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     statusTracker = new ScheduledBatchStatusTracker();
@@ -213,7 +212,7 @@ public class ScheduledBatchStatusTrackerTest
                                                   .map(BatchSupervisorTaskStatus::getTaskStatus)
                                                   .sorted(Comparator.comparing(TaskStatus::getId))
                                                   .collect(Collectors.toList());
-    Assert.assertEquals(
+    assertEquals(
         sortedActualStatues,
         ImmutableList.of(TaskStatus.success(TASK_ID_1), TaskStatus.failure(TASK_ID_2, "Task failed"))
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorSpecTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import org.apache.druid.client.broker.BrokerClient;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.guice.SupervisorModule;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.jackson.DefaultObjectMapper;
@@ -33,18 +32,17 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.explain.ExplainAttributes;
 import org.apache.druid.query.explain.ExplainPlan;
 import org.apache.druid.query.http.ClientSqlQuery;
-import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ScheduledBatchSupervisorSpecTest
 {
@@ -53,7 +51,7 @@ public class ScheduledBatchSupervisorSpecTest
   private ScheduledBatchTaskManager scheduler;
   private ClientSqlQuery query;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     brokerClient = Mockito.mock(BrokerClient.class);
@@ -206,23 +204,25 @@ public class ScheduledBatchSupervisorSpecTest
                ))
            ));
 
-    MatcherAssert.assertThat(
-        assertThrows(
-            DruidException.class,
-            () -> new ScheduledBatchSupervisorSpec(
-              query,
-              new UnixCronSchedulerConfig("* * * * *"),
-              true,
-              null,
-              null,
-              OBJECT_MAPPER,
-              scheduler,
-              brokerClient
-            )
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "SELECT queries are not supported by the [scheduled_batch] supervisor. Only INSERT or REPLACE ingest queries are allowed."
+    final DruidException exception = assertThrows(
+        DruidException.class,
+        () -> new ScheduledBatchSupervisorSpec(
+          query,
+          new UnixCronSchedulerConfig("* * * * *"),
+          true,
+          null,
+          null,
+          OBJECT_MAPPER,
+          scheduler,
+          brokerClient
         )
+    );
+    assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    assertEquals("invalidInput", exception.getErrorCode());
+    assertEquals(
+        "SELECT queries are not supported by the [scheduled_batch] supervisor. Only INSERT or REPLACE ingest queries are allowed.",
+        exception.getMessage()
     );
   }
 
@@ -239,7 +239,7 @@ public class ScheduledBatchSupervisorSpecTest
         scheduler,
         brokerClient
     );
-    Assert.assertTrue(supervisorSpec.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(supervisorSpec.getInputSourceResources().isEmpty());
   }
 
   private void testSerde(final ScheduledBatchSupervisorSpec spec)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchSupervisorTest.java
@@ -31,11 +31,11 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.explain.ExplainAttributes;
 import org.apache.druid.query.explain.ExplainPlan;
 import org.apache.druid.query.http.ClientSqlQuery;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ScheduledBatchSupervisorTest
 {
@@ -44,7 +44,7 @@ public class ScheduledBatchSupervisorTest
   private ScheduledBatchTaskManager scheduler;
   private ClientSqlQuery query;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     brokerClient = Mockito.mock(BrokerClient.class);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/ScheduledBatchTaskManagerTest.java
@@ -41,17 +41,17 @@ import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ScheduledBatchTaskManagerTest
 {
@@ -89,7 +89,7 @@ public class ScheduledBatchTaskManagerTest
 
   private ScheduledBatchTaskManager scheduler;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     brokerClient = Mockito.mock(BrokerClient.class);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/UnixCronSchedulerConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/scheduledbatch/UnixCronSchedulerConfigTest.java
@@ -22,17 +22,15 @@ package org.apache.druid.indexing.scheduledbatch;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.jackson.DefaultObjectMapper;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class UnixCronSchedulerConfigTest
 {
@@ -109,14 +107,16 @@ public class UnixCronSchedulerConfigTest
   @Test
   public void testInvalidUnixCronExpression()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            DruidException.class,
-            () -> new UnixCronSchedulerConfig("0 15 10 * * ? *")
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Unix schedule[0 15 10 * * ? *] is invalid: [Cron expression contains 7 parts but we expect one of [5]]"
-        )
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () -> new UnixCronSchedulerConfig("0 15 10 * * ? *")
+    );
+    assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    assertEquals("invalidInput", exception.getErrorCode());
+    assertEquals(
+        "Unix schedule[0 15 10 * * ? *] is invalid: [Cron expression contains 7 parts but we expect one of [5]]",
+        exception.getMessage()
     );
   }
 }


### PR DESCRIPTION
## Summary

- Migrate the common indexing-service support tests to JUnit 5.
- Cover appenderator, residual common support, task logs, compact, input, and scheduled-batch tests.
- Replace JUnit 4 and Hamcrest usage with Jupiter and AssertJ APIs, while using Druid's existing temporary-directory utilities.
- Keep this batch independent from the Task Actions/Compaction, ingestion/parallel, Overlord, seekable-stream, and worker batches.

## Validation

- Test compilation passed.
- 33 targeted classes passed: 191 tests, 0 failures, 0 errors, 0 skips.
- Maven static verification passed with Checkstyle, forbidden APIs, PMD, and Enforcer.
- Legacy/prohibited usage scans and `git diff --check` passed.

## Tracking

Part of [#13948](https://github.com/apache/druid/issues/13948).

Related: [#19910](https://github.com/apache/druid/pull/19910).
