### PR TITLE
test(indexing-service): migrate worker tests to JUnit 5

### DIFF
--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -199,6 +199,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-migrationsupport</artifactId>
             <scope>test</scope>
         </dependency>

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/TaskAnnouncementTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/TaskAnnouncementTest.java
@@ -29,8 +29,8 @@ import org.apache.druid.indexing.common.task.IndexTask;
 import org.apache.druid.indexing.common.task.Task;
 import org.apache.druid.indexing.common.task.TaskResource;
 import org.apache.druid.segment.indexing.DataSchema;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class TaskAnnouncementTest
 {
@@ -70,15 +70,15 @@ public class TaskAnnouncementTest
         TaskAnnouncement.class
     );
 
-    Assert.assertEquals("theid", statusFromStatus.getId());
-    Assert.assertEquals("theid", statusFromAnnouncement.getId());
-    Assert.assertEquals("theid", announcementFromStatus.getTaskStatus().getId());
-    Assert.assertEquals("theid", announcementFromAnnouncement.getTaskStatus().getId());
+    Assertions.assertEquals("theid", statusFromStatus.getId());
+    Assertions.assertEquals("theid", statusFromAnnouncement.getId());
+    Assertions.assertEquals("theid", announcementFromStatus.getTaskStatus().getId());
+    Assertions.assertEquals("theid", announcementFromAnnouncement.getTaskStatus().getId());
 
-    Assert.assertEquals("theid", announcementFromStatus.getTaskResource().getAvailabilityGroup());
-    Assert.assertEquals("rofl", announcementFromAnnouncement.getTaskResource().getAvailabilityGroup());
+    Assertions.assertEquals("theid", announcementFromStatus.getTaskResource().getAvailabilityGroup());
+    Assertions.assertEquals("rofl", announcementFromAnnouncement.getTaskResource().getAvailabilityGroup());
 
-    Assert.assertEquals(1, announcementFromStatus.getTaskResource().getRequiredCapacity());
-    Assert.assertEquals(2, announcementFromAnnouncement.getTaskResource().getRequiredCapacity());
+    Assertions.assertEquals(1, announcementFromStatus.getTaskResource().getRequiredCapacity());
+    Assertions.assertEquals(2, announcementFromAnnouncement.getTaskResource().getRequiredCapacity());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -68,6 +68,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -95,6 +96,9 @@ public class WorkerTaskManagerTest
   private final IndexMergerV9Factory indexMergerV9Factory;
   private final IndexIO indexIO;
 
+  @TempDir
+  private File tempDir;
+
   @Parameter(0)
   public boolean restoreTasksOnRestart;
 
@@ -119,7 +123,7 @@ public class WorkerTaskManagerTest
 
   private WorkerTaskManager createWorkerTaskManager()
   {
-    return createWorkerTaskManager(FileUtils.createTempDir(), new WorkerConfig());
+    return createWorkerTaskManager(tempDir, new WorkerConfig());
   }
 
   private WorkerTaskManager createWorkerTaskManager(File baseDir)
@@ -569,7 +573,7 @@ public class WorkerTaskManagerTest
     EasyMock.expect(overlordClient.withRetryPolicy(EasyMock.anyObject())).andReturn(overlordClient).anyTimes();
     EasyMock.replay(overlordClient);
 
-    final File baseTaskDir = FileUtils.createTempDir();
+    final File baseTaskDir = tempDir;
 
     workerTaskManager = createWorkerTaskManager(baseTaskDir);
     workerTaskManager.start();
@@ -594,7 +598,7 @@ public class WorkerTaskManagerTest
     EasyMock.expect(overlordClient.withRetryPolicy(EasyMock.anyObject())).andReturn(overlordClient).anyTimes();
     EasyMock.replay(overlordClient);
 
-    final File baseTaskDir = FileUtils.createTempDir();
+    final File baseTaskDir = tempDir;
 
     workerTaskManager = createWorkerTaskManager(baseTaskDir);
     workerTaskManager.start();
@@ -639,7 +643,7 @@ public class WorkerTaskManagerTest
     EasyMock.expect(overlordClient.withRetryPolicy(EasyMock.anyObject())).andReturn(overlordClient).anyTimes();
     EasyMock.replay(overlordClient);
 
-    final File baseTaskDir = FileUtils.createTempDir();
+    final File baseTaskDir = tempDir;
 
     workerTaskManager = createWorkerTaskManager(baseTaskDir);
     workerTaskManager.start();
@@ -666,7 +670,7 @@ public class WorkerTaskManagerTest
     final WorkerConfig workerConfig = new WorkerConfig().cloneBuilder()
         .setStartAlwaysEnabled(true)
         .build();
-    workerTaskManager = createWorkerTaskManager(FileUtils.createTempDir(), workerConfig);
+    workerTaskManager = createWorkerTaskManager(tempDir, workerConfig);
     workerTaskManager.start();
     Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
     Assertions.assertFalse(workerTaskManager.getStateFile().exists());
@@ -681,7 +685,7 @@ public class WorkerTaskManagerTest
     final WorkerConfig workerConfig = new WorkerConfig().cloneBuilder()
         .setStartAlwaysEnabled(true)
         .build();
-    workerTaskManager = createWorkerTaskManager(FileUtils.createTempDir(), workerConfig);
+    workerTaskManager = createWorkerTaskManager(tempDir, workerConfig);
     workerTaskManager.start();
     workerTaskManager.workerDisabled();
     Assertions.assertFalse(workerTaskManager.isWorkerEnabled());

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -63,12 +63,14 @@ import org.easymock.EasyMock;
 import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,11 +80,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  *
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("getParameters")
 public class WorkerTaskManagerTest
 {
   private final TaskLocation location = TaskLocation.create("localhost", 1, 2);
@@ -91,22 +95,21 @@ public class WorkerTaskManagerTest
   private final IndexMergerV9Factory indexMergerV9Factory;
   private final IndexIO indexIO;
 
-  private final boolean restoreTasksOnRestart;
+  @Parameter(0)
+  private boolean restoreTasksOnRestart;
 
   private WorkerTaskManager workerTaskManager;
   private OverlordClient overlordClient;
 
-  public WorkerTaskManagerTest(boolean restoreTasksOnRestart)
+  public WorkerTaskManagerTest()
   {
     testUtils = new TestUtils();
     jsonMapper = testUtils.getTestObjectMapper();
     TestTasks.registerSubtypes(jsonMapper);
     indexMergerV9Factory = testUtils.getIndexMergerV9Factory();
     indexIO = testUtils.getTestIndexIO();
-    this.restoreTasksOnRestart = restoreTasksOnRestart;
   }
 
-  @Parameterized.Parameters(name = "restoreTasksOnRestart = {0}")
   public static Collection<Object[]> getParameters()
   {
     Object[][] parameters = new Object[][]{{false}, {true}};
@@ -195,19 +198,20 @@ public class WorkerTaskManagerTest
     );
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     workerTaskManager = createWorkerTaskManager();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     workerTaskManager.stop();
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @Timeout(value = 60_000L, unit = TimeUnit.MILLISECONDS)
   public void testTaskRun() throws Exception
   {
     EasyMock.expect(overlordClient.withRetryPolicy(EasyMock.anyObject())).andReturn(overlordClient).anyTimes();
@@ -233,30 +237,30 @@ public class WorkerTaskManagerTest
     );
     workerTaskManager.start();
 
-    Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task2.getId()).getTaskStatus().isSuccess());
+    Assertions.assertTrue(workerTaskManager.getCompletedTasks().get(task2.getId()).getTaskStatus().isSuccess());
 
     while (!workerTaskManager.getCompletedTasks().containsKey(task1.getId())) {
       Thread.sleep(100);
     }
-    Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task1.getId()).getTaskStatus().isSuccess());
-    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(), task1.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(), task1.getId()).exists());
+    Assertions.assertTrue(workerTaskManager.getCompletedTasks().get(task1.getId()).getTaskStatus().isSuccess());
+    Assertions.assertTrue(new File(workerTaskManager.getCompletedTaskDir(), task1.getId()).exists());
+    Assertions.assertFalse(new File(workerTaskManager.getAssignedTaskDir(), task1.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> baseHistory = workerTaskManager
         .getChangesSince(new ChangeRequestHistory.Counter(-1, 0))
         .get();
 
-    Assert.assertFalse(baseHistory.isResetCounter());
-    Assert.assertEquals(3, baseHistory.getRequests().size());
-    Assert.assertFalse(((WorkerHistoryItem.Metadata) baseHistory.getRequests().get(0)).isDisabled());
+    Assertions.assertFalse(baseHistory.isResetCounter());
+    Assertions.assertEquals(3, baseHistory.getRequests().size());
+    Assertions.assertFalse(((WorkerHistoryItem.Metadata) baseHistory.getRequests().get(0)).isDisabled());
 
     WorkerHistoryItem.TaskUpdate baseUpdate1 = (WorkerHistoryItem.TaskUpdate) baseHistory.getRequests().get(1);
     WorkerHistoryItem.TaskUpdate baseUpdate2 = (WorkerHistoryItem.TaskUpdate) baseHistory.getRequests().get(2);
 
-    Assert.assertTrue(baseUpdate1.getTaskAnnouncement().getTaskStatus().isSuccess());
-    Assert.assertTrue(baseUpdate2.getTaskAnnouncement().getTaskStatus().isSuccess());
+    Assertions.assertTrue(baseUpdate1.getTaskAnnouncement().getTaskStatus().isSuccess());
+    Assertions.assertTrue(baseUpdate2.getTaskAnnouncement().getTaskStatus().isSuccess());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(task1.getId(), task2.getId()),
         ImmutableSet.of(
             baseUpdate1.getTaskAnnouncement().getTaskStatus().getId(),
@@ -271,37 +275,38 @@ public class WorkerTaskManagerTest
       Thread.sleep(100);
     }
 
-    Assert.assertTrue(workerTaskManager.getCompletedTasks().get(task3.getId()).getTaskStatus().isSuccess());
-    Assert.assertTrue(new File(workerTaskManager.getCompletedTaskDir(), task3.getId()).exists());
-    Assert.assertFalse(new File(workerTaskManager.getAssignedTaskDir(), task3.getId()).exists());
+    Assertions.assertTrue(workerTaskManager.getCompletedTasks().get(task3.getId()).getTaskStatus().isSuccess());
+    Assertions.assertTrue(new File(workerTaskManager.getCompletedTaskDir(), task3.getId()).exists());
+    Assertions.assertFalse(new File(workerTaskManager.getAssignedTaskDir(), task3.getId()).exists());
 
     ChangeRequestsSnapshot<WorkerHistoryItem> changes = workerTaskManager.getChangesSince(baseHistory.getCounter())
                                                                          .get();
-    Assert.assertFalse(changes.isResetCounter());
-    Assert.assertEquals(4, changes.getRequests().size());
+    Assertions.assertFalse(changes.isResetCounter());
+    Assertions.assertEquals(4, changes.getRequests().size());
 
     WorkerHistoryItem.TaskUpdate update1 = (WorkerHistoryItem.TaskUpdate) changes.getRequests().get(0);
-    Assert.assertEquals(task3.getId(), update1.getTaskAnnouncement().getTaskStatus().getId());
-    Assert.assertTrue(update1.getTaskAnnouncement().getTaskStatus().isRunnable());
-    Assert.assertNull(update1.getTaskAnnouncement().getTaskLocation().getHost());
+    Assertions.assertEquals(task3.getId(), update1.getTaskAnnouncement().getTaskStatus().getId());
+    Assertions.assertTrue(update1.getTaskAnnouncement().getTaskStatus().isRunnable());
+    Assertions.assertNull(update1.getTaskAnnouncement().getTaskLocation().getHost());
 
     WorkerHistoryItem.TaskUpdate update2 = (WorkerHistoryItem.TaskUpdate) changes.getRequests().get(1);
-    Assert.assertEquals(task3.getId(), update2.getTaskAnnouncement().getTaskStatus().getId());
-    Assert.assertTrue(update2.getTaskAnnouncement().getTaskStatus().isRunnable());
-    Assert.assertNull(update2.getTaskAnnouncement().getTaskLocation().getHost());
+    Assertions.assertEquals(task3.getId(), update2.getTaskAnnouncement().getTaskStatus().getId());
+    Assertions.assertTrue(update2.getTaskAnnouncement().getTaskStatus().isRunnable());
+    Assertions.assertNull(update2.getTaskAnnouncement().getTaskLocation().getHost());
 
     WorkerHistoryItem.TaskUpdate update3 = (WorkerHistoryItem.TaskUpdate) changes.getRequests().get(2);
-    Assert.assertEquals(task3.getId(), update3.getTaskAnnouncement().getTaskStatus().getId());
-    Assert.assertTrue(update3.getTaskAnnouncement().getTaskStatus().isRunnable());
-    Assert.assertNotNull(update3.getTaskAnnouncement().getTaskLocation().getHost());
+    Assertions.assertEquals(task3.getId(), update3.getTaskAnnouncement().getTaskStatus().getId());
+    Assertions.assertTrue(update3.getTaskAnnouncement().getTaskStatus().isRunnable());
+    Assertions.assertNotNull(update3.getTaskAnnouncement().getTaskLocation().getHost());
 
     WorkerHistoryItem.TaskUpdate update4 = (WorkerHistoryItem.TaskUpdate) changes.getRequests().get(3);
-    Assert.assertEquals(task3.getId(), update4.getTaskAnnouncement().getTaskStatus().getId());
-    Assert.assertTrue(update4.getTaskAnnouncement().getTaskStatus().isSuccess());
-    Assert.assertNotNull(update4.getTaskAnnouncement().getTaskLocation().getHost());
+    Assertions.assertEquals(task3.getId(), update4.getTaskAnnouncement().getTaskStatus().getId());
+    Assertions.assertTrue(update4.getTaskAnnouncement().getTaskStatus().isSuccess());
+    Assertions.assertNotNull(update4.getTaskAnnouncement().getTaskLocation().getHost());
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @Timeout(value = 30_000L, unit = TimeUnit.MILLISECONDS)
   public void testTaskStatusWhenTaskRunnerFutureThrowsException() throws Exception
   {
     Task task = new NoopTask("id", null, null, 100, 0, ImmutableMap.of(Tasks.PRIORITY_KEY, 0))
@@ -321,17 +326,18 @@ public class WorkerTaskManagerTest
       Thread.sleep(10);
     } while (completeTasks.isEmpty());
 
-    Assert.assertEquals(1, completeTasks.size());
+    Assertions.assertEquals(1, completeTasks.size());
     TaskAnnouncement announcement = completeTasks.get(task.getId());
-    Assert.assertNotNull(announcement);
-    Assert.assertEquals(TaskState.FAILED, announcement.getStatus());
-    Assert.assertEquals(
+    Assertions.assertNotNull(announcement);
+    Assertions.assertEquals(TaskState.FAILED, announcement.getStatus());
+    Assertions.assertEquals(
         "Failed to run task with an exception. See middleManager or indexer logs for more details.",
         announcement.getTaskStatus().getErrorMsg()
     );
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @Timeout(value = 30_000L, unit = TimeUnit.MILLISECONDS)
   public void test_completedTasksCleanup_running() throws Exception
   {
     final Task task = setUpCompletedTasksCleanupTest();
@@ -342,12 +348,13 @@ public class WorkerTaskManagerTest
     EasyMock.replay(overlordClient);
 
     workerTaskManager.doCompletedTasksCleanup();
-    Assert.assertEquals(1, workerTaskManager.getCompletedTasks().size());
+    Assertions.assertEquals(1, workerTaskManager.getCompletedTasks().size());
 
     EasyMock.verify(overlordClient);
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @Timeout(value = 30_000L, unit = TimeUnit.MILLISECONDS)
   public void test_completedTasksCleanup_noStatus() throws Exception
   {
     final Task task = setUpCompletedTasksCleanupTest();
@@ -360,12 +367,13 @@ public class WorkerTaskManagerTest
     // Missing status (empty map) means we clean up the task. The idea is that this means the Overlord has *never*
     // heard of it, so we should forget about it.
     workerTaskManager.doCompletedTasksCleanup();
-    Assert.assertEquals(0, workerTaskManager.getCompletedTasks().size());
+    Assertions.assertEquals(0, workerTaskManager.getCompletedTasks().size());
 
     EasyMock.verify(overlordClient);
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @Timeout(value = 30_000L, unit = TimeUnit.MILLISECONDS)
   public void test_completedTasksCleanup_success() throws Exception
   {
     final Task task = setUpCompletedTasksCleanupTest();
@@ -376,12 +384,13 @@ public class WorkerTaskManagerTest
     EasyMock.replay(overlordClient);
 
     workerTaskManager.doCompletedTasksCleanup();
-    Assert.assertEquals(0, workerTaskManager.getCompletedTasks().size());
+    Assertions.assertEquals(0, workerTaskManager.getCompletedTasks().size());
 
     EasyMock.verify(overlordClient);
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @Timeout(value = 30_000L, unit = TimeUnit.MILLISECONDS)
   public void test_completedTasksCleanup_404error() throws Exception
   {
     final Task task = setUpCompletedTasksCleanupTest();
@@ -403,12 +412,13 @@ public class WorkerTaskManagerTest
     // Ending size zero, because 404 means we assume the Overlord does not have the taskStatuses API. In this case
     // we remove all completed task statuses periodically regardless of Overlord confirmation.
     workerTaskManager.doCompletedTasksCleanup();
-    Assert.assertEquals(0, workerTaskManager.getCompletedTasks().size());
+    Assertions.assertEquals(0, workerTaskManager.getCompletedTasks().size());
 
     EasyMock.verify(overlordClient);
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @Timeout(value = 30_000L, unit = TimeUnit.MILLISECONDS)
   public void test_completedTasksCleanup_500error() throws Exception
   {
     final Task task = setUpCompletedTasksCleanupTest();
@@ -429,12 +439,13 @@ public class WorkerTaskManagerTest
 
     // HTTP 500 is ignored and no cleanup happens.
     workerTaskManager.doCompletedTasksCleanup();
-    Assert.assertEquals(1, workerTaskManager.getCompletedTasks().size());
+    Assertions.assertEquals(1, workerTaskManager.getCompletedTasks().size());
 
     EasyMock.verify(overlordClient);
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @Timeout(value = 30_000L, unit = TimeUnit.MILLISECONDS)
   public void test_completedTasksCleanup_ioException() throws Exception
   {
     final Task task = setUpCompletedTasksCleanupTest();
@@ -446,7 +457,7 @@ public class WorkerTaskManagerTest
 
     // IOException is ignored and no cleanup happens.
     workerTaskManager.doCompletedTasksCleanup();
-    Assert.assertEquals(1, workerTaskManager.getCompletedTasks().size());
+    Assertions.assertEquals(1, workerTaskManager.getCompletedTasks().size());
 
     EasyMock.verify(overlordClient);
   }
@@ -496,10 +507,10 @@ public class WorkerTaskManagerTest
       Thread.sleep(10);
     } while (completeTasks.isEmpty());
 
-    Assert.assertEquals(1, completeTasks.size());
+    Assertions.assertEquals(1, completeTasks.size());
     TaskAnnouncement announcement = completeTasks.get(task.getId());
-    Assert.assertNotNull(announcement);
-    Assert.assertEquals(TaskState.SUCCESS, announcement.getStatus());
+    Assertions.assertNotNull(announcement);
+    Assertions.assertEquals(TaskState.SUCCESS, announcement.getStatus());
 
     EasyMock.reset(overlordClient);
     return task;
@@ -517,7 +528,7 @@ public class WorkerTaskManagerTest
 
     workerTaskManager.start();
     // befor assigning tasks we should get no running tasks
-    Assert.assertEquals(workerTaskManager.getWorkerRunningTasks().size(), 0L);
+    Assertions.assertEquals(workerTaskManager.getWorkerRunningTasks().size(), 0L);
 
     workerTaskManager.assignTask(task1);
     workerTaskManager.assignTask(task2);
@@ -525,7 +536,7 @@ public class WorkerTaskManagerTest
 
     Thread.sleep(25);
     //should return all 3 tasks as running
-    Assert.assertEquals(workerTaskManager.getWorkerRunningTasks(), ImmutableMap.of(
+    Assertions.assertEquals(workerTaskManager.getWorkerRunningTasks(), ImmutableMap.of(
         "wikipedia", 2L,
         "animals", 1L
     ));
@@ -539,17 +550,17 @@ public class WorkerTaskManagerTest
     // When running tasks are empty all task should be reported as completed and
     // one of the task for animals datasource should fail and other 2 tasks in
     // the wikipedia datasource should succeed
-    Assert.assertEquals(workerTaskManager.getWorkerCompletedTasks(), ImmutableMap.of(
+    Assertions.assertEquals(workerTaskManager.getWorkerCompletedTasks(), ImmutableMap.of(
         "wikipedia", 2L,
         "animals", 1L
     ));
-    Assert.assertEquals(workerTaskManager.getWorkerFailedTasks(), ImmutableMap.of(
+    Assertions.assertEquals(workerTaskManager.getWorkerFailedTasks(), ImmutableMap.of(
             "animals", 1L
     ));
-    Assert.assertEquals(workerTaskManager.getWorkerSuccessfulTasks(), ImmutableMap.of(
+    Assertions.assertEquals(workerTaskManager.getWorkerSuccessfulTasks(), ImmutableMap.of(
             "wikipedia", 2L
     ));
-    Assert.assertEquals(workerTaskManager.getWorkerAssignedTasks().size(), 0L);
+    Assertions.assertEquals(workerTaskManager.getWorkerAssignedTasks().size(), 0L);
   }
 
   @Test
@@ -562,19 +573,19 @@ public class WorkerTaskManagerTest
 
     workerTaskManager = createWorkerTaskManager(baseTaskDir);
     workerTaskManager.start();
-    Assert.assertTrue(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
     workerTaskManager.workerDisabled();
-    Assert.assertFalse(workerTaskManager.isWorkerEnabled());
-    Assert.assertTrue(workerTaskManager.getStateFile().exists());
+    Assertions.assertFalse(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.getStateFile().exists());
     workerTaskManager.stop();
 
     workerTaskManager = createWorkerTaskManager(baseTaskDir);
     workerTaskManager.start();
-    Assert.assertFalse(workerTaskManager.isWorkerEnabled());
+    Assertions.assertFalse(workerTaskManager.isWorkerEnabled());
 
     final ChangeRequestsSnapshot<WorkerHistoryItem> history =
         workerTaskManager.getChangesSince(new ChangeRequestHistory.Counter(-1, 0)).get();
-    Assert.assertTrue(((WorkerHistoryItem.Metadata) history.getRequests().get(0)).isDisabled());
+    Assertions.assertTrue(((WorkerHistoryItem.Metadata) history.getRequests().get(0)).isDisabled());
   }
 
   @Test
@@ -589,12 +600,12 @@ public class WorkerTaskManagerTest
     workerTaskManager.start();
     workerTaskManager.workerDisabled();
     workerTaskManager.workerEnabled();
-    Assert.assertTrue(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
     workerTaskManager.stop();
 
     workerTaskManager = createWorkerTaskManager(baseTaskDir);
     workerTaskManager.start();
-    Assert.assertTrue(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
   }
 
   @Test
@@ -604,7 +615,7 @@ public class WorkerTaskManagerTest
     EasyMock.replay(overlordClient);
 
     workerTaskManager.start();
-    Assert.assertTrue(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
   }
 
   @Test
@@ -619,7 +630,7 @@ public class WorkerTaskManagerTest
     Files.write(stateFile.toPath(), "not valid json".getBytes(StandardCharsets.UTF_8));
 
     workerTaskManager.start();
-    Assert.assertTrue(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
   }
 
   @Test
@@ -633,8 +644,8 @@ public class WorkerTaskManagerTest
     workerTaskManager = createWorkerTaskManager(baseTaskDir);
     workerTaskManager.start();
     workerTaskManager.workerDisabled();
-    Assert.assertFalse(workerTaskManager.isWorkerEnabled());
-    Assert.assertTrue(workerTaskManager.getStateFile().exists());
+    Assertions.assertFalse(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.getStateFile().exists());
     workerTaskManager.stop();
 
     final WorkerConfig workerConfig = new WorkerConfig().cloneBuilder()
@@ -642,8 +653,8 @@ public class WorkerTaskManagerTest
         .build();
     workerTaskManager = createWorkerTaskManager(baseTaskDir, workerConfig);
     workerTaskManager.start();
-    Assert.assertTrue(workerTaskManager.isWorkerEnabled());
-    Assert.assertFalse(workerTaskManager.getStateFile().exists());
+    Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
+    Assertions.assertFalse(workerTaskManager.getStateFile().exists());
   }
 
   @Test
@@ -657,8 +668,8 @@ public class WorkerTaskManagerTest
         .build();
     workerTaskManager = createWorkerTaskManager(FileUtils.createTempDir(), workerConfig);
     workerTaskManager.start();
-    Assert.assertTrue(workerTaskManager.isWorkerEnabled());
-    Assert.assertFalse(workerTaskManager.getStateFile().exists());
+    Assertions.assertTrue(workerTaskManager.isWorkerEnabled());
+    Assertions.assertFalse(workerTaskManager.getStateFile().exists());
   }
 
   @Test
@@ -673,7 +684,7 @@ public class WorkerTaskManagerTest
     workerTaskManager = createWorkerTaskManager(FileUtils.createTempDir(), workerConfig);
     workerTaskManager.start();
     workerTaskManager.workerDisabled();
-    Assert.assertFalse(workerTaskManager.isWorkerEnabled());
-    Assert.assertTrue(workerTaskManager.getStateFile().exists());
+    Assertions.assertFalse(workerTaskManager.isWorkerEnabled());
+    Assertions.assertTrue(workerTaskManager.getStateFile().exists());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/WorkerTaskManagerTest.java
@@ -96,7 +96,7 @@ public class WorkerTaskManagerTest
   private final IndexIO indexIO;
 
   @Parameter(0)
-  private boolean restoreTasksOnRestart;
+  public boolean restoreTasksOnRestart;
 
   private WorkerTaskManager workerTaskManager;
   private OverlordClient overlordClient;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycleConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/executor/ExecutorLifecycleConfigTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.indexing.worker.executor;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
 public class ExecutorLifecycleConfigTest
@@ -30,6 +30,6 @@ public class ExecutorLifecycleConfigTest
   {
     ExecutorLifecycleConfig config = new ExecutorLifecycleConfig();
     config.setParentStreamDefined(false);
-    Assert.assertFalse(config.isParentStreamDefined());
+    Assertions.assertFalse(config.isParentStreamDefined());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/http/WorkerResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/http/WorkerResourceTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.indexing.worker.Worker;
 import org.apache.druid.indexing.worker.WorkerTaskManager;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 
@@ -38,7 +38,7 @@ public class WorkerResourceTest
   private WorkerTaskManager workerTaskManager;
   private WorkerResource workerResource;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     worker = new Worker(
@@ -65,7 +65,7 @@ public class WorkerResourceTest
     EasyMock.replay(workerTaskManager);
 
     Response res = workerResource.doDisable();
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
 
     EasyMock.verify(workerTaskManager);
   }
@@ -78,7 +78,7 @@ public class WorkerResourceTest
     EasyMock.replay(workerTaskManager);
 
     Response res = workerResource.doEnable();
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
 
     EasyMock.verify(workerTaskManager);
   }
@@ -90,7 +90,7 @@ public class WorkerResourceTest
     EasyMock.replay(workerTaskManager);
 
     Response res = workerResource.isEnabled();
-    Assert.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), res.getStatus());
 
     EasyMock.verify(workerTaskManager);
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
@@ -40,11 +40,10 @@ import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.ShardSpecLookup;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,17 +55,16 @@ import java.util.Set;
 
 public class LocalIntermediaryDataManagerAutoCleanupTest
 {
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
+  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
 
   private TaskConfig taskConfig;
   private OverlordClient overlordClient;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     this.taskConfig = new TaskConfigBuilder()
-        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(tempDir.newFolder(), null, null)))
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(newTempDir("shuffle"), null, null)))
         .build();
     this.overlordClient = new NoopOverlordClient()
     {
@@ -83,10 +81,16 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
     };
   }
 
+  @AfterEach
+  public void teardown() throws IOException
+  {
+    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
+  }
+
   @Test
   public void testCompletedExpiredSupervisor() throws IOException, InterruptedException
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         isCleanedUpAfter3s("supervisor_1", new Period("PT1S"))
     );
   }
@@ -94,7 +98,7 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
   @Test
   public void testCompletedNotExpiredSupervisor() throws IOException, InterruptedException
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         isCleanedUpAfter3s("supervisor_2", new Period("PT10S"))
     );
   }
@@ -102,7 +106,7 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
   @Test
   public void testRunningSupervisor() throws IOException, InterruptedException
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         isCleanedUpAfter3s("running_supervisor_1", new Period("PT1S"))
     );
   }
@@ -148,10 +152,17 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
   private File generateSegmentDir(String fileName) throws IOException
   {
     // Each file size is 138 bytes after compression
-    final File segmentDir = tempDir.newFolder();
+    final File segmentDir = newTempDir("segment");
     FileUtils.write(new File(segmentDir, fileName), "test data.", StandardCharsets.UTF_8);
     FileUtils.writeByteArrayToFile(new File(segmentDir, "version.bin"), Ints.toByteArray(9));
     return segmentDir;
+  }
+
+  private File newTempDir(String name) throws IOException
+  {
+    final File directory = new File(tempDir, name);
+    org.apache.druid.java.util.common.FileUtils.mkdirp(directory);
+    return directory;
   }
 
   private DataSegment newSegment(Interval interval)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerAutoCleanupTest.java
@@ -40,10 +40,10 @@ import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.ShardSpecLookup;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,7 +55,8 @@ import java.util.Set;
 
 public class LocalIntermediaryDataManagerAutoCleanupTest
 {
-  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
+  @TempDir
+  private File tempDir;
 
   private TaskConfig taskConfig;
   private OverlordClient overlordClient;
@@ -79,12 +80,6 @@ public class LocalIntermediaryDataManagerAutoCleanupTest
         return Futures.immediateFuture(result);
       }
     };
-  }
-
-  @AfterEach
-  public void teardown() throws IOException
-  {
-    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerConcurrencyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerConcurrencyTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,7 +69,8 @@ public class LocalIntermediaryDataManagerConcurrencyTest
   private static final int CALLS_PER_THREAD = 200;
   private static final String SUPERVISOR_TASK_ID = "supervisorTaskId";
 
-  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
+  @TempDir
+  private File tempDir;
 
   private LocalIntermediaryDataManager intermediaryDataManager;
   private File sharedSegmentDir;
@@ -97,7 +99,6 @@ public class LocalIntermediaryDataManagerConcurrencyTest
   public void tearDown() throws IOException
   {
     intermediaryDataManager.stop();
-    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerConcurrencyTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerConcurrencyTest.java
@@ -36,12 +36,11 @@ import org.apache.druid.timeline.partition.BuildingShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.ShardSpecLookup;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.File;
 import java.io.IOException;
@@ -69,19 +68,18 @@ public class LocalIntermediaryDataManagerConcurrencyTest
   private static final int CALLS_PER_THREAD = 200;
   private static final String SUPERVISOR_TASK_ID = "supervisorTaskId";
 
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
+  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
 
   private LocalIntermediaryDataManager intermediaryDataManager;
   private File sharedSegmentDir;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     final WorkerConfig workerConfig = new WorkerConfig();
     final ImmutableList.Builder<StorageLocationConfig> locations = ImmutableList.builder();
     for (int i = 0; i < LOCATION_COUNT; i++) {
-      locations.add(new StorageLocationConfig(tempDir.newFolder("loc_" + i), LOCATION_CAPACITY_BYTES, null));
+      locations.add(new StorageLocationConfig(newTempDir("loc_" + i), LOCATION_CAPACITY_BYTES, null));
     }
     final TaskConfig taskConfig = new TaskConfigBuilder()
         .setShuffleDataLocations(locations.build())
@@ -90,18 +88,20 @@ public class LocalIntermediaryDataManagerConcurrencyTest
     intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient);
     intermediaryDataManager.start();
     // Pre-built shared input dir keeps per-call work small so the race window dominates wall time.
-    sharedSegmentDir = tempDir.newFolder("shared_input");
+    sharedSegmentDir = newTempDir("shared_input");
     FileUtils.write(new File(sharedSegmentDir, "data.txt"), "x", StandardCharsets.UTF_8);
     FileUtils.writeByteArrayToFile(new File(sharedSegmentDir, "version.bin"), Ints.toByteArray(9));
   }
 
-  @After
-  public void tearDown()
+  @AfterEach
+  public void tearDown() throws IOException
   {
     intermediaryDataManager.stop();
+    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
-  @Test(timeout = 90_000)
+  @Test
+  @Timeout(value = 90_000L, unit = TimeUnit.MILLISECONDS)
   public void testConcurrentAddSegmentSharedSupervisorIsThreadSafe() throws Exception
   {
     final Interval interval = Intervals.of("2018/2019");
@@ -130,7 +130,14 @@ public class LocalIntermediaryDataManagerConcurrencyTest
       f.get(60, TimeUnit.SECONDS);
     }
     executor.shutdown();
-    Assert.assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    Assertions.assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+  }
+
+  private File newTempDir(String name) throws IOException
+  {
+    final File directory = new File(tempDir, name);
+    org.apache.druid.java.util.common.FileUtils.mkdirp(directory);
+    return directory;
   }
 
   private DataSegment newSegment(Interval interval, int bucketId)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -51,7 +52,8 @@ import java.util.Optional;
 
 public class LocalIntermediaryDataManagerManualAddAndDeleteTest
 {
-  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
+  @TempDir
+  private File tempDir;
 
   private LocalIntermediaryDataManager intermediaryDataManager;
   private File intermediarySegmentsLocation;
@@ -75,7 +77,6 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
   public void teardown() throws IOException
   {
     intermediaryDataManager.stop();
-    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/LocalIntermediaryDataManagerManualAddAndDeleteTest.java
@@ -24,7 +24,6 @@ import com.google.common.io.ByteSource;
 import com.google.common.primitives.Ints;
 import org.apache.commons.io.FileUtils;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
 import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.config.TaskConfigBuilder;
 import org.apache.druid.indexing.worker.config.WorkerConfig;
@@ -38,14 +37,11 @@ import org.apache.druid.timeline.partition.BucketNumberedShardSpec;
 import org.apache.druid.timeline.partition.BuildingShardSpec;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.ShardSpecLookup;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,19 +51,18 @@ import java.util.Optional;
 
 public class LocalIntermediaryDataManagerManualAddAndDeleteTest
 {
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
+  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
 
   private LocalIntermediaryDataManager intermediaryDataManager;
   private File intermediarySegmentsLocation;
   private File siblingLocation;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     final WorkerConfig workerConfig = new WorkerConfig();
-    intermediarySegmentsLocation = tempDir.newFolder();
-    siblingLocation = tempDir.newFolder();
+    intermediarySegmentsLocation = newTempDir("intermediary");
+    siblingLocation = newTempDir("sibling");
     final TaskConfig taskConfig = new TaskConfigBuilder()
         .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(intermediarySegmentsLocation, 1200L, null)))
         .build();
@@ -76,10 +71,11 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
     intermediaryDataManager.start();
   }
 
-  @After
-  public void teardown()
+  @AfterEach
+  public void teardown() throws IOException
   {
     intermediaryDataManager.stop();
+    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
   @Test
@@ -94,11 +90,11 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
     File segmentFile = generateSegmentDir("file_" + i);
     DataSegment segment = newSegment(Intervals.of("2018/2019"), 4);
 
-    IllegalStateException e = Assert.assertThrows(
+    final IllegalStateException e = Assertions.assertThrows(
         IllegalStateException.class,
         () -> intermediaryDataManager.addSegment("supervisorTaskId", "subTaskId", segment, segmentFile)
     );
-    Assert.assertEquals(StringUtils.format("Can't find location to handle segment[%s]", segment), e.getMessage());
+    Assertions.assertEquals(StringUtils.format("Can't find location to handle segment[%s]", segment), e.getMessage());
   }
 
   @Test
@@ -119,7 +115,7 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
           interval,
           partitionId
       );
-      Assert.assertTrue(file.isPresent());
+      Assertions.assertTrue(file.isPresent());
     }
   }
 
@@ -140,7 +136,7 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
 
     for (int partitionId = 0; partitionId < 2; partitionId++) {
       for (int subTaskId = 0; subTaskId < 2; subTaskId++) {
-        Assert.assertFalse(
+        Assertions.assertFalse(
             intermediaryDataManager.findPartitionFile(supervisorTaskId, "subTaskId_" + subTaskId, interval, partitionId)
                                    .isPresent()
         );
@@ -176,19 +172,24 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
         "test data",
         StandardCharsets.UTF_8
     );
-    Assert.assertTrue(new File(intermediarySegmentsLocation, supervisorTaskId).exists());
-    Assert.assertTrue(dataFile.exists());
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () -> intermediaryDataManager.deletePartitions(supervisorTaskId)),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format(
-                "Invalid value for field [supervisorTaskId]: Value [%s] cannot start with '.'.",
-                supervisorTaskId
-            )
-        )
+    Assertions.assertTrue(new File(intermediarySegmentsLocation, supervisorTaskId).exists());
+    Assertions.assertTrue(dataFile.exists());
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () -> intermediaryDataManager.deletePartitions(supervisorTaskId)
     );
-    Assert.assertTrue(new File(intermediarySegmentsLocation, supervisorTaskId).exists());
-    Assert.assertTrue(dataFile.exists());
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals(
+        StringUtils.format(
+            "Invalid value for field [supervisorTaskId]: Value [%s] cannot start with '.'.",
+            supervisorTaskId
+        ),
+        exception.getMessage()
+    );
+    Assertions.assertTrue(new File(intermediarySegmentsLocation, supervisorTaskId).exists());
+    Assertions.assertTrue(dataFile.exists());
   }
 
   @Test
@@ -213,35 +214,47 @@ public class LocalIntermediaryDataManagerManualAddAndDeleteTest
         StandardCharsets.UTF_8
     );
 
-    Assert.assertTrue(new File(intermediarySegmentsLocation, supervisorTaskId).exists());
-    Assert.assertTrue(
+    Assertions.assertTrue(new File(intermediarySegmentsLocation, supervisorTaskId).exists());
+    Assertions.assertTrue(
         new File(intermediarySegmentsLocation, supervisorTaskId + "/" + someFilePath).exists());
 
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () ->
             intermediaryDataManager.findPartitionFile(
                 supervisorTaskId,
                 someFile,
                 interval,
                 partitionId
-            )),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            StringUtils.format(
-                "Invalid value for field [supervisorTaskId]: Value [%s] cannot start with '.'.",
-                supervisorTaskId
             )
-        )
+    );
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals(
+        StringUtils.format(
+            "Invalid value for field [supervisorTaskId]: Value [%s] cannot start with '.'.",
+            supervisorTaskId
+        ),
+        exception.getMessage()
     );
   }
 
   private File generateSegmentDir(String fileName) throws IOException
   {
     // Each file size is 138 bytes after compression
-    final File segmentDir = tempDir.newFolder();
+    final File segmentDir = newTempDir(fileName);
     FileUtils.write(new File(segmentDir, fileName), "test data.", StandardCharsets.UTF_8);
     FileUtils.writeByteArrayToFile(new File(segmentDir, "version.bin"), Ints.toByteArray(9));
     return segmentDir;
+  }
+
+  private File newTempDir(String name) throws IOException
+  {
+    final File directory = new File(tempDir, name);
+    org.apache.druid.java.util.common.FileUtils.mkdirp(directory);
+    return directory;
   }
 
   private DataSegment newSegment(Interval interval, int bucketId)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
@@ -80,7 +80,7 @@ public class ShuffleDataSegmentPusherTest
   }
 
   @Parameter(0)
-  private String intermediateDataStore;
+  public String intermediateDataStore;
 
   private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
 
@@ -178,7 +178,10 @@ public class ShuffleDataSegmentPusherTest
     unzippedFiles.sort(Comparator.comparing(File::getName));
     final File dataFile = unzippedFiles.get(0);
     Assertions.assertEquals("test", dataFile.getName());
-    Assertions.assertEquals("test data.", Files.readFirstLine(dataFile, StandardCharsets.UTF_8));
+    Assertions.assertEquals(
+        "test data.",
+        Files.asCharSource(dataFile, StandardCharsets.UTF_8).readFirstLine()
+    );
     final File versionFile = unzippedFiles.get(1);
     Assertions.assertEquals("version.bin", versionFile.getName());
     Assertions.assertArrayEquals(Ints.toByteArray(0x9), Files.toByteArray(versionFile));

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
@@ -49,14 +49,13 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.BucketNumberedShardSpec;
 import org.apache.druid.utils.CompressionUtils;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -68,45 +67,41 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("data")
 public class ShuffleDataSegmentPusherTest
 {
   private static final String LOCAL = "local";
   private static final String DEEPSTORE = "deepstore";
 
-  @Parameterized.Parameters(name = "intermediateDataManager={0}")
   public static Collection<Object[]> data()
   {
     return ImmutableList.of(new Object[]{LOCAL}, new Object[]{DEEPSTORE});
   }
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Parameter(0)
+  private String intermediateDataStore;
+
+  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
 
   private IntermediaryDataManager intermediaryDataManager;
   private ShuffleDataSegmentPusher segmentPusher;
   private ObjectMapper mapper;
 
-  private final String intermediateDataStore;
   private File localDeepStore;
 
-  public ShuffleDataSegmentPusherTest(String intermediateDataStore)
-  {
-    this.intermediateDataStore = intermediateDataStore;
-  }
-
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     final WorkerConfig workerConfig = new WorkerConfig();
     final TaskConfig taskConfig = new TaskConfigBuilder()
-        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(temporaryFolder.newFolder(), null, null)))
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(newTempDir("shuffle"), null, null)))
         .build();
     final OverlordClient overlordClient = new NoopOverlordClient();
     if (LOCAL.equals(intermediateDataStore)) {
       intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient);
     } else if (DEEPSTORE.equals(intermediateDataStore)) {
-      localDeepStore = temporaryFolder.newFolder("localStorage");
+      localDeepStore = newTempDir("localStorage");
       intermediaryDataManager = new DeepStorageIntermediaryDataManager(
           new LocalDataSegmentPusher(
               new LocalDataSegmentPusherConfig()
@@ -136,10 +131,11 @@ public class ShuffleDataSegmentPusherTest
     );
   }
 
-  @After
-  public void teardown()
+  @AfterEach
+  public void teardown() throws IOException
   {
     intermediaryDataManager.stop();
+    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
   @Test
@@ -149,10 +145,10 @@ public class ShuffleDataSegmentPusherTest
     final DataSegment segment = newSegment(Intervals.of("2018/2019"));
     final DataSegment pushed = segmentPusher.push(segmentDir, segment, true);
 
-    Assert.assertEquals(9, pushed.getBinaryVersion().intValue());
-    Assert.assertEquals(14, pushed.getSize()); // 10 bytes data + 4 bytes version
+    Assertions.assertEquals(9, pushed.getBinaryVersion().intValue());
+    Assertions.assertEquals(14, pushed.getSize()); // 10 bytes data + 4 bytes version
 
-    final File tempDir = temporaryFolder.newFolder();
+    final File tempDir = newTempDir("unzipped");
     if (intermediaryDataManager instanceof LocalIntermediaryDataManager) {
       final Optional<ByteSource> zippedSegment = intermediaryDataManager.findPartitionFile(
           "supervisorTaskId",
@@ -160,7 +156,7 @@ public class ShuffleDataSegmentPusherTest
           segment.getInterval(),
           segment.getShardSpec().getPartitionNum()
       );
-      Assert.assertTrue(zippedSegment.isPresent());
+      Assertions.assertTrue(zippedSegment.isPresent());
       CompressionUtils.unzip(
           zippedSegment.get(),
           tempDir,
@@ -169,32 +165,39 @@ public class ShuffleDataSegmentPusherTest
       );
     } else if (intermediaryDataManager instanceof DeepStorageIntermediaryDataManager) {
       final LoadSpec loadSpec = mapper.convertValue(pushed.getLoadSpec(), LoadSpec.class);
-      Assert.assertTrue(pushed.getLoadSpec()
-                              .get("path")
-                              .toString()
-                              .startsWith(localDeepStore.getAbsolutePath()
-                                          + "/"
-                                          + DeepStorageIntermediaryDataManager.SHUFFLE_DATA_DIR_PREFIX));
+      Assertions.assertTrue(pushed.getLoadSpec()
+                                  .get("path")
+                                  .toString()
+                                  .startsWith(localDeepStore.getAbsolutePath()
+                                              + "/"
+                                              + DeepStorageIntermediaryDataManager.SHUFFLE_DATA_DIR_PREFIX));
       loadSpec.loadSegment(tempDir);
     }
 
     final List<File> unzippedFiles = Arrays.asList(tempDir.listFiles());
     unzippedFiles.sort(Comparator.comparing(File::getName));
     final File dataFile = unzippedFiles.get(0);
-    Assert.assertEquals("test", dataFile.getName());
-    Assert.assertEquals("test data.", Files.readFirstLine(dataFile, StandardCharsets.UTF_8));
+    Assertions.assertEquals("test", dataFile.getName());
+    Assertions.assertEquals("test data.", Files.readFirstLine(dataFile, StandardCharsets.UTF_8));
     final File versionFile = unzippedFiles.get(1);
-    Assert.assertEquals("version.bin", versionFile.getName());
-    Assert.assertArrayEquals(Ints.toByteArray(0x9), Files.toByteArray(versionFile));
+    Assertions.assertEquals("version.bin", versionFile.getName());
+    Assertions.assertArrayEquals(Ints.toByteArray(0x9), Files.toByteArray(versionFile));
   }
 
   private File generateSegmentDir() throws IOException
   {
     // Each file size is 138 bytes after compression
-    final File segmentDir = temporaryFolder.newFolder();
+    final File segmentDir = newTempDir("segment");
     Files.asByteSink(new File(segmentDir, "version.bin")).write(Ints.toByteArray(0x9));
     FileUtils.write(new File(segmentDir, "test"), "test data.", StandardCharsets.UTF_8);
     return segmentDir;
+  }
+
+  private File newTempDir(String name) throws IOException
+  {
+    final File directory = new File(tempDir, name);
+    org.apache.druid.java.util.common.FileUtils.mkdirp(directory);
+    return directory;
   }
 
   private DataSegment newSegment(Interval interval)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleDataSegmentPusherTest.java
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.Parameter;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -82,7 +83,8 @@ public class ShuffleDataSegmentPusherTest
   @Parameter(0)
   public String intermediateDataStore;
 
-  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
+  @TempDir
+  private File tempDir;
 
   private IntermediaryDataManager intermediaryDataManager;
   private ShuffleDataSegmentPusher segmentPusher;
@@ -135,7 +137,6 @@ public class ShuffleDataSegmentPusherTest
   public void teardown() throws IOException
   {
     intermediaryDataManager.stop();
-    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleMetricsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleMetricsTest.java
@@ -22,10 +22,9 @@ package org.apache.druid.indexing.worker.shuffle;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.indexing.worker.shuffle.ShuffleMetrics.PerDatasourceShuffleMetrics;
 import org.apache.druid.java.util.common.concurrent.Execs;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,12 +35,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 public class ShuffleMetricsTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testShuffleRequested()
   {
@@ -56,26 +53,28 @@ public class ShuffleMetricsTest
     metrics.shuffleRequested(supervisorTask2, 30);
 
     final Map<String, PerDatasourceShuffleMetrics> snapshot = metrics.snapshotAndReset();
-    Assert.assertEquals(ImmutableSet.of(supervisorTask1, supervisorTask2, supervisorTask3), snapshot.keySet());
+    Assertions.assertEquals(ImmutableSet.of(supervisorTask1, supervisorTask2, supervisorTask3), snapshot.keySet());
 
     PerDatasourceShuffleMetrics perDatasourceShuffleMetrics = snapshot.get(supervisorTask1);
-    Assert.assertEquals(2, perDatasourceShuffleMetrics.getShuffleRequests());
-    Assert.assertEquals(1536, perDatasourceShuffleMetrics.getShuffleBytes());
+    Assertions.assertEquals(2, perDatasourceShuffleMetrics.getShuffleRequests());
+    Assertions.assertEquals(1536, perDatasourceShuffleMetrics.getShuffleBytes());
 
     perDatasourceShuffleMetrics = snapshot.get(supervisorTask2);
-    Assert.assertEquals(2, perDatasourceShuffleMetrics.getShuffleRequests());
-    Assert.assertEquals(40, perDatasourceShuffleMetrics.getShuffleBytes());
+    Assertions.assertEquals(2, perDatasourceShuffleMetrics.getShuffleRequests());
+    Assertions.assertEquals(40, perDatasourceShuffleMetrics.getShuffleBytes());
 
     perDatasourceShuffleMetrics = snapshot.get(supervisorTask3);
-    Assert.assertEquals(1, perDatasourceShuffleMetrics.getShuffleRequests());
-    Assert.assertEquals(10000, perDatasourceShuffleMetrics.getShuffleBytes());
+    Assertions.assertEquals(1, perDatasourceShuffleMetrics.getShuffleRequests());
+    Assertions.assertEquals(10000, perDatasourceShuffleMetrics.getShuffleBytes());
   }
 
   @Test
   public void testSnapshotUnmodifiable()
   {
-    expectedException.expect(UnsupportedOperationException.class);
-    new ShuffleMetrics().snapshotAndReset().put("k", new PerDatasourceShuffleMetrics());
+    Assertions.assertThrows(
+        UnsupportedOperationException.class,
+        () -> new ShuffleMetrics().snapshotAndReset().put("k", new PerDatasourceShuffleMetrics())
+    );
   }
 
   @Test
@@ -87,10 +86,11 @@ public class ShuffleMetricsTest
     shuffleMetrics.shuffleRequested("supervisor2", 10);
     shuffleMetrics.snapshotAndReset();
 
-    Assert.assertEquals(Collections.emptyMap(), shuffleMetrics.getDatasourceMetrics());
+    Assertions.assertEquals(Collections.emptyMap(), shuffleMetrics.getDatasourceMetrics());
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(value = 5000L, unit = TimeUnit.MILLISECONDS)
   public void testConcurrency() throws ExecutionException, InterruptedException
   {
     final ExecutorService exec = Execs.multiThreaded(3, "shuffle-metrics-test-%d"); // 2 for write, 1 for read
@@ -133,13 +133,13 @@ public class ShuffleMetricsTest
       boolean task1ShouldBeInSecondSnapshot = false;
       boolean task2ShouldBeInSecondSnapshot = false;
 
-      Assert.assertEquals(2, firstSnapshot.size());
-      Assert.assertNotNull(firstSnapshot.get(supervisorTask1));
-      Assert.assertTrue(
+      Assertions.assertEquals(2, firstSnapshot.size());
+      Assertions.assertNotNull(firstSnapshot.get(supervisorTask1));
+      Assertions.assertTrue(
           2048 == firstSnapshot.get(supervisorTask1).getShuffleBytes()
           || 2080 == firstSnapshot.get(supervisorTask1).getShuffleBytes()
       );
-      Assert.assertTrue(
+      Assertions.assertTrue(
           2 == firstSnapshot.get(supervisorTask1).getShuffleRequests()
           || 3 == firstSnapshot.get(supervisorTask1).getShuffleRequests()
       );
@@ -147,12 +147,12 @@ public class ShuffleMetricsTest
         expectedSecondSnapshotSize++;
         task1ShouldBeInSecondSnapshot = true;
       }
-      Assert.assertNotNull(firstSnapshot.get(supervisorTask2));
-      Assert.assertTrue(
+      Assertions.assertNotNull(firstSnapshot.get(supervisorTask2));
+      Assertions.assertTrue(
           60 == firstSnapshot.get(supervisorTask2).getShuffleBytes()
           || 70 == firstSnapshot.get(supervisorTask2).getShuffleBytes()
       );
-      Assert.assertTrue(
+      Assertions.assertTrue(
           2 == firstSnapshot.get(supervisorTask2).getShuffleRequests()
           || 3 == firstSnapshot.get(supervisorTask2).getShuffleRequests()
       );
@@ -166,16 +166,16 @@ public class ShuffleMetricsTest
       }
       final Map<String, PerDatasourceShuffleMetrics> secondSnapshot = metrics.snapshotAndReset();
 
-      Assert.assertEquals(expectedSecondSnapshotSize, secondSnapshot.size());
-      Assert.assertEquals(task1ShouldBeInSecondSnapshot, secondSnapshot.containsKey(supervisorTask1));
+      Assertions.assertEquals(expectedSecondSnapshotSize, secondSnapshot.size());
+      Assertions.assertEquals(task1ShouldBeInSecondSnapshot, secondSnapshot.containsKey(supervisorTask1));
       if (task1ShouldBeInSecondSnapshot) {
-        Assert.assertEquals(32, secondSnapshot.get(supervisorTask1).getShuffleBytes());
-        Assert.assertEquals(1, secondSnapshot.get(supervisorTask1).getShuffleRequests());
+        Assertions.assertEquals(32, secondSnapshot.get(supervisorTask1).getShuffleBytes());
+        Assertions.assertEquals(1, secondSnapshot.get(supervisorTask1).getShuffleRequests());
       }
-      Assert.assertEquals(task2ShouldBeInSecondSnapshot, secondSnapshot.containsKey(supervisorTask2));
+      Assertions.assertEquals(task2ShouldBeInSecondSnapshot, secondSnapshot.containsKey(supervisorTask2));
       if (task2ShouldBeInSecondSnapshot) {
-        Assert.assertEquals(10, secondSnapshot.get(supervisorTask2).getShuffleBytes());
-        Assert.assertEquals(1, secondSnapshot.get(supervisorTask2).getShuffleRequests());
+        Assertions.assertEquals(10, secondSnapshot.get(supervisorTask2).getShuffleBytes());
+        Assertions.assertEquals(1, secondSnapshot.get(supervisorTask2).getShuffleRequests());
       }
 
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleModuleTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleModuleTest.java
@@ -26,9 +26,9 @@ import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 import org.apache.druid.guice.LazySingleton;
 import org.apache.druid.java.util.metrics.MonitorScheduler;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -38,7 +38,7 @@ public class ShuffleModuleTest
 {
   private ShuffleModule shuffleModule;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     shuffleModule = new ShuffleModule();
@@ -55,7 +55,7 @@ public class ShuffleModuleTest
     final Optional<ShuffleMetrics> optional = injector.getInstance(
         Key.get(new TypeLiteral<>() {})
     );
-    Assert.assertTrue(optional.isPresent());
+    Assertions.assertTrue(optional.isPresent());
   }
 
   @Test
@@ -68,7 +68,7 @@ public class ShuffleModuleTest
     final Optional<ShuffleMetrics> optional = injector.getInstance(
         Key.get(new TypeLiteral<>() {})
     );
-    Assert.assertFalse(optional.isPresent());
+    Assertions.assertFalse(optional.isPresent());
   }
 
   private Injector createInjector(MonitorScheduler monitorScheduler)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleMonitorTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.indexing.worker.shuffle;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexing.worker.shuffle.ShuffleMetrics.PerDatasourceShuffleMetrics;
 import org.apache.druid.java.util.metrics.StubServiceEmitter;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Map;
@@ -43,8 +43,8 @@ public class ShuffleMonitorTest
     final StubServiceEmitter emitter = new StubServiceEmitter("service", "host");
     final ShuffleMonitor monitor = new ShuffleMonitor();
     monitor.setShuffleMetrics(shuffleMetrics);
-    Assert.assertTrue(monitor.doMonitor(emitter));
-    Assert.assertEquals(2, emitter.getNumEmittedEvents());
+    Assertions.assertTrue(monitor.doMonitor(emitter));
+    Assertions.assertEquals(2, emitter.getNumEmittedEvents());
     emitter.verifyValue(
         ShuffleMonitor.SHUFFLE_BYTES_KEY,
         Map.of(ShuffleMonitor.SUPERVISOR_TASK_ID_DIMENSION, "supervisor"),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
@@ -39,11 +39,10 @@ import org.apache.druid.timeline.partition.BucketNumberedShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.ws.rs.core.Response;
@@ -60,14 +59,13 @@ public class ShuffleResourceTest
 {
   private static final String DATASOURCE = "datasource";
 
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
+  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
 
   private LocalIntermediaryDataManager intermediaryDataManager;
   private ShuffleMetrics shuffleMetrics;
   private ShuffleResource shuffleResource;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     final WorkerConfig workerConfig = new WorkerConfig()
@@ -92,7 +90,7 @@ public class ShuffleResourceTest
 
     };
     final TaskConfig taskConfig = new TaskConfigBuilder()
-        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(tempDir.newFolder(), null, null)))
+        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(newTempDir("shuffle"), null, null)))
         .build();
     final OverlordClient overlordClient = new NoopOverlordClient()
     {
@@ -111,6 +109,12 @@ public class ShuffleResourceTest
     shuffleResource = new ShuffleResource(intermediaryDataManager, Optional.of(shuffleMetrics));
   }
 
+  @AfterEach
+  public void teardown() throws IOException
+  {
+    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
+  }
+
   @Test
   public void testGetUnknownPartitionReturnNotFound()
   {
@@ -121,10 +125,10 @@ public class ShuffleResourceTest
         "2020-01-02",
         0
     );
-    Assert.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
-    Assert.assertNotNull(response.getEntity());
+    Assertions.assertEquals(Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    Assertions.assertNotNull(response.getEntity());
     final String errorMessage = (String) response.getEntity();
-    Assert.assertTrue(errorMessage.contains("Can't find the partition for supervisorTask"));
+    Assertions.assertTrue(errorMessage.contains("Can't find the partition for supervisorTask"));
   }
 
   @Test
@@ -145,16 +149,16 @@ public class ShuffleResourceTest
         segment.getId().getPartitionNum()
     );
     final Map<String, PerDatasourceShuffleMetrics> snapshot = shuffleMetrics.snapshotAndReset();
-    Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
-    Assert.assertEquals(1, snapshot.get(supervisorTaskId).getShuffleRequests());
-    Assert.assertEquals(254, snapshot.get(supervisorTaskId).getShuffleBytes());
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(1, snapshot.get(supervisorTaskId).getShuffleRequests());
+    Assertions.assertEquals(254, snapshot.get(supervisorTaskId).getShuffleBytes());
   }
 
   @Test
   public void testDeleteUnknownPartitionReturnOk()
   {
     final Response response = shuffleResource.deletePartitions("unknownSupervisorTask");
-    Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
 
   @Test
@@ -168,7 +172,7 @@ public class ShuffleResourceTest
     intermediaryDataManager.addSegment(supervisorTaskId, subtaskId, segment, segmentDir);
 
     final Response response = shuffleResource.deletePartitions(supervisorTaskId);
-    Assert.assertEquals(Status.OK.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.OK.getStatusCode(), response.getStatus());
   }
 
   @Test
@@ -181,7 +185,7 @@ public class ShuffleResourceTest
     final ShuffleResource shuffleResource = new ShuffleResource(exceptionThrowingManager, Optional.of(shuffleMetrics));
 
     final Response response = shuffleResource.deletePartitions("supervisorTask");
-    Assert.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
+    Assertions.assertEquals(Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
   }
 
   private static DataSegment newSegment(Interval interval)
@@ -205,9 +209,16 @@ public class ShuffleResourceTest
   private File generateSegmentDir(String fileName) throws IOException
   {
     // Each file size is 138 bytes after compression
-    final File segmentDir = tempDir.newFolder();
+    final File segmentDir = newTempDir(fileName);
     FileUtils.write(new File(segmentDir, fileName), "test data.", StandardCharsets.UTF_8);
     FileUtils.writeByteArrayToFile(new File(segmentDir, "version.bin"), Ints.toByteArray(9));
     return segmentDir;
+  }
+
+  private File newTempDir(String name) throws IOException
+  {
+    final File directory = new File(tempDir, name);
+    org.apache.druid.java.util.common.FileUtils.mkdirp(directory);
+    return directory;
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/worker/shuffle/ShuffleResourceTest.java
@@ -39,10 +39,10 @@ import org.apache.druid.timeline.partition.BucketNumberedShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import javax.ws.rs.core.Response;
@@ -59,7 +59,8 @@ public class ShuffleResourceTest
 {
   private static final String DATASOURCE = "datasource";
 
-  private final File tempDir = org.apache.druid.java.util.common.FileUtils.createTempDir();
+  @TempDir
+  private File tempDir;
 
   private LocalIntermediaryDataManager intermediaryDataManager;
   private ShuffleMetrics shuffleMetrics;
@@ -107,12 +108,6 @@ public class ShuffleResourceTest
     intermediaryDataManager = new LocalIntermediaryDataManager(workerConfig, taskConfig, overlordClient);
     shuffleMetrics = new ShuffleMetrics();
     shuffleResource = new ShuffleResource(intermediaryDataManager, Optional.of(shuffleMetrics));
-  }
-
-  @AfterEach
-  public void teardown() throws IOException
-  {
-    org.apache.druid.java.util.common.FileUtils.deleteDirectory(tempDir);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Migrate the indexing-service worker, executor, HTTP resource, and shuffle tests to JUnit 5.
- Replace JUnit 4 temporary-folder fixtures with Druid's `FileUtils` helpers.
- Add the JUnit 5 parameterized-test dependency required by the migrated worker tests.

## Validation

- Targeted worker tests: 61 passed, 0 failures, 0 errors, 0 skipped.
- `mvn verify -pl indexing-service -am -Dweb.console.skip=true -T1C`: passed.
- Checkstyle, PMD, Enforcer, forbidden-API checks, test compilation, and `git diff --check`: passed.

Part of #13948.

Related migration PRs: #19910, #19920, #19922, #19923.
