### PR TITLE
fix(test): retry Kafka partition readiness

### DIFF
--- a/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/org/apache/druid/indexing/kafka/simulate/KafkaResource.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.kafka.simulate;
 
 import org.apache.druid.indexing.kafka.KafkaConsumerConfigs;
 import org.apache.druid.indexing.kafka.KafkaIndexTaskModule;
+import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
 import org.apache.druid.testing.embedded.StreamIngestResource;
 import org.apache.kafka.clients.admin.Admin;
@@ -34,6 +35,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.testcontainers.kafka.KafkaContainer;
@@ -61,6 +63,7 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
    * image should set the system property to {@code apache/kafka-native}.
    */
   private static final String KAFKA_IMAGE = System.getProperty("druid.testing.kafka.image", "apache/kafka:4.3.0");
+  private static final int PARTITION_READINESS_MAX_TRIES = 5;
 
   private EmbeddedDruidCluster cluster;
 
@@ -308,11 +311,21 @@ public class KafkaResource extends StreamIngestResource<KafkaContainer>
     // Topic and partition creation may complete before the partition leaders
     // are ready to handle requests. Verify all partitions through their
     // leaders before allowing callers to publish records.
-    final Map<TopicPartition, OffsetSpec> partitionOffsets = new HashMap<>();
+    final Map<TopicPartition, OffsetSpec> partitionOffsetRequests = new HashMap<>();
     for (int partition = 0; partition < partitionCount; partition++) {
-      partitionOffsets.put(new TopicPartition(topic, partition), OffsetSpec.latest());
+      partitionOffsetRequests.put(new TopicPartition(topic, partition), OffsetSpec.latest());
     }
-    admin.listOffsets(partitionOffsets).all().get();
+    RetryUtils.retry(
+        () -> admin.listOffsets(partitionOffsetRequests).all().get(),
+        KafkaResource::isRetriableKafkaException,
+        PARTITION_READINESS_MAX_TRIES
+    );
+  }
+
+  private static boolean isRetriableKafkaException(Throwable throwable)
+  {
+    return throwable instanceof RetriableException
+           || (throwable.getCause() != null && isRetriableKafkaException(throwable.getCause()));
   }
 
   private Map<String, Object> commonClientProperties()


### PR DESCRIPTION
### Description

This is a follow-up to [#19922](https://github.com/apache/druid/pull/19922) that hardens the embedded Kafka test resource against the topic metadata propagation race observed during that PR's CI run.

`KafkaResource.createTopicWithPartitions()` waits for the topic-creation future, but Kafka can acknowledge creation before the topic metadata and partition leaders are ready for a subsequent `listOffsets` request. The existing `waitForPartitionsToBeReady()` performed that request only once, so the test setup could fail with `UnknownTopicOrPartitionException` during the propagation window.

This PR:

- retries the partition latest-offset readiness probe up to five times with Druid's retry backoff;
- retries only Kafka `RetriableException` instances, including exceptions nested in `ExecutionException`;
- keeps the readiness check shared by both topic creation and partition expansion.

There is no end-user behavior change; this only stabilizes embedded test setup.

### Evidence

- PR #19922 run [31319365598](https://github.com/apache/druid/actions/runs/31319365598), failed job [93259746963](https://github.com/apache/druid/actions/runs/31319365598/job/93259746963), reported one error in `KafkaIndexFaultToleranceTest`.
- The stack trace was `KafkaFutureImpl.get` -> `KafkaResource.waitForPartitionsToBeReady` -> `KafkaResource.createTopicWithPartitions`, with `UnknownTopicOrPartitionException` as the cause.
- The same topic-readiness error occurred in an unrelated historical job (job `93262496826`), while nearby runs passed, confirming a timing-dependent failure.
- Before this change, the focused fault-tolerance test passed locally twice but did not eliminate the one-shot readiness race. After this change, `KafkaResourceTest` passed (1 test), and the focused fault-tolerance test passed twice, including both parameterizations: 9 tests, 0 failures, 0 errors on each run.

### Validation

```text
mvn -B -ntp -Pskip-static-checks -pl extensions-core/kafka-indexing-service -am test \
  -Dtest=org.apache.druid.indexing.kafka.simulate.KafkaResourceTest \
  -Dsurefire.failIfNoSpecifiedTests=false -Dweb.console.skip=true -T1C

mvn -B -ntp -Pskip-static-checks -pl embedded-tests -am test \
  -Dtest=org.apache.druid.testing.embedded.indexing.KafkaIndexFaultToleranceTest \
  -Dsurefire.failIfNoSpecifiedTests=false -Dweb.console.skip=true -T1C

mvn -B -ntp -pl extensions-core/kafka-indexing-service -am -DskipTests \
  -Dweb.console.skip=true checkstyle:check pmd:check forbiddenapis:check forbiddenapis:testCheck
```

All commands passed locally.
