### PR TITLE
test: Fix NPE alert noise in DruidCoordinatorTest.

### DIFF
--- a/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/coordinator/DruidCoordinatorTest.java
@@ -52,6 +52,7 @@ import org.apache.druid.server.coordinator.config.CoordinatorKillConfigs;
 import org.apache.druid.server.coordinator.config.CoordinatorPeriodConfig;
 import org.apache.druid.server.coordinator.config.CoordinatorRunConfig;
 import org.apache.druid.server.coordinator.config.DruidCoordinatorConfig;
+import org.apache.druid.server.coordinator.config.MetadataCleanupConfig;
 import org.apache.druid.server.coordinator.duty.CompactSegments;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDuty;
 import org.apache.druid.server.coordinator.duty.CoordinatorCustomDutyGroup;
@@ -135,10 +136,27 @@ public class DruidCoordinatorTest
     ).andReturn(new AtomicReference<>(DruidCompactionConfig.empty())).anyTimes();
     EasyMock.replay(configManager);
     statusTracker = new CompactionStatusTracker();
+
+    final MetadataCleanupConfig cleanupDisabled = new MetadataCleanupConfig(false, null, null);
     druidCoordinatorConfig = new DruidCoordinatorConfig(
         new CoordinatorRunConfig(new Duration(COORDINATOR_START_DELAY), new Duration(COORDINATOR_PERIOD)),
         new CoordinatorPeriodConfig(null, null),
-        CoordinatorKillConfigs.DEFAULT,
+        new CoordinatorKillConfigs(
+            cleanupDisabled,
+            cleanupDisabled,
+            cleanupDisabled,
+            cleanupDisabled,
+            cleanupDisabled,
+            cleanupDisabled,
+            cleanupDisabled,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        ),
         new CostBalancerStrategyFactory(),
         null
     );


### PR DESCRIPTION
  Summary:
  The shared test `MetadataManager` in `DruidCoordinatorTest` intentionally passes
  null supervisor/audit/indexer managers. With metadata-store cleanup enabled (the
  `CoordinatorKillConfigs.DEFAULT`), the `Kill*` duties dereference those nulls and
  emit unrelated NPE alerts on every run that starts a real coordinator.

  Disable metadata cleanup in the shared coordinator config so the `Kill*` duties
  self-skip instead of dereferencing the null managers. These duties are tested in other 
  places anyway and not asserted in this test.

  Alternative considered: keep `DEFAULT` and supply mocked managers (auditManager,
  metadataSupervisorManager, storageCoordinator, connector, etc) with stubbed returns.
  Rejected — it needs several mocks + stubs for duties these tests never assert on.