### PR TITLE
perf: materialize child emitters in ComposingEmitter to avoid per-event Guice resolution

### DIFF
--- a/server/src/main/java/org/apache/druid/server/emitter/ComposingEmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/ComposingEmitterModule.java
@@ -19,8 +19,7 @@
 
 package org.apache.druid.server.emitter;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Injector;
 import com.google.inject.Key;
@@ -55,17 +54,13 @@ public class ComposingEmitterModule implements DruidModule
   {
     log.info("Creating Composing Emitter with %s", config.getEmitters());
 
-    List<Emitter> emitters = Lists.transform(
-        config.getEmitters(),
-        new Function<>()
-        {
-          @Override
-          public Emitter apply(String s)
-          {
-            return injector.getInstance(Key.get(Emitter.class, Names.named(s)));
-          }
-        }
-    );
+    // Resolve child emitters eagerly, once, into a materialized list. A lazy view (e.g. Lists.transform) would
+    // re-resolve each child from the injector on every ComposingEmitter.emit(event) call, and each resolution takes a
+    // synchronized monitor in LifecycleScope#get(), causing severe lock contention on the metrics emit path.
+    List<Emitter> emitters = config.getEmitters()
+                                   .stream()
+                                   .map(s -> injector.getInstance(Key.get(Emitter.class, Names.named(s))))
+                                   .collect(ImmutableList.toImmutableList());
 
     return new ComposingEmitter(emitters);
   }

--- a/server/src/main/java/org/apache/druid/server/emitter/ComposingEmitterModule.java
+++ b/server/src/main/java/org/apache/druid/server/emitter/ComposingEmitterModule.java
@@ -54,9 +54,6 @@ public class ComposingEmitterModule implements DruidModule
   {
     log.info("Creating Composing Emitter with %s", config.getEmitters());
 
-    // Resolve child emitters eagerly, once, into a materialized list. A lazy view (e.g. Lists.transform) would
-    // re-resolve each child from the injector on every ComposingEmitter.emit(event) call, and each resolution takes a
-    // synchronized monitor in LifecycleScope#get(), causing severe lock contention on the metrics emit path.
     List<Emitter> emitters = config.getEmitters()
                                    .stream()
                                    .map(s -> injector.getInstance(Key.get(Emitter.class, Names.named(s))))

--- a/server/src/test/java/org/apache/druid/initialization/ComposingEmitterModuleTest.java
+++ b/server/src/test/java/org/apache/druid/initialization/ComposingEmitterModuleTest.java
@@ -28,6 +28,7 @@ import com.google.inject.name.Names;
 import org.apache.druid.guice.DruidGuiceExtensions;
 import org.apache.druid.guice.LifecycleModule;
 import org.apache.druid.java.util.emitter.core.Emitter;
+import org.apache.druid.java.util.emitter.core.Event;
 import org.apache.druid.server.emitter.ComposingEmitterConfig;
 import org.apache.druid.server.emitter.ComposingEmitterModule;
 import org.easymock.EasyMock;
@@ -68,6 +69,36 @@ public class ComposingEmitterModuleTest
     composingEmitter.start();
 
     EasyMock.verify(config, emitter, injector);
+  }
+
+  @Test
+  public void testEmitDoesNotReResolveChildEmitters()
+  {
+    ComposingEmitterConfig config = EasyMock.createMock(ComposingEmitterConfig.class);
+    EasyMock.expect(config.getEmitters()).andReturn(Collections.singletonList(testEmitterType)).anyTimes();
+
+    Event event = EasyMock.createNiceMock(Event.class);
+
+    Emitter child = EasyMock.createMock(Emitter.class);
+    child.start();
+    child.emit(event);
+    EasyMock.expectLastCall().times(3);
+    EasyMock.replay(child, event);
+
+    Injector injector = EasyMock.createMock(Injector.class);
+    // The child emitter must be resolved from the injector exactly once (at construction), not once per emitted event.
+    EasyMock.expect(injector.getInstance(Key.get(Emitter.class, Names.named(testEmitterType))))
+            .andReturn(child)
+            .once();
+    EasyMock.replay(config, injector);
+
+    Emitter composingEmitter = new ComposingEmitterModule().getEmitter(config, injector);
+    composingEmitter.start();
+    composingEmitter.emit(event);
+    composingEmitter.emit(event);
+    composingEmitter.emit(event);
+
+    EasyMock.verify(config, injector, child);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/apache/druid/issues/19943

### Description

When Druid is configured with `druid.emitter=composing`, the composing emitter was re-resolving all of its child emitters from the Guice injector on **every** emitted event. Because Druid emits a metric per segment scanned, on busy nodes this executes tens of thousands of times per second, and each resolution takes a monitor lock. Lock profiling on affected nodes attributed the large majority of lock-contention samples to `LifecycleScope$1.get`.

#### Root cause

`ComposingEmitterModule#getEmitter` built its child-emitter list with `Lists.transform(...)`, which returns a **lazy** Guava view rather than a materialized list:

```java
List<Emitter> emitters = Lists.transform(
    config.getEmitters(),
    s -> injector.getInstance(Key.get(Emitter.class, Names.named(s)))
);
return new ComposingEmitter(emitters);
```

`ComposingEmitter.emit(Event)` iterates this list once per event:

```java
public void emit(Event event) {
  for (Emitter e : emitters) {
    e.emit(event);
  }
}
```

Since `emitters` is a lazy view, each iteration re-ran the transform function, which re-resolved every child emitter from the injector. For lifecycle-scoped bindings, that resolution goes through `LifecycleScope#get()`, which is `synchronized` and so takes a monitor lock on every call — even though, after startup, it does nothing but return an already-cached instance. The child emitters were therefore being looked up (and locked) on the hottest path in the process rather than resolved once at startup.

#### Fixed the lock contention in the composing emitter

The child emitters are now resolved **eagerly, exactly once**, into an `ImmutableList` at construction time, so `ComposingEmitter.emit()` iterates a plain materialized list with no injector lookups and no locking:

```java
List<Emitter> emitters = config.getEmitters()
                               .stream()
                               .map(s -> injector.getInstance(Key.get(Emitter.class, Names.named(s))))
                               .collect(ImmutableList.toImmutableList());
return new ComposingEmitter(emitters);
```

This is purely an internal change — the same set of child emitters is composed in the same order. The only difference is *when* they are resolved: once during provisioning instead of on every emitted event. This also aligns `ComposingEmitterModule` with its sibling `SwitchingEmitterModule`, which already resolves its child emitters eagerly into materialized lists.

#### Release note

Fixed lock contention on the metrics emit path when using the composing emitter (`druid.emitter=composing`). Child emitters are now resolved once at startup instead of on every emitted event, which previously caused significant monitor contention on nodes emitting metrics at high volume.

<hr>

##### Key changed/added classes in this PR
 * `ComposingEmitterModule`
 * Added regression test that emits multiple events and asserts the child is resolved only once
<hr>

This PR has:

- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.