### PR TITLE
feat: Implement IntervalAwareBalancerStrategy to balance segment count per interval

### DIFF
--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactory.java
@@ -31,7 +31,8 @@ import org.apache.druid.java.util.common.logger.Logger;
     @JsonSubTypes.Type(name = "cost", value = CostBalancerStrategyFactory.class),
     @JsonSubTypes.Type(name = "cachingCost", value = DisabledCachingCostBalancerStrategyFactory.class),
     @JsonSubTypes.Type(name = "diskNormalized", value = DiskNormalizedCostBalancerStrategyFactory.class),
-    @JsonSubTypes.Type(name = "random", value = RandomBalancerStrategyFactory.class)
+    @JsonSubTypes.Type(name = "random", value = RandomBalancerStrategyFactory.class),
+    @JsonSubTypes.Type(name = "intervalAware", value = IntervalAwareBalancerStrategyFactory.class)
 })
 public abstract class BalancerStrategyFactory
 {

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
@@ -146,10 +146,19 @@ public class IntervalAwareBalancerStrategy implements BalancerStrategy
         }
       }
 
-      // Only move if it strictly reduces the maximum per-interval count, i.e. the
-      // destination (after gaining the segment) would hold fewer segments for this
-      // interval than the source currently does. This avoids pointless moves and
-      // oscillation between two servers that differ by a single segment.
+      // A decommissioning source must be fully evacuated regardless of interval
+      // balance, so the anti-oscillation guard below is skipped for it. The source
+      // is never itself a candidate here (the caller excludes a decommissioning
+      // source from the destination list), so any chosen destination strictly
+      // makes progress towards draining the server.
+      if (bestDestination != null && sourceServer.isDecommissioning()) {
+        return bestDestination;
+      }
+
+      // Otherwise, only move if it strictly reduces the maximum per-interval count,
+      // i.e. the destination (after gaining the segment) would hold fewer segments
+      // for this interval than the source currently does. This avoids pointless
+      // moves and oscillation between two servers that differ by a single segment.
       if (bestDestination != null && bestCount + 1 < sourceCount) {
         return bestDestination;
       }

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategy.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import com.google.common.base.Stopwatch;
+import org.apache.druid.server.coordinator.SegmentCountsPerInterval;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.server.coordinator.stats.Stats;
+import org.apache.druid.timeline.DataSegment;
+import org.joda.time.Interval;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A lightweight {@link BalancerStrategy} that spreads segments covering the same
+ * time interval as evenly as possible across the historicals in a tier.
+ * <p>
+ * For a segment being placed (or moved), the "cost" of a server is simply the
+ * number of segments already projected on that server for the segment's interval
+ * (see {@link SegmentCountsPerInterval}). The cheapest
+ * (least-loaded-for-this-interval) server is preferred.
+ * <p>
+ * The count can be scoped in two ways, controlled by {@code perDatasource}:
+ * <ul>
+ *   <li>{@code perDatasource=true} (default): counts only segments of the
+ *   <b>same datasource</b> for the interval. Each datasource is balanced
+ *   independently, which is optimal when a query targets a single datasource.</li>
+ *   <li>{@code perDatasource=false}: counts segments of <b>all datasources</b>
+ *   for the interval. This is optimal when a query unions multiple datasources
+ *   covering the same time range.</li>
+ * </ul>
+ * Compared to {@link CostBalancerStrategy}, this strategy:
+ * <ul>
+ *   <li>does not model query-time-decay across the whole retention window; it
+ *   only equalises the per-interval segment count, which is what matters for
+ *   workloads that query a narrow, recent time range;</li>
+ *   <li>is O(numServers) per placement using an O(1) per-server count lookup,
+ *   instead of the O(segmentsPerServer) pairwise cost computation, so it does
+ *   not inflate the coordinator duty-cycle time.</li>
+ * </ul>
+ * Ties are broken randomly (via a shuffle before a stable sort) so that servers
+ * holding an equal number of segments for the interval are not always picked in
+ * the same order.
+ * <p>
+ * This strategy is only consulted for initial placement when round-robin
+ * assignment is disabled (i.e. {@code useRoundRobinSegmentAssignment=false},
+ * which also requires {@code smartSegmentLoading=false}). It is always used for
+ * balancing moves.
+ */
+public class IntervalAwareBalancerStrategy implements BalancerStrategy
+{
+  private final boolean perDatasource;
+
+  private final CoordinatorRunStats stats = new CoordinatorRunStats();
+  private final AtomicLong computeTimeNanos = new AtomicLong(0);
+
+  public IntervalAwareBalancerStrategy(boolean perDatasource)
+  {
+    this.perDatasource = perDatasource;
+  }
+
+  @Override
+  public Iterator<ServerHolder> findServersToLoadSegment(
+      DataSegment segmentToLoad,
+      List<ServerHolder> serverHolders
+  )
+  {
+    final Stopwatch computeTime = Stopwatch.createStarted();
+    try {
+      final List<ServerHolder> eligibleServers = new ArrayList<>();
+      for (ServerHolder server : serverHolders) {
+        if (server.canLoadSegment(segmentToLoad)) {
+          eligibleServers.add(server);
+        }
+      }
+
+      // Shuffle first so that a subsequent stable sort breaks ties randomly.
+      Collections.shuffle(eligibleServers);
+      eligibleServers.sort(Comparator.comparingInt(server -> countSegmentsInInterval(server, segmentToLoad)));
+
+      return eligibleServers.iterator();
+    }
+    finally {
+      recordComputeTime(computeTime);
+    }
+  }
+
+  @Override
+  public ServerHolder findDestinationServerToMoveSegment(
+      DataSegment segmentToMove,
+      ServerHolder sourceServer,
+      List<ServerHolder> destinationServers
+  )
+  {
+    final Stopwatch computeTime = Stopwatch.createStarted();
+    try {
+      final int sourceCount = countSegmentsInInterval(sourceServer, segmentToMove);
+
+      ServerHolder bestDestination = null;
+      int bestCount = Integer.MAX_VALUE;
+      int numTiedAtBest = 0;
+      for (ServerHolder server : destinationServers) {
+        if (server.equals(sourceServer) || !server.canLoadSegment(segmentToMove)) {
+          continue;
+        }
+        final int count = countSegmentsInInterval(server, segmentToMove);
+        if (count < bestCount) {
+          bestCount = count;
+          bestDestination = server;
+          numTiedAtBest = 1;
+        } else if (count == bestCount) {
+          // Reservoir sampling over the servers tied at the minimum count, so that
+          // ties are broken uniformly at random rather than always picking the
+          // server that appears earliest in the list. Without this, when many
+          // servers share the lowest count for an interval (common on a large,
+          // lightly-loaded tier), moves would persistently favour the same
+          // early-ordered servers and skew the distribution over repeated runs.
+          if (ThreadLocalRandom.current().nextInt(++numTiedAtBest) == 0) {
+            bestDestination = server;
+          }
+        }
+      }
+
+      // Only move if it strictly reduces the maximum per-interval count, i.e. the
+      // destination (after gaining the segment) would hold fewer segments for this
+      // interval than the source currently does. This avoids pointless moves and
+      // oscillation between two servers that differ by a single segment.
+      if (bestDestination != null && bestCount + 1 < sourceCount) {
+        return bestDestination;
+      }
+      return null;
+    }
+    finally {
+      recordComputeTime(computeTime);
+    }
+  }
+
+  @Override
+  public Iterator<ServerHolder> findServersToDropSegment(
+      DataSegment segmentToDrop,
+      List<ServerHolder> serverHolders
+  )
+  {
+    final List<ServerHolder> servers = new ArrayList<>(serverHolders);
+    // Shuffle first so that a subsequent stable sort breaks ties randomly.
+    Collections.shuffle(servers);
+    // Drop from the most heavily loaded server for this interval first.
+    servers.sort(Comparator.comparingInt((ServerHolder server) -> countSegmentsInInterval(server, segmentToDrop)).reversed());
+
+    return servers.iterator();
+  }
+
+  @Override
+  public CoordinatorRunStats getStats()
+  {
+    stats.add(
+        Stats.Balancer.COMPUTATION_TIME,
+        TimeUnit.NANOSECONDS.toMillis(computeTimeNanos.getAndSet(0))
+    );
+    return stats;
+  }
+
+  private void recordComputeTime(Stopwatch computeTime)
+  {
+    computeTime.stop();
+    stats.add(Stats.Balancer.COMPUTATION_COUNT, 1);
+    computeTimeNanos.addAndGet(computeTime.elapsed(TimeUnit.NANOSECONDS));
+  }
+
+  /**
+   * Number of segments projected on the given server for the segment's interval,
+   * scoped either to the segment's datasource or to all datasources depending on
+   * {@link #perDatasource}. Uses the O(1) per-interval counts maintained by
+   * {@link ServerHolder#getProjectedSegmentCounts()}.
+   */
+  private int countSegmentsInInterval(ServerHolder server, DataSegment segment)
+  {
+    final SegmentCountsPerInterval counts = server.getProjectedSegmentCounts();
+    final Interval interval = segment.getInterval();
+    if (perDatasource) {
+      return counts.getIntervalToSegmentCount(segment.getDataSource()).getInt(interval);
+    } else {
+      return counts.getIntervalToTotalSegmentCount().getInt(interval);
+    }
+  }
+}

--- a/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyFactory.java
+++ b/server/src/main/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyFactory.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+public class IntervalAwareBalancerStrategyFactory extends BalancerStrategyFactory
+{
+  /**
+   * Whether to balance the segment count per interval independently for each
+   * datasource ({@code true}, default) or across all datasources ({@code false}).
+   */
+  private final boolean perDatasource;
+
+  @JsonCreator
+  public IntervalAwareBalancerStrategyFactory(
+      @JsonProperty("perDatasource") @Nullable Boolean perDatasource
+  )
+  {
+    this.perDatasource = perDatasource == null || perDatasource;
+  }
+
+  @JsonProperty
+  public boolean isPerDatasource()
+  {
+    return perDatasource;
+  }
+
+  @Override
+  public BalancerStrategy createBalancerStrategy(int numBalancerThreads)
+  {
+    return new IntervalAwareBalancerStrategy(perDatasource);
+  }
+}

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/BalancerStrategyFactoryTest.java
@@ -44,6 +44,33 @@ public class BalancerStrategyFactoryTest
   }
 
   @Test
+  public void testIntervalAwareStrategyIsDeserialized() throws JsonProcessingException
+  {
+    final String json = "{\"strategy\":\"intervalAware\"}";
+    BalancerStrategyFactory factory = MAPPER.readValue(json, BalancerStrategyFactory.class);
+    BalancerStrategy strategy = factory.createBalancerStrategy(1);
+
+    Assert.assertTrue(factory instanceof IntervalAwareBalancerStrategyFactory);
+    // perDatasource defaults to true when not specified
+    Assert.assertTrue(((IntervalAwareBalancerStrategyFactory) factory).isPerDatasource());
+    Assert.assertTrue(strategy instanceof IntervalAwareBalancerStrategy);
+
+    factory.stopExecutor();
+  }
+
+  @Test
+  public void testIntervalAwareStrategyRespectsPerDatasourceFlag() throws JsonProcessingException
+  {
+    final String json = "{\"strategy\":\"intervalAware\",\"perDatasource\":false}";
+    BalancerStrategyFactory factory = MAPPER.readValue(json, BalancerStrategyFactory.class);
+
+    Assert.assertTrue(factory instanceof IntervalAwareBalancerStrategyFactory);
+    Assert.assertFalse(((IntervalAwareBalancerStrategyFactory) factory).isPerDatasource());
+
+    factory.stopExecutor();
+  }
+
+  @Test
   public void testBalancerFactoryCreatesNewExecutorIfNumThreadsChanges()
   {
     BalancerStrategyFactory factory = new CostBalancerStrategyFactory();

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
@@ -184,6 +184,102 @@ public class IntervalAwareBalancerStrategyTest
   }
 
   @Test
+  public void testNodeLossReplicatesToLeastLoadedServerForInterval()
+  {
+    // Simulates a historical being deleted (e.g. pod delete): its replicas are
+    // gone from the cluster view, so the segment is under-replicated and must be
+    // re-loaded onto one of the surviving servers via the load path. The strategy
+    // must pick the survivor holding the fewest segments for this interval.
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 5);
+
+    // The lost node held intervalSegments 0..2; these are no longer on any server.
+    final DataSegment lostReplica = intervalSegments.get(0);
+
+    // Surviving servers with differing load for the interval.
+    final ServerHolder survivorHeavy = createServerWith(intervalSegments.subList(3, 5)); // count = 2
+    final ServerHolder survivorLight = createServerWith(intervalSegments.subList(3, 4)); // count = 1
+    final ServerHolder survivorEmpty = createServerWith(new ArrayList<>());              // count = 0
+
+    final Iterator<ServerHolder> ordered = strategy.findServersToLoadSegment(
+        lostReplica,
+        Arrays.asList(survivorHeavy, survivorLight, survivorEmpty)
+    );
+
+    // Re-replication targets the emptiest survivor for the interval first.
+    Assert.assertSame(survivorEmpty, ordered.next());
+    Assert.assertSame(survivorLight, ordered.next());
+    Assert.assertSame(survivorHeavy, ordered.next());
+    Assert.assertFalse(ordered.hasNext());
+  }
+
+  @Test
+  public void testDecommissioningSourceIsEvacuatedEvenWhenGuardWouldBlock()
+  {
+    // Simulates a historical being drained (e.g. pod drain / marked
+    // decommissioning): every segment must be moved off it regardless of interval
+    // balance. Here the source holds a single replica for the interval
+    // (sourceCount = 1) and the only destination already holds one segment for the
+    // same interval, so the anti-oscillation guard (bestCount + 1 < sourceCount)
+    // would otherwise block the move and strand the segment on the draining node.
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 3);
+
+    final ServerHolder decommissioningSource = createDecommissioningServerWith(intervalSegments.subList(0, 1));
+    final ServerHolder activeDest = createServerWith(intervalSegments.subList(1, 2));
+
+    final DataSegment toMove = intervalSegments.get(0);
+    // The caller excludes a decommissioning source from the destination list.
+    final ServerHolder chosen = strategy.findDestinationServerToMoveSegment(
+        toMove,
+        decommissioningSource,
+        Arrays.asList(activeDest)
+    );
+
+    Assert.assertSame(activeDest, chosen);
+  }
+
+  @Test
+  public void testDecommissioningSourceEvacuatesToLeastLoadedDestination()
+  {
+    // When draining, the segment must still go to the emptiest destination for the
+    // interval among the active servers.
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 5);
+
+    final ServerHolder decommissioningSource = createDecommissioningServerWith(intervalSegments.subList(0, 1));
+    final ServerHolder destHeavy = createServerWith(intervalSegments.subList(1, 4)); // count = 3
+    final ServerHolder destLight = createServerWith(intervalSegments.subList(4, 5)); // count = 1
+
+    final DataSegment toMove = intervalSegments.get(0);
+    final ServerHolder chosen = strategy.findDestinationServerToMoveSegment(
+        toMove,
+        decommissioningSource,
+        Arrays.asList(destHeavy, destLight)
+    );
+
+    Assert.assertSame(destLight, chosen);
+  }
+
+  @Test
+  public void testActiveSourceStillHonoursOscillationGuard()
+  {
+    // The evacuation fast-path must not affect a normal (non-decommissioning)
+    // source: a move that does not strictly reduce the max per-interval count is
+    // still skipped. Source has 1 for the interval, destination also has 1, so no
+    // move should happen.
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 3);
+
+    final ServerHolder activeSource = createServerWith(intervalSegments.subList(0, 1));
+    final ServerHolder activeDest = createServerWith(intervalSegments.subList(1, 2));
+
+    final ServerHolder chosen = strategy.findDestinationServerToMoveSegment(
+        intervalSegments.get(0),
+        activeSource,
+        Arrays.asList(activeDest)
+    );
+
+    Assert.assertNull(chosen);
+  }
+
+  @Test
   public void testDropPrefersMostLoadedServerForInterval()
   {
     final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 5);
@@ -262,12 +358,26 @@ public class IntervalAwareBalancerStrategyTest
 
   private ServerHolder createServerWith(List<DataSegment> segments, long maxSizeBytes)
   {
+    return new ServerHolder(buildServer(segments, maxSizeBytes).toImmutableDruidServer(), new TestLoadQueuePeon());
+  }
+
+  private ServerHolder createDecommissioningServerWith(List<DataSegment> segments)
+  {
+    return new ServerHolder(
+        buildServer(segments, 10L << 30).toImmutableDruidServer(),
+        new TestLoadQueuePeon(),
+        true
+    );
+  }
+
+  private DruidServer buildServer(List<DataSegment> segments, long maxSizeBytes)
+  {
     final String name = "hist_" + uniqueServerId++;
     final DruidServer server =
         new DruidServer(name, name, null, maxSizeBytes, null, ServerType.HISTORICAL, "hot", 1);
     for (DataSegment segment : segments) {
       server.addDataSegment(segment);
     }
-    return new ServerHolder(server.toImmutableDruidServer(), new TestLoadQueuePeon());
+    return server;
   }
 }

--- a/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/balancer/IntervalAwareBalancerStrategyTest.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.server.coordinator.balancer;
+
+import org.apache.druid.client.DruidServer;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.server.coordination.ServerType;
+import org.apache.druid.server.coordinator.CreateDataSegments;
+import org.apache.druid.server.coordinator.ServerHolder;
+import org.apache.druid.server.coordinator.loading.TestLoadQueuePeon;
+import org.apache.druid.server.coordinator.stats.CoordinatorRunStats;
+import org.apache.druid.server.coordinator.stats.Stats;
+import org.apache.druid.timeline.DataSegment;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+public class IntervalAwareBalancerStrategyTest
+{
+  private static final String DS_WIKI = "wiki";
+  private static final String DS_KOALA = "koala";
+  private static final String MINUTE_START = "2024-01-01T00:00:00.000Z";
+
+  private IntervalAwareBalancerStrategy strategy;
+  private int uniqueServerId;
+
+  @Before
+  public void setUp()
+  {
+    // Default tests use per-datasource scoping; the cross-datasource behaviour
+    // is covered explicitly in the dedicated tests below.
+    strategy = new IntervalAwareBalancerStrategy(true);
+    uniqueServerId = 0;
+  }
+
+  @Test
+  public void testLeastLoadedServerForIntervalIsPreferred()
+  {
+    // Segments for the target 1-minute interval
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 6);
+
+    // serverA already holds 3 of them, serverB holds 1, serverC holds none
+    final ServerHolder serverA = createServerWith(intervalSegments.subList(0, 3));
+    final ServerHolder serverB = createServerWith(intervalSegments.subList(3, 4));
+    final ServerHolder serverC = createServerWith(new ArrayList<>());
+
+    final DataSegment newSegment = intervalSegments.get(5);
+    final Iterator<ServerHolder> ordered =
+        strategy.findServersToLoadSegment(newSegment, Arrays.asList(serverA, serverB, serverC));
+
+    // Emptiest server for this interval comes first, fullest last
+    Assert.assertSame(serverC, ordered.next());
+    Assert.assertSame(serverB, ordered.next());
+    Assert.assertSame(serverA, ordered.next());
+    Assert.assertFalse(ordered.hasNext());
+  }
+
+  @Test
+  public void testPerDatasourceCountIgnoresOtherDatasources()
+  {
+    final IntervalAwareBalancerStrategy perDsStrategy = new IntervalAwareBalancerStrategy(true);
+
+    final List<DataSegment> wikiSegments = minuteSegments(DS_WIKI, 3);
+    final List<DataSegment> koalaSegments = minuteSegments(DS_KOALA, 3);
+
+    // serverA holds 2 koala + 0 wiki (wiki count = 0 for the interval)
+    // serverB holds 2 wiki (wiki count = 2 for the interval)
+    final ServerHolder serverA = createServerWith(koalaSegments.subList(0, 2));
+    final ServerHolder serverB = createServerWith(wikiSegments.subList(0, 2));
+
+    // A new wiki segment should prefer serverA, because only the wiki count
+    // matters in per-datasource mode (serverA has 0 wiki despite holding koala).
+    final DataSegment newWiki = wikiSegments.get(2);
+    final Iterator<ServerHolder> ordered =
+        perDsStrategy.findServersToLoadSegment(newWiki, Arrays.asList(serverA, serverB));
+
+    Assert.assertSame(serverA, ordered.next());
+    Assert.assertSame(serverB, ordered.next());
+  }
+
+  @Test
+  public void testTotalCountIsAcrossAllDatasources()
+  {
+    final IntervalAwareBalancerStrategy totalStrategy = new IntervalAwareBalancerStrategy(false);
+
+    final List<DataSegment> wikiSegments = minuteSegments(DS_WIKI, 3);
+    final List<DataSegment> koalaSegments = minuteSegments(DS_KOALA, 3);
+
+    // serverA holds 2 wiki + 1 koala (total 3 for the interval)
+    // serverB holds 1 wiki only (total 1 for the interval)
+    final List<DataSegment> serverASegments = new ArrayList<>(wikiSegments.subList(0, 2));
+    serverASegments.add(koalaSegments.get(0));
+    final ServerHolder serverA = createServerWith(serverASegments);
+    final ServerHolder serverB = createServerWith(wikiSegments.subList(2, 3));
+
+    // A new koala segment should prefer serverB, because in total mode the count
+    // is across all datasources, not just koala.
+    final DataSegment newKoala = koalaSegments.get(1);
+    final Iterator<ServerHolder> ordered =
+        totalStrategy.findServersToLoadSegment(newKoala, Arrays.asList(serverA, serverB));
+
+    Assert.assertSame(serverB, ordered.next());
+    Assert.assertSame(serverA, ordered.next());
+  }
+
+  @Test
+  public void testMovePrefersEmptierServerAndAvoidsOscillation()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 4);
+
+    // source holds 3 segments for the interval, dest holds 0
+    final ServerHolder source = createServerWith(intervalSegments.subList(0, 3));
+    final ServerHolder dest = createServerWith(new ArrayList<>());
+
+    final DataSegment toMove = intervalSegments.get(0);
+    final ServerHolder chosen =
+        strategy.findDestinationServerToMoveSegment(toMove, source, Arrays.asList(source, dest));
+    Assert.assertSame(dest, chosen);
+
+    // When source has 2 and dest has 1 (differ by one), no move should happen
+    // to avoid oscillation.
+    final ServerHolder source2 = createServerWith(intervalSegments.subList(0, 2));
+    final ServerHolder dest2 = createServerWith(intervalSegments.subList(2, 3));
+    final ServerHolder chosen2 =
+        strategy.findDestinationServerToMoveSegment(
+            intervalSegments.get(0),
+            source2,
+            Arrays.asList(source2, dest2)
+        );
+    Assert.assertNull(chosen2);
+  }
+
+  @Test
+  public void testMoveTieBreakIsNotBiasedTowardListOrder()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 4);
+
+    // Source holds 3 segments for the interval; two candidate destinations both
+    // hold 0 (a tie at the minimum). Over many runs, both should be chosen — a
+    // first-wins linear scan would always return destA.
+    final ServerHolder source = createServerWith(intervalSegments.subList(0, 3));
+    final ServerHolder destA = createServerWith(new ArrayList<>());
+    final ServerHolder destB = createServerWith(new ArrayList<>());
+    final DataSegment toMove = intervalSegments.get(0);
+
+    int chosenA = 0;
+    int chosenB = 0;
+    for (int i = 0; i < 2000; i++) {
+      final ServerHolder chosen =
+          strategy.findDestinationServerToMoveSegment(toMove, source, Arrays.asList(destA, destB));
+      if (chosen == destA) {
+        chosenA++;
+      } else if (chosen == destB) {
+        chosenB++;
+      }
+    }
+
+    // Both tied servers must be selected a meaningful fraction of the time.
+    Assert.assertTrue("destA never chosen: " + chosenA, chosenA > 700);
+    Assert.assertTrue("destB never chosen: " + chosenB, chosenB > 700);
+    Assert.assertEquals(2000, chosenA + chosenB);
+  }
+
+  @Test
+  public void testDropPrefersMostLoadedServerForInterval()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 5);
+
+    final ServerHolder serverA = createServerWith(intervalSegments.subList(0, 1));
+    final ServerHolder serverB = createServerWith(intervalSegments.subList(1, 4));
+
+    final DataSegment segmentToDrop = intervalSegments.get(0);
+    final Iterator<ServerHolder> ordered =
+        strategy.findServersToDropSegment(segmentToDrop, Arrays.asList(serverA, serverB));
+
+    // Most heavily loaded server for the interval should be dropped from first
+    Assert.assertSame(serverB, ordered.next());
+    Assert.assertSame(serverA, ordered.next());
+  }
+
+  @Test
+  public void testFullServerIsExcludedFromLoadCandidates()
+  {
+    final List<DataSegment> targetInterval = minuteSegments(DS_WIKI, 4);
+    // A different interval, used only to fill up the "full" server.
+    final List<DataSegment> otherInterval =
+        CreateDataSegments.ofDatasource(DS_WIKI)
+                          .forIntervals(1, Granularities.MINUTE)
+                          .startingAt("2024-01-01T01:00:00.000Z")
+                          .withNumPartitions(2)
+                          .eachOfSizeInMb(100);
+
+    // Full server: 200 MB capacity holding 2 x 100 MB segments of another interval.
+    // It therefore has 0 segments for the target interval (so by count alone it
+    // would rank first), but it cannot fit any more data.
+    final ServerHolder fullServer = createServerWith(otherInterval, 200L << 20);
+    // Normal server holds 1 segment of the target interval (count = 1).
+    final ServerHolder normalServer = createServerWith(targetInterval.subList(0, 1));
+
+    final DataSegment newSegment = targetInterval.get(1);
+    final Iterator<ServerHolder> ordered =
+        strategy.findServersToLoadSegment(newSegment, Arrays.asList(fullServer, normalServer));
+
+    final List<ServerHolder> result = new ArrayList<>();
+    ordered.forEachRemaining(result::add);
+
+    // Despite having the lowest interval count, the full server must be filtered out.
+    Assert.assertFalse("full server must be excluded", result.contains(fullServer));
+    Assert.assertTrue(result.contains(normalServer));
+    Assert.assertEquals(1, result.size());
+  }
+
+  @Test
+  public void testGetStatsTracksComputation()
+  {
+    final List<DataSegment> intervalSegments = minuteSegments(DS_WIKI, 2);
+    final ServerHolder serverA = createServerWith(new ArrayList<>());
+    final ServerHolder serverB = createServerWith(intervalSegments.subList(0, 1));
+
+    strategy.findServersToLoadSegment(intervalSegments.get(1), Arrays.asList(serverA, serverB));
+
+    final CoordinatorRunStats computeStats = strategy.getStats();
+    Assert.assertEquals(1L, computeStats.get(Stats.Balancer.COMPUTATION_COUNT));
+    Assert.assertTrue(computeStats.get(Stats.Balancer.COMPUTATION_TIME) >= 0);
+  }
+
+  private List<DataSegment> minuteSegments(String datasource, int count)
+  {
+    return CreateDataSegments.ofDatasource(datasource)
+                             .forIntervals(1, Granularities.MINUTE)
+                             .startingAt(MINUTE_START)
+                             .withNumPartitions(count)
+                             .eachOfSizeInMb(100);
+  }
+
+  private ServerHolder createServerWith(List<DataSegment> segments)
+  {
+    return createServerWith(segments, 10L << 30);
+  }
+
+  private ServerHolder createServerWith(List<DataSegment> segments, long maxSizeBytes)
+  {
+    final String name = "hist_" + uniqueServerId++;
+    final DruidServer server =
+        new DruidServer(name, name, null, maxSizeBytes, null, ServerType.HISTORICAL, "hot", 1);
+    for (DataSegment segment : segments) {
+      server.addDataSegment(segment);
+    }
+    return new ServerHolder(server.toImmutableDruidServer(), new TestLoadQueuePeon());
+  }
+}


### PR DESCRIPTION
### Description

The default `roundRobin` segment distribution creates a skew in how many segments each historical must scan to answer scan/export endpoint calls that target a narrow, recent time range. Segments covering the same interval can land unevenly across historicals, so some historicals do disproportionately more work for such queries.

This PR adds a new `intervalAware` balancer strategy that spreads segments covering the same time interval as evenly as possible across the historicals in a tier.

#### Added `IntervalAwareBalancerStrategy`

For a segment being placed, moved, or dropped, the "cost" of a server is the number of segments already projected on that server for the segment's interval. The least-loaded-for-this-interval server is preferred.

- **O(1) per-server cost.** The count comes from the per-interval tallies already maintained in `SegmentCountsPerInterval` (via `ServerHolder.getProjectedSegmentCounts()`), so each placement is O(numServers) with an O(1) lookup per server, rather than the O(segmentsPerServer) pairwise computation of `cost`. This keeps the coordinator duty-cycle time low.
- **Interval-scoped, not decay-based.** Unlike `cost`, it does not model query-time-decay across the whole retention window; it only equalises the per-interval segment count, which is what matters for workloads that query a narrow, recent time range.
- **Tie-breaking.** Ties are broken randomly — shuffle-then-stable-sort for load/drop ordering, and reservoir sampling over the servers tied at the minimum count for moves — so servers holding an equal count for an interval are not always picked in the same order (which would otherwise skew distribution over repeated runs).
- **Oscillation avoidance.** For balancing between active servers, a move is only made when it strictly reduces the maximum per-interval count (the destination, after gaining the segment, would hold fewer segments for the interval than the source currently does). This avoids pointless moves between servers that differ by a single segment.
- **Decommissioning evacuation.** The anti-oscillation guard is bypassed when the source server is decommissioning (`ServerHolder.isDecommissioning()`), so a draining server is fully evacuated regardless of interval balance. Without this, a single-replica segment on a draining node (source count = 1) could never satisfy the `bestCount + 1 < sourceCount` guard and would be stranded, stalling decommissioning. The caller (`StrategicSegmentAssigner#moveSegment`) already excludes a decommissioning source from the destination list, so any chosen destination strictly makes progress towards draining the server, and decommissioning targets are additionally guarded by `canLoadSegment` returning `false`.

#### Added the `perDatasource` option

The count can be scoped two ways via the `perDatasource` flag on the factory:

- `perDatasource=true` (default): counts only segments of the **same datasource** for the interval. Each datasource is balanced independently — optimal when a query targets a single datasource.
- `perDatasource=false`: counts segments of **all datasources** for the interval — optimal when a query unions multiple datasources covering the same time range.

#### Registered the `intervalAware` strategy

Added the `intervalAware` subtype to `BalancerStrategyFactory` so it can be selected via the coordinator dynamic config:

```json
{ "strategy": "intervalAware" }
{ "strategy": "intervalAware", "perDatasource": false }
```

This strategy is only consulted for initial placement when round-robin assignment is disabled (`useRoundRobinSegmentAssignment=false`, which also requires `smartSegmentLoading=false`). It is always used for balancing moves.

#### Release note

Added a new `intervalAware` balancer strategy that distributes the segments of an interval evenly across the historicals in a tier, reducing per-historical scan skew for workloads that query a narrow, recent time range. It can be enabled by setting the balancer `strategy` to `intervalAware` in the coordinator dynamic config, with an optional `perDatasource` flag (default `true`) to control whether the per-interval count is scoped to a single datasource or across all datasources.

<hr>

##### Key changed/added classes in this PR
 * `IntervalAwareBalancerStrategy`
 * `IntervalAwareBalancerStrategyFactory`
 * `BalancerStrategyFactory`

<hr>

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.