### PR TITLE
test(indexing): migrate seekable-stream tests to JUnit 5

### DIFF
--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -109,16 +109,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>provided</scope>

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -35,10 +35,11 @@ import com.google.common.util.concurrent.AsyncFunction;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.inject.Guice;
 import com.google.inject.Injector;
+import com.google.inject.Scopes;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.cli.CliPeon;
-import org.apache.druid.cli.CliPeonTest;
 import org.apache.druid.cli.PeonLoadSpecHolder;
 import org.apache.druid.cli.PeonTaskHolder;
 import org.apache.druid.data.input.InputEntity;
@@ -59,6 +60,8 @@ import org.apache.druid.data.input.kafkainput.KafkaInputFormat;
 import org.apache.druid.data.input.kafkainput.KafkaStringHeaderFormat;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.guice.GuiceInjectors;
+import org.apache.druid.guice.LazySingleton;
+import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.indexer.IngestionState;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
@@ -81,6 +84,7 @@ import org.apache.druid.indexing.seekablestream.SeekableStreamIndexTaskTestBase;
 import org.apache.druid.indexing.seekablestream.SeekableStreamStartSequenceNumbers;
 import org.apache.druid.indexing.seekablestream.SettableByteEntity;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
+import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -93,6 +97,7 @@ import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.java.util.emitter.core.EventMap;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
+import org.apache.druid.java.util.metrics.StubServiceEmitterModule;
 import org.apache.druid.java.util.metrics.TaskHolder;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.query.DefaultGenericQueryMetricsFactory;
@@ -148,9 +153,12 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import javax.validation.Validation;
+import javax.validation.Validator;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -301,9 +309,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
   @BeforeEach
   public void setupTest() throws IOException
   {
-    super.tempFolder.create();
-    derby.before();
-    setupBase();
     handoffConditionTimeout = 0;
     reportParseExceptions = false;
     logParseExceptions = true;
@@ -328,9 +333,6 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
     reportsFile.delete();
     destroyToolboxFactory();
-    tearDownBase();
-    derby.after();
-    super.tempFolder.delete();
   }
 
   @AfterAll
@@ -3505,7 +3507,7 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
         )
     );
 
-    final Injector peonInjector = CliPeonTest.makePeonInjectorWithStubEmitter(task, super.tempFolder, OBJECT_MAPPER);
+    final Injector peonInjector = makePeonInjectorWithStubEmitter(task);
     Emitter peonEmitter = peonInjector.getInstance(Emitter.class);
     Assertions.assertTrue(peonEmitter instanceof StubServiceEmitter);
     emitter = (StubServiceEmitter) peonEmitter;
@@ -3673,6 +3675,41 @@ public class KafkaIndexTaskTest extends SeekableStreamIndexTaskTestBase
       return baseInputFormat;
     }
 
+  }
+
+  private Injector makePeonInjectorWithStubEmitter(Task task) throws IOException
+  {
+    final File taskFile = new File(super.tempFolder, "task.json");
+    FileUtils.write(taskFile, OBJECT_MAPPER.writeValueAsString(task), StandardCharsets.UTF_8);
+
+    final Properties properties = new Properties();
+    properties.setProperty("druid.emitter", "stub");
+
+    final Injector baseInjector = Guice.createInjector(
+        new JacksonModule(),
+        new LifecycleModule(),
+        binder -> {
+          binder.bind(Validator.class).toInstance(Validation.buildDefaultValidatorFactory().getValidator());
+          binder.bindScope(LazySingleton.class, Scopes.SINGLETON);
+          binder.bind(Properties.class).toInstance(properties);
+        }
+    );
+
+    final CliPeon peon = new CliPeon()
+    {
+      @Override
+      protected List<? extends com.google.inject.Module> getModules()
+      {
+        final List<com.google.inject.Module> modules = new ArrayList<>(super.getModules());
+        modules.add(new StubServiceEmitterModule());
+        return modules;
+      }
+    };
+
+    peon.taskAndStatusFile = ImmutableList.of(taskFile.getParent(), "1");
+    peon.configure(properties);
+    peon.configure(properties, baseInjector);
+    return peon.makeInjector(Set.of(NodeRole.PEON));
   }
 
   private static File newFolder(File root, String... subDirs)

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/KafkaRecordSupplierTest.java
@@ -46,7 +46,6 @@ import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,7 +64,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaRecordSupplierTest
@@ -265,16 +263,22 @@ public class KafkaRecordSupplierTest
 
     properties.put("sasl.oauthbearer.token.endpoint.url", "http://localhost:8080/token");
 
-    assertThat(
-        assertThrows(KafkaException.class, () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false, null)),
-        CoreMatchers.instanceOf(KafkaException.class)
+    Assertions.assertInstanceOf(
+        KafkaException.class,
+        Assertions.assertThrows(
+            KafkaException.class,
+            () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false, null)
+        )
     );
 
     properties.remove("sasl.oauthbearer.token.endpoint.url");
     properties.put("sasl.oauthbearer.jwks.endpoint.url", "http://localhost:8080/jwks");
-    assertThat(
-        assertThrows(KafkaException.class, () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false, null)),
-        CoreMatchers.instanceOf(KafkaException.class)
+    Assertions.assertInstanceOf(
+        KafkaException.class,
+        Assertions.assertThrows(
+            KafkaException.class,
+            () -> new KafkaRecordSupplier(properties, OBJECT_MAPPER, null, false, null)
+        )
     );
   }
 

--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpecTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/supervisor/KafkaSupervisorSpecTest.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
 import org.apache.druid.indexing.kafka.KafkaIndexTaskClientFactory;
 import org.apache.druid.indexing.kafka.KafkaIndexTaskModule;
@@ -52,11 +51,18 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Map;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaSupervisorSpecTest
 {
+  private static void assertInvalidInputException(DruidException exception, String message)
+  {
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals(message, exception.getMessage());
+  }
+
   private final ObjectMapper mapper;
 
   public KafkaSupervisorSpecTest()
@@ -473,79 +479,53 @@ public class KafkaSupervisorSpecTest
 
     // Proposed spec being non-kafka is not allowed
     TestSupervisorSpec otherSpec = new TestSupervisorSpec("test", new Object());
-    assertThat(
+    assertInvalidInputException(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(otherSpec)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-            StringUtils.format("Cannot change spec from type[%s] to type[%s]", sourceSpec.getClass().getSimpleName(), otherSpec.getClass().getSimpleName())
+        StringUtils.format(
+            "Cannot change spec from type[%s] to type[%s]",
+            sourceSpec.getClass().getSimpleName(),
+            otherSpec.getClass().getSimpleName()
         )
     );
 
     KafkaSupervisorSpec multiTopicProposedSpec = getSpec(null, "metrics-.*");
-    assertThat(
+    assertInvalidInputException(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(multiTopicProposedSpec)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-             "Update of the input source stream from [(single-topic) metrics] to [(multi-topic) metrics-.*] is not supported for a running supervisor."
-             + "\nTo perform the update safely, follow these steps:"
-             + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
-             + "\n(2) Create a new supervisor with the new input source stream."
-             + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
-         )
+        "Update of the input source stream from [(single-topic) metrics] to [(multi-topic) metrics-.*] is not supported for a running supervisor."
+        + "\nTo perform the update safely, follow these steps:"
+        + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
+        + "\n(2) Create a new supervisor with the new input source stream."
+        + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
     );
 
     KafkaSupervisorSpec singleTopicNewStreamProposedSpec = getSpec("metricsNew", null);
-    assertThat(
+    assertInvalidInputException(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(singleTopicNewStreamProposedSpec)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-            "Update of the input source stream from [metrics] to [metricsNew] is not supported for a running supervisor."
-            + "\nTo perform the update safely, follow these steps:"
-            + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
-            + "\n(2) Create a new supervisor with the new input source stream."
-            + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
-        )
+        "Update of the input source stream from [metrics] to [metricsNew] is not supported for a running supervisor."
+        + "\nTo perform the update safely, follow these steps:"
+        + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
+        + "\n(2) Create a new supervisor with the new input source stream."
+        + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
     );
 
     KafkaSupervisorSpec multiTopicMatchingSourceString = getSpec(null, "metrics");
-    assertThat(
+    assertInvalidInputException(
         assertThrows(DruidException.class, () -> sourceSpec.validateSpecUpdateTo(multiTopicMatchingSourceString)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-            "Update of the input source stream from [(single-topic) metrics] to [(multi-topic) metrics] is not supported for a running supervisor."
-            + "\nTo perform the update safely, follow these steps:"
-            + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
-            + "\n(2) Create a new supervisor with the new input source stream."
-            + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
-        )
+        "Update of the input source stream from [(single-topic) metrics] to [(multi-topic) metrics] is not supported for a running supervisor."
+        + "\nTo perform the update safely, follow these steps:"
+        + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
+        + "\n(2) Create a new supervisor with the new input source stream."
+        + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
     );
 
     // test the inverse as well
-    assertThat(
+    assertInvalidInputException(
         assertThrows(DruidException.class, () -> multiTopicMatchingSourceString.validateSpecUpdateTo(sourceSpec)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-            "Update of the input source stream from [(multi-topic) metrics] to [(single-topic) metrics] is not supported for a running supervisor."
-            + "\nTo perform the update safely, follow these steps:"
-            + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
-            + "\n(2) Create a new supervisor with the new input source stream."
-            + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
-        )
+        "Update of the input source stream from [(multi-topic) metrics] to [(single-topic) metrics] is not supported for a running supervisor."
+        + "\nTo perform the update safely, follow these steps:"
+        + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
+        + "\n(2) Create a new supervisor with the new input source stream."
+        + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
     );
 
     // Test valid spec update. This spec changes context vs the sourceSpec

--- a/extensions-core/kinesis-indexing-service/pom.xml
+++ b/extensions-core/kinesis-indexing-service/pom.xml
@@ -158,7 +158,6 @@
         </dependency>
 
         <!-- Tests -->
-        <!-- SeekableStreamIndexTaskTestBase still uses JUnit 4 rules. -->
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
@@ -208,11 +207,6 @@
             <artifactId>druid-indexing-service</artifactId>
             <version>${project.parent.version}</version>
             <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
+++ b/extensions-core/kinesis-indexing-service/src/test/java/org/apache/druid/indexing/kinesis/KinesisIndexTaskTest.java
@@ -97,7 +97,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
@@ -129,9 +128,6 @@ import java.util.stream.Collectors;
 @SuppressWarnings("unchecked")
 public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
 {
-  @TempDir
-  private File tempFolder;
-
   private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
   private static final String STREAM = "stream";
   private static final String SHARD_ID1 = "1";
@@ -214,9 +210,6 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
   public void setupTest() throws IOException, InterruptedException
   {
     ExpressionProcessing.initializeForTests();
-    super.tempFolder.create();
-    derby.before();
-    super.setupBase();
     handoffConditionTimeout = 0;
     reportParseExceptions = false;
     logParseExceptions = true;
@@ -246,9 +239,6 @@ public class KinesisIndexTaskTest extends SeekableStreamIndexTaskTestBase
     }
     reportsFile.delete();
     destroyToolboxFactory();
-    super.tearDownBase();
-    derby.after();
-    super.tempFolder.delete();
   }
 
   @AfterAll

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorResourceTest.java
@@ -57,13 +57,13 @@ import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.easymock.EasyMockRunner;
+import org.easymock.EasyMockExtension;
 import org.easymock.EasyMockSupport;
 import org.easymock.Mock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -77,7 +77,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-@RunWith(EasyMockRunner.class)
+@ExtendWith(EasyMockExtension.class)
 public class SupervisorResourceTest extends EasyMockSupport
 {
   private static final ObjectMapper OBJECT_MAPPER = TestHelper.makeJsonMapper();
@@ -112,7 +112,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
   private SupervisorResource supervisorResource;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     supervisorResource = new SupervisorResource(
@@ -179,8 +179,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specPost(spec, false, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", true), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", true), response.getEntity());
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
@@ -199,8 +199,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specPost(spec, false, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(Map.of("id", "my-id", "modified", false, "restarted", true), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(Map.of("id", "my-id", "modified", false, "restarted", true), response.getEntity());
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());
@@ -209,7 +209,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specPost(spec, false, request);
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -241,8 +241,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specPost(spec, false, request);
     verifyAll();
 
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "nope"), response.getEntity());
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", "nope"), response.getEntity());
   }
 
   @Test
@@ -274,8 +274,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specPost(spec, true, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", false), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", false), response.getEntity());
 
     resetAll();
 
@@ -292,8 +292,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specPost(spec, true, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(Map.of("id", "my-id", "modified", false, "restarted", false), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(Map.of("id", "my-id", "modified", false, "restarted", false), response.getEntity());
 
     resetAll();
 
@@ -313,8 +313,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specPost(spec, true, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", true), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", true), response.getEntity());
   }
 
   @Test
@@ -345,8 +345,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specPost(spec, false, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", true), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(Map.of("id", "my-id", "modified", true, "restarted", true), response.getEntity());
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());
@@ -355,13 +355,13 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specPost(spec, false, request);
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
 
     resetAll();
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());
     replayAll();
     response = supervisorResource.specPost(spec, null, request);
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
     verifyAll();
   }
 
@@ -389,8 +389,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     EasyMock.expect(authConfig.isEnableInputSourceSecurity()).andReturn(true).times(2);
     replayAll();
 
-    Assert.assertThrows(ForbiddenException.class, () -> supervisorResource.specPost(spec, false, request));
-    Assert.assertThrows(ForbiddenException.class, () -> supervisorResource.specPost(spec, null, request));
+    Assertions.assertThrows(ForbiddenException.class, () -> supervisorResource.specPost(spec, false, request));
+    Assertions.assertThrows(ForbiddenException.class, () -> supervisorResource.specPost(spec, null, request));
     verifyAll();
   }
 
@@ -407,8 +407,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specGetAll(null, null, null, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(SUPERVISOR_IDS, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(SUPERVISOR_IDS, response.getEntity());
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.absent());
@@ -417,7 +417,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specGetAll(null, null, null, request);
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -433,10 +433,10 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specGetAll(null, null, null, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     // Only id1 (datasource1) should be returned since user lacks READ access to datasource2
     Set<String> returnedIds = (Set<String>) response.getEntity();
-    Assert.assertEquals(ImmutableSet.of("id1"), returnedIds);
+    Assertions.assertEquals(ImmutableSet.of("id1"), returnedIds);
   }
 
   @Test
@@ -457,9 +457,9 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specGetAll("", null, null, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     List<SupervisorStatus> specs = (List<SupervisorStatus>) response.getEntity();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         specs.stream()
              .allMatch(spec ->
                            ("id1".equals(spec.getId()) && spec.getDataSource().equals("datasource1") && SPEC1.equals(spec.getSpec())) ||
@@ -486,19 +486,19 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specGetAll(null, null, "", request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     List<SupervisorStatus> specs = (List<SupervisorStatus>) response.getEntity();
     specs.sort(Comparator.comparing(SupervisorStatus::getId));
-    Assert.assertEquals(2, specs.size());
+    Assertions.assertEquals(2, specs.size());
     SupervisorStatus spec = specs.get(0);
-    Assert.assertEquals("id1", spec.getId());
-    Assert.assertEquals("RUNNING", spec.getState());
-    Assert.assertEquals("RUNNING", spec.getDetailedState());
-    Assert.assertEquals(true, spec.isHealthy());
-    Assert.assertEquals("{\"type\":\"SupervisorResourceTest$TestSupervisorSpec\"}", spec.getSpecString());
-    Assert.assertEquals("test", spec.getType());
-    Assert.assertEquals("dummy", spec.getSource());
-    Assert.assertEquals(false, spec.isSuspended());
+    Assertions.assertEquals("id1", spec.getId());
+    Assertions.assertEquals("RUNNING", spec.getState());
+    Assertions.assertEquals("RUNNING", spec.getDetailedState());
+    Assertions.assertEquals(true, spec.isHealthy());
+    Assertions.assertEquals("{\"type\":\"SupervisorResourceTest$TestSupervisorSpec\"}", spec.getSpecString());
+    Assertions.assertEquals("test", spec.getType());
+    Assertions.assertEquals("dummy", spec.getSource());
+    Assertions.assertEquals(false, spec.isSuspended());
   }
 
   @Test
@@ -519,9 +519,9 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specGetAll(null, true, null, request);
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     List<SupervisorStatus> states = (List<SupervisorStatus>) response.getEntity();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         states.stream()
               .allMatch(state -> {
                 final String id = (String) state.getId();
@@ -553,12 +553,12 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.specGet("my-id");
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(spec, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(spec, response.getEntity());
 
     response = supervisorResource.specGet("my-id-2");
 
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
     verifyAll();
 
     resetAll();
@@ -569,7 +569,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specGet("my-id");
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -584,12 +584,12 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.specGetStatus("my-id");
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(report, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(report, response.getEntity());
 
     response = supervisorResource.specGetStatus("my-id-2");
 
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
     verifyAll();
 
     resetAll();
@@ -600,7 +600,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specGetStatus("my-id");
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -614,18 +614,18 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.specGetHealth("my-id");
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("healthy", true), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("healthy", true), response.getEntity());
 
     response = supervisorResource.specGetHealth("my-id-2");
 
-    Assert.assertEquals(503, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("healthy", false), response.getEntity());
+    Assertions.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("healthy", false), response.getEntity());
 
     response = supervisorResource.specGetHealth("my-id-3");
 
-    Assert.assertEquals(404, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("error", "[my-id-3] does not exist or health check not implemented"),
         response.getEntity()
     );
@@ -653,10 +653,10 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specSuspend("my-id");
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     TestSupervisorSpec responseSpec = (TestSupervisorSpec) response.getEntity();
-    Assert.assertEquals(suspended.id, responseSpec.id);
-    Assert.assertEquals(suspended.suspended, responseSpec.suspended);
+    Assertions.assertEquals(suspended.id, responseSpec.id);
+    Assertions.assertEquals(suspended.suspended, responseSpec.suspended);
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
@@ -667,8 +667,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specSuspend("my-id");
     verifyAll();
 
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "[my-id] is already suspended"), response.getEntity());
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", "[my-id] is already suspended"), response.getEntity());
   }
 
   @Test
@@ -691,10 +691,10 @@ public class SupervisorResourceTest extends EasyMockSupport
     Response response = supervisorResource.specResume("my-id");
     verifyAll();
 
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     TestSupervisorSpec responseSpec = (TestSupervisorSpec) response.getEntity();
-    Assert.assertEquals(running.id, responseSpec.id);
-    Assert.assertEquals(running.suspended, responseSpec.suspended);
+    Assertions.assertEquals(running.id, responseSpec.id);
+    Assertions.assertEquals(running.suspended, responseSpec.suspended);
     resetAll();
 
     EasyMock.expect(taskMaster.getSupervisorManager()).andReturn(Optional.of(supervisorManager));
@@ -705,8 +705,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specResume("my-id");
     verifyAll();
 
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("error", "[my-id] is already running"), response.getEntity());
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("error", "[my-id] is already running"), response.getEntity());
   }
 
   @Test
@@ -719,12 +719,12 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.terminate("my-id");
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
 
     response = supervisorResource.terminate("my-id-2");
 
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
     verifyAll();
 
     resetAll();
@@ -735,7 +735,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.terminate("my-id");
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -752,8 +752,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.suspendAll(request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
     verifyAll();
   }
 
@@ -770,8 +770,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.suspendAll(request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
     verifyAll();
   }
 
@@ -789,8 +789,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.resumeAll(request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
     verifyAll();
   }
 
@@ -807,8 +807,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.resumeAll(request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
     verifyAll();
   }
 
@@ -826,8 +826,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.terminateAll(request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
     verifyAll();
   }
 
@@ -844,8 +844,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.terminateAll(request);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("status", "success"), response.getEntity());
     verifyAll();
   }
 
@@ -920,8 +920,8 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.specGetAllHistory(request);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(history, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(history, response.getEntity());
 
     resetAll();
 
@@ -931,7 +931,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specGetAllHistory(request);
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -1054,8 +1054,8 @@ public class SupervisorResourceTest extends EasyMockSupport
         )
     );
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(filteredHistory, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(filteredHistory, response.getEntity());
 
     resetAll();
 
@@ -1065,7 +1065,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specGetAllHistory(request);
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -1109,17 +1109,17 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.specGetHistory(request, "id1", null);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(versions1, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(versions1, response.getEntity());
 
     response = supervisorResource.specGetHistory(request, "id2", null);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(versions2, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(versions2, response.getEntity());
 
     response = supervisorResource.specGetHistory(request, "id3", null);
 
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
 
     resetAll();
 
@@ -1129,7 +1129,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specGetHistory(request, "id1", null);
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -1202,17 +1202,17 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.specGetHistory(request, "id1", null);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(versions1, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(versions1, response.getEntity());
 
     response = supervisorResource.specGetHistory(request, "id2", null);
 
     // user is not authorized to access datasource2
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
 
     response = supervisorResource.specGetHistory(request, "id3", null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         ImmutableList.of(
             new VersionedSupervisorSpec(
                 new TestSupervisorSpec("id3", null, Collections.singletonList("datasource3")),
@@ -1239,7 +1239,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     );
 
     response = supervisorResource.specGetHistory(request, "id4", null);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
 
 
     resetAll();
@@ -1250,7 +1250,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     response = supervisorResource.specGetHistory(request, "id1", null);
     verifyAll();
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
   }
 
   @Test
@@ -1290,29 +1290,29 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     // Test with valid limit
     Response response = supervisorResource.specGetHistory(request, "id1", 2);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(limitedVersions, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(limitedVersions, response.getEntity());
 
     // Test with limit=0 (should return 400 Bad Request)
     response = supervisorResource.specGetHistory(request, "id1", 0);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("error", "Count must be greater than zero if set (count was 0)"),
         response.getEntity()
     );
 
     // Test with negative limit (should return 400 Bad Request)
     response = supervisorResource.specGetHistory(request, "id1", -1);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("error", "Count must be greater than zero if set (count was -1)"),
         response.getEntity()
     );
 
     // Test with limit larger than available history
     response = supervisorResource.specGetHistory(request, "id1", 100);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(versions, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(versions, response.getEntity());
 
     verifyAll();
   }
@@ -1333,8 +1333,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.specGetHistory(request, "id1", null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(versions, response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(versions, response.getEntity());
 
     verifyAll();
   }
@@ -1357,14 +1357,14 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.reset("my-id");
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
 
     response = supervisorResource.reset("my-id-2");
 
-    Assert.assertEquals(404, response.getStatus());
-    Assert.assertEquals("my-id", id1.getValue());
-    Assert.assertEquals("my-id-2", id2.getValue());
+    Assertions.assertEquals(404, response.getStatus());
+    Assertions.assertEquals("my-id", id1.getValue());
+    Assertions.assertEquals("my-id-2", id2.getValue());
     verifyAll();
 
     resetAll();
@@ -1374,7 +1374,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     response = supervisorResource.terminate("my-id");
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
     verifyAll();
   }
 
@@ -1404,14 +1404,14 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     Response response = supervisorResource.resetOffsets("my-id", datasourceMetadata);
 
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(ImmutableMap.of("id", "my-id"), response.getEntity());
 
     response = supervisorResource.resetOffsets("my-id-2", datasourceMetadata);
 
-    Assert.assertEquals(404, response.getStatus());
-    Assert.assertEquals("my-id", id1.getValue());
-    Assert.assertEquals("my-id-2", id2.getValue());
+    Assertions.assertEquals(404, response.getStatus());
+    Assertions.assertEquals("my-id", id1.getValue());
+    Assertions.assertEquals("my-id-2", id2.getValue());
     verifyAll();
 
     resetAll();
@@ -1421,7 +1421,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     response = supervisorResource.terminate("my-id");
 
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
     verifyAll();
   }
 
@@ -1436,8 +1436,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     Response response = supervisorResource.resetToLatestAndBackfill("my-id", null);
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("id", "my-id", "backfillSupervisorId", "my-id_backfill_abcdefgh"),
         response.getEntity()
     );
@@ -1450,7 +1450,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     response = supervisorResource.resetToLatestAndBackfill("my-id", null);
-    Assert.assertEquals(404, response.getStatus());
+    Assertions.assertEquals(404, response.getStatus());
     verifyAll();
     resetAll();
 
@@ -1462,8 +1462,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     response = supervisorResource.resetToLatestAndBackfill("my-id", null);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("error", "Supervisor[my-id] must be in a RUNNING state"),
         response.getEntity()
     );
@@ -1478,8 +1478,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     response = supervisorResource.resetToLatestAndBackfill("my-id", null);
-    Assert.assertEquals(500, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(500, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("error", "Failed to get latest offsets from stream"),
         response.getEntity()
     );
@@ -1490,8 +1490,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     response = supervisorResource.resetToLatestAndBackfill("my-id", 0);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("error", "backfillTaskCount must be a positive integer"),
         response.getEntity()
     );
@@ -1502,8 +1502,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     response = supervisorResource.resetToLatestAndBackfill("my-id", -1);
-    Assert.assertEquals(400, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(400, response.getStatus());
+    Assertions.assertEquals(
         ImmutableMap.of("error", "backfillTaskCount must be a positive integer"),
         response.getEntity()
     );
@@ -1515,7 +1515,7 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     response = supervisorResource.resetToLatestAndBackfill("my-id", null);
-    Assert.assertEquals(503, response.getStatus());
+    Assertions.assertEquals(503, response.getStatus());
     verifyAll();
   }
 
@@ -1526,11 +1526,11 @@ public class SupervisorResourceTest extends EasyMockSupport
     String oldSpec = "{\"type\":\"NoopSupervisorSpec\",\"id\":null,\"dataSources\":null}";
     NoopSupervisorSpec expectedSpec = new NoopSupervisorSpec(null, null);
     NoopSupervisorSpec deserializedSpec = mapper.readValue(oldSpec, NoopSupervisorSpec.class);
-    Assert.assertEquals(expectedSpec, deserializedSpec);
+    Assertions.assertEquals(expectedSpec, deserializedSpec);
 
     NoopSupervisorSpec spec = new NoopSupervisorSpec("abcd", Collections.singletonList("defg"));
     NoopSupervisorSpec specRoundTrip = mapper.readValue(mapper.writeValueAsBytes(spec), NoopSupervisorSpec.class);
-    Assert.assertEquals(spec, specRoundTrip);
+    Assertions.assertEquals(spec, specRoundTrip);
   }
 
   @Test
@@ -1542,7 +1542,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     newSpec.merge(existingSpec);
 
-    Assert.assertEquals(5, newSpec.getIoConfig().getTaskCount());
+    Assertions.assertEquals(5, newSpec.getIoConfig().getTaskCount());
   }
 
   @Test
@@ -1554,7 +1554,7 @@ public class SupervisorResourceTest extends EasyMockSupport
 
     newSpec.merge(existingSpec);
 
-    Assert.assertEquals(3, newSpec.getIoConfig().getTaskCount());
+    Assertions.assertEquals(3, newSpec.getIoConfig().getTaskCount());
   }
 
   @Test
@@ -1566,12 +1566,12 @@ public class SupervisorResourceTest extends EasyMockSupport
     final TestSeekableStreamSupervisorSpec existingSpec = createTestSpec(null, 1);
     final TestSeekableStreamSupervisorSpec newSpec = createTestSpec(null, 4);
 
-    Assert.assertEquals(1, existingSpec.getIoConfig().getTaskCount());
-    Assert.assertEquals(4, newSpec.getIoConfig().getTaskCount());
+    Assertions.assertEquals(1, existingSpec.getIoConfig().getTaskCount());
+    Assertions.assertEquals(4, newSpec.getIoConfig().getTaskCount());
 
     newSpec.merge(existingSpec);
 
-    Assert.assertEquals(1, newSpec.getIoConfig().getTaskCount());
+    Assertions.assertEquals(1, newSpec.getIoConfig().getTaskCount());
   }
 
   @Test
@@ -1590,8 +1590,8 @@ public class SupervisorResourceTest extends EasyMockSupport
     replayAll();
 
     final Response response = supervisorResource.handoffTaskGroups(spec.getId(), handoffRequest);
-    Assert.assertEquals(202, response.getStatus());
-    Assert.assertNull(response.getEntity());
+    Assertions.assertEquals(202, response.getStatus());
+    Assertions.assertNull(response.getEntity());
 
     verifyAll();
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -44,9 +44,9 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
@@ -70,13 +70,8 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   private static final int NUM_ROWS = 128;
   private static final String TIMESTAMP_STRING = "2019-01-01";
 
-  private final File temporaryFolder = FileUtils.createTempDir();
-
-  @AfterEach
-  public void tearDown() throws IOException
-  {
-    FileUtils.deleteDirectory(temporaryFolder);
-  }
+  @TempDir
+  private File temporaryFolder;
 
   @Test
   public void testRead() throws IOException

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -40,17 +40,17 @@ import org.apache.druid.indexing.seekablestream.common.RecordSupplier;
 import org.apache.druid.indexing.seekablestream.common.StreamException;
 import org.apache.druid.indexing.seekablestream.common.StreamPartition;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -69,8 +69,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   private static final int NUM_ROWS = 128;
   private static final String TIMESTAMP_STRING = "2019-01-01";
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final File temporaryFolder = FileUtils.createTempDir();
 
   @Test
   public void testRead() throws IOException
@@ -88,7 +87,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
             ColumnsFilter.all()
         ),
         inputFormat,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null)
     );
 
     int read = 0;
@@ -96,14 +95,14 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
     try (CloseableIterator<InputRow> iterator = reader.read(inputStats)) {
       for (; read < NUM_ROWS && iterator.hasNext(); read++) {
         final InputRow inputRow = iterator.next();
-        Assert.assertEquals(DateTimes.of(TIMESTAMP_STRING), inputRow.getTimestamp());
-        Assert.assertEquals(NUM_COLS - 1, inputRow.getDimensions().size());
+        Assertions.assertEquals(DateTimes.of(TIMESTAMP_STRING), inputRow.getTimestamp());
+        Assertions.assertEquals(NUM_COLS - 1, inputRow.getDimensions().size());
       }
     }
 
-    Assert.assertTrue(inputStats.getProcessedBytes() > NUM_ROWS * supplier.getMinRowSize());
-    Assert.assertEquals(NUM_ROWS, read);
-    Assert.assertTrue(supplier.isClosed());
+    Assertions.assertTrue(inputStats.getProcessedBytes() > NUM_ROWS * supplier.getMinRowSize());
+    Assertions.assertEquals(NUM_ROWS, read);
+    Assertions.assertTrue(supplier.isClosed());
   }
 
   @Test
@@ -122,7 +121,7 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
             ColumnsFilter.all()
         ),
         inputFormat,
-        temporaryFolder.newFolder()
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null)
     );
 
     int read = 0;
@@ -132,9 +131,9 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
         iterator.next();
       }
     }
-    Assert.assertEquals(0, inputStats.getProcessedBytes());
-    Assert.assertEquals(0, read);
-    Assert.assertTrue(supplier.isClosed());
+    Assertions.assertEquals(0, inputStats.getProcessedBytes());
+    Assertions.assertEquals(0, read);
+    Assertions.assertTrue(supplier.isClosed());
   }
 
   @Test
@@ -145,11 +144,11 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
            .thenThrow(new StreamException(new Exception("Something bad happened")));
 
     //noinspection ResultOfObjectAllocationIgnored
-    final SamplerException exception = Assert.assertThrows(
+    final SamplerException exception = Assertions.assertThrows(
         SamplerException.class,
         () -> new RecordSupplierInputSource<>("test-stream", supplier, false, null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Exception while seeking to the [latest] offset of partitions in topic [test-stream]: Something bad happened",
         exception.getMessage()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/RecordSupplierInputSourceTest.java
@@ -44,6 +44,7 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -70,6 +71,12 @@ public class RecordSupplierInputSourceTest extends InitializedNullHandlingTest
   private static final String TIMESTAMP_STRING = "2019-01-01";
 
   private final File temporaryFolder = FileUtils.createTempDir();
+
+  @AfterEach
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(temporaryFolder);
+  }
 
   @Test
   public void testRead() throws IOException

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamAppenderatorConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamAppenderatorConfigTest.java
@@ -33,8 +33,8 @@ import org.apache.druid.segment.indexing.TuningConfig;
 import org.apache.druid.utils.JvmUtils;
 import org.apache.druid.utils.RuntimeInfo;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -66,36 +66,36 @@ public class SeekableStreamAppenderatorConfigTest
     final SeekableStreamAppenderatorConfig appenderatorConfig =
         SeekableStreamAppenderatorConfig.fromTuningConfig(tuningConfig, null);
 
-    Assert.assertEquals(tuningConfig.isReportParseExceptions(), appenderatorConfig.isReportParseExceptions());
-    Assert.assertEquals(tuningConfig.getMaxPendingPersists(), appenderatorConfig.getMaxPendingPersists());
-    Assert.assertEquals(
+    Assertions.assertEquals(tuningConfig.isReportParseExceptions(), appenderatorConfig.isReportParseExceptions());
+    Assertions.assertEquals(tuningConfig.getMaxPendingPersists(), appenderatorConfig.getMaxPendingPersists());
+    Assertions.assertEquals(
         tuningConfig.isSkipBytesInMemoryOverheadCheck(),
         appenderatorConfig.isSkipBytesInMemoryOverheadCheck()
     );
-    Assert.assertEquals(tuningConfig.getIntermediatePersistPeriod(), appenderatorConfig.getIntermediatePersistPeriod());
-    Assert.assertEquals(tuningConfig.getBasePersistDirectory(), appenderatorConfig.getBasePersistDirectory());
-    Assert.assertEquals(tuningConfig.getMaxRowsInMemory(), appenderatorConfig.getMaxRowsInMemory());
-    Assert.assertEquals(tuningConfig.getMaxBytesInMemory(), appenderatorConfig.getMaxBytesInMemory());
-    Assert.assertEquals(tuningConfig.getIndexSpec(), appenderatorConfig.getIndexSpec());
-    Assert.assertEquals(
+    Assertions.assertEquals(tuningConfig.getIntermediatePersistPeriod(), appenderatorConfig.getIntermediatePersistPeriod());
+    Assertions.assertEquals(tuningConfig.getBasePersistDirectory(), appenderatorConfig.getBasePersistDirectory());
+    Assertions.assertEquals(tuningConfig.getMaxRowsInMemory(), appenderatorConfig.getMaxRowsInMemory());
+    Assertions.assertEquals(tuningConfig.getMaxBytesInMemory(), appenderatorConfig.getMaxBytesInMemory());
+    Assertions.assertEquals(tuningConfig.getIndexSpec(), appenderatorConfig.getIndexSpec());
+    Assertions.assertEquals(
         tuningConfig.getIndexSpecForIntermediatePersists(),
         appenderatorConfig.getIndexSpecForIntermediatePersists()
     );
-    Assert.assertEquals(tuningConfig.getNumPersistThreads(), appenderatorConfig.getNumPersistThreads());
-    Assert.assertEquals(tuningConfig.getMaxRowsPerSegment(), appenderatorConfig.getMaxRowsPerSegment());
-    Assert.assertEquals(tuningConfig.getMaxTotalRows(), appenderatorConfig.getMaxTotalRows());
-    Assert.assertEquals(tuningConfig.getMaxColumnsToMerge(), appenderatorConfig.getMaxColumnsToMerge());
-    Assert.assertEquals(
+    Assertions.assertEquals(tuningConfig.getNumPersistThreads(), appenderatorConfig.getNumPersistThreads());
+    Assertions.assertEquals(tuningConfig.getMaxRowsPerSegment(), appenderatorConfig.getMaxRowsPerSegment());
+    Assertions.assertEquals(tuningConfig.getMaxTotalRows(), appenderatorConfig.getMaxTotalRows());
+    Assertions.assertEquals(tuningConfig.getMaxColumnsToMerge(), appenderatorConfig.getMaxColumnsToMerge());
+    Assertions.assertEquals(
         tuningConfig.isSkipBytesInMemoryOverheadCheck(),
         appenderatorConfig.isSkipBytesInMemoryOverheadCheck()
     );
-    Assert.assertEquals(tuningConfig.getMaxColumnsToMerge(), appenderatorConfig.getMaxColumnsToMerge());
+    Assertions.assertEquals(tuningConfig.getMaxColumnsToMerge(), appenderatorConfig.getMaxColumnsToMerge());
   }
 
   @Test
   public void test_calculateDefaultMaxColumnsToMerge_direct2g_xmx1g_maxBytesAuto_2proc_1merge()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         17293,
         SeekableStreamAppenderatorConfig.calculateDefaultMaxColumnsToMerge(
             new DruidProcessingConfigTest.MockRuntimeInfo(2, 2_000_000_000L, 1_000_000_000L),
@@ -108,7 +108,7 @@ public class SeekableStreamAppenderatorConfigTest
   @Test
   public void test_calculateDefaultMaxColumnsToMerge_direct2g_xmx1g_maxBytesUnlimited_2proc_1merge()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         17293,
         SeekableStreamAppenderatorConfig.calculateDefaultMaxColumnsToMerge(
             new DruidProcessingConfigTest.MockRuntimeInfo(2, 2_000_000_000L, 1_000_000_000L),
@@ -121,7 +121,7 @@ public class SeekableStreamAppenderatorConfigTest
   @Test
   public void test_calculateDefaultMaxColumnsToMerge_direct1800m_xmx1g_maxBytesUnlimited_2proc_1merge()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         15258,
         SeekableStreamAppenderatorConfig.calculateDefaultMaxColumnsToMerge(
             new DruidProcessingConfigTest.MockRuntimeInfo(2, 1_800_000_000L, 1_000_000_000L),
@@ -134,7 +134,7 @@ public class SeekableStreamAppenderatorConfigTest
   @Test
   public void test_calculateDefaultMaxColumnsToMerge_direct1800m_xmx1g_maxBytesUnlimited_3proc_2merge()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         13224,
         SeekableStreamAppenderatorConfig.calculateDefaultMaxColumnsToMerge(
             new DruidProcessingConfigTest.MockRuntimeInfo(3, 1_800_000_000L, 1_000_000_000L),
@@ -147,7 +147,7 @@ public class SeekableStreamAppenderatorConfigTest
   @Test
   public void test_calculateDefaultMaxColumnsToMerge_direct2g_xmx1g_maxBytes20m_2proc_1merge()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         6666,
         SeekableStreamAppenderatorConfig.calculateDefaultMaxColumnsToMerge(
             new DruidProcessingConfigTest.MockRuntimeInfo(2, 2_000_000_000L, 1_000_000_000L),
@@ -160,7 +160,7 @@ public class SeekableStreamAppenderatorConfigTest
   @Test
   public void test_calculateDefaultMaxColumnsToMerge_directUnsupported_xmx1g_maxBytes20m_2proc_1merge()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1017,
         SeekableStreamAppenderatorConfig.calculateDefaultMaxColumnsToMerge(
             new RuntimeInfo()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamEndSequenceNumbersTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamEndSequenceNumbersTest.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -53,7 +53,7 @@ public class SeekableStreamEndSequenceNumbersTest
         new TypeReference<>() {}
     );
 
-    Assert.assertEquals("Round trip", partitions, partitions2);
+    Assertions.assertEquals(partitions, partitions2, "Round trip");
 
     // Check backwards compatibility.
     final Map<String, Object> asMap = OBJECT_MAPPER.readValue(
@@ -61,15 +61,15 @@ public class SeekableStreamEndSequenceNumbersTest
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    Assert.assertEquals(stream, asMap.get("stream"));
-    Assert.assertEquals(stream, asMap.get("topic"));
+    Assertions.assertEquals(stream, asMap.get("stream"));
+    Assertions.assertEquals(stream, asMap.get("topic"));
 
     // Jackson will deserialize the maps as string -> int maps, not int -> long.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionSequenceNumberMap"), new TypeReference<Map<Integer, Long>>() {})
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionOffsetMap"), new TypeReference<Map<Integer, Long>>() {})
     );
@@ -86,12 +86,12 @@ public class SeekableStreamEndSequenceNumbersTest
         offsetMap
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new SeekableStreamStartSequenceNumbers<>(stream, offsetMap, ImmutableSet.of(1, 3)),
         endSequenceNumbers.asStartPartitions(false)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new SeekableStreamStartSequenceNumbers<>(stream, offsetMap, ImmutableSet.of()),
         endSequenceNumbers.asStartPartitions(true)
     );
@@ -112,7 +112,7 @@ public class SeekableStreamEndSequenceNumbersTest
         stream,
         offsetMap2
     );
-    Assert.assertEquals(1, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
+    Assertions.assertEquals(1, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
   }
 
   @Test
@@ -130,6 +130,6 @@ public class SeekableStreamEndSequenceNumbersTest
         stream,
         offsetMap2
     );
-    Assert.assertEquals(0, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
+    Assertions.assertEquals(0, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClientAsyncImplTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskClientAsyncImplTest.java
@@ -40,18 +40,16 @@ import org.apache.druid.rpc.ServiceLocations;
 import org.apache.druid.rpc.ServiceNotAvailableException;
 import org.apache.druid.segment.incremental.ParseExceptionReport;
 import org.easymock.EasyMock;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
@@ -74,18 +72,18 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
   private ServiceClientFactory serviceClientFactory;
   private SeekableStreamIndexTaskClient<Integer, Long> client;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     serviceClient = new MockServiceClient();
     serviceClientFactory = (serviceName, serviceLocator, retryPolicy) -> {
-      Assert.assertEquals(TASK_ID, serviceName);
+      Assertions.assertEquals(TASK_ID, serviceName);
       return serviceClient;
     };
     client = new TestSeekableStreamIndexTaskClientAsyncImpl();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     serviceClient.verify();
@@ -103,7 +101,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(checkpoints)
     );
 
-    Assert.assertEquals(checkpoints, client.getCheckpointsAsync(TASK_ID, false).get());
+    Assertions.assertEquals(checkpoints, client.getCheckpointsAsync(TASK_ID, false).get());
   }
 
   @Test
@@ -118,7 +116,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(offsets)
     );
 
-    Assert.assertEquals(offsets, client.getCurrentOffsetsAsync(TASK_ID, false).get());
+    Assertions.assertEquals(offsets, client.getCurrentOffsetsAsync(TASK_ID, false).get());
   }
 
   @Test
@@ -133,7 +131,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(offsets)
     );
 
-    Assert.assertEquals(offsets, client.getEndOffsetsAsync(TASK_ID).get());
+    Assertions.assertEquals(offsets, client.getEndOffsetsAsync(TASK_ID).get());
   }
 
   @Test
@@ -144,7 +142,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new ServiceNotAvailableException(TASK_ID)
     );
 
-    Assert.assertEquals(Collections.emptyMap(), client.getEndOffsetsAsync(TASK_ID).get());
+    Assertions.assertEquals(Collections.emptyMap(), client.getEndOffsetsAsync(TASK_ID).get());
   }
 
   @Test
@@ -157,7 +155,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         ByteArrays.EMPTY_ARRAY
     );
 
-    Assert.assertEquals(true, client.stopAsync(TASK_ID, true).get());
+    Assertions.assertEquals(true, client.stopAsync(TASK_ID, true).get());
   }
 
   @Test
@@ -170,7 +168,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         ByteArrays.EMPTY_ARRAY
     );
 
-    Assert.assertEquals(true, client.stopAsync(TASK_ID, false).get());
+    Assertions.assertEquals(true, client.stopAsync(TASK_ID, false).get());
   }
 
   @Test
@@ -186,7 +184,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         )
     );
 
-    Assert.assertEquals(false, client.stopAsync(TASK_ID, false).get());
+    Assertions.assertEquals(false, client.stopAsync(TASK_ID, false).get());
   }
 
   @Test
@@ -197,7 +195,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new ServiceNotAvailableException(TASK_ID)
     );
 
-    Assert.assertEquals(false, client.stopAsync(TASK_ID, false).get());
+    Assertions.assertEquals(false, client.stopAsync(TASK_ID, false).get());
   }
 
   @Test
@@ -208,7 +206,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new ServiceClosedException(TASK_ID)
     );
 
-    Assert.assertEquals(true, client.stopAsync(TASK_ID, false).get());
+    Assertions.assertEquals(true, client.stopAsync(TASK_ID, false).get());
   }
 
   @Test
@@ -219,12 +217,12 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new IOException()
     );
 
-    final ExecutionException e = Assert.assertThrows(
+    final ExecutionException e = Assertions.assertThrows(
         ExecutionException.class,
         () -> client.stopAsync(TASK_ID, false).get()
     );
 
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
+    Assertions.assertInstanceOf(IOException.class, e.getCause());
   }
 
   @Test
@@ -237,7 +235,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         ByteArrays.EMPTY_ARRAY
     );
 
-    Assert.assertEquals(true, client.resumeAsync(TASK_ID).get());
+    Assertions.assertEquals(true, client.resumeAsync(TASK_ID).get());
   }
 
   @Test
@@ -248,7 +246,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new IOException()
     );
 
-    Assert.assertEquals(false, client.resumeAsync(TASK_ID).get());
+    Assertions.assertEquals(false, client.resumeAsync(TASK_ID).get());
   }
 
   @Test
@@ -265,7 +263,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         ByteArrays.EMPTY_ARRAY
     );
 
-    Assert.assertEquals(true, client.setEndOffsetsAsync(TASK_ID, offsets, false).get());
+    Assertions.assertEquals(true, client.setEndOffsetsAsync(TASK_ID, offsets, false).get());
   }
 
   @Test
@@ -276,7 +274,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new IOException()
     );
 
-    Assert.assertEquals(false, client.resumeAsync(TASK_ID).get());
+    Assertions.assertEquals(false, client.resumeAsync(TASK_ID).get());
   }
 
   @Test
@@ -289,7 +287,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(SeekableStreamIndexTaskRunner.Status.READING)
     );
 
-    Assert.assertEquals(SeekableStreamIndexTaskRunner.Status.READING, client.getStatusAsync(TASK_ID).get());
+    Assertions.assertEquals(SeekableStreamIndexTaskRunner.Status.READING, client.getStatusAsync(TASK_ID).get());
   }
 
   @Test
@@ -300,7 +298,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new ServiceNotAvailableException(TASK_ID)
     );
 
-    Assert.assertEquals(SeekableStreamIndexTaskRunner.Status.NOT_STARTED, client.getStatusAsync(TASK_ID).get());
+    Assertions.assertEquals(SeekableStreamIndexTaskRunner.Status.NOT_STARTED, client.getStatusAsync(TASK_ID).get());
   }
 
   @Test
@@ -315,7 +313,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(startTime)
     );
 
-    Assert.assertEquals(startTime, client.getStartTimeAsync(TASK_ID).get());
+    Assertions.assertEquals(startTime, client.getStartTimeAsync(TASK_ID).get());
   }
 
   @Test
@@ -328,7 +326,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         ByteArrays.EMPTY_ARRAY
     );
 
-    Assert.assertNull(client.getStartTimeAsync(TASK_ID).get());
+    Assertions.assertNull(client.getStartTimeAsync(TASK_ID).get());
   }
 
   @Test
@@ -339,7 +337,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new ServiceNotAvailableException(TASK_ID)
     );
 
-    Assert.assertNull(client.getStartTimeAsync(TASK_ID).get());
+    Assertions.assertNull(client.getStartTimeAsync(TASK_ID).get());
   }
 
   @Test
@@ -354,7 +352,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(offsets)
     );
 
-    Assert.assertEquals(offsets, client.pauseAsync(TASK_ID).get());
+    Assertions.assertEquals(offsets, client.pauseAsync(TASK_ID).get());
   }
 
   @Test
@@ -369,15 +367,14 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(offsets)
     );
 
-    final ExecutionException e = Assert.assertThrows(
+    final ExecutionException e = Assertions.assertThrows(
         ExecutionException.class,
         () -> client.pauseAsync(TASK_ID).get()
     );
 
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(
-        e.getCause().getMessage(),
-        CoreMatchers.startsWith("Pause request for task [the-task] failed with response [100 Continue]")
+    Assertions.assertInstanceOf(IllegalStateException.class, e.getCause());
+    Assertions.assertTrue(
+        e.getCause().getMessage().startsWith("Pause request for task [the-task] failed with response [100 Continue]")
     );
   }
 
@@ -403,7 +400,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(offsets)
     );
 
-    Assert.assertEquals(offsets, client.pauseAsync(TASK_ID).get());
+    Assertions.assertEquals(offsets, client.pauseAsync(TASK_ID).get());
   }
 
   @Test
@@ -419,12 +416,12 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         new IOException()
     );
 
-    final ExecutionException e = Assert.assertThrows(
+    final ExecutionException e = Assertions.assertThrows(
         ExecutionException.class,
         () -> client.pauseAsync(TASK_ID).get()
     );
 
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IOException.class));
+    Assertions.assertInstanceOf(IOException.class, e.getCause());
   }
 
   @Test
@@ -454,7 +451,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(offsets)
     );
 
-    Assert.assertEquals(offsets, client.pauseAsync(TASK_ID).get());
+    Assertions.assertEquals(offsets, client.pauseAsync(TASK_ID).get());
   }
 
   @Test
@@ -482,15 +479,14 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(SeekableStreamIndexTaskRunner.Status.READING)
     );
 
-    final ExecutionException e = Assert.assertThrows(
+    final ExecutionException e = Assertions.assertThrows(
         ExecutionException.class,
         () -> client.pauseAsync(TASK_ID).get()
     );
 
-    MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(
-        e.getCause().getMessage(),
-        CoreMatchers.startsWith("Task [the-task] failed to change its status from [READING] to [PAUSED]")
+    Assertions.assertInstanceOf(IllegalStateException.class, e.getCause());
+    Assertions.assertTrue(
+        e.getCause().getMessage().startsWith("Task [the-task] failed to change its status from [READING] to [PAUSED]")
     );
   }
 
@@ -506,7 +502,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(retVal)
     );
 
-    Assert.assertEquals(retVal, client.getMovingAveragesAsync(TASK_ID).get());
+    Assertions.assertEquals(retVal, client.getMovingAveragesAsync(TASK_ID).get());
   }
 
   @Test
@@ -519,7 +515,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         ByteArrays.EMPTY_ARRAY
     );
 
-    Assert.assertNull(client.getMovingAveragesAsync(TASK_ID).get());
+    Assertions.assertNull(client.getMovingAveragesAsync(TASK_ID).get());
   }
 
   @Test
@@ -532,7 +528,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         null
     );
 
-    Assert.assertNull(client.getMovingAveragesAsync(TASK_ID).get());
+    Assertions.assertNull(client.getMovingAveragesAsync(TASK_ID).get());
   }
 
   @Test
@@ -549,7 +545,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         jsonMapper.writeValueAsBytes(retVal)
     );
 
-    Assert.assertEquals(retVal, client.getParseErrorsAsync(TASK_ID).get());
+    Assertions.assertEquals(retVal, client.getParseErrorsAsync(TASK_ID).get());
   }
 
   @Test
@@ -562,7 +558,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
         ByteArrays.EMPTY_ARRAY
     );
 
-    Assert.assertNull(client.getParseErrorsAsync(TASK_ID).get());
+    Assertions.assertNull(client.getParseErrorsAsync(TASK_ID).get());
   }
 
   @Test
@@ -575,7 +571,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
 
     try (final SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator locator =
              new SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator(taskInfoProvider, TASK_ID)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ServiceLocations.closed(),
           locator.locate().get()
       );
@@ -596,7 +592,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
 
     try (final SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator locator =
              new SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator(taskInfoProvider, TASK_ID)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ServiceLocations.forLocations(Collections.emptySet()),
           locator.locate().get()
       );
@@ -617,7 +613,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
 
     try (final SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator locator =
              new SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator(taskInfoProvider, TASK_ID)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ServiceLocations.forLocation(new ServiceLocation("foo", 80, -1, "/druid/worker/v1/chat/" + TASK_ID)),
           locator.locate().get()
       );
@@ -636,7 +632,7 @@ public class SeekableStreamIndexTaskClientAsyncImplTest
 
     try (final SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator locator =
              new SeekableStreamIndexTaskClientAsyncImpl.SeekableStreamTaskLocator(taskInfoProvider, TASK_ID)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ServiceLocations.closed(),
           locator.locate().get()
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerAuthTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerAuthTest.java
@@ -50,10 +50,9 @@ import org.apache.druid.server.security.ForbiddenException;
 import org.apache.druid.server.security.ResourceType;
 import org.easymock.EasyMock;
 import org.joda.time.Period;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -80,10 +79,7 @@ public class SeekableStreamIndexTaskRunnerAuthTest
    */
   private TestSeekableStreamIndexTaskRunner taskRunner;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setUp()
   {
     // Create an AuthorizerMapper that only allows access to a Datasource resource
@@ -230,8 +226,7 @@ public class SeekableStreamIndexTaskRunnerAuthTest
     // Verify that no other user can access
     HttpServletRequest blockedRequest = createRequest(Users.DATASOURCE_READ, "POST");
     replay(blockedRequest);
-    expectedException.expect(ForbiddenException.class);
-    method.accept(blockedRequest);
+    Assertions.assertThrows(ForbiddenException.class, () -> method.accept(blockedRequest));
   }
 
   private void verifyOnlyDatasourceReadUserCanAccess(
@@ -246,8 +241,7 @@ public class SeekableStreamIndexTaskRunnerAuthTest
     // Verify that no other user can access
     HttpServletRequest blockedRequest = createRequest(Users.DATASOURCE_WRITE, "GET");
     replay(blockedRequest);
-    expectedException.expect(ForbiddenException.class);
-    method.accept(blockedRequest);
+    Assertions.assertThrows(ForbiddenException.class, () -> method.accept(blockedRequest));
   }
 
   private HttpServletRequest createRequest(String username, String method)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerTest.java
@@ -66,6 +66,7 @@ import org.apache.druid.timeline.partition.DimensionValueSetShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,14 +109,28 @@ public class SeekableStreamIndexTaskRunnerTest
 
   @Mock
   private SeekableStreamIndexTask task;
+  private AutoCloseable mocks;
 
   private StubServiceEmitter emitter;
 
   @BeforeEach
   public void setup()
   {
-    MockitoAnnotations.openMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
     emitter = new StubServiceEmitter();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    try {
+      if (mocks != null) {
+        mocks.close();
+      }
+    }
+    finally {
+      FileUtils.deleteDirectory(temporaryFolder);
+    }
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerTest.java
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -102,7 +103,8 @@ public class SeekableStreamIndexTaskRunnerTest
 {
   private static final String DATA_SOURCE = "datasource";
 
-  private final File temporaryFolder = FileUtils.createTempDir();
+  @TempDir
+  private File temporaryFolder;
 
   @Mock
   private InputRow row;
@@ -123,13 +125,8 @@ public class SeekableStreamIndexTaskRunnerTest
   @AfterEach
   public void tearDown() throws Exception
   {
-    try {
-      if (mocks != null) {
-        mocks.close();
-      }
-    }
-    finally {
-      FileUtils.deleteDirectory(temporaryFolder);
+    if (mocks != null) {
+      mocks.close();
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskRunnerTest.java
@@ -66,15 +66,12 @@ import org.apache.druid.timeline.partition.DimensionValueSetShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
@@ -100,13 +97,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.ArgumentMatchers.any;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SeekableStreamIndexTaskRunnerTest
 {
   private static final String DATA_SOURCE = "datasource";
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final File temporaryFolder = FileUtils.createTempDir();
 
   @Mock
   private InputRow row;
@@ -116,9 +111,10 @@ public class SeekableStreamIndexTaskRunnerTest
 
   private StubServiceEmitter emitter;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    MockitoAnnotations.openMocks(this);
     emitter = new StubServiceEmitter();
   }
 
@@ -152,9 +148,9 @@ public class SeekableStreamIndexTaskRunnerTest
 
     sequences.removeFirstElementDuringNextSnapshotOrSize();
 
-    Assert.assertSame(secondSequence, runner.getLastSequenceMetadata());
-    Assert.assertEquals(1, sequences.size());
-    Assert.assertSame(secondSequence, sequences.get(0));
+    Assertions.assertSame(secondSequence, runner.getLastSequenceMetadata());
+    Assertions.assertEquals(1, sequences.size());
+    Assertions.assertSame(secondSequence, sequences.get(0));
   }
 
   @Test
@@ -168,8 +164,8 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final Response response = runner.setEndOffsets(ImmutableMap.of("partition", "5"), false);
 
-    Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    Assert.assertEquals("Task must be paused before changing the end offsets", response.getEntity());
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertEquals("Task must be paused before changing the end offsets", response.getEntity());
   }
 
   @Test
@@ -196,8 +192,8 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final Response response = runner.setEndOffsets(ImmutableMap.of("partition", "6"), false);
 
-    Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    Assert.assertTrue(response.getEntity().toString().contains("has already endOffsets set"));
+    Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    Assertions.assertTrue(response.getEntity().toString().contains("has already endOffsets set"));
   }
 
   @Test
@@ -212,13 +208,13 @@ public class SeekableStreamIndexTaskRunnerTest
     try (final PausedRunner ignored = pauseRunner(runner)) {
       final Response response = runner.setEndOffsets(ImmutableMap.of("partition", "4"), false);
 
-      Assert.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-      Assert.assertEquals(
+      Assertions.assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+      Assertions.assertEquals(
           "End sequence must be >= current sequence for partition [partition] (current: 5)",
           response.getEntity()
       );
-      Assert.assertFalse(runner.getLastSequenceMetadata().isCheckpointed());
-      Assert.assertEquals(1, runner.getSequences().size());
+      Assertions.assertFalse(runner.getLastSequenceMetadata().isCheckpointed());
+      Assertions.assertEquals(1, runner.getSequences().size());
     }
   }
 
@@ -234,18 +230,18 @@ public class SeekableStreamIndexTaskRunnerTest
     try (final PausedRunner pausedRunner = pauseRunner(runner)) {
       final Response response = runner.setEndOffsets(ImmutableMap.of("partition", "5"), false);
 
-      Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+      Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
       pausedRunner.awaitResumed();
     }
 
     final List<SequenceMetadata<String, String>> sequences = runner.getSequences();
-    Assert.assertEquals(2, sequences.size());
-    Assert.assertTrue(sequences.get(0).isCheckpointed());
-    Assert.assertEquals(ImmutableMap.of("partition", "5"), sequences.get(0).getEndOffsets());
-    Assert.assertEquals("test_1", sequences.get(1).getSequenceName());
-    Assert.assertEquals(ImmutableMap.of("partition", "5"), sequences.get(1).getStartOffsets());
-    Assert.assertEquals(ImmutableMap.of("partition", "10"), sequences.get(1).getEndOffsets());
-    Assert.assertEquals(ImmutableSet.of("partition"), sequences.get(1).getExclusiveStartPartitions());
+    Assertions.assertEquals(2, sequences.size());
+    Assertions.assertTrue(sequences.get(0).isCheckpointed());
+    Assertions.assertEquals(ImmutableMap.of("partition", "5"), sequences.get(0).getEndOffsets());
+    Assertions.assertEquals("test_1", sequences.get(1).getSequenceName());
+    Assertions.assertEquals(ImmutableMap.of("partition", "5"), sequences.get(1).getStartOffsets());
+    Assertions.assertEquals(ImmutableMap.of("partition", "10"), sequences.get(1).getEndOffsets());
+    Assertions.assertEquals(ImmutableSet.of("partition"), sequences.get(1).getExclusiveStartPartitions());
   }
 
   @Test
@@ -260,14 +256,14 @@ public class SeekableStreamIndexTaskRunnerTest
     try (final PausedRunner pausedRunner = pauseRunner(runner)) {
       final Response response = runner.setEndOffsets(ImmutableMap.of("partition", "6"), true);
 
-      Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+      Assertions.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
       pausedRunner.awaitResumed();
     }
 
     final List<SequenceMetadata<String, String>> sequences = runner.getSequences();
-    Assert.assertEquals(1, sequences.size());
-    Assert.assertTrue(sequences.get(0).isCheckpointed());
-    Assert.assertEquals(ImmutableMap.of("partition", "6"), sequences.get(0).getEndOffsets());
+    Assertions.assertEquals(1, sequences.size());
+    Assertions.assertTrue(sequences.get(0).isCheckpointed());
+    Assertions.assertEquals(ImmutableMap.of("partition", "6"), sequences.get(0).getEndOffsets());
   }
 
   @Test
@@ -281,13 +277,13 @@ public class SeekableStreamIndexTaskRunnerTest
     );
 
     Mockito.when(row.getTimestamp()).thenReturn(now);
-    Assert.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
+    Assertions.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
 
     Mockito.when(row.getTimestamp()).thenReturn(now.minusHours(2).minusMinutes(1));
-    Assert.assertEquals(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
+    Assertions.assertEquals(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
 
     Mockito.when(row.getTimestamp()).thenReturn(now.plusHours(2).plusMinutes(1));
-    Assert.assertEquals(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
+    Assertions.assertEquals(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
   }
 
   @Test
@@ -297,13 +293,13 @@ public class SeekableStreamIndexTaskRunnerTest
     final TestSeekableStreamIndexTaskRunner runner = createRunner();
 
     Mockito.when(row.getTimestamp()).thenReturn(now);
-    Assert.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
+    Assertions.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
 
     Mockito.when(row.getTimestamp()).thenReturn(now.minusHours(2).minusMinutes(1));
-    Assert.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
+    Assertions.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
 
     Mockito.when(row.getTimestamp()).thenReturn(now.plusHours(2).plusMinutes(1));
-    Assert.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
+    Assertions.assertEquals(InputRowFilterResult.ACCEPTED, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(row));
   }
 
   @Test
@@ -311,7 +307,7 @@ public class SeekableStreamIndexTaskRunnerTest
   {
     final TestSeekableStreamIndexTaskRunner runner = createRunner();
 
-    Assert.assertEquals(InputRowFilterResult.NULL_OR_EMPTY_RECORD, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(null));
+    Assertions.assertEquals(InputRowFilterResult.NULL_OR_EMPTY_RECORD, runner.ensureRowIsNonNullAndWithinMessageTimeBounds(null));
   }
 
   @Test
@@ -320,7 +316,7 @@ public class SeekableStreamIndexTaskRunnerTest
     final TestSeekableStreamIndexTaskRunner runner = createRunner();
     Mockito.when(task.getId()).thenReturn("task1");
     Mockito.when(task.getSupervisorId()).thenReturn("supervisorId");
-    Assert.assertEquals("supervisorId", runner.getSupervisorId());
+    Assertions.assertEquals("supervisorId", runner.getSupervisorId());
 
     // Setup the task to return a RecordSupplier, StreamAppenderatorDriver, Appenderator
     final RecordSupplier<?, ?, ?> recordSupplier = Mockito.mock(RecordSupplier.class);
@@ -376,12 +372,12 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertTrue(
-        "A segment created during the current run with observed values should get a DimensionValueSetShardSpec",
-        annotated.getShardSpec() instanceof DimensionValueSetShardSpec
+    Assertions.assertTrue(
+        annotated.getShardSpec() instanceof DimensionValueSetShardSpec,
+        "A segment created during the current run with observed values should get a DimensionValueSetShardSpec"
     );
     final DimensionValueSetShardSpec shardSpec = (DimensionValueSetShardSpec) annotated.getShardSpec();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("tenant_a", "tenant_b", "tenant_c"),
         shardSpec.getPartitionDimensionValues().get("tenant")
     );
@@ -413,14 +409,14 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
+        annotated.getShardSpec() instanceof DimensionValueSetShardSpec,
         "A restart-spanned segment must be stamped with a DimensionValueSetShardSpec (class-uniform with freshly-stamped "
-        + "segments in the same interval) so SegmentPublisherHelper does not reject the publish",
-        annotated.getShardSpec() instanceof DimensionValueSetShardSpec
+        + "segments in the same interval) so SegmentPublisherHelper does not reject the publish"
     );
-    Assert.assertTrue(
-        "Its filters must be empty (no pruning) so incompletely-observed pre-restart rows are never pruned away",
-        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty()
+    Assertions.assertTrue(
+        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty(),
+        "Its filters must be empty (no pruning) so incompletely-observed pre-restart rows are never pruned away"
     );
   }
 
@@ -454,15 +450,15 @@ public class SeekableStreamIndexTaskRunnerTest
     final DataSegment annotatedRestartSpanned = runner.annotateSegmentWithPartitionDimensionValues(restartSpanned);
     final DataSegment annotatedFreshlyObserved = runner.annotateSegmentWithPartitionDimensionValues(freshlyObserved);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         annotatedRestartSpanned.getShardSpec().getClass(),
         annotatedFreshlyObserved.getShardSpec().getClass()
     );
-    Assert.assertTrue(annotatedRestartSpanned.getShardSpec() instanceof DimensionValueSetShardSpec);
-    Assert.assertTrue(
+    Assertions.assertTrue(annotatedRestartSpanned.getShardSpec() instanceof DimensionValueSetShardSpec);
+    Assertions.assertTrue(
         ((DimensionValueSetShardSpec) annotatedRestartSpanned.getShardSpec()).getPartitionDimensionValues().isEmpty()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of("tenant_a"),
         ((DimensionValueSetShardSpec) annotatedFreshlyObserved.getShardSpec()).getPartitionDimensionValues().get("tenant")
     );
@@ -490,16 +486,16 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         annotated.getShardSpec() instanceof DimensionValueSetShardSpec
     );
     final DimensionValueSetShardSpec shardSpec = (DimensionValueSetShardSpec) annotated.getShardSpec();
     // tenant declares both its non-null value AND null, so IS NULL queries are not pruned.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(null, "tenant_a"),
         shardSpec.getPartitionDimensionValues().get("tenant")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("us-west"),
         ImmutableSet.copyOf(shardSpec.getPartitionDimensionValues().get("region"))
     );
@@ -525,9 +521,9 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
+    Assertions.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
     final DimensionValueSetShardSpec shardSpec = (DimensionValueSetShardSpec) annotated.getShardSpec();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonList(null),
         shardSpec.getPartitionDimensionValues().get("tenant")
     );
@@ -551,10 +547,10 @@ public class SeekableStreamIndexTaskRunnerTest
     // No observe(...) call: nothing was recorded for this segment.
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(createSingleSegment());
 
-    Assert.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
-    Assert.assertTrue(
-        "A segment with no observed values declares no filters (no pruning) but stays a DimensionValueSetShardSpec",
-        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty()
+    Assertions.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
+    Assertions.assertTrue(
+        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty(),
+        "A segment with no observed values declares no filters (no pruning) but stays a DimensionValueSetShardSpec"
     );
   }
 
@@ -574,7 +570,7 @@ public class SeekableStreamIndexTaskRunnerTest
     final DataSegment segment = createSingleSegment();
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertSame("With the feature off the segment must be returned unchanged", segment, annotated);
+    Assertions.assertSame(segment, annotated, "With the feature off the segment must be returned unchanged");
   }
 
   /** Boundary: observed values exactly equal the cap, dim must still stamp. */
@@ -592,8 +588,8 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
-    Assert.assertEquals(
+    Assertions.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
+    Assertions.assertEquals(
         Arrays.asList("tenant_a", "tenant_b", "tenant_c"),
         ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().get("tenant")
     );
@@ -614,10 +610,10 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
-    Assert.assertTrue(
-        "Over-cap dimension must be absent from the filter map so possibleInDomain treats it as unconstrained",
-        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty()
+    Assertions.assertTrue(annotated.getShardSpec() instanceof DimensionValueSetShardSpec);
+    Assertions.assertTrue(
+        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty(),
+        "Over-cap dimension must be absent from the filter map so possibleInDomain treats it as unconstrained"
     );
   }
 
@@ -641,14 +637,14 @@ public class SeekableStreamIndexTaskRunnerTest
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
     final DimensionValueSetShardSpec shardSpec = (DimensionValueSetShardSpec) annotated.getShardSpec();
-    Assert.assertNull(
-        "Over-cap dim must be absent",
-        shardSpec.getPartitionDimensionValues().get("tenant")
+    Assertions.assertNull(
+        shardSpec.getPartitionDimensionValues().get("tenant"),
+        "Over-cap dim must be absent"
     );
-    Assert.assertEquals(
-        "Under-cap dim must be stamped normally",
+    Assertions.assertEquals(
         Arrays.asList("us-east", "us-west"),
-        shardSpec.getPartitionDimensionValues().get("region")
+        shardSpec.getPartitionDimensionValues().get("region"),
+        "Under-cap dim must be stamped normally"
     );
   }
 
@@ -667,9 +663,9 @@ public class SeekableStreamIndexTaskRunnerTest
 
     final DataSegment annotated = runner.annotateSegmentWithPartitionDimensionValues(segment);
 
-    Assert.assertTrue(
-        "Null counts toward the cap; over-cap dim must be omitted",
-        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty()
+    Assertions.assertTrue(
+        ((DimensionValueSetShardSpec) annotated.getShardSpec()).getPartitionDimensionValues().isEmpty(),
+        "Null counts toward the cap; over-cap dim must be omitted"
     );
   }
 
@@ -755,7 +751,7 @@ public class SeekableStreamIndexTaskRunnerTest
   private File createTaskWorkDirectory()
   {
     try {
-      final File taskWorkDir = temporaryFolder.newFolder();
+      final File taskWorkDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null);
       FileUtils.mkdirp(taskWorkDir);
       FileUtils.mkdirp(new File(taskWorkDir, "persist"));
       return taskWorkDir;
@@ -951,7 +947,7 @@ public class SeekableStreamIndexTaskRunnerTest
       }
       Thread.sleep(10);
     }
-    Assert.fail("Timed out waiting for status [" + status + "]");
+    Assertions.fail("Timed out waiting for status [" + status + "]");
   }
 
   private static boolean invokePossiblyPause(SeekableStreamIndexTaskRunner runner) throws Exception
@@ -992,7 +988,7 @@ public class SeekableStreamIndexTaskRunnerTest
 
     void awaitResumed() throws Exception
     {
-      Assert.assertTrue(possiblyPauseFuture.get(2, TimeUnit.SECONDS));
+      Assertions.assertTrue(possiblyPauseFuture.get(2, TimeUnit.SECONDS));
     }
 
     @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -226,10 +226,11 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
   }
 
   @AfterEach
-  public void tearDownBase()
+  public void tearDownBase() throws IOException
   {
     emitter.close();
     derby.after();
+    FileUtils.deleteDirectory(tempFolder);
   }
 
   protected static ByteEntity jb(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -136,6 +136,7 @@ import org.joda.time.Interval;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -160,7 +161,8 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
 {
   private static final Logger log = new Logger(SeekableStreamIndexTaskTestBase.class);
 
-  protected final File tempFolder = FileUtils.createTempDir();
+  @TempDir
+  protected File tempFolder;
 
   public final TestDerbyConnector.DerbyConnectorRule derby = new TestDerbyConnector.DerbyConnectorRule();
 
@@ -230,7 +232,6 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
   {
     emitter.close();
     derby.after();
-    FileUtils.deleteDirectory(tempFolder);
   }
 
   protected static ByteEntity jb(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTaskTestBase.java
@@ -72,6 +72,7 @@ import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
 import org.apache.druid.indexing.test.TestDataSegmentAnnouncer;
 import org.apache.druid.indexing.test.TestDataSegmentKiller;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
@@ -129,15 +130,12 @@ import org.apache.druid.server.security.AuthTestUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.utils.CompressionUtils;
 import org.apache.druid.utils.JvmUtils;
-import org.assertj.core.api.Assertions;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -156,14 +154,14 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
 {
   private static final Logger log = new Logger(SeekableStreamIndexTaskTestBase.class);
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  protected final File tempFolder = FileUtils.createTempDir();
 
-  @Rule
   public final TestDerbyConnector.DerbyConnectorRule derby = new TestDerbyConnector.DerbyConnectorRule();
 
   protected static final ObjectMapper OBJECT_MAPPER;
@@ -218,18 +216,20 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
     this.lockGranularity = lockGranularity;
   }
 
-  @Before
+  @BeforeEach
   public void setupBase()
   {
+    derby.before();
     emitter = new StubServiceEmitter();
     emitter.start();
     EmittingLogger.registerEmitter(emitter);
   }
 
-  @After
+  @AfterEach
   public void tearDownBase()
   {
     emitter.close();
+    derby.after();
   }
 
   protected static ByteEntity jb(
@@ -391,12 +391,12 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
 
   protected void verifyPersistAndMergeTimeMetricsArePositive(SegmentGenerationMetrics observedSegmentGenerationMetrics)
   {
-    Assert.assertNotNull(observedSegmentGenerationMetrics);
-    Assert.assertTrue(observedSegmentGenerationMetrics.persistTimeMillis() > 0);
-    Assert.assertTrue(observedSegmentGenerationMetrics.persistCpuTime() > 0);
+    Assertions.assertNotNull(observedSegmentGenerationMetrics);
+    Assertions.assertTrue(observedSegmentGenerationMetrics.persistTimeMillis() > 0);
+    Assertions.assertTrue(observedSegmentGenerationMetrics.persistCpuTime() > 0);
 
-    Assert.assertTrue(observedSegmentGenerationMetrics.mergeTimeMillis() > 0);
-    Assert.assertTrue(observedSegmentGenerationMetrics.mergeCpuTime() > 0);
+    Assertions.assertTrue(observedSegmentGenerationMetrics.mergeTimeMillis() > 0);
+    Assertions.assertTrue(observedSegmentGenerationMetrics.mergeCpuTime() > 0);
   }
 
   protected void assertEqualsExceptVersion(
@@ -404,7 +404,7 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
       List<SegmentDescriptor> actualDescriptors
   ) throws IOException
   {
-    Assert.assertEquals("number of segments", expectedDescriptors.size(), actualDescriptors.size());
+    Assertions.assertEquals(expectedDescriptors.size(), actualDescriptors.size(), "number of segments");
     final Comparator<SegmentDescriptor> comparator = (s1, s2) -> {
       final int intervalCompare = Comparators.intervalsByStartThenEnd().compare(s1.getInterval(), s2.getInterval());
       if (intervalCompare == 0) {
@@ -424,20 +424,20 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
     for (int i = 0; i < expectedDescsCopy.size(); i++) {
       SegmentDescriptorAndExpectedDim1Values expectedDesc = expectedDescsCopy.get(i);
       SegmentDescriptor actualDesc = actualDescsCopy.get(i);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedDesc.segmentDescriptor.getInterval(),
           actualDesc.getInterval()
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedDesc.segmentDescriptor.getPartitionNumber(),
           actualDesc.getPartitionNumber()
       );
       if (expectedDesc.expectedDim1Values.isEmpty()) {
         continue; // Treating empty expectedDim1Values as a signal that checking the dim1 column value is not needed.
       }
-      Assertions.assertThat(readSegmentColumn("dim1", actualDesc))
-                .describedAs("dim1 values")
-                .isIn(expectedDesc.expectedDim1Values);
+      assertThat(readSegmentColumn("dim1", actualDesc))
+          .describedAs("dim1 values")
+          .isIn(expectedDesc.expectedDim1Values);
     }
   }
 
@@ -548,7 +548,7 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
       RowIngestionMetersTotals expectedTotals
   )
   {
-    Assert.assertEquals(expectedTotals, task.getRunner().getRowIngestionMeters().getTotals());
+    Assertions.assertEquals(expectedTotals, task.getRunner().getRowIngestionMeters().getTotals());
   }
 
   protected abstract QueryRunnerFactoryConglomerate makeQueryRunnerConglomerate();
@@ -557,7 +557,7 @@ public abstract class SeekableStreamIndexTaskTestBase extends EasyMockSupport
       throws IOException
   {
     final ObjectMapper objectMapper = testUtils.getTestObjectMapper();
-    directory = tempFolder.newFolder();
+    directory = FileUtils.createTempDirInLocation(tempFolder.toPath(), null);
     final TaskConfig taskConfig =
         new TaskConfigBuilder()
             .setBaseDir(new File(directory, "baseDir").getPath())

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamSamplerSpecTest.java
@@ -54,13 +54,15 @@ import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class SeekableStreamSamplerSpecTest extends EasyMockSupport
 {
@@ -93,7 +95,8 @@ public class SeekableStreamSamplerSpecTest extends EasyMockSupport
     );
   }
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
   public void testSampleWithInputRowParser() throws Exception
   {
     DataSchema dataSchema = DataSchema.builder()
@@ -166,13 +169,13 @@ public class SeekableStreamSamplerSpecTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertEquals(5, response.getNumRowsRead());
-    Assert.assertEquals(3, response.getNumRowsIndexed());
-    Assert.assertEquals(5, response.getData().size());
+    Assertions.assertEquals(5, response.getNumRowsRead());
+    Assertions.assertEquals(3, response.getNumRowsIndexed());
+    Assertions.assertEquals(5, response.getData().size());
 
     Iterator<SamplerResponse.SamplerResponseRow> it = response.getData().iterator();
 
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "2008")
             .put("dim1", "a")
@@ -194,7 +197,7 @@ public class SeekableStreamSamplerSpecTest extends EasyMockSupport
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "2009")
             .put("dim1", "b")
@@ -216,7 +219,7 @@ public class SeekableStreamSamplerSpecTest extends EasyMockSupport
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "2010")
             .put("dim1", "c")
@@ -238,7 +241,7 @@ public class SeekableStreamSamplerSpecTest extends EasyMockSupport
         null,
         null
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         ImmutableMap.<String, Object>builder()
             .put("timestamp", "246140482-04-24T15:36:27.903Z")
             .put("dim1", "x")
@@ -251,14 +254,14 @@ public class SeekableStreamSamplerSpecTest extends EasyMockSupport
         true,
         "Encountered row with timestamp[246140482-04-24T15:36:27.903Z] that cannot be represented as a long: [{timestamp=246140482-04-24T15:36:27.903Z, dim1=x, dim2=z, dimLong=10, dimFloat=20.0, met1=1.0}]"
     ), it.next());
-    Assert.assertEquals(new SamplerResponse.SamplerResponseRow(
+    Assertions.assertEquals(new SamplerResponse.SamplerResponseRow(
         null,
         null,
         true,
         "Unable to parse row [unparseable] into JSON"
     ), it.next());
 
-    Assert.assertFalse(it.hasNext());
+    Assertions.assertFalse(it.hasNext());
   }
 
   private static List<ByteEntity> jb(String ts, String dim1, String dim2, String dimLong, String dimFloat, String met1)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamStartSequenceNumbersTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SeekableStreamStartSequenceNumbersTest.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.java.util.common.jackson.JacksonUtils;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -54,7 +54,7 @@ public class SeekableStreamStartSequenceNumbersTest
         new TypeReference<>() {}
     );
 
-    Assert.assertEquals("Round trip", partitions, partitions2);
+    Assertions.assertEquals(partitions, partitions2, "Round trip");
 
     // Check backwards compatibility.
     final Map<String, Object> asMap = OBJECT_MAPPER.readValue(
@@ -62,15 +62,15 @@ public class SeekableStreamStartSequenceNumbersTest
         JacksonUtils.TYPE_REFERENCE_MAP_STRING_OBJECT
     );
 
-    Assert.assertEquals(stream, asMap.get("stream"));
-    Assert.assertEquals(stream, asMap.get("topic"));
+    Assertions.assertEquals(stream, asMap.get("stream"));
+    Assertions.assertEquals(stream, asMap.get("topic"));
 
     // Jackson will deserialize the maps as string -> int maps, not int -> long.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionSequenceNumberMap"), new TypeReference<Map<Integer, Long>>() {})
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         offsetMap,
         OBJECT_MAPPER.convertValue(asMap.get("partitionOffsetMap"), new TypeReference<Map<Integer, Long>>() {})
     );
@@ -93,7 +93,7 @@ public class SeekableStreamStartSequenceNumbersTest
         offsetMap2,
         ImmutableSet.of(6)
     );
-    Assert.assertEquals(1, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
+    Assertions.assertEquals(1, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
   }
 
   @Test
@@ -113,6 +113,6 @@ public class SeekableStreamStartSequenceNumbersTest
         offsetMap2,
         ImmutableSet.of(6)
     );
-    Assert.assertEquals(0, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
+    Assertions.assertEquals(0, partitions1.compareTo(partitions2, Comparator.naturalOrder()));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
@@ -34,6 +34,7 @@ import org.apache.druid.segment.realtime.appenderator.Appenderator;
 import org.apache.druid.segment.realtime.appenderator.TransactionalSegmentPublisher;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,11 +63,20 @@ public class SequenceMetadataTest
 
   @Mock
   private TaskToolbox mockTaskToolbox;
+  private AutoCloseable mocks;
 
   @BeforeEach
   public void setup()
   {
-    MockitoAnnotations.openMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    if (mocks != null) {
+      mocks.close();
+    }
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/SequenceMetadataTest.java
@@ -34,19 +34,18 @@ import org.apache.druid.segment.realtime.appenderator.Appenderator;
 import org.apache.druid.segment.realtime.appenderator.TransactionalSegmentPublisher;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
 import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Set;
 
-@RunWith(MockitoJUnitRunner.class)
 public class SequenceMetadataTest
 {
   @Mock
@@ -63,6 +62,12 @@ public class SequenceMetadataTest
 
   @Mock
   private TaskToolbox mockTaskToolbox;
+
+  @BeforeEach
+  public void setup()
+  {
+    MockitoAnnotations.openMocks(this);
+  }
 
   @Test
   public void testPublishAnnotatedSegmentsThrowExceptionIfOverwriteSegmentsNotNullAndNotEmpty()
@@ -88,11 +93,11 @@ public class SequenceMetadataTest
     TransactionalSegmentPublisher transactionalSegmentPublisher
         = sequenceMetadata.createPublisher(mockSeekableStreamIndexTaskRunner, mockTaskToolbox, true);
 
-    ISE exception = Assert.assertThrows(
+    ISE exception = Assertions.assertThrows(
         ISE.class,
         () -> transactionalSegmentPublisher.publishAnnotatedSegments(notNullNotEmptySegment, ImmutableSet.of(), null, null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Stream ingestion task unexpectedly attempted to overwrite segments: "
         + SegmentUtils.commaSeparatedIdentifiers(notNullNotEmptySegment),
         exception.getMessage()
@@ -166,10 +171,10 @@ public class SequenceMetadataTest
 
     Mockito.when(mockSeekableStreamIndexTaskRunner.createSequenceNumber(ArgumentMatchers.any())).thenReturn(makeSequenceNumber("1", false));
     Mockito.when(mockSeekableStreamIndexTaskRunner.isEndOffsetExclusive()).thenReturn(true);
-    Assert.assertFalse(sequenceMetadata.canHandle(mockSeekableStreamIndexTaskRunner, record));
+    Assertions.assertFalse(sequenceMetadata.canHandle(mockSeekableStreamIndexTaskRunner, record));
 
     Mockito.when(mockSeekableStreamIndexTaskRunner.isEndOffsetExclusive()).thenReturn(false);
-    Assert.assertFalse(sequenceMetadata.canHandle(mockSeekableStreamIndexTaskRunner, record));
+    Assertions.assertFalse(sequenceMetadata.canHandle(mockSeekableStreamIndexTaskRunner, record));
   }
 
   private OrderedSequenceNumber<String> makeSequenceNumber(String seq, boolean isExclusive)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
@@ -46,6 +46,7 @@ import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.incremental.SimpleRowIngestionMeters;
 import org.apache.druid.segment.transform.TransformSpec;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,11 +76,25 @@ public class StreamChunkReaderTest
 
   @Mock
   private SettableByteEntityReader mockedByteEntityReader;
+  private AutoCloseable mocks;
 
   @BeforeEach
   public void setup()
   {
-    MockitoAnnotations.openMocks(this);
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception
+  {
+    try {
+      if (mocks != null) {
+        mocks.close();
+      }
+    }
+    finally {
+      FileUtils.deleteDirectory(temporaryFolder);
+    }
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
@@ -33,6 +33,7 @@ import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.common.task.InputRowFilter;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.RE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.JSONPathSpec;
@@ -45,15 +46,12 @@ import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
 import org.apache.druid.segment.incremental.SimpleRowIngestionMeters;
 import org.apache.druid.segment.transform.TransformSpec;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.MockitoAnnotations;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -63,14 +61,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-@RunWith(MockitoJUnitRunner.class)
 public class StreamChunkReaderTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  private final File temporaryFolder = FileUtils.createTempDir();
 
   private final RowIngestionMeters rowIngestionMeters = new SimpleRowIngestionMeters();
   private final ParseExceptionHandler parseExceptionHandler = new ParseExceptionHandler(
@@ -83,6 +76,12 @@ public class StreamChunkReaderTest
   @Mock
   private SettableByteEntityReader mockedByteEntityReader;
 
+  @BeforeEach
+  public void setup()
+  {
+    MockitoAnnotations.openMocks(this);
+  }
+
   @Test
   public void testInputformatParseProperly() throws IOException
   {
@@ -91,7 +90,7 @@ public class StreamChunkReaderTest
         inputFormat,
         new InputRowSchema(TimestampSpec.DEFAULT, DimensionsSpec.EMPTY, ColumnsFilter.all()),
         TransformSpec.NONE,
-        temporaryFolder.newFolder(),
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null),
         InputRowFilter.allowAll(),
         rowIngestionMeters,
         parseExceptionHandler
@@ -102,7 +101,7 @@ public class StreamChunkReaderTest
   @Test
   public void testWithNullParserAndNullInputformatFailToCreateParser()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> new StreamChunkReader<>(
             null,
@@ -114,7 +113,7 @@ public class StreamChunkReaderTest
             parseExceptionHandler
         )
     );
-    Assert.assertEquals("inputFormat must not be null", t.getMessage());
+    Assertions.assertEquals("inputFormat must not be null", t.getMessage());
   }
 
 
@@ -129,15 +128,15 @@ public class StreamChunkReaderTest
         inputFormat,
         new InputRowSchema(TimestampSpec.DEFAULT, DimensionsSpec.EMPTY, ColumnsFilter.all()),
         TransformSpec.NONE,
-        temporaryFolder.newFolder(),
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null),
         InputRowFilter.allowAll(),
         rowIngestionMeters,
         parseExceptionHandler
     );
     List<InputRow> parsedRows = chunkParser.parse(ImmutableList.of(), false);
-    Assert.assertEquals(0, parsedRows.size());
-    Assert.assertEquals(0, rowIngestionMeters.getUnparseable());
-    Assert.assertEquals(1, rowIngestionMeters.getThrownAway());
+    Assertions.assertEquals(0, parsedRows.size());
+    Assertions.assertEquals(0, rowIngestionMeters.getUnparseable());
+    Assertions.assertEquals(1, rowIngestionMeters.getThrownAway());
   }
 
   @Test
@@ -151,15 +150,15 @@ public class StreamChunkReaderTest
         inputFormat,
         new InputRowSchema(TimestampSpec.DEFAULT, DimensionsSpec.EMPTY, ColumnsFilter.all()),
         TransformSpec.NONE,
-        temporaryFolder.newFolder(),
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null),
         InputRowFilter.allowAll(),
         rowIngestionMeters,
         parseExceptionHandler
     );
     List<InputRow> parsedRows = chunkParser.parse(ImmutableList.of(), true);
-    Assert.assertEquals(0, parsedRows.size());
-    Assert.assertEquals(0, rowIngestionMeters.getUnparseable());
-    Assert.assertEquals(0, rowIngestionMeters.getThrownAway());
+    Assertions.assertEquals(0, parsedRows.size());
+    Assertions.assertEquals(0, rowIngestionMeters.getUnparseable());
+    Assertions.assertEquals(0, rowIngestionMeters.getThrownAway());
   }
 
   @Test
@@ -183,7 +182,7 @@ public class StreamChunkReaderTest
         inputFormat,
         new InputRowSchema(TimestampSpec.DEFAULT, DimensionsSpec.EMPTY, ColumnsFilter.all()),
         transformSpec,
-        temporaryFolder.newFolder(),
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null),
         InputRowFilter.allowAll(),
         rowIngestionMeters,
         parseExceptionHandler
@@ -202,13 +201,13 @@ public class StreamChunkReaderTest
         false
     );
 
-    Assert.assertEquals(1, parsedRows.size());
-    Assert.assertEquals("title1", Iterables.getOnlyElement(parsedRows.get(0).getDimension("column_b")));
-    Assert.assertEquals(1, rowIngestionMeters.getThrownAway());
+    Assertions.assertEquals(1, parsedRows.size());
+    Assertions.assertEquals("title1", Iterables.getOnlyElement(parsedRows.get(0).getDimension("column_b")));
+    Assertions.assertEquals(1, rowIngestionMeters.getThrownAway());
 
     final Map<String, Long> thrownAwayByReason = rowIngestionMeters.getThrownAwayByReason();
-    Assert.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.CUSTOM_FILTER.getReason()));
-    Assert.assertFalse(thrownAwayByReason.containsKey(InputRowFilterResult.NULL_OR_EMPTY_RECORD.getReason()));
+    Assertions.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.CUSTOM_FILTER.getReason()));
+    Assertions.assertFalse(thrownAwayByReason.containsKey(InputRowFilterResult.NULL_OR_EMPTY_RECORD.getReason()));
   }
 
   @Test
@@ -242,7 +241,7 @@ public class StreamChunkReaderTest
         inputFormat,
         new InputRowSchema(TimestampSpec.DEFAULT, DimensionsSpec.EMPTY, ColumnsFilter.all()),
         transformSpec,
-        temporaryFolder.newFolder(),
+        FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null),
         rowFilter,
         rowIngestionMeters,
         parseExceptionHandler
@@ -271,16 +270,16 @@ public class StreamChunkReaderTest
         false
     );
 
-    Assert.assertEquals(1, parsedRows.size());
-    Assert.assertEquals("title1", Iterables.getOnlyElement(parsedRows.get(0).getDimension("column_b")));
-    Assert.assertEquals(4, rowIngestionMeters.getThrownAway());
+    Assertions.assertEquals(1, parsedRows.size());
+    Assertions.assertEquals("title1", Iterables.getOnlyElement(parsedRows.get(0).getDimension("column_b")));
+    Assertions.assertEquals(4, rowIngestionMeters.getThrownAway());
 
     final Map<String, Long> thrownAwayByReason = rowIngestionMeters.getThrownAwayByReason();
-    Assert.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.NULL_OR_EMPTY_RECORD.getReason()));
-    Assert.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME.getReason()));
-    Assert.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME.getReason()));
-    Assert.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.CUSTOM_FILTER.getReason()));
-    Assert.assertFalse(thrownAwayByReason.containsKey(InputRowFilterResult.UNKNOWN.getReason()));
+    Assertions.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.NULL_OR_EMPTY_RECORD.getReason()));
+    Assertions.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME.getReason()));
+    Assertions.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME.getReason()));
+    Assertions.assertEquals(Long.valueOf(1), thrownAwayByReason.get(InputRowFilterResult.CUSTOM_FILTER.getReason()));
+    Assertions.assertFalse(thrownAwayByReason.containsKey(InputRowFilterResult.UNKNOWN.getReason()));
   }
 
   @Test
@@ -306,8 +305,8 @@ public class StreamChunkReaderTest
             new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))), false
     );
     // no exception and no parsed rows
-    Assert.assertEquals(0, parsedRows.size());
-    Assert.assertEquals(maxAllowedParseExceptions, rowIngestionMeters.getUnparseable());
+    Assertions.assertEquals(0, parsedRows.size());
+    Assertions.assertEquals(maxAllowedParseExceptions, rowIngestionMeters.getUnparseable());
   }
 
   @Test
@@ -329,12 +328,12 @@ public class StreamChunkReaderTest
         new ByteEntity(json.getBytes(StringUtils.UTF8_STRING)),
         new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))
     );
-    Assert.assertThrows(
-        "Max parse exceptions[0] exceeded",
+    Assertions.assertThrows(
         RE.class,
-        () -> chunkParser.parse(byteEntities, false)
+        () -> chunkParser.parse(byteEntities, false),
+        "Max parse exceptions[0] exceeded"
     );
-    Assert.assertEquals(1, rowIngestionMeters.getUnparseable()); // should barf on the first unparseable row
+    Assertions.assertEquals(1, rowIngestionMeters.getUnparseable()); // should barf on the first unparseable row
   }
 
   @Test
@@ -365,14 +364,14 @@ public class StreamChunkReaderTest
 
     List<InputRow> parsedRows = chunkParser.parse(byteEntities, false);
     // no exception since we've unlimited threhold for parse exceptions
-    Assert.assertEquals(0, parsedRows.size());
-    Assert.assertEquals(byteEntities.size(), rowIngestionMeters.getUnparseable());
+    Assertions.assertEquals(0, parsedRows.size());
+    Assertions.assertEquals(byteEntities.size(), rowIngestionMeters.getUnparseable());
   }
 
   @Test
   public void testWithNullParserAndNullByteEntityReaderFailToInstantiate()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> new StreamChunkReader<>(
             null,
@@ -381,19 +380,19 @@ public class StreamChunkReaderTest
             parseExceptionHandler
         )
     );
-    Assert.assertEquals("byteEntityReader must not be null", t.getMessage());
+    Assertions.assertEquals("byteEntityReader must not be null", t.getMessage());
   }
 
   private void parseAndAssertResult(StreamChunkReader<ByteEntity> chunkParser) throws IOException
   {
     final String json = "{\"timestamp\": \"2020-01-01\", \"dim\": \"val\", \"met\": \"val2\"}";
     List<InputRow> parsedRows = chunkParser.parse(Collections.singletonList(new ByteEntity(json.getBytes(StringUtils.UTF8_STRING))), false);
-    Assert.assertEquals(1, parsedRows.size());
+    Assertions.assertEquals(1, parsedRows.size());
     InputRow row = parsedRows.get(0);
-    Assert.assertEquals(DateTimes.of("2020-01-01"), row.getTimestamp());
-    Assert.assertEquals("val", Iterables.getOnlyElement(row.getDimension("dim")));
-    Assert.assertEquals("val2", Iterables.getOnlyElement(row.getDimension("met")));
-    Assert.assertEquals(0, rowIngestionMeters.getUnparseable());
+    Assertions.assertEquals(DateTimes.of("2020-01-01"), row.getTimestamp());
+    Assertions.assertEquals("val", Iterables.getOnlyElement(row.getDimension("dim")));
+    Assertions.assertEquals("val2", Iterables.getOnlyElement(row.getDimension("met")));
+    Assertions.assertEquals(0, rowIngestionMeters.getUnparseable());
   }
 
   private static class TrackingJsonInputFormat extends JsonInputFormat

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/StreamChunkReaderTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -64,7 +65,8 @@ import java.util.Map;
 
 public class StreamChunkReaderTest
 {
-  private final File temporaryFolder = FileUtils.createTempDir();
+  @TempDir
+  private File temporaryFolder;
 
   private final RowIngestionMeters rowIngestionMeters = new SimpleRowIngestionMeters();
   private final ParseExceptionHandler parseExceptionHandler = new ParseExceptionHandler(
@@ -87,13 +89,8 @@ public class StreamChunkReaderTest
   @AfterEach
   public void tearDown() throws Exception
   {
-    try {
-      if (mocks != null) {
-        mocks.close();
-      }
-    }
-    finally {
-      FileUtils.deleteDirectory(temporaryFolder);
+    if (mocks != null) {
+      mocks.close();
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/BoundedStreamConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/BoundedStreamConfigTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing.seekablestream.supervisor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.error.DruidException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -43,51 +43,51 @@ public class BoundedStreamConfigTest
   @Test
   public void testConstructorWithNullStartSequenceNumbers()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new BoundedStreamConfig(null, Map.of("0", 500L))
     );
-    Assert.assertTrue(ex.getMessage().contains("cannot be null or empty"));
+    Assertions.assertTrue(ex.getMessage().contains("cannot be null or empty"));
   }
 
   @Test
   public void testConstructorWithNullEndSequenceNumbers()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new BoundedStreamConfig(Map.of("0", 100L), null)
     );
-    Assert.assertTrue(ex.getMessage().contains("cannot be null or empty"));
+    Assertions.assertTrue(ex.getMessage().contains("cannot be null or empty"));
   }
 
   @Test
   public void testConstructorWithEmptyStartSequenceNumbers()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new BoundedStreamConfig(Map.of(), Map.of("0", 500L))
     );
-    Assert.assertTrue(ex.getMessage().contains("cannot be null or empty"));
+    Assertions.assertTrue(ex.getMessage().contains("cannot be null or empty"));
   }
 
   @Test
   public void testConstructorWithEmptyEndSequenceNumbers()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new BoundedStreamConfig(Map.of("0", 100L), Map.of())
     );
-    Assert.assertTrue(ex.getMessage().contains("cannot be null or empty"));
+    Assertions.assertTrue(ex.getMessage().contains("cannot be null or empty"));
   }
 
   @Test
   public void testConstructorWithMismatchedPartitions()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new BoundedStreamConfig(Map.of("0", 100L), Map.of("1", 500L))
     );
-    Assert.assertTrue(ex.getMessage().contains("must have matching partition sets"));
+    Assertions.assertTrue(ex.getMessage().contains("must have matching partition sets"));
   }
 
   @Test
@@ -103,12 +103,12 @@ public class BoundedStreamConfigTest
         BoundedStreamConfig.class
     );
 
-    Assert.assertEquals(2, deserialized.getStartSequenceNumbers().size());
-    Assert.assertEquals(2, deserialized.getEndSequenceNumbers().size());
-    Assert.assertEquals(100, deserialized.getStartSequenceNumbers().get("0"));
-    Assert.assertEquals(200, deserialized.getStartSequenceNumbers().get("1"));
-    Assert.assertEquals(500, deserialized.getEndSequenceNumbers().get("0"));
-    Assert.assertEquals(600, deserialized.getEndSequenceNumbers().get("1"));
+    Assertions.assertEquals(2, deserialized.getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, deserialized.getEndSequenceNumbers().size());
+    Assertions.assertEquals(100, deserialized.getStartSequenceNumbers().get("0"));
+    Assertions.assertEquals(200, deserialized.getStartSequenceNumbers().get("1"));
+    Assertions.assertEquals(500, deserialized.getEndSequenceNumbers().get("0"));
+    Assertions.assertEquals(600, deserialized.getEndSequenceNumbers().get("1"));
   }
 
   @Test
@@ -121,8 +121,8 @@ public class BoundedStreamConfigTest
 
     BoundedStreamConfig config = mapper.readValue(json, BoundedStreamConfig.class);
 
-    Assert.assertEquals(2, config.getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getEndSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getEndSequenceNumbers().size());
   }
 
   @Test
@@ -135,7 +135,7 @@ public class BoundedStreamConfigTest
 
     BoundedStreamConfig config = mapper.readValue(json, BoundedStreamConfig.class);
 
-    Assert.assertEquals(2, config.getStartSequenceNumbers().size());
-    Assert.assertEquals(2, config.getEndSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getStartSequenceNumbers().size());
+    Assertions.assertEquals(2, config.getEndSequenceNumbers().size());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/OffsetSnapshotTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/OffsetSnapshotTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.indexing.seekablestream.supervisor;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,10 +37,10 @@ public class OffsetSnapshotTest
         Collections.emptyMap()
     );
 
-    Assert.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
-    Assert.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
-    Assert.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
-    Assert.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
+    Assertions.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
+    Assertions.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
+    Assertions.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
+    Assertions.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
   }
 
   @Test
@@ -48,10 +48,10 @@ public class OffsetSnapshotTest
   {
     OffsetSnapshot<Integer, Long> snapshot = OffsetSnapshot.of(null, null);
 
-    Assert.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
-    Assert.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
-    Assert.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
-    Assert.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
+    Assertions.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
+    Assertions.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
+    Assertions.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
+    Assertions.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
   }
 
   @Test
@@ -61,9 +61,9 @@ public class OffsetSnapshotTest
 
     OffsetSnapshot<Integer, Long> snapshot = OffsetSnapshot.of(null, endOffsets);
 
-    Assert.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
-    Assert.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
-    Assert.assertEquals(endOffsets, snapshot.getLatestOffsetsFromStream());
+    Assertions.assertTrue(snapshot.getHighestIngestedOffsets().isEmpty());
+    Assertions.assertEquals(ImmutableMap.of(), snapshot.getHighestIngestedOffsets());
+    Assertions.assertEquals(endOffsets, snapshot.getLatestOffsetsFromStream());
   }
 
   @Test
@@ -73,9 +73,9 @@ public class OffsetSnapshotTest
 
     OffsetSnapshot<Integer, Long> snapshot = OffsetSnapshot.of(currentOffsets, null);
 
-    Assert.assertEquals(currentOffsets, snapshot.getHighestIngestedOffsets());
-    Assert.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
-    Assert.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
+    Assertions.assertEquals(currentOffsets, snapshot.getHighestIngestedOffsets());
+    Assertions.assertTrue(snapshot.getLatestOffsetsFromStream().isEmpty());
+    Assertions.assertEquals(ImmutableMap.of(), snapshot.getLatestOffsetsFromStream());
   }
 
   @Test
@@ -91,8 +91,8 @@ public class OffsetSnapshotTest
 
     OffsetSnapshot<String, String> snapshot = OffsetSnapshot.of(current, end);
 
-    Assert.assertEquals(Map.of("p0", "100", "p1", "200"), snapshot.getHighestIngestedOffsets());
-    Assert.assertEquals(Map.of("p0", "150", "p2", "300"), snapshot.getLatestOffsetsFromStream());
+    Assertions.assertEquals(Map.of("p0", "100", "p1", "200"), snapshot.getHighestIngestedOffsets());
+    Assertions.assertEquals(Map.of("p0", "150", "p2", "300"), snapshot.getLatestOffsetsFromStream());
   }
 
   @Test
@@ -109,11 +109,11 @@ public class OffsetSnapshotTest
 
     OffsetSnapshot<Integer, Long> snapshot = OffsetSnapshot.of(current, end);
 
-    Assert.assertEquals(Map.of(0, 100L, 2, 200L), snapshot.getHighestIngestedOffsets());
-    Assert.assertEquals(2, snapshot.getHighestIngestedOffsets().size());
+    Assertions.assertEquals(Map.of(0, 100L, 2, 200L), snapshot.getHighestIngestedOffsets());
+    Assertions.assertEquals(2, snapshot.getHighestIngestedOffsets().size());
 
-    Assert.assertEquals(Map.of(1, 300L), snapshot.getLatestOffsetsFromStream());
-    Assert.assertEquals(1, snapshot.getLatestOffsetsFromStream().size());
+    Assertions.assertEquals(Map.of(1, 300L), snapshot.getLatestOffsetsFromStream());
+    Assertions.assertEquals(1, snapshot.getLatestOffsetsFromStream().size());
   }
 
   @Test
@@ -130,7 +130,7 @@ public class OffsetSnapshotTest
     inputCurrent.clear();
     inputEnd.put(999, 999L);
 
-    Assert.assertEquals(Map.of(1, 10L), snapshot.getHighestIngestedOffsets());
-    Assert.assertEquals(Map.of(2, 20L), snapshot.getLatestOffsetsFromStream());
+    Assertions.assertEquals(Map.of(1, 10L), snapshot.getHighestIngestedOffsets());
+    Assertions.assertEquals(Map.of(2, 20L), snapshot.getLatestOffsetsFromStream());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorIOConfigTest.java
@@ -23,17 +23,15 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.apache.druid.data.input.InputFormat;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.AutoScalerConfig;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -43,6 +41,14 @@ import static org.mockito.Mockito.when;
 
 public class SeekableStreamSupervisorIOConfigTest
 {
+
+  private static void assertInvalidInputException(DruidException exception, String message)
+  {
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals(message, exception.getMessage());
+  }
 
   private final Map<Integer, Integer> serverPriorityToReplicas = Map.of(
       1, 2,
@@ -78,23 +84,23 @@ public class SeekableStreamSupervisorIOConfigTest
     {
     };
 
-    Assert.assertEquals("stream", config.getStream());
-    Assert.assertEquals(inputFormat, config.getInputFormat());
-    Assert.assertEquals(Integer.valueOf(1), config.getReplicas());
-    Assert.assertEquals(1, config.getTaskCount());
-    Assert.assertEquals(Duration.standardHours(1), config.getTaskDuration());
-    Assert.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
-    Assert.assertEquals(Duration.standardSeconds(30), config.getPeriod());
-    Assert.assertFalse(config.isUseEarliestSequenceNumber());
-    Assert.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
-    Assert.assertFalse(config.getEarlyMessageRejectionPeriod().isPresent());
-    Assert.assertFalse(config.getLateMessageRejectionPeriod().isPresent());
-    Assert.assertFalse(config.getLateMessageRejectionStartDateTime().isPresent());
-    Assert.assertNull(config.getIdleConfig());
-    Assert.assertNull(config.getStopTaskCount());
-    Assert.assertEquals(lagAggregator, config.getLagAggregator());
-    Assert.assertEquals(1, config.getMaxAllowedStops());
-    Assert.assertNull(config.getServerPriorityToReplicas());
+    Assertions.assertEquals("stream", config.getStream());
+    Assertions.assertEquals(inputFormat, config.getInputFormat());
+    Assertions.assertEquals(Integer.valueOf(1), config.getReplicas());
+    Assertions.assertEquals(1, config.getTaskCount());
+    Assertions.assertEquals(Duration.standardHours(1), config.getTaskDuration());
+    Assertions.assertEquals(Duration.standardSeconds(5), config.getStartDelay());
+    Assertions.assertEquals(Duration.standardSeconds(30), config.getPeriod());
+    Assertions.assertFalse(config.isUseEarliestSequenceNumber());
+    Assertions.assertEquals(Duration.standardMinutes(30), config.getCompletionTimeout());
+    Assertions.assertFalse(config.getEarlyMessageRejectionPeriod().isPresent());
+    Assertions.assertFalse(config.getLateMessageRejectionPeriod().isPresent());
+    Assertions.assertFalse(config.getLateMessageRejectionStartDateTime().isPresent());
+    Assertions.assertNull(config.getIdleConfig());
+    Assertions.assertNull(config.getStopTaskCount());
+    Assertions.assertEquals(lagAggregator, config.getLagAggregator());
+    Assertions.assertEquals(1, config.getMaxAllowedStops());
+    Assertions.assertNull(config.getServerPriorityToReplicas());
   }
 
   @Test
@@ -154,8 +160,8 @@ public class SeekableStreamSupervisorIOConfigTest
     )
     {
     };
-    Assert.assertEquals(expectedTaskCount, config.getTaskCount());
-    Assert.assertEquals(expectedExplicit, config.isTaskCountExplicit());
+    Assertions.assertEquals(expectedTaskCount, config.getTaskCount());
+    Assertions.assertEquals(expectedExplicit, config.isTaskCountExplicit());
   }
 
   @Test
@@ -163,7 +169,7 @@ public class SeekableStreamSupervisorIOConfigTest
   {
     LagAggregator lagAggregator = mock(LagAggregator.class);
 
-    IAE ex = Assert.assertThrows(
+    IAE ex = Assertions.assertThrows(
         IAE.class,
         () -> new TestableSeekableStreamSupervisorIOConfig(
             "stream",
@@ -188,7 +194,7 @@ public class SeekableStreamSupervisorIOConfigTest
         {
         }
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ex.getMessage()
           .contains(
               "SeekableStreamSupervisorIOConfig does not support both properties lateMessageRejectionStartDateTime and lateMessageRejectionPeriod"
@@ -199,7 +205,7 @@ public class SeekableStreamSupervisorIOConfigTest
   @Test
   public void testNullAggregatorThrows()
   {
-    DruidException ex = Assert.assertThrows(
+    DruidException ex = Assertions.assertThrows(
         DruidException.class,
         () -> new TestableSeekableStreamSupervisorIOConfig(
             "stream",
@@ -224,7 +230,7 @@ public class SeekableStreamSupervisorIOConfigTest
         {
         }
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ex.getMessage().contains("'lagAggregator' must be specified in supervisor 'spec.ioConfig'")
     );
   }
@@ -257,7 +263,7 @@ public class SeekableStreamSupervisorIOConfigTest
     )
     {
     };
-    Assert.assertEquals(7, config1.getMaxAllowedStops());
+    Assertions.assertEquals(7, config1.getMaxAllowedStops());
 
     // Autoscaler disabled, stopTaskCount set
     SeekableStreamSupervisorIOConfig config2 = new TestableSeekableStreamSupervisorIOConfig(
@@ -282,7 +288,7 @@ public class SeekableStreamSupervisorIOConfigTest
     )
     {
     };
-    Assert.assertEquals(3, config2.getMaxAllowedStops());
+    Assertions.assertEquals(3, config2.getMaxAllowedStops());
   }
 
   @Test
@@ -320,11 +326,11 @@ public class SeekableStreamSupervisorIOConfigTest
     {
     };
 
-    Assert.assertEquals(5, config.getMaxAllowedStops());
+    Assertions.assertEquals(5, config.getMaxAllowedStops());
 
     // Ensure never goes below 1
     when(autoScalerConfig.getStopTaskCountRatio()).thenReturn(0.05);
-    Assert.assertEquals(1, config.getMaxAllowedStops());
+    Assertions.assertEquals(1, config.getMaxAllowedStops());
 
     // Autoscaler enabled, stopTaskCountRatio unset, stopTaskCount set
     when(autoScalerConfig.getEnableTaskAutoScaler()).thenReturn(true);
@@ -354,7 +360,7 @@ public class SeekableStreamSupervisorIOConfigTest
     {
     };
 
-    Assert.assertEquals(1, config2.getMaxAllowedStops());
+    Assertions.assertEquals(1, config2.getMaxAllowedStops());
 
 
     // Autoscaler enabled, stopTaskCountRatio unset, stopTaskCount unset
@@ -385,47 +391,45 @@ public class SeekableStreamSupervisorIOConfigTest
     {
     };
 
-    Assert.assertEquals(10, config3.getMaxAllowedStops());
+    Assertions.assertEquals(10, config3.getMaxAllowedStops());
   }
 
   @Test
   public void testReplicasIsSetWhenserverPriorityToReplicas()
   {
     final SeekableStreamSupervisorIOConfig config = makeSeekableStreamSupervisorIOConfig(null, serverPriorityToReplicas);
-    Assert.assertEquals(serverPriorityToReplicas, config.getServerPriorityToReplicas());
-    Assert.assertEquals(Integer.valueOf(5), config.getReplicas());
+    Assertions.assertEquals(serverPriorityToReplicas, config.getServerPriorityToReplicas());
+    Assertions.assertEquals(Integer.valueOf(5), config.getReplicas());
   }
 
   @Test
   public void testReplicasOnlyConfig()
   {
     final SeekableStreamSupervisorIOConfig config = makeSeekableStreamSupervisorIOConfig(4, null);
-    Assert.assertEquals(Integer.valueOf(4), config.getReplicas());
-    Assert.assertNull(config.getServerPriorityToReplicas());
+    Assertions.assertEquals(Integer.valueOf(4), config.getReplicas());
+    Assertions.assertNull(config.getServerPriorityToReplicas());
   }
 
   @Test
   public void testMatchingReplicasAndServerPriority()
   {
     final SeekableStreamSupervisorIOConfig config = makeSeekableStreamSupervisorIOConfig(5, serverPriorityToReplicas);
-    Assert.assertEquals(Integer.valueOf(5), config.getReplicas());
-    Assert.assertEquals(serverPriorityToReplicas, config.getServerPriorityToReplicas());
+    Assertions.assertEquals(Integer.valueOf(5), config.getReplicas());
+    Assertions.assertEquals(serverPriorityToReplicas, config.getServerPriorityToReplicas());
   }
 
   @Test
   public void testMismatchBetweenReplicasAndServerPriorityReplicasThrowsException()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    assertInvalidInputException(
+        Assertions.assertThrows(
             DruidException.class,
             () -> makeSeekableStreamSupervisorIOConfig(3, serverPriorityToReplicas)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format(
-                "Configured replicas[3] does not match the sum of replicas[5] specified in serverPriorityToReplicas[%s]."
-                + " To avoid ambiguity, consider removing [ioConfig.replicas] in favor of [ioConfig.serverPriorityToReplicas].",
-                serverPriorityToReplicas
-            )
+        StringUtils.format(
+            "Configured replicas[3] does not match the sum of replicas[5] specified in serverPriorityToReplicas[%s]."
+            + " To avoid ambiguity, consider removing [ioConfig.replicas] in favor of [ioConfig.serverPriorityToReplicas].",
+            serverPriorityToReplicas
         )
     );
   }
@@ -434,16 +438,14 @@ public class SeekableStreamSupervisorIOConfigTest
   public void testNegativeReplicasThrowsException()
   {
     final Map<Integer, Integer> invalidServerPriorityToReplicas = Map.of(0, 2, 1, -1);
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
+    assertInvalidInputException(
+        Assertions.assertThrows(
             DruidException.class,
             () -> makeSeekableStreamSupervisorIOConfig(null, invalidServerPriorityToReplicas)
         ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format(
-                "Found invalid server replica[-1] for priority[1] in serverPriorityToReplicas[%s]. Replicas must be >= 0.",
-                invalidServerPriorityToReplicas
-            )
+        StringUtils.format(
+            "Found invalid server replica[-1] for priority[1] in serverPriorityToReplicas[%s]. Replicas must be >= 0.",
+            invalidServerPriorityToReplicas
         )
     );
   }
@@ -506,9 +508,9 @@ public class SeekableStreamSupervisorIOConfigTest
     {
     };
 
-    Assert.assertTrue(config.isBounded());
-    Assert.assertNotNull(config.getBoundedStreamConfig());
-    Assert.assertEquals(boundedConfig, config.getBoundedStreamConfig());
+    Assertions.assertTrue(config.isBounded());
+    Assertions.assertNotNull(config.getBoundedStreamConfig());
+    Assertions.assertEquals(boundedConfig, config.getBoundedStreamConfig());
   }
 
   @Test
@@ -539,8 +541,8 @@ public class SeekableStreamSupervisorIOConfigTest
     {
     };
 
-    Assert.assertFalse(config.isBounded());
-    Assert.assertNull(config.getBoundedStreamConfig());
+    Assertions.assertFalse(config.isBounded());
+    Assertions.assertNull(config.getBoundedStreamConfig());
   }
 
   @Test
@@ -571,8 +573,8 @@ public class SeekableStreamSupervisorIOConfigTest
     {
     };
 
-    Assert.assertFalse(config.isBounded());
-    Assert.assertNull(config.getBoundedStreamConfig());
+    Assertions.assertFalse(config.isBounded());
+    Assertions.assertNull(config.getBoundedStreamConfig());
   }
 
   private static SupervisorIOConfigBuilder.DefaultSupervisorIOConfigBuilder ioConfigBuilder()
@@ -589,15 +591,15 @@ public class SeekableStreamSupervisorIOConfigTest
   public void testEqualsAndHashCode()
   {
     final SeekableStreamSupervisorIOConfig config = ioConfigBuilder().build();
-    Assert.assertEquals(config, ioConfigBuilder().build());
-    Assert.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
-    Assert.assertNotEquals(config, null);
-    Assert.assertNotEquals(config, "not an io config");
-    Assert.assertNotEquals(config, ioConfigBuilder().withStream("other").build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withStopTaskCount(7).build());
-    Assert.assertNotEquals(config, ioConfigBuilder().withIdleConfig(new IdleConfig(true, 5L)).build());
+    Assertions.assertEquals(config, ioConfigBuilder().build());
+    Assertions.assertEquals(config.hashCode(), ioConfigBuilder().build().hashCode());
+    Assertions.assertNotEquals(config, null);
+    Assertions.assertNotEquals(config, "not an io config");
+    Assertions.assertNotEquals(config, ioConfigBuilder().withStream("other").build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withReplicas(9).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withTaskCount(9).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withStopTaskCount(7).build());
+    Assertions.assertNotEquals(config, ioConfigBuilder().withIdleConfig(new IdleConfig(true, 5L)).build());
   }
 
   @Test
@@ -631,10 +633,10 @@ public class SeekableStreamSupervisorIOConfigTest
   {
     // The default aggregator is a stateless singleton; instance() always returns DEFAULT.
     final LagAggregator aggregator = LagAggregator.DefaultLagAggregator.instance();
-    Assert.assertSame(LagAggregator.DEFAULT, aggregator);
-    Assert.assertEquals(aggregator, LagAggregator.DefaultLagAggregator.instance());
-    Assert.assertNotEquals(aggregator, null);
-    Assert.assertNotEquals(aggregator, "not a lag aggregator");
+    Assertions.assertSame(LagAggregator.DEFAULT, aggregator);
+    Assertions.assertEquals(aggregator, LagAggregator.DefaultLagAggregator.instance());
+    Assertions.assertNotEquals(aggregator, null);
+    Assertions.assertNotEquals(aggregator, "not a lag aggregator");
   }
 
   /**

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorScaleDuringTaskRolloverTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorScaleDuringTaskRolloverTest.java
@@ -25,9 +25,9 @@ import org.apache.druid.indexing.overlord.supervisor.autoscaler.SupervisorTaskAu
 import org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScalerConfig;
 import org.apache.druid.query.DruidMetrics;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends SeekableStreamSupervisorTestBase
 {
@@ -35,7 +35,7 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
 
   private SupervisorStateManagerConfig supervisorConfig;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     supervisorConfig = new SupervisorStateManagerConfig();
@@ -62,7 +62,7 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
     supervisor.maybeScaleDuringTaskRollover();
 
     // Then
-    Assert.assertNull(supervisor.getIoConfig().getAutoScalerConfig());
+    Assertions.assertNull(supervisor.getIoConfig().getAutoScalerConfig());
   }
 
   @Test
@@ -85,11 +85,11 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
     supervisor.maybeScaleDuringTaskRollover();
 
     // Then
-    Assert.assertNotNull(supervisor.getIoConfig().getAutoScalerConfig());
-    Assert.assertEquals(
-        "Task count should not change when rolloverTaskCount <= 0",
+    Assertions.assertNotNull(supervisor.getIoConfig().getAutoScalerConfig());
+    Assertions.assertEquals(
         beforeTaskCount,
-        (int) supervisor.getIoConfig().getTaskCount()
+        (int) supervisor.getIoConfig().getTaskCount(),
+        "Task count should not change when rolloverTaskCount <= 0"
     );
   }
 
@@ -113,11 +113,11 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
     supervisor.maybeScaleDuringTaskRollover();
 
     // Then
-    Assert.assertNotNull(supervisor.getIoConfig().getAutoScalerConfig());
-    Assert.assertEquals(
-        "Task count should be updated to " + targetTaskCount + " when rolloverTaskCount > 0",
+    Assertions.assertNotNull(supervisor.getIoConfig().getAutoScalerConfig());
+    Assertions.assertEquals(
         targetTaskCount,
-        (int) supervisor.getIoConfig().getTaskCount()
+        (int) supervisor.getIoConfig().getTaskCount(),
+        "Task count should be updated to " + targetTaskCount + " when rolloverTaskCount > 0"
     );
   }
 
@@ -141,11 +141,11 @@ public class SeekableStreamSupervisorScaleDuringTaskRolloverTest extends Seekabl
     supervisor.maybeScaleDuringTaskRollover();
 
     // Then
-    Assert.assertNotNull(supervisor.getIoConfig().getAutoScalerConfig());
-    Assert.assertEquals(
-        "Task count should not change when rolloverTaskCount is 0",
+    Assertions.assertNotNull(supervisor.getIoConfig().getAutoScalerConfig());
+    Assertions.assertEquals(
         beforeTaskCount,
-        (int) supervisor.getIoConfig().getTaskCount()
+        (int) supervisor.getIoConfig().getTaskCount(),
+        "Task count should not change when rolloverTaskCount is 0"
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorSpecTest.java
@@ -25,7 +25,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexing.overlord.supervisor.NoopSupervisorSpec;
 import org.apache.druid.indexing.overlord.supervisor.Supervisor;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
@@ -49,11 +48,10 @@ import org.apache.druid.metadata.TestSupervisorSpec;
 import org.apache.druid.query.DruidMetrics;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.easymock.EasyMock;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -64,10 +62,16 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import static org.junit.Assert.assertThrows;
-
 public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTestBase
 {
+  private static void assertInvalidInputException(DruidException exception, String message)
+  {
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals(message, exception.getMessage());
+  }
+
   private SeekableStreamSupervisorIngestionSpec ingestionSchema;
   private DataSchema dataSchema;
   private SeekableStreamSupervisorTuningConfig seekableStreamSupervisorTuningConfig;
@@ -80,7 +84,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
   private DruidMonitorSchedulerConfig monitorSchedulerConfig;
   private SupervisorStateManagerConfig supervisorStateManagerConfig;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     ingestionSchema = EasyMock.mock(SeekableStreamSupervisorIngestionSpec.class);
@@ -104,25 +108,25 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
   public void testAutoScalerConfig()
   {
     AutoScalerConfig autoScalerConfigEmpty = mapper.convertValue(new HashMap<>(), AutoScalerConfig.class);
-    Assert.assertTrue(autoScalerConfigEmpty instanceof LagBasedAutoScalerConfig);
-    Assert.assertFalse(autoScalerConfigEmpty.getEnableTaskAutoScaler());
+    Assertions.assertTrue(autoScalerConfigEmpty instanceof LagBasedAutoScalerConfig);
+    Assertions.assertFalse(autoScalerConfigEmpty.getEnableTaskAutoScaler());
 
     AutoScalerConfig autoScalerConfigNull = mapper.convertValue(null, AutoScalerConfig.class);
-    Assert.assertNull(autoScalerConfigNull);
+    Assertions.assertNull(autoScalerConfigNull);
 
     AutoScalerConfig autoScalerConfigDefault = mapper.convertValue(
         ImmutableMap.of("autoScalerStrategy", "lagBased"),
         AutoScalerConfig.class
     );
-    Assert.assertTrue(autoScalerConfigDefault instanceof LagBasedAutoScalerConfig);
+    Assertions.assertTrue(autoScalerConfigDefault instanceof LagBasedAutoScalerConfig);
 
     AutoScalerConfig autoScalerConfigValue = mapper.convertValue(
         ImmutableMap.of("lagCollectionIntervalMillis", "1"),
         AutoScalerConfig.class
     );
-    Assert.assertTrue(autoScalerConfigValue instanceof LagBasedAutoScalerConfig);
+    Assertions.assertTrue(autoScalerConfigValue instanceof LagBasedAutoScalerConfig);
     LagBasedAutoScalerConfig lagBasedAutoScalerConfig = (LagBasedAutoScalerConfig) autoScalerConfigValue;
-    Assert.assertEquals(lagBasedAutoScalerConfig.getLagCollectionIntervalMillis(), 1);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getLagCollectionIntervalMillis(), 1);
 
     Exception e = null;
     try {
@@ -140,7 +144,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     catch (RuntimeException ex) {
       e = ex;
     }
-    Assert.assertNotNull(e);
+    Assertions.assertNotNull(e);
 
     e = null;
     try {
@@ -153,7 +157,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     catch (RuntimeException ex) {
       e = ex;
     }
-    Assert.assertNotNull(e);
+    Assertions.assertNotNull(e);
   }
 
   @Test
@@ -207,7 +211,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         "id1"
     );
     SupervisorTaskAutoScaler autoscaler = spec.createAutoscaler(supervisor4);
-    Assert.assertTrue(autoscaler instanceof LagBasedAutoScaler);
+    Assertions.assertTrue(autoscaler instanceof LagBasedAutoScaler);
 
     EasyMock.reset(seekableStreamSupervisorIOConfig);
     autoScalerConfig.put("enableTaskAutoScaler", false);
@@ -216,7 +220,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
             .anyTimes();
     EasyMock.replay(seekableStreamSupervisorIOConfig);
     SupervisorTaskAutoScaler autoscaler2 = spec.createAutoscaler(supervisor4);
-    Assert.assertTrue(autoscaler2 instanceof NoopTaskAutoScaler);
+    Assertions.assertTrue(autoscaler2 instanceof NoopTaskAutoScaler);
 
     EasyMock.reset(seekableStreamSupervisorIOConfig);
     autoScalerConfig.remove("enableTaskAutoScaler");
@@ -225,7 +229,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
             .anyTimes();
     EasyMock.replay(seekableStreamSupervisorIOConfig);
     SupervisorTaskAutoScaler autoscaler3 = spec.createAutoscaler(supervisor4);
-    Assert.assertTrue(autoscaler3 instanceof NoopTaskAutoScaler);
+    Assertions.assertTrue(autoscaler3 instanceof NoopTaskAutoScaler);
 
     EasyMock.reset(seekableStreamSupervisorIOConfig);
     autoScalerConfig.clear();
@@ -233,9 +237,9 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
             .andReturn(mapper.convertValue(autoScalerConfig, AutoScalerConfig.class))
             .anyTimes();
     EasyMock.replay(seekableStreamSupervisorIOConfig);
-    Assert.assertTrue(autoScalerConfig.isEmpty());
+    Assertions.assertTrue(autoScalerConfig.isEmpty());
     SupervisorTaskAutoScaler autoscaler4 = spec.createAutoscaler(supervisor4);
-    Assert.assertTrue(autoscaler4 instanceof NoopTaskAutoScaler);
+    Assertions.assertTrue(autoscaler4 instanceof NoopTaskAutoScaler);
   }
 
   @Test
@@ -285,9 +289,9 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
 
     // When passing a non-SeekableStreamSupervisor, should return NoopTaskAutoScaler
     SupervisorTaskAutoScaler autoscaler = spec.createAutoscaler(nonSeekableStreamSupervisor);
-    Assert.assertTrue(
-        "Should return NoopTaskAutoScaler when supervisor is not SeekableStreamSupervisor",
-        autoscaler instanceof NoopTaskAutoScaler
+    Assertions.assertTrue(
+        autoscaler instanceof NoopTaskAutoScaler,
+        "Should return NoopTaskAutoScaler when supervisor is not SeekableStreamSupervisor"
     );
   }
 
@@ -329,9 +333,9 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
 
     // When autoScalerConfig is null, should return NoopTaskAutoScaler
     SupervisorTaskAutoScaler autoscaler = spec.createAutoscaler(supervisor4);
-    Assert.assertTrue(
-        "Should return NoopTaskAutoScaler when autoScalerConfig is null",
-        autoscaler instanceof NoopTaskAutoScaler
+    Assertions.assertTrue(
+        autoscaler instanceof NoopTaskAutoScaler,
+        "Should return NoopTaskAutoScaler when autoScalerConfig is null"
     );
   }
 
@@ -381,20 +385,20 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         "id1"
     );
     SupervisorTaskAutoScaler autoscaler = spec.createAutoscaler(supervisor4);
-    Assert.assertTrue(autoscaler instanceof LagBasedAutoScaler);
+    Assertions.assertTrue(autoscaler instanceof LagBasedAutoScaler);
     LagBasedAutoScaler lagBasedAutoScaler = (LagBasedAutoScaler) autoscaler;
     LagBasedAutoScalerConfig lagBasedAutoScalerConfig = lagBasedAutoScaler.getAutoScalerConfig();
-    Assert.assertEquals(lagBasedAutoScalerConfig.getLagCollectionIntervalMillis(), 1);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getLagCollectionRangeMillis(), 600000);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getScaleActionStartDelayMillis(), 300000);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getScaleActionPeriodMillis(), 60000);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getScaleOutThreshold(), 6000000);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getScaleInThreshold(), 1000000);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getTaskCountMax(), 4);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getTaskCountMin(), 1);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getScaleInStep(), 1);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getScaleOutStep(), 2);
-    Assert.assertEquals(lagBasedAutoScalerConfig.getMinTriggerScaleActionFrequencyMillis(), 600000);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getLagCollectionIntervalMillis(), 1);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getLagCollectionRangeMillis(), 600000);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getScaleActionStartDelayMillis(), 300000);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getScaleActionPeriodMillis(), 60000);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getScaleOutThreshold(), 6000000);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getScaleInThreshold(), 1000000);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getTaskCountMax(), 4);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getTaskCountMin(), 1);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getScaleInStep(), 1);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getScaleOutStep(), 2);
+    Assertions.assertEquals(lagBasedAutoScalerConfig.getMinTriggerScaleActionFrequencyMillis(), 600000);
   }
 
   @Test
@@ -440,11 +444,11 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
 
     int taskCountBeforeScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountBeforeScaleOut);
+    Assertions.assertEquals(1, taskCountBeforeScaleOut);
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(3, taskCountAfterScaleOut);
-    Assert.assertTrue(
+    Assertions.assertEquals(3, taskCountAfterScaleOut);
+    Assertions.assertTrue(
         dynamicActionEmitter
             .getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC)
             .stream()
@@ -496,7 +500,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
     Thread.sleep(1000);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         dynamicActionEmitter
             .getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC)
             .stream()
@@ -549,10 +553,10 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     autoScaler.start();
     supervisor.runInternal();
     int taskCountBeforeScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountBeforeScaleOut);
+    Assertions.assertEquals(1, taskCountBeforeScaleOut);
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountAfterScaleOut);
+    Assertions.assertEquals(1, taskCountAfterScaleOut);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -595,11 +599,11 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
 
     int taskCountBeforeScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountBeforeScaleOut);
+    Assertions.assertEquals(1, taskCountBeforeScaleOut);
     Thread.sleep(1000);
 
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(2, taskCountAfterScaleOut);
+    Assertions.assertEquals(2, taskCountAfterScaleOut);
     emitter.verifyEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC, 1);
 
     autoScaler.reset();
@@ -639,7 +643,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     );
 
     // enable autoscaler so that taskcount config will be ignored and init value of taskCount will use taskCountMin.
-    Assert.assertEquals(1, (int) supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(1, (int) supervisor.getIoConfig().getTaskCount());
     supervisor.getIoConfig().setTaskCount(2);
 
     supervisor.start();
@@ -647,11 +651,11 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
 
     int taskCountBeforeScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(2, taskCountBeforeScaleOut);
+    Assertions.assertEquals(2, taskCountBeforeScaleOut);
 
     Thread.sleep(1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountAfterScaleOut);
+    Assertions.assertEquals(1, taskCountAfterScaleOut);
     emitter.verifyEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC, 1);
 
     autoScaler.reset();
@@ -715,17 +719,17 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
 
     // Initial taskCount comes from the ioConfig's autoScalerConfig.taskCountMin (15) since
     // taskCount was passed null in the ioConfig above.
-    Assert.assertEquals(15, (int) supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(15, (int) supervisor.getIoConfig().getTaskCount());
     supervisor.getIoConfig().setTaskCount(2);
 
     supervisor.start();
     autoScaler.start();
     supervisor.runInternal();
 
-    Assert.assertEquals(2, (int) supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(2, (int) supervisor.getIoConfig().getTaskCount());
     Thread.sleep(2000);
     // Supervisor caps min/max at partitionCount=10, so the first scale settles at partitionCount.
-    Assert.assertEquals(10, (int) supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(10, (int) supervisor.getIoConfig().getTaskCount());
 
     emitter.verifyEmitted(SeekableStreamSupervisor.AUTOSCALER_SCALING_TIME_METRIC, 1);
 
@@ -796,7 +800,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
     Thread.sleep(1000);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         dynamicActionEmitter
             .getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC)
             .stream()
@@ -849,10 +853,10 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     autoScaler.start();
     supervisor.runInternal();
     int taskCountBeforeScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountBeforeScaleOut);
+    Assertions.assertEquals(1, taskCountBeforeScaleOut);
     Thread.sleep(1 * 1000);
     int taskCountAfterScaleOut = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, taskCountAfterScaleOut);
+    Assertions.assertEquals(1, taskCountAfterScaleOut);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -935,7 +939,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
       }
     };
 
-    Assert.assertTrue(Objects.requireNonNull(spec.getIoConfig().getIdleConfig()).isEnabled());
+    Assertions.assertTrue(Objects.requireNonNull(spec.getIoConfig().getIdleConfig()).isEnabled());
   }
 
   @Test
@@ -958,7 +962,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         supervisor4,
         "id1"
     );
-    Assert.assertNull(spec.getContextValue("key"));
+    Assertions.assertNull(spec.getContextValue("key"));
   }
 
   @Test
@@ -981,7 +985,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         supervisor4,
         "id1"
     );
-    Assert.assertNull(spec.getContextValue("key_not_exists"));
+    Assertions.assertNull(spec.getContextValue("key_not_exists"));
   }
 
   @Test
@@ -1004,7 +1008,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         supervisor4,
         SUPERVISOR
     );
-    Assert.assertEquals(SUPERVISOR, spec.getId());
+    Assertions.assertEquals(SUPERVISOR, spec.getId());
   }
 
   @Test
@@ -1027,7 +1031,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         supervisor4,
         SUPERVISOR
     );
-    Assert.assertEquals(SUPERVISOR, spec.getId());
+    Assertions.assertEquals(SUPERVISOR, spec.getId());
   }
 
   @Test
@@ -1050,7 +1054,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         supervisor4,
         "id1"
     );
-    Assert.assertEquals("value", spec.getContextValue("key"));
+    Assertions.assertEquals("value", spec.getContextValue("key"));
   }
 
   @Test
@@ -1089,31 +1093,19 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         supervisor4,
         "id1"
     );
-    MatcherAssert.assertThat(
-        assertThrows(DruidException.class, () -> originalSpec.validateSpecUpdateTo(proposedSpec)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-            "Cannot update supervisor spec since one or both of the specs have not provided an input source stream in the 'ioConfig'."
-        )
+    assertInvalidInputException(
+        Assertions.assertThrows(DruidException.class, () -> originalSpec.validateSpecUpdateTo(proposedSpec)),
+        "Cannot update supervisor spec since one or both of the specs have not provided an input source stream in the 'ioConfig'."
     );
 
 
     TestSupervisorSpec otherSpec = new TestSupervisorSpec("fake", new Object());
-    MatcherAssert.assertThat(
-        assertThrows(DruidException.class, () -> originalSpec.validateSpecUpdateTo(otherSpec)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-            StringUtils.format(
-                "Cannot update supervisor spec from type[%s] to type[%s]",
-                proposedSpec.getClass().getSimpleName(),
-                otherSpec.getClass().getSimpleName()
-            )
+    assertInvalidInputException(
+        Assertions.assertThrows(DruidException.class, () -> originalSpec.validateSpecUpdateTo(otherSpec)),
+        StringUtils.format(
+            "Cannot update supervisor spec from type[%s] to type[%s]",
+            proposedSpec.getClass().getSimpleName(),
+            otherSpec.getClass().getSimpleName()
         )
     );
   }
@@ -1193,19 +1185,13 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     };
 
     // Mismatched stream strings test
-    MatcherAssert.assertThat(
-        assertThrows(DruidException.class, () -> originalSpec.validateSpecUpdateTo(proposedSpecDiffSource)),
-        new DruidExceptionMatcher(
-            DruidException.Persona.USER,
-            DruidException.Category.INVALID_INPUT,
-            "invalidInput"
-        ).expectMessageIs(
-            "Update of the input source stream from [source1] to [source2] is not supported for a running supervisor."
-            + "\nTo perform the update safely, follow these steps:"
-            + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
-            + "\n(2) Create a new supervisor with the new input source stream."
-            + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
-        )
+    assertInvalidInputException(
+        Assertions.assertThrows(DruidException.class, () -> originalSpec.validateSpecUpdateTo(proposedSpecDiffSource)),
+        "Update of the input source stream from [source1] to [source2] is not supported for a running supervisor."
+        + "\nTo perform the update safely, follow these steps:"
+        + "\n(1) Suspend this supervisor, reset its offsets and then terminate it. "
+        + "\n(2) Create a new supervisor with the new input source stream."
+        + "\nNote that doing the reset can cause data duplication or loss if any topic used in the old supervisor is included in the new one too."
     );
 
     // Happy path test
@@ -1262,8 +1248,8 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
     Thread.sleep(1000); // ensure a dynamic allocation notice completes
 
-    Assert.assertEquals(1, supervisor.getIoConfig().getTaskCount());
-    Assert.assertTrue(
+    Assertions.assertEquals(1, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertTrue(
         dynamicActionEmitter
             .getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC)
             .stream()
@@ -1319,7 +1305,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     Thread.sleep(1000);
     int after = supervisor.getIoConfig().getTaskCount();
     // No scaling expected because supervisor is suspended
-    Assert.assertEquals(before, after);
+    Assertions.assertEquals(before, after);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -1369,11 +1355,11 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
 
     int before = supervisor.getIoConfig().getTaskCount();
-    Assert.assertEquals(1, before);
+    Assertions.assertEquals(1, before);
     Thread.sleep(1000); // allow one dynamic allocation cycle
     int after = supervisor.getIoConfig().getTaskCount();
     // Even though metadata insert failed, taskCount should still be updated in ioConfig
-    Assert.assertEquals(2, after);
+    Assertions.assertEquals(2, after);
 
     autoScaler.reset();
     autoScaler.stop();
@@ -1431,7 +1417,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.NONE, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.NONE, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1441,7 +1427,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().taskCount(2).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().taskCount(5).build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.NONE, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.NONE, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1450,7 +1436,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     final TestSeekableStreamSupervisorSpec seed = buildSpecWithIoConfig("id", createIOConfig(2, null));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().taskCount(2).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().taskCount(5).build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1460,7 +1446,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().context(Map.of("k", "v")).build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1470,7 +1456,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().suspended(false).build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().suspended(true).build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1480,7 +1466,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec = seed.toBuilder().dataSchema(getDataSchema("other-datasource")).build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1488,7 +1474,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
   {
     final TestSeekableStreamSupervisorSpec seed =
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null)));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS,
         seed.toBuilder().build().getActionOnUpdateTo(new NoopSupervisorSpec("id", List.of("ds")))
     );
@@ -1504,7 +1490,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
         buildSpecWithIoConfig("id", createIOConfig(2, lagBasedAutoScalerConfig(1, 8, null))).toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec =
         buildSpecWithIoConfig("id", createIOConfig(5, null)).toBuilder().build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   @Test
@@ -1515,7 +1501,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     final SeekableStreamSupervisorSpec oldSpec = seed.toBuilder().build();
     final SeekableStreamSupervisorSpec newSpec =
         seed.toBuilder().tuningConfig(EasyMock.mock(SeekableStreamSupervisorTuningConfig.class)).build();
-    Assert.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
+    Assertions.assertEquals(SupervisorSpecUpdateAction.RESTART_SUPERVISOR_AND_TASKS, oldSpec.getActionOnUpdateTo(newSpec));
   }
 
   private void assertMergeResult(
@@ -1525,7 +1511,7 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
   )
   {
     newSpec.merge(existingSpec);
-    Assert.assertEquals(expectedTaskCount, newSpec.getIoConfig().getTaskCount());
+    Assertions.assertEquals(expectedTaskCount, newSpec.getIoConfig().getTaskCount());
   }
 
   private TestSeekableStreamSupervisorSpec spec(
@@ -1711,10 +1697,10 @@ public class SeekableStreamSupervisorSpecTest extends SeekableStreamSupervisorTe
     supervisor.runInternal();
 
     // Verify bounded config is properly set
-    Assert.assertTrue(supervisor.getIoConfig().isBounded());
-    Assert.assertNotNull(supervisor.getIoConfig().getBoundedStreamConfig());
-    Assert.assertEquals(startOffsets, supervisor.getIoConfig().getBoundedStreamConfig().getStartSequenceNumbers());
-    Assert.assertEquals(endOffsets, supervisor.getIoConfig().getBoundedStreamConfig().getEndSequenceNumbers());
+    Assertions.assertTrue(supervisor.getIoConfig().isBounded());
+    Assertions.assertNotNull(supervisor.getIoConfig().getBoundedStreamConfig());
+    Assertions.assertEquals(startOffsets, supervisor.getIoConfig().getBoundedStreamConfig().getStartSequenceNumbers());
+    Assertions.assertEquals(endOffsets, supervisor.getIoConfig().getBoundedStreamConfig().getEndSequenceNumbers());
   }
 
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateManagerTest.java
@@ -368,14 +368,14 @@ public class SeekableStreamSupervisorStateManagerTest
   public void testExceptionEventSerde() throws IOException
   {
     SupervisorStateManager.ExceptionEvent event =
-        new SupervisorStateManager.ExceptionEvent(new NullPointerException("msg"), true);
+        new SeekableStreamExceptionEvent(new StreamException(new NullPointerException("msg")), true);
 
     String serialized = defaultMapper.writeValueAsString(event);
 
     Map<String, String> deserialized = defaultMapper.readValue(serialized, new TypeReference<>() {});
     Assertions.assertNotNull(deserialized.get("timestamp"));
     Assertions.assertEquals("java.lang.NullPointerException", deserialized.get("exceptionClass"));
-    Assertions.assertFalse(Boolean.getBoolean(deserialized.get("streamException")));
+    Assertions.assertTrue(Boolean.parseBoolean(deserialized.get("streamException")));
     Assertions.assertNotNull(deserialized.get("message"));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateManagerTest.java
@@ -31,9 +31,9 @@ import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervi
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorStateManager.SeekableStreamState;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Pair;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -46,7 +46,7 @@ public class SeekableStreamSupervisorStateManagerTest
   private SupervisorStateManagerConfig config;
   private ObjectMapper defaultMapper;
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     config = new SupervisorStateManagerConfig(10);
@@ -57,108 +57,108 @@ public class SeekableStreamSupervisorStateManagerTest
   @Test
   public void testHappyPath()
   {
-    Assert.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamSupervisorStateManager.SeekableStreamState.CONNECTING_TO_STREAM);
-    Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.DISCOVERING_INITIAL_TASKS);
-    Assert.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.CREATING_TASKS);
-    Assert.assertEquals(SeekableStreamState.CREATING_TASKS, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.CREATING_TASKS, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.markRunFinished();
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
 
     stateManager.maybeSetState(BasicState.PENDING);
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.CONNECTING_TO_STREAM);
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.DISCOVERING_INITIAL_TASKS);
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.CREATING_TASKS);
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.markRunFinished();
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
   }
 
   @Test
   public void testIdlePath()
   {
-    Assert.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamSupervisorStateManager.SeekableStreamState.CONNECTING_TO_STREAM);
-    Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.DISCOVERING_INITIAL_TASKS);
-    Assert.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.CREATING_TASKS);
-    Assert.assertEquals(SeekableStreamState.CREATING_TASKS, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.CREATING_TASKS, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.markRunFinished();
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     // Emulates submitting Idle notice
     stateManager.maybeSetState(BasicState.IDLE);
-    Assert.assertEquals(BasicState.IDLE, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.IDLE, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.IDLE, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.IDLE, stateManager.getSupervisorState().getBasicState());
 
     // Stay in idle state when supervisor is running until or unless it is specifically set to a different state
     stateManager.markRunFinished();
-    Assert.assertEquals(BasicState.IDLE, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.IDLE, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.IDLE, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.IDLE, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(BasicState.RUNNING);
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
   }
 
   @Test
   public void testStoppingPath()
   {
-    Assert.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamSupervisorStateManager.SeekableStreamState.CONNECTING_TO_STREAM);
-    Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.maybeSetState(SeekableStreamState.DISCOVERING_INITIAL_TASKS);
-    Assert.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
 
     // Emulates graceful shutdown
     stateManager.maybeSetState(BasicState.STOPPING);
 
     stateManager.maybeSetState(SeekableStreamState.CREATING_TASKS);
-    Assert.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState().getBasicState());
 
     stateManager.markRunFinished();
-    Assert.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.STOPPING, stateManager.getSupervisorState().getBasicState());
   }
 
   @Test
@@ -166,20 +166,20 @@ public class SeekableStreamSupervisorStateManagerTest
   {
     stateManager.markRunFinished(); // clean run without errors
 
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
 
     for (int i = 0; i < config.getUnhealthinessThreshold(); i++) {
-      Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
       stateManager.recordThrowableEvent(new StreamException(new IllegalStateException("DOH!")));
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
+    Assertions.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
 
     stateManager.getExceptionEvents().forEach(x -> {
-      Assert.assertTrue(((SeekableStreamExceptionEvent) x).isStreamException());
-      Assert.assertEquals(IllegalStateException.class.getName(), x.getExceptionClass());
+      Assertions.assertTrue(((SeekableStreamExceptionEvent) x).isStreamException());
+      Assertions.assertEquals(IllegalStateException.class.getName(), x.getExceptionClass());
     });
   }
 
@@ -188,17 +188,17 @@ public class SeekableStreamSupervisorStateManagerTest
   {
     stateManager.maybeSetState(SeekableStreamState.CONNECTING_TO_STREAM);
     for (int i = 0; i < config.getUnhealthinessThreshold(); i++) {
-      Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
+      Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, stateManager.getSupervisorState());
       stateManager.recordThrowableEvent(new StreamException(new IllegalStateException("DOH!")));
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
+    Assertions.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
 
     stateManager.getExceptionEvents().forEach(x -> {
-      Assert.assertTrue(((SeekableStreamExceptionEvent) x).isStreamException());
-      Assert.assertEquals(IllegalStateException.class.getName(), x.getExceptionClass());
+      Assertions.assertTrue(((SeekableStreamExceptionEvent) x).isStreamException());
+      Assertions.assertEquals(IllegalStateException.class.getName(), x.getExceptionClass());
     });
   }
 
@@ -207,17 +207,17 @@ public class SeekableStreamSupervisorStateManagerTest
   {
     stateManager.maybeSetState(SeekableStreamState.DISCOVERING_INITIAL_TASKS);
     for (int i = 0; i < config.getUnhealthinessThreshold(); i++) {
-      Assert.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
+      Assertions.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, stateManager.getSupervisorState());
       stateManager.recordThrowableEvent(new NullPointerException("oof"));
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
 
     stateManager.getExceptionEvents().forEach(x -> {
-      Assert.assertFalse(((SeekableStreamExceptionEvent) x).isStreamException());
-      Assert.assertEquals(NullPointerException.class.getName(), x.getExceptionClass());
+      Assertions.assertFalse(((SeekableStreamExceptionEvent) x).isStreamException());
+      Assertions.assertEquals(NullPointerException.class.getName(), x.getExceptionClass());
     });
   }
 
@@ -229,13 +229,13 @@ public class SeekableStreamSupervisorStateManagerTest
       for (int i = 0; i < config.getUnhealthinessThreshold() - 1; i++) {
         stateManager.recordThrowableEvent(new NullPointerException("oof"));
         stateManager.markRunFinished();
-        Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+        Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
       }
 
       stateManager.markRunFinished(); // clean run
-      Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-      Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
-      Assert.assertEquals(j * (config.getUnhealthinessThreshold() - 1), stateManager.getExceptionEvents().size());
+      Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+      Assertions.assertEquals(j * (config.getUnhealthinessThreshold() - 1), stateManager.getExceptionEvents().size());
     }
   }
 
@@ -244,13 +244,13 @@ public class SeekableStreamSupervisorStateManagerTest
   {
     stateManager.markRunFinished();
     for (int i = 0; i < config.getTaskUnhealthinessThreshold(); i++) {
-      Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
       stateManager.recordCompletedTaskState(TaskState.FAILED);
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(0, stateManager.getExceptionEvents().size());
+    Assertions.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(0, stateManager.getExceptionEvents().size());
   }
 
   @Test
@@ -259,14 +259,14 @@ public class SeekableStreamSupervisorStateManagerTest
     // Only half are failing
     stateManager.markRunFinished();
     for (int i = 0; i < config.getTaskUnhealthinessThreshold() + 3; i++) {
-      Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
       stateManager.recordCompletedTaskState(TaskState.FAILED);
       stateManager.recordCompletedTaskState(TaskState.SUCCESS);
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(0, stateManager.getExceptionEvents().size());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(0, stateManager.getExceptionEvents().size());
   }
 
   @Test
@@ -274,23 +274,23 @@ public class SeekableStreamSupervisorStateManagerTest
   {
     // Put into an unhealthy state
     for (int i = 0; i < config.getUnhealthinessThreshold(); i++) {
-      Assert.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.PENDING, stateManager.getSupervisorState());
       stateManager.recordThrowableEvent(new Exception("Except the inevitable"));
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
 
     // Recover after config.healthinessThreshold successful task completions
     for (int i = 0; i < config.getHealthinessThreshold(); i++) {
-      Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
-    Assert.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(config.getUnhealthinessThreshold(), stateManager.getExceptionEvents().size());
 
     stateManager.getExceptionEvents().forEach(x -> {
-      Assert.assertFalse(((SeekableStreamExceptionEvent) x).isStreamException());
-      Assert.assertEquals(Exception.class.getName(), x.getExceptionClass());
+      Assertions.assertFalse(((SeekableStreamExceptionEvent) x).isStreamException());
+      Assertions.assertEquals(Exception.class.getName(), x.getExceptionClass());
     });
   }
 
@@ -301,19 +301,19 @@ public class SeekableStreamSupervisorStateManagerTest
 
     // Put into an unhealthy state
     for (int i = 0; i < config.getTaskUnhealthinessThreshold(); i++) {
-      Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
       stateManager.recordCompletedTaskState(TaskState.FAILED);
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState());
 
     // Recover after config.healthinessThreshold successful task completions
     for (int i = 0; i < config.getTaskHealthinessThreshold(); i++) {
-      Assert.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState());
+      Assertions.assertEquals(BasicState.UNHEALTHY_TASKS, stateManager.getSupervisorState());
       stateManager.recordCompletedTaskState(TaskState.SUCCESS);
       stateManager.markRunFinished();
     }
-    Assert.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, stateManager.getSupervisorState());
   }
 
   @Test
@@ -327,7 +327,7 @@ public class SeekableStreamSupervisorStateManagerTest
       stateManager.markRunFinished();
     }
     // UNHEALTHY_SUPERVISOR should take priority over UNHEALTHY_TASKS
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
   }
 
   @Test
@@ -344,7 +344,7 @@ public class SeekableStreamSupervisorStateManagerTest
       stateManager.markRunFinished();
     }
 
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, stateManager.getSupervisorState());
 
     List<Pair<String, Boolean>> expected = ImmutableList.of(
         Pair.of("java.lang.UnsupportedOperationException", true),
@@ -356,12 +356,12 @@ public class SeekableStreamSupervisorStateManagerTest
     Iterator<SupervisorStateManager.ExceptionEvent> it = stateManager.getExceptionEvents().iterator();
     expected.forEach(x -> {
       SupervisorStateManager.ExceptionEvent event = it.next();
-      Assert.assertNotNull(event.getMessage());
-      Assert.assertEquals(x.lhs, event.getExceptionClass());
-      Assert.assertEquals(x.rhs, ((SeekableStreamExceptionEvent) event).isStreamException());
+      Assertions.assertNotNull(event.getMessage());
+      Assertions.assertEquals(x.lhs, event.getExceptionClass());
+      Assertions.assertEquals(x.rhs, ((SeekableStreamExceptionEvent) event).isStreamException());
     });
 
-    Assert.assertFalse(it.hasNext());
+    Assertions.assertFalse(it.hasNext());
   }
 
   @Test
@@ -373,9 +373,9 @@ public class SeekableStreamSupervisorStateManagerTest
     String serialized = defaultMapper.writeValueAsString(event);
 
     Map<String, String> deserialized = defaultMapper.readValue(serialized, new TypeReference<>() {});
-    Assert.assertNotNull(deserialized.get("timestamp"));
-    Assert.assertEquals("java.lang.NullPointerException", deserialized.get("exceptionClass"));
-    Assert.assertFalse(Boolean.getBoolean(deserialized.get("streamException")));
-    Assert.assertNotNull(deserialized.get("message"));
+    Assertions.assertNotNull(deserialized.get("timestamp"));
+    Assertions.assertEquals("java.lang.NullPointerException", deserialized.get("exceptionClass"));
+    Assertions.assertFalse(Boolean.getBoolean(deserialized.get("streamException")));
+    Assertions.assertNotNull(deserialized.get("message"));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorStateTest.java
@@ -35,7 +35,6 @@ import org.apache.druid.data.input.impl.JsonInputFormat;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexer.TaskLocation;
 import org.apache.druid.indexer.TaskStatus;
 import org.apache.druid.indexer.granularity.UniformGranularitySpec;
@@ -101,13 +100,13 @@ import org.easymock.Capture;
 import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.easymock.EasyMockSupport;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -147,6 +146,14 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   private static final int DEFAULT_WORKER_THREADS = 2;
   private static final int DEFAULT_TASKS_PER_WORKER_THREAD = 4;
 
+  private static void assertInvalidInputException(DruidException exception, String message)
+  {
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals(message, exception.getMessage());
+  }
+
   private TaskStorage taskStorage;
   private TaskMaster taskMaster;
   private TaskRunner taskRunner;
@@ -163,7 +170,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
   private StubServiceEmitter emitter;
 
-  @Before
+  @BeforeEach
   public void setupTest()
   {
     taskStorage = createMock(TaskStorage.class);
@@ -225,27 +232,27 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -267,12 +274,12 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     );
     checkOffsetAvailability.setAccessible(true);
 
-    final InvocationTargetException exception = Assert.assertThrows(
+    final InvocationTargetException exception = Assertions.assertThrows(
         InvocationTargetException.class,
         () -> checkOffsetAvailability.invoke(supervisor, SHARD_ID, "1")
     );
-    Assert.assertEquals(IllegalStateException.class, exception.getCause().getClass());
-    Assert.assertFalse(supervisor.getRecordSupplierLock().isLocked());
+    Assertions.assertEquals(IllegalStateException.class, exception.getCause().getClass());
+    Assertions.assertFalse(supervisor.getRecordSupplierLock().isLocked());
     verifyAll();
   }
 
@@ -293,37 +300,37 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
     List<SupervisorStateManager.ExceptionEvent> exceptionEvents = supervisor.stateManager.getExceptionEvents();
-    Assert.assertEquals(1, exceptionEvents.size());
-    Assert.assertFalse(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
-    Assert.assertEquals(ISE.class.getName(), exceptionEvents.get(0).getExceptionClass());
-    Assert.assertEquals(StringUtils.format("unable to fetch sequence number for partition[%s] from stream", SHARD_ID), exceptionEvents.get(0).getMessage());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertEquals(1, exceptionEvents.size());
+    Assertions.assertFalse(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
+    Assertions.assertEquals(ISE.class.getName(), exceptionEvents.get(0).getExceptionClass());
+    Assertions.assertEquals(StringUtils.format("unable to fetch sequence number for partition[%s] from stream", SHARD_ID), exceptionEvents.get(0).getMessage());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -367,15 +374,15 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     for (Future<Boolean> future : futures) {
       try {
         Boolean result = future.get();
-        Assert.assertTrue(result);
+        Assertions.assertTrue(result);
       }
       catch (ExecutionException e) {
-        Assert.fail();
+        Assertions.fail();
       }
     }
     CopyOnWriteArrayList<SeekableStreamSupervisor.TaskGroup> taskGroups = supervisor.getPendingCompletionTaskGroups(0);
-    Assert.assertEquals(1, taskGroups.size());
-    Assert.assertEquals(3, taskGroups.get(0).tasks.size());
+    Assertions.assertEquals(1, taskGroups.size());
+    Assertions.assertEquals(3, taskGroups.get(0).tasks.size());
 
     // Test concurrent threads adding to different task groups
     task1 = () -> {
@@ -416,20 +423,20 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     for (Future<Boolean> future : futures) {
       try {
         Boolean result = future.get();
-        Assert.assertTrue(result);
+        Assertions.assertTrue(result);
       }
       catch (ExecutionException e) {
-        Assert.fail();
+        Assertions.fail();
       }
     }
 
     taskGroups = supervisor.getPendingCompletionTaskGroups(1);
-    Assert.assertEquals(1, taskGroups.size());
-    Assert.assertEquals(3, taskGroups.get(0).tasks.size());
+    Assertions.assertEquals(1, taskGroups.size());
+    Assertions.assertEquals(3, taskGroups.get(0).tasks.size());
 
     taskGroups = supervisor.getPendingCompletionTaskGroups(2);
-    Assert.assertEquals(1, taskGroups.size());
-    Assert.assertEquals(2, taskGroups.get(0).tasks.size());
+    Assertions.assertEquals(1, taskGroups.size());
+    Assertions.assertEquals(2, taskGroups.get(0).tasks.size());
   }
 
   @Test
@@ -489,18 +496,18 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     for (Future<Boolean> future : futures) {
       try {
         Boolean result = future.get();
-        Assert.assertTrue(result);
+        Assertions.assertTrue(result);
       }
       catch (ExecutionException e) {
-        Assert.fail();
+        Assertions.fail();
       }
     }
 
     CopyOnWriteArrayList<SeekableStreamSupervisor.TaskGroup> taskGroups = supervisor.getPendingCompletionTaskGroups(0);
 
-    Assert.assertEquals(2, taskGroups.size());
-    Assert.assertEquals(3, taskGroups.get(0).tasks.size());
-    Assert.assertEquals(3, taskGroups.get(1).tasks.size());
+    Assertions.assertEquals(2, taskGroups.size());
+    Assertions.assertEquals(3, taskGroups.get(0).tasks.size());
+    Assertions.assertEquals(3, taskGroups.get(1).tasks.size());
   }
 
   @Test
@@ -519,41 +526,41 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
     List<SupervisorStateManager.ExceptionEvent> exceptionEvents = supervisor.stateManager.getExceptionEvents();
-    Assert.assertEquals(1, exceptionEvents.size());
-    Assert.assertTrue(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
-    Assert.assertEquals(IllegalStateException.class.getName(), exceptionEvents.get(0).getExceptionClass());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, exceptionEvents.size());
+    Assertions.assertTrue(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
+    Assertions.assertEquals(IllegalStateException.class.getName(), exceptionEvents.get(0).getExceptionClass());
+    Assertions.assertEquals(
         StringUtils.format("%s: %s", IllegalStateException.class.getName(), EXCEPTION_MSG),
         exceptionEvents.get(0).getMessage()
     );
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -580,54 +587,54 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CONNECTING_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
     supervisor.runInternal();
-    Assert.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(SeekableStreamState.UNABLE_TO_CONNECT_TO_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
     supervisor.runInternal();
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
     supervisor.runInternal();
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
     supervisor.runInternal();
-    Assert.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, supervisor.stateManager.getSupervisorState());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.LOST_CONTACT_WITH_STREAM, supervisor.stateManager.getSupervisorState());
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -648,62 +655,62 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.start();
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
     List<SupervisorStateManager.ExceptionEvent> exceptionEvents = supervisor.stateManager.getExceptionEvents();
-    Assert.assertEquals(1, exceptionEvents.size());
-    Assert.assertFalse(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
-    Assert.assertEquals(IllegalStateException.class.getName(), exceptionEvents.get(0).getExceptionClass());
-    Assert.assertEquals(EXCEPTION_MSG, exceptionEvents.get(0).getMessage());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertEquals(1, exceptionEvents.size());
+    Assertions.assertFalse(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
+    Assertions.assertEquals(IllegalStateException.class.getName(), exceptionEvents.get(0).getExceptionClass());
+    Assertions.assertEquals(EXCEPTION_MSG, exceptionEvents.get(0).getMessage());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.DISCOVERING_INITIAL_TASKS, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -750,46 +757,46 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.setStreamOffsets(ImmutableMap.of("0", "10"));
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     Thread.sleep(100L);
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     Thread.sleep(100L);
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     Thread.sleep(100L);
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -851,29 +858,29 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.setStreamOffsets(initialOffsets);
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.IDLE, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.setStreamOffsets(laterOffsets);
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
   }
 
   @Test
@@ -893,63 +900,63 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.start();
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
     List<SupervisorStateManager.ExceptionEvent> exceptionEvents = supervisor.stateManager.getExceptionEvents();
-    Assert.assertEquals(1, exceptionEvents.size());
-    Assert.assertFalse(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
-    Assert.assertEquals(IllegalStateException.class.getName(), exceptionEvents.get(0).getExceptionClass());
-    Assert.assertEquals(EXCEPTION_MSG, exceptionEvents.get(0).getMessage());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertEquals(1, exceptionEvents.size());
+    Assertions.assertFalse(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
+    Assertions.assertEquals(IllegalStateException.class.getName(), exceptionEvents.get(0).getExceptionClass());
+    Assertions.assertEquals(EXCEPTION_MSG, exceptionEvents.get(0).getMessage());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(SeekableStreamState.CREATING_TASKS, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(2, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(3, supervisor.stateManager.getExceptionEvents().size());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
-    Assert.assertFalse(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertFalse(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.UNHEALTHY_SUPERVISOR, supervisor.stateManager.getSupervisorState());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -968,27 +975,27 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     verifyAll();
   }
@@ -1011,25 +1018,25 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.stop(false);
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState().getBasicState());
 
     verifyAll();
   }
@@ -1074,35 +1081,36 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.RUNNING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
     supervisor.stop(true);
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState().getBasicState());
 
     // Subsequent run after graceful shutdown has begun
     supervisor.runInternal();
-    Assert.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.STOPPING, supervisor.stateManager.getSupervisorState().getBasicState());
 
     verifyAll();
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testCheckpointForActiveTaskGroup() throws InterruptedException, JsonProcessingException
   {
     DateTime startTime = DateTimes.nowUtc();
@@ -1309,10 +1317,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertTrue(supervisor.getNoticesQueueSize() == 0);
+    Assertions.assertTrue(supervisor.getNoticesQueueSize() == 0);
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60, unit = TimeUnit.SECONDS)
   public void testEarlyStoppingOfTaskGroupBasedOnStopTaskCount() throws InterruptedException, JsonProcessingException
   {
     // Assuming tasks have surpassed their duration limit at test execution
@@ -1526,7 +1535,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.start();
     supervisor.runInternal();
 
-    Assert.assertNull(id1.getCurrentRunnerStatus());
+    Assertions.assertNull(id1.getCurrentRunnerStatus());
 
     supervisor.checkpoint(
         0,
@@ -1541,10 +1550,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertTrue(supervisor.getNoticesQueueSize() == 0);
+    Assertions.assertTrue(supervisor.getNoticesQueueSize() == 0);
   }
 
-  @Test(timeout = 10_000L)
+  @Test
+  @Timeout(value = 10, unit = TimeUnit.SECONDS)
   public void testSupervisorStopTaskGroupEarly() throws JsonProcessingException, InterruptedException
   {
     DateTime startTime = DateTimes.nowUtc();
@@ -1664,8 +1674,8 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.runInternal();
     supervisor.handoffTaskGroupsEarly(ImmutableList.of(0));
 
-    Assert.assertNull(id1.getCurrentRunnerStatus());
-    Assert.assertEquals("NOT_STARTED", id1.getCurrentRunnerStatus());
+    Assertions.assertNull(id1.getCurrentRunnerStatus());
+    Assertions.assertEquals("NOT_STARTED", id1.getCurrentRunnerStatus());
 
     while (supervisor.getNoticesQueueSize() > 0) {
       Thread.sleep(100);
@@ -1690,11 +1700,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
 
     latch.await();
@@ -1724,11 +1734,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
 
     latch.await();
@@ -1756,11 +1766,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
 
     latch.await();
@@ -1789,11 +1799,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.start();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
 
 
     latch.await();
@@ -1819,11 +1829,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         null
     );
     supervisor.start();
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
-    Assert.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.PENDING, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertFalse(supervisor.stateManager.isAtLeastOneSuccessfulRun());
     latch.await();
 
     final Map<String, Object> dimFilters = ImmutableMap.of(
@@ -1832,7 +1842,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         "noticeType", "run_notice"
     );
     long observedNoticeTime = emitter.getValue("ingest/notices/time", dimFilters).longValue();
-    Assert.assertTrue(observedNoticeTime > 0);
+    Assertions.assertTrue(observedNoticeTime > 0);
 
     verifyAll();
   }
@@ -1854,10 +1864,10 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.start();
     supervisor.runInternal();
 
-    Assert.assertTrue(supervisor.stateManager.isHealthy());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState());
-    Assert.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState().getBasicState());
-    Assert.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
+    Assertions.assertTrue(supervisor.stateManager.isHealthy());
+    Assertions.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState());
+    Assertions.assertEquals(BasicState.SUSPENDED, supervisor.stateManager.getSupervisorState().getBasicState());
+    Assertions.assertTrue(supervisor.stateManager.getExceptionEvents().isEmpty());
 
 
     latch.await();
@@ -1910,9 +1920,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     verifyAll();
 
-    Assert.assertEquals(1, stats.size());
-    Assert.assertEquals(ImmutableSet.of("0"), stats.keySet());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, stats.size());
+    Assertions.assertEquals(ImmutableSet.of("0"), stats.keySet());
+    Assertions.assertEquals(
         ImmutableMap.of(
             "task1", ImmutableMap.of("prop1", "val1"),
             "task2", ImmutableMap.of("prop2", "val2")
@@ -1955,9 +1965,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         null
     );
 
-    Assert.assertEquals(1, supervisor.getActiveTaskGroupsCount());
-    Assert.assertEquals(0, supervisor.getNoticesQueueSize());
-    Assert.assertEquals(0, supervisor.getPartitionOffsets().size());
+    Assertions.assertEquals(1, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(0, supervisor.getNoticesQueueSize());
+    Assertions.assertEquals(0, supervisor.getPartitionOffsets().size());
 
     supervisor.reset(null);
     validateSupervisorStateAfterResetOffsets(supervisor, ImmutableMap.of(), 0);
@@ -2014,9 +2024,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         )
     );
 
-    Assert.assertEquals(1, supervisor.getActiveTaskGroupsCount());
-    Assert.assertEquals(0, supervisor.getNoticesQueueSize());
-    Assert.assertEquals(0, supervisor.getPartitionOffsets().size());
+    Assertions.assertEquals(1, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(0, supervisor.getNoticesQueueSize());
+    Assertions.assertEquals(0, supervisor.getPartitionOffsets().size());
 
     supervisor.resetOffsets(resetMetadata);
 
@@ -2101,12 +2111,12 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.registerNewVersionOfPendingSegment(pendingSegmentRecord0);
     supervisor.registerNewVersionOfPendingSegment(pendingSegmentRecord1);
 
-    Assert.assertEquals(pendingSegmentRecord0, captured0.getValue());
-    Assert.assertEquals(pendingSegmentRecord1, captured1.getValue());
+    Assertions.assertEquals(pendingSegmentRecord0, captured0.getValue());
+    Assertions.assertEquals(pendingSegmentRecord1, captured1.getValue());
 
     // Both records matched a running task, so each emits a notified metric and none is unmatched.
-    Assert.assertEquals(2, emitter.getMetricEventCount(SegmentUpgradeMetrics.NOTIFIED));
-    Assert.assertEquals(0, emitter.getMetricEventCount(SegmentUpgradeMetrics.UNMATCHED));
+    Assertions.assertEquals(2, emitter.getMetricEventCount(SegmentUpgradeMetrics.NOTIFIED));
+    Assertions.assertEquals(0, emitter.getMetricEventCount(SegmentUpgradeMetrics.UNMATCHED));
     verifyAll();
   }
 
@@ -2141,8 +2151,8 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.registerNewVersionOfPendingSegment(record);
 
-    Assert.assertEquals(1, emitter.getMetricEventCount(SegmentUpgradeMetrics.UNMATCHED));
-    Assert.assertEquals(0, emitter.getMetricEventCount(SegmentUpgradeMetrics.NOTIFIED));
+    Assertions.assertEquals(1, emitter.getMetricEventCount(SegmentUpgradeMetrics.UNMATCHED));
+    Assertions.assertEquals(0, emitter.getMetricEventCount(SegmentUpgradeMetrics.NOTIFIED));
     verifyAll();
   }
 
@@ -2180,8 +2190,8 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.registerNewVersionOfPendingSegment(record);
 
     // The record matched task0 (so notified fires) but delivery failed over the wire (so sendFailed fires).
-    Assert.assertEquals(1, emitter.getMetricEventCount(SegmentUpgradeMetrics.NOTIFIED));
-    Assert.assertEquals(1, emitter.getMetricEventCount(SegmentUpgradeMetrics.SEND_FAILED));
+    Assertions.assertEquals(1, emitter.getMetricEventCount(SegmentUpgradeMetrics.NOTIFIED));
+    Assertions.assertEquals(1, emitter.getMetricEventCount(SegmentUpgradeMetrics.SEND_FAILED));
     verifyAll();
   }
 
@@ -2259,9 +2269,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         )
     );
 
-    Assert.assertEquals(3, supervisor.getActiveTaskGroupsCount());
-    Assert.assertEquals(0, supervisor.getNoticesQueueSize());
-    Assert.assertEquals(0, supervisor.getPartitionOffsets().size());
+    Assertions.assertEquals(3, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(0, supervisor.getNoticesQueueSize());
+    Assertions.assertEquals(0, supervisor.getPartitionOffsets().size());
 
     supervisor.resetOffsets(resetMetadata);
 
@@ -2333,9 +2343,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         )
     );
 
-    Assert.assertEquals(3, supervisor.getActiveTaskGroupsCount());
-    Assert.assertEquals(0, supervisor.getNoticesQueueSize());
-    Assert.assertEquals(0, supervisor.getPartitionOffsets().size());
+    Assertions.assertEquals(3, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(0, supervisor.getNoticesQueueSize());
+    Assertions.assertEquals(0, supervisor.getPartitionOffsets().size());
 
     supervisor.resetOffsets(resetMetadata);
 
@@ -2401,9 +2411,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         )
     );
 
-    Assert.assertEquals(2, supervisor.getActiveTaskGroupsCount());
-    Assert.assertEquals(0, supervisor.getNoticesQueueSize());
-    Assert.assertEquals(0, supervisor.getPartitionOffsets().size());
+    Assertions.assertEquals(2, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(0, supervisor.getNoticesQueueSize());
+    Assertions.assertEquals(0, supervisor.getPartitionOffsets().size());
 
     supervisor.resetOffsets(resetMetadata);
 
@@ -2470,9 +2480,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         )
     );
 
-    Assert.assertEquals(2, supervisor.getActiveTaskGroupsCount());
-    Assert.assertEquals(0, supervisor.getNoticesQueueSize());
-    Assert.assertEquals(0, supervisor.getPartitionOffsets().size());
+    Assertions.assertEquals(2, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(0, supervisor.getNoticesQueueSize());
+    Assertions.assertEquals(0, supervisor.getPartitionOffsets().size());
 
     supervisor.resetOffsets(resetMetadata);
 
@@ -2510,13 +2520,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     verifyAll();
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
-            supervisor.resetOffsets(null)
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Reset dataSourceMetadata is required for resetOffsets."
-        )
+    assertInvalidInputException(
+        Assertions.assertThrows(DruidException.class, () -> supervisor.resetOffsets(null)),
+        "Reset dataSourceMetadata is required for resetOffsets."
     );
   }
 
@@ -2559,15 +2565,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         )
     );
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
-            supervisor.resetOffsets(dataSourceMetadata)
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format(
-                "Provided datasourceMetadata[%s] is invalid. Sequence numbers can only be of type[SeekableStreamEndSequenceNumbers], but found[SeekableStreamStartSequenceNumbers].",
-                dataSourceMetadata
-            )
+    assertInvalidInputException(
+        Assertions.assertThrows(DruidException.class, () -> supervisor.resetOffsets(dataSourceMetadata)),
+        StringUtils.format(
+            "Provided datasourceMetadata[%s] is invalid. Sequence numbers can only be of type[SeekableStreamEndSequenceNumbers], but found[SeekableStreamStartSequenceNumbers].",
+            dataSourceMetadata
         )
     );
   }
@@ -2610,13 +2612,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         )
     );
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
-            supervisor.resetOffsets(dataSourceMetadata)
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "Stream[i-am-not-real] doesn't exist in the supervisor[testSupervisorId]. Supervisor is consuming stream[stream]."
-        )
+    assertInvalidInputException(
+        Assertions.assertThrows(DruidException.class, () -> supervisor.resetOffsets(dataSourceMetadata)),
+        "Stream[i-am-not-real] doesn't exist in the supervisor[testSupervisorId]. Supervisor is consuming stream[stream]."
     );
   }
 
@@ -2641,9 +2639,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     latch.await();
 
     supervisor.emitLag();
-    Assert.assertEquals(0, emitter.getMetricEvents("ingest/test/lag").size());
-    Assert.assertEquals(0, emitter.getMetricEvents("ingest/test/maxLag").size());
-    Assert.assertEquals(0, emitter.getMetricEvents("ingest/test/avgLag").size());
+    Assertions.assertEquals(0, emitter.getMetricEvents("ingest/test/lag").size());
+    Assertions.assertEquals(0, emitter.getMetricEvents("ingest/test/maxLag").size());
+    Assertions.assertEquals(0, emitter.getMetricEvents("ingest/test/avgLag").size());
   }
 
   private void validateSupervisorStateAfterResetOffsets(
@@ -2657,10 +2655,10 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
       Thread.sleep(100);
     }
     Thread.sleep(1000);
-    Assert.assertEquals(expectedActiveTaskCount, supervisor.getActiveTaskGroupsCount());
-    Assert.assertEquals(expectedResetOffsets.size(), supervisor.getPartitionOffsets().size());
+    Assertions.assertEquals(expectedActiveTaskCount, supervisor.getActiveTaskGroupsCount());
+    Assertions.assertEquals(expectedResetOffsets.size(), supervisor.getPartitionOffsets().size());
     for (Map.Entry<String, String> entry : expectedResetOffsets.entrySet()) {
-      Assert.assertEquals(supervisor.getNotSetMarker(), supervisor.getPartitionOffsets().get(entry.getKey()));
+      Assertions.assertEquals(supervisor.getNotSetMarker(), supervisor.getPartitionOffsets().get(entry.getKey()));
     }
     verifyAll();
   }
@@ -2721,7 +2719,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     final int taskCount = 1;
     SeekableStreamSupervisorTuningConfig tuningConfig = createSupervisorTuningConfigWithWorkerThreads(numWorkerThreads);
     SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(taskCount, null);
-    Assert.assertEquals(numWorkerThreads, SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig));
+    Assertions.assertEquals(numWorkerThreads, SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig));
   }
 
   @Test
@@ -2730,7 +2728,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     final int taskCount = 1;
     SeekableStreamSupervisorTuningConfig tuningConfig = createSupervisorTuningConfig();
     SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(taskCount, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         DEFAULT_WORKER_THREADS,
         SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
     );
@@ -2742,7 +2740,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     final int taskCount = 7;
     SeekableStreamSupervisorTuningConfig tuningConfig = createSupervisorTuningConfig();
     SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(taskCount, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         DEFAULT_WORKER_THREADS,
         SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
     );
@@ -2754,7 +2752,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     final int taskCount = 18;
     SeekableStreamSupervisorTuningConfig tuningConfig = createSupervisorTuningConfig();
     SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(taskCount, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         taskCount / DEFAULT_TASKS_PER_WORKER_THREAD,
         SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
     );
@@ -2788,7 +2786,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         null
     );
     SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(1, autoScalerConfig, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         taskCountMax / DEFAULT_TASKS_PER_WORKER_THREAD,
         SeekableStreamSupervisor.calculateWorkerThreads(tuningConfig, ioConfig)
     );
@@ -2870,9 +2868,9 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
         .withStopTaskCount(1) // ensure this is overridden
         .build();
 
-    Assert.assertEquals(2, config.getMaxAllowedStops());
+    Assertions.assertEquals(2, config.getMaxAllowedStops());
     config.setTaskCount(30);
-    Assert.assertEquals(12, config.getMaxAllowedStops());
+    Assertions.assertEquals(12, config.getMaxAllowedStops());
   }
 
   @Test
@@ -2891,7 +2889,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     EasyMock.expect(mockSpec.createAutoscaler(supervisor)).andReturn(null).once();
     EasyMock.replay(mockSpec);
 
-    Assert.assertNull(supervisor.createAutoscaler(mockSpec));
+    Assertions.assertNull(supervisor.createAutoscaler(mockSpec));
     EasyMock.verify(mockSpec);
 
     verifyAll();
@@ -2902,7 +2900,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   {
     final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(5, Map.of(10, 2, 20, 3));
 
-    Assert.assertEquals(5, (int) ioConfig.getReplicas());
+    Assertions.assertEquals(5, (int) ioConfig.getReplicas());
 
     EasyMock.reset(spec);
     EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
@@ -2930,7 +2928,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             Map.of()
         );
 
-    Assert.assertEquals(List.of(20, 20, 20, 10, 10), supervisor.computeUnassignedServerPriorities(taskGroup1, 5));
+    Assertions.assertEquals(List.of(20, 20, 20, 10, 10), supervisor.computeUnassignedServerPriorities(taskGroup1, 5));
 
     // Two tasks with priority 10 already assigned, need 3 more replicas
     final SeekableStreamSupervisor<String, String, ByteEntity>.TaskGroup taskGroup2 =
@@ -2944,7 +2942,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             Map.of("task1", 10, "task2", 10)
         );
 
-    Assert.assertEquals(List.of(20, 20, 20), supervisor.computeUnassignedServerPriorities(taskGroup2, 3));
+    Assertions.assertEquals(List.of(20, 20, 20), supervisor.computeUnassignedServerPriorities(taskGroup2, 3));
 
     // Two tasks with priority 10 and one with priority 20 assigned, need 2 more replicas
     final SeekableStreamSupervisor<String, String, ByteEntity>.TaskGroup taskGroup3 =
@@ -2958,7 +2956,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
             Map.of("task1", 10, "task2", 10, "task3", 20)
         );
 
-    Assert.assertEquals(List.of(20, 20), supervisor.computeUnassignedServerPriorities(taskGroup3, 2));
+    Assertions.assertEquals(List.of(20, 20), supervisor.computeUnassignedServerPriorities(taskGroup3, 2));
 
     verifyAll();
   }
@@ -3119,8 +3117,8 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     // The StreamException is recorded exactly once — not once per unavailable partition.
     final List<SupervisorStateManager.ExceptionEvent> exceptionEvents = supervisor.stateManager.getExceptionEvents();
-    Assert.assertEquals(1, exceptionEvents.size());
-    Assert.assertTrue(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
+    Assertions.assertEquals(1, exceptionEvents.size());
+    Assertions.assertTrue(((SeekableStreamExceptionEvent) exceptionEvents.get(0)).isStreamException());
 
     // EasyMock validates that resetDataSourceMetadata was called exactly once (see .times(1) above).
     verifyAll();
@@ -3802,7 +3800,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   {
     final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(5, Map.of(10, 2, 20, 3));
 
-    Assert.assertEquals(5, (int) ioConfig.getReplicas());
+    Assertions.assertEquals(5, (int) ioConfig.getReplicas());
 
     final SeekableStreamIndexTaskIOConfig taskIoConfig = createTaskIoConfigExt(
         0,
@@ -3865,14 +3863,14 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     // Verify that tasks were discovered and their server priorities were captured
     SeekableStreamSupervisor.TaskGroup taskGroup = supervisor.getActiveTaskGroup(0);
-    Assert.assertEquals(0, taskGroup.groupId);
-    Assert.assertEquals(3, taskGroup.tasks.size());
+    Assertions.assertEquals(0, taskGroup.groupId);
+    Assertions.assertEquals(3, taskGroup.tasks.size());
 
     // Verify server priorities were correctly stored
     Map<String, Integer> taskIdToServerPriority = taskGroup.taskIdToServerPriority;
-    Assert.assertEquals(Integer.valueOf(20), taskIdToServerPriority.get("task1"));
-    Assert.assertEquals(Integer.valueOf(20), taskIdToServerPriority.get("task2"));
-    Assert.assertEquals(Integer.valueOf(10), taskIdToServerPriority.get("task3"));
+    Assertions.assertEquals(Integer.valueOf(20), taskIdToServerPriority.get("task1"));
+    Assertions.assertEquals(Integer.valueOf(20), taskIdToServerPriority.get("task2"));
+    Assertions.assertEquals(Integer.valueOf(10), taskIdToServerPriority.get("task3"));
 
     verifyAll();
   }
@@ -3888,7 +3886,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     // replicas=2, taskCount=1, priorities {0:1, 1:1}
     final SeekableStreamSupervisorIOConfig ioConfig = createSupervisorIOConfig(1, Map.of(0, 1, 1, 1));
 
-    Assert.assertEquals(2, (int) ioConfig.getReplicas());
+    Assertions.assertEquals(2, (int) ioConfig.getReplicas());
 
     EasyMock.reset(spec);
     EasyMock.expect(spec.getId()).andReturn(SUPERVISOR_ID).anyTimes();
@@ -3963,10 +3961,10 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     // Run 1 should have submitted 2 replicas.
     final List<Task> run1Tasks = submittedTasks.getValues();
-    Assert.assertEquals(2, run1Tasks.size());
+    Assertions.assertEquals(2, run1Tasks.size());
     final TestSeekableStreamIndexTask orphan = (TestSeekableStreamIndexTask) run1Tasks.get(0);
     final TestSeekableStreamIndexTask survivor = (TestSeekableStreamIndexTask) run1Tasks.get(1);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Set.of(0, 1),
         Set.of(orphan.getServerPriority(), survivor.getServerPriority())
     );
@@ -3990,7 +3988,7 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     // Replacement task should carry the orphan's missing priority, not duplicate the survivor's.
     final TestSeekableStreamIndexTask replacement = (TestSeekableStreamIndexTask) replacementCapture.getValue();
-    Assert.assertEquals(orphan.getServerPriority(), replacement.getServerPriority());
+    Assertions.assertEquals(orphan.getServerPriority(), replacement.getServerPriority());
   }
 
 
@@ -4006,11 +4004,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     // minScaleUpDelay = 0 means any scale-up is immediately allowed.
     supervisor.handleDynamicAllocationTasksNotice(() -> 5, () -> {}, scalingEmitter);
 
-    Assert.assertEquals(5, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(5, supervisor.getIoConfig().getTaskCount());
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals("Exactly one required-tasks emission expected", 1, events.size());
+    Assertions.assertEquals(1, events.size(), "Exactly one required-tasks emission expected");
     assertScaledToTaskCount(events.get(0), 5);
   }
 
@@ -4025,15 +4023,15 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     // First scale-up succeeds and stamps the last-scale timestamp.
     supervisor.handleDynamicAllocationTasksNotice(() -> 5, () -> {}, scalingEmitter);
-    Assert.assertEquals(5, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(5, supervisor.getIoConfig().getTaskCount());
 
     // Second scale-up is within the 1h minScaleUpDelay window and must be blocked.
     supervisor.handleDynamicAllocationTasksNotice(() -> 7, () -> {}, scalingEmitter);
-    Assert.assertEquals("Second scale-up must not take effect", 5, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(5, supervisor.getIoConfig().getTaskCount(), "Second scale-up must not take effect");
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals("Two required-tasks emissions expected (one applied, one skipped)", 2, events.size());
+    Assertions.assertEquals(2, events.size(), "Two required-tasks emissions expected (one applied, one skipped)");
     // First emission: the successful scale carries no skip-reason dim and reports the applied count.
     assertScaledToTaskCount(events.get(0), 5);
     // Second emission: the gated scale carries the cooldown skip-reason dim and the proposed (not applied) count.
@@ -4052,11 +4050,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     // minScaleDownDelay = 0 means any scale-down is immediately allowed.
     supervisor.handleDynamicAllocationTasksNotice(() -> 2, () -> {}, scalingEmitter);
 
-    Assert.assertEquals(2, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(2, supervisor.getIoConfig().getTaskCount());
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals("Exactly one required-tasks emission expected", 1, events.size());
+    Assertions.assertEquals(1, events.size(), "Exactly one required-tasks emission expected");
     assertScaledToTaskCount(events.get(0), 2);
   }
 
@@ -4071,15 +4069,15 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     // First scale-down succeeds and stamps the last-scale timestamp.
     supervisor.handleDynamicAllocationTasksNotice(() -> 3, () -> {}, scalingEmitter);
-    Assert.assertEquals(3, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(3, supervisor.getIoConfig().getTaskCount());
 
     // Second scale-down is within the 1h minScaleDownDelay window and must be blocked.
     supervisor.handleDynamicAllocationTasksNotice(() -> 1, () -> {}, scalingEmitter);
-    Assert.assertEquals("Second scale-down must not take effect", 3, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(3, supervisor.getIoConfig().getTaskCount(), "Second scale-down must not take effect");
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals("Two required-tasks emissions expected (one applied, one skipped)", 2, events.size());
+    Assertions.assertEquals(2, events.size(), "Two required-tasks emissions expected (one applied, one skipped)");
     assertScaledToTaskCount(events.get(0), 3);
     assertScaleSkipped(events.get(1), 1, "Scale cooldown not elapsed yet");
   }
@@ -4096,11 +4094,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
     supervisor.handleDynamicAllocationTasksNotice(() -> 20, () -> {}, scalingEmitter);
 
     // Task count is clamped to max (10), not the scaler's desired (20).
-    Assert.assertEquals(10, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(10, supervisor.getIoConfig().getTaskCount());
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
     // The emitted metric value reflects the scaler's unclamped desired (the operator hint), not
     // the clamped value the supervisor actually applied.
     assertScaledToTaskCount(events.get(0), 20);
@@ -4117,11 +4115,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.handleDynamicAllocationTasksNotice(() -> 1, () -> {}, scalingEmitter);
 
-    Assert.assertEquals(3, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(3, supervisor.getIoConfig().getTaskCount());
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
     assertScaledToTaskCount(events.get(0), 1);
   }
 
@@ -4137,11 +4135,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.handleDynamicAllocationTasksNotice(() -> 15, () -> {}, scalingEmitter);
 
-    Assert.assertEquals("Task count must not change when at max", 10, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(10, supervisor.getIoConfig().getTaskCount(), "Task count must not change when at max");
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
     assertScaleSkipped(events.get(0), 15, "Already at max task count");
   }
 
@@ -4157,11 +4155,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.handleDynamicAllocationTasksNotice(() -> 1, () -> {}, scalingEmitter);
 
-    Assert.assertEquals("Task count must not change when at min", 3, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(3, supervisor.getIoConfig().getTaskCount(), "Task count must not change when at min");
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
     assertScaleSkipped(events.get(0), 1, "Already at min task count");
   }
 
@@ -4176,11 +4174,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.handleDynamicAllocationTasksNotice(() -> 5, () -> {}, scalingEmitter);
 
-    Assert.assertEquals(5, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(5, supervisor.getIoConfig().getTaskCount());
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertTrue("No metric should be emitted in the steady-state no-op case", events.isEmpty());
+    Assertions.assertTrue(events.isEmpty(), "No metric should be emitted in the steady-state no-op case");
   }
 
   @Test
@@ -4195,11 +4193,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
 
     supervisor.handleDynamicAllocationTasksNotice(() -> -1, () -> {}, scalingEmitter);
 
-    Assert.assertEquals("Task count must not change on pathological return", 5, supervisor.getIoConfig().getTaskCount());
+    Assertions.assertEquals(5, supervisor.getIoConfig().getTaskCount(), "Task count must not change on pathological return");
 
     final List<ServiceMetricEvent> events =
         scalingEmitter.getMetricEvents(SeekableStreamSupervisor.AUTOSCALER_REQUIRED_TASKS_METRIC);
-    Assert.assertEquals(1, events.size());
+    Assertions.assertEquals(1, events.size());
     assertScaleSkipped(events.get(0), -1, "Auto-scaler failed to compute a task count");
   }
 
@@ -4211,11 +4209,11 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   private static void assertScaledToTaskCount(ServiceMetricEvent event, int expectedRequiredCount)
   {
     assertStandardDimensions(event);
-    Assert.assertNull(
-        "Attempted scale must not carry a scalingSkipReason dim",
-        event.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION)
+    Assertions.assertNull(
+        event.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION),
+        "Attempted scale must not carry a scalingSkipReason dim"
     );
-    Assert.assertEquals(expectedRequiredCount, event.getValue().intValue());
+    Assertions.assertEquals(expectedRequiredCount, event.getValue().intValue());
   }
 
   /**
@@ -4226,19 +4224,19 @@ public class SeekableStreamSupervisorStateTest extends EasyMockSupport
   private static void assertScaleSkipped(ServiceMetricEvent event, int expectedRequiredCount, String expectedReason)
   {
     assertStandardDimensions(event);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedReason,
         event.getUserDims().get(SeekableStreamSupervisor.AUTOSCALER_SKIP_REASON_DIMENSION)
     );
-    Assert.assertEquals(expectedRequiredCount, event.getValue().intValue());
+    Assertions.assertEquals(expectedRequiredCount, event.getValue().intValue());
   }
 
   private static void assertStandardDimensions(ServiceMetricEvent event)
   {
     final Map<String, Object> dims = event.getUserDims();
-    Assert.assertEquals(SUPERVISOR_ID, dims.get(DruidMetrics.SUPERVISOR_ID));
-    Assert.assertEquals(DATASOURCE, dims.get(DruidMetrics.DATASOURCE));
-    Assert.assertEquals(STREAM, dims.get(DruidMetrics.STREAM));
+    Assertions.assertEquals(SUPERVISOR_ID, dims.get(DruidMetrics.SUPERVISOR_ID));
+    Assertions.assertEquals(DATASOURCE, dims.get(DruidMetrics.DATASOURCE));
+    Assertions.assertEquals(STREAM, dims.get(DruidMetrics.STREAM));
   }
 
   private static TestSeekableStreamIndexTask createTestTask(String taskId, String groupId, @Nullable Integer serverPriority, SeekableStreamIndexTaskIOConfig taskIoConfig, RecordSupplier recordSupplier)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/SeekableStreamSupervisorTestBase.java
@@ -59,7 +59,7 @@ import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Period;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -87,7 +87,7 @@ public abstract class SeekableStreamSupervisorTestBase
   protected SeekableStreamIndexTaskClientFactory taskClientFactory;
   protected SeekableStreamSupervisorSpec spec;
 
-  @Before
+  @BeforeEach
   public void before() throws Exception
   {
     taskStorage = EasyMock.mock(TaskStorage.class);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerConfigTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing.seekablestream.supervisor.autoscaler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScalerConfig.DEFAULT_IDLE_WEIGHT;
 import static org.apache.druid.indexing.seekablestream.supervisor.autoscaler.CostBasedAutoScalerConfig.DEFAULT_LAG_WEIGHT;
@@ -64,30 +64,30 @@ public class CostBasedAutoScalerConfigTest
 
     final CostBasedAutoScalerConfig config = mapper.readValue(json, CostBasedAutoScalerConfig.class);
 
-    Assert.assertTrue(config.getEnableTaskAutoScaler());
-    Assert.assertEquals(100, config.getTaskCountMax());
-    Assert.assertEquals(5, config.getTaskCountMin());
-    Assert.assertEquals(Integer.valueOf(10), config.getTaskCountStart());
-    Assert.assertEquals(Double.valueOf(0.8), config.getStopTaskCountRatio());
-    Assert.assertEquals(60000L, config.getScaleActionPeriodMillis());
-    Assert.assertEquals(0.6, config.getLagWeight(), 0.001);
-    Assert.assertEquals(0.4, config.getIdleWeight(), 0.001);
-    Assert.assertEquals(0.3, config.getOptimalTaskIdleRatio(), 0.001);
-    Assert.assertEquals(Duration.standardMinutes(5), config.getMinScaleUpDelay());
-    Assert.assertEquals(Duration.standardMinutes(10), config.getMinScaleDownDelay());
-    Assert.assertTrue(config.isScaleDownOnTaskRolloverOnly());
-    Assert.assertFalse(config.isUsePollIdleRatio());
-    Assert.assertFalse(config.isUseTaskCountBoundariesOnScaleUp());
-    Assert.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
-    Assert.assertEquals(Long.valueOf(500000), config.getCriticalLagThreshold());
-    Assert.assertEquals(10, config.getMinCostDropPercentForScaling());
-    Assert.assertEquals(8.0, config.getHighLagCostFactor(), 0.001);
+    Assertions.assertTrue(config.getEnableTaskAutoScaler());
+    Assertions.assertEquals(100, config.getTaskCountMax());
+    Assertions.assertEquals(5, config.getTaskCountMin());
+    Assertions.assertEquals(Integer.valueOf(10), config.getTaskCountStart());
+    Assertions.assertEquals(Double.valueOf(0.8), config.getStopTaskCountRatio());
+    Assertions.assertEquals(60000L, config.getScaleActionPeriodMillis());
+    Assertions.assertEquals(0.6, config.getLagWeight(), 0.001);
+    Assertions.assertEquals(0.4, config.getIdleWeight(), 0.001);
+    Assertions.assertEquals(0.3, config.getOptimalTaskIdleRatio(), 0.001);
+    Assertions.assertEquals(Duration.standardMinutes(5), config.getMinScaleUpDelay());
+    Assertions.assertEquals(Duration.standardMinutes(10), config.getMinScaleDownDelay());
+    Assertions.assertTrue(config.isScaleDownOnTaskRolloverOnly());
+    Assertions.assertFalse(config.isUsePollIdleRatio());
+    Assertions.assertFalse(config.isUseTaskCountBoundariesOnScaleUp());
+    Assertions.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
+    Assertions.assertEquals(Long.valueOf(500000), config.getCriticalLagThreshold());
+    Assertions.assertEquals(10, config.getMinCostDropPercentForScaling());
+    Assertions.assertEquals(8.0, config.getHighLagCostFactor(), 0.001);
 
     // Test serialization back to JSON
     final String serialized = mapper.writeValueAsString(config);
     final CostBasedAutoScalerConfig deserialized = mapper.readValue(serialized, CostBasedAutoScalerConfig.class);
 
-    Assert.assertEquals(config, deserialized);
+    Assertions.assertEquals(config, deserialized);
   }
 
   @Test
@@ -102,27 +102,27 @@ public class CostBasedAutoScalerConfigTest
 
     final CostBasedAutoScalerConfig config = mapper.readValue(json, CostBasedAutoScalerConfig.class);
 
-    Assert.assertTrue(config.getEnableTaskAutoScaler());
-    Assert.assertEquals(50, config.getTaskCountMax());
-    Assert.assertEquals(2, config.getTaskCountMin());
+    Assertions.assertTrue(config.getEnableTaskAutoScaler());
+    Assertions.assertEquals(50, config.getTaskCountMax());
+    Assertions.assertEquals(2, config.getTaskCountMin());
 
     // Check defaults
-    Assert.assertEquals(DEFAULT_SCALE_ACTION_PERIOD.getMillis(), config.getScaleActionPeriodMillis());
-    Assert.assertEquals(DEFAULT_LAG_WEIGHT, config.getLagWeight(), 0.001);
-    Assert.assertEquals(DEFAULT_IDLE_WEIGHT, config.getIdleWeight(), 0.001);
-    Assert.assertEquals(OPTIMAL_TASK_IDLE_RATIO, config.getOptimalTaskIdleRatio(), 0.001);
+    Assertions.assertEquals(DEFAULT_SCALE_ACTION_PERIOD.getMillis(), config.getScaleActionPeriodMillis());
+    Assertions.assertEquals(DEFAULT_LAG_WEIGHT, config.getLagWeight(), 0.001);
+    Assertions.assertEquals(DEFAULT_IDLE_WEIGHT, config.getIdleWeight(), 0.001);
+    Assertions.assertEquals(OPTIMAL_TASK_IDLE_RATIO, config.getOptimalTaskIdleRatio(), 0.001);
     // minScaleUpDelay and minScaleDownDelay each have their own independent default
-    Assert.assertEquals(DEFAULT_MIN_SCALE_UP_DELAY, config.getMinScaleUpDelay());
-    Assert.assertEquals(DEFAULT_MIN_SCALE_DOWN_DELAY, config.getMinScaleDownDelay());
-    Assert.assertFalse(config.isScaleDownOnTaskRolloverOnly());
-    Assert.assertTrue(config.isUsePollIdleRatio());
-    Assert.assertFalse(config.isUseTaskCountBoundariesOnScaleUp());
-    Assert.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
-    Assert.assertNull(config.getTaskCountStart());
-    Assert.assertNull(config.getStopTaskCountRatio());
-    Assert.assertNull(config.getCriticalLagThreshold());
-    Assert.assertEquals(0, config.getMinCostDropPercentForScaling());
-    Assert.assertEquals(DEFAULT_HIGH_LAG_COST_FACTOR, config.getHighLagCostFactor(), 0.001);
+    Assertions.assertEquals(DEFAULT_MIN_SCALE_UP_DELAY, config.getMinScaleUpDelay());
+    Assertions.assertEquals(DEFAULT_MIN_SCALE_DOWN_DELAY, config.getMinScaleDownDelay());
+    Assertions.assertFalse(config.isScaleDownOnTaskRolloverOnly());
+    Assertions.assertTrue(config.isUsePollIdleRatio());
+    Assertions.assertFalse(config.isUseTaskCountBoundariesOnScaleUp());
+    Assertions.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
+    Assertions.assertNull(config.getTaskCountStart());
+    Assertions.assertNull(config.getStopTaskCountRatio());
+    Assertions.assertNull(config.getCriticalLagThreshold());
+    Assertions.assertEquals(0, config.getMinCostDropPercentForScaling());
+    Assertions.assertEquals(DEFAULT_HIGH_LAG_COST_FACTOR, config.getHighLagCostFactor(), 0.001);
   }
 
   @Test
@@ -135,82 +135,103 @@ public class CostBasedAutoScalerConfigTest
 
     CostBasedAutoScalerConfig config = mapper.readValue(json, CostBasedAutoScalerConfig.class);
 
-    Assert.assertFalse(config.getEnableTaskAutoScaler());
+    Assertions.assertFalse(config.getEnableTaskAutoScaler());
     // When disabled, taskCountMax and taskCountMin default to 0
-    Assert.assertEquals(0, config.getTaskCountMax());
-    Assert.assertEquals(0, config.getTaskCountMin());
+    Assertions.assertEquals(0, config.getTaskCountMax());
+    Assertions.assertEquals(0, config.getTaskCountMin());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testValidation_MissingTaskCountMax()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMin(5)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMin(5)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testValidation_MissingTaskCountMin()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testValidation_MaxLessThanMin()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(5)
-                             .taskCountMin(10)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(5)
+                                       .taskCountMin(10)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testValidation_TaskCountStartOutOfRange()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .taskCountStart(200)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        RuntimeException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .taskCountStart(200)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidation_InvalidStopTaskCountRatio()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .stopTaskCountRatio(1.5)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .stopTaskCountRatio(1.5)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidationZeroOptimalTaskIdleRatio()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .optimalTaskIdleRatio(0.0)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .optimalTaskIdleRatio(0.0)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidationOneOptimalTaskIdleRatio()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .optimalTaskIdleRatio(1.0)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .optimalTaskIdleRatio(1.0)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
   @Test
@@ -236,67 +257,79 @@ public class CostBasedAutoScalerConfigTest
                                                                       .highLagCostFactor(8.0)
                                                                       .build();
 
-    Assert.assertTrue(config.getEnableTaskAutoScaler());
-    Assert.assertEquals(100, config.getTaskCountMax());
-    Assert.assertEquals(5, config.getTaskCountMin());
-    Assert.assertEquals(Integer.valueOf(10), config.getTaskCountStart());
-    Assert.assertEquals(Double.valueOf(0.8), config.getStopTaskCountRatio());
-    Assert.assertEquals(60000L, config.getScaleActionPeriodMillis());
-    Assert.assertEquals(0.6, config.getLagWeight(), 0.001);
-    Assert.assertEquals(0.4, config.getIdleWeight(), 0.001);
-    Assert.assertEquals(0.3, config.getOptimalTaskIdleRatio(), 0.001);
-    Assert.assertTrue(config.isUseTaskCountBoundariesOnScaleUp());
-    Assert.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
-    Assert.assertEquals(Duration.standardMinutes(5), config.getMinScaleUpDelay());
-    Assert.assertEquals(Duration.standardMinutes(10), config.getMinScaleDownDelay());
-    Assert.assertTrue(config.isScaleDownOnTaskRolloverOnly());
-    Assert.assertFalse(config.isUsePollIdleRatio());
-    Assert.assertEquals(Long.valueOf(500000), config.getCriticalLagThreshold());
-    Assert.assertEquals(8.0, config.getHighLagCostFactor(), 0.001);
+    Assertions.assertTrue(config.getEnableTaskAutoScaler());
+    Assertions.assertEquals(100, config.getTaskCountMax());
+    Assertions.assertEquals(5, config.getTaskCountMin());
+    Assertions.assertEquals(Integer.valueOf(10), config.getTaskCountStart());
+    Assertions.assertEquals(Double.valueOf(0.8), config.getStopTaskCountRatio());
+    Assertions.assertEquals(60000L, config.getScaleActionPeriodMillis());
+    Assertions.assertEquals(0.6, config.getLagWeight(), 0.001);
+    Assertions.assertEquals(0.4, config.getIdleWeight(), 0.001);
+    Assertions.assertEquals(0.3, config.getOptimalTaskIdleRatio(), 0.001);
+    Assertions.assertTrue(config.isUseTaskCountBoundariesOnScaleUp());
+    Assertions.assertTrue(config.isUseTaskCountBoundariesOnScaleDown());
+    Assertions.assertEquals(Duration.standardMinutes(5), config.getMinScaleUpDelay());
+    Assertions.assertEquals(Duration.standardMinutes(10), config.getMinScaleDownDelay());
+    Assertions.assertTrue(config.isScaleDownOnTaskRolloverOnly());
+    Assertions.assertFalse(config.isUsePollIdleRatio());
+    Assertions.assertEquals(Long.valueOf(500000), config.getCriticalLagThreshold());
+    Assertions.assertEquals(8.0, config.getHighLagCostFactor(), 0.001);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidation_NegativeCriticalLagAmplificationMultiplier()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .highLagCostFactor(-1.0)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .highLagCostFactor(-1.0)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidation_ZeroCriticalLagThreshold()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .criticalLagThreshold(0L)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .criticalLagThreshold(0L)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidation_NegativeMinCostDropPercentForScaling()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .minCostDropPercentForScaling(-1)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .minCostDropPercentForScaling(-1)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testValidation_MinCostDropPercentForScalingAbove100()
   {
-    CostBasedAutoScalerConfig.builder()
-                             .taskCountMax(100)
-                             .taskCountMin(5)
-                             .minCostDropPercentForScaling(101)
-                             .enableTaskAutoScaler(true)
-                             .build();
+    Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> CostBasedAutoScalerConfig.builder()
+                                       .taskCountMax(100)
+                                       .taskCountMin(5)
+                                       .minCostDropPercentForScaling(101)
+                                       .enableTaskAutoScaler(true)
+                                       .build()
+    );
   }
 
   @Test
@@ -307,8 +340,8 @@ public class CostBasedAutoScalerConfigTest
                                                                   .taskCountMax(10)
                                                                   .taskCountMin(1)
                                                                   .build();
-    Assert.assertEquals(DEFAULT_MIN_SCALE_UP_DELAY, defaults.getMinScaleUpDelay());
-    Assert.assertEquals(DEFAULT_MIN_SCALE_DOWN_DELAY, defaults.getMinScaleDownDelay());
+    Assertions.assertEquals(DEFAULT_MIN_SCALE_UP_DELAY, defaults.getMinScaleUpDelay());
+    Assertions.assertEquals(DEFAULT_MIN_SCALE_DOWN_DELAY, defaults.getMinScaleDownDelay());
 
     // Only minScaleUpDelay set: up uses explicit value, down uses its default
     CostBasedAutoScalerConfig upOnly = CostBasedAutoScalerConfig.builder()
@@ -316,8 +349,8 @@ public class CostBasedAutoScalerConfigTest
                                                                 .taskCountMin(1)
                                                                 .minScaleUpDelay(Duration.standardMinutes(5))
                                                                 .build();
-    Assert.assertEquals(Duration.standardMinutes(5), upOnly.getMinScaleUpDelay());
-    Assert.assertEquals(DEFAULT_MIN_SCALE_DOWN_DELAY, upOnly.getMinScaleDownDelay());
+    Assertions.assertEquals(Duration.standardMinutes(5), upOnly.getMinScaleUpDelay());
+    Assertions.assertEquals(DEFAULT_MIN_SCALE_DOWN_DELAY, upOnly.getMinScaleDownDelay());
 
     // Only minScaleDownDelay set: down uses explicit value, up uses its own default (does not fall back to down)
     CostBasedAutoScalerConfig downOnly = CostBasedAutoScalerConfig.builder()
@@ -325,8 +358,8 @@ public class CostBasedAutoScalerConfigTest
                                                                   .taskCountMin(1)
                                                                   .minScaleDownDelay(Duration.standardMinutes(20))
                                                                   .build();
-    Assert.assertEquals(DEFAULT_MIN_SCALE_UP_DELAY, downOnly.getMinScaleUpDelay());
-    Assert.assertEquals(Duration.standardMinutes(20), downOnly.getMinScaleDownDelay());
+    Assertions.assertEquals(DEFAULT_MIN_SCALE_UP_DELAY, downOnly.getMinScaleUpDelay());
+    Assertions.assertEquals(Duration.standardMinutes(20), downOnly.getMinScaleDownDelay());
 
     // Both set: serde roundtrip preserves values
     CostBasedAutoScalerConfig bothSet = CostBasedAutoScalerConfig.builder()
@@ -335,13 +368,13 @@ public class CostBasedAutoScalerConfigTest
                                                                  .minScaleUpDelay(Duration.standardMinutes(5))
                                                                  .minScaleDownDelay(Duration.standardMinutes(20))
                                                                  .build();
-    Assert.assertEquals(Duration.standardMinutes(5), bothSet.getMinScaleUpDelay());
-    Assert.assertEquals(Duration.standardMinutes(20), bothSet.getMinScaleDownDelay());
+    Assertions.assertEquals(Duration.standardMinutes(5), bothSet.getMinScaleUpDelay());
+    Assertions.assertEquals(Duration.standardMinutes(20), bothSet.getMinScaleDownDelay());
     CostBasedAutoScalerConfig roundTripped = mapper.readValue(
         mapper.writeValueAsString(bothSet),
         CostBasedAutoScalerConfig.class
     );
-    Assert.assertEquals(bothSet, roundTripped);
+    Assertions.assertEquals(bothSet, roundTripped);
   }
 
   @Test
@@ -358,9 +391,9 @@ public class CostBasedAutoScalerConfigTest
           "{\"autoScalerStrategy\":\"costBased\",\"enableTaskAutoScaler\":true,\"taskCountMax\":10,\"taskCountMin\":1}",
           CostBasedAutoScalerConfig.class
       );
-      Assert.assertEquals(defaultMinTriggerMillis, config.getMinTriggerScaleActionFrequencyMillis());
-      Assert.assertEquals(defaultUp, config.getMinScaleUpDelay());
-      Assert.assertEquals(defaultDown, config.getMinScaleDownDelay());
+      Assertions.assertEquals(defaultMinTriggerMillis, config.getMinTriggerScaleActionFrequencyMillis());
+      Assertions.assertEquals(defaultUp, config.getMinScaleUpDelay());
+      Assertions.assertEquals(defaultDown, config.getMinScaleDownDelay());
       assertRoundTrips(config);
     }
 
@@ -372,8 +405,8 @@ public class CostBasedAutoScalerConfigTest
           + "\"minTriggerScaleActionFrequencyMillis\":900000}",
           CostBasedAutoScalerConfig.class
       );
-      Assert.assertEquals(defaultUp, config.getMinScaleUpDelay());
-      Assert.assertEquals(defaultDown, config.getMinScaleDownDelay());
+      Assertions.assertEquals(defaultUp, config.getMinScaleUpDelay());
+      Assertions.assertEquals(defaultDown, config.getMinScaleDownDelay());
       assertRoundTrips(config);
     }
 
@@ -384,9 +417,9 @@ public class CostBasedAutoScalerConfigTest
           + "\"minScaleUpDelay\":\"PT2M\",\"minScaleDownDelay\":\"PT15M\"}",
           CostBasedAutoScalerConfig.class
       );
-      Assert.assertEquals(defaultMinTriggerMillis, config.getMinTriggerScaleActionFrequencyMillis());
-      Assert.assertEquals(Duration.standardMinutes(2), config.getMinScaleUpDelay());
-      Assert.assertEquals(Duration.standardMinutes(15), config.getMinScaleDownDelay());
+      Assertions.assertEquals(defaultMinTriggerMillis, config.getMinTriggerScaleActionFrequencyMillis());
+      Assertions.assertEquals(Duration.standardMinutes(2), config.getMinScaleUpDelay());
+      Assertions.assertEquals(Duration.standardMinutes(15), config.getMinScaleDownDelay());
       assertRoundTrips(config);
     }
 
@@ -399,8 +432,8 @@ public class CostBasedAutoScalerConfigTest
           + "\"minScaleUpDelay\":\"PT2M\",\"minScaleDownDelay\":\"PT15M\"}",
           CostBasedAutoScalerConfig.class
       );
-      Assert.assertEquals(Duration.standardMinutes(2), config.getMinScaleUpDelay());
-      Assert.assertEquals(Duration.standardMinutes(15), config.getMinScaleDownDelay());
+      Assertions.assertEquals(Duration.standardMinutes(2), config.getMinScaleUpDelay());
+      Assertions.assertEquals(Duration.standardMinutes(15), config.getMinScaleDownDelay());
       assertRoundTrips(config);
     }
 
@@ -413,8 +446,8 @@ public class CostBasedAutoScalerConfigTest
           + "\"minScaleUpDelay\":\"PT2M\"}",
           CostBasedAutoScalerConfig.class
       );
-      Assert.assertEquals(Duration.standardMinutes(2), config.getMinScaleUpDelay());
-      Assert.assertEquals(defaultDown, config.getMinScaleDownDelay());
+      Assertions.assertEquals(Duration.standardMinutes(2), config.getMinScaleUpDelay());
+      Assertions.assertEquals(defaultDown, config.getMinScaleDownDelay());
       assertRoundTrips(config);
     }
 
@@ -426,8 +459,8 @@ public class CostBasedAutoScalerConfigTest
           + "\"minScaleDownDelay\":\"PT15M\"}",
           CostBasedAutoScalerConfig.class
       );
-      Assert.assertEquals(defaultUp, config.getMinScaleUpDelay());
-      Assert.assertEquals(Duration.standardMinutes(15), config.getMinScaleDownDelay());
+      Assertions.assertEquals(defaultUp, config.getMinScaleUpDelay());
+      Assertions.assertEquals(Duration.standardMinutes(15), config.getMinScaleDownDelay());
       assertRoundTrips(config);
     }
   }
@@ -438,6 +471,6 @@ public class CostBasedAutoScalerConfigTest
         mapper.writeValueAsString(config),
         CostBasedAutoScalerConfig.class
     );
-    Assert.assertEquals(config, roundTripped);
+    Assertions.assertEquals(config, roundTripped);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerMockTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerMockTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervi
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -51,7 +51,7 @@ public class CostBasedAutoScalerMockTest
   private SeekableStreamSupervisorIOConfig mockIoConfig;
   private CostBasedAutoScalerConfig config;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mockSpec = Mockito.mock(SupervisorSpec.class);
@@ -85,10 +85,10 @@ public class CostBasedAutoScalerMockTest
     doReturn(scaleUpOptimal).when(autoScaler).computeOptimalTaskCount(any());
     setupMocksForMetricsCollection(autoScaler, currentTaskCount, 5000.0, 0.1);
 
-    Assert.assertEquals(
-        "Should return optimal count when it's greater than current (scale-up)",
+    Assertions.assertEquals(
         scaleUpOptimal,
-        autoScaler.computeTaskCountForScaleAction()
+        autoScaler.computeTaskCountForScaleAction(),
+        "Should return optimal count when it's greater than current (scale-up)"
     );
   }
 
@@ -107,7 +107,7 @@ public class CostBasedAutoScalerMockTest
 
     int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals("Scaler should return its optimal count even when it equals current", optimalCount, result);
+    Assertions.assertEquals(optimalCount, result, "Scaler should return its optimal count even when it equals current");
   }
 
   @Test
@@ -125,10 +125,10 @@ public class CostBasedAutoScalerMockTest
 
     int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Should return -1 when computeOptimalTaskCount returns -1 (e.g., due to invalid metrics)",
+    Assertions.assertEquals(
         -1,
-        result
+        result,
+        "Should return -1 when computeOptimalTaskCount returns -1 (e.g., due to invalid metrics)"
     );
   }
 
@@ -146,10 +146,10 @@ public class CostBasedAutoScalerMockTest
 
     int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Should return -1 when computeOptimalTaskCount returns -1 (e.g., due to null lag stats)",
+    Assertions.assertEquals(
         -1,
-        result
+        result,
+        "Should return -1 when computeOptimalTaskCount returns -1 (e.g., due to null lag stats)"
     );
   }
 
@@ -166,10 +166,10 @@ public class CostBasedAutoScalerMockTest
 
     int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Should allow scale-up from the minimum task count",
+    Assertions.assertEquals(
         expectedOptimalCount,
-        result
+        result,
+        "Should allow scale-up from the minimum task count"
     );
   }
 
@@ -193,10 +193,10 @@ public class CostBasedAutoScalerMockTest
 
     final int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Scaler should return unclamped optimal; clamping is a supervisor concern",
+    Assertions.assertEquals(
         belowMinOptimal,
-        result
+        result,
+        "Scaler should return unclamped optimal; clamping is a supervisor concern"
     );
   }
 
@@ -220,10 +220,10 @@ public class CostBasedAutoScalerMockTest
 
     final int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Scaler should return unclamped optimal; clamping is a supervisor concern",
+    Assertions.assertEquals(
         aboveMaxOptimal,
-        result
+        result,
+        "Scaler should return unclamped optimal; clamping is a supervisor concern"
     );
   }
 
@@ -240,10 +240,10 @@ public class CostBasedAutoScalerMockTest
 
     int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Should allow scale-up to maximum task count",
+    Assertions.assertEquals(
         expectedOptimalCount,
-        result
+        result,
+        "Should allow scale-up to maximum task count"
     );
   }
 
@@ -260,10 +260,10 @@ public class CostBasedAutoScalerMockTest
 
     int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Should allow scale-up by exactly one task",
+    Assertions.assertEquals(
         expectedOptimalCount,
-        result
+        result,
+        "Should allow scale-up by exactly one task"
     );
   }
 
@@ -280,10 +280,10 @@ public class CostBasedAutoScalerMockTest
 
     int result = autoScaler.computeTaskCountForScaleAction();
 
-    Assert.assertEquals(
-        "Should allow scale-down by one task when cooldown has elapsed",
+    Assertions.assertEquals(
         optimalCount,
-        result
+        result,
+        "Should allow scale-down by one task when cooldown has elapsed"
     );
   }
 
@@ -314,10 +314,10 @@ public class CostBasedAutoScalerMockTest
     doReturn(optimalCount).when(autoScaler).computeOptimalTaskCount(any());
     setupMocksForMetricsCollection(autoScaler, currentTaskCount, 10.0, 0.9);
 
-    Assert.assertEquals(
-        "Should return current count (no-op signal) when scaleDownDuringTaskRolloverOnly suppresses the scale-down",
+    Assertions.assertEquals(
         currentTaskCount,
-        autoScaler.computeTaskCountForScaleAction()
+        autoScaler.computeTaskCountForScaleAction(),
+        "Should return current count (no-op signal) when scaleDownDuringTaskRolloverOnly suppresses the scale-down"
     );
   }
 
@@ -348,10 +348,10 @@ public class CostBasedAutoScalerMockTest
     autoScaler.computeTaskCountForScaleAction(); // This populates lastKnownMetrics
 
     doReturn(optimalCount).when(autoScaler).computeOptimalTaskCount(any());
-    Assert.assertEquals(
-        "Should scale-down during rollover when scaleDownDuringTaskRolloverOnly is true",
+    Assertions.assertEquals(
         optimalCount,
-        autoScaler.computeTaskCountForRollover()
+        autoScaler.computeTaskCountForRollover(),
+        "Should scale-down during rollover when scaleDownDuringTaskRolloverOnly is true"
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/CostBasedAutoScalerTest.java
@@ -26,12 +26,10 @@ import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervi
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
 import org.apache.druid.segment.incremental.RowIngestionMeters;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
@@ -50,7 +48,7 @@ public class CostBasedAutoScalerTest
 {
   private CostBasedAutoScaler autoScaler;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     SupervisorSpec mockSupervisorSpec = Mockito.mock(SupervisorSpec.class);
@@ -81,7 +79,7 @@ public class CostBasedAutoScalerTest
     final int partitionCount = 100;
     final int minTaskCount = 1;
     final int maxTaskCount = 100;
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 15, 17, 20, 25, 34, 50, 100},
         computeValidTaskCounts(partitionCount, minTaskCount, maxTaskCount)
     );
@@ -93,7 +91,7 @@ public class CostBasedAutoScalerTest
     final int partitionCount = 1;
     final int minTaskCount = 1;
     final int maxTaskCount = 100;
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{1},
         computeValidTaskCounts(partitionCount, minTaskCount, maxTaskCount)
     );
@@ -105,7 +103,7 @@ public class CostBasedAutoScalerTest
     final int partitionCount = 30;
     final int taskCountMin = 1;
     final int taskCountMax = 3;
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{1, 2, 3},
         computeValidTaskCounts(partitionCount, taskCountMin, taskCountMax)
     );
@@ -117,7 +115,7 @@ public class CostBasedAutoScalerTest
     final int partitionCount = 100;
     final int taskCountMin = 10;
     final int taskCountMax = 30;
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new int[]{10, 12, 13, 15, 17, 20, 25},
         computeValidTaskCounts(partitionCount, taskCountMin, taskCountMax)
     );
@@ -127,33 +125,29 @@ public class CostBasedAutoScalerTest
   public void testComputeOptimalTaskCount()
   {
     // Invalid inputs return -1
-    Assert.assertEquals(-1, autoScaler.computeOptimalTaskCount(null));
-    Assert.assertEquals(-1, autoScaler.computeOptimalTaskCount(createMetrics(0.0, 10, 0, 0.0)));
-    Assert.assertEquals(-1, autoScaler.computeOptimalTaskCount(createMetrics(100.0, 10, -5, 0.3)));
-    Assert.assertEquals(-1, autoScaler.computeOptimalTaskCount(createMetrics(100.0, -1, 100, 0.3)));
+    Assertions.assertEquals(-1, autoScaler.computeOptimalTaskCount(null));
+    Assertions.assertEquals(-1, autoScaler.computeOptimalTaskCount(createMetrics(0.0, 10, 0, 0.0)));
+    Assertions.assertEquals(-1, autoScaler.computeOptimalTaskCount(createMetrics(100.0, 10, -5, 0.3)));
+    Assertions.assertEquals(-1, autoScaler.computeOptimalTaskCount(createMetrics(100.0, -1, 100, 0.3)));
 
     // Negative pollIdleRatio (metric unavailable) should still allow scaling
     final int unavailableIdleResult = autoScaler.computeOptimalTaskCount(createMetrics(100.0, 25, 100, -1.0));
-    MatcherAssert.assertThat(
-        "Negative pollIdleRatio should not reject scaling",
-        unavailableIdleResult,
-        Matchers.greaterThanOrEqualTo(1)
-    );
+    Assertions.assertTrue(unavailableIdleResult >= 1, "Negative pollIdleRatio should not reject scaling");
 
     // High idle (underutilized) - should scale down
     final int scaleDownResult = autoScaler.computeOptimalTaskCount(createMetrics(100.0, 25, 100, 0.8));
-    Assert.assertTrue("Expected scale-down when idle ratio is high (>0.6)", scaleDownResult < 25);
+    Assertions.assertTrue(scaleDownResult < 25, "Expected scale-down when idle ratio is high (>0.6)");
 
     // Very high idle with high task count - should scale down
     final int highIdleResult = autoScaler.computeOptimalTaskCount(createMetrics(10.0, 50, 100, 0.9));
-    Assert.assertTrue("High idle should not suggest scale-up", highIdleResult <= 50);
+    Assertions.assertTrue(highIdleResult <= 50, "High idle should not suggest scale-up");
 
     // With idle below ideal (0.1 < 0.25), U-shaped cost penalizes under-provisioning,
     // driving a moderate scale-up toward the ideal operating point.
     final int lowIdleResult = autoScaler.computeOptimalTaskCount(createMetrics(1000.0, 25, 100, 0.1));
-    Assert.assertTrue(
-        "Low idle below ideal should drive scale-up toward ideal operating point",
-        lowIdleResult > 25
+    Assertions.assertTrue(
+        lowIdleResult > 25,
+        "Low idle below ideal should drive scale-up toward ideal operating point"
     );
   }
 
@@ -164,9 +158,9 @@ public class CostBasedAutoScalerTest
     // consolidation as near-ideal idle (not a false overload), so it scales down; linear stayed at 100.
     final int currentTaskCount = 100;
     final int optimal = autoScaler.computeOptimalTaskCount(createMetrics(0.0, currentTaskCount, 100, 0.4));
-    Assert.assertTrue(
-        "Moderate idle (0.4) with minimal lag should scale an over-provisioned supervisor down",
-        optimal < currentTaskCount
+    Assertions.assertTrue(
+        optimal < currentTaskCount,
+        "Moderate idle (0.4) with minimal lag should scale an over-provisioned supervisor down"
     );
   }
 
@@ -185,10 +179,10 @@ public class CostBasedAutoScalerTest
         .build();
     final CostBasedAutoScaler boundedScaleUpScaler = createAutoScaler(boundedScaleUpConfig);
 
-    Assert.assertEquals(
-        "Scale-up should only evaluate two task-count candidates above the current count",
+    Assertions.assertEquals(
         13,
-        boundedScaleUpScaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 100, 0.25))
+        boundedScaleUpScaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 100, 0.25)),
+        "Scale-up should only evaluate two task-count candidates above the current count"
     );
 
     final CostBasedAutoScalerConfig unboundedScaleUpConfig = CostBasedAutoScalerConfig
@@ -200,10 +194,10 @@ public class CostBasedAutoScalerTest
         .idleWeight(0.0)
         .build();
     final CostBasedAutoScaler unboundedScaleUpScaler = createAutoScaler(unboundedScaleUpConfig);
-    Assert.assertEquals(
-        "Without scale-up boundaries, lag-only optimization should jump to max task count",
+    Assertions.assertEquals(
         100,
-        unboundedScaleUpScaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 100, 0.25))
+        unboundedScaleUpScaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 100, 0.25)),
+        "Without scale-up boundaries, lag-only optimization should jump to max task count"
     );
 
     final CostBasedAutoScalerConfig boundedScaleDownConfig = CostBasedAutoScalerConfig
@@ -218,10 +212,10 @@ public class CostBasedAutoScalerTest
         .build();
     final CostBasedAutoScaler boundedScaleDownScaler = createAutoScaler(boundedScaleDownConfig);
 
-    Assert.assertEquals(
-        "Scale-down should only evaluate two task-count candidates below the current count",
+    Assertions.assertEquals(
         34,
-        boundedScaleDownScaler.computeOptimalTaskCount(createMetrics(0.0, 100, 100, 0.9))
+        boundedScaleDownScaler.computeOptimalTaskCount(createMetrics(0.0, 100, 100, 0.9)),
+        "Scale-down should only evaluate two task-count candidates below the current count"
     );
 
     final CostBasedAutoScalerConfig unboundedScaleDownConfig = CostBasedAutoScalerConfig
@@ -233,10 +227,10 @@ public class CostBasedAutoScalerTest
         .idleWeight(1.0)
         .build();
     final CostBasedAutoScaler unboundedScaleDownScaler = createAutoScaler(unboundedScaleDownConfig);
-    Assert.assertEquals(
-        "Without scale-down boundaries, idle-only optimization may select a much lower task count",
+    Assertions.assertEquals(
         1,
-        unboundedScaleDownScaler.computeOptimalTaskCount(createMetrics(0.0, 100, 100, 0.9))
+        unboundedScaleDownScaler.computeOptimalTaskCount(createMetrics(0.0, 100, 100, 0.9)),
+        "Without scale-down boundaries, idle-only optimization may select a much lower task count"
     );
   }
 
@@ -258,17 +252,17 @@ public class CostBasedAutoScalerTest
         .build();
     final CostBasedAutoScaler scaler = createAutoScaler(boundedScaleUpConfig);
 
-    Assert.assertEquals(
-        "High lag should bypass the scale-up boundary and jump straight to the argmin",
+    Assertions.assertEquals(
         100,
-        scaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 100, 0.25))
+        scaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 100, 0.25)),
+        "High lag should bypass the scale-up boundary and jump straight to the argmin"
     );
 
     // Below the threshold, the boundary still applies as usual.
-    Assert.assertEquals(
-        "Below criticalLagThreshold, the scale-up boundary still limits candidates",
+    Assertions.assertEquals(
         13,
-        scaler.computeOptimalTaskCount(createMetrics(10.0, 10, 100, 0.25))
+        scaler.computeOptimalTaskCount(createMetrics(10.0, 10, 100, 0.25)),
+        "Below criticalLagThreshold, the scale-up boundary still limits candidates"
     );
   }
 
@@ -287,10 +281,10 @@ public class CostBasedAutoScalerTest
         .build();
     final CostBasedAutoScaler scaler = createAutoScaler(boundedScaleUpConfig);
 
-    Assert.assertEquals(
-        "Exact aggregate lag should engage high lag even when integer average lag is zero",
+    Assertions.assertEquals(
         1_000,
-        scaler.computeOptimalTaskCount(createMetrics(0.0, 999.0, 10, 1_000, 0.25))
+        scaler.computeOptimalTaskCount(createMetrics(0.0, 999.0, 10, 1_000, 0.25)),
+        "Exact aggregate lag should engage high lag even when integer average lag is zero"
     );
   }
 
@@ -311,10 +305,10 @@ public class CostBasedAutoScalerTest
     final CostBasedAutoScaler scaler = createAutoScaler(config);
 
     // Idle-heavy weights would normally argue for scaling down, but critical lag overrides that entirely.
-    Assert.assertEquals(
-        "Critical lag should jump straight to the maximum task count regardless of idle-favoring weights",
+    Assertions.assertEquals(
         500,
-        scaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 500, 0.9))
+        scaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 500, 0.9)),
+        "Critical lag should jump straight to the maximum task count regardless of idle-favoring weights"
     );
   }
 
@@ -335,10 +329,10 @@ public class CostBasedAutoScalerTest
         .build();
     final CostBasedAutoScaler scaler = createAutoScaler(config);
 
-    Assert.assertEquals(
-        "Critical lag should jump to the maximum task count even if it costs more than the current count",
+    Assertions.assertEquals(
         500,
-        scaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 500, 0.9))
+        scaler.computeOptimalTaskCount(createMetrics(100_000.0, 10, 500, 0.9)),
+        "Critical lag should jump to the maximum task count even if it costs more than the current count"
     );
   }
 
@@ -357,15 +351,15 @@ public class CostBasedAutoScalerTest
         .build();
     final CostBasedAutoScaler scaler = createAutoScaler(config);
 
-    Assert.assertNotEquals(
-        "Tier 2 should not trigger below the full critical lag threshold",
+    Assertions.assertNotEquals(
         500,
-        scaler.computeOptimalTaskCount(createMetrics(20_000.0, 9_999_999.0, 10, 500, 0.9))
+        scaler.computeOptimalTaskCount(createMetrics(20_000.0, 9_999_999.0, 10, 500, 0.9)),
+        "Tier 2 should not trigger below the full critical lag threshold"
     );
-    Assert.assertEquals(
-        "Tier 2 should trigger at the full critical lag threshold",
+    Assertions.assertEquals(
         500,
-        scaler.computeOptimalTaskCount(createMetrics(20_000.0, 10_000_000.0, 10, 500, 0.9))
+        scaler.computeOptimalTaskCount(createMetrics(20_000.0, 10_000_000.0, 10, 500, 0.9)),
+        "Tier 2 should trigger at the full critical lag threshold"
     );
   }
 
@@ -373,27 +367,27 @@ public class CostBasedAutoScalerTest
   public void testExtractPollIdleRatio()
   {
     // Null and empty return -1 (no data)
-    Assert.assertEquals(
-        "Null stats should yield -1 idle ratio",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractPollIdleRatio(null),
-        0.0001
+        0.0001,
+        "Null stats should yield -1 idle ratio"
     );
-    Assert.assertEquals(
-        "Empty stats should yield -1 idle ratio",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractPollIdleRatio(Collections.emptyMap()),
-        0.0001
+        0.0001,
+        "Empty stats should yield -1 idle ratio"
     );
 
     // Missing metrics return -1 (no data)
     Map<String, Map<String, Object>> missingMetrics = new HashMap<>();
     missingMetrics.put("0", Collections.singletonMap("task-0", new HashMap<>()));
-    Assert.assertEquals(
-        "Missing autoscaler metrics should yield -1 idle ratio",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractPollIdleRatio(missingMetrics),
-        0.0001
+        0.0001,
+        "Missing autoscaler metrics should yield -1 idle ratio"
     );
 
     // Valid stats return average
@@ -402,21 +396,21 @@ public class CostBasedAutoScalerTest
     group.put("task-0", buildTaskStatsWithPollIdle(0.3));
     group.put("task-1", buildTaskStatsWithPollIdle(0.5));
     validStats.put("0", group);
-    Assert.assertEquals(
-        "Average poll idle ratio should be computed across tasks",
+    Assertions.assertEquals(
         0.4,
         CostBasedAutoScaler.extractPollIdleRatio(validStats),
-        0.0001
+        0.0001,
+        "Average poll idle ratio should be computed across tasks"
     );
 
     // Invalid types: non-map task metric
     Map<String, Map<String, Object>> nonMapTask = new HashMap<>();
     nonMapTask.put("0", Collections.singletonMap("task-0", "not-a-map"));
-    Assert.assertEquals(
-        "Non-map task stats should be ignored",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractPollIdleRatio(nonMapTask),
-        0.0001
+        0.0001,
+        "Non-map task stats should be ignored"
     );
 
     // Invalid types: empty autoscaler metrics
@@ -424,11 +418,11 @@ public class CostBasedAutoScalerTest
     Map<String, Object> taskStats1 = new HashMap<>();
     taskStats1.put(SeekableStreamIndexTaskRunner.AUTOSCALER_METRICS_KEY, new HashMap<>());
     emptyAutoscaler.put("0", Collections.singletonMap("task-0", taskStats1));
-    Assert.assertEquals(
-        "Empty autoscaler metrics should yield -1 idle ratio",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractPollIdleRatio(emptyAutoscaler),
-        0.0001
+        0.0001,
+        "Empty autoscaler metrics should yield -1 idle ratio"
     );
 
     // Invalid types: non-map autoscaler metrics
@@ -436,11 +430,11 @@ public class CostBasedAutoScalerTest
     Map<String, Object> taskStats2 = new HashMap<>();
     taskStats2.put(SeekableStreamIndexTaskRunner.AUTOSCALER_METRICS_KEY, "not-a-map");
     nonMapAutoscaler.put("0", Collections.singletonMap("task-0", taskStats2));
-    Assert.assertEquals(
-        "Non-map autoscaler metrics should be ignored",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractPollIdleRatio(nonMapAutoscaler),
-        0.0001
+        0.0001,
+        "Non-map autoscaler metrics should be ignored"
     );
 
     // Invalid types: non-number poll idle ratio
@@ -450,11 +444,11 @@ public class CostBasedAutoScalerTest
     autoscalerMetrics.put(SeekableStreamIndexTaskRunner.POLL_IDLE_RATIO_KEY, "not-a-number");
     taskStats3.put(SeekableStreamIndexTaskRunner.AUTOSCALER_METRICS_KEY, autoscalerMetrics);
     nonNumberRatio.put("0", Collections.singletonMap("task-0", taskStats3));
-    Assert.assertEquals(
-        "Non-numeric poll idle ratio should be ignored",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractPollIdleRatio(nonNumberRatio),
-        0.0001
+        0.0001,
+        "Non-numeric poll idle ratio should be ignored"
     );
   }
 
@@ -462,27 +456,27 @@ public class CostBasedAutoScalerTest
   public void testExtractMovingAverage()
   {
     // Null and empty return -1
-    Assert.assertEquals(
-        "Null stats should yield -1 moving average",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractMovingAverage(null),
-        0.0001
+        0.0001,
+        "Null stats should yield -1 moving average"
     );
-    Assert.assertEquals(
-        "Empty stats should yield -1 moving average",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractMovingAverage(Collections.emptyMap()),
-        0.0001
+        0.0001,
+        "Empty stats should yield -1 moving average"
     );
 
     // Missing metrics return -1
     Map<String, Map<String, Object>> missingMetrics = new HashMap<>();
     missingMetrics.put("0", Collections.singletonMap("task-0", new HashMap<>()));
-    Assert.assertEquals(
-        "Missing moving averages should yield -1",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractMovingAverage(missingMetrics),
-        0.0001
+        0.0001,
+        "Missing moving averages should yield -1"
     );
 
     // Valid stats return average (using 5-minute)
@@ -491,11 +485,11 @@ public class CostBasedAutoScalerTest
     group.put("task-0", buildTaskStatsWithMovingAverage(1000.0));
     group.put("task-1", buildTaskStatsWithMovingAverage(2000.0));
     validStats.put("0", group);
-    Assert.assertEquals(
-        "Average 5-minute processing rate should be computed across tasks",
+    Assertions.assertEquals(
         1500.0,
         CostBasedAutoScaler.extractMovingAverage(validStats),
-        0.0001
+        0.0001,
+        "Average 5-minute processing rate should be computed across tasks"
     );
 
     // Interval fallback: 15-minute preferred, then 5-minute, then 1-minute
@@ -507,11 +501,11 @@ public class CostBasedAutoScalerTest
             buildTaskStatsWithMovingAverageForInterval(FIFTEEN_MINUTE_NAME, 1500.0)
         )
     );
-    Assert.assertEquals(
-        "15-minute interval should be preferred when available",
+    Assertions.assertEquals(
         1500.0,
         CostBasedAutoScaler.extractMovingAverage(fifteenMin),
-        0.0001
+        0.0001,
+        "15-minute interval should be preferred when available"
     );
 
     // 1-minute as a final fallback
@@ -520,11 +514,11 @@ public class CostBasedAutoScalerTest
         "0",
         Collections.singletonMap("task-0", buildTaskStatsWithMovingAverageForInterval(ONE_MINUTE_NAME, 500.0))
     );
-    Assert.assertEquals(
-        "1-minute interval should be used as a final fallback",
+    Assertions.assertEquals(
         500.0,
         CostBasedAutoScaler.extractMovingAverage(oneMin),
-        0.0001
+        0.0001,
+        "1-minute interval should be used as a final fallback"
     );
 
     // 15-minute preferred over 5-minute when both available
@@ -533,11 +527,11 @@ public class CostBasedAutoScalerTest
         "0",
         Collections.singletonMap("task-0", buildTaskStatsWithMultipleMovingAverages(1500.0, 1000.0, 500.0))
     );
-    Assert.assertEquals(
-        "15-minute interval should win when multiple intervals are present",
+    Assertions.assertEquals(
         1500.0,
         CostBasedAutoScaler.extractMovingAverage(allIntervals),
-        0.0001
+        0.0001,
+        "15-minute interval should win when multiple intervals are present"
     );
 
     // Falls back to 5-minute when 15-minute is null
@@ -549,21 +543,21 @@ public class CostBasedAutoScalerTest
             buildTaskStatsWithNullInterval(FIFTEEN_MINUTE_NAME, FIVE_MINUTE_NAME, 750.0)
         )
     );
-    Assert.assertEquals(
-        "Should fall back to 5-minute when 15-minute is null",
+    Assertions.assertEquals(
         750.0,
         CostBasedAutoScaler.extractMovingAverage(nullFifteen),
-        0.0001
+        0.0001,
+        "Should fall back to 5-minute when 15-minute is null"
     );
 
     // Falls back to 1-minute when both 15 and 5 are null
     Map<String, Map<String, Object>> bothNull = new HashMap<>();
     bothNull.put("0", Collections.singletonMap("task-0", buildTaskStatsWithTwoNullIntervals(250.0)));
-    Assert.assertEquals(
-        "Should fall back to 1-minute when 15 and 5 are null",
+    Assertions.assertEquals(
         250.0,
         CostBasedAutoScaler.extractMovingAverage(bothNull),
-        0.0001
+        0.0001,
+        "Should fall back to 1-minute when 15 and 5 are null"
     );
   }
 
@@ -573,33 +567,33 @@ public class CostBasedAutoScalerTest
     // Non-map task metric
     Map<String, Map<String, Object>> nonMapTask = new HashMap<>();
     nonMapTask.put("0", Collections.singletonMap("task-0", "not-a-map"));
-    Assert.assertEquals(
-        "Non-map task stats should be ignored",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractMovingAverage(nonMapTask),
-        0.0001
+        0.0001,
+        "Non-map task stats should be ignored"
     );
 
     Map<String, Map<String, Object>> missingBuild = new HashMap<>();
     Map<String, Object> taskStats1 = new HashMap<>();
     taskStats1.put("movingAverages", new HashMap<>());
     missingBuild.put("0", Collections.singletonMap("task-0", taskStats1));
-    Assert.assertEquals(
-        "Missing buildSegments moving average should yield -1",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractMovingAverage(missingBuild),
-        0.0001
+        0.0001,
+        "Missing buildSegments moving average should yield -1"
     );
 
     Map<String, Map<String, Object>> nonMapMA = new HashMap<>();
     Map<String, Object> taskStats2 = new HashMap<>();
     taskStats2.put("movingAverages", "not-a-map");
     nonMapMA.put("0", Collections.singletonMap("task-0", taskStats2));
-    Assert.assertEquals(
-        "Non-map movingAverages should be ignored",
+    Assertions.assertEquals(
         -1.,
         CostBasedAutoScaler.extractMovingAverage(nonMapMA),
-        0.0001
+        0.0001,
+        "Non-map movingAverages should be ignored"
     );
   }
 
@@ -622,11 +616,11 @@ public class CostBasedAutoScalerTest
                                                                          .taskCountMin(1)
                                                                          .enableTaskAutoScaler(true)
                                                                          .build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         CostBasedAutoScalerConfig.DEFAULT_MIN_SCALE_DOWN_DELAY,
         cfgWithDefaults.getMinScaleDownDelay()
     );
-    Assert.assertFalse(cfgWithDefaults.isScaleDownOnTaskRolloverOnly());
+    Assertions.assertFalse(cfgWithDefaults.isScaleDownOnTaskRolloverOnly());
 
     // Test custom config values
     CostBasedAutoScalerConfig cfgWithCustom = CostBasedAutoScalerConfig.builder()
@@ -636,17 +630,17 @@ public class CostBasedAutoScalerTest
                                                                        .minScaleDownDelay(Duration.standardMinutes(10))
                                                                        .scaleDownDuringTaskRolloverOnly(true)
                                                                        .build();
-    Assert.assertEquals(Duration.standardMinutes(10), cfgWithCustom.getMinScaleDownDelay());
-    Assert.assertTrue(cfgWithCustom.isScaleDownOnTaskRolloverOnly());
+    Assertions.assertEquals(Duration.standardMinutes(10), cfgWithCustom.getMinScaleDownDelay());
+    Assertions.assertTrue(cfgWithCustom.isScaleDownOnTaskRolloverOnly());
 
     // computeTaskCountForRollover returns -1 when scaleDownDuringTaskRolloverOnly=false (default)
     when(spec.isSuspended()).thenReturn(false);
     CostBasedAutoScaler scaler = new CostBasedAutoScaler(supervisor, cfgWithDefaults, spec, emitter);
-    Assert.assertEquals(-1, scaler.computeTaskCountForRollover());
+    Assertions.assertEquals(-1, scaler.computeTaskCountForRollover());
 
     // computeTaskCountForRollover returns -1 when lastKnownMetrics is null (even with scaleDownDuringTaskRolloverOnly=true)
     CostBasedAutoScaler scalerWithRolloverOnly = new CostBasedAutoScaler(supervisor, cfgWithCustom, spec, emitter);
-    Assert.assertEquals(-1, scalerWithRolloverOnly.computeTaskCountForRollover());
+    Assertions.assertEquals(-1, scalerWithRolloverOnly.computeTaskCountForRollover());
   }
 
   @Test
@@ -675,10 +669,10 @@ public class CostBasedAutoScalerTest
                                                                 .build();
     CostBasedAutoScaler scaler = new CostBasedAutoScaler(supervisor, config, spec, emitter);
 
-    Assert.assertEquals(
-        "No scaling action should be requested when the moving average rate is unavailable",
+    Assertions.assertEquals(
         -1,
-        scaler.computeTaskCountForScaleAction()
+        scaler.computeTaskCountForScaleAction(),
+        "No scaling action should be requested when the moving average rate is unavailable"
     );
   }
 
@@ -708,7 +702,7 @@ public class CostBasedAutoScalerTest
                                                                        .build();
     final CostBasedAutoScaler scaler = new CostBasedAutoScaler(supervisor, config, spec, emitter);
 
-    Assert.assertEquals(999.0, scaler.collectMetrics().getAggregateLag(), 0.0);
+    Assertions.assertEquals(999.0, scaler.collectMetrics().getAggregateLag(), 0.0);
   }
 
   @Test
@@ -736,9 +730,9 @@ public class CostBasedAutoScalerTest
                                                                        .build();
     when(supervisor.getStats()).thenReturn(buildTaskStatsForRate(500.0));
     CostBasedAutoScaler defaultScaler = new CostBasedAutoScaler(supervisor, defaultConfig, spec, emitter);
-    Assert.assertNull(
-        "With usePollIdleRatio=true (the default), samples are never collected",
-        defaultScaler.collectMetrics().getMaxObservedRate()
+    Assertions.assertNull(
+        defaultScaler.collectMetrics().getMaxObservedRate(),
+        "With usePollIdleRatio=true (the default), samples are never collected"
     );
 
     // Disabling usePollIdleRatio switches the idle cost to the processing-rate-based estimate,
@@ -763,27 +757,27 @@ public class CostBasedAutoScalerTest
         new LagStats(1, 1, 0)
     );
 
-    Assert.assertNull(
-        "A rate sample without lag must not establish the watermark",
-        autoScalerWithoutPollIdleRatio.collectMetrics().getMaxObservedRate()
+    Assertions.assertNull(
+        autoScalerWithoutPollIdleRatio.collectMetrics().getMaxObservedRate(),
+        "A rate sample without lag must not establish the watermark"
     );
-    Assert.assertEquals(
-        "First positive-lag sample becomes the watermark",
+    Assertions.assertEquals(
         9000.0,
         autoScalerWithoutPollIdleRatio.collectMetrics().getMaxObservedRate(),
-        0.0001
+        0.0001,
+        "First positive-lag sample becomes the watermark"
     );
-    Assert.assertEquals(
-        "Watermark tracks the max across observed samples",
+    Assertions.assertEquals(
         9000.0,
         autoScalerWithoutPollIdleRatio.collectMetrics().getMaxObservedRate(),
-        0.0001
+        0.0001,
+        "Watermark tracks the max across observed samples"
     );
-    Assert.assertEquals(
-        "Watermark does not drop when a lower rate is observed",
+    Assertions.assertEquals(
         9000.0,
         autoScalerWithoutPollIdleRatio.collectMetrics().getMaxObservedRate(),
-        0.0001
+        0.0001,
+        "Watermark does not drop when a lower rate is observed"
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/LagBasedAutoScalerTest.java
@@ -23,9 +23,9 @@ import org.apache.druid.indexing.overlord.supervisor.SupervisorSpec;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisor;
 import org.apache.druid.indexing.seekablestream.supervisor.SeekableStreamSupervisorIOConfig;
 import org.apache.druid.java.util.emitter.service.ServiceEmitter;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ public class LagBasedAutoScalerTest
   private ServiceEmitter mockEmitter;
   private LagBasedAutoScalerConfig config;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     mockSpec = Mockito.mock(SupervisorSpec.class);
@@ -90,7 +90,7 @@ public class LagBasedAutoScalerTest
     when(mockIoConfig.getTaskCount()).thenReturn(50);
     when(mockSupervisor.getPartitionCount()).thenReturn(PARTITION_COUNT);
 
-    Assert.assertEquals(54, createAutoScaler().computeDesiredTaskCount(createLagSamples(2_000_001L)));
+    Assertions.assertEquals(54, createAutoScaler().computeDesiredTaskCount(createLagSamples(2_000_001L)));
   }
 
   @Test
@@ -102,7 +102,7 @@ public class LagBasedAutoScalerTest
     when(mockSupervisor.getPartitionCount()).thenReturn(PARTITION_COUNT);
 
     // current (1) + scaleOutStep (4) = 5 — below configured taskCountMin (50); not clamped here.
-    Assert.assertEquals(5, createAutoScaler().computeDesiredTaskCount(createLagSamples(2_000_001L)));
+    Assertions.assertEquals(5, createAutoScaler().computeDesiredTaskCount(createLagSamples(2_000_001L)));
   }
 
   @Test
@@ -116,7 +116,7 @@ public class LagBasedAutoScalerTest
     // current (101) - scaleInStep (1) = 100 — above configured taskCountMax (100) is still not
     // clamped here. (In this particular case the result happens to equal taskCountMax; we just
     // want the scaler's raw computation.)
-    Assert.assertEquals(100, createAutoScaler().computeDesiredTaskCount(createLagSamples(299_999L)));
+    Assertions.assertEquals(100, createAutoScaler().computeDesiredTaskCount(createLagSamples(299_999L)));
   }
 
   private LagBasedAutoScaler createAutoScaler()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunctionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/seekablestream/supervisor/autoscaler/WeightedCostFunctionTest.java
@@ -20,16 +20,16 @@
 package org.apache.druid.indexing.seekablestream.supervisor.autoscaler;
 
 import org.apache.druid.error.DruidException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class WeightedCostFunctionTest
 {
   private WeightedCostFunction costFunction;
   private CostBasedAutoScalerConfig config;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     costFunction = new WeightedCostFunction();
@@ -47,11 +47,11 @@ public class WeightedCostFunctionTest
   {
     CostMetrics validMetrics = createMetrics(100000.0, 10, 100, 0.3);
 
-    Assert.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(null, 10, config).totalCost(), 0.0);
-    Assert.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(validMetrics, 10, null).totalCost(), 0.0);
-    Assert.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(validMetrics, 0, config).totalCost(), 0.0);
-    Assert.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(validMetrics, -5, config).totalCost(), 0.0);
-    Assert.assertEquals(
+    Assertions.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(null, 10, config).totalCost(), 0.0);
+    Assertions.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(validMetrics, 10, null).totalCost(), 0.0);
+    Assertions.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(validMetrics, 0, config).totalCost(), 0.0);
+    Assertions.assertEquals(Double.POSITIVE_INFINITY, costFunction.computeCost(validMetrics, -5, config).totalCost(), 0.0);
+    Assertions.assertEquals(
         Double.POSITIVE_INFINITY,
         costFunction.computeCost(createMetrics(0.0, 10, 0, 0.3), 10, config).totalCost(),
         0.0
@@ -76,9 +76,9 @@ public class WeightedCostFunctionTest
 
     // Scale down uses absolute model: lag / (5 * rate) = higher recovery time
     // Current uses absolute model: lag / (10 * rate) = lower recovery time
-    Assert.assertTrue(
-        "Scale-down should have higher lag cost than current",
-        costScaleDown > costCurrent
+    Assertions.assertTrue(
+        costScaleDown > costCurrent,
+        "Scale-down should have higher lag cost than current"
     );
   }
 
@@ -101,31 +101,31 @@ public class WeightedCostFunctionTest
     double amplification = 1.0 + WeightedCostFunction.LAG_AMPLIFICATION_MULTIPLIER * Math.log(aggregateLag / 100);
 
     double costCurrent = costFunction.computeCost(metrics, 10, lagOnlyConfig).totalCost();
-    Assert.assertEquals(
-        "Cost of current tasks",
+    Assertions.assertEquals(
         aggregateLag * amplification / (10 * WeightedCostFunction.MIN_PROCESSING_RATE),
         costCurrent,
-        0.1
+        0.1,
+        "Cost of current tasks"
     );
 
     double costUp5 = costFunction.computeCost(metrics, 15, lagOnlyConfig).totalCost();
-    Assert.assertEquals(
-        "Cost when scaling up by 5",
+    Assertions.assertEquals(
         aggregateLag * amplification / (15 * WeightedCostFunction.MIN_PROCESSING_RATE),
         costUp5,
-        0.1
+        0.1,
+        "Cost when scaling up by 5"
     );
 
     double costUp10 = costFunction.computeCost(metrics, 20, lagOnlyConfig).totalCost();
-    Assert.assertEquals(
-        "Cost when scaling up by 10",
+    Assertions.assertEquals(
         aggregateLag * amplification / (20 * WeightedCostFunction.MIN_PROCESSING_RATE),
         costUp10,
-        0.1
+        0.1,
+        "Cost when scaling up by 10"
     );
 
     // Adding more tasks reduces lag recovery time
-    Assert.assertTrue("Adding more tasks reduces lag cost", costUp10 < costUp5);
+    Assertions.assertTrue(costUp10 < costUp5, "Adding more tasks reduces lag cost");
   }
 
   @Test
@@ -136,9 +136,9 @@ public class WeightedCostFunctionTest
     double costCurrent = costFunction.computeCost(metrics, 10, config).totalCost();
     double costScaleUp = costFunction.computeCost(metrics, 20, config).totalCost();
 
-    Assert.assertTrue(
-        "With balanced weights, staying at current count is cheaper than scale-up",
-        costCurrent < costScaleUp
+    Assertions.assertTrue(
+        costCurrent < costScaleUp,
+        "With balanced weights, staying at current count is cheaper than scale-up"
     );
   }
 
@@ -166,9 +166,9 @@ public class WeightedCostFunctionTest
     double costLag = costFunction.computeCost(metrics, 10, lagOnly).totalCost();
     double costIdle = costFunction.computeCost(metrics, 10, idleOnly).totalCost();
 
-    Assert.assertNotEquals("Different weights should produce different costs", costLag, costIdle, 0.0001);
-    Assert.assertTrue("Lag-only cost should be positive", costLag > 0.0);
-    Assert.assertTrue("Idle-only cost should be positive", costIdle > 0.0);
+    Assertions.assertNotEquals(costLag, costIdle, 0.0001, "Different weights should produce different costs");
+    Assertions.assertTrue(costLag > 0.0, "Lag-only cost should be positive");
+    Assertions.assertTrue(costIdle > 0.0, "Idle-only cost should be positive");
   }
 
   @Test
@@ -189,13 +189,13 @@ public class WeightedCostFunctionTest
     double costScaleUp = costFunction.computeCost(metricsNoRate, currentTaskCount + 5, config).totalCost();
     double costScaleDown = costFunction.computeCost(metricsNoRate, currentTaskCount - 5, config).totalCost();
 
-    Assert.assertTrue(
-        "Cost at current should be less than cost for scale up",
-        costAtCurrent > costScaleUp
+    Assertions.assertTrue(
+        costAtCurrent > costScaleUp,
+        "Cost at current should be less than cost for scale up"
     );
-    Assert.assertTrue(
-        "Cost at current should be less than cost for scale down",
-        costAtCurrent < costScaleDown
+    Assertions.assertTrue(
+        costAtCurrent < costScaleDown,
+        "Cost at current should be less than cost for scale down"
     );
   }
 
@@ -203,7 +203,7 @@ public class WeightedCostFunctionTest
   public void testNegativeProcessingRate_throwsDefensiveException()
   {
     final CostMetrics metrics = createMetricsWithRate(50000.0, 1, 100, 0.5, -1);
-    Assert.assertThrows(
+    Assertions.assertThrows(
         DruidException.class,
         () -> costFunction.computeCost(metrics, 2, config)
     );
@@ -233,8 +233,8 @@ public class WeightedCostFunctionTest
     // Scale up → predicted idle rises above ideal → over-provisioning penalty
     double costScaleUp = costFunction.computeCost(metrics, 20, idleOnlyConfig).totalCost();
 
-    Assert.assertTrue("scale-down costs more than ideal", costScaleDown > costAtIdeal);
-    Assert.assertTrue("scale-up costs more than ideal", costScaleUp > costAtIdeal);
+    Assertions.assertTrue(costScaleDown > costAtIdeal, "scale-down costs more than ideal");
+    Assertions.assertTrue(costScaleUp > costAtIdeal, "scale-up costs more than ideal");
   }
 
   @Test
@@ -259,8 +259,7 @@ public class WeightedCostFunctionTest
         WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO
         + WeightedCostFunction.UNDER_PROVISIONING_PENALTY
     );
-    Assert.assertEquals("Idle cost at clamped-to-zero idle ratio should reflect full under-provisioning penalty",
-                        expectedAt2, costAt2, 0.0001);
+    Assertions.assertEquals(expectedAt2, costAt2, 0.0001, "Idle cost at clamped-to-zero idle ratio should reflect full under-provisioning penalty");
 
     // Extreme scale-up shouldn't exceed 1.0 for idle ratio
     // 10 tasks → 100 tasks with 10% idle
@@ -268,7 +267,7 @@ public class WeightedCostFunctionTest
     // predictedIdle = 1 - 0.431 ≈ 0.569 (within bounds)
     CostMetrics lowIdle = createMetrics(0.0, 10, 100, 0.1);
     double costAt100 = costFunction.computeCost(lowIdle, 100, idleOnlyConfig).totalCost();
-    Assert.assertTrue("Cost should be finite and positive", Double.isFinite(costAt100) && costAt100 > 0);
+    Assertions.assertTrue(Double.isFinite(costAt100) && costAt100 > 0, "Cost should be finite and positive");
   }
 
   @Test
@@ -288,17 +287,17 @@ public class WeightedCostFunctionTest
     double costCurrent = costFunction.computeCost(metrics, 10, idleOnlyConfig).totalCost();
     double costScaleDown = costFunction.computeCost(metrics, 5, idleOnlyConfig).totalCost();
 
-    Assert.assertTrue(
-        "Healthy 2x consolidation should be cheaper than staying at the current count",
-        costScaleDown < costCurrent
+    Assertions.assertTrue(
+        costScaleDown < costCurrent,
+        "Healthy 2x consolidation should be cheaper than staying at the current count"
     );
 
     // Far below the clamped-to-zero cost the linear model produced: idle is healthy, not clamped.
     double clampedToZeroCost =
         5 * (WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO + WeightedCostFunction.UNDER_PROVISIONING_PENALTY);
-    Assert.assertTrue(
-        "Predicted idle should be healthy, not clamped to zero",
-        costScaleDown < clampedToZeroCost
+    Assertions.assertTrue(
+        costScaleDown < clampedToZeroCost,
+        "Predicted idle should be healthy, not clamped to zero"
     );
   }
 
@@ -323,9 +322,9 @@ public class WeightedCostFunctionTest
     // U-shaped cost at idle=0.5: idle > IDEAL(0.25), norm=(0.5-0.25)/0.75=1/3, penalty=1*(1/3)^2=1/9
     double expectedCostPerTask = WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO
                                  + WeightedCostFunction.OVER_PROVISIONING_PENALTY * (1.0 / 3.0) * (1.0 / 3.0);
-    Assert.assertEquals("Cost at 10 tasks with missing idle data", 10 * expectedCostPerTask, cost10, 0.0001);
-    Assert.assertEquals("Cost at 20 tasks with missing idle data", 20 * expectedCostPerTask, cost20, 0.0001);
-    Assert.assertEquals("Cost scales linearly with task count at fixed idle ratio", 2 * cost10, cost20, 0.0001);
+    Assertions.assertEquals(10 * expectedCostPerTask, cost10, 0.0001, "Cost at 10 tasks with missing idle data");
+    Assertions.assertEquals(20 * expectedCostPerTask, cost20, 0.0001, "Cost at 20 tasks with missing idle data");
+    Assertions.assertEquals(2 * cost10, cost20, 0.0001, "Cost scales linearly with task count at fixed idle ratio");
   }
 
   @Test
@@ -352,7 +351,7 @@ public class WeightedCostFunctionTest
     double aggregateLag = 150.0 * partitionCount;
     double expected = aggregateLag / (proposedTaskCount * WeightedCostFunction.MIN_PROCESSING_RATE);
 
-    Assert.assertEquals("Normal lag cost should use raw recovery time", expected, costWithAmp, 0.0001);
+    Assertions.assertEquals(expected, costWithAmp, 0.0001, "Normal lag cost should use raw recovery time");
   }
 
   @Test
@@ -394,26 +393,26 @@ public class WeightedCostFunctionTest
                                                                   .build();
 
     double costBelowTier1 = costFunction.computeCost(metrics, proposedTaskCount, belowTier1).totalCost();
-    Assert.assertEquals(
-        "Below tier1, amplification uses the default multiplier",
+    Assertions.assertEquals(
         costFunction.computeCost(metrics, proposedTaskCount, noThreshold).totalCost(),
         costBelowTier1,
-        0.0001
+        0.0001,
+        "Below tier1, amplification uses the default multiplier"
     );
 
     double lagPerPartition = aggregateLag / partitionCount;
     double highLagCostFactor =
         1.0 + WeightedCostFunction.DEFAULT_HIGH_LAG_COST_FACTOR * Math.log(lagPerPartition);
     double costAtTier1 = costFunction.computeCost(metrics, proposedTaskCount, atTier1).totalCost();
-    Assert.assertEquals(
-        "At/above the high-lag threshold, the cost factor maxes out at DEFAULT_HIGH_LAG_COST_FACTOR",
+    Assertions.assertEquals(
         aggregateLag * highLagCostFactor / (proposedTaskCount * WeightedCostFunction.MIN_PROCESSING_RATE),
         costAtTier1,
-        0.0001
+        0.0001,
+        "At/above the high-lag threshold, the cost factor maxes out at DEFAULT_HIGH_LAG_COST_FACTOR"
     );
-    Assert.assertTrue(
-        "High-lag cost should exceed the default-multiplier cost for the same lag",
-        costAtTier1 > costBelowTier1
+    Assertions.assertTrue(
+        costAtTier1 > costBelowTier1,
+        "High-lag cost should exceed the default-multiplier cost for the same lag"
     );
   }
 
@@ -440,16 +439,16 @@ public class WeightedCostFunctionTest
     double lowCost = costFunction.computeCost(lowLag, proposedTaskCount, lagOnly).totalCost();
     double highCost = costFunction.computeCost(highLag, proposedTaskCount, lagOnly).totalCost();
 
-    Assert.assertTrue("Higher lag should produce higher cost", highCost > lowCost);
+    Assertions.assertTrue(highCost > lowCost, "Higher lag should produce higher cost");
 
     // The ratio of costs matches the ratio of raw lags.
     double lagRatio = 10_000.0 / 100.0;
     double costRatio = highCost / lowCost;
-    Assert.assertEquals(
-        "Normal lag cost should grow linearly with lag",
+    Assertions.assertEquals(
         lagRatio,
         costRatio,
-        0.0001
+        0.0001,
+        "Normal lag cost should grow linearly with lag"
     );
   }
 
@@ -460,7 +459,7 @@ public class WeightedCostFunctionTest
     int n = 10;
 
     // At optimal ratio: penalty = 0, cost = n * OPTIMAL_TASK_IDLE_RATIO
-    Assert.assertEquals(
+    Assertions.assertEquals(
         n * WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO,
         costFunction.uShapedIdleCost(
             WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO,
@@ -471,14 +470,14 @@ public class WeightedCostFunctionTest
     );
 
     // At idle = 0 (fully under-provisioned): norm = 1, penalty = UNDER_PROVISIONING_PENALTY
-    Assert.assertEquals(
+    Assertions.assertEquals(
         n * (WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO + WeightedCostFunction.UNDER_PROVISIONING_PENALTY),
         costFunction.uShapedIdleCost(0.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         1e-9
     );
 
     // At idle = 1 (fully over-provisioned): norm = 1, penalty = OVER_PROVISIONING_PENALTY
-    Assert.assertEquals(
+    Assertions.assertEquals(
         n * (WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO + WeightedCostFunction.OVER_PROVISIONING_PENALTY),
         costFunction.uShapedIdleCost(1.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         1e-9
@@ -490,24 +489,24 @@ public class WeightedCostFunctionTest
         n,
         WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO
     );
-    Assert.assertTrue(
-        "idle=0 costs more than optimal",
-        costFunction.uShapedIdleCost(0.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO) > optimalCost
+    Assertions.assertTrue(
+        costFunction.uShapedIdleCost(0.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO) > optimalCost,
+        "idle=0 costs more than optimal"
     );
-    Assert.assertTrue(
-        "idle=1 costs more than optimal",
-        costFunction.uShapedIdleCost(1.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO) > optimalCost
+    Assertions.assertTrue(
+        costFunction.uShapedIdleCost(1.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO) > optimalCost,
+        "idle=1 costs more than optimal"
     );
 
     // Over-provisioning is penalized more than under-provisioning (OVER > UNDER)
-    Assert.assertTrue(
-        "over-provisioning penalty exceeds under-provisioning penalty",
+    Assertions.assertTrue(
         costFunction.uShapedIdleCost(1.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO)
-        > costFunction.uShapedIdleCost(0.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO)
+        > costFunction.uShapedIdleCost(0.0, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
+        "over-provisioning penalty exceeds under-provisioning penalty"
     );
 
     // Cost scales linearly with task count at any fixed idle ratio
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2 * costFunction.uShapedIdleCost(0.5, n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         costFunction.uShapedIdleCost(0.5, 2 * n, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         1e-9
@@ -519,7 +518,7 @@ public class WeightedCostFunctionTest
   {
     // 75% utilization (750/1000) -> idle = 0.25
     final CostMetrics utilized = createMetricsWithMaxObservedRate(750.0, 1000.0, 0.3);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0.25,
         utilized.estimateIdleRatioFromProcessingRate(),
         0.0001
@@ -527,7 +526,7 @@ public class WeightedCostFunctionTest
 
     // Utilization above 100% (rate exceeds the watermark) clamps idle to 0, not negative
     final CostMetrics overUtilized = createMetricsWithMaxObservedRate(1500.0, 1000.0, 0.3);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0.0,
         overUtilized.estimateIdleRatioFromProcessingRate(),
         0.0001
@@ -535,7 +534,7 @@ public class WeightedCostFunctionTest
 
     // No throughput baseline yet (maxObservedRate=0) -> return negative (unknown), never NaN from 0/0
     final CostMetrics noBaseline = createMetricsWithMaxObservedRate(0.0, 0.0, 0.3);
-    Assert.assertTrue(noBaseline.estimateIdleRatioFromProcessingRate() < 0);
+    Assertions.assertTrue(noBaseline.estimateIdleRatioFromProcessingRate() < 0);
   }
 
   @Test
@@ -562,35 +561,35 @@ public class WeightedCostFunctionTest
     CostMetrics metrics = createMetricsWithMaxObservedRate(100.0, 1000.0, 0.9);
 
     double costWithPollIdleRatio = costFunction.computeCost(metrics, 10, idleOnlyConfig).totalCost();
-    Assert.assertEquals(
-        "Default config should cost using the raw pollIdleRatio",
+    Assertions.assertEquals(
         costFunction.uShapedIdleCost(0.9, 10, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         costWithPollIdleRatio,
-        0.0001
+        0.0001,
+        "Default config should cost using the raw pollIdleRatio"
     );
 
     double costWithUtilizationRatio = costFunction.computeCost(metrics, 10, utilizationConfig).totalCost();
-    Assert.assertEquals(
-        "usePollIdleRatio=false should cost using the rate-derived idle ratio instead of pollIdleRatio",
+    Assertions.assertEquals(
         costFunction.uShapedIdleCost(0.9, 10, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         costWithUtilizationRatio,
-        0.0001
+        0.0001,
+        "usePollIdleRatio=false should cost using the rate-derived idle ratio instead of pollIdleRatio"
     );
 
     // Now diverge pollIdleRatio from the utilization-derived value to prove the flag actually switches sources.
     CostMetrics divergingMetrics = createMetricsWithMaxObservedRate(100.0, 1000.0, 0.1);
     double costStillPollIdle = costFunction.computeCost(divergingMetrics, 10, idleOnlyConfig).totalCost();
     double costStillUtilization = costFunction.computeCost(divergingMetrics, 10, utilizationConfig).totalCost();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         costFunction.uShapedIdleCost(0.1, 10, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         costStillPollIdle,
         0.0001
     );
-    Assert.assertEquals(
-        "Utilization-derived idle ratio (0.9) should be used instead of the diverging pollIdleRatio (0.1)",
+    Assertions.assertEquals(
         costFunction.uShapedIdleCost(0.9, 10, WeightedCostFunction.OPTIMAL_TASK_IDLE_RATIO),
         costStillUtilization,
-        0.0001
+        0.0001,
+        "Utilization-derived idle ratio (0.9) should be used instead of the diverging pollIdleRatio (0.1)"
     );
   }
 


### PR DESCRIPTION
## Summary

- Migrate the seekable-stream indexing tests and their supervisor support to JUnit 5.
- Migrate the Kafka and Kinesis direct consumers covered by this batch.
- Replace JUnit 4, Hamcrest, and legacy lifecycle usage with Jupiter, AssertJ, and Jupiter-compatible Mockito/EasyMock lifecycle APIs.
- Use Druid's existing temporary-directory utilities and remove unused direct Hamcrest dependencies from the Kafka and Kinesis module POMs.
- Keep this batch independent from Task Actions/Compaction, ingestion/parallel indexing, common support, Overlord, and worker migrations.

## Validation

- Indexing targeted tests: 347 passed, 0 failures, 0 errors, 0 skips.
- Kafka targeted tests: 120 passed, 0 failures, 0 errors, 0 skips.
- Kinesis targeted tests: 57 passed, 0 failures, 0 errors; one configured retry/flaky execution ultimately passed.
- Full reactor test compilation passed.
- Static-enabled Maven verification across 13 modules passed with Checkstyle, PMD, Enforcer, forbidden APIs, compilation, and lifecycle checks.
- `git diff --check` passed.

## Tracking

Part of [#13948](https://github.com/apache/druid/issues/13948).

Related: [#19910](https://github.com/apache/druid/pull/19910), [#19920](https://github.com/apache/druid/pull/19920), and [#19922](https://github.com/apache/druid/pull/19922).
