### PR TITLE
fix: honor maxRowCount in Druid JDBC Statement (setMaxRows)

### DIFF
--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcResultSet.java
@@ -130,7 +130,7 @@ public class DruidJdbcResultSet implements Closeable
         rowCount++;
       }
 
-      final Meta.Frame result = new Meta.Frame(offset, yielder.isDone(), rows);
+      final Meta.Frame result = new Meta.Frame(offset, yielder.isDone() || offset >= limit, rows);
       offset += rowCount;
       return result;
     }

--- a/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcStatement.java
+++ b/sql/src/main/java/org/apache/druid/sql/avatica/DruidJdbcStatement.java
@@ -69,7 +69,7 @@ public class DruidJdbcStatement extends AbstractDruidJdbcStatement
     closeResultSet();
     this.sqlQuery = queryPlus.withContext(defaultContext, queryContext).freshCopy();
     DirectStatement stmt = lifecycleFactory.directStatement(this.sqlQuery, remoteAddress);
-    resultSet = new DruidJdbcResultSet(this, stmt, Long.MAX_VALUE, fetcherFactory);
+    resultSet = new DruidJdbcResultSet(this, stmt, maxRowCount, fetcherFactory);
     try {
       resultSet.execute();
     }

--- a/sql/src/test/java/org/apache/druid/sql/avatica/DruidStatementTest.java
+++ b/sql/src/test/java/org/apache/druid/sql/avatica/DruidStatementTest.java
@@ -355,6 +355,53 @@ public class DruidStatementTest extends CalciteTestBase
     }
   }
 
+  @Test
+  public void testMaxRowCountDirect()
+  {
+    // SELECT_FROM_FOO returns 6 rows. Verify that maxRowCount=2 limits to 2 rows.
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
+    try (final DruidJdbcStatement statement = jdbcStatement()) {
+      statement.execute(queryPlus, 2, null);
+      Meta.Frame frame = statement.nextFrame(AbstractDruidJdbcStatement.START_OFFSET, 10);
+      Assert.assertEquals(2, frame.rows.size());
+      Assert.assertTrue(frame.done);
+      Assert.assertTrue(statement.isDone());
+    }
+  }
+
+  @Test
+  public void testMaxRowCountOverMultipleFramesDirect()
+  {
+    // SELECT_FROM_FOO returns 6 rows. Verify that maxRowCount=2 limits across
+    // multiple frames, returning 2 rows total and terminating.
+    SqlQueryPlus queryPlus =
+        SqlQueryPlus.builder()
+                    .sql(SELECT_FROM_FOO)
+                    .auth(AllowAllAuthenticator.ALLOW_ALL_RESULT)
+                    .buildJdbc();
+    try (final DruidJdbcStatement statement = jdbcStatement()) {
+      statement.execute(queryPlus, 2, null);
+      // First frame, ask for 1 row.
+      Assert.assertEquals(0, statement.getCurrentOffset());
+      Assert.assertFalse(statement.isDone());
+      Meta.Frame frame = statement.nextFrame(AbstractDruidJdbcStatement.START_OFFSET, 1);
+      Assert.assertEquals(1, frame.rows.size());
+      Assert.assertFalse(frame.done);
+      Assert.assertFalse(statement.isDone());
+      Assert.assertEquals(1, statement.getCurrentOffset());
+
+      // Second frame, ask for the remaining row.
+      frame = statement.nextFrame(1, 10);
+      Assert.assertEquals(1, frame.rows.size());
+      Assert.assertTrue(frame.done);
+      Assert.assertTrue(statement.isDone());
+    }
+  }
+
   /**
    * Verify that JDBC automatically closes the first result set when we
    * open a second for the same statement.


### PR DESCRIPTION
### Problem

`Statement.setMaxRows()` was ignored for ordinary JDBC Statements because `DruidJdbcStatement.execute()` hardcoded `Long.MAX_VALUE` instead of forwarding the `maxRowCount` parameter. Additionally, `ResultFetcher` only marked a frame complete when the underlying yielder was exhausted, so reaching the row limit produced empty non-terminal frames indefinitely.

See [issue #19918](https://github.com/apache/druid/issues/19918) for the full analysis.

### Changes

1. **DruidJdbcStatement**: pass `maxRowCount` through to `DruidJdbcResultSet` instead of `Long.MAX_VALUE`
2. **DruidJdbcResultSet.ResultFetcher**: mark frame `done` when the row limit is reached (`offset >= limit`), not only when the yielder is exhausted
3. **Tests**: added `testMaxRowCountDirect` (single frame) and `testMaxRowCountOverMultipleFramesDirect` (cross-frame limit)

### Key insight

The `maxRowCount` was already correctly threaded through the PreparedStatement path (`DruidJdbcPreparedStatement`). The bug was specific to the ordinary Statement path (`DruidJdbcStatement.execute()`).

Fixes #19918