### PR TITLE
test(indexing-service): migrate ingestion and parallel tests to JUnit 5

### DIFF
--- a/indexing-service/pom.xml
+++ b/indexing-service/pom.xml
@@ -199,6 +199,11 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-migrationsupport</artifactId>
             <scope>test</scope>
         </dependency>
@@ -259,6 +264,11 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ArchiveTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ArchiveTaskTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.indexing.common.task;
 
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ArchiveTaskTest
 {
@@ -35,6 +35,6 @@ public class ArchiveTaskTest
         null
     );
 
-    Assert.assertTrue(task.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(task.getInputSourceResources().isEmpty());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientKillUnusedSegmentsTaskQuerySerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ClientKillUnusedSegmentsTaskQuerySerdeTest.java
@@ -27,9 +27,9 @@ import org.apache.druid.client.indexing.ClientTaskQuery;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -37,7 +37,7 @@ public class ClientKillUnusedSegmentsTaskQuerySerdeTest
 {
   private ObjectMapper objectMapper;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     objectMapper = new DefaultObjectMapper();
@@ -60,13 +60,13 @@ public class ClientKillUnusedSegmentsTaskQuerySerdeTest
     );
     final byte[] json = objectMapper.writeValueAsBytes(taskQuery);
     final KillUnusedSegmentsTask fromJson = (KillUnusedSegmentsTask) objectMapper.readValue(json, Task.class);
-    Assert.assertEquals(taskQuery.getId(), fromJson.getId());
-    Assert.assertEquals(taskQuery.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(taskQuery.getInterval(), fromJson.getInterval());
-    Assert.assertNull(taskQuery.getVersions());
-    Assert.assertEquals(taskQuery.getBatchSize(), Integer.valueOf(fromJson.getBatchSize()));
-    Assert.assertEquals(taskQuery.getLimit(), fromJson.getLimit());
-    Assert.assertEquals(taskQuery.getMaxUsedStatusLastUpdatedTime(), fromJson.getMaxUsedStatusLastUpdatedTime());
+    Assertions.assertEquals(taskQuery.getId(), fromJson.getId());
+    Assertions.assertEquals(taskQuery.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(taskQuery.getInterval(), fromJson.getInterval());
+    Assertions.assertNull(taskQuery.getVersions());
+    Assertions.assertEquals(taskQuery.getBatchSize(), Integer.valueOf(fromJson.getBatchSize()));
+    Assertions.assertEquals(taskQuery.getLimit(), fromJson.getLimit());
+    Assertions.assertEquals(taskQuery.getMaxUsedStatusLastUpdatedTime(), fromJson.getMaxUsedStatusLastUpdatedTime());
   }
 
   @Test
@@ -83,13 +83,13 @@ public class ClientKillUnusedSegmentsTaskQuerySerdeTest
     );
     final byte[] json = objectMapper.writeValueAsBytes(taskQuery);
     final KillUnusedSegmentsTask fromJson = (KillUnusedSegmentsTask) objectMapper.readValue(json, Task.class);
-    Assert.assertEquals(taskQuery.getId(), fromJson.getId());
-    Assert.assertEquals(taskQuery.getDataSource(), fromJson.getDataSource());
-    Assert.assertEquals(taskQuery.getInterval(), fromJson.getInterval());
-    Assert.assertNull(taskQuery.getVersions());
-    Assert.assertEquals(100, fromJson.getBatchSize());
-    Assert.assertNull(taskQuery.getLimit());
-    Assert.assertNull(taskQuery.getMaxUsedStatusLastUpdatedTime());
+    Assertions.assertEquals(taskQuery.getId(), fromJson.getId());
+    Assertions.assertEquals(taskQuery.getDataSource(), fromJson.getDataSource());
+    Assertions.assertEquals(taskQuery.getInterval(), fromJson.getInterval());
+    Assertions.assertNull(taskQuery.getVersions());
+    Assertions.assertEquals(100, fromJson.getBatchSize());
+    Assertions.assertNull(taskQuery.getLimit());
+    Assertions.assertNull(taskQuery.getMaxUsedStatusLastUpdatedTime());
   }
 
   @Test
@@ -110,13 +110,13 @@ public class ClientKillUnusedSegmentsTaskQuerySerdeTest
         json,
         ClientTaskQuery.class
     );
-    Assert.assertEquals(task.getId(), taskQuery.getId());
-    Assert.assertEquals(task.getDataSource(), taskQuery.getDataSource());
-    Assert.assertEquals(task.getInterval(), taskQuery.getInterval());
-    Assert.assertNull(taskQuery.getVersions());
-    Assert.assertEquals(Integer.valueOf(task.getBatchSize()), taskQuery.getBatchSize());
-    Assert.assertNull(taskQuery.getLimit());
-    Assert.assertNull(taskQuery.getMaxUsedStatusLastUpdatedTime());
+    Assertions.assertEquals(task.getId(), taskQuery.getId());
+    Assertions.assertEquals(task.getDataSource(), taskQuery.getDataSource());
+    Assertions.assertEquals(task.getInterval(), taskQuery.getInterval());
+    Assertions.assertNull(taskQuery.getVersions());
+    Assertions.assertEquals(Integer.valueOf(task.getBatchSize()), taskQuery.getBatchSize());
+    Assertions.assertNull(taskQuery.getLimit());
+    Assertions.assertNull(taskQuery.getMaxUsedStatusLastUpdatedTime());
   }
 
   @Test
@@ -137,12 +137,12 @@ public class ClientKillUnusedSegmentsTaskQuerySerdeTest
         json,
         ClientTaskQuery.class
     );
-    Assert.assertEquals(task.getId(), taskQuery.getId());
-    Assert.assertEquals(task.getDataSource(), taskQuery.getDataSource());
-    Assert.assertEquals(task.getInterval(), taskQuery.getInterval());
-    Assert.assertEquals(task.getVersions(), taskQuery.getVersions());
-    Assert.assertEquals(Integer.valueOf(task.getBatchSize()), taskQuery.getBatchSize());
-    Assert.assertEquals(task.getLimit(), taskQuery.getLimit());
-    Assert.assertEquals(task.getMaxUsedStatusLastUpdatedTime(), taskQuery.getMaxUsedStatusLastUpdatedTime());
+    Assertions.assertEquals(task.getId(), taskQuery.getId());
+    Assertions.assertEquals(task.getDataSource(), taskQuery.getDataSource());
+    Assertions.assertEquals(task.getInterval(), taskQuery.getInterval());
+    Assertions.assertEquals(task.getVersions(), taskQuery.getVersions());
+    Assertions.assertEquals(Integer.valueOf(task.getBatchSize()), taskQuery.getBatchSize());
+    Assertions.assertEquals(task.getLimit(), taskQuery.getLimit());
+    Assertions.assertEquals(task.getMaxUsedStatusLastUpdatedTime(), taskQuery.getMaxUsedStatusLastUpdatedTime());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/CompactionTaskParallelRunTest.java
@@ -55,6 +55,7 @@ import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexSupervi
 import org.apache.druid.indexing.common.task.batch.parallel.ParallelIndexTuningConfig;
 import org.apache.druid.indexing.input.DruidInputSource;
 import org.apache.druid.indexing.input.WindowedSegmentId;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.AggregatorFactory;
@@ -80,12 +81,12 @@ import org.apache.druid.timeline.partition.PartitionIds;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.apache.druid.timeline.partition.SingleDimensionShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.io.BufferedWriter;
@@ -102,10 +103,10 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}")
+@MethodSource("constructorFeeder")
 public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervisorTaskTest
 {
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -145,13 +146,13 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     this.lockGranularity = lockGranularity;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     getObjectMapper().registerSubtypes(ParallelIndexTuningConfig.class, DruidInputSource.class);
     getObjectMapper().registerSubtypes(CompactionTask.CompactionTuningConfig.class, DruidInputSource.class);
 
-    inputDir = temporaryFolder.newFolder();
+    inputDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "input");
     final File tmpFile = File.createTempFile("druid", "index", inputDir);
 
     try (BufferedWriter writer = Files.newWriter(tmpFile, StandardCharsets.UTF_8)) {
@@ -187,7 +188,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     final Set<DataSegment> compactedSegments = dataSegmentsWithSchemas.getSegments();
 
     for (DataSegment segment : compactedSegments) {
-      Assert.assertSame(
+      Assertions.assertSame(
           lockGranularity == LockGranularity.TIME_CHUNK ? NumberedShardSpec.class : NumberedOverwriteShardSpec.class,
           segment.getShardSpec().getClass()
       );
@@ -211,7 +212,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -221,7 +222,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     allowSegmentFetchesByCompactionTask = true;
 
     // Hash partitioning is not supported with segment lock yet
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
     runIndexTask(null, true);
 
     final Builder builder = new Builder(
@@ -239,7 +240,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     for (DataSegment segment : compactedSegments) {
       // Expect compaction state to exist as store compaction state by default
       LongSumAggregatorFactory expectedLongSumMetric = new LongSumAggregatorFactory("val", "val");
-      Assert.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
       CompactionState expectedState =
           CompactionState.builder()
                          .partitionsSpec(new HashedPartitionsSpec(null, 3, null))
@@ -258,18 +259,18 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
 
     List<IngestionStatsAndErrors> reports = getIngestionReports();
-    Assert.assertEquals(reports.size(), 3); // since three index tasks are run by single compaction task
+    Assertions.assertEquals(reports.size(), 3); // since three index tasks are run by single compaction task
 
     // this test reads 3 segments and publishes 6 segments
-    Assert.assertEquals(
+    Assertions.assertEquals(
         3,
         reports.stream().mapToLong(IngestionStatsAndErrors::getSegmentsRead).sum()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         6,
         reports.stream()
                .mapToLong(IngestionStatsAndErrors::getSegmentsPublished)
@@ -283,7 +284,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     allowSegmentFetchesByCompactionTask = true;
 
     // Range partitioning is not supported with segment lock yet
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
     runIndexTask(null, true);
 
     final Builder builder = new Builder(
@@ -301,7 +302,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     for (DataSegment segment : compactedSegments) {
       // Expect compaction state to exist as store compaction state by default
       LongSumAggregatorFactory expectedLongSumMetric = new LongSumAggregatorFactory("val", "val");
-      Assert.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
       CompactionState expectedState =
           CompactionState.builder()
                          .partitionsSpec(new SingleDimensionPartitionsSpec(7, null, "dim", false))
@@ -320,7 +321,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -330,7 +331,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     allowSegmentFetchesByCompactionTask = false;
 
     // Range partitioning is not supported with segment lock yet
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
     runIndexTask(null, true);
 
     final Builder builder = new Builder(
@@ -358,7 +359,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     for (DataSegment segment : compactedSegments) {
       // Expect compaction state to exist as store compaction state by default
       LongSumAggregatorFactory expectedLongSumMetric = new LongSumAggregatorFactory("val", "val");
-      Assert.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
       CompactionState expectedState =
           CompactionState.builder()
                          .partitionsSpec(new SingleDimensionPartitionsSpec(7, null, "dim", false))
@@ -381,7 +382,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(Intervals.of("2014-01-01T00:00:00Z/2014-01-01T03:00:00Z"))
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -391,7 +392,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     allowSegmentFetchesByCompactionTask = true;
 
     // Range partitioning is not supported with segment lock yet
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
     runIndexTask(null, true);
 
     final Builder builder = new Builder(
@@ -412,7 +413,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     for (DataSegment segment : compactedSegments) {
       // Expect compaction state to exist as store compaction state by default
       LongSumAggregatorFactory expectedLongSumMetric = new LongSumAggregatorFactory("val", "val");
-      Assert.assertSame(DimensionRangeShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(DimensionRangeShardSpec.class, segment.getShardSpec().getClass());
       CompactionState expectedState =
           CompactionState.builder()
                          .partitionsSpec(new DimensionRangePartitionsSpec(
@@ -436,7 +437,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -446,7 +447,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     allowSegmentFetchesByCompactionTask = true;
 
     // Range partitioning is not supported with segment lock yet
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
     runIndexTask(null, true);
 
     final Builder builder = new Builder(
@@ -464,7 +465,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     for (DataSegment segment : compactedSegments) {
       // Expect compaction state to exist as store compaction state by default
       LongSumAggregatorFactory expectedLongSumMetric = new LongSumAggregatorFactory("val", "val");
-      Assert.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
       CompactionState expectedState =
           CompactionState.builder()
                          .partitionsSpec(new SingleDimensionPartitionsSpec(7, null, "dim", false))
@@ -483,7 +484,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -493,7 +494,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     allowSegmentFetchesByCompactionTask = true;
 
     // Range partitioning is not supported with segment lock yet
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
     runIndexTask(null, true);
 
     final Builder builder = new Builder(
@@ -514,7 +515,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     for (DataSegment segment : compactedSegments) {
       // Expect compaction state to exist as store compaction state by default
       LongSumAggregatorFactory expectedLongSumMetric = new LongSumAggregatorFactory("val", "val");
-      Assert.assertSame(DimensionRangeShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(DimensionRangeShardSpec.class, segment.getShardSpec().getClass());
       CompactionState expectedState =
           CompactionState.builder()
                          .partitionsSpec(new DimensionRangePartitionsSpec(
@@ -538,7 +539,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -563,12 +564,12 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     final Set<DataSegment> compactedSegments = dataSegmentsWithSchemas.getSegments();
 
     for (DataSegment segment : compactedSegments) {
-      Assert.assertSame(
+      Assertions.assertSame(
           lockGranularity == LockGranularity.TIME_CHUNK ? NumberedShardSpec.class : NumberedOverwriteShardSpec.class,
           segment.getShardSpec().getClass()
       );
       // Expect compaction state to exist as store compaction state by default
-      Assert.assertEquals(null, segment.getLastCompactionState());
+      Assertions.assertEquals(null, segment.getLastCompactionState());
     }
   }
 
@@ -592,10 +593,10 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     verifySchema(dataSegmentsWithSchemas);
     final Set<DataSegment> compactedSegments = dataSegmentsWithSchemas.getSegments();
 
-    Assert.assertEquals(3, compactedSegments.size());
+    Assertions.assertEquals(3, compactedSegments.size());
 
     for (DataSegment segment : compactedSegments) {
-      Assert.assertSame(
+      Assertions.assertSame(
           lockGranularity == LockGranularity.TIME_CHUNK ? NumberedShardSpec.class : NumberedOverwriteShardSpec.class,
           segment.getShardSpec().getClass()
       );
@@ -619,7 +620,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -646,10 +647,10 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     verifySchema(dataSegmentsWithSchemas);
     final Set<DataSegment> compactedSegments = dataSegmentsWithSchemas.getSegments();
 
-    Assert.assertEquals(3, compactedSegments.size());
+    Assertions.assertEquals(3, compactedSegments.size());
 
     for (DataSegment segment : compactedSegments) {
-      Assert.assertSame(
+      Assertions.assertSame(
           lockGranularity == LockGranularity.TIME_CHUNK ? NumberedShardSpec.class : NumberedOverwriteShardSpec.class,
           segment.getShardSpec().getClass()
       );
@@ -674,7 +675,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                              ImmutableList.of(segment.getInterval())
                          ))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -700,8 +701,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     final Map<Interval, List<DataSegment>> intervalToSegments = SegmentUtils.groupSegmentsByInterval(
         compactedSegments
     );
-    Assert.assertEquals(3, intervalToSegments.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(3, intervalToSegments.size());
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2014-01-01T00/PT1H"),
             Intervals.of("2014-01-01T01/PT1H"),
@@ -711,18 +712,18 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     );
     for (Entry<Interval, List<DataSegment>> entry : intervalToSegments.entrySet()) {
       final List<DataSegment> segmentsInInterval = entry.getValue();
-      Assert.assertEquals(1, segmentsInInterval.size());
+      Assertions.assertEquals(1, segmentsInInterval.size());
       final ShardSpec shardSpec = segmentsInInterval.get(0).getShardSpec();
       if (lockGranularity == LockGranularity.TIME_CHUNK) {
-        Assert.assertSame(NumberedShardSpec.class, shardSpec.getClass());
+        Assertions.assertSame(NumberedShardSpec.class, shardSpec.getClass());
         final NumberedShardSpec numberedShardSpec = (NumberedShardSpec) shardSpec;
-        Assert.assertEquals(0, numberedShardSpec.getPartitionNum());
-        Assert.assertEquals(1, numberedShardSpec.getNumCorePartitions());
+        Assertions.assertEquals(0, numberedShardSpec.getPartitionNum());
+        Assertions.assertEquals(1, numberedShardSpec.getNumCorePartitions());
       } else {
-        Assert.assertSame(NumberedOverwriteShardSpec.class, shardSpec.getClass());
+        Assertions.assertSame(NumberedOverwriteShardSpec.class, shardSpec.getClass());
         final NumberedOverwriteShardSpec numberedShardSpec = (NumberedOverwriteShardSpec) shardSpec;
-        Assert.assertEquals(PartitionIds.NON_ROOT_GEN_START_PARTITION_ID, numberedShardSpec.getPartitionNum());
-        Assert.assertEquals(1, numberedShardSpec.getAtomicUpdateGroupSize());
+        Assertions.assertEquals(PartitionIds.NON_ROOT_GEN_START_PARTITION_ID, numberedShardSpec.getPartitionNum());
+        Assertions.assertEquals(1, numberedShardSpec.getAtomicUpdateGroupSize());
       }
     }
   }
@@ -749,8 +750,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     final Map<Interval, List<DataSegment>> intervalToSegments = SegmentUtils.groupSegmentsByInterval(
         compactedSegments
     );
-    Assert.assertEquals(3, intervalToSegments.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(3, intervalToSegments.size());
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2014-01-01T00/PT1H"),
             Intervals.of("2014-01-01T01/PT1H"),
@@ -760,18 +761,18 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     );
     for (Entry<Interval, List<DataSegment>> entry : intervalToSegments.entrySet()) {
       final List<DataSegment> segmentsInInterval = entry.getValue();
-      Assert.assertEquals(1, segmentsInInterval.size());
+      Assertions.assertEquals(1, segmentsInInterval.size());
       final ShardSpec shardSpec = segmentsInInterval.get(0).getShardSpec();
       if (lockGranularity == LockGranularity.TIME_CHUNK) {
-        Assert.assertSame(NumberedShardSpec.class, shardSpec.getClass());
+        Assertions.assertSame(NumberedShardSpec.class, shardSpec.getClass());
         final NumberedShardSpec numberedShardSpec = (NumberedShardSpec) shardSpec;
-        Assert.assertEquals(0, numberedShardSpec.getPartitionNum());
-        Assert.assertEquals(1, numberedShardSpec.getNumCorePartitions());
+        Assertions.assertEquals(0, numberedShardSpec.getPartitionNum());
+        Assertions.assertEquals(1, numberedShardSpec.getNumCorePartitions());
       } else {
-        Assert.assertSame(NumberedOverwriteShardSpec.class, shardSpec.getClass());
+        Assertions.assertSame(NumberedOverwriteShardSpec.class, shardSpec.getClass());
         final NumberedOverwriteShardSpec numberedShardSpec = (NumberedOverwriteShardSpec) shardSpec;
-        Assert.assertEquals(PartitionIds.NON_ROOT_GEN_START_PARTITION_ID, numberedShardSpec.getPartitionNum());
-        Assert.assertEquals(1, numberedShardSpec.getAtomicUpdateGroupSize());
+        Assertions.assertEquals(PartitionIds.NON_ROOT_GEN_START_PARTITION_ID, numberedShardSpec.getPartitionNum());
+        Assertions.assertEquals(1, numberedShardSpec.getAtomicUpdateGroupSize());
       }
     }
   }
@@ -801,12 +802,12 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
 
     Set<String> segmentIdsFromSplits = new HashSet<>();
     Set<String> segmentIdsFromCoordinator = new HashSet<>();
-    Assert.assertEquals(segments.size(), splits.size());
+    Assertions.assertEquals(segments.size(), splits.size());
     for (int i = 0; i < segments.size(); i++) {
       segmentIdsFromCoordinator.add(segments.get(i).getId().toString());
       segmentIdsFromSplits.add(splits.get(i).get().get(0).getSegmentId());
     }
-    Assert.assertEquals(segmentIdsFromCoordinator, segmentIdsFromSplits);
+    Assertions.assertEquals(segmentIdsFromCoordinator, segmentIdsFromSplits);
   }
 
   @Test
@@ -819,9 +820,9 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         DATA_SOURCE,
         ImmutableList.of(INTERVAL_TO_INDEX)
     ).get();
-    Assert.assertEquals(3, usedSegments.size());
+    Assertions.assertEquals(3, usedSegments.size());
     for (DataSegment segment : usedSegments) {
-      Assert.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
+      Assertions.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
     }
 
     final Builder builder = new Builder(
@@ -844,15 +845,15 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     ).get();
     // All the HOUR segments got covered by tombstones even if we do not have all MINUTES segments fully covering the 3 HOURS interval.
     // In fact, we only have 3 minutes of data out of the 3 hours interval.
-    Assert.assertEquals(180, usedSegments.size());
+    Assertions.assertEquals(180, usedSegments.size());
     int tombstonesCount = 0;
     for (DataSegment segment : usedSegments) {
-      Assert.assertTrue(Granularities.MINUTE.isAligned(segment.getInterval()));
+      Assertions.assertTrue(Granularities.MINUTE.isAligned(segment.getInterval()));
       if (segment.isTombstone()) {
         tombstonesCount++;
       }
     }
-    Assert.assertEquals(177, tombstonesCount);
+    Assertions.assertEquals(177, tombstonesCount);
   }
 
   @Test
@@ -865,9 +866,9 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         DATA_SOURCE,
         ImmutableList.of(INTERVAL_TO_INDEX)
     ).get();
-    Assert.assertEquals(3, usedSegments.size());
+    Assertions.assertEquals(3, usedSegments.size());
     for (DataSegment segment : usedSegments) {
-      Assert.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
+      Assertions.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
     }
 
     final Builder builder = new Builder(
@@ -888,7 +889,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         ImmutableList.of(INTERVAL_TO_INDEX)
     ).get();
     // All the HOUR segments did not get dropped since MINUTES segments did not fully covering the 3 HOURS interval.
-    Assert.assertEquals(6, usedSegments.size());
+    Assertions.assertEquals(6, usedSegments.size());
     int hourSegmentCount = 0;
     int minuteSegmentCount = 0;
     for (DataSegment segment : usedSegments) {
@@ -899,8 +900,8 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         hourSegmentCount++;
       }
     }
-    Assert.assertEquals(3, hourSegmentCount);
-    Assert.assertEquals(3, minuteSegmentCount);
+    Assertions.assertEquals(3, hourSegmentCount);
+    Assertions.assertEquals(3, minuteSegmentCount);
   }
 
 
@@ -925,7 +926,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     final Set<DataSegment> compactedSegments = dataSegmentsWithSchemas.getSegments();
 
     for (DataSegment segment : compactedSegments) {
-      Assert.assertSame(
+      Assertions.assertSame(
           lockGranularity == LockGranularity.TIME_CHUNK ? NumberedShardSpec.class : NumberedOverwriteShardSpec.class,
           segment.getShardSpec().getClass()
       );
@@ -950,7 +951,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                          ))
                          .projections(ImmutableList.of(PROJECTION_SPEC))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -984,7 +985,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     final Set<DataSegment> compactedSegments = dataSegmentsWithSchemas.getSegments();
 
     for (DataSegment segment : compactedSegments) {
-      Assert.assertSame(
+      Assertions.assertSame(
           lockGranularity == LockGranularity.TIME_CHUNK ? NumberedShardSpec.class : NumberedOverwriteShardSpec.class,
           segment.getShardSpec().getClass()
       );
@@ -1009,7 +1010,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
                          ))
                          .projections(ImmutableList.of(PROJECTION_SPEC, addProjection))
                          .build();
-      Assert.assertEquals("Compaction state for " + segment.getId(), expectedState, segment.getLastCompactionState());
+      Assertions.assertEquals(expectedState, segment.getLastCompactionState(), "Compaction state for " + segment.getId());
     }
   }
 
@@ -1019,7 +1020,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
     allowSegmentFetchesByCompactionTask = true;
 
     // Range partitioning is not supported with segment lock yet
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
 
     runIndexTask(null, true);
 
@@ -1027,7 +1028,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         DATA_SOURCE,
         ImmutableList.of(INTERVAL_TO_INDEX)
     ).get();
-    Assert.assertEquals(3, usedSegments.size());
+    Assertions.assertEquals(3, usedSegments.size());
 
     // Compact with a transform that filters out ALL rows
     final Builder builder = new Builder(DATA_SOURCE, getSegmentCacheManagerFactory());
@@ -1051,7 +1052,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         ImmutableList.of(INTERVAL_TO_INDEX)
     ).get();
 
-    Assert.assertNotNull(usedSegments);
+    Assertions.assertNotNull(usedSegments);
 
     int tombstoneCount = 0;
     for (DataSegment segment : usedSegments) {
@@ -1060,7 +1061,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
       }
     }
 
-    Assert.assertTrue("Expected tombstones when all rows filtered in REPLACE mode", tombstoneCount > 0);
+    Assertions.assertTrue(tombstoneCount > 0, "Expected tombstones when all rows filtered in REPLACE mode");
   }
 
   @Test
@@ -1068,7 +1069,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
   {
     allowSegmentFetchesByCompactionTask = true;
 
-    Assume.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
+    Assumptions.assumeFalse(lockGranularity == LockGranularity.SEGMENT);
 
     runIndexTask(null, true);
 
@@ -1076,7 +1077,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         DATA_SOURCE,
         ImmutableList.of(INTERVAL_TO_INDEX)
     ).get();
-    Assert.assertEquals(3, usedSegments.size());
+    Assertions.assertEquals(3, usedSegments.size());
 
     final Builder builder = new Builder(DATA_SOURCE, getSegmentCacheManagerFactory());
     final CompactionTask compactionTask = builder
@@ -1101,19 +1102,16 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         ImmutableList.of(INTERVAL_TO_INDEX)
     ).get();
 
-    Assert.assertNotNull(usedSegments);
+    Assertions.assertNotNull(usedSegments);
 
-    Assert.assertEquals(
-        "Original segments should remain in REPLACE_LEGACY mode when all rows filtered",
+    Assertions.assertEquals(
         3,
-        usedSegments.size()
+        usedSegments.size(),
+        "Original segments should remain in REPLACE_LEGACY mode when all rows filtered"
     );
 
     for (DataSegment segment : usedSegments) {
-      Assert.assertFalse(
-          "No tombstones should be created in REPLACE_LEGACY mode",
-          segment.isTombstone()
-      );
+      Assertions.assertFalse(segment.isTombstone(), "No tombstones should be created in REPLACE_LEGACY mode");
     }
   }
 
@@ -1170,7 +1168,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(
                 new Resource(
@@ -1237,7 +1235,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(
                 new Resource(
@@ -1256,7 +1254,7 @@ public class CompactionTaskParallelRunTest extends AbstractParallelIndexSupervis
   {
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
     TaskStatus status = getIndexingServiceClient().runAndWait(task);
-    Assert.assertEquals(status.toString(), TaskState.SUCCESS, status.getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, status.getStatusCode(), status.toString());
     return getIndexingServiceClient().getSegmentAndSchemas(task);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskSerdeTest.java
@@ -32,11 +32,9 @@ import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.segment.indexing.TuningConfig;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -44,10 +42,7 @@ public class IndexTaskSerdeTest
 {
   private static final ObjectMapper MAPPER = new DefaultObjectMapper();
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @BeforeClass
+  @BeforeAll
   public static void setup()
   {
     MAPPER.registerSubtypes(new NamedType(IndexTuningConfig.class, "index"));
@@ -132,29 +127,33 @@ public class IndexTaskSerdeTest
   @Test
   public void testForceGuaranteedRollupWithDynamicPartitionsSpec()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("DynamicPartitionsSpec cannot be used for perfect rollup");
-    TuningConfigBuilder.forIndexTask()
-                       .withForceGuaranteedRollup(true)
-                       .withPartitionsSpec(new DynamicPartitionsSpec(1000, 2000L))
-                       .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> TuningConfigBuilder.forIndexTask()
+                                  .withForceGuaranteedRollup(true)
+                                  .withPartitionsSpec(new DynamicPartitionsSpec(1000, 2000L))
+                                  .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("DynamicPartitionsSpec cannot be used for perfect rollup"));
   }
 
   @Test
   public void testBestEffortRollupWithHashedPartitionsSpec()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
-    TuningConfigBuilder.forIndexTask()
-                       .withForceGuaranteedRollup(false)
-                       .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
-                       .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> TuningConfigBuilder.forIndexTask()
+                                  .withForceGuaranteedRollup(false)
+                                  .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+                                  .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("DynamicPartitionsSpec must be used for best-effort rollup"));
   }
 
   private static void assertSerdeTuningConfig(IndexTuningConfig tuningConfig) throws IOException
   {
     final byte[] json = MAPPER.writeValueAsBytes(tuningConfig);
     final IndexTuningConfig fromJson = (IndexTuningConfig) MAPPER.readValue(json, TuningConfig.class);
-    Assert.assertEquals(tuningConfig, fromJson);
+    Assertions.assertEquals(tuningConfig, fromJson);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskTest.java
@@ -53,6 +53,7 @@ import org.apache.druid.indexing.common.config.TaskConfig;
 import org.apache.druid.indexing.common.task.IndexTask.IndexIOConfig;
 import org.apache.druid.indexing.common.task.IndexTask.IndexIngestionSpec;
 import org.apache.druid.indexing.common.task.IndexTask.IndexTuningConfig;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.Pair;
@@ -108,16 +109,12 @@ import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.PartitionIds;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.easymock.EasyMock;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -137,12 +134,10 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}")
+@MethodSource("constructorFeeder")
 public class IndexTaskTest extends IngestionTestBase
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
   private static final String DATASOURCE = "test";
   private static final TimestampSpec DEFAULT_TIMESTAMP_SPEC = new TimestampSpec("ts", "auto", null);
   private static final DimensionsSpec DEFAULT_DIMENSIONS_SPEC = new DimensionsSpec(
@@ -176,7 +171,6 @@ public class IndexTaskTest extends IngestionTestBase
                 )
                 .build();
 
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -201,11 +195,11 @@ public class IndexTaskTest extends IngestionTestBase
     this.lockGranularity = lockGranularity;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    final File cacheDir = temporaryFolder.newFolder();
-    tmpDir = temporaryFolder.newFolder();
+    final File cacheDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "cache");
+    tmpDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "input");
     final SegmentLoaderConfig loaderConfig = SegmentLoaderConfig.builder()
         .locations(new StorageLocationConfig(cacheDir, null, null))
         .build();
@@ -238,7 +232,7 @@ public class IndexTaskTest extends IngestionTestBase
         null
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 LocalInputSource.TYPE_KEY,
@@ -274,9 +268,9 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
-    Assert.assertEquals(ImmutableList.of("ts", "dim", "valDim"), segments.get(0).getDimensions());
-    Assert.assertEquals(ImmutableList.of("valMet"), segments.get(0).getMetrics());
+    Assertions.assertEquals(1, segments.size());
+    Assertions.assertEquals(ImmutableList.of("ts", "dim", "valDim"), segments.get(0).getDimensions());
+    Assertions.assertEquals(ImmutableList.of("valMet"), segments.get(0).getMetrics());
 
     verifySchemaAndAggFactory(
         segmentWithSchemas,
@@ -316,10 +310,10 @@ public class IndexTaskTest extends IngestionTestBase
 
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     // only empty string dimensions are ignored currently
-    Assert.assertEquals(ImmutableList.of("ts", "valDim"), segments.get(0).getDimensions());
-    Assert.assertEquals(ImmutableList.of("valMet"), segments.get(0).getMetrics());
+    Assertions.assertEquals(ImmutableList.of("ts", "valDim"), segments.get(0).getDimensions());
+    Assertions.assertEquals(ImmutableList.of("valMet"), segments.get(0).getMetrics());
 
     verifySchemaAndAggFactory(
         segmentWithSchemas,
@@ -354,31 +348,31 @@ public class IndexTaskTest extends IngestionTestBase
 
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
-    Assert.assertEquals(2, segments.size());
+    Assertions.assertEquals(2, segments.size());
 
-    Assert.assertEquals(DATASOURCE, segments.get(0).getDataSource());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
-    Assert.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
-    Assert.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
-    Assert.assertEquals(2, segments.get(0).getShardSpec().getNumCorePartitions());
-    Assert.assertEquals(
+    Assertions.assertEquals(DATASOURCE, segments.get(0).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+    Assertions.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
+    Assertions.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(2, segments.get(0).getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(
         HashPartitionFunction.MURMUR3_32_ABS,
         ((HashBasedNumberedShardSpec) segments.get(0).getShardSpec()).getPartitionFunction()
     );
 
-    Assert.assertEquals(DATASOURCE, segments.get(1).getDataSource());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(1).getInterval());
-    Assert.assertEquals(HashBasedNumberedShardSpec.class, segments.get(1).getShardSpec().getClass());
-    Assert.assertEquals(1, segments.get(1).getShardSpec().getPartitionNum());
-    Assert.assertEquals(2, segments.get(1).getShardSpec().getNumCorePartitions());
-    Assert.assertEquals(
+    Assertions.assertEquals(DATASOURCE, segments.get(1).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(1).getInterval());
+    Assertions.assertEquals(HashBasedNumberedShardSpec.class, segments.get(1).getShardSpec().getClass());
+    Assertions.assertEquals(1, segments.get(1).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(2, segments.get(1).getShardSpec().getNumCorePartitions());
+    Assertions.assertEquals(
         HashPartitionFunction.MURMUR3_32_ABS,
         ((HashBasedNumberedShardSpec) segments.get(1).getShardSpec()).getPartitionFunction()
     );
 
-    Assert.assertEquals(2, segmentWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size());
-    Assert.assertEquals(1, segmentWithSchemas.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, segmentWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size());
+    Assertions.assertEquals(1, segmentWithSchemas.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
+    Assertions.assertEquals(
         RowSignature.builder()
                     .add("__time", ColumnType.LONG)
                     .add("ts", ColumnType.STRING)
@@ -393,7 +387,7 @@ public class IndexTaskTest extends IngestionTestBase
                         .get()
                         .getRowSignature()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singletonMap("val", new LongSumAggregatorFactory("val", "val")),
         segmentWithSchemas.getSegmentSchemaMapping()
                         .getSchemaFingerprintToPayloadMap()
@@ -457,12 +451,12 @@ public class IndexTaskTest extends IngestionTestBase
 
     IndexTask indexTask = createIndexTask(indexIngestionSpec, null);
 
-    Assert.assertEquals(indexTask.getId(), indexTask.getGroupId());
+    Assertions.assertEquals(indexTask.getId(), indexTask.getGroupId());
 
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     DataSegment segment = segments.get(0);
     segmentCacheManager.load(segment);
     final File segmentFile = segmentCacheManager.getSegmentFiles(segment);
@@ -502,16 +496,16 @@ public class IndexTaskTest extends IngestionTestBase
       transforms.add(row);
       cursor.advance();
 
-      Assert.assertEquals(1, transforms.size());
-      Assert.assertEquals("bb", transforms.get(0).get("dimt"));
-      Assert.assertEquals(ImmutableList.of("b", "b"), transforms.get(0).get("dimtarray1"));
-      Assert.assertEquals(ImmutableList.of("anotherfoo", "arrayfoo"), transforms.get(0).get("dimtarray2"));
-      Assert.assertEquals(ImmutableList.of("6.0", "7.0"), transforms.get(0).get("dimtnum_array"));
+      Assertions.assertEquals(1, transforms.size());
+      Assertions.assertEquals("bb", transforms.get(0).get("dimt"));
+      Assertions.assertEquals(ImmutableList.of("b", "b"), transforms.get(0).get("dimtarray1"));
+      Assertions.assertEquals(ImmutableList.of("anotherfoo", "arrayfoo"), transforms.get(0).get("dimtarray2"));
+      Assertions.assertEquals(ImmutableList.of("6.0", "7.0"), transforms.get(0).get("dimtnum_array"));
 
-      Assert.assertEquals(DATASOURCE, segments.get(0).getDataSource());
-      Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
-      Assert.assertEquals(NumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
-      Assert.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
+      Assertions.assertEquals(DATASOURCE, segments.get(0).getDataSource());
+      Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+      Assertions.assertEquals(NumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
+      Assertions.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
 
       verifySchemaAndAggFactory(
           segmentWithSchemas,
@@ -557,7 +551,7 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
     invokeApi(req -> indexTask.getLiveReports(req, null));
     invokeApi(req -> indexTask.getLiveReports(req, "full"));
@@ -590,7 +584,7 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
   }
 
   @Test
@@ -615,13 +609,13 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
-    Assert.assertEquals(DATASOURCE, segments.get(0).getDataSource());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
-    Assert.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
-    Assert.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
-    Assert.assertEquals(
+    Assertions.assertEquals(DATASOURCE, segments.get(0).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+    Assertions.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
+    Assertions.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(
         HashPartitionFunction.MURMUR3_32_ABS,
         ((HashBasedNumberedShardSpec) segments.get(0).getShardSpec()).getPartitionFunction()
     );
@@ -651,13 +645,13 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
-    Assert.assertEquals(DATASOURCE, segments.get(0).getDataSource());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
-    Assert.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
-    Assert.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
-    Assert.assertEquals(
+    Assertions.assertEquals(DATASOURCE, segments.get(0).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+    Assertions.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
+    Assertions.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(
         HashPartitionFunction.MURMUR3_32_ABS,
         ((HashBasedNumberedShardSpec) segments.get(0).getShardSpec()).getPartitionFunction()
     );
@@ -685,14 +679,14 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(2, segments.size());
+    Assertions.assertEquals(2, segments.size());
 
     for (DataSegment segment : segments) {
-      Assert.assertEquals(DATASOURCE, segment.getDataSource());
-      Assert.assertEquals(Intervals.of("2014/P1D"), segment.getInterval());
-      Assert.assertEquals(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertEquals(DATASOURCE, segment.getDataSource());
+      Assertions.assertEquals(Intervals.of("2014/P1D"), segment.getInterval());
+      Assertions.assertEquals(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
       final HashBasedNumberedShardSpec hashBasedNumberedShardSpec = (HashBasedNumberedShardSpec) segment.getShardSpec();
-      Assert.assertEquals(HashPartitionFunction.MURMUR3_32_ABS, hashBasedNumberedShardSpec.getPartitionFunction());
+      Assertions.assertEquals(HashPartitionFunction.MURMUR3_32_ABS, hashBasedNumberedShardSpec.getPartitionFunction());
 
       segmentCacheManager.load(segment);
       final File segmentFile = segmentCacheManager.getSegmentFiles(segment);
@@ -720,7 +714,7 @@ public class IndexTaskTest extends IngestionTestBase
           cursor.advance();
         }
 
-        Assert.assertTrue(hashes.stream().allMatch(h -> h.intValue() == hashes.get(0)));
+        Assertions.assertTrue(hashes.stream().allMatch(h -> h.intValue() == hashes.get(0)));
       }
     }
   }
@@ -744,23 +738,23 @@ public class IndexTaskTest extends IngestionTestBase
         null
     );
 
-    Assert.assertEquals("index_append_test", indexTask.getGroupId());
+    Assertions.assertEquals("index_append_test", indexTask.getGroupId());
 
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(2, taskRunner.getTaskActionClient().getActionCount(SegmentAllocateAction.class));
-    Assert.assertEquals(2, segments.size());
+    Assertions.assertEquals(2, taskRunner.getTaskActionClient().getActionCount(SegmentAllocateAction.class));
+    Assertions.assertEquals(2, segments.size());
 
-    Assert.assertEquals(DATASOURCE, segments.get(0).getDataSource());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
-    Assert.assertEquals(NumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
-    Assert.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(DATASOURCE, segments.get(0).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+    Assertions.assertEquals(NumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
+    Assertions.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
 
-    Assert.assertEquals(DATASOURCE, segments.get(1).getDataSource());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(1).getInterval());
-    Assert.assertEquals(NumberedShardSpec.class, segments.get(1).getShardSpec().getClass());
-    Assert.assertEquals(1, segments.get(1).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(DATASOURCE, segments.get(1).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(1).getInterval());
+    Assertions.assertEquals(NumberedShardSpec.class, segments.get(1).getShardSpec().getClass());
+    Assertions.assertEquals(1, segments.get(1).getShardSpec().getPartitionNum());
   }
 
   @Test
@@ -789,22 +783,22 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(3, segments.size());
+    Assertions.assertEquals(3, segments.size());
 
-    Assert.assertEquals(DATASOURCE, segments.get(0).getDataSource());
-    Assert.assertEquals(Intervals.of("2014-01-01T00/PT1H"), segments.get(0).getInterval());
-    Assert.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
-    Assert.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(DATASOURCE, segments.get(0).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014-01-01T00/PT1H"), segments.get(0).getInterval());
+    Assertions.assertEquals(HashBasedNumberedShardSpec.class, segments.get(0).getShardSpec().getClass());
+    Assertions.assertEquals(0, segments.get(0).getShardSpec().getPartitionNum());
 
-    Assert.assertEquals(DATASOURCE, segments.get(1).getDataSource());
-    Assert.assertEquals(Intervals.of("2014-01-01T01/PT1H"), segments.get(1).getInterval());
-    Assert.assertEquals(HashBasedNumberedShardSpec.class, segments.get(1).getShardSpec().getClass());
-    Assert.assertEquals(0, segments.get(1).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(DATASOURCE, segments.get(1).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014-01-01T01/PT1H"), segments.get(1).getInterval());
+    Assertions.assertEquals(HashBasedNumberedShardSpec.class, segments.get(1).getShardSpec().getClass());
+    Assertions.assertEquals(0, segments.get(1).getShardSpec().getPartitionNum());
 
-    Assert.assertEquals(DATASOURCE, segments.get(2).getDataSource());
-    Assert.assertEquals(Intervals.of("2014-01-01T02/PT1H"), segments.get(2).getInterval());
-    Assert.assertEquals(HashBasedNumberedShardSpec.class, segments.get(2).getShardSpec().getClass());
-    Assert.assertEquals(0, segments.get(2).getShardSpec().getPartitionNum());
+    Assertions.assertEquals(DATASOURCE, segments.get(2).getDataSource());
+    Assertions.assertEquals(Intervals.of("2014-01-01T02/PT1H"), segments.get(2).getInterval());
+    Assertions.assertEquals(HashBasedNumberedShardSpec.class, segments.get(2).getShardSpec().getClass());
+    Assertions.assertEquals(0, segments.get(2).getShardSpec().getPartitionNum());
   }
 
   @Test
@@ -817,7 +811,7 @@ public class IndexTaskTest extends IngestionTestBase
     }
 
     // Expect exception if reingest with dropExisting and null intervals is attempted
-    Exception exception = Assert.assertThrows(
+    Exception exception = Assertions.assertThrows(
         IAE.class,
         () -> createIndexTask(
             createDefaultIngestionSpec(
@@ -833,7 +827,7 @@ public class IndexTaskTest extends IngestionTestBase
             null
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "GranularitySpec's intervals cannot be empty for replace.",
         exception.getMessage()
     );
@@ -868,11 +862,11 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
-    Assert.assertEquals(Collections.singletonList("d"), segments.get(0).getDimensions());
-    Assert.assertEquals(Collections.singletonList("val"), segments.get(0).getMetrics());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+    Assertions.assertEquals(Collections.singletonList("d"), segments.get(0).getDimensions());
+    Assertions.assertEquals(Collections.singletonList("val"), segments.get(0).getMetrics());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
   }
 
   @Test
@@ -905,11 +899,11 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
 
-    Assert.assertEquals(Collections.singletonList("d"), segments.get(0).getDimensions());
-    Assert.assertEquals(Collections.singletonList("val"), segments.get(0).getMetrics());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+    Assertions.assertEquals(Collections.singletonList("d"), segments.get(0).getDimensions());
+    Assertions.assertEquals(Collections.singletonList("val"), segments.get(0).getMetrics());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
   }
 
   @Test
@@ -944,17 +938,17 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(6, segments.size());
+    Assertions.assertEquals(6, segments.size());
 
     for (int i = 0; i < 6; i++) {
       final DataSegment segment = segments.get(i);
       final Interval expectedInterval = Intervals.of(StringUtils.format("2014-01-01T0%d/PT1H", (i / 2)));
       final int expectedPartitionNum = i % 2;
 
-      Assert.assertEquals(DATASOURCE, segment.getDataSource());
-      Assert.assertEquals(expectedInterval, segment.getInterval());
-      Assert.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
-      Assert.assertEquals(expectedPartitionNum, segment.getShardSpec().getPartitionNum());
+      Assertions.assertEquals(DATASOURCE, segment.getDataSource());
+      Assertions.assertEquals(expectedInterval, segment.getInterval());
+      Assertions.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertEquals(expectedPartitionNum, segment.getShardSpec().getPartitionNum());
     }
   }
 
@@ -981,16 +975,16 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(3, segments.size());
+    Assertions.assertEquals(3, segments.size());
 
     for (int i = 0; i < 3; i++) {
       final DataSegment segment = segments.get(i);
       final Interval expectedInterval = Intervals.of("2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z");
 
-      Assert.assertEquals(DATASOURCE, segment.getDataSource());
-      Assert.assertEquals(expectedInterval, segment.getInterval());
-      Assert.assertEquals(segment.getShardSpec().getClass(), HashBasedNumberedShardSpec.class);
-      Assert.assertEquals(i, segment.getShardSpec().getPartitionNum());
+      Assertions.assertEquals(DATASOURCE, segment.getDataSource());
+      Assertions.assertEquals(expectedInterval, segment.getInterval());
+      Assertions.assertEquals(segment.getShardSpec().getClass(), HashBasedNumberedShardSpec.class);
+      Assertions.assertEquals(i, segment.getShardSpec().getPartitionNum());
     }
   }
 
@@ -1017,16 +1011,16 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(5, segments.size());
+    Assertions.assertEquals(5, segments.size());
 
     final Interval expectedInterval = Intervals.of("2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z");
     for (int i = 0; i < 5; i++) {
       final DataSegment segment = segments.get(i);
 
-      Assert.assertEquals(DATASOURCE, segment.getDataSource());
-      Assert.assertEquals(expectedInterval, segment.getInterval());
-      Assert.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
-      Assert.assertEquals(i, segment.getShardSpec().getPartitionNum());
+      Assertions.assertEquals(DATASOURCE, segment.getDataSource());
+      Assertions.assertEquals(expectedInterval, segment.getInterval());
+      Assertions.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertEquals(i, segment.getShardSpec().getPartitionNum());
     }
   }
 
@@ -1050,7 +1044,7 @@ public class IndexTaskTest extends IngestionTestBase
     );
 
     EasyMock.replay(mockToolbox);
-    Assert.assertTrue(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 1000));
+    Assertions.assertTrue(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 1000));
     EasyMock.verify(mockToolbox);
   }
 
@@ -1075,7 +1069,7 @@ public class IndexTaskTest extends IngestionTestBase
     );
 
     EasyMock.replay(mockToolbox);
-    Assert.assertFalse(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, -1));
+    Assertions.assertFalse(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, -1));
     EasyMock.verify(mockToolbox);
   }
 
@@ -1129,7 +1123,7 @@ public class IndexTaskTest extends IngestionTestBase
     EasyMock.replay(mockDataSegment1, mockDataSegment2);
     EasyMock.replay(mockFactory, mockNotifier);
 
-    Assert.assertFalse(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 1000));
+    Assertions.assertFalse(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 1000));
     EasyMock.verify(mockToolbox);
     EasyMock.verify(mockDataSegment1, mockDataSegment2);
     EasyMock.verify(mockFactory, mockNotifier);
@@ -1179,7 +1173,7 @@ public class IndexTaskTest extends IngestionTestBase
     EasyMock.replay(mockToolbox);
     EasyMock.replay(mockDataSegment1, mockDataSegment2);
 
-    Assert.assertTrue(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 30000));
+    Assertions.assertTrue(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 30000));
     EasyMock.verify(mockToolbox);
     EasyMock.verify(mockDataSegment1, mockDataSegment2);
   }
@@ -1230,7 +1224,7 @@ public class IndexTaskTest extends IngestionTestBase
     EasyMock.replay(mockToolbox);
     EasyMock.replay(mockDataSegment1, mockDataSegment2);
 
-    Assert.assertTrue(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 30000));
+    Assertions.assertTrue(indexTask.waitForSegmentAvailability(mockToolbox, segmentsToWaitFor, 30000));
     emitter.verifyEmitted("task/segmentAvailability/wait/time", 1);
     EasyMock.verify(mockToolbox);
     EasyMock.verify(mockDataSegment1, mockDataSegment2);
@@ -1288,9 +1282,9 @@ public class IndexTaskTest extends IngestionTestBase
     final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(Collections.singletonList("d"), segments.get(0).getDimensions());
-    Assert.assertEquals(Collections.singletonList("val"), segments.get(0).getMetrics());
-    Assert.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
+    Assertions.assertEquals(Collections.singletonList("d"), segments.get(0).getDimensions());
+    Assertions.assertEquals(Collections.singletonList("val"), segments.get(0).getMetrics());
+    Assertions.assertEquals(Intervals.of("2014/P1D"), segments.get(0).getInterval());
   }
 
   @Test
@@ -1328,17 +1322,17 @@ public class IndexTaskTest extends IngestionTestBase
     IndexTask indexTask = createIndexTask(indexIngestionSpec, null);
 
     TaskStatus status = runTask(indexTask).lhs;
-    Assert.assertEquals(TaskState.FAILED, status.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, status.getStatusCode());
     checkTaskStatusErrorMsgForParseExceptionsExceeded(status);
 
     IngestionStatsAndErrors reportData = getTaskReportData();
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = ImmutableList.of("{time=unparseable, d=a, val=1}");
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
   }
 
   @Test
@@ -1394,8 +1388,8 @@ public class IndexTaskTest extends IngestionTestBase
     IndexTask indexTask = createIndexTask(ingestionSpec, null);
 
     TaskStatus status = runTask(indexTask).lhs;
-    Assert.assertEquals(TaskState.SUCCESS, status.getStatusCode());
-    Assert.assertNull(status.getErrorMsg());
+    Assertions.assertEquals(TaskState.SUCCESS, status.getStatusCode());
+    Assertions.assertNull(status.getErrorMsg());
 
     IngestionStatsAndErrors reportData = getTaskReportData();
 
@@ -1421,7 +1415,7 @@ public class IndexTaskTest extends IngestionTestBase
             RowIngestionMeters.THROWN_AWAY_BY_REASON, expectedThrownAwayByReason
         )
     );
-    Assert.assertEquals(expectedMetrics, reportData.getRowStats());
+    Assertions.assertEquals(expectedMetrics, reportData.getRowStats());
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
@@ -1446,7 +1440,7 @@ public class IndexTaskTest extends IngestionTestBase
         )
     );
 
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = Arrays.asList(
         "this is not JSON",
@@ -1457,7 +1451,7 @@ public class IndexTaskTest extends IngestionTestBase
         "{time=2014-01-01T00:00:10Z, dim=b, dimLong=notnumber, dimFloat=3.0, val=1}",
         "{time=unparseable, dim=a, dimLong=2, dimFloat=3.0, val=1}"
     );
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
 
     parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.DETERMINE_PARTITIONS);
@@ -1478,7 +1472,7 @@ public class IndexTaskTest extends IngestionTestBase
         )
     );
 
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     expectedInputs = Arrays.asList(
         "this is not JSON",
@@ -1486,7 +1480,7 @@ public class IndexTaskTest extends IngestionTestBase
         "{\"time\":9.0x,\"dim\":\"a\",\"dimLong\":2,\"dimFloat\":3.0,\"val\":1}",
         "{time=unparseable, dim=a, dimLong=2, dimFloat=3.0, val=1}"
     );
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
   }
 
   @Test
@@ -1554,7 +1548,7 @@ public class IndexTaskTest extends IngestionTestBase
     );
 
     TaskStatus status = runTask(indexTask).lhs;
-    Assert.assertEquals(TaskState.FAILED, status.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, status.getStatusCode());
     checkTaskStatusErrorMsgForParseExceptionsExceeded(status);
 
     IngestionStatsAndErrors reportData = getTaskReportData();
@@ -1583,18 +1577,18 @@ public class IndexTaskTest extends IngestionTestBase
         )
     );
 
-    Assert.assertEquals(expectedMetrics, reportData.getRowStats());
+    Assertions.assertEquals(expectedMetrics, reportData.getRowStats());
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = Arrays.asList(
         "{time=99999999999-01-01T00:00:10Z, dim=b, dimLong=2, dimFloat=3.0, val=1}",
         "{time=9.0, dim=a, dimLong=2, dimFloat=3.0, val=1}",
         "{time=unparseable, dim=a, dimLong=2, dimFloat=3.0, val=1}"
     );
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
   }
 
   @Test
@@ -1653,7 +1647,7 @@ public class IndexTaskTest extends IngestionTestBase
     );
 
     TaskStatus status = runTask(indexTask).lhs;
-    Assert.assertEquals(TaskState.FAILED, status.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, status.getStatusCode());
     checkTaskStatusErrorMsgForParseExceptionsExceeded(status);
 
     IngestionStatsAndErrors reportData = getTaskReportData();
@@ -1681,18 +1675,18 @@ public class IndexTaskTest extends IngestionTestBase
         )
     );
 
-    Assert.assertEquals(expectedMetrics, reportData.getRowStats());
+    Assertions.assertEquals(expectedMetrics, reportData.getRowStats());
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.DETERMINE_PARTITIONS);
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = Arrays.asList(
         "{time=99999999999-01-01T00:00:10Z, dim=b, dimLong=2, dimFloat=3.0, val=1}",
         "{time=9.0, dim=a, dimLong=2, dimFloat=3.0, val=1}",
         "{time=unparseable, dim=a, dimLong=2, dimFloat=3.0, val=1}"
     );
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
   }
 
   @Test
@@ -1736,8 +1730,8 @@ public class IndexTaskTest extends IngestionTestBase
 
     // the order of result segments can be changed because hash shardSpec is used.
     // the below loop is to make this test deterministic.
-    Assert.assertEquals(2, segments.size());
-    Assert.assertNotEquals(segments.get(0), segments.get(1));
+    Assertions.assertEquals(2, segments.size());
+    Assertions.assertNotEquals(segments.get(0), segments.get(1));
 
     for (DataSegment segment : segments) {
       System.out.println(segment.getDimensions());
@@ -1747,14 +1741,14 @@ public class IndexTaskTest extends IngestionTestBase
       final DataSegment segment = segments.get(i);
       final Set<String> dimensions = new HashSet<>(segment.getDimensions());
 
-      Assert.assertTrue(
-          StringUtils.format("Actual dimensions: %s", dimensions),
+      Assertions.assertTrue(
           dimensions.equals(Sets.newHashSet("column_2")) ||
-          dimensions.equals(Sets.newHashSet("dim", "column_2", "column_3"))
+          dimensions.equals(Sets.newHashSet("dim", "column_2", "column_3")),
+          StringUtils.format("Actual dimensions: %s", dimensions)
       );
 
-      Assert.assertEquals(Collections.singletonList("val"), segment.getMetrics());
-      Assert.assertEquals(Intervals.of("2014/P1D"), segment.getInterval());
+      Assertions.assertEquals(Collections.singletonList("val"), segment.getMetrics());
+      Assertions.assertEquals(Intervals.of("2014/P1D"), segment.getInterval());
     }
   }
 
@@ -1792,7 +1786,7 @@ public class IndexTaskTest extends IngestionTestBase
     );
 
     TaskStatus status = runTask(indexTask).lhs;
-    Assert.assertEquals(TaskState.FAILED, status.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, status.getStatusCode());
 
     checkTaskStatusErrorMsgForParseExceptionsExceeded(status);
 
@@ -1800,12 +1794,12 @@ public class IndexTaskTest extends IngestionTestBase
 
     ParseExceptionReport parseExceptionReport =
         ParseExceptionReport.forPhase(reportData, RowIngestionMeters.BUILD_SEGMENTS);
-    Assert.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
+    Assertions.assertEquals(expectedMessages, parseExceptionReport.getErrorMessages());
 
     List<String> expectedInputs = ImmutableList.of(
         "{column_1=2014-01-01T00:00:10Z, column_2=a, column_3=1}"
     );
-    Assert.assertEquals(expectedInputs, parseExceptionReport.getInputs());
+    Assertions.assertEquals(expectedInputs, parseExceptionReport.getInputs());
   }
 
   @Test
@@ -1832,33 +1826,33 @@ public class IndexTaskTest extends IngestionTestBase
       final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
       final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-      Assert.assertEquals(5, segments.size());
+      Assertions.assertEquals(5, segments.size());
 
       final Interval expectedInterval = Intervals.of("2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z");
       for (int j = 0; j < 5; j++) {
         final DataSegment segment = segments.get(j);
-        Assert.assertEquals(DATASOURCE, segment.getDataSource());
-        Assert.assertEquals(expectedInterval, segment.getInterval());
+        Assertions.assertEquals(DATASOURCE, segment.getDataSource());
+        Assertions.assertEquals(expectedInterval, segment.getInterval());
         if (i == 0) {
-          Assert.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
-          Assert.assertEquals(j, segment.getShardSpec().getPartitionNum());
+          Assertions.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
+          Assertions.assertEquals(j, segment.getShardSpec().getPartitionNum());
         } else {
           if (lockGranularity == LockGranularity.SEGMENT) {
-            Assert.assertEquals(NumberedOverwriteShardSpec.class, segment.getShardSpec().getClass());
+            Assertions.assertEquals(NumberedOverwriteShardSpec.class, segment.getShardSpec().getClass());
             final NumberedOverwriteShardSpec numberedOverwriteShardSpec =
                 (NumberedOverwriteShardSpec) segment.getShardSpec();
-            Assert.assertEquals(
+            Assertions.assertEquals(
                 j + PartitionIds.NON_ROOT_GEN_START_PARTITION_ID,
                 numberedOverwriteShardSpec.getPartitionNum()
             );
-            Assert.assertEquals(1, numberedOverwriteShardSpec.getMinorVersion());
-            Assert.assertEquals(5, numberedOverwriteShardSpec.getAtomicUpdateGroupSize());
-            Assert.assertEquals(0, numberedOverwriteShardSpec.getStartRootPartitionId());
-            Assert.assertEquals(5, numberedOverwriteShardSpec.getEndRootPartitionId());
+            Assertions.assertEquals(1, numberedOverwriteShardSpec.getMinorVersion());
+            Assertions.assertEquals(5, numberedOverwriteShardSpec.getAtomicUpdateGroupSize());
+            Assertions.assertEquals(0, numberedOverwriteShardSpec.getStartRootPartitionId());
+            Assertions.assertEquals(5, numberedOverwriteShardSpec.getEndRootPartitionId());
           } else {
-            Assert.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
+            Assertions.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
             final NumberedShardSpec numberedShardSpec = (NumberedShardSpec) segment.getShardSpec();
-            Assert.assertEquals(j, numberedShardSpec.getPartitionNum());
+            Assertions.assertEquals(j, numberedShardSpec.getPartitionNum());
           }
         }
       }
@@ -1890,17 +1884,17 @@ public class IndexTaskTest extends IngestionTestBase
       final DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
       final List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-      Assert.assertEquals(5, segments.size());
+      Assertions.assertEquals(5, segments.size());
 
       final Interval expectedInterval = i == 0
                                         ? Intervals.of("2014-01-01/2014-01-02")
                                         : Intervals.of("2014-01-01/2014-02-01");
       for (int j = 0; j < 5; j++) {
         final DataSegment segment = segments.get(j);
-        Assert.assertEquals(DATASOURCE, segment.getDataSource());
-        Assert.assertEquals(expectedInterval, segment.getInterval());
-        Assert.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
-        Assert.assertEquals(j, segment.getShardSpec().getPartitionNum());
+        Assertions.assertEquals(DATASOURCE, segment.getDataSource());
+        Assertions.assertEquals(expectedInterval, segment.getInterval());
+        Assertions.assertEquals(NumberedShardSpec.class, segment.getShardSpec().getClass());
+        Assertions.assertEquals(j, segment.getShardSpec().getPartitionNum());
       }
     }
   }
@@ -1917,11 +1911,11 @@ public class IndexTaskTest extends IngestionTestBase
         ),
         null
     );
-    Exception exception = Assert.assertThrows(
+    Exception exception = Assertions.assertThrows(
         UnsupportedOperationException.class,
         () -> task.isReady(createActionClient(task))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "partitionsSpec[org.apache.druid.indexer.partitions.SingleDimensionPartitionsSpec] is not supported",
         exception.getMessage()
     );
@@ -1954,11 +1948,11 @@ public class IndexTaskTest extends IngestionTestBase
     DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     Set<DataSegment> usedSegmentsBeforeOverwrite = getAllUsedSegments();
-    Assert.assertEquals(1, usedSegmentsBeforeOverwrite.size());
+    Assertions.assertEquals(1, usedSegmentsBeforeOverwrite.size());
     for (DataSegment segment : usedSegmentsBeforeOverwrite) {
-      Assert.assertTrue(Granularities.YEAR.isAligned(segment.getInterval()));
+      Assertions.assertTrue(Granularities.YEAR.isAligned(segment.getInterval()));
     }
 
     indexTask = createIndexTask(
@@ -1979,24 +1973,24 @@ public class IndexTaskTest extends IngestionTestBase
     segmentWithSchemas = runSuccessfulTask(indexTask);
     segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(3, segments.size());
+    Assertions.assertEquals(3, segments.size());
     Set<DataSegment> usedSegmentsBeforeAfterOverwrite = getAllUsedSegments();
-    Assert.assertEquals(4, usedSegmentsBeforeAfterOverwrite.size());
+    Assertions.assertEquals(4, usedSegmentsBeforeAfterOverwrite.size());
     int yearSegmentFound = 0;
     int minuteSegmentFound = 0;
     for (DataSegment segment : usedSegmentsBeforeAfterOverwrite) {
       // Used segments after overwrite will contain 1 old segment with YEAR segmentGranularity (from first ingestion)
       // and 3 new segments with MINUTE segmentGranularity (from second ingestion)
       if (usedSegmentsBeforeOverwrite.contains(segment)) {
-        Assert.assertTrue(Granularities.YEAR.isAligned(segment.getInterval()));
+        Assertions.assertTrue(Granularities.YEAR.isAligned(segment.getInterval()));
         yearSegmentFound++;
       } else {
-        Assert.assertTrue(Granularities.MINUTE.isAligned(segment.getInterval()));
+        Assertions.assertTrue(Granularities.MINUTE.isAligned(segment.getInterval()));
         minuteSegmentFound++;
       }
     }
-    Assert.assertEquals(1, yearSegmentFound);
-    Assert.assertEquals(3, minuteSegmentFound);
+    Assertions.assertEquals(1, yearSegmentFound);
+    Assertions.assertEquals(3, minuteSegmentFound);
   }
 
   @Test
@@ -2027,11 +2021,11 @@ public class IndexTaskTest extends IngestionTestBase
     DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     Set<DataSegment> usedSegmentsBeforeOverwrite = getAllUsedSegments();
-    Assert.assertEquals(1, usedSegmentsBeforeOverwrite.size());
+    Assertions.assertEquals(1, usedSegmentsBeforeOverwrite.size());
     for (DataSegment segment : usedSegmentsBeforeOverwrite) {
-      Assert.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
+      Assertions.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
     }
 
     indexTask = createIndexTask(
@@ -2052,9 +2046,9 @@ public class IndexTaskTest extends IngestionTestBase
     segmentWithSchemas = runSuccessfulTask(indexTask);
     segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     Set<DataSegment> usedSegmentsBeforeAfterOverwrite = getAllUsedSegments();
-    Assert.assertEquals(2, usedSegmentsBeforeAfterOverwrite.size());
+    Assertions.assertEquals(2, usedSegmentsBeforeAfterOverwrite.size());
     int segmentFound = 0;
     int tombstonesFound = 0;
     int hourSegmentFound = 0;
@@ -2066,18 +2060,18 @@ public class IndexTaskTest extends IngestionTestBase
         segmentFound++;
       }
       if (usedSegmentsBeforeOverwrite.contains(segment)) {
-        Assert.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
+        Assertions.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
         daySegmentFound++;
       } else {
-        Assert.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
+        Assertions.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
         hourSegmentFound++;
       }
 
     }
-    Assert.assertEquals(1, daySegmentFound);
-    Assert.assertEquals(1, hourSegmentFound);
-    Assert.assertEquals(2, segmentFound);
-    Assert.assertEquals(0, tombstonesFound);
+    Assertions.assertEquals(1, daySegmentFound);
+    Assertions.assertEquals(1, hourSegmentFound);
+    Assertions.assertEquals(2, segmentFound);
+    Assertions.assertEquals(0, tombstonesFound);
   }
 
   @Test
@@ -2108,11 +2102,11 @@ public class IndexTaskTest extends IngestionTestBase
     DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     Set<DataSegment> usedSegmentsBeforeOverwrite = getAllUsedSegments();
-    Assert.assertEquals(1, usedSegmentsBeforeOverwrite.size());
+    Assertions.assertEquals(1, usedSegmentsBeforeOverwrite.size());
     for (DataSegment segment : usedSegmentsBeforeOverwrite) {
-      Assert.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
+      Assertions.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
     }
 
     indexTask = createIndexTask(
@@ -2133,16 +2127,16 @@ public class IndexTaskTest extends IngestionTestBase
     segmentWithSchemas = runSuccessfulTask(indexTask);
     segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(24, segments.size());
+    Assertions.assertEquals(24, segments.size());
     Set<DataSegment> usedSegmentsBeforeAfterOverwrite = getAllUsedSegments();
-    Assert.assertEquals(24, usedSegmentsBeforeAfterOverwrite.size());
+    Assertions.assertEquals(24, usedSegmentsBeforeAfterOverwrite.size());
     for (DataSegment segment : usedSegmentsBeforeAfterOverwrite) {
       // Used segments after overwrite and drop will contain only the
       // 24 new segments with HOUR segmentGranularity (from second ingestion)
       if (usedSegmentsBeforeOverwrite.contains(segment)) {
-        Assert.fail();
+        Assertions.fail();
       } else {
-        Assert.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
+        Assertions.assertTrue(Granularities.HOUR.isAligned(segment.getInterval()));
       }
     }
   }
@@ -2174,16 +2168,16 @@ public class IndexTaskTest extends IngestionTestBase
     DataSegmentsWithSchemas segmentWithSchemas = runSuccessfulTask(indexTask);
     List<DataSegment> segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     Set<DataSegment> usedSegmentsBeforeOverwrite = getAllUsedSegments();
-    Assert.assertEquals(1, usedSegmentsBeforeOverwrite.size());
+    Assertions.assertEquals(1, usedSegmentsBeforeOverwrite.size());
     for (DataSegment segment : usedSegmentsBeforeOverwrite) {
-      Assert.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
+      Assertions.assertTrue(Granularities.DAY.isAligned(segment.getInterval()));
     }
 
     // create new data but with an ingestion interval appropriate to filter it all out so that only tombstones
     // are created:
-    tmpDir = temporaryFolder.newFolder();
+    tmpDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "input");
     try (BufferedWriter writer = Files.newWriter(createTempFile(), StandardCharsets.UTF_8)) {
       writer.write("2014-01-01T00:00:10Z,a,1\n");
       writer.write("2014-01-01T01:00:20Z,b,1\n");
@@ -2208,15 +2202,15 @@ public class IndexTaskTest extends IngestionTestBase
     segmentWithSchemas = runSuccessfulTask(indexTask);
     segments = new ArrayList<>(segmentWithSchemas.getSegments());
 
-    Assert.assertEquals(1, segments.size()); // one tombstone
-    Assert.assertTrue(segments.get(0).isTombstone());
+    Assertions.assertEquals(1, segments.size()); // one tombstone
+    Assertions.assertTrue(segments.get(0).isTombstone());
   }
 
 
   @Test
   public void testErrorWhenDropFlagTrueAndOverwriteFalse()
   {
-    Exception exception = Assert.assertThrows(
+    Exception exception = Assertions.assertThrows(
         IAE.class,
         () -> createIndexTask(
             createDefaultIngestionSpec(
@@ -2232,7 +2226,7 @@ public class IndexTaskTest extends IngestionTestBase
             null
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot simultaneously replace and append to existing segments."
         + " Either dropExisting or appendToExisting should be set to false",
         exception.getMessage()
@@ -2298,16 +2292,13 @@ public class IndexTaskTest extends IngestionTestBase
   public static void checkTaskStatusErrorMsgForParseExceptionsExceeded(TaskStatus status)
   {
     // full stacktrace will be too long and make tests brittle (e.g. if line # changes), just match the main message
-    MatcherAssert.assertThat(
-        status.getErrorMsg(),
-        CoreMatchers.containsString("Max parse exceptions")
-    );
+    Assertions.assertTrue(status.getErrorMsg().contains("Max parse exceptions"));
   }
 
   private DataSegmentsWithSchemas runSuccessfulTask(IndexTask task) throws Exception
   {
     Pair<TaskStatus, DataSegmentsWithSchemas> pair = runTask(task);
-    Assert.assertEquals(pair.lhs.toString(), TaskState.SUCCESS, pair.lhs.getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, pair.lhs.getStatusCode(), pair.lhs.toString());
     return pair.rhs;
   }
 
@@ -2508,12 +2499,12 @@ public class IndexTaskTest extends IngestionTestBase
       Map<String, AggregatorFactory> aggregatorFactoryMap
   )
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         segmentWithSchemas.getSegments().size(),
         segmentWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size()
     );
-    Assert.assertEquals(1, segmentWithSchemas.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, segmentWithSchemas.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
+    Assertions.assertEquals(
         actualRowSignature,
         segmentWithSchemas.getSegmentSchemaMapping()
                           .getSchemaFingerprintToPayloadMap()
@@ -2523,7 +2514,7 @@ public class IndexTaskTest extends IngestionTestBase
                           .get()
                           .getRowSignature()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         aggregatorFactoryMap,
         segmentWithSchemas.getSegmentSchemaMapping()
                           .getSchemaFingerprintToPayloadMap()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskUtilsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IndexTaskUtilsTest.java
@@ -22,17 +22,20 @@ package org.apache.druid.indexing.common.task;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.emitter.service.ServiceMetricEvent;
 import org.apache.druid.query.DruidMetrics;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Map;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class IndexTaskUtilsTest
 {
   private static final Map<String, Object> METRIC_TAGS = ImmutableMap.of("k1", "v1", "k2", 20);
@@ -43,7 +46,7 @@ public class IndexTaskUtilsTest
   private AbstractTask abstractTask;
   private ServiceMetricEvent.Builder metricBuilder;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     metricBuilder = ServiceMetricEvent.builder();
@@ -60,14 +63,14 @@ public class IndexTaskUtilsTest
   public void testSetTaskDimensionsWithContextTagsShouldSetTags()
   {
     IndexTaskUtils.setTaskDimensions(metricBuilder, task);
-    Assert.assertEquals(METRIC_TAGS, metricBuilder.getDimension(DruidMetrics.TAGS));
+    Assertions.assertEquals(METRIC_TAGS, metricBuilder.getDimension(DruidMetrics.TAGS));
   }
 
   @Test
   public void testSetTaskDimensionsForAbstractTaskWithContextTagsShouldSetTags()
   {
     IndexTaskUtils.setTaskDimensions(metricBuilder, abstractTask);
-    Assert.assertEquals(METRIC_TAGS, metricBuilder.getDimension(DruidMetrics.TAGS));
+    Assertions.assertEquals(METRIC_TAGS, metricBuilder.getDimension(DruidMetrics.TAGS));
   }
 
   @Test
@@ -75,7 +78,7 @@ public class IndexTaskUtilsTest
   {
     task = new NoopTask(null, null, "wiki", 1L, 0L, null);
     IndexTaskUtils.setTaskDimensions(metricBuilder, task);
-    Assert.assertNull(metricBuilder.getDimension(DruidMetrics.TAGS));
+    Assertions.assertNull(metricBuilder.getDimension(DruidMetrics.TAGS));
   }
 
   @Test
@@ -83,21 +86,21 @@ public class IndexTaskUtilsTest
   {
     Mockito.when(abstractTask.getContextValue(DruidMetrics.TAGS)).thenReturn(null);
     IndexTaskUtils.setTaskDimensions(metricBuilder, abstractTask);
-    Assert.assertNull(metricBuilder.getDimension(DruidMetrics.TAGS));
+    Assertions.assertNull(metricBuilder.getDimension(DruidMetrics.TAGS));
   }
 
   @Test
   public void testSetTaskDimensionsWithGroupIdShouldSetGroupId()
   {
     IndexTaskUtils.setTaskDimensions(metricBuilder, task);
-    Assert.assertEquals(GROUP_ID, metricBuilder.getDimension(DruidMetrics.GROUP_ID));
+    Assertions.assertEquals(GROUP_ID, metricBuilder.getDimension(DruidMetrics.GROUP_ID));
   }
 
   @Test
   public void testSetTaskDimensionsForAbstractTaskWithGroupIdShouldSetGroupId()
   {
     IndexTaskUtils.setTaskDimensions(metricBuilder, abstractTask);
-    Assert.assertEquals(GROUP_ID, metricBuilder.getDimension(DruidMetrics.GROUP_ID));
+    Assertions.assertEquals(GROUP_ID, metricBuilder.getDimension(DruidMetrics.GROUP_ID));
   }
 
   @Test
@@ -105,6 +108,6 @@ public class IndexTaskUtilsTest
   {
     Mockito.when(abstractTask.getGroupId()).thenReturn(null);
     IndexTaskUtils.setTaskDimensions(metricBuilder, abstractTask);
-    Assert.assertNull(metricBuilder.getDimension(DruidMetrics.GROUP_ID));
+    Assertions.assertNull(metricBuilder.getDimension(DruidMetrics.GROUP_ID));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -95,6 +95,7 @@ import org.junit.Before;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -110,7 +111,8 @@ import java.util.stream.Collectors;
 
 public abstract class IngestionTestBase extends InitializedNullHandlingTest
 {
-  public final File temporaryFolder = FileUtils.createTempDir();
+  @TempDir
+  public File temporaryFolder;
 
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
@@ -202,12 +204,6 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
   {
     segmentMetadataCache.stopBeingLeader();
     segmentMetadataCache.stop();
-    try {
-      FileUtils.deleteDirectory(temporaryFolder);
-    }
-    catch (IOException e) {
-      throw new ISE(e, "Failed to delete temporary directory[%s]", temporaryFolder);
-    }
     derbyConnectorRule.after();
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -51,6 +51,7 @@ import org.apache.druid.indexing.overlord.TaskStorage;
 import org.apache.druid.indexing.overlord.autoscaling.ScalingStats;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorManager;
 import org.apache.druid.indexing.test.TestDataSegmentKiller;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
@@ -90,10 +91,10 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.utils.JvmUtils;
 import org.joda.time.Period;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
 import java.io.IOException;
@@ -109,10 +110,8 @@ import java.util.stream.Collectors;
 
 public abstract class IngestionTestBase extends InitializedNullHandlingTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  public final File temporaryFolder = FileUtils.createTempDir();
 
-  @Rule
   public final TestDerbyConnector.DerbyConnectorRule derbyConnectorRule =
       new TestDerbyConnector.DerbyConnectorRule(CentralizedDatasourceSchemaConfig.enabled(true));
 
@@ -145,11 +144,12 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
 
 
   @Before
+  @BeforeEach
   public void setUpIngestionTestBase() throws IOException
   {
+    derbyConnectorRule.before();
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
-    temporaryFolder.create();
-    baseDir = temporaryFolder.newFolder();
+    baseDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "base");
 
     final SQLMetadataConnector connector = derbyConnectorRule.getConnector();
     connector.createTaskTables();
@@ -188,7 +188,7 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
     lockbox = new GlobalTaskLockbox(taskStorage, storageCoordinator);
     lockbox.syncFromStorage();
     segmentCacheManagerFactory = SegmentCacheManagerFactory.createWithOwnedPool(TestIndex.INDEX_IO, getObjectMapper());
-    reportsFile = temporaryFolder.newFile();
+    reportsFile = new File(temporaryFolder, "reports.json");
     dataSegmentKiller = new TestDataSegmentKiller();
     taskActionToolbox = createTaskActionToolbox();
 
@@ -197,11 +197,18 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
   }
 
   @After
+  @AfterEach
   public void tearDownIngestionTestBase()
   {
-    temporaryFolder.delete();
     segmentMetadataCache.stopBeingLeader();
     segmentMetadataCache.stop();
+    try {
+      FileUtils.deleteDirectory(temporaryFolder);
+    }
+    catch (IOException e) {
+      throw new ISE(e, "Failed to delete temporary directory[%s]", temporaryFolder);
+    }
+    derbyConnectorRule.after();
   }
 
   public TestLocalTaskActionClientFactory createActionClientFactory()
@@ -468,7 +475,8 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
         lockbox.add(task);
         taskStorage.insert(task, TaskStatus.running(task.getId()));
         taskActionClient = createActionClient(task);
-        taskReportsFile = temporaryFolder.newFile(
+        taskReportsFile = new File(
+            temporaryFolder,
             StringUtils.format("ingestionTestBase-%s.json", System.currentTimeMillis())
         );
 
@@ -591,13 +599,13 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
         continue;
       }
       nonTombstoneSegments++;
-      Assert.assertTrue(
+      Assertions.assertTrue(
           dataSegmentsWithSchemas.getSegmentSchemaMapping()
                                  .getSegmentIdToMetadataMap()
                                  .containsKey(segment.getId().toString())
       );
     }
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nonTombstoneSegments,
         dataSegmentsWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/IngestionTestBase.java
@@ -111,6 +111,9 @@ import java.util.stream.Collectors;
 
 public abstract class IngestionTestBase extends InitializedNullHandlingTest
 {
+  @org.junit.Rule
+  public final org.junit.rules.TemporaryFolder junit4TemporaryFolder = new org.junit.rules.TemporaryFolder();
+
   @TempDir
   public File temporaryFolder;
 
@@ -149,6 +152,9 @@ public abstract class IngestionTestBase extends InitializedNullHandlingTest
   @BeforeEach
   public void setUpIngestionTestBase() throws IOException
   {
+    if (temporaryFolder == null) {
+      temporaryFolder = junit4TemporaryFolder.getRoot();
+    }
     derbyConnectorRule.before();
     EmittingLogger.registerEmitter(new NoopServiceEmitter());
     baseDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "base");

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/InputRowFilterTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/InputRowFilterTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.data.input.InputRow;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.segment.incremental.InputRowFilterResult;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class InputRowFilterTest
     InputRowFilter filter = InputRowFilter.fromPredicate(row -> true);
     InputRow row = newRow(100);
 
-    Assert.assertEquals(InputRowFilterResult.ACCEPTED, filter.test(row));
+    Assertions.assertEquals(InputRowFilterResult.ACCEPTED, filter.test(row));
   }
 
   @Test
@@ -49,7 +49,7 @@ public class InputRowFilterTest
     InputRowFilter filter = InputRowFilter.fromPredicate(row -> false);
     InputRow row = newRow(100);
 
-    Assert.assertEquals(InputRowFilterResult.CUSTOM_FILTER, filter.test(row));
+    Assertions.assertEquals(InputRowFilterResult.CUSTOM_FILTER, filter.test(row));
   }
 
   @Test
@@ -60,7 +60,7 @@ public class InputRowFilterTest
     InputRowFilter combined = filter1.and(filter2);
 
     InputRow row = newRow(100);
-    Assert.assertEquals(InputRowFilterResult.ACCEPTED, combined.test(row));
+    Assertions.assertEquals(InputRowFilterResult.ACCEPTED, combined.test(row));
   }
 
   @Test
@@ -71,7 +71,7 @@ public class InputRowFilterTest
     InputRowFilter combined = filter1.and(filter2);
 
     InputRow row = newRow(100);
-    Assert.assertEquals(InputRowFilterResult.NULL_OR_EMPTY_RECORD, combined.test(row));
+    Assertions.assertEquals(InputRowFilterResult.NULL_OR_EMPTY_RECORD, combined.test(row));
   }
 
   @Test
@@ -82,7 +82,7 @@ public class InputRowFilterTest
     InputRowFilter combined = filter1.and(filter2);
 
     InputRow row = newRow(100);
-    Assert.assertEquals(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME, combined.test(row));
+    Assertions.assertEquals(InputRowFilterResult.BEFORE_MIN_MESSAGE_TIME, combined.test(row));
   }
 
   @Test
@@ -94,7 +94,7 @@ public class InputRowFilterTest
 
     InputRow row = newRow(100);
     // Should return reason from first filter
-    Assert.assertEquals(InputRowFilterResult.NULL_OR_EMPTY_RECORD, combined.test(row));
+    Assertions.assertEquals(InputRowFilterResult.NULL_OR_EMPTY_RECORD, combined.test(row));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class InputRowFilterTest
     InputRowFilter combined = filter1.and(filter2).and(filter3);
 
     InputRow row = newRow(100);
-    Assert.assertEquals(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME, combined.test(row));
+    Assertions.assertEquals(InputRowFilterResult.AFTER_MAX_MESSAGE_TIME, combined.test(row));
   }
 
   private static InputRow newRow(Object dim1Val)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/KillUnusedSegmentsTaskTest.java
@@ -23,8 +23,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.druid.error.DruidException;
-import org.apache.druid.error.DruidExceptionMatcher;
-import org.apache.druid.error.ExceptionMatcher;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.report.KillTaskReport;
 import org.apache.druid.indexer.report.TaskReport;
@@ -45,17 +43,15 @@ import org.apache.druid.server.coordination.BroadcastDatasourceLoadingSpec;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
-import org.assertj.core.api.Assertions;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +62,10 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ParameterizedClass(name = "useSegmentMetadataCache={0}")
+@MethodSource("testParameters")
 public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 {
   private static final String DATA_SOURCE = "wiki";
@@ -79,7 +78,6 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
   private DataSegment segment3;
   private DataSegment segment4;
 
-  @Parameterized.Parameters(name = "useSegmentMetadataCache={0}")
   public static Object[][] testParameters()
   {
     return new Object[][]{{true}, {false}};
@@ -90,7 +88,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     super(useSegmentMetadataCache);
   }
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     taskRunner = new TestTaskRunner();
@@ -127,14 +125,14 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
   {
     final Set<DataSegment> segments = ImmutableSet.of(segment1, segment2, segment3, segment4);
     final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments, null);
-    Assert.assertEquals(segments, announced);
+    Assertions.assertEquals(segments, announced);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         getMetadataStorageCoordinator().markSegmentAsUnused(
             segment2.getId()
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         getMetadataStorageCoordinator().markSegmentAsUnused(
             segment3.getId()
         )
@@ -145,7 +143,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(Intervals.of("2019-03-01/2019-04-01"))
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -156,8 +154,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
           null
         );
 
-    Assert.assertEquals(ImmutableList.of(segment2), observedUnusedSegments);
-    Assertions.assertThat(
+    Assertions.assertEquals(ImmutableList.of(segment2), observedUnusedSegments);
+    assertThat(
         getMetadataStorageCoordinator().retrieveUsedSegmentsForInterval(
             DATA_SOURCE,
             Intervals.of("2019/2020"),
@@ -165,11 +163,11 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         )
     ).containsExactlyInAnyOrder(segment1, segment4);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KillTaskReport.Stats(1, 1),
         getReportedStats()
     );
-    Assert.assertEquals(ImmutableSet.of(segment3), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(ImmutableSet.of(segment3), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -191,7 +189,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(Intervals.ETERNITY)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -202,13 +200,13 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(Collections.emptyList(), observedUnusedSegments);
+    Assertions.assertEquals(Collections.emptyList(), observedUnusedSegments);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KillTaskReport.Stats(2, 1),
         getReportedStats()
     );
-    Assert.assertEquals(ImmutableSet.of(segment1, segment2), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(ImmutableSet.of(segment1, segment2), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -230,7 +228,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(segment1.getInterval())
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -241,13 +239,13 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(Collections.singletonList(segment2), observedUnusedSegments);
+    Assertions.assertEquals(Collections.singletonList(segment2), observedUnusedSegments);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KillTaskReport.Stats(0, 1),
         getReportedStats()
     );
-    Assert.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -269,7 +267,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(Intervals.ETERNITY)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -279,8 +277,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null,
             null
         );
-    Assert.assertEquals(ImmutableList.of(), observedUnusedSegments);
-    Assertions.assertThat(
+    Assertions.assertEquals(ImmutableList.of(), observedUnusedSegments);
+    assertThat(
         getMetadataStorageCoordinator().retrieveUsedSegmentsForInterval(
             DATA_SOURCE,
             Intervals.ETERNITY,
@@ -288,11 +286,11 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         )
     ).containsExactlyInAnyOrder(segment1);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KillTaskReport.Stats(0, 1),
         getReportedStats()
     );
-    Assert.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -314,7 +312,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(Intervals.ETERNITY)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -324,8 +322,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null,
             null
         );
-    Assert.assertEquals(ImmutableList.of(), observedUnusedSegments);
-    Assertions.assertThat(
+    Assertions.assertEquals(ImmutableList.of(), observedUnusedSegments);
+    assertThat(
         getMetadataStorageCoordinator().retrieveUsedSegmentsForInterval(
             DATA_SOURCE,
             Intervals.ETERNITY,
@@ -333,11 +331,11 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         )
     ).containsExactlyInAnyOrder(segment3);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KillTaskReport.Stats(0, 1),
         getReportedStats()
     );
-    Assert.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(Collections.emptySet(), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -360,7 +358,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(Intervals.ETERNITY)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -370,13 +368,13 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null,
             null
         );
-    Assert.assertEquals(ImmutableList.of(), observedUnusedSegments);
+    Assertions.assertEquals(ImmutableList.of(), observedUnusedSegments);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new KillTaskReport.Stats(3, 1),
         getReportedStats()
     );
-    Assert.assertEquals(ImmutableSet.of(segment1, segment2, segment3), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(ImmutableSet.of(segment1, segment2, segment3), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -402,9 +400,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(Intervals.ETERNITY)
         .build();
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(Exception.class, () -> taskRunner.run(task).get()),
-        ExceptionMatcher.of(Exception.class).expectMessageContains(
+    final Exception exception = Assertions.assertThrows(Exception.class, () -> taskRunner.run(task).get());
+    Assertions.assertTrue(
+        exception.getMessage().contains(
             "Could not retrieve parent segment ids using task action[retrieveUpgradedFromSegmentIds]."
             + " Stopping kill task to avoid data loss in case the segment files are shared by other segments."
         )
@@ -419,8 +417,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null,
             null
         );
-    Assert.assertEquals(List.of(segment1, segment2, segment3), observedUnusedSegments);
-    Assert.assertEquals(Set.of(), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(List.of(segment1, segment2, segment3), observedUnusedSegments);
+    Assertions.assertEquals(Set.of(), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -446,9 +444,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .interval(Intervals.ETERNITY)
         .build();
 
-    MatcherAssert.assertThat(
-        Assert.assertThrows(Exception.class, () -> taskRunner.run(task).get()),
-        ExceptionMatcher.of(Exception.class).expectMessageContains(
+    final Exception exception = Assertions.assertThrows(Exception.class, () -> taskRunner.run(task).get());
+    Assertions.assertTrue(
+        exception.getMessage().contains(
             "Could not perform task action[retrieveUpgradedToSegmentIds] to retrieve"
             + " segment IDs which share load specs with segments being killed."
             + " Stopping kill task to avoid data loss in case the segment files are shared by other segments."
@@ -464,8 +462,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null,
             null
         );
-    Assert.assertEquals(List.of(segment1, segment2, segment3), observedUnusedSegments);
-    Assert.assertEquals(Set.of(), getDataSegmentKiller().getKilledSegments());
+    Assertions.assertEquals(List.of(segment1, segment2, segment3), observedUnusedSegments);
+    Assertions.assertEquals(Set.of(), getDataSegmentKiller().getKilledSegments());
   }
 
   @Test
@@ -484,8 +482,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     final Set<DataSegment> segments = ImmutableSet.of(segment1V1, segment2V1, segment3V1, segment4V2, segment5V3);
 
-    Assert.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
-    Assert.assertEquals(
+    Assertions.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
+    Assertions.assertEquals(
         segments.size(),
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -500,8 +498,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(3)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
-    Assert.assertEquals(
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(
         new KillTaskReport.Stats(4, 2),
         getReportedStats()
     );
@@ -514,7 +512,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
           null
         );
 
-    Assert.assertEquals(ImmutableSet.of(segment5V3), new HashSet<>(observedUnusedSegments));
+    Assertions.assertEquals(ImmutableSet.of(segment5V3), new HashSet<>(observedUnusedSegments));
   }
 
   @Test
@@ -533,8 +531,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     final Set<DataSegment> segments = ImmutableSet.of(segment1V1, segment2V1, segment3V1, segment4V2, segment5V3);
 
-    Assert.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
-    Assert.assertEquals(
+    Assertions.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
+    Assertions.assertEquals(
         segments.size(),
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -549,8 +547,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(3)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
-    Assert.assertEquals(
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(
         new KillTaskReport.Stats(0, 0),
         getReportedStats()
     );
@@ -563,7 +561,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(segments, new HashSet<>(observedUnusedSegments));
+    Assertions.assertEquals(segments, new HashSet<>(observedUnusedSegments));
   }
 
   @Test
@@ -582,8 +580,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     final Set<DataSegment> segments = ImmutableSet.of(segment1V1, segment2V1, segment3V1, segment4V2, segment5V3);
 
-    Assert.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
-    Assert.assertEquals(
+    Assertions.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
+    Assertions.assertEquals(
         segments.size(),
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -599,8 +597,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .limit(2)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
-    Assert.assertEquals(
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(
         new KillTaskReport.Stats(2, 1),
         getReportedStats()
     );
@@ -613,7 +611,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
           null
       );
 
-    Assert.assertEquals(ImmutableSet.of(segment3V1, segment4V2, segment5V3), new HashSet<>(observedUnusedSegments));
+    Assertions.assertEquals(ImmutableSet.of(segment3V1, segment4V2, segment5V3), new HashSet<>(observedUnusedSegments));
   }
 
   @Test
@@ -632,8 +630,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     final Set<DataSegment> segments = ImmutableSet.of(segment1V1, segment2V1, segment3V1, segment4V2, segment5V3);
 
-    Assert.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
-    Assert.assertEquals(
+    Assertions.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
+    Assertions.assertEquals(
         segments.size(),
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -649,8 +647,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .limit(2)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
-    Assert.assertEquals(
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(
         new KillTaskReport.Stats(0, 0),
         getReportedStats()
     );
@@ -663,7 +661,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
           null
       );
 
-    Assert.assertEquals(segments, new HashSet<>(observedUnusedSegments));
+    Assertions.assertEquals(segments, new HashSet<>(observedUnusedSegments));
   }
 
   /**
@@ -687,8 +685,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     final Set<DataSegment> segments = ImmutableSet.of(segment1V1, segment2V2, segment3V3);
     final Set<DataSegment> unusedSegments = ImmutableSet.of(segment1V1, segment2V2);
 
-    Assert.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
-    Assert.assertEquals(
+    Assertions.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
+    Assertions.assertEquals(
         unusedSegments.size(),
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -703,8 +701,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .limit(100)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
-    Assert.assertEquals(
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(
         new KillTaskReport.Stats(0, 1),
         getReportedStats()
     );
@@ -717,7 +715,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
           null
       );
 
-    Assert.assertEquals(ImmutableSet.of(), new HashSet<>(observedUnusedSegments));
+    Assertions.assertEquals(ImmutableSet.of(), new HashSet<>(observedUnusedSegments));
   }
 
   @Test
@@ -727,7 +725,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .dataSource(DATA_SOURCE)
         .interval(Intervals.of("2019-03-01/2019-04-01"))
         .build();
-    Assert.assertTrue(task.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(task.getInputSourceResources().isEmpty());
   }
 
   @Test
@@ -737,7 +735,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .dataSource(DATA_SOURCE)
         .interval(Intervals.of("2019-03-01/2019-04-01"))
         .build();
-    Assert.assertEquals(LookupLoadingSpec.Mode.NONE, task.getLookupLoadingSpec().getMode());
+    Assertions.assertEquals(LookupLoadingSpec.Mode.NONE, task.getLookupLoadingSpec().getMode());
   }
 
   @Test
@@ -747,7 +745,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .dataSource(DATA_SOURCE)
         .interval(Intervals.of("2019-03-01/2019-04-01"))
         .build();
-    Assert.assertEquals(BroadcastDatasourceLoadingSpec.Mode.NONE, task.getBroadcastDatasourceLoadingSpec().getMode());
+    Assertions.assertEquals(BroadcastDatasourceLoadingSpec.Mode.NONE, task.getBroadcastDatasourceLoadingSpec().getMode());
   }
 
   @Test
@@ -756,8 +754,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     final Set<DataSegment> segments = ImmutableSet.of(segment1, segment2, segment3, segment4);
     final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments, null);
 
-    Assert.assertEquals(segments, announced);
-    Assert.assertEquals(
+    Assertions.assertEquals(segments, announced);
+    Assertions.assertEquals(
         segments.size(),
         getMetadataStorageCoordinator().markSegmentsWithinIntervalAsUnused(
             DATA_SOURCE,
@@ -773,7 +771,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .limit(4)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     // we expect ALL tasks to be deleted
 
@@ -785,8 +783,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(Collections.emptyList(), observedUnusedSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(Collections.emptyList(), observedUnusedSegments);
+    Assertions.assertEquals(
         new KillTaskReport.Stats(4, 4),
         getReportedStats()
     );
@@ -803,9 +801,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     final Set<DataSegment> segments = ImmutableSet.of(segment1, segment2, segment3, segment4);
     final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments, null);
 
-    Assert.assertEquals(segments, announced);
+    Assertions.assertEquals(segments, announced);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         getMetadataStorageCoordinator().markSegmentsWithinIntervalAsUnused(
             DATA_SOURCE,
@@ -814,7 +812,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         getMetadataStorageCoordinator().markSegmentsWithinIntervalAsUnused(
             DATA_SOURCE,
@@ -823,7 +821,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         getMetadataStorageCoordinator().markSegmentsWithinIntervalAsUnused(
             DATA_SOURCE,
@@ -845,7 +843,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .limit(10)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -855,8 +853,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(ImmutableList.of(), observedUnusedSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableList.of(), observedUnusedSegments);
+    Assertions.assertEquals(
         new KillTaskReport.Stats(3, 3),
         getReportedStats()
     );
@@ -880,9 +878,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     final Set<DataSegment> segments = ImmutableSet.of(segment1, segment2, segment3, segment4);
     final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments, null);
 
-    Assert.assertEquals(segments, announced);
+    Assertions.assertEquals(segments, announced);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         getMetadataStorageCoordinator().markSegmentsWithinIntervalAsUnused(
             DATA_SOURCE,
@@ -891,7 +889,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         getMetadataStorageCoordinator().markSegmentsWithinIntervalAsUnused(
             DATA_SOURCE,
@@ -905,7 +903,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     derbyConnectorRule.segments().updateUsedStatusLastUpdated(segment4.getId().toString(), lastUpdatedTime1);
 
     // Now mark the third segment as unused
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         getMetadataStorageCoordinator().markSegmentsWithinIntervalAsUnused(
             DATA_SOURCE,
@@ -931,7 +929,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .maxUsedStatusLastUpdatedTime(lastUpdatedTime1)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task1).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task1).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -941,8 +939,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(ImmutableList.of(segment3), observedUnusedSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableList.of(segment3), observedUnusedSegments);
+    Assertions.assertEquals(
         new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
@@ -955,7 +953,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .maxUsedStatusLastUpdatedTime(lastUpdatedTime2)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task2).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task2).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments2 =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -965,8 +963,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(ImmutableList.of(), observedUnusedSegments2);
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableList.of(), observedUnusedSegments2);
+    Assertions.assertEquals(
         new KillTaskReport.Stats(1, 1),
         getReportedStats()
     );
@@ -991,9 +989,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     final Set<DataSegment> segments = ImmutableSet.of(segment1, segment2, segment3, segment4);
     final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments, null);
 
-    Assert.assertEquals(segments, announced);
+    Assertions.assertEquals(segments, announced);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -1005,7 +1003,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     derbyConnectorRule.segments().updateUsedStatusLastUpdated(segment1.getId().toString(), lastUpdatedTime1);
     derbyConnectorRule.segments().updateUsedStatusLastUpdated(segment4.getId().toString(), lastUpdatedTime1);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -1031,7 +1029,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .maxUsedStatusLastUpdatedTime(lastUpdatedTime1)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task1).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task1).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments1 =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -1041,8 +1039,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(ImmutableList.of(segment2, segment3), observedUnusedSegments1);
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableList.of(segment2, segment3), observedUnusedSegments1);
+    Assertions.assertEquals(
         new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
@@ -1055,7 +1053,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .maxUsedStatusLastUpdatedTime(lastUpdatedTime2)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task2).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task2).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments2 =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -1065,8 +1063,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(ImmutableList.of(), observedUnusedSegments2);
-    Assert.assertEquals(
+    Assertions.assertEquals(ImmutableList.of(), observedUnusedSegments2);
+    Assertions.assertEquals(
         new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
@@ -1083,9 +1081,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     final DataSegment segment5 = newSegment(Intervals.of("2019-04-01/2019-05-01"), version.minusHours(3).toString());
 
     final Set<DataSegment> segments = ImmutableSet.of(segment1, segment2, segment3, segment4, segment5);
-    Assert.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
+    Assertions.assertEquals(segments, getMetadataStorageCoordinator().commitSegments(segments, null));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         3,
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -1098,7 +1096,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     derbyConnectorRule.segments().updateUsedStatusLastUpdated(segment2.getId().toString(), lastUpdatedTime1);
     derbyConnectorRule.segments().updateUsedStatusLastUpdated(segment4.getId().toString(), lastUpdatedTime1);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         2,
         getMetadataStorageCoordinator().markSegmentsAsUnused(
             DATA_SOURCE,
@@ -1124,8 +1122,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .maxUsedStatusLastUpdatedTime(lastUpdatedTime1)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task1).get().getStatusCode());
-    Assert.assertEquals(
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task1).get().getStatusCode());
+    Assertions.assertEquals(
         new KillTaskReport.Stats(2, 2),
         getReportedStats()
     );
@@ -1138,7 +1136,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(ImmutableSet.of(segment3, segment4, segment5), new HashSet<>(observedUnusedSegments));
+    Assertions.assertEquals(ImmutableSet.of(segment3, segment4, segment5), new HashSet<>(observedUnusedSegments));
 
     final KillUnusedSegmentsTask task2 = new KillUnusedSegmentsTaskBuilder()
         .dataSource(DATA_SOURCE)
@@ -1149,8 +1147,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .maxUsedStatusLastUpdatedTime(lastUpdatedTime2)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task2).get().getStatusCode());
-    Assert.assertEquals(
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task2).get().getStatusCode());
+    Assertions.assertEquals(
         new KillTaskReport.Stats(1, 1),
         getReportedStats()
     );
@@ -1163,7 +1161,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
             null
         );
 
-    Assert.assertEquals(ImmutableSet.of(segment4, segment5), new HashSet<>(observedUnusedSegments2));
+    Assertions.assertEquals(ImmutableSet.of(segment4, segment5), new HashSet<>(observedUnusedSegments2));
   }
 
   @Test
@@ -1172,10 +1170,10 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     final Set<DataSegment> segments = ImmutableSet.of(segment1, segment2, segment3, segment4);
     final Set<DataSegment> announced = getMetadataStorageCoordinator().commitSegments(segments, null);
 
-    Assert.assertEquals(segments, announced);
+    Assertions.assertEquals(segments, announced);
 
     for (DataSegment segment : segments) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           getMetadataStorageCoordinator().markSegmentAsUnused(
               segment.getId()
           )
@@ -1188,7 +1186,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(3)
         .build();
 
-    Assert.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskRunner.run(task).get().getStatusCode());
 
     final List<DataSegment> observedUnusedSegments =
         getMetadataStorageCoordinator().retrieveUnusedSegmentsForInterval(
@@ -1198,8 +1196,8 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
           null
         );
 
-    Assert.assertEquals(Collections.emptyList(), observedUnusedSegments);
-    Assert.assertEquals(
+    Assertions.assertEquals(Collections.emptyList(), observedUnusedSegments);
+    Assertions.assertEquals(
         new KillTaskReport.Stats(4, 2),
         getReportedStats()
     );
@@ -1212,7 +1210,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .dataSource(DATA_SOURCE)
         .interval(Intervals.of("2018-01-01/2020-01-01"))
         .build();
-    Assert.assertEquals(100, task.computeNextBatchSize(50));
+    Assertions.assertEquals(100, task.computeNextBatchSize(50));
   }
 
   @Test
@@ -1224,7 +1222,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(10)
         .limit(5)
         .build();
-    Assert.assertEquals(5, task.computeNextBatchSize(0));
+    Assertions.assertEquals(5, task.computeNextBatchSize(0));
   }
 
   @Test
@@ -1236,7 +1234,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(5)
         .limit(10)
         .build();
-    Assert.assertEquals(5, task.computeNextBatchSize(0));
+    Assertions.assertEquals(5, task.computeNextBatchSize(0));
   }
 
   @Test
@@ -1248,7 +1246,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(5)
         .limit(10)
         .build();
-    Assert.assertEquals(3, task.computeNextBatchSize(7));
+    Assertions.assertEquals(3, task.computeNextBatchSize(7));
   }
 
   @Test
@@ -1258,7 +1256,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .dataSource(DATA_SOURCE)
         .interval(Intervals.of("2018-01-01/2020-01-01"))
         .build();
-    Assert.assertNull(task.getNumTotalBatches());
+    Assertions.assertNull(task.getNumTotalBatches());
   }
 
   @Test
@@ -1270,43 +1268,41 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(10)
         .limit(5)
         .build();
-    Assert.assertEquals(1, (int) task.getNumTotalBatches());
+    Assertions.assertEquals(1, (int) task.getNumTotalBatches());
   }
 
   @Test
   public void testInvalidLimit()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            DruidException.class,
-            () -> new KillUnusedSegmentsTaskBuilder()
-                .dataSource(DATA_SOURCE)
-                .interval(Intervals.of("2018-01-01/2020-01-01"))
-                .limit(0)
-                .build()
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "limit[0] must be a positive integer."
-        )
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () -> new KillUnusedSegmentsTaskBuilder()
+            .dataSource(DATA_SOURCE)
+            .interval(Intervals.of("2018-01-01/2020-01-01"))
+            .limit(0)
+            .build()
     );
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals("limit[0] must be a positive integer.", exception.getMessage());
   }
 
   @Test
   public void testInvalidBatchSize()
   {
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            DruidException.class,
-            () -> new KillUnusedSegmentsTaskBuilder()
-                .dataSource(DATA_SOURCE)
-                .interval(Intervals.of("2018-01-01/2020-01-01"))
-                .batchSize(0)
-                .build()
-        ),
-        DruidExceptionMatcher.invalidInput().expectMessageIs(
-            "batchSize[0] must be a positive integer."
-        )
+    final DruidException exception = Assertions.assertThrows(
+        DruidException.class,
+        () -> new KillUnusedSegmentsTaskBuilder()
+            .dataSource(DATA_SOURCE)
+            .interval(Intervals.of("2018-01-01/2020-01-01"))
+            .batchSize(0)
+            .build()
     );
+    Assertions.assertEquals(DruidException.Persona.USER, exception.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, exception.getCategory());
+    Assertions.assertEquals("invalidInput", exception.getErrorCode());
+    Assertions.assertEquals("batchSize[0] must be a positive integer.", exception.getMessage());
   }
 
   @Test
@@ -1319,7 +1315,7 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
         .batchSize(5)
         .limit(10)
         .build();
-    Assert.assertEquals(2, (int) task.getNumTotalBatches());
+    Assertions.assertEquals(2, (int) task.getNumTotalBatches());
   }
 
   @Test
@@ -1332,12 +1328,12 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
 
     String json = getObjectMapper().writeValueAsString(report);
     TaskReport deserializedReport = getObjectMapper().readValue(json, TaskReport.class);
-    Assert.assertTrue(deserializedReport instanceof KillTaskReport);
+    Assertions.assertTrue(deserializedReport instanceof KillTaskReport);
 
     KillTaskReport deserializedKillReport = (KillTaskReport) deserializedReport;
-    Assert.assertEquals(KillTaskReport.REPORT_KEY, deserializedKillReport.getReportKey());
-    Assert.assertEquals(taskId, deserializedKillReport.getTaskId());
-    Assert.assertEquals(stats, deserializedKillReport.getPayload());
+    Assertions.assertEquals(KillTaskReport.REPORT_KEY, deserializedKillReport.getReportKey());
+    Assertions.assertEquals(taskId, deserializedKillReport.getTaskId());
+    Assertions.assertEquals(stats, deserializedKillReport.getPayload());
   }
 
 
@@ -1365,9 +1361,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     );
     EasyMock.replay(taskActionClient);
 
-    Assert.assertTrue(task.isReady(taskActionClient));
+    Assertions.assertTrue(task.isReady(taskActionClient));
 
-    Assert.assertEquals(TaskLockType.EXCLUSIVE, acquireActionCapture.getValue().getType());
+    Assertions.assertEquals(TaskLockType.EXCLUSIVE, acquireActionCapture.getValue().getType());
   }
 
   @Test
@@ -1396,9 +1392,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
       );
     EasyMock.replay(taskActionClient);
 
-    Assert.assertTrue(task.isReady(taskActionClient));
+    Assertions.assertTrue(task.isReady(taskActionClient));
 
-    Assert.assertEquals(TaskLockType.REPLACE, acquireActionCapture.getValue().getType());
+    Assertions.assertEquals(TaskLockType.REPLACE, acquireActionCapture.getValue().getType());
   }
 
   @Test
@@ -1427,9 +1423,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
       );
     EasyMock.replay(taskActionClient);
 
-    Assert.assertTrue(task.isReady(taskActionClient));
+    Assertions.assertTrue(task.isReady(taskActionClient));
 
-    Assert.assertEquals(TaskLockType.APPEND, acquireActionCapture.getValue().getType());
+    Assertions.assertEquals(TaskLockType.APPEND, acquireActionCapture.getValue().getType());
   }
 
   @Test
@@ -1458,9 +1454,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
       );
     EasyMock.replay(taskActionClient);
 
-    Assert.assertTrue(task.isReady(taskActionClient));
+    Assertions.assertTrue(task.isReady(taskActionClient));
 
-    Assert.assertEquals(TaskLockType.REPLACE, acquireActionCapture.getValue().getType());
+    Assertions.assertEquals(TaskLockType.REPLACE, acquireActionCapture.getValue().getType());
   }
 
 
@@ -1479,9 +1475,9 @@ public class KillUnusedSegmentsTaskTest extends IngestionTestBase
     EasyMock.expect(taskActionClient.submit(EasyMock.capture(acquireActionCapture))).andReturn(null);
     EasyMock.replay(taskActionClient);
 
-    Assert.assertFalse(task.isReady(taskActionClient));
+    Assertions.assertFalse(task.isReady(taskActionClient));
 
-    Assert.assertEquals(TaskLockType.REPLACE, acquireActionCapture.getValue().getType());
+    Assertions.assertEquals(TaskLockType.REPLACE, acquireActionCapture.getValue().getType());
   }
 
   private static class KillUnusedSegmentsTaskBuilder

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/MoveTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/MoveTaskTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common.task;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class MoveTaskTest
 {
@@ -38,6 +38,6 @@ public class MoveTaskTest
         null
     );
 
-    Assert.assertTrue(task.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(task.getInputSourceResources().isEmpty());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RangePartitionCachingLocalSegmentAllocatorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RangePartitionCachingLocalSegmentAllocatorTest.java
@@ -41,11 +41,9 @@ import org.apache.druid.timeline.partition.DimensionRangeBucketShardSpec;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -90,10 +88,7 @@ public class RangePartitionCachingLocalSegmentAllocatorTest
   private SegmentAllocator target;
   private SequenceNameFunction sequenceNameFunction;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     TaskToolbox toolbox = createToolbox(
@@ -123,11 +118,14 @@ public class RangePartitionCachingLocalSegmentAllocatorTest
     Interval interval = INTERVAL_EMPTY;
     InputRow row = createInputRow(interval, PARTITION9);
 
-    exception.expect(IllegalStateException.class);
-    exception.expectMessage("Failed to get shardSpec");
-
-    String sequenceName = sequenceNameFunction.getSequenceName(interval, row);
-    allocate(row, sequenceName);
+    final IllegalStateException exception = Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> {
+          final String sequenceName = sequenceNameFunction.getSequenceName(interval, row);
+          allocate(row, sequenceName);
+        }
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Failed to get shardSpec"));
   }
 
   @Test
@@ -164,7 +162,7 @@ public class RangePartitionCachingLocalSegmentAllocatorTest
     InputRow row = createInputRow(interval, PARTITION9);
     String sequenceName = sequenceNameFunction.getSequenceName(interval, row);
     String expectedSequenceName = StringUtils.format("%s_%s_%d", TASKID, interval, 1);
-    Assert.assertEquals(expectedSequenceName, sequenceName);
+    Assertions.assertEquals(expectedSequenceName, sequenceName);
   }
 
   @SuppressWarnings("SameParameterValue")
@@ -206,15 +204,15 @@ public class RangePartitionCachingLocalSegmentAllocatorTest
     String sequenceName = sequenceNameFunction.getSequenceName(interval, row);
     SegmentIdWithShardSpec segmentIdWithShardSpec = allocate(row, sequenceName);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SegmentId.of(DATASOURCE, interval, INTERVAL_TO_VERSION.get(interval), bucketId),
         segmentIdWithShardSpec.asSegmentId()
     );
     DimensionRangeBucketShardSpec shardSpec = (DimensionRangeBucketShardSpec) segmentIdWithShardSpec.getShardSpec();
-    Assert.assertEquals(PARTITION_DIMENSIONS, shardSpec.getDimensions());
-    Assert.assertEquals(bucketId, shardSpec.getBucketId());
-    Assert.assertEquals(partitionStart, shardSpec.getStart());
-    Assert.assertEquals(partitionEnd, shardSpec.getEnd());
+    Assertions.assertEquals(PARTITION_DIMENSIONS, shardSpec.getDimensions());
+    Assertions.assertEquals(bucketId, shardSpec.getBucketId());
+    Assertions.assertEquals(partitionStart, shardSpec.getStart());
+    Assertions.assertEquals(partitionEnd, shardSpec.getEnd());
   }
 
   private SegmentIdWithShardSpec allocate(InputRow row, String sequenceName)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RestoreTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/RestoreTaskTest.java
@@ -20,8 +20,8 @@
 package org.apache.druid.indexing.common.task;
 
 import org.apache.druid.java.util.common.Intervals;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RestoreTaskTest
 {
@@ -35,6 +35,6 @@ public class RestoreTaskTest
         null
     );
 
-    Assert.assertTrue(task.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(task.getInputSourceResources().isEmpty());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ShardSpecsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ShardSpecsTest.java
@@ -84,7 +84,7 @@ public class ShardSpecsTest extends IngestionTestBase
     ShardSpec spec4 = shardSpecs.getShardSpec(Intervals.of("2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z"), row2);
     ShardSpec spec5 = shardSpecs.getShardSpec(Intervals.of("2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z"), row3);
 
-    Assertions.assertSame(true, spec3 == spec4);
-    Assertions.assertSame(false, spec3 == spec5);
+    Assertions.assertSame(spec3, spec4);
+    Assertions.assertNotSame(spec3, spec5);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ShardSpecsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/ShardSpecsTest.java
@@ -34,8 +34,8 @@ import org.apache.druid.timeline.partition.HashBucketShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;
 import org.apache.druid.timeline.partition.ShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +84,7 @@ public class ShardSpecsTest extends IngestionTestBase
     ShardSpec spec4 = shardSpecs.getShardSpec(Intervals.of("2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z"), row2);
     ShardSpec spec5 = shardSpecs.getShardSpec(Intervals.of("2014-01-01T00:00:00.000Z/2014-01-02T00:00:00.000Z"), row3);
 
-    Assert.assertSame(true, spec3 == spec4);
-    Assert.assertSame(false, spec3 == spec5);
+    Assertions.assertSame(true, spec3 == spec4);
+    Assertions.assertSame(false, spec3 == spec5);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractMultiPhaseParallelIndexingTest.java
@@ -59,7 +59,7 @@ import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.segment.loading.TombstoneLoadSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -156,7 +156,7 @@ abstract class AbstractMultiPhaseParallelIndexingTest extends AbstractParallelIn
   {
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
     TaskStatus taskStatus = getIndexingServiceClient().runAndWait(task);
-    Assert.assertEquals("Actual task status: " + taskStatus, expectedTaskStatus, taskStatus.getStatusCode());
+    Assertions.assertEquals(expectedTaskStatus, taskStatus.getStatusCode(), "Actual task status: " + taskStatus);
   }
 
   DataSegmentsWithSchemas runTask(Task task, TaskState expectedTaskStatus)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -113,6 +113,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -165,7 +166,8 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
 
   private static final Logger LOG = new Logger(AbstractParallelIndexSupervisorTaskTest.class);
 
-  protected final File parallelTemporaryFolder = FileUtils.createTempDir();
+  @TempDir
+  protected File parallelTemporaryFolder;
 
   protected final File createTempDir()
   {
@@ -175,16 +177,6 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
   protected final File createTempDir(final String prefix)
   {
     return FileUtils.createTempDirInLocation(parallelTemporaryFolder.toPath(), prefix);
-  }
-
-  protected final void deleteTempDir()
-  {
-    try {
-      FileUtils.deleteDirectory(parallelTemporaryFolder);
-    }
-    catch (IOException e) {
-      throw new ISE(e, "Failed to delete temporary directory[%s]", parallelTemporaryFolder);
-    }
   }
 
   /**
@@ -260,7 +252,6 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
   {
     remoteApiExecutor.shutdownNow();
     taskRunner.shutdown();
-    deleteTempDir();
   }
 
   protected ParallelIndexTuningConfig newTuningConfig(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -165,25 +165,25 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
 
   private static final Logger LOG = new Logger(AbstractParallelIndexSupervisorTaskTest.class);
 
-  protected final File temporaryFolder = FileUtils.createTempDir();
+  protected final File parallelTemporaryFolder = FileUtils.createTempDir();
 
   protected final File createTempDir()
   {
-    return FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null);
+    return FileUtils.createTempDirInLocation(parallelTemporaryFolder.toPath(), null);
   }
 
   protected final File createTempDir(final String prefix)
   {
-    return FileUtils.createTempDirInLocation(temporaryFolder.toPath(), prefix);
+    return FileUtils.createTempDirInLocation(parallelTemporaryFolder.toPath(), prefix);
   }
 
   protected final void deleteTempDir()
   {
     try {
-      FileUtils.deleteDirectory(temporaryFolder);
+      FileUtils.deleteDirectory(parallelTemporaryFolder);
     }
     catch (IOException e) {
-      throw new ISE(e, "Failed to delete temporary directory[%s]", temporaryFolder);
+      throw new ISE(e, "Failed to delete temporary directory[%s]", parallelTemporaryFolder);
     }
   }
 
@@ -234,7 +234,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
   @BeforeEach
   public void setUpAbstractParallelIndexSupervisorTaskTest(TestInfo testInfo) throws IOException
   {
-    localDeepStorage = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "localStorage");
+    localDeepStorage = FileUtils.createTempDirInLocation(parallelTemporaryFolder.toPath(), "localStorage");
     taskRunner = new SimpleThreadingTaskRunner(testInfo.getTestMethod().orElseThrow().getName());
     objectMapper = getObjectMapper();
     indexingServiceClient = new LocalOverlordClient(objectMapper, taskRunner);
@@ -242,7 +242,7 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         .setShuffleDataLocations(
             ImmutableList.of(
                 new StorageLocationConfig(
-                    FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "shuffle"),
+                    FileUtils.createTempDirInLocation(parallelTemporaryFolder.toPath(), "shuffle"),
                     null,
                     null
                 )
@@ -698,10 +698,10 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         .dataSegmentKiller(new NoopDataSegmentKiller())
         .joinableFactory(NoopJoinableFactory.INSTANCE)
         .segmentCacheManager(
-            newSegmentLoader(FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "segmentCache"))
+            newSegmentLoader(FileUtils.createTempDirInLocation(parallelTemporaryFolder.toPath(), "segmentCache"))
         )
         .jsonMapper(objectMapper)
-        .taskWorkDir(FileUtils.createTempDirInLocation(temporaryFolder.toPath(), task.getId()))
+        .taskWorkDir(FileUtils.createTempDirInLocation(parallelTemporaryFolder.toPath(), task.getId()))
         .indexIO(getIndexIO())
         .indexMerger(getIndexMergerV9Factory().create(task.getContextValue(Tasks.STORE_EMPTY_COLUMNS_KEY, true)))
         .intermediaryDataManager(intermediaryDataManager)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/AbstractParallelIndexSupervisorTaskTest.java
@@ -109,12 +109,10 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -167,11 +165,27 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
 
   private static final Logger LOG = new Logger(AbstractParallelIndexSupervisorTaskTest.class);
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  protected final File temporaryFolder = FileUtils.createTempDir();
 
-  @Rule
-  public final TestName testName = new TestName();
+  protected final File createTempDir()
+  {
+    return FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null);
+  }
+
+  protected final File createTempDir(final String prefix)
+  {
+    return FileUtils.createTempDirInLocation(temporaryFolder.toPath(), prefix);
+  }
+
+  protected final void deleteTempDir()
+  {
+    try {
+      FileUtils.deleteDirectory(temporaryFolder);
+    }
+    catch (IOException e) {
+      throw new ISE(e, "Failed to delete temporary directory[%s]", temporaryFolder);
+    }
+  }
 
   /**
    * Transient task failure rate emulated by the taskKiller in {@link SimpleThreadingTaskRunner}.
@@ -217,15 +231,23 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     this.transientApiCallFailureRate = transientApiCallFailureRate;
   }
 
-  @Before
-  public void setUpAbstractParallelIndexSupervisorTaskTest() throws IOException
+  @BeforeEach
+  public void setUpAbstractParallelIndexSupervisorTaskTest(TestInfo testInfo) throws IOException
   {
-    localDeepStorage = temporaryFolder.newFolder("localStorage");
-    taskRunner = new SimpleThreadingTaskRunner(testName.getMethodName());
+    localDeepStorage = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "localStorage");
+    taskRunner = new SimpleThreadingTaskRunner(testInfo.getTestMethod().orElseThrow().getName());
     objectMapper = getObjectMapper();
     indexingServiceClient = new LocalOverlordClient(objectMapper, taskRunner);
     final TaskConfig taskConfig = new TaskConfigBuilder()
-        .setShuffleDataLocations(ImmutableList.of(new StorageLocationConfig(temporaryFolder.newFolder(), null, null)))
+        .setShuffleDataLocations(
+            ImmutableList.of(
+                new StorageLocationConfig(
+                    FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "shuffle"),
+                    null,
+                    null
+                )
+            )
+        )
         .build();
     intermediaryDataManager = new LocalIntermediaryDataManager(new WorkerConfig(), taskConfig, null);
     remoteApiExecutor = Execs.singleThreaded("coordinator-api-executor");
@@ -233,12 +255,12 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     prepareObjectMapper(objectMapper, getIndexIO());
   }
 
-  @After
+  @AfterEach
   public void tearDownAbstractParallelIndexSupervisorTaskTest()
   {
     remoteApiExecutor.shutdownNow();
     taskRunner.shutdown();
-    temporaryFolder.delete();
+    deleteTempDir();
   }
 
   protected ParallelIndexTuningConfig newTuningConfig(
@@ -675,9 +697,11 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         )
         .dataSegmentKiller(new NoopDataSegmentKiller())
         .joinableFactory(NoopJoinableFactory.INSTANCE)
-        .segmentCacheManager(newSegmentLoader(temporaryFolder.newFolder()))
+        .segmentCacheManager(
+            newSegmentLoader(FileUtils.createTempDirInLocation(temporaryFolder.toPath(), "segmentCache"))
+        )
         .jsonMapper(objectMapper)
-        .taskWorkDir(temporaryFolder.newFolder(task.getId()))
+        .taskWorkDir(FileUtils.createTempDirInLocation(temporaryFolder.toPath(), task.getId()))
         .indexIO(getIndexIO())
         .indexMerger(getIndexMergerV9Factory().create(task.getContextValue(Tasks.STORE_EMPTY_COLUMNS_KEY, true)))
         .intermediaryDataManager(intermediaryDataManager)
@@ -827,22 +851,22 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
     final java.util.Optional<IngestionStatsAndErrorsTaskReport> actualReportOptional
         = actualReports.findReport("ingestionStatsAndErrors");
 
-    Assert.assertTrue(expectedReportOptional.isPresent());
-    Assert.assertTrue(actualReportOptional.isPresent());
+    Assertions.assertTrue(expectedReportOptional.isPresent());
+    Assertions.assertTrue(actualReportOptional.isPresent());
 
     final IngestionStatsAndErrorsTaskReport expectedReport = expectedReportOptional.get();
     final IngestionStatsAndErrorsTaskReport actualReport = actualReportOptional.get();
 
-    Assert.assertEquals(expectedReport.getTaskId(), actualReport.getTaskId());
-    Assert.assertEquals(expectedReport.getReportKey(), actualReport.getReportKey());
+    Assertions.assertEquals(expectedReport.getTaskId(), actualReport.getTaskId());
+    Assertions.assertEquals(expectedReport.getReportKey(), actualReport.getReportKey());
 
     final IngestionStatsAndErrors expectedPayload = expectedReport.getPayload();
     final IngestionStatsAndErrors actualPayload = actualReport.getPayload();
-    Assert.assertEquals(expectedPayload.getIngestionState(), actualPayload.getIngestionState());
+    Assertions.assertEquals(expectedPayload.getIngestionState(), actualPayload.getIngestionState());
 
     Map<String, Object> expectedTotals = expectedPayload.getRowStats();
     Map<String, Object> actualTotals = actualPayload.getRowStats();
-    Assert.assertEquals(expectedTotals, actualTotals);
+    Assertions.assertEquals(expectedTotals, actualTotals);
 
     List<ParseExceptionReport> expectedParseExceptionReports =
         (List<ParseExceptionReport>) (expectedPayload.getUnparseableEvents()).get("buildSegments");
@@ -854,13 +878,13 @@ public class AbstractParallelIndexSupervisorTaskTest extends IngestionTestBase
         .stream().map(r -> r.getDetails().get(0)).collect(Collectors.toList());
     List<String> actualMessages = actualParseExceptionReports
         .stream().map(r -> r.getDetails().get(0)).collect(Collectors.toList());
-    Assert.assertEquals(expectedMessages, actualMessages);
+    Assertions.assertEquals(expectedMessages, actualMessages);
 
     List<String> expectedInputs = expectedParseExceptionReports
         .stream().map(ParseExceptionReport::getInput).collect(Collectors.toList());
     List<String> actualInputs = actualParseExceptionReports
         .stream().map(ParseExceptionReport::getInput).collect(Collectors.toList());
-    Assert.assertEquals(expectedInputs, actualInputs);
+    Assertions.assertEquals(expectedInputs, actualInputs);
   }
 
   static class LocalParallelIndexTaskClientProvider implements ParallelIndexSupervisorTaskClientProvider

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStoragePartitionLocationTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStoragePartitionLocationTest.java
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeepStoragePartitionLocationTest
 {
@@ -33,7 +33,7 @@ public class DeepStoragePartitionLocationTest
 
   private DeepStoragePartitionLocation target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new DeepStoragePartitionLocation(
@@ -53,7 +53,7 @@ public class DeepStoragePartitionLocationTest
   @Test
   public void hasPartitionIdThatMatchesShardSpec()
   {
-    Assert.assertEquals(ParallelIndexTestingFactory.PARTITION_ID, target.getBucketId());
+    Assertions.assertEquals(ParallelIndexTestingFactory.PARTITION_ID, target.getBucketId());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStoragePartitionStatTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStoragePartitionStatTest.java
@@ -25,9 +25,9 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.timeline.partition.HashBucketShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -37,7 +37,7 @@ public class DeepStoragePartitionStatTest
 
   private DeepStoragePartitionStat target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new DeepStoragePartitionStat(
@@ -62,7 +62,7 @@ public class DeepStoragePartitionStatTest
   @Test
   public void hasPartitionIdThatMatchesSecondaryPartition()
   {
-    Assert.assertEquals(target.getSecondaryPartition().getBucketId(), target.getBucketId());
+    Assertions.assertEquals(target.getSecondaryPartition().getBucketId(), target.getBucketId());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStorageShuffleClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStorageShuffleClientTest.java
@@ -29,16 +29,16 @@ import org.apache.druid.guice.GuiceAnnotationIntrospector;
 import org.apache.druid.guice.GuiceInjectableValues;
 import org.apache.druid.guice.GuiceInjectors;
 import org.apache.druid.jackson.DefaultObjectMapper;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.LocalDataSegmentPuller;
 import org.apache.druid.segment.loading.LocalLoadSpec;
 import org.apache.druid.utils.CompressionUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,11 +53,10 @@ public class DeepStorageShuffleClientTest
   private File segmentFile;
   private String segmentFileName;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private final File temporaryFolder = FileUtils.createTempDir();
 
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     final Injector injector = GuiceInjectors.makeStartupInjectorWithModules(
@@ -76,7 +75,7 @@ public class DeepStorageShuffleClientTest
     );
     deepStorageShuffleClient = new DeepStorageShuffleClient(mapper);
 
-    File temp = temporaryFolder.newFile();
+    final File temp = File.createTempFile("junit", null, temporaryFolder);
     segmentFileName = temp.getName();
     try (Writer writer = Files.newBufferedWriter(temp.toPath(), StandardCharsets.UTF_8)) {
       for (int j = 0; j < 10; j++) {
@@ -87,12 +86,18 @@ public class DeepStorageShuffleClientTest
     CompressionUtils.zip(segmentFile.getParentFile(), segmentFile);
   }
 
+  @AfterEach
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(temporaryFolder);
+  }
+
   @Test
   public void fetchSegmentFile() throws IOException
   {
-    File partitionDir = temporaryFolder.newFolder();
-    String subTaskId = "subTask";
-    File unzippedDir = deepStorageShuffleClient.fetchSegmentFile(
+    final File partitionDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null);
+    final String subTaskId = "subTask";
+    final File unzippedDir = deepStorageShuffleClient.fetchSegmentFile(
         partitionDir,
         "testSupervisor",
         new DeepStoragePartitionLocation(
@@ -102,12 +107,12 @@ public class DeepStorageShuffleClientTest
             ImmutableMap.of("type", "local", "path", segmentFile.getAbsolutePath())
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         StringUtils.format("%s/unzipped_%s", partitionDir.getAbsolutePath(), subTaskId),
         unzippedDir.getAbsolutePath()
     );
     File fetchedSegmentFile = unzippedDir.listFiles((dir, name) -> name.endsWith(".tmp"))[0];
-    Assert.assertEquals(segmentFileName, fetchedSegmentFile.getName());
-    Assert.assertTrue(fetchedSegmentFile.length() > 0);
+    Assertions.assertEquals(segmentFileName, fetchedSegmentFile.getName());
+    Assertions.assertTrue(fetchedSegmentFile.length() > 0);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStorageShuffleClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DeepStorageShuffleClientTest.java
@@ -35,10 +35,10 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.loading.LocalDataSegmentPuller;
 import org.apache.druid.segment.loading.LocalLoadSpec;
 import org.apache.druid.utils.CompressionUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,7 +53,8 @@ public class DeepStorageShuffleClientTest
   private File segmentFile;
   private String segmentFileName;
 
-  private final File temporaryFolder = FileUtils.createTempDir();
+  @TempDir
+  private File temporaryFolder;
 
 
   @BeforeEach
@@ -84,12 +85,6 @@ public class DeepStorageShuffleClientTest
     }
     segmentFile = new File(temp.getAbsolutePath() + ".zip");
     CompressionUtils.zip(segmentFile.getParentFile(), segmentFile);
-  }
-
-  @AfterEach
-  public void tearDown() throws IOException
-  {
-    FileUtils.deleteDirectory(temporaryFolder);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionCardinalityReportTest.java
@@ -32,10 +32,10 @@ import org.apache.druid.testing.junit.LoggerCaptureRule;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LogEvent;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
@@ -51,18 +51,24 @@ public class DimensionCardinalityReportTest
 
   private DimensionCardinalityReport target;
 
-  @Rule
-  public final LoggerCaptureRule logger = new LoggerCaptureRule(ParallelIndexSupervisorTask.class);
+  private final LoggerCaptureRule logger = new LoggerCaptureRule(ParallelIndexSupervisorTask.class);
 
 
-  @Before
+  @BeforeEach
   public void setup()
   {
+    logger.before();
     Interval interval = Intervals.ETERNITY;
     HyperLogLogCollector collector = HyperLogLogCollector.makeLatestCollector();
     Map<Interval, byte[]> intervalToCardinality = Collections.singletonMap(interval, collector.toByteArray());
     String taskId = "abc";
     target = new DimensionCardinalityReport(taskId, intervalToCardinality);
+  }
+
+  @AfterEach
+  public void tearDown()
+  {
+    logger.after();
   }
 
   @Test
@@ -125,7 +131,7 @@ public class DimensionCardinalityReportTest
         reports,
         1
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             4,
@@ -139,7 +145,7 @@ public class DimensionCardinalityReportTest
         reports,
         2
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             2,
@@ -153,7 +159,7 @@ public class DimensionCardinalityReportTest
         reports,
         3
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             1,
@@ -167,7 +173,7 @@ public class DimensionCardinalityReportTest
         reports,
         4
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             1,
@@ -181,7 +187,7 @@ public class DimensionCardinalityReportTest
         reports,
         5
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             1,
@@ -239,7 +245,7 @@ public class DimensionCardinalityReportTest
         reports,
         1
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             4,
@@ -253,7 +259,7 @@ public class DimensionCardinalityReportTest
         reports,
         2
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             2,
@@ -267,7 +273,7 @@ public class DimensionCardinalityReportTest
         reports,
         3
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             1,
@@ -281,7 +287,7 @@ public class DimensionCardinalityReportTest
         reports,
         4
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             1,
@@ -295,7 +301,7 @@ public class DimensionCardinalityReportTest
         reports,
         5
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of(
             Intervals.of("1970-01-01/P1D"),
             1,
@@ -317,20 +323,20 @@ public class DimensionCardinalityReportTest
     Map<Interval, Union> intervalToUnion = ImmutableMap.of(interval, negativeUnion);
     Map<Interval, Integer> intervalToNumShards =
         ParallelIndexSupervisorTask.computeIntervalToNumShards(10, intervalToUnion);
-    Assert.assertEquals(Integer.valueOf(7), intervalToNumShards.get(interval));
+    Assertions.assertEquals(Integer.valueOf(7), intervalToNumShards.get(interval));
 
     List<LogEvent> loggingEvents = logger.getLogEvents();
     String expectedLogMessage =
         "Estimated cardinality for union of estimates is zero or less: -1.00, setting num shards to 7";
-    Assert.assertTrue(
-        "Logging events: " + loggingEvents,
+    Assertions.assertTrue(
         loggingEvents.stream()
                      .anyMatch(l ->
                                    l.getLevel().equals(Level.WARN)
                                    && l.getMessage()
                                        .getFormattedMessage()
                                        .equals(expectedLogMessage)
-                     )
+                     ),
+        "Logging events: " + loggingEvents
     );
   }
 
@@ -343,7 +349,7 @@ public class DimensionCardinalityReportTest
     Map<Interval, Union> intervalToUnion = ImmutableMap.of(interval, union);
     Map<Interval, Integer> intervalToNumShards =
         ParallelIndexSupervisorTask.computeIntervalToNumShards(6, intervalToUnion);
-    Assert.assertEquals(Integer.valueOf(4), intervalToNumShards.get(interval));
+    Assertions.assertEquals(Integer.valueOf(4), intervalToNumShards.get(interval));
   }
 
   @Test
@@ -356,20 +362,20 @@ public class DimensionCardinalityReportTest
     Map<Interval, Union> intervalToUnion = ImmutableMap.of(interval, union);
     Map<Interval, Integer> intervalToNumShards =
         ParallelIndexSupervisorTask.computeIntervalToNumShards(24, intervalToUnion);
-    Assert.assertEquals(Integer.valueOf(1), intervalToNumShards.get(interval));
+    Assertions.assertEquals(Integer.valueOf(1), intervalToNumShards.get(interval));
 
     List<LogEvent> loggingEvents = logger.getLogEvents();
     String expectedLogMessage =
         "estimatedNumShards is ONE (1) given estimated cardinality 24.00 and maxRowsPerSegment 24";
-    Assert.assertTrue(
-        "Logging events: " + loggingEvents,
+    Assertions.assertTrue(
         loggingEvents.stream()
                      .anyMatch(l ->
                                    l.getLevel().equals(Level.INFO)
                                    && l.getMessage()
                                        .getFormattedMessage()
                                        .equals(expectedLogMessage)
-                     )
+                     ),
+        "Logging events: " + loggingEvents
     );
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionDistributionReportTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/DimensionDistributionReportTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringS
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.TestHelper;
 import org.joda.time.Interval;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Map;
@@ -38,7 +38,7 @@ public class DimensionDistributionReportTest
 
   private DimensionDistributionReport target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     Interval interval = Intervals.ETERNITY;

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/GenericPartitionLocationTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/GenericPartitionLocationTest.java
@@ -22,9 +22,9 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GenericPartitionLocationTest
 {
@@ -32,7 +32,7 @@ public class GenericPartitionLocationTest
 
   private GenericPartitionLocation target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new GenericPartitionLocation(
@@ -54,7 +54,7 @@ public class GenericPartitionLocationTest
   @Test
   public void hasPartitionIdThatMatchesShardSpec()
   {
-    Assert.assertEquals(ParallelIndexTestingFactory.PARTITION_ID, target.getBucketId());
+    Assertions.assertEquals(ParallelIndexTestingFactory.PARTITION_ID, target.getBucketId());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/GenericPartitionStatTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/GenericPartitionStatTest.java
@@ -24,9 +24,9 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.timeline.partition.HashBucketShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -36,7 +36,7 @@ public class GenericPartitionStatTest
 
   private GenericPartitionStat target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new GenericPartitionStat(
@@ -65,7 +65,7 @@ public class GenericPartitionStatTest
   @Test
   public void hasPartitionIdThatMatchesSecondaryPartition()
   {
-    Assert.assertEquals(target.getSecondaryPartition().getBucketId(), target.getBucketId());
+    Assertions.assertEquals(target.getSecondaryPartition().getBucketId(), target.getBucketId());
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionAdjustingCorePartitionSizeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionAdjustingCorePartitionSizeTest.java
@@ -33,10 +33,10 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.HashBasedNumberedShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +49,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}, maxNumConcurrentSubTasks={1}")
+@MethodSource("constructorFeeder")
 public class HashPartitionAdjustingCorePartitionSizeTest extends AbstractMultiPhaseParallelIndexingTest
 {
   private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec("ts", "auto", null);
@@ -66,7 +67,6 @@ public class HashPartitionAdjustingCorePartitionSizeTest extends AbstractMultiPh
   );
   private static final Interval INTERVAL_TO_INDEX = Intervals.of("2020-01-01/P1M");
 
-  @Parameterized.Parameters(name = "{0}, maxNumConcurrentSubTasks={1}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -87,7 +87,7 @@ public class HashPartitionAdjustingCorePartitionSizeTest extends AbstractMultiPh
   @Test
   public void testLessPartitionsThanBuckets() throws IOException
   {
-    final File inputDir = temporaryFolder.newFolder();
+    final File inputDir = createTempDir();
     for (int i = 0; i < 3; i++) {
       try (final Writer writer =
                Files.newBufferedWriter(new File(inputDir, "test_" + i).toPath(), StandardCharsets.UTF_8)) {
@@ -112,16 +112,16 @@ public class HashPartitionAdjustingCorePartitionSizeTest extends AbstractMultiPh
             TaskState.SUCCESS
         ).getSegments()
     );
-    Assert.assertEquals(3, segments.size());
+    Assertions.assertEquals(3, segments.size());
     segments.sort(Comparator.comparing(segment -> segment.getShardSpec().getPartitionNum()));
     int prevPartitionId = -1;
     for (DataSegment segment : segments) {
-      Assert.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
       final HashBasedNumberedShardSpec shardSpec = (HashBasedNumberedShardSpec) segment.getShardSpec();
-      Assert.assertEquals(3, shardSpec.getNumCorePartitions());
-      Assert.assertEquals(10, shardSpec.getNumBuckets());
-      Assert.assertEquals(ImmutableList.of("dim1"), shardSpec.getPartitionDimensions());
-      Assert.assertEquals(prevPartitionId + 1, shardSpec.getPartitionNum());
+      Assertions.assertEquals(3, shardSpec.getNumCorePartitions());
+      Assertions.assertEquals(10, shardSpec.getNumBuckets());
+      Assertions.assertEquals(ImmutableList.of("dim1"), shardSpec.getPartitionDimensions());
+      Assertions.assertEquals(prevPartitionId + 1, shardSpec.getPartitionNum());
       prevPartitionId = shardSpec.getPartitionNum();
     }
   }
@@ -129,7 +129,7 @@ public class HashPartitionAdjustingCorePartitionSizeTest extends AbstractMultiPh
   @Test
   public void testEqualNumberOfPartitionsToBuckets() throws IOException
   {
-    final File inputDir = temporaryFolder.newFolder();
+    final File inputDir = createTempDir();
     for (int i = 0; i < 10; i++) {
       try (final Writer writer =
                Files.newBufferedWriter(new File(inputDir, "test_" + i).toPath(), StandardCharsets.UTF_8)) {
@@ -152,13 +152,13 @@ public class HashPartitionAdjustingCorePartitionSizeTest extends AbstractMultiPh
         maxNumConcurrentSubTasks,
         TaskState.SUCCESS
     ).getSegments();
-    Assert.assertEquals(5, segments.size());
+    Assertions.assertEquals(5, segments.size());
     segments.forEach(segment -> {
-      Assert.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
       final HashBasedNumberedShardSpec shardSpec = (HashBasedNumberedShardSpec) segment.getShardSpec();
-      Assert.assertEquals(5, shardSpec.getNumCorePartitions());
-      Assert.assertEquals(5, shardSpec.getNumBuckets());
-      Assert.assertEquals(ImmutableList.of("dim1"), shardSpec.getPartitionDimensions());
+      Assertions.assertEquals(5, shardSpec.getNumCorePartitions());
+      Assertions.assertEquals(5, shardSpec.getNumBuckets());
+      Assertions.assertEquals(ImmutableList.of("dim1"), shardSpec.getPartitionDimensions());
     });
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionCachingLocalSegmentAllocatorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionCachingLocalSegmentAllocatorTest.java
@@ -44,9 +44,9 @@ import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.HashBucketShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -74,7 +74,7 @@ public class HashPartitionCachingLocalSegmentAllocatorTest
   private SegmentAllocator target;
   private SequenceNameFunction sequenceNameFunction;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     TaskToolbox toolbox = createToolbox();
@@ -99,14 +99,14 @@ public class HashPartitionCachingLocalSegmentAllocatorTest
     String sequenceName = sequenceNameFunction.getSequenceName(INTERVAL, row);
     SegmentIdWithShardSpec segmentIdWithShardSpec = target.allocate(row, sequenceName, null, false);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         SegmentId.of(DATASOURCE, INTERVAL, VERSION, PARTITION_NUM),
         segmentIdWithShardSpec.asSegmentId()
     );
     HashBucketShardSpec shardSpec = (HashBucketShardSpec) segmentIdWithShardSpec.getShardSpec();
-    Assert.assertEquals(PARTITION_DIMENSIONS, shardSpec.getPartitionDimensions());
-    Assert.assertEquals(NUM_PARTITONS, shardSpec.getNumBuckets());
-    Assert.assertEquals(PARTITION_NUM, shardSpec.getBucketId());
+    Assertions.assertEquals(PARTITION_DIMENSIONS, shardSpec.getPartitionDimensions());
+    Assertions.assertEquals(NUM_PARTITONS, shardSpec.getNumBuckets());
+    Assertions.assertEquals(PARTITION_NUM, shardSpec.getBucketId());
   }
 
   @Test
@@ -116,7 +116,7 @@ public class HashPartitionCachingLocalSegmentAllocatorTest
     InputRow row = createInputRow();
     String sequenceName = sequenceNameFunction.getSequenceName(INTERVAL, row);
     String expectedSequenceName = StringUtils.format("%s_%s_%d", TASKID, INTERVAL, PARTITION_NUM);
-    Assert.assertEquals(expectedSequenceName, sequenceName);
+    Assertions.assertEquals(expectedSequenceName, sequenceName);
   }
 
   private static TaskToolbox createToolbox()

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
@@ -339,7 +339,7 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
   private void assertHashedPartition(
       Set<DataSegment> publishedSegments,
       Map<Interval, Integer> expectedIntervalToNumSegments
-  ) throws IOException
+  )
   {
     final Map<Interval, List<DataSegment>> intervalToSegments = new HashMap<>();
     publishedSegments.forEach(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionMultiPhaseParallelIndexingTest.java
@@ -40,11 +40,11 @@ import org.apache.druid.timeline.partition.HashPartitionFunction;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -62,7 +62,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "lockGranularity={0}, maxNumConcurrentSubTasks={1}, intervalToIndex={2}, numShards={3}")
+@MethodSource("constructorFeeder")
 public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPhaseParallelIndexingTest
 {
   private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec("ts", "auto", null);
@@ -80,9 +81,6 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
   private static final Interval INTERVAL_TO_INDEX = Intervals.of("2017-12/P1M");
   private static final String INPUT_FILTER = "test_*";
 
-  @Parameterized.Parameters(
-      name = "lockGranularity={0}, maxNumConcurrentSubTasks={1}, intervalToIndex={2}, numShards={3}"
-  )
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -120,10 +118,10 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
     this.numShards = numShards;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
     final Set<Interval> intervals = new HashSet<>();
     // set up data
     for (int i = 0; i < 10; i++) {
@@ -210,12 +208,12 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
         expectedIntervalToNumSegmentsAfterReplace.put(ds.getInterval(), 1);
       }
     }
-    Assert.assertEquals(5, tombstones); // five tombstones
+    Assertions.assertEquals(5, tombstones); // five tombstones
     int expectedSegments = 12;
     if (numShards == null) {
       expectedSegments = 6;
     }
-    Assert.assertEquals(expectedSegments, publishedSegmentsAfterReplace.size() - tombstones); //  six segments
+    Assertions.assertEquals(expectedSegments, publishedSegmentsAfterReplace.size() - tombstones); //  six segments
     assertHashedPartition(publishedSegmentsAfterReplace, expectedIntervalToNumSegmentsAfterReplace);
   }
 
@@ -307,11 +305,11 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
       for (DataSegment hashedSegment : hashedSegments) {
         final HashBasedNumberedShardSpec hashShardSpec = (HashBasedNumberedShardSpec) hashedSegment.getShardSpec();
         for (DataSegment linearSegment : linearSegments) {
-          Assert.assertEquals(hashedSegment.getInterval(), linearSegment.getInterval());
-          Assert.assertEquals(hashedSegment.getVersion(), linearSegment.getVersion());
+          Assertions.assertEquals(hashedSegment.getInterval(), linearSegment.getInterval());
+          Assertions.assertEquals(hashedSegment.getVersion(), linearSegment.getVersion());
           final NumberedShardSpec numberedShardSpec = (NumberedShardSpec) linearSegment.getShardSpec();
-          Assert.assertEquals(hashShardSpec.getNumCorePartitions(), numberedShardSpec.getNumCorePartitions());
-          Assert.assertTrue(hashShardSpec.getPartitionNum() < numberedShardSpec.getPartitionNum());
+          Assertions.assertEquals(hashShardSpec.getNumCorePartitions(), numberedShardSpec.getNumCorePartitions());
+          Assertions.assertTrue(hashShardSpec.getPartitionNum() < numberedShardSpec.getPartitionNum());
         }
       }
     }
@@ -347,24 +345,24 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
     publishedSegments.forEach(
         segment -> intervalToSegments.computeIfAbsent(segment.getInterval(), k -> new ArrayList<>()).add(segment)
     );
-    Assert.assertEquals(new HashSet<>(inputIntervals), intervalToSegments.keySet());
-    final File tempSegmentDir = temporaryFolder.newFolder();
+    Assertions.assertEquals(new HashSet<>(inputIntervals), intervalToSegments.keySet());
+    final File tempSegmentDir = createTempDir();
     for (Entry<Interval, List<DataSegment>> entry : intervalToSegments.entrySet()) {
       Interval interval = entry.getKey();
       List<DataSegment> segmentsInInterval = entry.getValue();
-      Assert.assertEquals(expectedIntervalToNumSegments.get(interval).intValue(), segmentsInInterval.size());
+      Assertions.assertEquals(expectedIntervalToNumSegments.get(interval).intValue(), segmentsInInterval.size());
       for (DataSegment segment : segmentsInInterval) {
         HashBasedNumberedShardSpec shardSpec = null;
         if (segment.isTombstone()) {
-          Assert.assertSame(TombstoneShardSpec.class, segment.getShardSpec().getClass());
+          Assertions.assertSame(TombstoneShardSpec.class, segment.getShardSpec().getClass());
         } else {
-          Assert.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
+          Assertions.assertSame(HashBasedNumberedShardSpec.class, segment.getShardSpec().getClass());
           shardSpec = (HashBasedNumberedShardSpec) segment.getShardSpec();
-          Assert.assertEquals(HashPartitionFunction.MURMUR3_32_ABS, shardSpec.getPartitionFunction());
+          Assertions.assertEquals(HashPartitionFunction.MURMUR3_32_ABS, shardSpec.getPartitionFunction());
         }
         List<ScanResultValue> results = querySegment(segment, ImmutableList.of("dim1", "dim2"), tempSegmentDir);
         if (segment.isTombstone()) {
-          Assert.assertTrue(results.isEmpty());
+          Assertions.assertTrue(results.isEmpty());
         } else {
           final int hash = shardSpec.getPartitionFunction().hash(
               HashBasedNumberedShardSpec.serializeGroupKey(
@@ -374,7 +372,7 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
               shardSpec.getNumBuckets()
           );
           for (ScanResultValue value : results) {
-            Assert.assertEquals(
+            Assertions.assertEquals(
                 hash,
                 shardSpec.getPartitionFunction().hash(
                     HashBasedNumberedShardSpec.serializeGroupKey(
@@ -392,7 +390,7 @@ public class HashPartitionMultiPhaseParallelIndexingTest extends AbstractMultiPh
 
   private File newInputDirForReplace() throws IOException
   {
-    File inputDirectory = temporaryFolder.newFolder("dataReplace");
+    File inputDirectory = createTempDir("dataReplace");
     // set up data
     Set<Integer> fileIds = new HashSet<>();
     fileIds.add(3);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HashPartitionTaskKillTest.java
@@ -44,9 +44,10 @@ import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -90,10 +91,10 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     super(LockGranularity.TIME_CHUNK, 0, 0);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
     final Set<Interval> intervals = new HashSet<>();
     // set up data
     for (int i = 0; i < 10; i++) {
@@ -119,7 +120,8 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     inputIntervals.sort(Comparators.intervalsByStartThenEnd());
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void failsInFirstPhase() throws Exception
   {
     final ParallelIndexSupervisorTask task =
@@ -135,19 +137,20 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
 
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
     TaskStatus taskStatus = task.runHashPartitionMultiPhaseParallel(toolbox);
 
-    Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals(
+    Assertions.assertTrue(taskStatus.isFailure());
+    Assertions.assertEquals(
         "Failed in phase[PHASE-1]. See task logs for details.",
         taskStatus.getErrorMsg()
     );
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void failsInSecondPhase() throws Exception
   {
     final ParallelIndexSupervisorTask task =
@@ -163,19 +166,20 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
 
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
     TaskStatus taskStatus = task.runHashPartitionMultiPhaseParallel(toolbox);
 
-    Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals(
+    Assertions.assertTrue(taskStatus.isFailure());
+    Assertions.assertEquals(
         "Failed in phase[PHASE-2]. See task logs for details.",
         taskStatus.getErrorMsg()
     );
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void failsInThirdPhase() throws Exception
   {
     final ParallelIndexSupervisorTask task =
@@ -195,14 +199,14 @@ public class HashPartitionTaskKillTest extends AbstractMultiPhaseParallelIndexin
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
 
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
     task.setToolbox(toolbox);
     TaskStatus taskStatus = task.runHashPartitionMultiPhaseParallel(toolbox);
 
-    Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals(
+    Assertions.assertTrue(taskStatus.isFailure());
+    Assertions.assertEquals(
         "Failed in phase[PHASE-3]. See task logs for details.",
         taskStatus.getErrorMsg()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HttpShuffleClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HttpShuffleClientTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
@@ -29,12 +30,10 @@ import org.apache.druid.java.util.http.client.response.InputStreamResponseHandle
 import org.apache.druid.utils.CompressionUtils;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -59,18 +58,14 @@ public class HttpShuffleClientTest
   private static final int PORT = 1080;
   private static final int PARTITION_ID = 0;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  private final File temporaryFolder = FileUtils.createTempDir();
 
   private File segmentFile;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    File temp = temporaryFolder.newFile();
+    final File temp = File.createTempFile("junit", null, temporaryFolder);
     try (Writer writer = Files.newBufferedWriter(temp.toPath(), StandardCharsets.UTF_8)) {
       for (int j = 0; j < 10; j++) {
         writer.write(StringUtils.format("let's write some data.\n"));
@@ -80,28 +75,36 @@ public class HttpShuffleClientTest
     CompressionUtils.zip(segmentFile.getParentFile(), segmentFile);
   }
 
+  @AfterEach
+  public void tearDown() throws IOException
+  {
+    FileUtils.deleteDirectory(temporaryFolder);
+  }
+
   @Test
   public void testFetchSegmentFileWithValidParamsReturningCopiedFileInPartitoinDir() throws IOException
   {
     ShuffleClient shuffleClient = mockClient(0);
-    final File localDir = temporaryFolder.newFolder();
+    final File localDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null);
     final File fetchedFile = shuffleClient.fetchSegmentFile(
         localDir,
         SUPERVISOR_TASK_ID,
         new TestPartitionLocation()
     );
-    Assert.assertEquals(fetchedFile.getParentFile(), localDir);
+    Assertions.assertEquals(fetchedFile.getParentFile(), localDir);
   }
 
   @Test
   public void testFetchUnknownPartitionThrowingIOExceptionAfterRetries() throws IOException
   {
-    expectedException.expect(IOException.class);
     ShuffleClient shuffleClient = mockClient(HttpShuffleClient.NUM_FETCH_RETRIES + 1);
-    shuffleClient.fetchSegmentFile(
-        temporaryFolder.newFolder(),
-        SUPERVISOR_TASK_ID,
-        new TestPartitionLocation()
+    Assertions.assertThrows(
+        IOException.class,
+        () -> shuffleClient.fetchSegmentFile(
+            FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null),
+            SUPERVISOR_TASK_ID,
+            new TestPartitionLocation()
+        )
     );
   }
 
@@ -109,13 +112,13 @@ public class HttpShuffleClientTest
   public void testFetchSegmentFileWithTransientFailuresReturningCopiedFileInPartitionDir() throws IOException
   {
     ShuffleClient shuffleClient = mockClient(HttpShuffleClient.NUM_FETCH_RETRIES - 1);
-    final File localDir = temporaryFolder.newFolder();
+    final File localDir = FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null);
     final File fetchedFile = shuffleClient.fetchSegmentFile(
         localDir,
         SUPERVISOR_TASK_ID,
         new TestPartitionLocation()
     );
-    Assert.assertEquals(fetchedFile.getParentFile(), localDir);
+    Assertions.assertEquals(fetchedFile.getParentFile(), localDir);
   }
 
   @Test
@@ -128,7 +131,7 @@ public class HttpShuffleClientTest
       List<Future<File>> futures = new ArrayList<>();
       List<File> localDirs = new ArrayList<>();
       for (int i = 0; i < 2; i++) {
-        localDirs.add(temporaryFolder.newFolder());
+        localDirs.add(FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null));
       }
       for (int i = 0; i < 2; i++) {
         final File localDir = localDirs.get(i);
@@ -142,7 +145,7 @@ public class HttpShuffleClientTest
       }
 
       for (int i = 0; i < futures.size(); i++) {
-        Assert.assertEquals(futures.get(i).get().getParentFile(), localDirs.get(i));
+        Assertions.assertEquals(futures.get(i).get().getParentFile(), localDirs.get(i));
       }
     }
     finally {
@@ -160,7 +163,7 @@ public class HttpShuffleClientTest
       List<Future<File>> futures = new ArrayList<>();
       List<File> localDirs = new ArrayList<>();
       for (int i = 0; i < 2; i++) {
-        localDirs.add(temporaryFolder.newFolder());
+        localDirs.add(FileUtils.createTempDirInLocation(temporaryFolder.toPath(), null));
       }
       for (int i = 0; i < 2; i++) {
         final File localDir = localDirs.get(i);
@@ -174,7 +177,7 @@ public class HttpShuffleClientTest
       }
 
       for (int i = 0; i < futures.size(); i++) {
-        Assert.assertEquals(futures.get(i).get().getParentFile(), localDirs.get(i));
+        Assertions.assertEquals(futures.get(i).get().getParentFile(), localDirs.get(i));
       }
     }
     finally {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HttpShuffleClientTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/HttpShuffleClientTest.java
@@ -30,10 +30,10 @@ import org.apache.druid.java.util.http.client.response.InputStreamResponseHandle
 import org.apache.druid.utils.CompressionUtils;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -58,7 +58,8 @@ public class HttpShuffleClientTest
   private static final int PORT = 1080;
   private static final int PARTITION_ID = 0;
 
-  private final File temporaryFolder = FileUtils.createTempDir();
+  @TempDir
+  private File temporaryFolder;
 
   private File segmentFile;
 
@@ -73,12 +74,6 @@ public class HttpShuffleClientTest
     }
     segmentFile = new File(temp.getAbsolutePath() + ".zip");
     CompressionUtils.zip(segmentFile.getParentFile(), segmentFile);
-  }
-
-  @AfterEach
-  public void tearDown() throws IOException
-  {
-    FileUtils.deleteDirectory(temporaryFolder);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingRowStatsTest.java
@@ -34,9 +34,9 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.incremental.RowIngestionMetersTotals;
 import org.apache.druid.segment.incremental.RowMeters;
 import org.joda.time.Interval;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -77,10 +77,10 @@ public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhasePa
     );
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
 
     // set up data
     for (int i = 0; i < 10; i++) {
@@ -108,7 +108,7 @@ public class MultiPhaseParallelIndexingRowStatsTest extends AbstractMultiPhasePa
   }
 
   @Test
-  @Ignore("assumes record rates, to be fixed PR #12852")
+  @Disabled("assumes record rates, to be fixed PR #12852")
   public void testHashPartitionRowStats_concurrentSubTasks_1()
   {
     testHashPartitionRowStats(1);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingWithNullColumnTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/MultiPhaseParallelIndexingWithNullColumnTest.java
@@ -57,10 +57,10 @@ import org.apache.druid.java.util.common.parsers.JSONPathSpec;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -75,7 +75,8 @@ import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class MultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiPhaseParallelIndexingTest
 {
   private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec("ts", "auto", null);
@@ -85,7 +86,6 @@ public class MultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiP
   private static final InputFormat JSON_FORMAT = new JsonInputFormat(null, null, null, null, null);
   private static final List<Interval> INTERVAL_TO_INDEX = Collections.singletonList(Intervals.of("2022-01/P1M"));
 
-  @Parameterized.Parameters
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -155,14 +155,14 @@ public class MultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiP
         null
     );
 
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     Set<DataSegment> segments = getIndexingServiceClient().getSegmentAndSchemas(task).getSegments();
-    Assert.assertFalse(segments.isEmpty());
+    Assertions.assertFalse(segments.isEmpty());
     for (DataSegment segment : segments) {
-      Assert.assertEquals(dimensionSchemas.size(), segment.getDimensions().size());
+      Assertions.assertEquals(dimensionSchemas.size(), segment.getDimensions().size());
       for (int i = 0; i < dimensionSchemas.size(); i++) {
-        Assert.assertEquals(dimensionSchemas.get(i).getName(), segment.getDimensions().get(i));
+        Assertions.assertEquals(dimensionSchemas.get(i).getName(), segment.getDimensions().get(i));
       }
     }
   }
@@ -214,18 +214,18 @@ public class MultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiP
         null
     );
 
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     Set<DataSegment> segments = getIndexingServiceClient().getSegmentAndSchemas(task).getSegments();
-    Assert.assertFalse(segments.isEmpty());
+    Assertions.assertFalse(segments.isEmpty());
     final List<String> expectedExplicitDimensions = ImmutableList.of("ts", "unknownDim", "dim1");
     final Set<String> expectedImplicitDimensions = ImmutableSet.of("dim2", "dim3");
     for (DataSegment segment : segments) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedExplicitDimensions,
           segment.getDimensions().subList(0, expectedExplicitDimensions.size())
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedImplicitDimensions,
           new HashSet<>(segment.getDimensions().subList(expectedExplicitDimensions.size(), segment.getDimensions().size()))
       );
@@ -283,18 +283,18 @@ public class MultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiP
         null
     );
 
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     Set<DataSegment> segments = getIndexingServiceClient().getSegmentAndSchemas(task).getSegments();
-    Assert.assertFalse(segments.isEmpty());
+    Assertions.assertFalse(segments.isEmpty());
     final List<String> expectedExplicitDimensions = ImmutableList.of("dim1", "k");
     final Set<String> expectedImplicitDimensions = ImmutableSet.of("dim2", "dim3");
     for (DataSegment segment : segments) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedExplicitDimensions,
           segment.getDimensions().subList(0, expectedExplicitDimensions.size())
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           expectedImplicitDimensions,
           new HashSet<>(segment.getDimensions().subList(expectedExplicitDimensions.size(), segment.getDimensions().size()))
       );
@@ -343,17 +343,17 @@ public class MultiPhaseParallelIndexingWithNullColumnTest extends AbstractMultiP
     );
 
     task.addToContext(Tasks.STORE_EMPTY_COLUMNS_KEY, false);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     Set<DataSegment> segments = getIndexingServiceClient().getSegmentAndSchemas(task).getSegments();
-    Assert.assertFalse(segments.isEmpty());
+    Assertions.assertFalse(segments.isEmpty());
     final List<DimensionSchema> expectedDimensions = DimensionsSpec.getDefaultSchemas(
         Collections.singletonList("ts")
     );
     for (DataSegment segment : segments) {
-      Assert.assertEquals(expectedDimensions.size(), segment.getDimensions().size());
+      Assertions.assertEquals(expectedDimensions.size(), segment.getDimensions().size());
       for (int i = 0; i < expectedDimensions.size(); i++) {
-        Assert.assertEquals(expectedDimensions.get(i).getName(), segment.getDimensions().get(i));
+        Assertions.assertEquals(expectedDimensions.get(i).getName(), segment.getDimensions().get(i));
       }
     }
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexPhaseRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexPhaseRunnerTest.java
@@ -27,10 +27,10 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,10 +50,10 @@ public class ParallelIndexPhaseRunnerTest extends AbstractParallelIndexSuperviso
     super(DEFAULT_TRANSIENT_TASK_FAILURE_RATE, DEFAULT_TRANSIENT_API_FAILURE_RATE);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
     // set up data
     for (int i = 0; i < 5; i++) {
       try (final Writer writer =
@@ -73,10 +73,10 @@ public class ParallelIndexPhaseRunnerTest extends AbstractParallelIndexSuperviso
     getObjectMapper().registerSubtypes(new NamedType(ReportingNoopTask.class, "reporting_noop"));
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
-    temporaryFolder.delete();
+    deleteTempDir();
   }
 
   @Test
@@ -93,7 +93,7 @@ public class ParallelIndexPhaseRunnerTest extends AbstractParallelIndexSuperviso
         10,
         12
     );
-    Assert.assertEquals(TaskState.SUCCESS, runner.run());
+    Assertions.assertEquals(TaskState.SUCCESS, runner.run());
   }
 
   @Test
@@ -110,7 +110,7 @@ public class ParallelIndexPhaseRunnerTest extends AbstractParallelIndexSuperviso
         10,
         8
     );
-    Assert.assertEquals(TaskState.SUCCESS, runner.run());
+    Assertions.assertEquals(TaskState.SUCCESS, runner.run());
   }
 
   private static class TestPhaseRunner extends ParallelIndexPhaseRunner<ReportingNoopTask, EmptySubTaskReport>

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexPhaseRunnerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexPhaseRunnerTest.java
@@ -27,7 +27,6 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.actions.TaskActionClient;
 import org.apache.druid.indexing.common.task.NoopTask;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -71,12 +70,6 @@ public class ParallelIndexPhaseRunnerTest extends AbstractParallelIndexSuperviso
     }
 
     getObjectMapper().registerSubtypes(new NamedType(ReportingNoopTask.class, "reporting_noop"));
-  }
-
-  @AfterEach
-  public void tearDown()
-  {
-    deleteTempDir();
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -40,7 +40,6 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.joda.time.Interval;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -61,12 +60,6 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
   {
     // We don't need to emulate transient failures for this test.
     super(0.0, 0.0);
-  }
-
-  @AfterEach
-  public void teardown()
-  {
-    deleteTempDir();
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskKillTest.java
@@ -40,9 +40,10 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -62,13 +63,14 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
     super(0.0, 0.0);
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
-    temporaryFolder.delete();
+    deleteTempDir();
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void testStopGracefully() throws Exception
   {
     final ParallelIndexSupervisorTask task = newTask(
@@ -87,14 +89,15 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
     }
     task.stopGracefully(null);
 
-    Exception e = Assert.assertThrows(
+    Exception e = Assertions.assertThrows(
         RuntimeException.class,
         () -> getIndexingServiceClient().waitToFinish(task, 3000L, TimeUnit.MILLISECONDS)
     );
-    Assert.assertTrue(e.getCause() instanceof ExecutionException);
+    Assertions.assertTrue(e.getCause() instanceof ExecutionException);
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void testSubTaskFail() throws Exception
   {
     final ParallelIndexSupervisorTask task = newTask(
@@ -113,27 +116,27 @@ public class ParallelIndexSupervisorTaskKillTest extends AbstractParallelIndexSu
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
 
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
 
     final TaskStatus taskStatus = task.run(toolbox);
-    Assert.assertEquals("Failed in phase[segment generation]. See task logs for details.",
+    Assertions.assertEquals("Failed in phase[segment generation]. See task logs for details.",
                         taskStatus.getErrorMsg());
-    Assert.assertEquals(TaskState.FAILED, taskStatus.getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, taskStatus.getStatusCode());
 
     final SinglePhaseParallelIndexTaskRunner runner = (SinglePhaseParallelIndexTaskRunner) task.getCurrentRunner();
-    Assert.assertTrue(runner.getRunningTaskIds().isEmpty());
+    Assertions.assertTrue(runner.getRunningTaskIds().isEmpty());
     final List<SubTaskSpec<SinglePhaseSubTask>> completeSubTaskSpecs = runner.getCompleteSubTaskSpecs();
-    Assert.assertEquals(1, completeSubTaskSpecs.size());
+    Assertions.assertEquals(1, completeSubTaskSpecs.size());
     final TaskHistory<SinglePhaseSubTask> history = runner.getCompleteSubTaskSpecAttemptHistory(
         completeSubTaskSpecs.get(0).getId()
     );
-    Assert.assertNotNull(history);
-    Assert.assertEquals(3, history.getAttemptHistory().size());
+    Assertions.assertNotNull(history);
+    Assertions.assertEquals(3, history.getAttemptHistory().size());
     for (TaskStatusPlus status : history.getAttemptHistory()) {
-      Assert.assertEquals(TaskState.FAILED, status.getStatusCode());
+      Assertions.assertEquals(TaskState.FAILED, status.getStatusCode());
     }
 
-    Assert.assertEquals(3, runner.getTaskMonitor().getNumCanceledTasks());
+    Assertions.assertEquals(3, runner.getTaskMonitor().getNumCanceledTasks());
   }
 
   private ParallelIndexSupervisorTask newTask(

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -56,9 +56,10 @@ import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
@@ -117,13 +118,14 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
     super(0.0, 0.0);
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
-    temporaryFolder.delete();
+    deleteTempDir();
   }
 
-  @Test(timeout = 20000L)
+  @Test
+  @Timeout(20)
   public void testAPIs() throws Exception
   {
     task = newTask(
@@ -139,17 +141,17 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
     Thread.sleep(1000);
 
     final SinglePhaseParallelIndexTaskRunner runner = (SinglePhaseParallelIndexTaskRunner) task.getCurrentRunner();
-    Assert.assertNotNull("runner is null", runner);
+    Assertions.assertNotNull(runner, "runner is null");
 
     // test getMode
     Response response = task.getMode(newRequest());
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals("parallel", response.getEntity());
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals("parallel", response.getEntity());
 
     // test expectedNumSucceededTasks
     response = task.getProgress(newRequest());
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         NUM_SUB_TASKS,
         ((ParallelIndexingPhaseProgress) response.getEntity()).getEstimatedExpectedSucceeded()
     );
@@ -218,11 +220,11 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
         buildStateMap()
     );
 
-    Assert.assertEquals(1, runningSpecs.size());
+    Assertions.assertEquals(1, runningSpecs.size());
     final String lastRunningSpecId = runningSpecs.keySet().iterator().next();
     final List<TaskStatusPlus> taskHistory = taskHistories.get(lastRunningSpecId);
     // This should be a failed task history because new tasks appear later in runningTasks.
-    Assert.assertEquals(1, taskHistory.size());
+    Assertions.assertEquals(1, taskHistory.size());
 
     // Test one more failure
     runningTasks.get(0).setState(TaskState.FAILED);
@@ -239,7 +241,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
         failedTasks,
         buildStateMap()
     );
-    Assert.assertEquals(2, taskHistory.size());
+    Assertions.assertEquals(2, taskHistory.size());
 
     runningTasks.get(0).setState(TaskState.SUCCESS);
     succeededTasks++;
@@ -247,7 +249,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
       Thread.sleep(100);
     }
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         TaskState.SUCCESS,
         getIndexingServiceClient().waitToFinish(task, 1000, TimeUnit.MILLISECONDS).getStatusCode()
     );
@@ -257,7 +259,7 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
   private int getNumSubTasks(Function<ParallelIndexingPhaseProgress, Integer> func)
   {
     final Response response = task.getProgress(newRequest());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     return func.apply((ParallelIndexingPhaseProgress) response.getEntity());
   }
 
@@ -285,40 +287,40 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
   )
   {
     Response response = task.getProgress(newRequest());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     final ParallelIndexingPhaseProgress monitorStatus = (ParallelIndexingPhaseProgress) response.getEntity();
 
     // Verify the number of tasks in different states
-    Assert.assertEquals(runningTasks.size(), monitorStatus.getRunning());
-    Assert.assertEquals(expectedSucceededTasks, monitorStatus.getSucceeded());
-    Assert.assertEquals(expectedFailedTask, monitorStatus.getFailed());
-    Assert.assertEquals(expectedSucceededTasks + expectedFailedTask, monitorStatus.getComplete());
-    Assert.assertEquals(runningTasks.size() + expectedSucceededTasks + expectedFailedTask, monitorStatus.getTotal());
+    Assertions.assertEquals(runningTasks.size(), monitorStatus.getRunning());
+    Assertions.assertEquals(expectedSucceededTasks, monitorStatus.getSucceeded());
+    Assertions.assertEquals(expectedFailedTask, monitorStatus.getFailed());
+    Assertions.assertEquals(expectedSucceededTasks + expectedFailedTask, monitorStatus.getComplete());
+    Assertions.assertEquals(runningTasks.size() + expectedSucceededTasks + expectedFailedTask, monitorStatus.getTotal());
 
     // runningSubTasks
     response = task.getRunningTasks(newRequest());
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertEquals(
+    Assertions.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(
         runningTasks.stream().map(AbstractTask::getId).collect(Collectors.toSet()),
         new HashSet<>((Collection<String>) response.getEntity())
     );
 
     // subTaskSpecs
     response = task.getSubTaskSpecs(newRequest());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     List<SubTaskSpec<SinglePhaseSubTask>> actualSubTaskSpecMap =
         (List<SubTaskSpec<SinglePhaseSubTask>>) response.getEntity();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         subTaskSpecs.keySet(),
         actualSubTaskSpecMap.stream().map(SubTaskSpec::getId).collect(Collectors.toSet())
     );
 
     // runningSubTaskSpecs
     response = task.getRunningSubTaskSpecs(newRequest());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     actualSubTaskSpecMap =
         (List<SubTaskSpec<SinglePhaseSubTask>>) response.getEntity();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         runningSpecs.keySet(),
         actualSubTaskSpecMap.stream().map(SubTaskSpec::getId).collect(Collectors.toSet())
     );
@@ -333,31 +335,31 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
         .collect(Collectors.toList());
 
     response = task.getCompleteSubTaskSpecs(newRequest());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     List<SubTaskSpec<SinglePhaseSubTask>> actual = (List<SubTaskSpec<SinglePhaseSubTask>>) response.getEntity();
     actual.sort(Comparator.comparing(SubTaskSpec::getId));
-    Assert.assertEquals(completeSubTaskSpecs, actual);
+    Assertions.assertEquals(completeSubTaskSpecs, actual);
 
     // subTaskSpec
     final String subTaskId = runningSpecs.keySet().iterator().next();
     response = task.getSubTaskSpec(subTaskId, newRequest());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     final SubTaskSpec<SinglePhaseSubTask> subTaskSpec =
         (SubTaskSpec<SinglePhaseSubTask>) response.getEntity();
-    Assert.assertEquals(subTaskId, subTaskSpec.getId());
+    Assertions.assertEquals(subTaskId, subTaskSpec.getId());
 
     // subTaskState
     response = task.getSubTaskState(subTaskId, newRequest());
-    Assert.assertEquals(200, response.getStatus());
+    Assertions.assertEquals(200, response.getStatus());
     final SubTaskSpecStatus expectedResponse = Preconditions.checkNotNull(
         expectedSubTaskStateResponses.get(subTaskId),
         "response for task[%s]",
         subTaskId
     );
     final SubTaskSpecStatus actualResponse = (SubTaskSpecStatus) response.getEntity();
-    Assert.assertEquals(expectedResponse.getSpec().getId(), actualResponse.getSpec().getId());
-    Assert.assertEquals(expectedResponse.getCurrentStatus(), actualResponse.getCurrentStatus());
-    Assert.assertEquals(expectedResponse.getTaskHistory(), actualResponse.getTaskHistory());
+    Assertions.assertEquals(expectedResponse.getSpec().getId(), actualResponse.getSpec().getId());
+    Assertions.assertEquals(expectedResponse.getCurrentStatus(), actualResponse.getCurrentStatus());
+    Assertions.assertEquals(expectedResponse.getTaskHistory(), actualResponse.getTaskHistory());
 
     // completeSubTaskSpecAttemptHistory
     final String completeSubTaskSpecId = expectedSubTaskStateResponses
@@ -374,8 +376,8 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
         .orElse(null);
     if (completeSubTaskSpecId != null) {
       response = task.getCompleteSubTaskSpecAttemptHistory(completeSubTaskSpecId, newRequest());
-      Assert.assertEquals(200, response.getStatus());
-      Assert.assertEquals(
+      Assertions.assertEquals(200, response.getStatus());
+      Assertions.assertEquals(
           expectedSubTaskStateResponses.get(completeSubTaskSpecId).getTaskHistory(),
           response.getEntity()
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskResourceTest.java
@@ -56,7 +56,6 @@ import org.apache.druid.timeline.DataSegment;
 import org.easymock.EasyMock;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -116,12 +115,6 @@ public class ParallelIndexSupervisorTaskResourceTest extends AbstractParallelInd
   {
     // We don't need to emulate transient failures for this test.
     super(0.0, 0.0);
-  }
-
-  @AfterEach
-  public void teardown()
-  {
-    deleteTempDir();
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskSerdeTest.java
@@ -37,10 +37,8 @@ import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -55,9 +53,6 @@ public class ParallelIndexSupervisorTaskSerdeTest
   private static final ObjectMapper OBJECT_MAPPER = new TestUtils().getTestObjectMapper();
   private static final List<Interval> INTERVALS = Collections.singletonList(Intervals.of("2018/2019"));
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void serde() throws IOException
   {
@@ -70,7 +65,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
         .build();
 
     String json = OBJECT_MAPPER.writeValueAsString(task);
-    Assert.assertEquals(task, OBJECT_MAPPER.readValue(json, Task.class));
+    Assertions.assertEquals(task, OBJECT_MAPPER.readValue(json, Task.class));
   }
 
   @Test
@@ -87,7 +82,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
         .build();
 
     PartitionsSpec partitionsSpec = task.getIngestionSchema().getTuningConfig().getPartitionsSpec();
-    Assert.assertTrue(partitionsSpec instanceof HashedPartitionsSpec);
+    Assertions.assertTrue(partitionsSpec instanceof HashedPartitionsSpec);
   }
 
   @Test
@@ -105,24 +100,25 @@ public class ParallelIndexSupervisorTaskSerdeTest
         .build();
 
     PartitionsSpec partitionsSpec = task.getIngestionSchema().getTuningConfig().getPartitionsSpec();
-    Assert.assertTrue(partitionsSpec instanceof HashedPartitionsSpec);
+    Assertions.assertTrue(partitionsSpec instanceof HashedPartitionsSpec);
   }
 
   @Test
   public void forceGuaranteedRollupWithSingleDimPartitionsMissingDimension()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("partitionDimensions must be specified");
-
-    new ParallelIndexSupervisorTaskBuilder()
-        .ingestionSpec(
-            new ParallelIndexIngestionSpecBuilder()
-                .forceGuaranteedRollup(true)
-                .partitionsSpec(new SingleDimensionPartitionsSpec(1, null, null, true))
-                .inputIntervals(INTERVALS)
-                .build()
-        )
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new ParallelIndexSupervisorTaskBuilder()
+            .ingestionSpec(
+                new ParallelIndexIngestionSpecBuilder()
+                    .forceGuaranteedRollup(true)
+                    .partitionsSpec(new SingleDimensionPartitionsSpec(1, null, null, true))
+                    .inputIntervals(INTERVALS)
+                    .build()
+            )
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("partitionDimensions must be specified"));
   }
 
   @Test
@@ -139,7 +135,7 @@ public class ParallelIndexSupervisorTaskSerdeTest
         .build();
 
     PartitionsSpec partitionsSpec = task.getIngestionSchema().getTuningConfig().getPartitionsSpec();
-    Assert.assertTrue(partitionsSpec instanceof SingleDimensionPartitionsSpec);
+    Assertions.assertTrue(partitionsSpec instanceof SingleDimensionPartitionsSpec);
   }
 
   private static class ParallelIndexSupervisorTaskBuilder

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexSupervisorTaskTest.java
@@ -53,21 +53,15 @@ import org.apache.druid.timeline.partition.BuildingHashBasedNumberedShardSpec;
 import org.apache.druid.timeline.partition.DimensionRangeBucketShardSpec;
 import org.apache.druid.timeline.partition.HashPartitionFunction;
 import org.easymock.EasyMock;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -87,14 +81,14 @@ import static org.easymock.EasyMock.mock;
 
 public class ParallelIndexSupervisorTaskTest
 {
-  @RunWith(Parameterized.class)
+  @ParameterizedClass(name = "count = {0}, partitionLocationType = {1}")
+  @MethodSource("data")
   public static class CreateMergeIoConfigsTest
   {
     private static final int TOTAL_NUM_MERGE_TASKS = 10;
     private static final Function<List<PartitionLocation>, PartialSegmentMergeIOConfig>
         CREATE_PARTIAL_SEGMENT_MERGE_IO_CONFIG = PartialSegmentMergeIOConfig::new;
 
-    @Parameterized.Parameters(name = "count = {0}, partitionLocationType = {1}")
     public static Iterable<? extends Object[]> data()
     {
       // different scenarios for last (index = 10 - 1 = 9) partition:
@@ -136,10 +130,9 @@ public class ParallelIndexSupervisorTaskTest
       int maxPartitionSize = sortedPartitionSizes.get(sortedPartitionSizes.size() - 1);
       int partitionSizeRange = maxPartitionSize - minPartitionSize;
 
-      MatcherAssert.assertThat(
-          "partition sizes = " + actualPartitionSizes,
-          partitionSizeRange,
-          Matchers.is(Matchers.both(Matchers.greaterThanOrEqualTo(0)).and(Matchers.lessThanOrEqualTo(1)))
+      Assertions.assertTrue(
+          partitionSizeRange >= 0 && partitionSizeRange <= 1,
+          "partition sizes = " + actualPartitionSizes
       );
     }
 
@@ -216,15 +209,12 @@ public class ParallelIndexSupervisorTaskTest
                                                          .sorted()
                                                          .collect(Collectors.toList());
 
-      Assert.assertEquals(expectedIds, actualIds);
+      Assertions.assertEquals(expectedIds, actualIds);
     }
   }
 
   public static class ConstructorTest
   {
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void testFailToConstructWhenBothAppendToExistingAndForceGuaranteedRollupAreSet()
     {
@@ -271,14 +261,18 @@ public class ParallelIndexSupervisorTaskTest
           ioConfig,
           tuningConfig
       );
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Perfect rollup cannot be guaranteed when appending to existing dataSources");
-      new ParallelIndexSupervisorTask(
-          null,
-          null,
-          null,
-          indexIngestionSpec,
-          null
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> new ParallelIndexSupervisorTask(
+              null,
+              null,
+              null,
+              indexIngestionSpec,
+              null
+          )
+      );
+      Assertions.assertTrue(
+          exception.getMessage().contains("Perfect rollup cannot be guaranteed when appending to existing dataSources")
       );
     }
   }
@@ -289,7 +283,7 @@ public class ParallelIndexSupervisorTaskTest
     public void testIsParallelModeFalse_nullTuningConfig()
     {
       InputSource inputSource = mock(InputSource.class);
-      Assert.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, null));
+      Assertions.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, null));
     }
 
     @Test
@@ -304,9 +298,9 @@ public class ParallelIndexSupervisorTaskTest
       expect(tuningConfig.getMaxNumConcurrentSubTasks()).andReturn(0).andReturn(1).andReturn(2);
       EasyMock.replay(inputSource, tuningConfig);
 
-      Assert.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
-      Assert.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
-      Assert.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+      Assertions.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+      Assertions.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+      Assertions.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
     }
 
     @Test
@@ -321,9 +315,9 @@ public class ParallelIndexSupervisorTaskTest
       expect(tuningConfig.getMaxNumConcurrentSubTasks()).andReturn(1).andReturn(2).andReturn(3);
       EasyMock.replay(inputSource, tuningConfig);
 
-      Assert.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
-      Assert.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
-      Assert.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+      Assertions.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+      Assertions.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+      Assertions.assertTrue(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
     }
 
     @Test
@@ -338,7 +332,7 @@ public class ParallelIndexSupervisorTaskTest
       expect(tuningConfig.getMaxNumConcurrentSubTasks()).andReturn(3);
       EasyMock.replay(inputSource, tuningConfig);
 
-      Assert.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
+      Assertions.assertFalse(ParallelIndexSupervisorTask.isParallelMode(inputSource, tuningConfig));
     }
 
     @Test
@@ -367,7 +361,7 @@ public class ParallelIndexSupervisorTaskTest
 
       Map<ParallelIndexSupervisorTask.Partition, List<PartitionLocation>> partitionToLocations
           = ParallelIndexSupervisorTask.getPartitionToLocations(taskIdToReport);
-      Assert.assertEquals(6, partitionToLocations.size());
+      Assertions.assertEquals(6, partitionToLocations.size());
 
       // Verify that partitionIds are packed and in the same order as bucketIds
       verifyPartitionIdAndLocations(day1, 0, partitionToLocations,
@@ -395,7 +389,7 @@ public class ParallelIndexSupervisorTaskTest
       expect(client.taskReportAsMap(taskId)).andReturn(Futures.immediateFuture(report));
       EasyMock.replay(client);
 
-      Assert.assertEquals(report, ParallelIndexSupervisorTask.getTaskReport(client, taskId));
+      Assertions.assertEquals(report, ParallelIndexSupervisorTask.getTaskReport(client, taskId));
       EasyMock.verify(client);
     }
 
@@ -417,7 +411,7 @@ public class ParallelIndexSupervisorTaskTest
       );
       EasyMock.replay(client);
 
-      Assert.assertNull(ParallelIndexSupervisorTask.getTaskReport(client, taskId));
+      Assertions.assertNull(ParallelIndexSupervisorTask.getTaskReport(client, taskId));
       EasyMock.verify(client, response);
     }
 
@@ -439,16 +433,13 @@ public class ParallelIndexSupervisorTaskTest
       );
       EasyMock.replay(client);
 
-      final ExecutionException e = Assert.assertThrows(
+      final ExecutionException e = Assertions.assertThrows(
           ExecutionException.class,
           () -> ParallelIndexSupervisorTask.getTaskReport(client, taskId)
       );
 
-      MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(HttpResponseException.class));
-      MatcherAssert.assertThat(
-          e.getCause(),
-          ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("Server error [403 Forbidden]"))
-      );
+      Assertions.assertInstanceOf(HttpResponseException.class, e.getCause());
+      Assertions.assertTrue(e.getCause().getMessage().contains("Server error [403 Forbidden]"));
 
       EasyMock.verify(client, response);
     }
@@ -717,19 +708,19 @@ public class ParallelIndexSupervisorTaskTest
       final ParallelIndexSupervisorTask.Partition partition
           = new ParallelIndexSupervisorTask.Partition(interval, bucketId);
       List<PartitionLocation> locations = partitionToLocations.get(partition);
-      Assert.assertEquals(expectedTaskIds.length, locations.size());
+      Assertions.assertEquals(expectedTaskIds.length, locations.size());
 
       final Set<String> observedTaskIds = new HashSet<>();
       for (PartitionLocation location : locations) {
-        Assert.assertEquals(bucketId, location.getBucketId());
-        Assert.assertEquals(interval, location.getInterval());
-        Assert.assertEquals(expectedPartitionId, location.getShardSpec().getPartitionNum());
+        Assertions.assertEquals(bucketId, location.getBucketId());
+        Assertions.assertEquals(interval, location.getInterval());
+        Assertions.assertEquals(expectedPartitionId, location.getShardSpec().getPartitionNum());
 
         observedTaskIds.add(location.getSubTaskId());
       }
 
       // Verify the taskIds of the locations
-      Assert.assertEquals(
+      Assertions.assertEquals(
           new HashSet<>(Arrays.asList(expectedTaskIds)),
           observedTaskIds
       );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/ParallelIndexTuningConfigTest.java
@@ -30,11 +30,9 @@ import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.indexing.TuningConfig;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -43,10 +41,7 @@ public class ParallelIndexTuningConfigTest
 {
   private final ObjectMapper mapper = new DefaultObjectMapper();
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setup()
   {
     mapper.registerSubtypes(new NamedType(ParallelIndexTuningConfig.class, "index_parallel"));
@@ -94,50 +89,58 @@ public class ParallelIndexTuningConfigTest
   @Test
   public void testConfigWithBothMaxNumSubTasksAndMaxNumConcurrentSubTasksIsInvalid()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Can't use both maxNumSubTasks and maxNumConcurrentSubTasks");
     final int maxNumSubTasks = 250;
-    TuningConfigBuilder
-        .forParallelIndexTask()
-        .withMaxNumSubTasks(maxNumSubTasks)
-        .withMaxNumConcurrentSubTasks(maxNumSubTasks)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> TuningConfigBuilder
+            .forParallelIndexTask()
+            .withMaxNumSubTasks(maxNumSubTasks)
+            .withMaxNumConcurrentSubTasks(maxNumSubTasks)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Can't use both maxNumSubTasks and maxNumConcurrentSubTasks"));
   }
 
   @Test
   public void testConstructorWithHashedPartitionsSpecAndNonForceGuaranteedRollupFailToCreate()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
-    TuningConfigBuilder
-        .forParallelIndexTask()
-        .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
-        .withForceGuaranteedRollup(false)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> TuningConfigBuilder
+            .forParallelIndexTask()
+            .withPartitionsSpec(new HashedPartitionsSpec(null, 10, null))
+            .withForceGuaranteedRollup(false)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("DynamicPartitionsSpec must be used for best-effort rollup"));
   }
 
   @Test
   public void testConstructorWithSingleDimensionPartitionsSpecAndNonForceGuaranteedRollupFailToCreate()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("DynamicPartitionsSpec must be used for best-effort rollup");
-    TuningConfigBuilder
-        .forParallelIndexTask()
-        .withPartitionsSpec(new DimensionRangePartitionsSpec(null, 100, Collections.singletonList("dim1"), false))
-        .withForceGuaranteedRollup(false)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> TuningConfigBuilder
+            .forParallelIndexTask()
+            .withPartitionsSpec(new DimensionRangePartitionsSpec(null, 100, Collections.singletonList("dim1"), false))
+            .withForceGuaranteedRollup(false)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("DynamicPartitionsSpec must be used for best-effort rollup"));
   }
 
   @Test
   public void testConstructorWithDynamicPartitionsSpecAndForceGuaranteedRollupFailToCreate()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("cannot be used for perfect rollup");
-    TuningConfigBuilder
-        .forParallelIndexTask()
-        .withPartitionsSpec(new DynamicPartitionsSpec(100, null))
-        .withForceGuaranteedRollup(true)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> TuningConfigBuilder
+            .forParallelIndexTask()
+            .withPartitionsSpec(new DynamicPartitionsSpec(100, null))
+            .withForceGuaranteedRollup(true)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("cannot be used for perfect rollup"));
   }
 
   private void verifyConfigSerde(ParallelIndexTuningConfig tuningConfig) throws IOException
@@ -145,7 +148,7 @@ public class ParallelIndexTuningConfigTest
     final byte[] json = mapper.writeValueAsBytes(tuningConfig);
     final ParallelIndexTuningConfig fromJson =
         (ParallelIndexTuningConfig) mapper.readValue(json, TuningConfig.class);
-    Assert.assertEquals(fromJson, tuningConfig);
+    Assertions.assertEquals(fromJson, tuningConfig);
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialCompactionTest.java
@@ -39,9 +39,9 @@ import org.apache.druid.segment.DataSegmentsWithSchemas;
 import org.apache.druid.segment.SegmentUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -80,10 +80,10 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
     super(LockGranularity.TIME_CHUNK, DEFAULT_TRANSIENT_TASK_FAILURE_RATE, DEFAULT_TRANSIENT_API_FAILURE_RATE);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
     // set up data
     for (int i = 0; i < 10; i++) {
       try (final Writer writer =
@@ -158,7 +158,7 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
     for (List<DataSegment> segmentsInInterval : compactedSegments.values()) {
       final int expectedAtomicUpdateGroupSize = segmentsInInterval.size();
       for (DataSegment segment : segmentsInInterval) {
-        Assert.assertEquals(expectedAtomicUpdateGroupSize, segment.getShardSpec().getAtomicUpdateGroupSize());
+        Assertions.assertEquals(expectedAtomicUpdateGroupSize, segment.getShardSpec().getAtomicUpdateGroupSize());
       }
     }
   }
@@ -224,7 +224,7 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
     for (List<DataSegment> segmentsInInterval : compactedSegments.values()) {
       final int expectedAtomicUpdateGroupSize = segmentsInInterval.size();
       for (DataSegment segment : segmentsInInterval) {
-        Assert.assertEquals(expectedAtomicUpdateGroupSize, segment.getShardSpec().getAtomicUpdateGroupSize());
+        Assertions.assertEquals(expectedAtomicUpdateGroupSize, segment.getShardSpec().getAtomicUpdateGroupSize());
       }
     }
   }
@@ -259,7 +259,7 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
                         .map(segment -> segment.getId().toString())
                         .filter(segmentId -> !compactedSegmentIds.contains(segmentId))
                         .collect(Collectors.toSet());
-    Assert.assertFalse(nonCompactedSegmentIds.isEmpty());
+    Assertions.assertFalse(nonCompactedSegmentIds.isEmpty());
     final Set<String> originalSegmentIds = new HashSet<>(compactedSegmentIds);
     originalSegmentIds.addAll(nonCompactedSegmentIds);
 
@@ -278,7 +278,7 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
 
     // Check published segment set after compaction
     final Set<DataSegment> publishedAfterCompaction = dataSegmentsWithSchemas.getSegments();
-    Assert.assertFalse(SegmentUtils.groupSegmentsByInterval(publishedAfterCompaction).isEmpty());
+    Assertions.assertFalse(SegmentUtils.groupSegmentsByInterval(publishedAfterCompaction).isEmpty());
 
     final Set<String> finalSegmentIds = publishedAfterCompaction.stream()
                                                                 .map(segment -> segment.getId().toString())
@@ -286,18 +286,18 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
 
     final Map<String, String> upgradedFromSegmentIdMap =
         getStorageCoordinator().retrieveUpgradedFromSegmentIds(DATASOURCE, finalSegmentIds);
-    Assert.assertFalse(upgradedFromSegmentIdMap.isEmpty());
-    Assert.assertTrue(upgradedFromSegmentIdMap.values().stream().noneMatch(compactedSegmentIds::contains));
-    Assert.assertTrue(originalSegmentIds.containsAll(upgradedFromSegmentIdMap.values()));
+    Assertions.assertFalse(upgradedFromSegmentIdMap.isEmpty());
+    Assertions.assertTrue(upgradedFromSegmentIdMap.values().stream().noneMatch(compactedSegmentIds::contains));
+    Assertions.assertTrue(originalSegmentIds.containsAll(upgradedFromSegmentIdMap.values()));
     for (final String successorSegmentId : upgradedFromSegmentIdMap.keySet()) {
-      Assert.assertTrue(finalSegmentIds.contains(successorSegmentId));
+      Assertions.assertTrue(finalSegmentIds.contains(successorSegmentId));
     }
 
     // Validate new segment ids (replacements and/or upgraded replicas)
     final Set<String> newPublishedSegmentIds = new HashSet<>(finalSegmentIds);
     newPublishedSegmentIds.removeAll(originalSegmentIds);
-    Assert.assertFalse(newPublishedSegmentIds.isEmpty());
-    Assert.assertTrue(
+    Assertions.assertFalse(newPublishedSegmentIds.isEmpty());
+    Assertions.assertTrue(
         newPublishedSegmentIds.stream().anyMatch(id -> !upgradedFromSegmentIdMap.containsKey(id))
     );
 
@@ -323,19 +323,19 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
                                                                        .map(Map.Entry::getKey)
                                                                        .toList();
       if (finalSegmentIds.contains(parentSegmentId)) {
-        Assert.assertTrue(successorSegmentIds.isEmpty());
+        Assertions.assertTrue(successorSegmentIds.isEmpty());
       } else if (!successorSegmentIds.isEmpty()) {
-        Assert.assertEquals(1, successorSegmentIds.size());
-        Assert.assertTrue(finalSegmentIds.contains(successorSegmentIds.get(0)));
+        Assertions.assertEquals(1, successorSegmentIds.size());
+        Assertions.assertTrue(finalSegmentIds.contains(successorSegmentIds.get(0)));
       }
     }
 
     // Verify compacted segments have new published ID
     for (final DataSegment compactedSource : segmentsToCompact) {
       final String compactedSourceId = compactedSource.getId().toString();
-      Assert.assertFalse(finalSegmentIds.contains(compactedSourceId));
+      Assertions.assertFalse(finalSegmentIds.contains(compactedSourceId));
       final Set<String> newIdsInSameInterval = newSegmentIdsByInterval.getOrDefault(compactedSource.getInterval(), Set.of());
-      Assert.assertFalse(newIdsInSameInterval.isEmpty());
+      Assertions.assertFalse(newIdsInSameInterval.isEmpty());
     }
 
     // non-compacted parents removed from published set match retrieveUpgradedToSegmentIds
@@ -356,7 +356,7 @@ public class PartialCompactionTest extends AbstractMultiPhaseParallelIndexingTes
         final Set<String> coordinatorSuccessorIds =
             new HashSet<>(upgradedToSegmentIdsByParent.getOrDefault(parentSegmentId, Set.of()));
         coordinatorSuccessorIds.remove(parentSegmentId);
-        Assert.assertTrue(coordinatorSuccessorIds.containsAll(expectedSuccessorIds));
+        Assertions.assertTrue(coordinatorSuccessorIds.containsAll(expectedSuccessorIds));
       }
     }
   }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -42,7 +42,6 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.DateTimes;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.segment.TestHelper;
@@ -61,6 +60,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -148,7 +148,8 @@ public class PartialDimensionCardinalityTaskTest
 
   public static class RunTaskTest
   {
-    private final File temporaryFolder = FileUtils.createTempDir();
+    @TempDir
+    private File temporaryFolder;
     private final LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
 
     private Capture<SubTaskReport> reportCapture;
@@ -175,7 +176,6 @@ public class PartialDimensionCardinalityTaskTest
     public void tearDown() throws IOException
     {
       logger.after();
-      FileUtils.deleteDirectory(temporaryFolder);
     }
 
     @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionCardinalityTaskTest.java
@@ -42,6 +42,7 @@ import org.apache.druid.indexing.common.TaskToolbox;
 import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactory;
 import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.java.util.common.DateTimes;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.segment.TestHelper;
@@ -56,13 +57,13 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -75,32 +76,27 @@ public class PartialDimensionCardinalityTaskTest
 
   public static class ConstructorTest
   {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void requiresForceGuaranteedRollup()
     {
-      exception.expect(IllegalArgumentException.class);
-      exception.expectMessage("forceGuaranteedRollup must be set");
-
       ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
           .forParallelIndexTask()
           .withPartitionsSpec(new DynamicPartitionsSpec(null, null))
           .withForceGuaranteedRollup(false)
           .build();
 
-      new PartialDimensionCardinalityTaskBuilder()
-          .tuningConfig(tuningConfig)
-          .build();
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> new PartialDimensionCardinalityTaskBuilder()
+              .tuningConfig(tuningConfig)
+              .build()
+      );
+      Assertions.assertTrue(exception.getMessage().contains("forceGuaranteedRollup must be set"));
     }
 
     @Test
     public void requiresHashedPartitions()
     {
-      exception.expect(IllegalArgumentException.class);
-      exception.expectMessage("hashed partitionsSpec required");
-
       PartitionsSpec partitionsSpec = new SingleDimensionPartitionsSpec(null, 1, "a", false);
       ParallelIndexTuningConfig tuningConfig =
           TuningConfigBuilder.forParallelIndexTask()
@@ -108,9 +104,13 @@ public class PartialDimensionCardinalityTaskTest
                              .withPartitionsSpec(partitionsSpec)
                              .build();
 
-      new PartialDimensionCardinalityTaskBuilder()
-          .tuningConfig(tuningConfig)
-          .build();
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> new PartialDimensionCardinalityTaskBuilder()
+              .tuningConfig(tuningConfig)
+              .build()
+      );
+      Assertions.assertTrue(exception.getMessage().contains("hashed partitionsSpec required"));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class PartialDimensionCardinalityTaskTest
     {
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .build();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Collections.singleton(
               new ResourceAction(new Resource(
                   InlineInputSource.TYPE_KEY,
@@ -142,33 +142,28 @@ public class PartialDimensionCardinalityTaskTest
       PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
           .id(ParallelIndexTestingFactory.AUTOMATIC_ID)
           .build();
-      Assert.assertTrue(task.getId().startsWith(PartialDimensionCardinalityTask.TYPE));
+      Assertions.assertTrue(task.getId().startsWith(PartialDimensionCardinalityTask.TYPE));
     }
   }
 
   public static class RunTaskTest
   {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Rule
-    public LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
+    private final File temporaryFolder = FileUtils.createTempDir();
+    private final LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
 
     private Capture<SubTaskReport> reportCapture;
     private TaskToolbox taskToolbox;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
+      logger.before();
       reportCapture = Capture.newInstance();
       ParallelIndexSupervisorTaskClient taskClient = EasyMock.mock(ParallelIndexSupervisorTaskClient.class);
       taskClient.report(EasyMock.capture(reportCapture));
       EasyMock.replay(taskClient);
       taskToolbox = EasyMock.mock(TaskToolbox.class);
-      EasyMock.expect(taskToolbox.getIndexingTmpDir()).andStubReturn(temporaryFolder.getRoot());
+      EasyMock.expect(taskToolbox.getIndexingTmpDir()).andStubReturn(temporaryFolder);
       EasyMock.expect(taskToolbox.getSupervisorTaskClientProvider())
               .andReturn((supervisorTaskId, httpTimeout, numRetries) -> taskClient);
       EasyMock.expect(taskToolbox.getOverlordClient()).andReturn(null);
@@ -176,24 +171,33 @@ public class PartialDimensionCardinalityTaskTest
       EasyMock.replay(taskToolbox);
     }
 
+    @AfterEach
+    public void tearDown() throws IOException
+    {
+      logger.after();
+      FileUtils.deleteDirectory(temporaryFolder);
+    }
+
     @Test
     public void requiresPartitionDimension() throws Exception
     {
-      exception.expect(IllegalArgumentException.class);
-      exception.expectMessage("partitionDimensions must be specified");
-
-      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
-          .forParallelIndexTask()
-          .withForceGuaranteedRollup(true)
-          .withPartitionsSpec(
-              new DimensionRangePartitionsSpec(null, null, null, false)
-          )
-          .build();
-      PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
-          .tuningConfig(tuningConfig)
-          .build();
-
-      task.runTask(taskToolbox);
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+                .forParallelIndexTask()
+                .withForceGuaranteedRollup(true)
+                .withPartitionsSpec(
+                    new DimensionRangePartitionsSpec(null, null, null, false)
+                )
+                .build();
+            PartialDimensionCardinalityTask task = new PartialDimensionCardinalityTaskBuilder()
+                .tuningConfig(tuningConfig)
+                .build();
+            task.runTask(taskToolbox);
+          }
+      );
+      Assertions.assertTrue(exception.getMessage().contains("partitionDimensions must be specified"));
     }
 
     @Test
@@ -217,9 +221,9 @@ public class PartialDimensionCardinalityTaskTest
       task.runTask(taskToolbox);
 
       List<LogEvent> logEvents = logger.getLogEvents();
-      Assert.assertEquals(1, logEvents.size());
+      Assertions.assertEquals(1, logEvents.size());
       String logMessage = logEvents.get(0).getMessage().getFormattedMessage();
-      Assert.assertTrue(logMessage.contains("Encountered parse exception"));
+      Assertions.assertTrue(logMessage.contains("Encountered parse exception"));
     }
 
     @Test
@@ -237,7 +241,7 @@ public class PartialDimensionCardinalityTaskTest
 
       task.runTask(taskToolbox);
 
-      Assert.assertEquals(Collections.emptyList(), logger.getLogEvents());
+      Assertions.assertEquals(Collections.emptyList(), logger.getLogEvents());
     }
 
     @Test
@@ -253,10 +257,11 @@ public class PartialDimensionCardinalityTaskTest
           .tuningConfig(tuningConfig)
           .build();
 
-      exception.expect(RuntimeException.class);
-      exception.expectMessage("Max parse exceptions[0] exceeded");
-
-      task.runTask(taskToolbox);
+      final RuntimeException exception = Assertions.assertThrows(
+          RuntimeException.class,
+          () -> task.runTask(taskToolbox)
+      );
+      Assertions.assertTrue(exception.getMessage().contains("Max parse exceptions[0] exceeded"));
     }
 
     @Test
@@ -270,12 +275,12 @@ public class PartialDimensionCardinalityTaskTest
 
       DimensionCardinalityReport report = runTask(taskBuilder);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
       Map<Interval, byte[]> intervalToCardinalities = report.getIntervalToCardinalities();
       byte[] hllSketchBytes = Iterables.getOnlyElement(intervalToCardinalities.values());
       HllSketch hllSketch = HllSketch.wrap(Memory.wrap(hllSketchBytes));
-      Assert.assertNotNull(hllSketch);
-      Assert.assertEquals(1L, (long) hllSketch.getEstimate());
+      Assertions.assertNotNull(hllSketch);
+      Assertions.assertEquals(1L, (long) hllSketch.getEstimate());
     }
 
     @Test
@@ -302,12 +307,12 @@ public class PartialDimensionCardinalityTaskTest
 
       DimensionCardinalityReport report = runTask(taskBuilder);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
       Map<Interval, byte[]> intervalToCardinalities = report.getIntervalToCardinalities();
       byte[] hllSketchBytes = Iterables.getOnlyElement(intervalToCardinalities.values());
       HllSketch hllSketch = HllSketch.wrap(Memory.wrap(hllSketchBytes));
-      Assert.assertNotNull(hllSketch);
-      Assert.assertEquals(4L, (long) hllSketch.getEstimate());
+      Assertions.assertNotNull(hllSketch);
+      Assertions.assertEquals(4L, (long) hllSketch.getEstimate());
 
     }
 
@@ -327,21 +332,21 @@ public class PartialDimensionCardinalityTaskTest
 
       DimensionCardinalityReport report = runTask(taskBuilder);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
       Map<Interval, byte[]> intervalToCardinalities = report.getIntervalToCardinalities();
-      Assert.assertEquals(2, intervalToCardinalities.size());
+      Assertions.assertEquals(2, intervalToCardinalities.size());
 
       byte[] hllSketchBytes;
       HllSketch hllSketch;
       hllSketchBytes = intervalToCardinalities.get(Intervals.of("1970-01-01T00:00:00.000Z/1970-01-02T00:00:00.000Z"));
       hllSketch = HllSketch.wrap(Memory.wrap(hllSketchBytes));
-      Assert.assertNotNull(hllSketch);
-      Assert.assertEquals(1L, (long) hllSketch.getEstimate());
+      Assertions.assertNotNull(hllSketch);
+      Assertions.assertEquals(1L, (long) hllSketch.getEstimate());
 
       hllSketchBytes = intervalToCardinalities.get(Intervals.of("1970-01-02T00:00:00.000Z/1970-01-03T00:00:00.000Z"));
       hllSketch = HllSketch.wrap(Memory.wrap(hllSketchBytes));
-      Assert.assertNotNull(hllSketch);
-      Assert.assertEquals(4L, (long) hllSketch.getEstimate());
+      Assertions.assertNotNull(hllSketch);
+      Assertions.assertEquals(4L, (long) hllSketch.getEstimate());
     }
 
     @Test
@@ -352,8 +357,8 @@ public class PartialDimensionCardinalityTaskTest
 
       TaskStatus taskStatus = task.runTask(taskToolbox);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, taskStatus.getId());
-      Assert.assertEquals(TaskState.SUCCESS, taskStatus.getStatusCode());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, taskStatus.getId());
+      Assertions.assertEquals(TaskState.SUCCESS, taskStatus.getStatusCode());
     }
 
     private DimensionCardinalityReport runTask(PartialDimensionCardinalityTaskBuilder taskBuilder)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -36,6 +36,7 @@ import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactor
 import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringDistribution;
 import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringSketch;
+import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.indexing.DataSchema;
@@ -49,13 +50,13 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -72,40 +73,39 @@ public class PartialDimensionDistributionTaskTest
 
   public static class ConstructorTest
   {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void requiresForceGuaranteedRollup()
     {
-      exception.expect(IllegalArgumentException.class);
-      exception.expectMessage("forceGuaranteedRollup must be set");
-
       ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
           .forParallelIndexTask()
           .withForceGuaranteedRollup(false)
           .build();
 
-      new PartialDimensionDistributionTaskBuilder()
-          .tuningConfig(tuningConfig)
-          .build();
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> new PartialDimensionDistributionTaskBuilder()
+              .tuningConfig(tuningConfig)
+              .build()
+      );
+      Assertions.assertTrue(exception.getMessage().contains("forceGuaranteedRollup must be set"));
     }
 
     @Test
     public void requiresMultiDimensionPartitions()
     {
-      exception.expect(IllegalArgumentException.class);
-      exception.expectMessage("range partitionsSpec required");
-
       ParallelIndexTuningConfig tuningConfig =
           TuningConfigBuilder.forParallelIndexTask()
                              .withForceGuaranteedRollup(true)
                              .withPartitionsSpec(new HashedPartitionsSpec(null, 1, null))
                              .build();
 
-      new PartialDimensionDistributionTaskBuilder()
-          .tuningConfig(tuningConfig)
-          .build();
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> new PartialDimensionDistributionTaskBuilder()
+              .tuningConfig(tuningConfig)
+              .build()
+      );
+      Assertions.assertTrue(exception.getMessage().contains("range partitionsSpec required"));
     }
 
     @Test
@@ -114,33 +114,28 @@ public class PartialDimensionDistributionTaskTest
       PartialDimensionDistributionTask task = new PartialDimensionDistributionTaskBuilder()
           .id(ParallelIndexTestingFactory.AUTOMATIC_ID)
           .build();
-      Assert.assertTrue(task.getId().startsWith(PartialDimensionDistributionTask.TYPE));
+      Assertions.assertTrue(task.getId().startsWith(PartialDimensionDistributionTask.TYPE));
     }
   }
 
   public static class RunTaskTest
   {
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Rule
-    public LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
+    private final File temporaryFolder = FileUtils.createTempDir();
+    private final LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
 
     private Capture<SubTaskReport> reportCapture;
     private TaskToolbox taskToolbox;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
+      logger.before();
       reportCapture = Capture.newInstance();
       ParallelIndexSupervisorTaskClient taskClient = EasyMock.mock(ParallelIndexSupervisorTaskClient.class);
       taskClient.report(EasyMock.capture(reportCapture));
       EasyMock.replay(taskClient);
       taskToolbox = EasyMock.mock(TaskToolbox.class);
-      EasyMock.expect(taskToolbox.getIndexingTmpDir()).andStubReturn(temporaryFolder.getRoot());
+      EasyMock.expect(taskToolbox.getIndexingTmpDir()).andStubReturn(temporaryFolder);
       EasyMock.expect(taskToolbox.getSupervisorTaskClientProvider())
               .andReturn((supervisorTaskId, httpTimeout, numRetries) -> taskClient);
       EasyMock.expect(taskToolbox.getOverlordClient()).andReturn(null);
@@ -148,22 +143,31 @@ public class PartialDimensionDistributionTaskTest
       EasyMock.replay(taskToolbox);
     }
 
+    @AfterEach
+    public void tearDown() throws IOException
+    {
+      logger.after();
+      FileUtils.deleteDirectory(temporaryFolder);
+    }
+
     @Test
     public void requiresPartitionDimensions() throws Exception
     {
-      exception.expect(IllegalArgumentException.class);
-      exception.expectMessage("partitionDimensions must be specified");
-
-      ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
-          .forParallelIndexTask()
-          .withForceGuaranteedRollup(true)
-          .withPartitionsSpec(new DimensionRangePartitionsSpec(null, null, null, false))
-          .build();
-      PartialDimensionDistributionTask task = new PartialDimensionDistributionTaskBuilder()
-          .tuningConfig(tuningConfig)
-          .build();
-
-      task.runTask(taskToolbox);
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
+                .forParallelIndexTask()
+                .withForceGuaranteedRollup(true)
+                .withPartitionsSpec(new DimensionRangePartitionsSpec(null, null, null, false))
+                .build();
+            PartialDimensionDistributionTask task = new PartialDimensionDistributionTaskBuilder()
+                .tuningConfig(tuningConfig)
+                .build();
+            task.runTask(taskToolbox);
+          }
+      );
+      Assertions.assertTrue(exception.getMessage().contains("partitionDimensions must be specified"));
     }
 
     @Test
@@ -187,9 +191,9 @@ public class PartialDimensionDistributionTaskTest
       task.runTask(taskToolbox);
 
       List<LogEvent> logEvents = logger.getLogEvents();
-      Assert.assertEquals(1, logEvents.size());
+      Assertions.assertEquals(1, logEvents.size());
       String logMessage = logEvents.get(0).getMessage().getFormattedMessage();
-      Assert.assertTrue(logMessage.contains("Encountered parse exception"));
+      Assertions.assertTrue(logMessage.contains("Encountered parse exception"));
     }
 
     @Test
@@ -207,7 +211,7 @@ public class PartialDimensionDistributionTaskTest
 
       task.runTask(taskToolbox);
 
-      Assert.assertEquals(Collections.emptyList(), logger.getLogEvents());
+      Assertions.assertEquals(Collections.emptyList(), logger.getLogEvents());
     }
 
     @Test
@@ -223,10 +227,11 @@ public class PartialDimensionDistributionTaskTest
           .tuningConfig(tuningConfig)
           .build();
 
-      exception.expect(RuntimeException.class);
-      exception.expectMessage("Max parse exceptions[0] exceeded");
-
-      task.runTask(taskToolbox);
+      final RuntimeException exception = Assertions.assertThrows(
+          RuntimeException.class,
+          () -> task.runTask(taskToolbox)
+      );
+      Assertions.assertTrue(exception.getMessage().contains("Max parse exceptions[0] exceeded"));
     }
 
     @Test
@@ -238,10 +243,11 @@ public class PartialDimensionDistributionTaskTest
       PartialDimensionDistributionTaskBuilder taskBuilder = new PartialDimensionDistributionTaskBuilder()
           .inputSource(inlineInputSource);
 
-      exception.expect(RuntimeException.class);
-      exception.expectMessage("Cannot partition on multi-value dimension [dim]");
-
-      runTask(taskBuilder);
+      final RuntimeException exception = Assertions.assertThrows(
+          RuntimeException.class,
+          () -> runTask(taskBuilder)
+      );
+      Assertions.assertTrue(exception.getMessage().contains("Cannot partition on multi-value dimension [dim]"));
     }
 
     @Test
@@ -266,14 +272,14 @@ public class PartialDimensionDistributionTaskTest
 
       DimensionDistributionReport report = runTask(taskBuilder);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
       Map<Interval, StringDistribution> intervalToDistribution = report.getIntervalToDistribution();
       StringDistribution distribution = Iterables.getOnlyElement(intervalToDistribution.values());
-      Assert.assertNotNull(distribution);
+      Assertions.assertNotNull(distribution);
       PartitionBoundaries partitions = distribution.getEvenPartitionsByMaxSize(1);
-      Assert.assertEquals(2, partitions.size());
-      Assert.assertNull(partitions.get(0));
-      Assert.assertNull(partitions.get(1));
+      Assertions.assertEquals(2, partitions.size());
+      Assertions.assertNull(partitions.get(0));
+      Assertions.assertNull(partitions.get(1));
     }
 
     @Test
@@ -298,14 +304,14 @@ public class PartialDimensionDistributionTaskTest
 
       DimensionDistributionReport report = runTask(taskBuilder);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
       Map<Interval, StringDistribution> intervalToDistribution = report.getIntervalToDistribution();
       StringDistribution distribution = Iterables.getOnlyElement(intervalToDistribution.values());
-      Assert.assertNotNull(distribution);
+      Assertions.assertNotNull(distribution);
       PartitionBoundaries partitions = distribution.getEvenPartitionsByMaxSize(1);
-      Assert.assertEquals(2, partitions.size());
-      Assert.assertNull(partitions.get(0));
-      Assert.assertNull(partitions.get(1));
+      Assertions.assertEquals(2, partitions.size());
+      Assertions.assertNull(partitions.get(0));
+      Assertions.assertNull(partitions.get(1));
     }
 
     @Test
@@ -353,18 +359,18 @@ public class PartialDimensionDistributionTaskTest
 
       DimensionDistributionReport report = runTask(taskBuilder);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, report.getTaskId());
       Map<Interval, StringDistribution> intervalToDistribution = report.getIntervalToDistribution();
       StringDistribution distribution = Iterables.getOnlyElement(intervalToDistribution.values());
-      Assert.assertNotNull(distribution);
+      Assertions.assertNotNull(distribution);
       PartitionBoundaries partitions = distribution.getEvenPartitionsByMaxSize(1);
-      Assert.assertEquals(minBloomFilterBits + 2, partitions.size()); // 2 = min + max
+      Assertions.assertEquals(minBloomFilterBits + 2, partitions.size()); // 2 = min + max
 
       StringTuple minDimensionValue = StringTuple.create(dimensionValues.get(0));
-      Assert.assertEquals(minDimensionValue, ((StringSketch) distribution).getMin());
+      Assertions.assertEquals(minDimensionValue, ((StringSketch) distribution).getMin());
 
       StringTuple maxDimensionValue = StringTuple.create(dimensionValues.get(dimensionValues.size() - 1));
-      Assert.assertEquals(maxDimensionValue, ((StringSketch) distribution).getMax());
+      Assertions.assertEquals(maxDimensionValue, ((StringSketch) distribution).getMax());
     }
 
     @Test
@@ -375,8 +381,8 @@ public class PartialDimensionDistributionTaskTest
 
       TaskStatus taskStatus = task.runTask(taskToolbox);
 
-      Assert.assertEquals(ParallelIndexTestingFactory.ID, taskStatus.getId());
-      Assert.assertEquals(TaskState.SUCCESS, taskStatus.getStatusCode());
+      Assertions.assertEquals(ParallelIndexTestingFactory.ID, taskStatus.getId());
+      Assertions.assertEquals(TaskState.SUCCESS, taskStatus.getStatusCode());
     }
 
     @Test
@@ -385,7 +391,7 @@ public class PartialDimensionDistributionTaskTest
       PartialDimensionDistributionTask task = new PartialDimensionDistributionTaskBuilder()
           .build();
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Collections.singleton(
               new ResourceAction(
                   new Resource(InlineInputSource.TYPE_KEY, ResourceType.EXTERNAL),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -36,7 +36,6 @@ import org.apache.druid.indexing.common.stats.DropwizardRowIngestionMetersFactor
 import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringDistribution;
 import org.apache.druid.indexing.common.task.batch.parallel.distribution.StringSketch;
-import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.incremental.ParseExceptionHandler;
 import org.apache.druid.segment.indexing.DataSchema;
@@ -54,6 +53,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
@@ -120,7 +120,8 @@ public class PartialDimensionDistributionTaskTest
 
   public static class RunTaskTest
   {
-    private final File temporaryFolder = FileUtils.createTempDir();
+    @TempDir
+    private File temporaryFolder;
     private final LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
 
     private Capture<SubTaskReport> reportCapture;
@@ -147,7 +148,6 @@ public class PartialDimensionDistributionTaskTest
     public void tearDown() throws IOException
     {
       logger.after();
-      FileUtils.deleteDirectory(temporaryFolder);
     }
 
     @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialGenericSegmentMergeTaskTest.java
@@ -23,21 +23,20 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "partitionLocation = {0}")
+@MethodSource("data")
 public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSupervisorTaskTest
 {
-  @Parameterized.Parameters(name = "partitionLocation = {0}")
   public static Iterable<?> data()
   {
     return Arrays.asList(
@@ -46,7 +45,7 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
     );
   }
 
-  @Parameterized.Parameter
+  @Parameter
   public PartitionLocation partitionLocation;
 
   private static final GenericPartitionLocation GENERIC_PARTITION_LOCATION = new GenericPartitionLocation(
@@ -65,9 +64,6 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
       ImmutableMap.of()
   );
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   private PartialGenericSegmentMergeTask target;
   private PartialSegmentMergeIOConfig ioConfig;
   private HashedPartitionsSpec partitionsSpec;
@@ -78,7 +74,7 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
     super(0.0, 0.0);
   }
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     ioConfig = new PartialSegmentMergeIOConfig(Collections.singletonList(partitionLocation));
@@ -117,37 +113,38 @@ public class PartialGenericSegmentMergeTaskTest extends AbstractParallelIndexSup
   public void hasCorrectPrefixForAutomaticId()
   {
     String id = target.getId();
-    Assert.assertTrue(id.startsWith(PartialGenericSegmentMergeTask.TYPE));
+    Assertions.assertTrue(id.startsWith(PartialGenericSegmentMergeTask.TYPE));
   }
 
   @Test
   public void requiresGranularitySpecInputIntervals()
   {
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("Missing intervals in granularitySpec");
-
-    new PartialGenericSegmentMergeTask(
-        ParallelIndexTestingFactory.AUTOMATIC_ID,
-        ParallelIndexTestingFactory.GROUP_ID,
-        ParallelIndexTestingFactory.TASK_RESOURCE,
-        ParallelIndexTestingFactory.SUPERVISOR_TASK_ID,
-        ParallelIndexTestingFactory.SUBTASK_SPEC_ID,
-        ParallelIndexTestingFactory.NUM_ATTEMPTS,
-        new PartialSegmentMergeIngestionSpec(
-            ParallelIndexTestingFactory.createDataSchema(null),
-            ioConfig,
-            TuningConfigBuilder.forParallelIndexTask()
-                .withForceGuaranteedRollup(true)
-                .withPartitionsSpec(partitionsSpec)
-                .build()
-        ),
-        ParallelIndexTestingFactory.CONTEXT
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PartialGenericSegmentMergeTask(
+            ParallelIndexTestingFactory.AUTOMATIC_ID,
+            ParallelIndexTestingFactory.GROUP_ID,
+            ParallelIndexTestingFactory.TASK_RESOURCE,
+            ParallelIndexTestingFactory.SUPERVISOR_TASK_ID,
+            ParallelIndexTestingFactory.SUBTASK_SPEC_ID,
+            ParallelIndexTestingFactory.NUM_ATTEMPTS,
+            new PartialSegmentMergeIngestionSpec(
+                ParallelIndexTestingFactory.createDataSchema(null),
+                ioConfig,
+                TuningConfigBuilder.forParallelIndexTask()
+                    .withForceGuaranteedRollup(true)
+                    .withPartitionsSpec(partitionsSpec)
+                    .build()
+            ),
+            ParallelIndexTestingFactory.CONTEXT
+        )
     );
+    Assertions.assertTrue(exception.getMessage().contains("Missing intervals in granularitySpec"));
   }
 
   @Test
   public void testGetInputSourceResources()
   {
-    Assert.assertTrue(target.getInputSourceResources().isEmpty());
+    Assertions.assertTrue(target.getInputSourceResources().isEmpty());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialHashSegmentGenerateTaskTest.java
@@ -35,14 +35,10 @@ import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.Collections;
@@ -62,12 +58,9 @@ public class PartialHashSegmentGenerateTaskTest
       ParallelIndexTestingFactory.createDataSchema(ParallelIndexTestingFactory.INPUT_INTERVALS)
   );
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private PartialHashSegmentGenerateTask target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new PartialHashSegmentGenerateTask(
@@ -93,13 +86,13 @@ public class PartialHashSegmentGenerateTaskTest
   public void hasCorrectPrefixForAutomaticId()
   {
     String id = target.getId();
-    MatcherAssert.assertThat(id, Matchers.startsWith(PartialHashSegmentGenerateTask.TYPE));
+    Assertions.assertTrue(id.startsWith(PartialHashSegmentGenerateTask.TYPE));
   }
 
   @Test
   public void hasCorrectInputSourceResources()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 LocalInputSource.TYPE_KEY,
@@ -128,9 +121,9 @@ public class PartialHashSegmentGenerateTaskTest
             new HashedPartitionsSpec(null, expectedNumBuckets, null),
             null
         );
-    Assert.assertEquals(intervals.size(), partitionAnalysis.getNumTimePartitions());
+    Assertions.assertEquals(intervals.size(), partitionAnalysis.getNumTimePartitions());
     for (Interval interval : intervals) {
-      Assert.assertEquals(expectedNumBuckets, partitionAnalysis.getBucketAnalysis(interval).intValue());
+      Assertions.assertEquals(expectedNumBuckets, partitionAnalysis.getBucketAnalysis(interval).intValue());
     }
   }
 
@@ -160,9 +153,9 @@ public class PartialHashSegmentGenerateTaskTest
             new HashedPartitionsSpec(null, null, null),
             intervalToNumShards
         );
-    Assert.assertEquals(intervals.size(), partitionAnalysis.getNumTimePartitions());
+    Assertions.assertEquals(intervals.size(), partitionAnalysis.getNumTimePartitions());
     for (Interval interval : intervals) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           intervalToNumShards.get(interval).intValue(),
           partitionAnalysis.getBucketAnalysis(interval).intValue()
       );
@@ -172,27 +165,28 @@ public class PartialHashSegmentGenerateTaskTest
   @Test
   public void requiresGranularitySpecInputIntervals()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Missing intervals in granularitySpec");
-
-    new PartialHashSegmentGenerateTask(
-        ParallelIndexTestingFactory.AUTOMATIC_ID,
-        ParallelIndexTestingFactory.GROUP_ID,
-        ParallelIndexTestingFactory.TASK_RESOURCE,
-        ParallelIndexTestingFactory.SUPERVISOR_TASK_ID,
-        ParallelIndexTestingFactory.SUBTASK_SPEC_ID,
-        ParallelIndexTestingFactory.NUM_ATTEMPTS,
-        ParallelIndexTestingFactory.createIngestionSpec(
-            new LocalInputSource(new File("baseDir"), "filer"),
-            new JsonInputFormat(null, null, null, null, null),
-            TuningConfigBuilder.forParallelIndexTask()
-                               .withForceGuaranteedRollup(true)
-                               .withPartitionsSpec(new HashedPartitionsSpec(null, 2, null))
-                               .build(),
-            ParallelIndexTestingFactory.createDataSchema(null)
-        ),
-        ParallelIndexTestingFactory.CONTEXT,
-        null
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PartialHashSegmentGenerateTask(
+            ParallelIndexTestingFactory.AUTOMATIC_ID,
+            ParallelIndexTestingFactory.GROUP_ID,
+            ParallelIndexTestingFactory.TASK_RESOURCE,
+            ParallelIndexTestingFactory.SUPERVISOR_TASK_ID,
+            ParallelIndexTestingFactory.SUBTASK_SPEC_ID,
+            ParallelIndexTestingFactory.NUM_ATTEMPTS,
+            ParallelIndexTestingFactory.createIngestionSpec(
+                new LocalInputSource(new File("baseDir"), "filer"),
+                new JsonInputFormat(null, null, null, null, null),
+                TuningConfigBuilder.forParallelIndexTask()
+                                   .withForceGuaranteedRollup(true)
+                                   .withPartitionsSpec(new HashedPartitionsSpec(null, 2, null))
+                                   .build(),
+                ParallelIndexTestingFactory.createDataSchema(null)
+            ),
+            ParallelIndexTestingFactory.CONTEXT,
+            null
+        )
     );
+    Assertions.assertTrue(exception.getMessage().contains("Missing intervals in granularitySpec"));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialRangeSegmentGenerateTaskTest.java
@@ -38,18 +38,13 @@ import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
 public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSupervisorTaskTest
 {
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   public PartialRangeSegmentGenerateTaskTest()
   {
     // We don't need to emulate transient failures for this test.
@@ -59,24 +54,22 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
   @Test
   public void requiresForceGuaranteedRollup()
   {
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("range or single_dim partitionsSpec required");
-
     ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
         .forParallelIndexTask()
         .withPartitionsSpec(new DynamicPartitionsSpec(null, null))
         .build();
-    new PartialRangeSegmentGenerateTaskBuilder()
-        .tuningConfig(tuningConfig)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PartialRangeSegmentGenerateTaskBuilder()
+            .tuningConfig(tuningConfig)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("range or single_dim partitionsSpec required"));
   }
 
   @Test
   public void requiresMultiDimensionPartitions()
   {
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("range or single_dim partitionsSpec required");
-
     PartitionsSpec partitionsSpec = new HashedPartitionsSpec(null, 1, null);
     ParallelIndexTuningConfig tuningConfig = TuningConfigBuilder
         .forParallelIndexTask()
@@ -84,22 +77,27 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
         .withPartitionsSpec(partitionsSpec)
         .build();
 
-    new PartialRangeSegmentGenerateTaskBuilder()
-        .tuningConfig(tuningConfig)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PartialRangeSegmentGenerateTaskBuilder()
+            .tuningConfig(tuningConfig)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("range or single_dim partitionsSpec required"));
   }
 
   @Test
   public void requiresGranularitySpecInputIntervals()
   {
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("Missing intervals in granularitySpec");
-
     DataSchema dataSchema = ParallelIndexTestingFactory.createDataSchema(Collections.emptyList());
 
-    new PartialRangeSegmentGenerateTaskBuilder()
-        .dataSchema(dataSchema)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PartialRangeSegmentGenerateTaskBuilder()
+            .dataSchema(dataSchema)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Missing intervals in granularitySpec"));
   }
 
   @Test
@@ -113,7 +111,7 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
   public void hasCorrectInputSourceResources()
   {
     PartialRangeSegmentGenerateTask task = new PartialRangeSegmentGenerateTaskBuilder().build();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 InlineInputSource.TYPE_KEY,
@@ -127,7 +125,7 @@ public class PartialRangeSegmentGenerateTaskTest extends AbstractParallelIndexSu
   public void hasCorrectPrefixForAutomaticId()
   {
     PartialRangeSegmentGenerateTask task = new PartialRangeSegmentGenerateTaskBuilder().build();
-    Assert.assertTrue(task.getId().startsWith(PartialRangeSegmentGenerateTask.TYPE));
+    Assertions.assertTrue(task.getId().startsWith(PartialRangeSegmentGenerateTask.TYPE));
   }
 
   private static class PartialRangeSegmentGenerateTaskBuilder

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIOConfigTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIOConfigTest.java
@@ -23,15 +23,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.Collections;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "partitionLocation = {0}")
+@MethodSource("data")
 public class PartialSegmentMergeIOConfigTest
 {
   final PartitionLocation partitionLocation;
@@ -41,7 +42,6 @@ public class PartialSegmentMergeIOConfigTest
     this.partitionLocation = partitionLocation;
   }
 
-  @Parameterized.Parameters(name = "partitionLocation = {0}")
   public static Collection<Object[]> data()
   {
     return ImmutableList.of(new Object[]{
@@ -66,7 +66,7 @@ public class PartialSegmentMergeIOConfigTest
   private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();
   private PartialSegmentMergeIOConfig target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new PartialSegmentMergeIOConfig(Collections.singletonList(partitionLocation));

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIngestionSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialSegmentMergeIngestionSpecTest.java
@@ -24,20 +24,21 @@ import com.google.common.collect.ImmutableMap;
 import org.apache.druid.indexer.partitions.HashedPartitionsSpec;
 import org.apache.druid.indexing.common.task.TuningConfigBuilder;
 import org.apache.druid.segment.TestHelper;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.Parameter;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "partitionLocation = {0}")
+@MethodSource("data")
 public class PartialSegmentMergeIngestionSpecTest
 {
   private static final ObjectMapper OBJECT_MAPPER = ParallelIndexTestingFactory.createObjectMapper();
 
-  @Parameterized.Parameters(name = "partitionLocation = {0}")
   public static Iterable<?> data()
   {
     return Arrays.asList(
@@ -46,7 +47,7 @@ public class PartialSegmentMergeIngestionSpecTest
     );
   }
 
-  @Parameterized.Parameter
+  @Parameter
   public PartitionLocation partitionLocation;
 
   private static final GenericPartitionLocation GENERIC_PARTITION_LOCATION = new GenericPartitionLocation(
@@ -67,7 +68,7 @@ public class PartialSegmentMergeIngestionSpecTest
 
   private PartialSegmentMergeIngestionSpec target;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     PartialSegmentMergeIOConfig ioConfig =

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PerfectRollupWorkerTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PerfectRollupWorkerTaskTest.java
@@ -30,9 +30,8 @@ import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -41,18 +40,16 @@ import java.util.Map;
 
 public class PerfectRollupWorkerTaskTest
 {
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
   @Test
   public void requiresForceGuaranteedRollup()
   {
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("forceGuaranteedRollup must be set");
-
-    new PerfectRollupWorkerTaskBuilder()
-        .forceGuaranteedRollup(false)
-        .build();
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> new PerfectRollupWorkerTaskBuilder()
+            .forceGuaranteedRollup(false)
+            .build()
+    );
+    Assertions.assertTrue(exception.getMessage().contains("forceGuaranteedRollup must be set"));
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PushedSegmentsReportTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PushedSegmentsReportTest.java
@@ -22,7 +22,7 @@ package org.apache.druid.indexing.common.task.batch.parallel;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.indexer.report.KillTaskReport;
 import org.apache.druid.indexer.report.TaskReport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class PushedSegmentsReportTest
 {

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionAdjustingCorePartitionSizeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionAdjustingCorePartitionSizeTest.java
@@ -33,10 +33,10 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.SingleDimensionShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,7 +49,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}, maxNumConcurrentSubTasks={1}")
+@MethodSource("constructorFeeder")
 public class RangePartitionAdjustingCorePartitionSizeTest extends AbstractMultiPhaseParallelIndexingTest
 {
   private static final TimestampSpec TIMESTAMP_SPEC = new TimestampSpec("ts", "auto", null);
@@ -66,7 +67,6 @@ public class RangePartitionAdjustingCorePartitionSizeTest extends AbstractMultiP
   );
   private static final Interval INTERVAL_TO_INDEX = Intervals.of("2020-01-01/P1M");
 
-  @Parameterized.Parameters(name = "{0}, maxNumConcurrentSubTasks={1}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -87,7 +87,7 @@ public class RangePartitionAdjustingCorePartitionSizeTest extends AbstractMultiP
   @Test
   public void testLessPartitionsThanBuckets() throws IOException
   {
-    final File inputDir = temporaryFolder.newFolder();
+    final File inputDir = createTempDir();
     for (int i = 0; i < 2; i++) {
       try (final Writer writer =
                Files.newBufferedWriter(new File(inputDir, "test_" + i).toPath(), StandardCharsets.UTF_8)) {
@@ -120,19 +120,19 @@ public class RangePartitionAdjustingCorePartitionSizeTest extends AbstractMultiP
             TaskState.SUCCESS
         ).getSegments()
     );
-    Assert.assertEquals(1, segments.size());
+    Assertions.assertEquals(1, segments.size());
     final DataSegment segment = segments.get(0);
-    Assert.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
+    Assertions.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
     final SingleDimensionShardSpec shardSpec = (SingleDimensionShardSpec) segment.getShardSpec();
-    Assert.assertEquals(1, shardSpec.getNumCorePartitions());
-    Assert.assertEquals(0, shardSpec.getPartitionNum());
-    Assert.assertEquals(partitionDimensions, shardSpec.getDimensions());
+    Assertions.assertEquals(1, shardSpec.getNumCorePartitions());
+    Assertions.assertEquals(0, shardSpec.getPartitionNum());
+    Assertions.assertEquals(partitionDimensions, shardSpec.getDimensions());
   }
 
   @Test
   public void testEqualNumberOfPartitionsToBuckets() throws IOException
   {
-    final File inputDir = temporaryFolder.newFolder();
+    final File inputDir = createTempDir();
     for (int i = 0; i < 10; i++) {
       try (final Writer writer =
                Files.newBufferedWriter(new File(inputDir, "test_" + i).toPath(), StandardCharsets.UTF_8)) {
@@ -158,13 +158,13 @@ public class RangePartitionAdjustingCorePartitionSizeTest extends AbstractMultiP
         maxNumConcurrentSubTasks,
         TaskState.SUCCESS
     ).getSegments();
-    Assert.assertEquals(5, segments.size());
+    Assertions.assertEquals(5, segments.size());
     segments.forEach(segment -> {
-      Assert.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
+      Assertions.assertSame(SingleDimensionShardSpec.class, segment.getShardSpec().getClass());
       final SingleDimensionShardSpec shardSpec = (SingleDimensionShardSpec) segment.getShardSpec();
-      Assert.assertEquals(5, shardSpec.getNumCorePartitions());
-      Assert.assertTrue(shardSpec.getPartitionNum() < shardSpec.getNumCorePartitions());
-      Assert.assertEquals(partitionDimensions, shardSpec.getDimensions());
+      Assertions.assertEquals(5, shardSpec.getNumCorePartitions());
+      Assertions.assertTrue(shardSpec.getPartitionNum() < shardSpec.getNumCorePartitions());
+      Assertions.assertEquals(partitionDimensions, shardSpec.getDimensions());
     });
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
@@ -453,14 +453,14 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
     Assertions.assertTrue(start != null || end != null, shardSpec.toString());
 
     for (StringTuple value : values) {
-      if (start != null) {
-        Assertions.assertTrue(value.compareTo(start) >= 0);
-      }
+      if (value == null) {
+        Assertions.assertNull(start, "null values should be in first partition");
+      } else {
+        if (start != null) {
+          Assertions.assertTrue(value.compareTo(start) >= 0);
+        }
 
-      if (end != null) {
-        if (value == null) {
-          Assertions.assertNull(start, "null values should be in first partition");
-        } else {
+        if (end != null) {
           Assertions.assertTrue(value.compareTo(end) < 0);
         }
       }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
@@ -400,7 +400,7 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
     );
   }
 
-  private void assertRangePartitions(Set<DataSegment> publishedSegments) throws IOException
+  private void assertRangePartitions(Set<DataSegment> publishedSegments)
   {
     Multimap<Interval, DataSegment> intervalToSegments = ArrayListMultimap.create();
     publishedSegments.forEach(s -> intervalToSegments.put(s.getInterval(), s));

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionMultiPhaseParallelIndexingTest.java
@@ -43,14 +43,12 @@ import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.DimensionRangeShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.apache.druid.timeline.partition.SingleDimensionShardSpec;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -72,7 +70,8 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}, maxNumConcurrentSubTasks={1}, useMultiValueDim={2}, intervalToIndex={3}")
+@MethodSource("constructorFeeder")
 public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiPhaseParallelIndexingTest
 {
   private static final boolean USE_MULTIVALUE_DIM = true;
@@ -101,7 +100,6 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
       null
   );
 
-  @Parameterized.Parameters(name = "{0}, maxNumConcurrentSubTasks={1}, useMultiValueDim={2}, intervalToIndex={3}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -134,10 +132,10 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
     this.intervalToIndex = intervalToIndex;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
     intervalToDims = createInputFiles(inputDir, useMultivalueDim);
   }
 
@@ -259,10 +257,10 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
     final Set<DataSegment> publishedSegments = publishedDataSegmentsWithSchemas.getSegments();
     if (!useMultivalueDim) {
       assertRangePartitions(publishedSegments);
-      Assert.assertEquals(1, publishedDataSegmentsWithSchemas.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
-      Assert.assertEquals(publishedSegments.size(), publishedDataSegmentsWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size());
+      Assertions.assertEquals(1, publishedDataSegmentsWithSchemas.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
+      Assertions.assertEquals(publishedSegments.size(), publishedDataSegmentsWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size());
       for (DataSegment segment : publishedSegments) {
-        Assert.assertTrue(publishedDataSegmentsWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().containsKey(segment.getId().toString()));
+        Assertions.assertTrue(publishedDataSegmentsWithSchemas.getSegmentSchemaMapping().getSegmentIdToMetadataMap().containsKey(segment.getId().toString()));
       }
     }
 
@@ -272,7 +270,7 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
       return;
     }
 
-    File inputDirectory = temporaryFolder.newFolder("dataReplace");
+    File inputDirectory = createTempDir("dataReplace");
     createInputFilesForReplace(inputDirectory, useMultivalueDim);
 
     final DataSegmentsWithSchemas publishedDataSegmentsWithSchemasAfterReplace = runTask(runTestTask(
@@ -297,15 +295,15 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
     }
 
     if (!useMultivalueDim) {
-      Assert.assertEquals(11, tombstones);
-      Assert.assertEquals(10, publishedSegmentsAfterReplace.size() - tombstones);
+      Assertions.assertEquals(11, tombstones);
+      Assertions.assertEquals(10, publishedSegmentsAfterReplace.size() - tombstones);
       for (DataSegment segment : publishedSegmentsAfterReplace) {
         if (!segment.isTombstone()) {
-          Assert.assertTrue(publishedDataSegmentsWithSchemasAfterReplace.getSegmentSchemaMapping().getSegmentIdToMetadataMap().containsKey(segment.getId().toString()));
+          Assertions.assertTrue(publishedDataSegmentsWithSchemasAfterReplace.getSegmentSchemaMapping().getSegmentIdToMetadataMap().containsKey(segment.getId().toString()));
         }
       }
-      Assert.assertEquals(10, publishedDataSegmentsWithSchemasAfterReplace.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size());
-      Assert.assertEquals(1, publishedDataSegmentsWithSchemasAfterReplace.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
+      Assertions.assertEquals(10, publishedDataSegmentsWithSchemasAfterReplace.getSegmentSchemaMapping().getSegmentIdToMetadataMap().size());
+      Assertions.assertEquals(1, publishedDataSegmentsWithSchemasAfterReplace.getSegmentSchemaMapping().getSchemaFingerprintToPayloadMap().size());
     }
   }
 
@@ -371,11 +369,11 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
       for (DataSegment rangedSegment : rangedSegments) {
         final SingleDimensionShardSpec rangeShardSpec = (SingleDimensionShardSpec) rangedSegment.getShardSpec();
         for (DataSegment linearSegment : linearSegments) {
-          Assert.assertEquals(rangedSegment.getInterval(), linearSegment.getInterval());
-          Assert.assertEquals(rangedSegment.getVersion(), linearSegment.getVersion());
+          Assertions.assertEquals(rangedSegment.getInterval(), linearSegment.getInterval());
+          Assertions.assertEquals(rangedSegment.getVersion(), linearSegment.getVersion());
           final NumberedShardSpec numberedShardSpec = (NumberedShardSpec) linearSegment.getShardSpec();
-          Assert.assertEquals(rangeShardSpec.getNumCorePartitions(), numberedShardSpec.getNumCorePartitions());
-          Assert.assertTrue(rangeShardSpec.getPartitionNum() < numberedShardSpec.getPartitionNum());
+          Assertions.assertEquals(rangeShardSpec.getNumCorePartitions(), numberedShardSpec.getNumCorePartitions());
+          Assertions.assertTrue(rangeShardSpec.getPartitionNum() < numberedShardSpec.getPartitionNum());
         }
       }
     }
@@ -410,7 +408,7 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
     Set<Interval> publishedIntervals = intervalToSegments.keySet();
     assertHasExpectedIntervals(publishedIntervals);
 
-    File tempSegmentDir = temporaryFolder.newFolder();
+    File tempSegmentDir = createTempDir();
 
     intervalToSegments.asMap().forEach((interval, segments) -> {
       assertNumPartition(segments);
@@ -428,18 +426,18 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
 
   private void assertHasExpectedIntervals(Set<Interval> publishedSegmentIntervals)
   {
-    Assert.assertEquals(intervalToDims.keySet(), publishedSegmentIntervals);
+    Assertions.assertEquals(intervalToDims.keySet(), publishedSegmentIntervals);
   }
 
   private static void assertNumPartition(Collection<DataSegment> segments)
   {
-    Assert.assertEquals(NUM_PARTITION, segments.size());
+    Assertions.assertEquals(NUM_PARTITION, segments.size());
   }
 
   private List<StringTuple> getColumnValues(DataSegment segment, File tempDir)
   {
     List<ScanResultValue> results = querySegment(segment, DIMS, tempDir);
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
     List<LinkedHashMap<String, String>> rows = (List<LinkedHashMap<String, String>>) results.get(0).getEvents();
     return rows.stream()
                .map(row -> row.get(DIM1))
@@ -452,18 +450,18 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
     DimensionRangeShardSpec shardSpec = (DimensionRangeShardSpec) segment.getShardSpec();
     StringTuple start = shardSpec.getStartTuple();
     StringTuple end = shardSpec.getEndTuple();
-    Assert.assertTrue(shardSpec.toString(), start != null || end != null);
+    Assertions.assertTrue(start != null || end != null, shardSpec.toString());
 
     for (StringTuple value : values) {
       if (start != null) {
-        MatcherAssert.assertThat(value.compareTo(start), Matchers.greaterThanOrEqualTo(0));
+        Assertions.assertTrue(value.compareTo(start) >= 0);
       }
 
       if (end != null) {
         if (value == null) {
-          Assert.assertNull("null values should be in first partition", start);
+          Assertions.assertNull(start, "null values should be in first partition");
         } else {
-          MatcherAssert.assertThat(value.compareTo(end), Matchers.lessThan(0));
+          Assertions.assertTrue(value.compareTo(end) < 0);
         }
       }
     }
@@ -478,6 +476,6 @@ public class RangePartitionMultiPhaseParallelIndexingTest extends AbstractMultiP
                                                 .sorted(Comparators.naturalNullsFirst())
                                                 .collect(Collectors.toList());
     actualValues.sort(Comparators.naturalNullsFirst());
-    Assert.assertEquals(interval.toString(), expectedValues, actualValues);
+    Assertions.assertEquals(expectedValues, actualValues, interval.toString());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/RangePartitionTaskKillTest.java
@@ -43,9 +43,10 @@ import org.apache.druid.query.aggregation.LongSumAggregatorFactory;
 import org.apache.druid.segment.indexing.DataSchema;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -93,13 +94,14 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
     super(LockGranularity.SEGMENT, DEFAULT_TRANSIENT_TASK_FAILURE_RATE, DEFAULT_TRANSIENT_API_FAILURE_RATE);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void failsFirstPhase() throws Exception
   {
     int targetRowsPerSegment = NUM_ROW * 2 / DIM_FILE_CARDINALITY / NUM_PARTITION;
@@ -125,20 +127,21 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
 
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
 
     TaskStatus taskStatus = task.runRangePartitionMultiPhaseParallel(toolbox);
 
-    Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals(
+    Assertions.assertTrue(taskStatus.isFailure());
+    Assertions.assertEquals(
         "Failed in phase[PHASE-1]. See task logs for details.",
         taskStatus.getErrorMsg()
     );
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void failsSecondPhase() throws Exception
   {
     int targetRowsPerSegment = NUM_ROW * 2 / DIM_FILE_CARDINALITY / NUM_PARTITION;
@@ -164,20 +167,21 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
 
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
 
     TaskStatus taskStatus = task.runRangePartitionMultiPhaseParallel(toolbox);
 
-    Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals(
+    Assertions.assertTrue(taskStatus.isFailure());
+    Assertions.assertEquals(
         "Failed in phase[PHASE-2]. See task logs for details.",
         taskStatus.getErrorMsg()
     );
   }
 
-  @Test(timeout = 5000L)
+  @Test
+  @Timeout(5)
   public void failsThirdPhase() throws Exception
   {
     int targetRowsPerSegment = NUM_ROW * 2 / DIM_FILE_CARDINALITY / NUM_PARTITION;
@@ -203,14 +207,14 @@ public class RangePartitionTaskKillTest extends AbstractMultiPhaseParallelIndexi
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
 
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
     task.stopGracefully(null);
 
     task.setToolbox(toolbox);
     TaskStatus taskStatus = task.runRangePartitionMultiPhaseParallel(toolbox);
 
-    Assert.assertTrue(taskStatus.isFailure());
-    Assert.assertEquals(
+    Assertions.assertTrue(taskStatus.isFailure());
+    Assertions.assertEquals(
         "Failed in phase[PHASE-3]. See task logs for details.",
         taskStatus.getErrorMsg()
     );

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SegmentAllocationRequestTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SegmentAllocationRequestTest.java
@@ -23,8 +23,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.DateTimes;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -50,6 +50,6 @@ public class SegmentAllocationRequestTest
     );
     byte[] json = objectMapper.writeValueAsBytes(request);
     SegmentAllocationRequest fromJson = objectMapper.readValue(json, SegmentAllocationRequest.class);
-    Assert.assertEquals(request, fromJson);
+    Assertions.assertEquals(request, fromJson);
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -62,7 +62,6 @@ import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.NumberedOverwriteShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Interval;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -150,12 +149,6 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     }
 
     getObjectMapper().registerSubtypes(SettableSplittableLocalInputSource.class);
-  }
-
-  @AfterEach
-  public void teardown()
-  {
-    deleteTempDir();
   }
 
   @Test

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseParallelIndexingTest.java
@@ -62,15 +62,13 @@ import org.apache.druid.timeline.SegmentTimeline;
 import org.apache.druid.timeline.partition.NumberedOverwriteShardSpec;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -88,13 +86,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass(name = "{0}, useInputFormatApi={1}, useSegmentCache={2}, useConcurrentLocks={3}")
+@MethodSource("constructorFeeder")
 public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSupervisorTaskTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Parameterized.Parameters(name = "{0}, useInputFormatApi={1}, useSegmentCache={2}, useConcurrentLocks={3}")
   public static Iterable<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -126,10 +121,10 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     this.useConcurrentLocks = useConcurrentLocks;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
-    inputDir = temporaryFolder.newFolder("data");
+    inputDir = createTempDir("data");
     // set up data
     for (int i = 0; i < 5; i++) {
       try (final Writer writer =
@@ -157,10 +152,10 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     getObjectMapper().registerSubtypes(SettableSplittableLocalInputSource.class);
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
-    temporaryFolder.delete();
+    deleteTempDir();
   }
 
   @Test
@@ -170,7 +165,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     final TaskActionClient actionClient = createActionClient(task);
     final TaskToolbox toolbox = createTaskToolbox(task, actionClient);
     prepareTaskForLocking(task);
-    Assert.assertTrue(task.isReady(actionClient));
+    Assertions.assertTrue(task.isReady(actionClient));
 
     final SinglePhaseParallelIndexTaskRunner runner = task.createSinglePhaseTaskRunner(toolbox);
     final Iterator<SubTaskSpec<SinglePhaseSubTask>> subTaskSpecIterator = runner.subTaskSpecIterator();
@@ -189,8 +184,8 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
       );
       final TaskActionClient subTaskActionClient = createActionClient(subTask);
       prepareTaskForLocking(subTask);
-      Assert.assertTrue(subTask.isReady(subTaskActionClient));
-      Assert.assertEquals(
+      Assertions.assertTrue(subTask.isReady(subTaskActionClient));
+      Assertions.assertEquals(
           Collections.singleton(
               new ResourceAction(new Resource(
                   LocalInputSource.TYPE_KEY,
@@ -211,7 +206,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     // The task could run differently between when appendToExisting is false and true even when this is an initial write
     final ParallelIndexSupervisorTask task = newTask(interval, segmentGranularity, appendToExisting, true);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
     assertShardSpec(
         task,
         interval == null ? LockGranularity.TIME_CHUNK : lockGranularity,
@@ -230,7 +225,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
   {
     final ParallelIndexSupervisorTask task = newTask(interval, segmentGranularity, false, true);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
     assertShardSpecAfterOverwrite(task, actualLockGranularity);
     TaskContainer taskContainer = getIndexingServiceClient().getTaskContainer(task.getId());
     return (ParallelIndexSupervisorTask) taskContainer.getTask();
@@ -263,7 +258,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         inputInterval == null
         ? getStorageCoordinator().retrieveAllUsedSegments("dataSource", Segments.ONLY_VISIBLE)
         : getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", inputInterval, Segments.ONLY_VISIBLE);
-    Assert.assertFalse(newSegments.isEmpty());
+    Assertions.assertFalse(newSegments.isEmpty());
     allSegments.addAll(newSegments);
     final SegmentTimeline timeline = SegmentTimeline.forSegments(allSegments);
 
@@ -272,7 +267,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         timelineInterval,
         Partitions.ONLY_COMPLETE
     );
-    Assert.assertEquals(new HashSet<>(newSegments), visibles);
+    Assertions.assertEquals(new HashSet<>(newSegments), visibles);
   }
 
   private void assertShardSpec(
@@ -290,9 +285,9 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
       final Map<Interval, List<DataSegment>> intervalToSegments = SegmentUtils.groupSegmentsByInterval(segments);
       for (List<DataSegment> segmentsPerInterval : intervalToSegments.values()) {
         for (DataSegment segment : segmentsPerInterval) {
-          Assert.assertSame(NumberedShardSpec.class, segment.getShardSpec().getClass());
+          Assertions.assertSame(NumberedShardSpec.class, segment.getShardSpec().getClass());
           final NumberedShardSpec shardSpec = (NumberedShardSpec) segment.getShardSpec();
-          Assert.assertEquals(segmentsPerInterval.size(), shardSpec.getNumCorePartitions());
+          Assertions.assertEquals(segmentsPerInterval.size(), shardSpec.getNumCorePartitions());
         }
       }
     } else {
@@ -301,14 +296,14 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
           originalSegmentsIfAppend
       );
       for (DataSegment segment : segments) {
-        Assert.assertSame(NumberedShardSpec.class, segment.getShardSpec().getClass());
+        Assertions.assertSame(NumberedShardSpec.class, segment.getShardSpec().getClass());
         final NumberedShardSpec shardSpec = (NumberedShardSpec) segment.getShardSpec();
         final List<DataSegment> originalSegmentsInInterval = intervalToOriginalSegments.get(segment.getInterval());
         final int expectedNumCorePartitions =
             originalSegmentsInInterval == null || originalSegmentsInInterval.isEmpty()
             ? 0
             : originalSegmentsInInterval.get(0).getShardSpec().getNumCorePartitions();
-        Assert.assertEquals(expectedNumCorePartitions, shardSpec.getNumCorePartitions());
+        Assertions.assertEquals(expectedNumCorePartitions, shardSpec.getNumCorePartitions());
       }
     }
   }
@@ -323,17 +318,17 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
       // Check the core partition set in the shardSpec
       for (List<DataSegment> segmentsPerInterval : intervalToSegments.values()) {
         for (DataSegment segment : segmentsPerInterval) {
-          Assert.assertSame(NumberedShardSpec.class, segment.getShardSpec().getClass());
+          Assertions.assertSame(NumberedShardSpec.class, segment.getShardSpec().getClass());
           final NumberedShardSpec shardSpec = (NumberedShardSpec) segment.getShardSpec();
-          Assert.assertEquals(segmentsPerInterval.size(), shardSpec.getNumCorePartitions());
+          Assertions.assertEquals(segmentsPerInterval.size(), shardSpec.getNumCorePartitions());
         }
       }
     } else {
       for (List<DataSegment> segmentsPerInterval : intervalToSegments.values()) {
         for (DataSegment segment : segmentsPerInterval) {
-          Assert.assertSame(NumberedOverwriteShardSpec.class, segment.getShardSpec().getClass());
+          Assertions.assertSame(NumberedOverwriteShardSpec.class, segment.getShardSpec().getClass());
           final NumberedOverwriteShardSpec shardSpec = (NumberedOverwriteShardSpec) segment.getShardSpec();
-          Assert.assertEquals(segmentsPerInterval.size(), shardSpec.getAtomicUpdateGroupSize());
+          Assertions.assertEquals(segmentsPerInterval.size(), shardSpec.getAtomicUpdateGroupSize());
         }
       }
     }
@@ -376,18 +371,18 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     IngestionStatsAndErrors statsAndErrors = ((IngestionStatsAndErrorsTaskReport)
         reportMap.get("ingestionStatsAndErrors")).getPayload();
     Map<String, Object> rowStats = statsAndErrors.getRowStats();
-    Assert.assertTrue(rowStats.containsKey("totals"));
+    Assertions.assertTrue(rowStats.containsKey("totals"));
 
     getIndexingServiceClient().allowTasksToFinish();
 
     TaskStatus taskStatus = getIndexingServiceClient().waitToFinish(task, 2, TimeUnit.MINUTES);
-    Assert.assertEquals(TaskState.SUCCESS, taskStatus.getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, taskStatus.getStatusCode());
   }
 
   @Test
   public void testRunInParallelIngestNullColumn()
   {
-    Assume.assumeTrue(useInputFormatApi);
+    Assumptions.assumeTrue(useInputFormatApi);
     // Ingest all data.
     final List<DimensionSchema> dimensionSchemas = DimensionsSpec.getDefaultSchemas(
         Arrays.asList("ts", "unknownDim", "dim")
@@ -422,14 +417,14 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     );
 
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     DataSegmentsWithSchemas dataSegmentsWithSchemas = getIndexingServiceClient().getSegmentAndSchemas(task);
     verifySchema(dataSegmentsWithSchemas);
     Set<DataSegment> segments = dataSegmentsWithSchemas.getSegments();
     for (DataSegment segment : segments) {
       for (int i = 0; i < dimensionSchemas.size(); i++) {
-        Assert.assertEquals(dimensionSchemas.get(i).getName(), segment.getDimensions().get(i));
+        Assertions.assertEquals(dimensionSchemas.get(i).getName(), segment.getDimensions().get(i));
       }
     }
   }
@@ -437,7 +432,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
   @Test
   public void testRunInParallelIngestNullColumn_storeEmptyColumnsOff_shouldNotStoreEmptyColumns()
   {
-    Assume.assumeTrue(useInputFormatApi);
+    Assumptions.assumeTrue(useInputFormatApi);
     // Ingest all data.
     final List<DimensionSchema> dimensionSchemas = DimensionsSpec.getDefaultSchemas(
         Arrays.asList("ts", "unknownDim", "dim")
@@ -473,13 +468,13 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
 
     task.addToContext(Tasks.STORE_EMPTY_COLUMNS_KEY, false);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     DataSegmentsWithSchemas dataSegmentsWithSchemas = getIndexingServiceClient().getSegmentAndSchemas(task);
     verifySchema(dataSegmentsWithSchemas);
     Set<DataSegment> segments = dataSegmentsWithSchemas.getSegments();
     for (DataSegment segment : segments) {
-      Assert.assertFalse(segment.getDimensions().contains("unknownDim"));
+      Assertions.assertFalse(segment.getDimensions().contains("unknownDim"));
     }
   }
 
@@ -538,7 +533,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     final boolean appendToExisting = false;
     final ParallelIndexSupervisorTask task = newTask(interval, false);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
     assertShardSpec(task, lockGranularity, appendToExisting, Collections.emptyList());
 
     TaskContainer taskContainer = getIndexingServiceClient().getTaskContainer(task.getId());
@@ -588,7 +583,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
   {
     final ParallelIndexSupervisorTask task = newTask(Intervals.of("2020-12/P1M"), true);
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
   }
 
   @Test
@@ -607,8 +602,8 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         VALID_INPUT_SOURCE_FILTER
     );
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
-    Assert.assertNull("Runner must be null if the task was in the sequential mode", task.getCurrentRunner());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertNull(task.getCurrentRunner(), "Runner must be null if the task was in the sequential mode");
     assertShardSpec(task, lockGranularity, appendToExisting, Collections.emptyList());
   }
 
@@ -623,10 +618,10 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     runTestTask(interval, Granularities.DAY, true, oldSegments);
     final Collection<DataSegment> newSegments =
         getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", interval, Segments.ONLY_VISIBLE);
-    Assert.assertTrue(newSegments.containsAll(oldSegments));
+    Assertions.assertTrue(newSegments.containsAll(oldSegments));
     final SegmentTimeline timeline = SegmentTimeline.forSegments(newSegments);
     final Set<DataSegment> visibles = timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE);
-    Assert.assertEquals(new HashSet<>(newSegments), visibles);
+    Assertions.assertEquals(new HashSet<>(newSegments), visibles);
   }
 
   @Test
@@ -642,8 +637,8 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     getIndexingServiceClient().runTask(task.getId(), task);
     getIndexingServiceClient().runTask(task2.getId(), task2);
 
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().waitToFinish(task, 1, TimeUnit.DAYS).getStatusCode());
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().waitToFinish(task2, 1, TimeUnit.DAYS).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().waitToFinish(task, 1, TimeUnit.DAYS).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().waitToFinish(task2, 1, TimeUnit.DAYS).getStatusCode());
   }
 
   @Test
@@ -661,7 +656,7 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     );
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
     // Task state should still be SUCCESS even if no input split to process
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
   }
 
   @Test
@@ -680,10 +675,10 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     );
     final Collection<DataSegment> afterAppendSegments =
         getStorageCoordinator().retrieveUsedSegmentsForInterval("dataSource", interval, Segments.ONLY_VISIBLE);
-    Assert.assertTrue(afterAppendSegments.containsAll(beforeAppendSegments));
+    Assertions.assertTrue(afterAppendSegments.containsAll(beforeAppendSegments));
     final SegmentTimeline timeline = SegmentTimeline.forSegments(afterAppendSegments);
     final Set<DataSegment> visibles = timeline.findNonOvershadowedObjectsInInterval(interval, Partitions.ONLY_COMPLETE);
-    Assert.assertEquals(new HashSet<>(afterAppendSegments), visibles);
+    Assertions.assertEquals(new HashSet<>(afterAppendSegments), visibles);
   }
 
   @Test
@@ -705,14 +700,14 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
 
     if (lockGranularity.equals(LockGranularity.TIME_CHUNK)) {
-      expectedException.expect(RuntimeException.class);
-      expectedException.expectMessage(
-          "Number of locks exceeded maxAllowedLockCount [0]"
+      final RuntimeException exception = Assertions.assertThrows(
+          RuntimeException.class,
+          () -> getIndexingServiceClient().runAndWait(task)
       );
-      getIndexingServiceClient().runAndWait(task);
+      Assertions.assertTrue(exception.getMessage().contains("Number of locks exceeded maxAllowedLockCount [0]"));
     } else {
-      Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
-      Assert.assertNull("Runner must be null if the task was in the sequential mode", task.getCurrentRunner());
+      Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+      Assertions.assertNull(task.getCurrentRunner(), "Runner must be null if the task was in the sequential mode");
       assertShardSpec(task, lockGranularity, appendToExisting, Collections.emptyList());
     }
   }
@@ -737,14 +732,14 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
 
     if (lockGranularity.equals(LockGranularity.TIME_CHUNK)) {
-      expectedException.expect(RuntimeException.class);
-      expectedException.expectMessage(
-          "Number of locks exceeded maxAllowedLockCount [0]"
+      final RuntimeException exception = Assertions.assertThrows(
+          RuntimeException.class,
+          () -> getIndexingServiceClient().runAndWait(task)
       );
-      getIndexingServiceClient().runAndWait(task);
+      Assertions.assertTrue(exception.getMessage().contains("Number of locks exceeded maxAllowedLockCount [0]"));
     } else {
-      Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
-      Assert.assertNull("Runner must be null if the task was in the sequential mode", task.getCurrentRunner());
+      Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+      Assertions.assertNull(task.getCurrentRunner(), "Runner must be null if the task was in the sequential mode");
       assertShardSpec(task, lockGranularity, appendToExisting, Collections.emptyList());
     }
   }
@@ -824,14 +819,14 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         null
     );
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     DataSegmentsWithSchemas dataSegmentsWithSchemas = getIndexingServiceClient().getSegmentAndSchemas(task);
     verifySchema(dataSegmentsWithSchemas);
     Set<DataSegment> segments = dataSegmentsWithSchemas.getSegments();
 
     for (DataSegment segment : segments) {
-      Assert.assertEquals(ImmutableList.of("ts", "explicitDim", "implicitDim"), segment.getDimensions());
+      Assertions.assertEquals(ImmutableList.of("ts", "explicitDim", "implicitDim"), segment.getDimensions());
     }
   }
 
@@ -910,13 +905,13 @@ public class SinglePhaseParallelIndexingTest extends AbstractParallelIndexSuperv
         null
     );
     task.addToContext(Tasks.FORCE_TIME_CHUNK_LOCK_KEY, lockGranularity == LockGranularity.TIME_CHUNK);
-    Assert.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
+    Assertions.assertEquals(TaskState.SUCCESS, getIndexingServiceClient().runAndWait(task).getStatusCode());
 
     DataSegmentsWithSchemas dataSegmentsWithSchemas = getIndexingServiceClient().getSegmentAndSchemas(task);
     verifySchema(dataSegmentsWithSchemas);
     Set<DataSegment> segments = dataSegmentsWithSchemas.getSegments();
     for (DataSegment segment : segments) {
-      Assert.assertEquals(ImmutableList.of("ts", "explicitDim", "implicitDim"), segment.getDimensions());
+      Assertions.assertEquals(ImmutableList.of("ts", "explicitDim", "implicitDim"), segment.getDimensions());
     }
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTaskSpecTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/SinglePhaseSubTaskSpecTest.java
@@ -31,9 +31,9 @@ import org.apache.druid.server.security.Action;
 import org.apache.druid.server.security.Resource;
 import org.apache.druid.server.security.ResourceAction;
 import org.apache.druid.server.security.ResourceType;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -66,7 +66,7 @@ public class SinglePhaseSubTaskSpecTest
 
   private ObjectMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     mapper = new TestUtils().getTestObjectMapper();
@@ -78,7 +78,7 @@ public class SinglePhaseSubTaskSpecTest
     final SinglePhaseSubTask expected = SPEC.newSubTask(0);
     final byte[] json = mapper.writeValueAsBytes(expected);
     final Map<String, Object> actual = mapper.readValue(json, Map.class);
-    Assert.assertEquals(SinglePhaseSubTask.TYPE, actual.get("type"));
+    Assertions.assertEquals(SinglePhaseSubTask.TYPE, actual.get("type"));
   }
 
   @Test
@@ -87,8 +87,8 @@ public class SinglePhaseSubTaskSpecTest
     final SinglePhaseSubTask expected = SPEC.newSubTaskWithBackwardCompatibleType(0);
     final byte[] json = mapper.writeValueAsBytes(expected);
     final Map<String, Object> actual = mapper.readValue(json, Map.class);
-    Assert.assertEquals(SinglePhaseSubTask.OLD_TYPE_NAME, actual.get("type"));
-    Assert.assertEquals(
+    Assertions.assertEquals(SinglePhaseSubTask.OLD_TYPE_NAME, actual.get("type"));
+    Assertions.assertEquals(
         Collections.singleton(
             new ResourceAction(new Resource(
                 LocalInputSource.TYPE_KEY,

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitorTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TaskMonitorTest.java
@@ -43,10 +43,10 @@ import org.apache.druid.segment.IndexMergerV9;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnConfig;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -75,14 +75,14 @@ public class TaskMonitorTest
       0
   );
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     tasks.clear();
     monitor.start(100);
   }
 
-  @After
+  @AfterEach
   public void teardown()
   {
     monitor.stop();
@@ -102,11 +102,11 @@ public class TaskMonitorTest
       // # of threads of taskRunner is 5, so the expected max timeout is 2 sec. We additionally wait three more seconds
       // here to make sure the test passes.
       final SubTaskCompleteEvent<TestTask> result = futures.get(i).get(1, TimeUnit.SECONDS);
-      Assert.assertEquals("supervisorId", result.getSpec().getSupervisorTaskId());
-      Assert.assertEquals("specId" + i, result.getSpec().getId());
-      Assert.assertNotNull(result.getLastStatus());
-      Assert.assertEquals(TaskState.SUCCESS, result.getLastStatus().getStatusCode());
-      Assert.assertEquals(TaskState.SUCCESS, result.getLastState());
+      Assertions.assertEquals("supervisorId", result.getSpec().getSupervisorTaskId());
+      Assertions.assertEquals("specId" + i, result.getSpec().getId());
+      Assertions.assertNotNull(result.getLastStatus());
+      Assertions.assertEquals(TaskState.SUCCESS, result.getLastStatus().getStatusCode());
+      Assertions.assertEquals(TaskState.SUCCESS, result.getLastState());
     }
   }
 
@@ -136,21 +136,21 @@ public class TaskMonitorTest
       // # of threads of taskRunner is 5, and each task is expected to be run 3 times (with 2 retries), so the expected
       // max timeout is 6 sec. We additionally wait 4 more seconds here to make sure the test passes.
       final SubTaskCompleteEvent<TestTask> result = futures.get(i).get(2, TimeUnit.SECONDS);
-      Assert.assertEquals("supervisorId", result.getSpec().getSupervisorTaskId());
-      Assert.assertEquals("specId" + i, result.getSpec().getId());
+      Assertions.assertEquals("supervisorId", result.getSpec().getSupervisorTaskId());
+      Assertions.assertEquals("specId" + i, result.getSpec().getId());
 
-      Assert.assertNotNull(result.getLastStatus());
-      Assert.assertEquals(TaskState.SUCCESS, result.getLastStatus().getStatusCode());
-      Assert.assertEquals(TaskState.SUCCESS, result.getLastState());
+      Assertions.assertNotNull(result.getLastStatus());
+      Assertions.assertEquals(TaskState.SUCCESS, result.getLastStatus().getStatusCode());
+      Assertions.assertEquals(TaskState.SUCCESS, result.getLastState());
 
       final TaskHistory<TestTask> taskHistory = monitor.getCompleteSubTaskSpecHistory(specs.get(i).getId());
-      Assert.assertNotNull(taskHistory);
+      Assertions.assertNotNull(taskHistory);
 
       final List<TaskStatusPlus> attemptHistory = taskHistory.getAttemptHistory();
-      Assert.assertNotNull(attemptHistory);
-      Assert.assertEquals(3, attemptHistory.size());
-      Assert.assertEquals(TaskState.FAILED, attemptHistory.get(0).getStatusCode());
-      Assert.assertEquals(TaskState.FAILED, attemptHistory.get(1).getStatusCode());
+      Assertions.assertNotNull(attemptHistory);
+      Assertions.assertEquals(3, attemptHistory.size());
+      Assertions.assertEquals(TaskState.FAILED, attemptHistory.get(0).getStatusCode());
+      Assertions.assertEquals(TaskState.FAILED, attemptHistory.get(1).getStatusCode());
     }
   }
 
@@ -180,20 +180,20 @@ public class TaskMonitorTest
       // # of threads of taskRunner is 5, and each task is expected to be run 3 times (with 2 retries), so the expected
       // max timeout is 6 sec. We additionally wait 4 more seconds here to make sure the test passes.
       final SubTaskCompleteEvent<TestTask> result = futures.get(i).get(2, TimeUnit.SECONDS);
-      Assert.assertEquals("supervisorId", result.getSpec().getSupervisorTaskId());
-      Assert.assertEquals("specId" + i, result.getSpec().getId());
+      Assertions.assertEquals("supervisorId", result.getSpec().getSupervisorTaskId());
+      Assertions.assertEquals("specId" + i, result.getSpec().getId());
 
-      Assert.assertNotNull(result.getLastStatus());
-      Assert.assertEquals(TaskState.SUCCESS, result.getLastStatus().getStatusCode());
-      Assert.assertEquals(TaskState.SUCCESS, result.getLastState());
+      Assertions.assertNotNull(result.getLastStatus());
+      Assertions.assertEquals(TaskState.SUCCESS, result.getLastStatus().getStatusCode());
+      Assertions.assertEquals(TaskState.SUCCESS, result.getLastState());
 
       final TaskHistory<TestTask> taskHistory = monitor.getCompleteSubTaskSpecHistory(specs.get(i).getId());
-      Assert.assertNotNull(taskHistory);
+      Assertions.assertNotNull(taskHistory);
 
       final List<TaskStatusPlus> attemptHistory = taskHistory.getAttemptHistory();
-      Assert.assertNotNull(attemptHistory);
-      Assert.assertEquals(1, attemptHistory.size());
-      Assert.assertEquals(TaskState.SUCCESS, attemptHistory.get(0).getStatusCode());
+      Assertions.assertNotNull(attemptHistory);
+      Assertions.assertEquals(1, attemptHistory.size());
+      Assertions.assertEquals(TaskState.SUCCESS, attemptHistory.get(0).getStatusCode());
     }
   }
 
@@ -211,9 +211,9 @@ public class TaskMonitorTest
             new TestTaskSpec("timeoutSpec", "groupId", "supervisorId", null, new IntegerInputSplit(0), 100L, 0, false)
     );
     SubTaskCompleteEvent<TestTask> result = future.get(1, TimeUnit.SECONDS);
-    Assert.assertNotNull(result.getLastStatus());
-    Assert.assertEquals(TaskState.FAILED, result.getLastStatus().getStatusCode());
-    Assert.assertEquals(TaskState.FAILED, result.getLastState());
+    Assertions.assertNotNull(result.getLastStatus());
+    Assertions.assertEquals(TaskState.FAILED, result.getLastStatus().getStatusCode());
+    Assertions.assertEquals(TaskState.FAILED, result.getLastState());
     timeoutMonitor.stop();
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelperTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/TombstoneHelperTest.java
@@ -39,8 +39,8 @@ import org.apache.druid.segment.realtime.appenderator.SegmentIdWithShardSpec;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.TombstoneShardSpec;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -81,12 +81,12 @@ public class TombstoneHelperTest
 
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
     List<Interval> tombstoneIntervals = tombstoneHelper.computeTombstoneIntervals(pushedSegments, dataSchema);
-    Assert.assertTrue(tombstoneIntervals.isEmpty());
+    Assertions.assertTrue(tombstoneIntervals.isEmpty());
 
     Map<Interval, SegmentIdWithShardSpec> intervalToLockVersion = Collections.emptyMap();
     Set<DataSegment> tombstones = tombstoneHelper.computeTombstones(dataSchema, intervalToLockVersion);
 
-    Assert.assertEquals(0, tombstones.size());
+    Assertions.assertEquals(0, tombstones.size());
 
   }
 
@@ -113,13 +113,13 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
 
     List<Interval> tombstoneIntervals = tombstoneHelper.computeTombstoneIntervals(pushedSegments, dataSchema);
-    Assert.assertEquals(3, tombstoneIntervals.size());
+    Assertions.assertEquals(3, tombstoneIntervals.size());
     Map<Interval, SegmentIdWithShardSpec> intervalToVersion = new HashMap<>();
     for (Interval ti : tombstoneIntervals) {
       intervalToVersion.put(
@@ -128,8 +128,8 @@ public class TombstoneHelperTest
       );
     }
     Set<DataSegment> tombstones = tombstoneHelper.computeTombstones(dataSchema, intervalToVersion);
-    Assert.assertEquals(3, tombstones.size());
-    tombstones.forEach(ts -> Assert.assertTrue(ts.isTombstone()));
+    Assertions.assertEquals(3, tombstones.size());
+    tombstones.forEach(ts -> Assertions.assertTrue(ts.isTombstone()));
   }
 
   @Test
@@ -147,7 +147,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -159,7 +159,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-03-05/2020-03-06"),
             Intervals.of("2020-03-06/2020-03-07")
@@ -197,7 +197,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-03-01/2020-04-01"),
             Intervals.of("2020-07-01/2020-08-01"),
@@ -222,7 +222,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -234,7 +234,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(ImmutableSet.of(Intervals.of("2020-02-01/2020-02-02")), tombstoneIntervals);
+    Assertions.assertEquals(ImmutableSet.of(Intervals.of("2020-02-01/2020-02-02")), tombstoneIntervals);
   }
 
   @Test
@@ -252,7 +252,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -264,7 +264,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(ImmutableSet.of(), tombstoneIntervals);
+    Assertions.assertEquals(ImmutableSet.of(), tombstoneIntervals);
   }
 
   @Test
@@ -282,7 +282,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -294,7 +294,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-12-25/2020-12-26"),
             Intervals.of("2020-12-26/2020-12-27"),
@@ -322,7 +322,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -334,7 +334,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-01-01/2020-01-02"),
             Intervals.of("2020-01-02/2020-01-03"),
@@ -363,7 +363,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -375,7 +375,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-01-01/2020-01-02"),
             Intervals.of("2020-01-02/2020-01-03"),
@@ -408,7 +408,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -420,7 +420,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-01-01/2020-01-02"),
             Intervals.of("2020-01-02/2020-01-03"),
@@ -446,7 +446,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -458,7 +458,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("2020-12-25/2020-12-26"),
             Intervals.of("2020-12-26/2020-12-27"),
@@ -489,7 +489,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -501,7 +501,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("-146136543-09-08T08:23:32.096Z/1970-01-01T00:00:00.000Z"),
             Intervals.of("1970-01-01T00:00:00.000Z/146140482-04-24T15:36:27.903Z")
@@ -529,7 +529,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -541,7 +541,7 @@ public class TombstoneHelperTest
         replaceGranularity,
         MAX_BUCKETS
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(
             Intervals.of("-146136543-09-08T08:23:32.096Z/2000-01-01T00:00:00.000Z"),
             Intervals.of("3000-01-01/3000-01-02"),
@@ -570,7 +570,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
 
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
@@ -584,7 +584,7 @@ public class TombstoneHelperTest
         MAX_BUCKETS
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(Intervals.ETERNITY),
         tombstoneIntervals
     );
@@ -608,12 +608,12 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         TooManyBucketsException.class,
         () -> tombstoneHelper.computeTombstoneIntervalsForReplace(
             dropIntervals,
@@ -643,7 +643,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
@@ -657,7 +657,7 @@ public class TombstoneHelperTest
     );
 
     // (365 * 2) ~= 730 day intervals
-    Assert.assertEquals(
+    Assertions.assertEquals(
         dropIntervals.stream()
                      .mapToLong(interval -> interval.toDuration().getStandardDays())
                      .sum(),
@@ -690,14 +690,14 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment1.isTombstone());
-    Assert.assertFalse(existingUsedSegment2.isTombstone());
+    Assertions.assertFalse(existingUsedSegment1.isTombstone());
+    Assertions.assertFalse(existingUsedSegment2.isTombstone());
 
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Arrays.asList(existingUsedSegment1, existingUsedSegment2));
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         TooManyBucketsException.class,
         () -> tombstoneHelper.computeTombstoneIntervalsForReplace(
             dropIntervals,
@@ -734,8 +734,8 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment1.isTombstone());
-    Assert.assertFalse(existingUsedSegment2.isTombstone());
+    Assertions.assertFalse(existingUsedSegment1.isTombstone());
+    Assertions.assertFalse(existingUsedSegment2.isTombstone());
 
     Mockito.when(taskActionClient.submit(any(TaskAction.class)))
            .thenReturn(Arrays.asList(existingUsedSegment1, existingUsedSegment2));
@@ -750,7 +750,7 @@ public class TombstoneHelperTest
     );
 
     // (365 * 2) ~= 730 day intervals
-    Assert.assertEquals(
+    Assertions.assertEquals(
         usedInterval1.toDuration().getStandardDays() + usedInterval2.toDuration().getStandardDays(),
         tombstoneIntervals.size()
     );
@@ -771,7 +771,7 @@ public class TombstoneHelperTest
                    .version("oldVersion")
                    .size(100)
                    .build();
-    Assert.assertFalse(existingUsedSegment.isTombstone());
+    Assertions.assertFalse(existingUsedSegment.isTombstone());
     Mockito.when(taskActionClient.submit(any(RetrieveUsedSegmentsAction.class)))
            .thenReturn(Collections.singletonList(existingUsedSegment));
     Mockito.when(taskActionClient.submit(any(LockListAction.class)))
@@ -779,7 +779,7 @@ public class TombstoneHelperTest
 
     TombstoneHelper tombstoneHelper = new TombstoneHelper(taskActionClient);
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         ISE.class,
         () -> tombstoneHelper.computeTombstoneSegmentsForReplace(
             ImmutableList.of(dropInterval),

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/ArrayOfStringTuplesSerDeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/ArrayOfStringTuplesSerDeTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common.task.batch.parallel.distribution;
 
 import org.apache.datasketches.memory.Memory;
 import org.apache.druid.data.input.StringTuple;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ArrayOfStringTuplesSerDeTest
 {
@@ -59,31 +59,31 @@ public class ArrayOfStringTuplesSerDeTest
   public void testSizeOf()
   {
     StringTuple stringTuple = StringTuple.create("a", "b");
-    Assert.assertEquals(serde.sizeOf(stringTuple), serde.serializeToByteArray(stringTuple).length);
+    Assertions.assertEquals(serde.sizeOf(stringTuple), serde.serializeToByteArray(stringTuple).length);
   }
 
   private void testSerde(StringTuple stringTuple)
   {
     byte[] bytes = serde.serializeToByteArray(stringTuple);
-    Assert.assertEquals(serde.sizeOf(stringTuple), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(stringTuple), bytes.length);
 
     Memory wrappedMemory = Memory.wrap(bytes);
-    Assert.assertEquals(serde.sizeOf(wrappedMemory, 0, 1), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(wrappedMemory, 0, 1), bytes.length);
 
     StringTuple[] deserialized = serde.deserializeFromMemory(wrappedMemory, 1);
-    Assert.assertArrayEquals(new StringTuple[]{stringTuple}, deserialized);
+    Assertions.assertArrayEquals(new StringTuple[]{stringTuple}, deserialized);
   }
 
   private void testSerde(StringTuple[] inputArray)
   {
     byte[] bytes = serde.serializeToByteArray(inputArray);
-    Assert.assertEquals(serde.sizeOf(inputArray), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(inputArray), bytes.length);
 
     Memory wrappedMemory = Memory.wrap(bytes);
-    Assert.assertEquals(serde.sizeOf(wrappedMemory, 0, inputArray.length), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(wrappedMemory, 0, inputArray.length), bytes.length);
 
     StringTuple[] deserialized = serde.deserializeFromMemory(wrappedMemory, inputArray.length);
-    Assert.assertArrayEquals(inputArray, deserialized);
+    Assertions.assertArrayEquals(inputArray, deserialized);
   }
 
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/ArrayOfStringsNullSafeSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/ArrayOfStringsNullSafeSerdeTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.indexing.common.task.batch.parallel.distribution;
 
 import org.apache.datasketches.memory.Memory;
 import org.apache.druid.java.util.common.IAE;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ArrayOfStringsNullSafeSerdeTest
 {
@@ -71,11 +71,11 @@ public class ArrayOfStringsNullSafeSerdeTest
   {
     // bytes for length = -2
     final byte[] bytes = {-2, -1, -1, -1};
-    IAE exception = Assert.assertThrows(
+    IAE exception = Assertions.assertThrows(
         IAE.class,
         () -> serde.deserializeFromMemory(Memory.wrap(bytes), 1)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Illegal strLength [-2] at offset [4]. Must be -1, 0 or a positive integer.",
         exception.getMessage()
     );
@@ -84,9 +84,9 @@ public class ArrayOfStringsNullSafeSerdeTest
   private void testSerde(String... inputArray)
   {
     byte[] bytes = serde.serializeToByteArray(inputArray);
-    Assert.assertEquals(serde.sizeOf(inputArray), bytes.length);
+    Assertions.assertEquals(serde.sizeOf(inputArray), bytes.length);
     String[] deserialized = serde.deserializeFromMemory(Memory.wrap(bytes), inputArray.length);
-    Assert.assertArrayEquals(inputArray, deserialized);
+    Assertions.assertArrayEquals(inputArray, deserialized);
   }
 
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchMergerTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchMergerTest.java
@@ -22,20 +22,15 @@ package org.apache.druid.indexing.common.task.batch.parallel.distribution;
 import org.apache.druid.data.input.StringTuple;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
 import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class StringSketchMergerTest
 {
   private StringSketchMerger target;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
-
-  @Before
+  @BeforeEach
   public void setup()
   {
     target = new StringSketchMerger();
@@ -46,10 +41,11 @@ public class StringSketchMergerTest
   {
     StringDistribution distribution = EasyMock.mock(StringDistribution.class);
 
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("Only merging StringSketch instances is currently supported");
-
-    target.merge(distribution);
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> target.merge(distribution)
+    );
+    Assertions.assertTrue(exception.getMessage().contains("Only merging StringSketch instances is currently supported"));
   }
 
   @Test
@@ -73,9 +69,9 @@ public class StringSketchMergerTest
     StringDistribution merged = target.getResult();
 
     PartitionBoundaries partitions = merged.getEvenPartitionsByMaxSize(1);
-    Assert.assertEquals(3, partitions.size());
-    Assert.assertNull(partitions.get(0));
-    Assert.assertEquals(string2, partitions.get(1));
-    Assert.assertNull(partitions.get(2));
+    Assertions.assertEquals(3, partitions.size());
+    Assertions.assertNull(partitions.get(0));
+    Assertions.assertEquals(string2, partitions.get(1));
+    Assertions.assertNull(partitions.get(2));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/distribution/StringSketchTest.java
@@ -27,14 +27,9 @@ import org.apache.druid.jackson.JacksonModule;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.timeline.partition.PartitionBoundaries;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.hamcrest.number.IsCloseTo;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -92,7 +87,7 @@ public class StringSketchTest
   {
     private StringSketch target;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
       target = new StringSketch();
@@ -102,40 +97,40 @@ public class StringSketchTest
     public void putIfNewMin()
     {
       StringTuple value = MAX_STRING;
-      Assert.assertEquals(0, getCount());
+      Assertions.assertEquals(0, getCount());
 
       target.putIfNewMin(value);
-      Assert.assertEquals(1, getCount());
+      Assertions.assertEquals(1, getCount());
 
       target.putIfNewMin(value);
-      Assert.assertEquals(1, getCount());
-      Assert.assertEquals(value, target.getDelegate().getMinItem());
-      Assert.assertEquals(value, target.getDelegate().getMaxItem());
+      Assertions.assertEquals(1, getCount());
+      Assertions.assertEquals(value, target.getDelegate().getMinItem());
+      Assertions.assertEquals(value, target.getDelegate().getMaxItem());
 
       target.putIfNewMin(MIN_STRING);
-      Assert.assertEquals(2, getCount());
-      Assert.assertEquals(MIN_STRING, target.getDelegate().getMinItem());
-      Assert.assertEquals(MAX_STRING, target.getDelegate().getMaxItem());
+      Assertions.assertEquals(2, getCount());
+      Assertions.assertEquals(MIN_STRING, target.getDelegate().getMinItem());
+      Assertions.assertEquals(MAX_STRING, target.getDelegate().getMaxItem());
     }
 
     @Test
     public void putIfNewMax()
     {
       StringTuple value = MIN_STRING;
-      Assert.assertEquals(0, getCount());
+      Assertions.assertEquals(0, getCount());
 
       target.putIfNewMax(value);
-      Assert.assertEquals(1, getCount());
+      Assertions.assertEquals(1, getCount());
 
       target.putIfNewMax(value);
-      Assert.assertEquals(1, getCount());
-      Assert.assertEquals(value, target.getDelegate().getMinItem());
-      Assert.assertEquals(value, target.getDelegate().getMaxItem());
+      Assertions.assertEquals(1, getCount());
+      Assertions.assertEquals(value, target.getDelegate().getMinItem());
+      Assertions.assertEquals(value, target.getDelegate().getMaxItem());
 
       target.putIfNewMax(MAX_STRING);
-      Assert.assertEquals(2, getCount());
-      Assert.assertEquals(MIN_STRING, target.getDelegate().getMinItem());
-      Assert.assertEquals(MAX_STRING, target.getDelegate().getMaxItem());
+      Assertions.assertEquals(2, getCount());
+      Assertions.assertEquals(MIN_STRING, target.getDelegate().getMinItem());
+      Assertions.assertEquals(MAX_STRING, target.getDelegate().getMaxItem());
     }
 
     private long getCount()
@@ -155,16 +150,14 @@ public class StringSketchTest
 
     public static class TargetSizeTest
     {
-      @Rule
-      public ExpectedException exception = ExpectedException.none();
-
       @Test
       public void requiresPositiveSize()
       {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("targetSize must be positive but is 0");
-
-        SKETCH.getEvenPartitionsByTargetSize(0);
+        final IllegalArgumentException exception = Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> SKETCH.getEvenPartitionsByTargetSize(0)
+        );
+        Assertions.assertTrue(exception.getMessage().contains("targetSize must be positive but is 0"));
       }
 
       @Test
@@ -172,7 +165,7 @@ public class StringSketchTest
       {
         StringSketch sketch = new StringSketch();
         PartitionBoundaries partitionBoundaries = sketch.getEvenPartitionsByTargetSize(1);
-        Assert.assertEquals(0, partitionBoundaries.size());
+        Assertions.assertEquals(0, partitionBoundaries.size());
       }
 
       @Test
@@ -181,9 +174,9 @@ public class StringSketchTest
         StringSketch sketch = new StringSketch();
         sketch.put(MIN_STRING);
         PartitionBoundaries partitionBoundaries = sketch.getEvenPartitionsByTargetSize(1);
-        Assert.assertEquals(2, partitionBoundaries.size());
-        Assert.assertNull(partitionBoundaries.get(0));
-        Assert.assertNull(partitionBoundaries.get(1));
+        Assertions.assertEquals(2, partitionBoundaries.size());
+        Assertions.assertNull(partitionBoundaries.get(0));
+        Assertions.assertNull(partitionBoundaries.get(1));
       }
 
       @Test
@@ -209,25 +202,24 @@ public class StringSketchTest
         String partitionBoundariesString = PartitionTest.toString(partitionBoundaries);
         int expectedHighPartitionBoundaryCount = (int) Math.ceil((double) NUM_STRING / targetSize);
         int expectedLowPartitionBoundaryCount = expectedHighPartitionBoundaryCount - 1;
-        MatcherAssert.assertThat(
-            "targetSize=" + targetSize + " " + partitionBoundariesString,
-            partitionBoundaries.size(),
-            Matchers.lessThanOrEqualTo(expectedHighPartitionBoundaryCount + 1)
+        Assertions.assertTrue(
+            partitionBoundaries.size() <= expectedHighPartitionBoundaryCount + 1,
+            "targetSize=" + targetSize + " " + partitionBoundariesString
         );
-        MatcherAssert.assertThat(
-            "targetSize=" + targetSize + " " + partitionBoundariesString,
-            partitionBoundaries.size(),
-            Matchers.greaterThanOrEqualTo(expectedLowPartitionBoundaryCount + 1)
+        Assertions.assertTrue(
+            partitionBoundaries.size() >= expectedLowPartitionBoundaryCount + 1,
+            "targetSize=" + targetSize + " " + partitionBoundariesString
         );
 
         int previous = 0;
         for (int i = 1; i < partitionBoundaries.size() - 1; i++) {
           int current = Integer.parseInt(partitionBoundaries.get(i).get(0));
           int size = current - previous;
-          MatcherAssert.assertThat(
-              getErrMsgPrefix(targetSize, i) + partitionBoundariesString,
+          Assertions.assertEquals(
+              targetSize,
               (double) size,
-              IsCloseTo.closeTo(targetSize, Math.ceil(DELTA) * 2)
+              Math.ceil(DELTA) * 2,
+              getErrMsgPrefix(targetSize, i) + partitionBoundariesString
           );
           previous = current;
         }
@@ -250,16 +242,14 @@ public class StringSketchTest
 
     public static class MaxSizeTest
     {
-      @Rule
-      public ExpectedException exception = ExpectedException.none();
-
       @Test
       public void requiresPositiveSize()
       {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("maxSize must be positive but is 0");
-
-        SKETCH.getEvenPartitionsByMaxSize(0);
+        final IllegalArgumentException exception = Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> SKETCH.getEvenPartitionsByMaxSize(0)
+        );
+        Assertions.assertTrue(exception.getMessage().contains("maxSize must be positive but is 0"));
       }
 
       @Test
@@ -267,7 +257,7 @@ public class StringSketchTest
       {
         StringSketch sketch = new StringSketch();
         PartitionBoundaries partitionBoundaries = sketch.getEvenPartitionsByMaxSize(1);
-        Assert.assertEquals(0, partitionBoundaries.size());
+        Assertions.assertEquals(0, partitionBoundaries.size());
       }
 
       @Test
@@ -276,9 +266,9 @@ public class StringSketchTest
         StringSketch sketch = new StringSketch();
         sketch.put(MIN_STRING);
         PartitionBoundaries partitionBoundaries = sketch.getEvenPartitionsByMaxSize(1);
-        Assert.assertEquals(2, partitionBoundaries.size());
-        Assert.assertNull(partitionBoundaries.get(0));
-        Assert.assertNull(partitionBoundaries.get(1));
+        Assertions.assertEquals(2, partitionBoundaries.size());
+        Assertions.assertNull(partitionBoundaries.get(0));
+        Assertions.assertNull(partitionBoundaries.get(1));
       }
 
       @Test
@@ -303,10 +293,10 @@ public class StringSketchTest
 
         String partitionBoundariesString = PartitionTest.toString(partitionBoundaries);
         long expectedPartitionCount = (long) Math.ceil((double) NUM_STRING / maxSize);
-        Assert.assertEquals(
-            "maxSize=" + maxSize + " " + partitionBoundariesString,
+        Assertions.assertEquals(
             expectedPartitionCount + 1,
-            partitionBoundaries.size()
+            partitionBoundaries.size(),
+            "maxSize=" + maxSize + " " + partitionBoundariesString
         );
 
         double minSize = (double) NUM_STRING / expectedPartitionCount - DELTA;
@@ -315,15 +305,13 @@ public class StringSketchTest
         for (int i = 1; i < partitionBoundaries.size() - 1; i++) {
           int current = Integer.parseInt(partitionBoundaries.get(i).get(0));
           int size = current - previous;
-          MatcherAssert.assertThat(
-              getErrMsgPrefix(maxSize, i) + partitionBoundariesString,
-              size,
-              Matchers.lessThanOrEqualTo(maxSize)
+          Assertions.assertTrue(
+              size <= maxSize,
+              getErrMsgPrefix(maxSize, i) + partitionBoundariesString
           );
-          MatcherAssert.assertThat(
-              getErrMsgPrefix(maxSize, i) + partitionBoundariesString,
-              (double) size,
-              Matchers.greaterThanOrEqualTo(minSize)
+          Assertions.assertTrue(
+              size >= minSize,
+              getErrMsgPrefix(maxSize, i) + partitionBoundariesString
           );
           previous = current;
         }
@@ -350,17 +338,21 @@ public class StringSketchTest
     {
       String partitionBoundariesString = toString(partitionBoundaries);
 
-      Assert.assertEquals(partitionBoundariesString, StringSketch.SKETCH_K + 1, partitionBoundaries.size());
+      Assertions.assertEquals(
+          StringSketch.SKETCH_K + 1,
+          partitionBoundaries.size(),
+          partitionBoundariesString
+      );
       assertFirstAndLastPartitionsCorrect(partitionBoundaries);
 
       int previous = 0;
       for (int i = 1; i < partitionBoundaries.size() - 1; i++) {
         int current = Integer.parseInt(partitionBoundaries.get(i).get(0));
-        Assert.assertEquals(
-            getErrMsgPrefix(1, i) + partitionBoundariesString,
+        Assertions.assertEquals(
             1,
             current - previous,
-            FACTOR
+            FACTOR,
+            getErrMsgPrefix(1, i) + partitionBoundariesString
         );
         previous = current;
       }
@@ -368,14 +360,14 @@ public class StringSketchTest
 
     private static void assertSinglePartition(PartitionBoundaries partitionBoundaries)
     {
-      Assert.assertEquals(2, partitionBoundaries.size());
+      Assertions.assertEquals(2, partitionBoundaries.size());
       assertFirstAndLastPartitionsCorrect(partitionBoundaries);
     }
 
     private static void assertFirstAndLastPartitionsCorrect(PartitionBoundaries partitionBoundaries)
     {
-      Assert.assertNull(partitionBoundaries.get(0));
-      Assert.assertNull(partitionBoundaries.get(partitionBoundaries.size() - 1));
+      Assertions.assertNull(partitionBoundaries.get(0));
+      Assertions.assertNull(partitionBoundaries.get(partitionBoundaries.size() - 1));
     }
 
     private static String getErrMsgPrefix(int size, int i)

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/DefaultIndexTaskInputRowIteratorBuilderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/DefaultIndexTaskInputRowIteratorBuilderTest.java
@@ -26,10 +26,8 @@ import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.List;
@@ -41,29 +39,28 @@ public class DefaultIndexTaskInputRowIteratorBuilderTest
     private static final CloseableIterator<InputRow> ITERATOR = EasyMock.mock(CloseableIterator.class);
     private static final GranularitySpec GRANULARITY_SPEC = EasyMock.mock(GranularitySpec.class);
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void requiresDelegate()
     {
-      exception.expect(NullPointerException.class);
-      exception.expectMessage("delegate required");
-
-      new DefaultIndexTaskInputRowIteratorBuilder()
-          .granularitySpec(GRANULARITY_SPEC)
-          .build();
+      final NullPointerException exception = Assertions.assertThrows(
+          NullPointerException.class,
+          () -> new DefaultIndexTaskInputRowIteratorBuilder()
+              .granularitySpec(GRANULARITY_SPEC)
+              .build()
+      );
+      Assertions.assertTrue(exception.getMessage().contains("delegate required"));
     }
 
     @Test
     public void requiresGranularitySpec()
     {
-      exception.expect(NullPointerException.class);
-      exception.expectMessage("granularitySpec required");
-
-      new DefaultIndexTaskInputRowIteratorBuilder()
-          .delegate(ITERATOR)
-          .build();
+      final NullPointerException exception = Assertions.assertThrows(
+          NullPointerException.class,
+          () -> new DefaultIndexTaskInputRowIteratorBuilder()
+              .delegate(ITERATOR)
+              .build()
+      );
+      Assertions.assertTrue(exception.getMessage().contains("granularitySpec required"));
     }
 
     @Test
@@ -83,9 +80,6 @@ public class DefaultIndexTaskInputRowIteratorBuilderTest
             DefaultIndexTaskInputRowIteratorBuilder::new
         );
     private static final InputRow NO_NEXT_INPUT_ROW = null;
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void invokesAppendedHandlersLast()
@@ -109,7 +103,7 @@ public class DefaultIndexTaskInputRowIteratorBuilderTest
               NO_NEXT_INPUT_ROW
           );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Collections.singletonList(IndexTaskInputRowIteratorBuilderTestingFactory.HandlerTester.Handler.APPENDED),
           handlerInvocationHistory
       );
@@ -130,7 +124,7 @@ public class DefaultIndexTaskInputRowIteratorBuilderTest
       List<IndexTaskInputRowIteratorBuilderTestingFactory.HandlerTester.Handler> handlerInvocationHistory =
           HANDLER_TESTER.invokeHandlers(inputRowIterator, granularitySpec, inputRow);
 
-      Assert.assertEquals(Collections.emptyList(), handlerInvocationHistory);
+      Assertions.assertEquals(Collections.emptyList(), handlerInvocationHistory);
     }
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/IndexTaskInputRowIteratorBuilderTestingFactory.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/IndexTaskInputRowIteratorBuilderTestingFactory.java
@@ -30,7 +30,7 @@ import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -155,7 +155,7 @@ class IndexTaskInputRowIteratorBuilderTestingFactory
       HandlingInputRowIterator iterator = iteratorBuilder.build();
 
       InputRow nextInputRow = iterator.next();
-      Assert.assertEquals(expectedNextInputRow, nextInputRow);
+      Assertions.assertEquals(expectedNextInputRow, nextInputRow);
 
       return handlerInvocationHistory;
     }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilderTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/iterator/RangePartitionIndexTaskInputRowIteratorBuilderTest.java
@@ -22,13 +22,9 @@ package org.apache.druid.indexing.common.task.batch.parallel.iterator;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.indexer.granularity.GranularitySpec;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,9 +41,6 @@ public class RangePartitionIndexTaskInputRowIteratorBuilderTest
           )
       );
   private static final InputRow NO_NEXT_INPUT_ROW = null;
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   @Test
   public void invokesDimensionValueCountFilterLast()
@@ -100,14 +93,15 @@ public class RangePartitionIndexTaskInputRowIteratorBuilderTest
         IndexTaskInputRowIteratorBuilderTestingFactory.PRESENT_BUCKET_INTERVAL_OPT
     );
 
-    exception.expect(IllegalArgumentException.class);
-    exception.expectMessage("Cannot partition on multi-value dimension [dimension]");
-
-    HANDLER_TESTER.invokeHandlers(
-        inputRowIterator,
-        granularitySpec,
-        NO_NEXT_INPUT_ROW
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> HANDLER_TESTER.invokeHandlers(
+            inputRowIterator,
+            granularitySpec,
+            NO_NEXT_INPUT_ROW
+        )
     );
+    Assertions.assertTrue(exception.getMessage().contains("Cannot partition on multi-value dimension [dimension]"));
   }
 
   @Test
@@ -131,7 +125,7 @@ public class RangePartitionIndexTaskInputRowIteratorBuilderTest
             inputRow
         );
 
-    Assert.assertEquals(Collections.emptyList(), handlerInvocationHistory);
+    Assertions.assertEquals(Collections.emptyList(), handlerInvocationHistory);
   }
 
   @Test
@@ -193,7 +187,7 @@ public class RangePartitionIndexTaskInputRowIteratorBuilderTest
             inputRow
         );
 
-    Assert.assertEquals(Collections.emptyList(), handlerInvocationHistory);
+    Assertions.assertEquals(Collections.emptyList(), handlerInvocationHistory);
   }
 
   private static void assertNotInHandlerInvocationHistory(
@@ -201,6 +195,6 @@ public class RangePartitionIndexTaskInputRowIteratorBuilderTest
       IndexTaskInputRowIteratorBuilderTestingFactory.HandlerTester.Handler handler
   )
   {
-    MatcherAssert.assertThat(handlerInvocationHistory, Matchers.not(Matchers.contains(handler)));
+    Assertions.assertFalse(handlerInvocationHistory.contains(handler));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndAppendTest.java
@@ -23,8 +23,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import org.apache.druid.error.DruidExceptionMatcher;
-import org.apache.druid.error.ExceptionMatcher;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.indexing.common.MultipleFileTaskReportFileWriter;
 import org.apache.druid.indexing.common.TaskLock;
 import org.apache.druid.indexing.common.TaskStorageDirTracker;
@@ -67,13 +66,12 @@ import org.apache.druid.tasklogs.NoopTaskLogs;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.NumberedShardSpec;
-import org.hamcrest.MatcherAssert;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -125,7 +123,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
   private final AtomicInteger groupId = new AtomicInteger(0);
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     final TaskConfig taskConfig = new TaskConfigBuilder().build();
@@ -164,7 +162,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     replaceTask = createAndStartTask();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     for (ActionsTestTask task : runningTasks) {
@@ -183,7 +181,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(segmentV10.getVersion(), pendingSegment.getVersion());
+    Assertions.assertEquals(segmentV10.getVersion(), pendingSegment.getVersion());
 
     final DataSegment segmentV11 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV11);
@@ -199,7 +197,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -225,7 +223,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV10 = createSegment(FIRST_OF_JAN_23, v1);
     replaceTask.commitReplaceSegments(segmentV10);
@@ -249,7 +247,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23).getVersion();
 
@@ -275,7 +273,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23).getVersion();
 
@@ -302,7 +300,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -333,8 +331,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     // Verify that the allocated segment takes the version and interval of previous replace
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(v1, pendingSegment.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(v1, pendingSegment.getVersion());
 
     final DataSegment segmentV11 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV11);
@@ -350,8 +348,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -379,8 +377,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV10 = createSegment(JAN_23, v1);
     replaceTask.commitReplaceSegments(segmentV10);
@@ -406,8 +404,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(JAN_23).getVersion();
 
@@ -435,8 +433,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(JAN_23).getVersion();
 
@@ -464,8 +462,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -495,13 +493,13 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     // Verify that an APPEND lock cannot be acquired on month
     TaskLock appendLock = appendTask.acquireAppendLockOn(JAN_23);
-    Assert.assertNull(appendLock);
+    Assertions.assertNull(appendLock);
 
     // Verify that new segment gets allocated with DAY granularity even though preferred was MONTH
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(v1, pendingSegment.getVersion());
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(v1, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
 
     final DataSegment segmentV11 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV11);
@@ -517,13 +515,13 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     // Verify that an APPEND lock cannot be acquired on month
     TaskLock appendLock = appendTask.acquireAppendLockOn(JAN_23);
-    Assert.assertNull(appendLock);
+    Assertions.assertNull(appendLock);
 
     // Verify that the segment is allocated for DAY granularity
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -551,13 +549,13 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     // Verify that an APPEND lock cannot be acquired on month
     TaskLock appendLock = appendTask.acquireAppendLockOn(JAN_23);
-    Assert.assertNull(appendLock);
+    Assertions.assertNull(appendLock);
 
     // Verify that the segment is allocated for DAY granularity instead of MONTH
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV10 = createSegment(FIRST_OF_JAN_23, v1);
     replaceTask.commitReplaceSegments(segmentV10);
@@ -583,18 +581,18 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     // Verify that replace lock cannot be acquired on MONTH
     TaskLock replaceLock = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23);
-    Assert.assertNull(replaceLock);
+    Assertions.assertNull(replaceLock);
 
     // Verify that segment cannot be committed since there is no lock
     final DataSegment segmentV10 = createSegment(FIRST_OF_JAN_23, SEGMENT_V0);
-    final ISE exception = Assert.assertThrows(ISE.class, () -> replaceTask.commitReplaceSegments(segmentV10));
+    final ISE exception = Assertions.assertThrows(ISE.class, () -> replaceTask.commitReplaceSegments(segmentV10));
     final Throwable throwable = Throwables.getRootCause(exception);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         StringUtils.format(
             "Segment IDs[[%s]] are not covered by locks[[]] for task[%s]",
             segmentV10.getId(), replaceTask.getId()
@@ -612,14 +610,14 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   public void testLockReplaceQuarterAllocateAppendYear()
   {
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(YEAR_23);
-    Assert.assertNotNull(replaceLock);
+    Assertions.assertNotNull(replaceLock);
 
     final DataSegment segmentV1Q1 = createSegment(JAN_FEB_MAR_23, replaceLock.getVersion());
     final DataSegment segmentV1Q2 = createSegment(APR_MAY_JUN_23, replaceLock.getVersion());
     final DataSegment segmentV1Q3 = createSegment(JUL_AUG_SEP_23, replaceLock.getVersion());
     final DataSegment segmentV1Q4 = createSegment(OCT_NOV_DEC_23, replaceLock.getVersion());
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         replaceTask.commitReplaceSegments(segmentV1Q1, segmentV1Q2, segmentV1Q3, segmentV1Q4)
                    .isSuccess()
     );
@@ -628,8 +626,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(YEAR_23.getStart(), Granularities.YEAR);
-    Assert.assertEquals(JAN_FEB_MAR_23, pendingSegment.getInterval());
-    Assert.assertEquals(replaceLock.getVersion(), pendingSegment.getVersion());
+    Assertions.assertEquals(JAN_FEB_MAR_23, pendingSegment.getInterval());
+    Assertions.assertEquals(replaceLock.getVersion(), pendingSegment.getVersion());
 
     final DataSegment appendedSegment = asSegment(pendingSegment);
     appendTask.commitAppendSegments(appendedSegment);
@@ -642,12 +640,12 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   public void testLockAllocateAppendYearReplaceQuarter()
   {
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(YEAR_23);
-    Assert.assertNotNull(replaceLock);
+    Assertions.assertNotNull(replaceLock);
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(YEAR_23.getStart(), Granularities.YEAR);
-    Assert.assertEquals(YEAR_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(YEAR_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -660,7 +658,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     final DataSegment segmentV1Q3 = createSegment(JUL_AUG_SEP_23, replaceLock.getVersion());
     final DataSegment segmentV1Q4 = createSegment(OCT_NOV_DEC_23, replaceLock.getVersion());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         replaceTask.commitReplaceSegments(segmentV1Q1, segmentV1Q2, segmentV1Q3, segmentV1Q4)
                    .isSuccess()
     );
@@ -673,19 +671,19 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   public void testLockAllocateReplaceQuarterAppendYear()
   {
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(YEAR_23);
-    Assert.assertNotNull(replaceLock);
+    Assertions.assertNotNull(replaceLock);
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(YEAR_23.getStart(), Granularities.YEAR);
-    Assert.assertEquals(YEAR_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(YEAR_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV1Q1 = createSegment(JAN_FEB_MAR_23, replaceLock.getVersion());
     final DataSegment segmentV1Q2 = createSegment(APR_MAY_JUN_23, replaceLock.getVersion());
     final DataSegment segmentV1Q3 = createSegment(JUL_AUG_SEP_23, replaceLock.getVersion());
     final DataSegment segmentV1Q4 = createSegment(OCT_NOV_DEC_23, replaceLock.getVersion());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         replaceTask.commitReplaceSegments(segmentV1Q1, segmentV1Q2, segmentV1Q3, segmentV1Q4)
                    .isSuccess()
     );
@@ -702,18 +700,18 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(YEAR_23.getStart(), Granularities.YEAR);
-    Assert.assertEquals(YEAR_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(YEAR_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(YEAR_23);
-    Assert.assertNotNull(replaceLock);
+    Assertions.assertNotNull(replaceLock);
 
     final DataSegment segmentV1Q1 = createSegment(JAN_FEB_MAR_23, replaceLock.getVersion());
     final DataSegment segmentV1Q2 = createSegment(APR_MAY_JUN_23, replaceLock.getVersion());
     final DataSegment segmentV1Q3 = createSegment(JUL_AUG_SEP_23, replaceLock.getVersion());
     final DataSegment segmentV1Q4 = createSegment(OCT_NOV_DEC_23, replaceLock.getVersion());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         replaceTask.commitReplaceSegments(segmentV1Q1, segmentV1Q2, segmentV1Q3, segmentV1Q4)
                    .isSuccess()
     );
@@ -730,11 +728,11 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(YEAR_23.getStart(), Granularities.YEAR);
-    Assert.assertEquals(YEAR_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(YEAR_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(YEAR_23);
-    Assert.assertNotNull(replaceLock);
+    Assertions.assertNotNull(replaceLock);
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -747,7 +745,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     final DataSegment segmentV1Q3 = createSegment(JUL_AUG_SEP_23, replaceLock.getVersion());
     final DataSegment segmentV1Q4 = createSegment(OCT_NOV_DEC_23, replaceLock.getVersion());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         replaceTask.commitReplaceSegments(segmentV1Q1, segmentV1Q2, segmentV1Q3, segmentV1Q4)
                    .isSuccess()
     );
@@ -761,8 +759,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(YEAR_23.getStart(), Granularities.YEAR);
-    Assert.assertEquals(YEAR_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(YEAR_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -771,14 +769,14 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     verifyIntervalHasVisibleSegments(YEAR_23, segmentV01);
 
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(YEAR_23);
-    Assert.assertNotNull(replaceLock);
+    Assertions.assertNotNull(replaceLock);
 
     final DataSegment segmentV1Q1 = createSegment(JAN_FEB_MAR_23, replaceLock.getVersion());
     final DataSegment segmentV1Q2 = createSegment(APR_MAY_JUN_23, replaceLock.getVersion());
     final DataSegment segmentV1Q3 = createSegment(JUL_AUG_SEP_23, replaceLock.getVersion());
     final DataSegment segmentV1Q4 = createSegment(OCT_NOV_DEC_23, replaceLock.getVersion());
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         replaceTask.commitReplaceSegments(segmentV1Q1, segmentV1Q2, segmentV1Q3, segmentV1Q4)
                    .isSuccess()
     );
@@ -792,8 +790,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -803,7 +801,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     // Verify that replace lock cannot be acquired on DAY as MONTH is already locked
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23);
-    Assert.assertNull(replaceLock);
+    Assertions.assertNull(replaceLock);
   }
 
   @Test
@@ -823,8 +821,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     final ActionsTestTask appendTask1 = createAndStartTask();
     final SegmentIdWithShardSpec pendingSegmentV11
         = appendTask1.allocateSegmentForTimestamp(YEAR_23.getStart(), Granularities.YEAR);
-    Assert.assertEquals(v1, pendingSegmentV11.getVersion());
-    Assert.assertEquals(YEAR_23, pendingSegmentV11.getInterval());
+    Assertions.assertEquals(v1, pendingSegmentV11.getVersion());
+    Assertions.assertEquals(YEAR_23, pendingSegmentV11.getInterval());
 
     // Commit replace segment for v2
     final ActionsTestTask replaceTask2 = createAndStartTask();
@@ -843,7 +841,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     final DataSegment segmentV11 = asSegment(pendingSegmentV11);
     final DataSegment segmentV21 = DataSegment.builder(segmentV11).version(v2).build();
     Set<DataSegment> appendedSegments = appendTask1.commitAppendSegments(segmentV11).getSegments();
-    Assert.assertEquals(Sets.newHashSet(segmentV21, segmentV11), appendedSegments);
+    Assertions.assertEquals(Sets.newHashSet(segmentV21, segmentV11), appendedSegments);
 
     appendTask1.finishRunAndGetStatus();
     verifyIntervalHasUsedSegments(
@@ -877,13 +875,13 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     appendTask.acquireAppendLockOn(FIRST_OF_JAN_23);
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(segmentV10.getVersion(), pendingSegment.getVersion());
+    Assertions.assertEquals(segmentV10.getVersion(), pendingSegment.getVersion());
 
     final ActionsTestTask appendTask2 = createAndStartTask();
     appendTask2.acquireAppendLockOn(FIRST_OF_JAN_23);
     final SegmentIdWithShardSpec pendingSegment2
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(segmentV10.getVersion(), pendingSegment2.getVersion());
+    Assertions.assertEquals(segmentV10.getVersion(), pendingSegment2.getVersion());
 
     final DataSegment segmentV11 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV11);
@@ -902,16 +900,16 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     appendTask.acquireAppendLockOn(FIRST_OF_JAN_23);
     final SegmentIdWithShardSpec pendingSegment01
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment01.getVersion());
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment01.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment01.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment01.getInterval());
 
     // Allocate segment for Oct-Dec
     final ActionsTestTask appendTask2 = createAndStartTask();
     appendTask2.acquireAppendLockOn(OCT_NOV_DEC_23);
     final SegmentIdWithShardSpec pendingSegment02
         = appendTask2.allocateSegmentForTimestamp(OCT_NOV_DEC_23.getStart(), Granularities.QUARTER);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment02.getVersion());
-    Assert.assertEquals(OCT_NOV_DEC_23, pendingSegment02.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment02.getVersion());
+    Assertions.assertEquals(OCT_NOV_DEC_23, pendingSegment02.getInterval());
 
     // Append segment for Oct-Dec
     final DataSegment segmentV02 = asSegment(pendingSegment02);
@@ -927,8 +925,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
         = appendTask3.allocateSegmentForTimestamp(DEC_23.getStart(), Granularities.MONTH);
 
     // Verify that segment gets allocated for quarter instead of month
-    Assert.assertEquals(SEGMENT_V0, pendingSegment03.getVersion());
-    Assert.assertEquals(OCT_NOV_DEC_23, pendingSegment03.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment03.getVersion());
+    Assertions.assertEquals(OCT_NOV_DEC_23, pendingSegment03.getInterval());
 
     // Acquire replace lock on whole year
     final String v1 = replaceTask.acquireReplaceLockOn(YEAR_23).getVersion();
@@ -975,15 +973,15 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegmentV01
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(SEGMENT_V0, pendingSegmentV01.getVersion());
-    Assert.assertEquals(JAN_23, pendingSegmentV01.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegmentV01.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegmentV01.getInterval());
 
     final String v1 = replaceTask.acquireReplaceLockOn(JAN_23).getVersion();
     final DataSegment segmentV10 = createSegment(JAN_23, v1);
     final SegmentPublishResult replacePublishResult = replaceTask.commitReplaceSegments(segmentV10);
 
     final List<PendingSegmentRecord> upgradedPendingSegments = replacePublishResult.getUpgradedPendingSegments();
-    Assert.assertNotNull(upgradedPendingSegments);
+    Assertions.assertNotNull(upgradedPendingSegments);
     final SegmentIdWithShardSpec pendingSegmentV11 = upgradedPendingSegments.getFirst().getId();
 
     verifyIntervalHasUsedSegments(JAN_23, segmentV10);
@@ -992,10 +990,10 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     // New pending segment is allocated at v1
     final SegmentIdWithShardSpec pendingSegmentV12
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV12.asSegmentId());
-    Assert.assertNotEquals(pendingSegmentV11.asSegmentId(), pendingSegmentV12.asSegmentId());
-    Assert.assertEquals(v1, pendingSegmentV12.getVersion());
-    Assert.assertEquals(JAN_23, pendingSegmentV12.getInterval());
+    Assertions.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV12.asSegmentId());
+    Assertions.assertNotEquals(pendingSegmentV11.asSegmentId(), pendingSegmentV12.asSegmentId());
+    Assertions.assertEquals(v1, pendingSegmentV12.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegmentV12.getInterval());
 
     // Verify that no new segment has been allocated at v0
     verifyIntervalHasPendingSegments(
@@ -1013,9 +1011,9 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegmentV23
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV23.asSegmentId());
-    Assert.assertEquals(v2, pendingSegmentV23.getVersion());
-    Assert.assertEquals(JAN_23, pendingSegmentV23.getInterval());
+    Assertions.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV23.asSegmentId());
+    Assertions.assertEquals(v2, pendingSegmentV23.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegmentV23.getInterval());
 
     // Commit the append segments
     final DataSegment segmentV01 = asSegment(pendingSegmentV01);
@@ -1024,26 +1022,26 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     Set<DataSegment> appendedSegments
         = appendTask.commitAppendSegments(segmentV01, segmentV12, segmentV23).getSegments();
-    Assert.assertEquals(3 + 3, appendedSegments.size());
+    Assertions.assertEquals(3 + 3, appendedSegments.size());
 
     // Verify that the original append segments have been committed
-    Assert.assertTrue(appendedSegments.remove(segmentV01));
-    Assert.assertTrue(appendedSegments.remove(segmentV12));
-    Assert.assertTrue(appendedSegments.remove(segmentV23));
+    Assertions.assertTrue(appendedSegments.remove(segmentV01));
+    Assertions.assertTrue(appendedSegments.remove(segmentV12));
+    Assertions.assertTrue(appendedSegments.remove(segmentV23));
 
     // Verify that segmentV01 has been upgraded to both v1 and v2
     final DataSegment segmentV11 = findSegmentWith(v1, segmentV01.getLoadSpec(), appendedSegments);
-    Assert.assertNotNull(segmentV11);
+    Assertions.assertNotNull(segmentV11);
     final DataSegment segmentV21 = findSegmentWith(v2, segmentV01.getLoadSpec(), appendedSegments);
-    Assert.assertNotNull(segmentV21);
+    Assertions.assertNotNull(segmentV21);
 
     // Verify that segmentV12 has been upgraded to v2
     final DataSegment segmentV22 = findSegmentWith(v2, segmentV12.getLoadSpec(), appendedSegments);
-    Assert.assertNotNull(segmentV22);
+    Assertions.assertNotNull(segmentV22);
 
     // Verify that segmentV23 is not downgraded to v1
     final DataSegment segmentV13 = findSegmentWith(v1, segmentV23.getLoadSpec(), appendedSegments);
-    Assert.assertNull(segmentV13);
+    Assertions.assertNull(segmentV13);
 
     verifyIntervalHasUsedSegments(
         YEAR_23,
@@ -1059,16 +1057,16 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegmentV01
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(SEGMENT_V0, pendingSegmentV01.getVersion());
-    Assert.assertEquals(JAN_23, pendingSegmentV01.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegmentV01.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegmentV01.getInterval());
     final DataSegment segment1 = asSegment(pendingSegmentV01);
     appendTask.commitAppendSegments(segment1);
 
     final SegmentIdWithShardSpec pendingSegmentV02
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV02.asSegmentId());
-    Assert.assertEquals(SEGMENT_V0, pendingSegmentV02.getVersion());
-    Assert.assertEquals(JAN_23, pendingSegmentV02.getInterval());
+    Assertions.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV02.asSegmentId());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegmentV02.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegmentV02.getInterval());
 
     verifyInputSegments(replaceTask, JAN_23, segment1);
 
@@ -1084,10 +1082,10 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegmentV03
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV03.asSegmentId());
-    Assert.assertNotEquals(pendingSegmentV02.asSegmentId(), pendingSegmentV03.asSegmentId());
-    Assert.assertEquals(SEGMENT_V0, pendingSegmentV03.getVersion());
-    Assert.assertEquals(JAN_23, pendingSegmentV03.getInterval());
+    Assertions.assertNotEquals(pendingSegmentV01.asSegmentId(), pendingSegmentV03.asSegmentId());
+    Assertions.assertNotEquals(pendingSegmentV02.asSegmentId(), pendingSegmentV03.asSegmentId());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegmentV03.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegmentV03.getInterval());
     final DataSegment segment3 = asSegment(pendingSegmentV03);
     appendTask.commitAppendSegments(segment3);
     appendTask.releaseLock(JAN_23);
@@ -1116,23 +1114,23 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegmentV1
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(segmentV10.getVersion(), pendingSegmentV1.getVersion());
+    Assertions.assertEquals(segmentV10.getVersion(), pendingSegmentV1.getVersion());
 
     final DataSegment segmentV00 = asSegment(pendingSegmentV0);
     final DataSegment segmentV11 = asSegment(pendingSegmentV1);
     Set<DataSegment> appendSegments = appendTask.commitAppendSegments(segmentV00, segmentV11)
                                                 .getSegments();
 
-    Assert.assertEquals(3, appendSegments.size());
+    Assertions.assertEquals(3, appendSegments.size());
     // Segment V11 is committed
-    Assert.assertTrue(appendSegments.remove(segmentV11));
+    Assertions.assertTrue(appendSegments.remove(segmentV11));
     // Segment V00 is also committed
-    Assert.assertTrue(appendSegments.remove(segmentV00));
+    Assertions.assertTrue(appendSegments.remove(segmentV00));
     // Segment V00 is upgraded to v1 with MONTH granularlity at the time of commit as V12
     final DataSegment segmentV12 = Iterables.getOnlyElement(appendSegments);
-    Assert.assertEquals(v1, segmentV12.getVersion());
-    Assert.assertEquals(JAN_23, segmentV12.getInterval());
-    Assert.assertEquals(segmentV00.getLoadSpec(), segmentV12.getLoadSpec());
+    Assertions.assertEquals(v1, segmentV12.getVersion());
+    Assertions.assertEquals(JAN_23, segmentV12.getInterval());
+    Assertions.assertEquals(segmentV00.getLoadSpec(), segmentV12.getLoadSpec());
 
     verifyIntervalHasUsedSegments(JAN_23, segmentV00, segmentV10, segmentV11, segmentV12);
     verifyIntervalHasVisibleSegments(JAN_23, segmentV10, segmentV11, segmentV12);
@@ -1144,8 +1142,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     // Allocate and commit an APPEND segment
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
-    Assert.assertEquals(0, pendingSegment.getShardSpec().getPartitionNum());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(0, pendingSegment.getShardSpec().getPartitionNum());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -1162,12 +1160,12 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
 
     // Verify that the new segment gets a different version
-    Assert.assertEquals(SEGMENT_V0 + "S", pendingSegment2.getVersion());
-    Assert.assertEquals(0, pendingSegment2.getShardSpec().getPartitionNum());
+    Assertions.assertEquals(SEGMENT_V0 + "S", pendingSegment2.getVersion());
+    Assertions.assertEquals(0, pendingSegment2.getShardSpec().getPartitionNum());
 
     final DataSegment segmentV02 = asSegment(pendingSegment2);
     appendTask.commitAppendSegments(segmentV02);
-    Assert.assertNotEquals(segmentV01, segmentV02);
+    Assertions.assertNotEquals(segmentV01, segmentV02);
 
     verifyIntervalHasUsedSegments(FIRST_OF_JAN_23, segmentV02);
     verifyIntervalHasVisibleSegments(FIRST_OF_JAN_23, segmentV02);
@@ -1186,15 +1184,15 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
       final SegmentIdWithShardSpec pendingSegment
           = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
 
-      Assert.assertEquals(expectedVersion, pendingSegment.getVersion());
-      Assert.assertEquals(expectedParitionNum, pendingSegment.getShardSpec().getPartitionNum());
+      Assertions.assertEquals(expectedVersion, pendingSegment.getVersion());
+      Assertions.assertEquals(expectedParitionNum, pendingSegment.getShardSpec().getPartitionNum());
 
       // Commit the segment and verify its version and partition number
       final DataSegment segment = asSegment(pendingSegment);
       appendTask.commitAppendSegments(segment);
 
-      Assert.assertEquals(expectedVersion, segment.getVersion());
-      Assert.assertEquals(expectedParitionNum, segment.getShardSpec().getPartitionNum());
+      Assertions.assertEquals(expectedVersion, segment.getVersion());
+      Assertions.assertEquals(expectedParitionNum, segment.getShardSpec().getPartitionNum());
 
       verifyIntervalHasUsedSegments(FIRST_OF_JAN_23, segment);
       verifyIntervalHasVisibleSegments(FIRST_OF_JAN_23, segment);
@@ -1205,19 +1203,23 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     }
 
     // Verify that the next attempt fails
-    MatcherAssert.assertThat(
-        Assert.assertThrows(
-            ISE.class,
-            () -> appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY)
-        ),
-        ExceptionMatcher.of(ISE.class).expectRootCause(
-            DruidExceptionMatcher.internalServerError().expectMessageIs(
-                "Could not allocate segment"
-                + "[wiki_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_1970-01-01T00:00:00.000Z]"
-                + " as there are too many clashing unused versions(upto [1970-01-01T00:00:00.000ZSSSSSSSSSS])"
-                + " in the interval. Kill the old unused versions to proceed."
-            )
-        )
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY)
+    );
+    final DruidException rootCause = Assertions.assertInstanceOf(
+        DruidException.class,
+        Throwables.getRootCause(exception)
+    );
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, rootCause.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, rootCause.getCategory());
+    Assertions.assertEquals("internalServerError", rootCause.getErrorCode());
+    Assertions.assertEquals(
+        "Could not allocate segment"
+        + "[wiki_2023-01-01T00:00:00.000Z_2023-01-02T00:00:00.000Z_1970-01-01T00:00:00.000Z]"
+        + " as there are too many clashing unused versions(upto [1970-01-01T00:00:00.000ZSSSSSSSSSS])"
+        + " in the interval. Kill the old unused versions to proceed.",
+        rootCause.getMessage()
     );
   }
 
@@ -1227,8 +1229,8 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
     // Allocate a segment on an empty interval
     final SegmentIdWithShardSpec pendingSegmentV01
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(SEGMENT_V0, pendingSegmentV01.getVersion());
-    Assert.assertEquals(JAN_23, pendingSegmentV01.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegmentV01.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegmentV01.getInterval());
 
     // Replace the segments in the interval
     final String v1 = replaceTask.acquireReplaceLockOn(JAN_23).getVersion();
@@ -1237,14 +1239,14 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
 
     // Verify that pendingSegmentV01 has been upgraded to version v1
     final List<PendingSegmentRecord> upgradedPendingSegments = replacePublishResult.getUpgradedPendingSegments();
-    Assert.assertNotNull(upgradedPendingSegments);
-    Assert.assertEquals(1, upgradedPendingSegments.size());
+    Assertions.assertNotNull(upgradedPendingSegments);
+    Assertions.assertEquals(1, upgradedPendingSegments.size());
     PendingSegmentRecord upgradedPendingSegment = upgradedPendingSegments.getFirst();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         pendingSegmentV01.asSegmentId().toString(),
         upgradedPendingSegment.getUpgradedFromSegmentId()
     );
-    Assert.assertEquals(v1, upgradedPendingSegment.getId().getVersion());
+    Assertions.assertEquals(v1, upgradedPendingSegment.getId().getVersion());
 
     verifyIntervalHasPendingSegments(
         JAN_23,
@@ -1282,7 +1284,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
         .stream()
         .map(PendingSegmentRecord::getId)
         .collect(Collectors.toSet());
-    Assert.assertEquals(expected, observed);
+    Assertions.assertEquals(expected, observed);
   }
 
   private void verifyIntervalHasUsedSegments(Interval interval, DataSegment... expectedSegments)
@@ -1305,7 +1307,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
               visibility
           )
       );
-      Assert.assertEquals(Sets.newHashSet(expectedSegments), Sets.newHashSet(allUsedSegments));
+      Assertions.assertEquals(Sets.newHashSet(expectedSegments), Sets.newHashSet(allUsedSegments));
     }
     catch (IOException e) {
       throw new ISE(e, "Error while fetching used segments in interval[%s]", interval);
@@ -1322,7 +1324,7 @@ public class ConcurrentReplaceAndAppendTest extends IngestionTestBase
               Collections.singletonList(interval)
           )
       );
-      Assert.assertEquals(Sets.newHashSet(expectedSegments), Sets.newHashSet(allUsedSegments));
+      Assertions.assertEquals(Sets.newHashSet(expectedSegments), Sets.newHashSet(allUsedSegments));
     }
     catch (IOException e) {
       throw new ISE(e, "Error while fetching segments to replace in interval[%s]", interval);

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndStreamingAppendTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/concurrent/ConcurrentReplaceAndStreamingAppendTest.java
@@ -70,10 +70,10 @@ import org.easymock.CaptureType;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -125,7 +125,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   private Map<String, Object> parentSegmentToLoadSpec;
 
   @Override
-  @Before
+  @BeforeEach
   public void setUpIngestionTestBase() throws IOException
   {
     EasyMock.reset(supervisorManager);
@@ -177,7 +177,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
     parentSegmentToLoadSpec = new HashMap<>();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     verifyVersionIntervalLoadSpecUniqueness();
@@ -197,7 +197,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(segmentV10.getVersion(), pendingSegment.getVersion());
+    Assertions.assertEquals(segmentV10.getVersion(), pendingSegment.getVersion());
 
     final DataSegment segmentV11 = asSegment(pendingSegment);
     commitAppendSegments(segmentV11);
@@ -213,7 +213,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     commitAppendSegments(segmentV01);
@@ -239,7 +239,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV10 = createSegment(FIRST_OF_JAN_23, v1);
     commitReplaceSegments(segmentV10);
@@ -263,7 +263,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23).getVersion();
 
@@ -289,7 +289,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23).getVersion();
 
@@ -316,7 +316,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     commitAppendSegments(segmentV01);
@@ -347,8 +347,8 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
     // Verify that the allocated segment takes the version and interval of previous replace
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(v1, pendingSegment.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(v1, pendingSegment.getVersion());
 
     final DataSegment segmentV11 = asSegment(pendingSegment);
     commitAppendSegments(segmentV11);
@@ -364,8 +364,8 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     commitAppendSegments(segmentV01);
@@ -393,8 +393,8 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV10 = createSegment(JAN_23, v1);
     commitReplaceSegments(segmentV10);
@@ -420,8 +420,8 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(JAN_23).getVersion();
 
@@ -449,8 +449,8 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final String v1 = replaceTask.acquireReplaceLockOn(JAN_23).getVersion();
 
@@ -478,8 +478,8 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     commitAppendSegments(segmentV01);
@@ -509,13 +509,13 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     // Verify that an APPEND lock cannot be acquired on month
     TaskLock appendLock = appendTask.acquireAppendLockOn(JAN_23);
-    Assert.assertNull(appendLock);
+    Assertions.assertNull(appendLock);
 
     // Verify that new segment gets allocated with DAY granularity even though preferred was MONTH
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(v1, pendingSegment.getVersion());
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(v1, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
 
     final DataSegment segmentV11 = asSegment(pendingSegment);
     commitAppendSegments(segmentV11);
@@ -531,13 +531,13 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     // Verify that an APPEND lock cannot be acquired on month
     TaskLock appendLock = appendTask.acquireAppendLockOn(JAN_23);
-    Assert.assertNull(appendLock);
+    Assertions.assertNull(appendLock);
 
     // Verify that the segment is allocated for DAY granularity
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     commitAppendSegments(segmentV01);
@@ -565,13 +565,13 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     // Verify that an APPEND lock cannot be acquired on month
     TaskLock appendLock = appendTask.acquireAppendLockOn(JAN_23);
-    Assert.assertNull(appendLock);
+    Assertions.assertNull(appendLock);
 
     // Verify that the segment is allocated for DAY granularity instead of MONTH
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(FIRST_OF_JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV10 = createSegment(FIRST_OF_JAN_23, v1);
     commitReplaceSegments(segmentV10);
@@ -597,18 +597,18 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     // Verify that replace lock cannot be acquired on MONTH
     TaskLock replaceLock = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23);
-    Assert.assertNull(replaceLock);
+    Assertions.assertNull(replaceLock);
 
     // Verify that segment cannot be committed since there is no lock
     final DataSegment segmentV10 = createSegment(FIRST_OF_JAN_23, SEGMENT_V0);
-    final ISE exception = Assert.assertThrows(ISE.class, () -> commitReplaceSegments(segmentV10));
+    final ISE exception = Assertions.assertThrows(ISE.class, () -> commitReplaceSegments(segmentV10));
     final Throwable throwable = Throwables.getRootCause(exception);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         StringUtils.format(
             "Segment IDs[[%s]] are not covered by locks[[]] for task[%s]",
             segmentV10.getId(), replaceTask.getId()
@@ -627,8 +627,8 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
   {
     final SegmentIdWithShardSpec pendingSegment
         = appendTask.allocateSegmentForTimestamp(JAN_23.getStart(), Granularities.MONTH);
-    Assert.assertEquals(JAN_23, pendingSegment.getInterval());
-    Assert.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
+    Assertions.assertEquals(JAN_23, pendingSegment.getInterval());
+    Assertions.assertEquals(SEGMENT_V0, pendingSegment.getVersion());
 
     final DataSegment segmentV01 = asSegment(pendingSegment);
     appendTask.commitAppendSegments(segmentV01);
@@ -638,7 +638,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     // Verify that replace lock cannot be acquired on DAY as MONTH is already locked
     final TaskLock replaceLock = replaceTask.acquireReplaceLockOn(FIRST_OF_JAN_23);
-    Assert.assertNull(replaceLock);
+    Assertions.assertNull(replaceLock);
   }
 
   @Test
@@ -655,23 +655,23 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
 
     final SegmentIdWithShardSpec pendingSegmentV1
         = appendTask.allocateSegmentForTimestamp(FIRST_OF_JAN_23.getStart(), Granularities.DAY);
-    Assert.assertEquals(segmentV10.getVersion(), pendingSegmentV1.getVersion());
+    Assertions.assertEquals(segmentV10.getVersion(), pendingSegmentV1.getVersion());
 
     final DataSegment segmentV00 = asSegment(pendingSegmentV0);
     final DataSegment segmentV11 = asSegment(pendingSegmentV1);
     Set<DataSegment> appendSegments = commitAppendSegments(segmentV00, segmentV11)
                                                 .getSegments();
 
-    Assert.assertEquals(3, appendSegments.size());
+    Assertions.assertEquals(3, appendSegments.size());
     // Segment V11 is committed
-    Assert.assertTrue(appendSegments.remove(segmentV11));
+    Assertions.assertTrue(appendSegments.remove(segmentV11));
     // Segment V00 is also committed
-    Assert.assertTrue(appendSegments.remove(segmentV00));
+    Assertions.assertTrue(appendSegments.remove(segmentV00));
     // Segment V00 is upgraded to v1 with MONTH granularlity at the time of commit as V12
     final DataSegment segmentV12 = Iterables.getOnlyElement(appendSegments);
-    Assert.assertEquals(v1, segmentV12.getVersion());
-    Assert.assertEquals(JAN_23, segmentV12.getInterval());
-    Assert.assertEquals(segmentV00.getLoadSpec(), segmentV12.getLoadSpec());
+    Assertions.assertEquals(v1, segmentV12.getVersion());
+    Assertions.assertEquals(JAN_23, segmentV12.getInterval());
+    Assertions.assertEquals(segmentV00.getLoadSpec(), segmentV12.getLoadSpec());
 
     verifyIntervalHasUsedSegments(JAN_23, segmentV00, segmentV10, segmentV11, segmentV12);
     verifyIntervalHasVisibleSegments(JAN_23, segmentV10, segmentV11, segmentV12);
@@ -706,7 +706,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
               visibility
           )
       );
-      Assert.assertEquals(Sets.newHashSet(expectedSegments), Sets.newHashSet(allUsedSegments));
+      Assertions.assertEquals(Sets.newHashSet(expectedSegments), Sets.newHashSet(allUsedSegments));
     }
     catch (IOException e) {
       throw new ISE(e, "Error while fetching used segments in interval[%s]", interval);
@@ -798,7 +798,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
           = versionToIntervalToLoadSpecs.computeIfAbsent(version, v -> new HashMap<>());
       Set<Object> loadSpecs
           = intervalToLoadSpecs.computeIfAbsent(interval, i -> new HashSet<>());
-      Assert.assertFalse(loadSpecs.contains(loadSpec));
+      Assertions.assertFalse(loadSpecs.contains(loadSpec));
       loadSpecs.add(loadSpec);
     }
 
@@ -810,7 +810,7 @@ public class ConcurrentReplaceAndStreamingAppendTest extends IngestionTestBase
           = versionToIntervalToLoadSpecs.computeIfAbsent(version, v -> new HashMap<>());
       Set<Object> loadSpecs
           = intervalToLoadSpecs.computeIfAbsent(interval, i -> new HashSet<>());
-      Assert.assertFalse(loadSpecs.contains(loadSpec));
+      Assertions.assertFalse(loadSpecs.contains(loadSpec));
       loadSpecs.add(loadSpec);
     }
   }


### PR DESCRIPTION
## Summary

- Migrate the ingestion-task and parallel-indexing tests in `indexing-service` to JUnit 5.
- Replace JUnit 4 assertions, lifecycle annotations, rules, Hamcrest matchers, and temporary-folder APIs in this batch with Jupiter/AssertJ and Druid's existing temporary-directory utilities.
- Add the Jupiter parameterized-test and Mockito Jupiter test dependencies required by the migrated tests.
- Keep the remaining JUnit 4 lifecycle annotations in the shared `IngestionTestBase` only as a compatibility bridge for legacy tests outside this batch.
- Keep this batch independent from the Task Actions/Compaction, common-support, Overlord, seekable-stream, and worker batches.

## Validation

- Two fresh focused reruns of `ParallelIndexSupervisorTaskResourceTest`: 1 test each, 0 failures/errors.
- Test compilation passed.
- Static module verification passed with Checkstyle, PMD, Enforcer, forbidden APIs, packaging, and install.
- Legacy/prohibited usage scans and `git diff --check` passed.

## Tracking

Part of [#13948](https://github.com/apache/druid/issues/13948).

Related migration PRs: [#19910](https://github.com/apache/druid/pull/19910), [#19920](https://github.com/apache/druid/pull/19920), [#19922](https://github.com/apache/druid/pull/19922), [#19923](https://github.com/apache/druid/pull/19923), and [#19925](https://github.com/apache/druid/pull/19925).
