### PR TITLE
feat: Allow BINDABLE plans for Dart.

### DIFF
--- a/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartSqlEngine.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/dart/controller/sql/DartSqlEngine.java
@@ -146,12 +146,12 @@ public class DartSqlEngine implements SqlEngine
       case WINDOW_FUNCTIONS:
       case WINDOW_LEAF_OPERATOR:
       case UNNEST:
+      case ALLOW_BINDABLE_PLAN:
         return true;
 
       case CAN_INSERT:
       case CAN_REPLACE:
       case READ_EXTERNAL_DATA:
-      case ALLOW_BINDABLE_PLAN:
       case ALLOW_BROADCAST_RIGHTY_JOIN:
       case ALLOW_TOP_LEVEL_UNION_ALL:
       case TIMESERIES_QUERY:

--- a/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
+++ b/multi-stage-query/src/test/java/org/apache/druid/msq/dart/controller/http/DartSqlResourceTest.java
@@ -536,6 +536,66 @@ public class DartSqlResourceTest extends MSQTestBase
   }
 
   @Test
+  public void test_doPost_informationSchema()
+  {
+    final MockAsyncContext asyncContext = new MockAsyncContext();
+    final MockHttpServletResponse asyncResponse = new MockHttpServletResponse();
+    asyncContext.response = asyncResponse;
+
+    Mockito.when(httpServletRequest.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+           .thenReturn(makeAuthenticationResult(CalciteTests.TEST_SUPERUSER_NAME));
+    Mockito.when(httpServletRequest.startAsync())
+           .thenReturn(asyncContext);
+
+    final SqlQuery sqlQuery = new SqlQuery(
+        "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA ORDER BY SCHEMA_NAME",
+        ResultFormat.ARRAY,
+        false,
+        false,
+        false,
+        Map.of(QueryContexts.ENGINE, DartSqlEngine.NAME),
+        Collections.emptyList()
+    );
+
+    Assertions.assertNull(sqlResource.doPost(sqlQuery, httpServletRequest));
+    Assertions.assertEquals(Response.Status.OK.getStatusCode(), asyncResponse.getStatus());
+    Assertions.assertEquals(
+        "[[\"INFORMATION_SCHEMA\"],[\"druid\"],[\"lookup\"],[\"sys\"],[\"view\"]]\n",
+        StringUtils.fromUtf8(asyncResponse.baos.toByteArray())
+    );
+  }
+
+  @Test
+  public void test_doPost_sysTableJoinedToDatasource()
+  {
+    final MockAsyncContext asyncContext = new MockAsyncContext();
+    final MockHttpServletResponse asyncResponse = new MockHttpServletResponse();
+    asyncContext.response = asyncResponse;
+
+    Mockito.when(httpServletRequest.getAttribute(AuthConfig.DRUID_AUTHENTICATION_RESULT))
+           .thenReturn(makeAuthenticationResult(CalciteTests.TEST_SUPERUSER_NAME));
+    Mockito.when(httpServletRequest.startAsync())
+           .thenReturn(asyncContext);
+
+    final SqlQuery sqlQuery = new SqlQuery(
+        StringUtils.format(
+            "SELECT s.segment_id, f.dim1 FROM sys.segments AS s, %s AS f",
+            CalciteTests.DATASOURCE1
+        ),
+        ResultFormat.ARRAY,
+        false,
+        false,
+        false,
+        Map.of(QueryContexts.ENGINE, DartSqlEngine.NAME),
+        Collections.emptyList()
+    );
+
+    // 501 Not Implemented.
+    final Response response = sqlResource.doPost(sqlQuery, httpServletRequest);
+    Assertions.assertEquals(501, response.getStatus());
+  }
+
+  @Test
   public void test_doPost_regularUser_forbidden()
   {
     final MockAsyncContext asyncContext = new MockAsyncContext();


### PR DESCRIPTION
This switch allows the "msq-dart" engine to be used for metadata tables such as those in "sys" and "INFORMATION_SCHEMA".