### PR TITLE
test(processing): migrate segment tests to JUnit 5

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/AutoTypeColumnIndexerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/AutoTypeColumnIndexerTest.java
@@ -35,11 +35,12 @@ import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.nested.StructuredData;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
+
 import java.util.Map;
 
 public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
@@ -52,7 +53,7 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
   private static final String VARIANT_COL = "variant";
   private static final String NESTED_COL = "nested";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup()
   {
     BuiltInTypesModule.registerHandlersAndSerde();
@@ -62,65 +63,65 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
   public void testKeySizeEstimation()
   {
     AutoTypeColumnIndexer indexer = new AutoTypeColumnIndexer("test", null, null);
-    Assert.assertEquals(DimensionDictionarySelector.CARDINALITY_UNKNOWN, indexer.getCardinality());
+    Assertions.assertEquals(DimensionDictionarySelector.CARDINALITY_UNKNOWN, indexer.getCardinality());
     int baseCardinality = 0;
-    Assert.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
 
     EncodedKeyComponent<StructuredData> key;
     // new raw value, new field, new dictionary entry
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableMap.of("x", "foo"), false);
-    Assert.assertEquals(228, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(228, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     // adding same value only adds estimated size of value itself
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableMap.of("x", "foo"), false);
-    Assert.assertEquals(112, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(112, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     // new raw value, new field, new dictionary entry
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(10L, false);
-    Assert.assertEquals(94, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 2, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(94, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 2, indexer.globalDictionary.getCardinality());
     // adding same value only adds estimated size of value itself
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(10L, false);
-    Assert.assertEquals(16, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 2, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(16, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 2, indexer.globalDictionary.getCardinality());
     // new raw value, new dictionary entry
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(11L, false);
-    Assert.assertEquals(48, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 3, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(48, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 3, indexer.globalDictionary.getCardinality());
 
     // new raw value, new fields
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(1L, 2L, 10L), false);
-    Assert.assertEquals(168, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(168, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
     // new raw value, re-use fields and dictionary
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(1L, 2L, 10L), false);
-    Assert.assertEquals(104, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(104, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
     // new raw value, new fields
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(
         ImmutableMap.of("x", ImmutableList.of(1L, 2L, 10L)),
         false
     );
-    Assert.assertEquals(166, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(166, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
     // new raw value
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(
         ImmutableMap.of("x", ImmutableList.of(1L, 2L, 10L)),
         false
     );
-    Assert.assertEquals(166, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(166, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 6, indexer.globalDictionary.getCardinality());
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent("", false);
 
-    Assert.assertEquals(104, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 7, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(104, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 7, indexer.globalDictionary.getCardinality());
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(0L, false);
 
-    Assert.assertEquals(48, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 8, indexer.globalDictionary.getCardinality());
-    Assert.assertEquals(DimensionDictionarySelector.CARDINALITY_UNKNOWN, indexer.getCardinality());
+    Assertions.assertEquals(48, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 8, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(DimensionDictionarySelector.CARDINALITY_UNKNOWN, indexer.getCardinality());
   }
 
   @Test
@@ -143,36 +144,36 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
 
       ColumnValueSelector valueSelector = columnSelectorFactory.makeColumnValueSelector(STRING_COL);
       DimensionSelector dimensionSelector = columnSelectorFactory.makeDimensionSelector(dimensionSpec);
-      Assert.assertEquals("a", valueSelector.getObject());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("a", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("a", dimensionSelector.getObject());
+      Assertions.assertEquals("a", valueSelector.getObject());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("a", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("a", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals("b", valueSelector.getObject());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("b", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("b", dimensionSelector.getObject());
+      Assertions.assertEquals("b", valueSelector.getObject());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("b", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("b", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals("c", valueSelector.getObject());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("c", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("c", dimensionSelector.getObject());
+      Assertions.assertEquals("c", valueSelector.getObject());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("c", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("c", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertNull(dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertNull(dimensionSelector.getObject());
 
-      Assert.assertEquals(ColumnType.STRING, cursorFactory.getColumnCapabilities(STRING_COL).toColumnType());
+      Assertions.assertEquals(ColumnType.STRING, cursorFactory.getColumnCapabilities(STRING_COL).toColumnType());
     }
   }
 
@@ -196,43 +197,43 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
 
       ColumnValueSelector valueSelector = columnSelectorFactory.makeColumnValueSelector(LONG_COL);
       DimensionSelector dimensionSelector = columnSelectorFactory.makeDimensionSelector(dimensionSpec);
-      Assert.assertEquals(1L, valueSelector.getObject());
-      Assert.assertEquals(1L, valueSelector.getLong());
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("1", dimensionSelector.getObject());
+      Assertions.assertEquals(1L, valueSelector.getObject());
+      Assertions.assertEquals(1L, valueSelector.getLong());
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("1", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals(2L, valueSelector.getObject());
-      Assert.assertEquals(2L, valueSelector.getLong());
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("2", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("2", dimensionSelector.getObject());
+      Assertions.assertEquals(2L, valueSelector.getObject());
+      Assertions.assertEquals(2L, valueSelector.getLong());
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("2", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("2", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals(3L, valueSelector.getObject());
-      Assert.assertEquals(3L, valueSelector.getLong());
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("3", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("3", dimensionSelector.getObject());
+      Assertions.assertEquals(3L, valueSelector.getObject());
+      Assertions.assertEquals(3L, valueSelector.getLong());
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("3", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("3", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertTrue(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertTrue(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertNull(dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertTrue(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertNull(dimensionSelector.getObject());
-      Assert.assertEquals(ColumnType.LONG, cursorFactory.getColumnCapabilities(LONG_COL).toColumnType());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertTrue(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertNull(dimensionSelector.getObject());
+      Assertions.assertEquals(ColumnType.LONG, cursorFactory.getColumnCapabilities(LONG_COL).toColumnType());
     }
   }
 
@@ -256,44 +257,44 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
 
       ColumnValueSelector valueSelector = columnSelectorFactory.makeColumnValueSelector(DOUBLE_COL);
       DimensionSelector dimensionSelector = columnSelectorFactory.makeDimensionSelector(dimensionSpec);
-      Assert.assertEquals(1.1, valueSelector.getObject());
-      Assert.assertEquals(1.1, valueSelector.getDouble(), 0.0);
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("1.1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("1.1", dimensionSelector.getObject());
+      Assertions.assertEquals(1.1, valueSelector.getObject());
+      Assertions.assertEquals(1.1, valueSelector.getDouble(), 0.0);
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("1.1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("1.1", dimensionSelector.getObject());
 
 
       cursor.advance();
-      Assert.assertEquals(2.2, valueSelector.getObject());
-      Assert.assertEquals(2.2, valueSelector.getDouble(), 0.0);
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("2.2", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("2.2", dimensionSelector.getObject());
+      Assertions.assertEquals(2.2, valueSelector.getObject());
+      Assertions.assertEquals(2.2, valueSelector.getDouble(), 0.0);
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("2.2", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("2.2", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals(3.3, valueSelector.getObject());
-      Assert.assertEquals(3.3, valueSelector.getDouble(), 0.0);
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertEquals("3.3", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertEquals("3.3", dimensionSelector.getObject());
+      Assertions.assertEquals(3.3, valueSelector.getObject());
+      Assertions.assertEquals(3.3, valueSelector.getDouble(), 0.0);
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertEquals("3.3", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertEquals("3.3", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertTrue(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertTrue(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertNull(dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertTrue(valueSelector.isNull());
-      Assert.assertEquals(1, dimensionSelector.getRow().size());
-      Assert.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-      Assert.assertNull(dimensionSelector.getObject());
-      Assert.assertEquals(ColumnType.DOUBLE, cursorFactory.getColumnCapabilities(DOUBLE_COL).toColumnType());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertTrue(valueSelector.isNull());
+      Assertions.assertEquals(1, dimensionSelector.getRow().size());
+      Assertions.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+      Assertions.assertNull(dimensionSelector.getObject());
+      Assertions.assertEquals(ColumnType.DOUBLE, cursorFactory.getColumnCapabilities(DOUBLE_COL).toColumnType());
     }
   }
 
@@ -321,24 +322,24 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
       ColumnSelectorFactory columnSelectorFactory = cursor.getColumnSelectorFactory();
 
       ColumnValueSelector valueSelector = columnSelectorFactory.makeColumnValueSelector(STRING_ARRAY_COL);
-      Assert.assertThrows(
+      Assertions.assertThrows(
           UnsupportedOperationException.class,
           () -> cursor.getColumnSelectorFactory().makeDimensionSelector(dimensionSpec)
       );
-      Assert.assertArrayEquals(new Object[]{"a"}, (Object[]) valueSelector.getObject());
+      Assertions.assertArrayEquals(new Object[]{"a"}, (Object[]) valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertArrayEquals(new Object[]{"b", "c"}, (Object[]) valueSelector.getObject());
+      Assertions.assertArrayEquals(new Object[]{"b", "c"}, (Object[]) valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertArrayEquals(new Object[]{"d", "e"}, (Object[]) valueSelector.getObject());
+      Assertions.assertArrayEquals(new Object[]{"d", "e"}, (Object[]) valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertEquals(
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertEquals(
           ColumnType.STRING_ARRAY,
           cursorFactory.getColumnCapabilities(STRING_ARRAY_COL).toColumnType()
       );
@@ -365,27 +366,27 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
 
       ColumnValueSelector valueSelector = columnSelectorFactory.makeColumnValueSelector(VARIANT_COL);
       DimensionSelector dimensionSelector = cursor.getColumnSelectorFactory().makeDimensionSelector(dimensionSpec);
-      Assert.assertEquals("a", valueSelector.getObject());
-      Assert.assertEquals("a", dimensionSelector.getObject());
+      Assertions.assertEquals("a", valueSelector.getObject());
+      Assertions.assertEquals("a", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals(2L, valueSelector.getObject());
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals("2", dimensionSelector.getObject());
+      Assertions.assertEquals(2L, valueSelector.getObject());
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals("2", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals(3.3, valueSelector.getObject());
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals("3.3", dimensionSelector.getObject());
+      Assertions.assertEquals(3.3, valueSelector.getObject());
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals("3.3", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertNull(dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertNull(dimensionSelector.getObject());
-      Assert.assertEquals(ColumnType.STRING, cursorFactory.getColumnCapabilities(VARIANT_COL).toColumnType());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertNull(dimensionSelector.getObject());
+      Assertions.assertEquals(ColumnType.STRING, cursorFactory.getColumnCapabilities(VARIANT_COL).toColumnType());
     }
   }
 
@@ -408,24 +409,24 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
       ColumnSelectorFactory columnSelectorFactory = cursor.getColumnSelectorFactory();
 
       ColumnValueSelector valueSelector = columnSelectorFactory.makeColumnValueSelector(NESTED_COL);
-      Assert.assertThrows(
+      Assertions.assertThrows(
           UnsupportedOperationException.class,
           () -> cursor.getColumnSelectorFactory().makeDimensionSelector(dimensionSpec)
       );
-      Assert.assertEquals(StructuredData.wrap("a"), valueSelector.getObject());
+      Assertions.assertEquals(StructuredData.wrap("a"), valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals(StructuredData.wrap(2L), valueSelector.getObject());
+      Assertions.assertEquals(StructuredData.wrap(2L), valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals(StructuredData.wrap(ImmutableMap.of("x", 1.1, "y", 2L)), valueSelector.getObject());
+      Assertions.assertEquals(StructuredData.wrap(ImmutableMap.of("x", 1.1, "y", 2L)), valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertEquals(ColumnType.NESTED_DATA, cursorFactory.getColumnCapabilities(NESTED_COL).toColumnType());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertEquals(ColumnType.NESTED_DATA, cursorFactory.getColumnCapabilities(NESTED_COL).toColumnType());
     }
   }
 
@@ -455,7 +456,7 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     index.add(makeInputRow(minTimestamp + 1, true, NESTED_COL, "a"));
     index.add(makeInputRow(minTimestamp + 2, true, NESTED_COL, 2L));
     IncrementalIndexAddResult result = index.add(makeInputRow(minTimestamp + 3, true, NESTED_COL, ImmutableMap.of("x", 1.1, "y", 2L)));
-    Assert.assertTrue(result.hasParseException());
+    Assertions.assertTrue(result.hasParseException());
     index.add(makeInputRow(minTimestamp + 4, true, NESTED_COL, null));
     index.add(makeInputRow(minTimestamp + 5, false, NESTED_COL, null));
 
@@ -467,27 +468,27 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
 
       ColumnValueSelector valueSelector = columnSelectorFactory.makeColumnValueSelector(NESTED_COL);
       DimensionSelector dimensionSelector = cursor.getColumnSelectorFactory().makeDimensionSelector(dimensionSpec);
-      Assert.assertEquals("a", valueSelector.getObject());
-      Assert.assertEquals("a", dimensionSelector.getObject());
+      Assertions.assertEquals("a", valueSelector.getObject());
+      Assertions.assertEquals("a", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertEquals("2", valueSelector.getObject());
-      Assert.assertFalse(valueSelector.isNull());
-      Assert.assertEquals("2", dimensionSelector.getObject());
+      Assertions.assertEquals("2", valueSelector.getObject());
+      Assertions.assertFalse(valueSelector.isNull());
+      Assertions.assertEquals("2", dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertNull(dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertNull(dimensionSelector.getObject());
 
       cursor.advance();
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertNull(dimensionSelector.getObject());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertNull(dimensionSelector.getObject());
 
-      Assert.assertEquals(ColumnType.STRING, cursorFactory.getColumnCapabilities(NESTED_COL).toColumnType());
+      Assertions.assertEquals(ColumnType.STRING, cursorFactory.getColumnCapabilities(NESTED_COL).toColumnType());
     }
   }
 
@@ -499,21 +500,21 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     EncodedKeyComponent<StructuredData> key;
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(null, true);
-    Assert.assertEquals(0, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(0, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(null, true);
 
-    Assert.assertEquals(0, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(0, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(null, true);
-    Assert.assertEquals(0, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(0, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
 
 
-    Assert.assertTrue(indexer.hasNulls);
-    Assert.assertFalse(indexer.hasNestedData);
-    Assert.assertTrue(indexer.isConstant());
-    Assert.assertEquals(ColumnType.STRING, indexer.getLogicalType());
+    Assertions.assertTrue(indexer.hasNulls);
+    Assertions.assertFalse(indexer.hasNestedData);
+    Assertions.assertTrue(indexer.isConstant());
+    Assertions.assertEquals(ColumnType.STRING, indexer.getLogicalType());
   }
 
   @Test
@@ -524,20 +525,20 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     EncodedKeyComponent<StructuredData> key;
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent("abcd", true);
-    Assert.assertEquals(166, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(166, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent("abcd", true);
 
-    Assert.assertEquals(52, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(52, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent("abcd", true);
-    Assert.assertEquals(52, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(52, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
 
-    Assert.assertFalse(indexer.hasNulls);
-    Assert.assertFalse(indexer.hasNestedData);
-    Assert.assertTrue(indexer.isConstant());
-    Assert.assertEquals(ColumnType.STRING, indexer.getLogicalType());
+    Assertions.assertFalse(indexer.hasNulls);
+    Assertions.assertFalse(indexer.hasNestedData);
+    Assertions.assertTrue(indexer.isConstant());
+    Assertions.assertEquals(ColumnType.STRING, indexer.getLogicalType());
   }
 
   @Test
@@ -548,20 +549,20 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     EncodedKeyComponent<StructuredData> key;
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(1234L, true);
-    Assert.assertEquals(94, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(94, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(1234L, true);
 
-    Assert.assertEquals(16, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(16, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(1234L, true);
-    Assert.assertEquals(16, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(16, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
 
-    Assert.assertFalse(indexer.hasNulls);
-    Assert.assertFalse(indexer.hasNestedData);
-    Assert.assertTrue(indexer.isConstant());
-    Assert.assertEquals(ColumnType.LONG, indexer.getLogicalType());
+    Assertions.assertFalse(indexer.hasNulls);
+    Assertions.assertFalse(indexer.hasNestedData);
+    Assertions.assertTrue(indexer.isConstant());
+    Assertions.assertEquals(ColumnType.LONG, indexer.getLogicalType());
   }
 
   @Test
@@ -572,20 +573,20 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     EncodedKeyComponent<StructuredData> key;
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(), true);
-    Assert.assertEquals(54, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(54, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(), true);
 
-    Assert.assertEquals(8, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(8, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(), true);
-    Assert.assertEquals(8, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(8, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 1, indexer.globalDictionary.getCardinality());
 
-    Assert.assertFalse(indexer.hasNulls);
-    Assert.assertFalse(indexer.hasNestedData);
-    Assert.assertTrue(indexer.isConstant());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, indexer.getLogicalType());
+    Assertions.assertFalse(indexer.hasNulls);
+    Assertions.assertFalse(indexer.hasNestedData);
+    Assertions.assertTrue(indexer.isConstant());
+    Assertions.assertEquals(ColumnType.LONG_ARRAY, indexer.getLogicalType());
   }
 
   @Test
@@ -596,20 +597,20 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     EncodedKeyComponent<StructuredData> key;
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(1L, 2L, 3L), true);
-    Assert.assertEquals(246, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 4, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(246, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 4, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(1L, 2L, 3L), true);
 
-    Assert.assertEquals(104, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 4, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(104, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 4, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableList.of(1L, 2L, 3L), true);
-    Assert.assertEquals(104, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality + 4, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(104, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality + 4, indexer.globalDictionary.getCardinality());
 
-    Assert.assertFalse(indexer.hasNulls);
-    Assert.assertFalse(indexer.hasNestedData);
-    Assert.assertTrue(indexer.isConstant());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, indexer.getLogicalType());
+    Assertions.assertFalse(indexer.hasNulls);
+    Assertions.assertFalse(indexer.hasNestedData);
+    Assertions.assertTrue(indexer.isConstant());
+    Assertions.assertEquals(ColumnType.LONG_ARRAY, indexer.getLogicalType());
   }
 
   @Test
@@ -620,20 +621,20 @@ public class AutoTypeColumnIndexerTest extends InitializedNullHandlingTest
     EncodedKeyComponent<StructuredData> key;
 
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableMap.of(), true);
-    Assert.assertEquals(16, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(16, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableMap.of(), true);
 
-    Assert.assertEquals(16, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(16, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
     key = indexer.processRowValsToUnsortedEncodedKeyComponent(ImmutableMap.of(), true);
-    Assert.assertEquals(16, key.getEffectiveSizeBytes());
-    Assert.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
+    Assertions.assertEquals(16, key.getEffectiveSizeBytes());
+    Assertions.assertEquals(baseCardinality, indexer.globalDictionary.getCardinality());
 
-    Assert.assertFalse(indexer.hasNulls);
-    Assert.assertTrue(indexer.hasNestedData);
-    Assert.assertTrue(indexer.isConstant());
-    Assert.assertEquals(ColumnType.NESTED_DATA, indexer.getLogicalType());
+    Assertions.assertFalse(indexer.hasNulls);
+    Assertions.assertTrue(indexer.hasNestedData);
+    Assertions.assertTrue(indexer.isConstant());
+    Assertions.assertEquals(ColumnType.NESTED_DATA, indexer.getLogicalType());
   }
 
   @Nonnull

--- a/processing/src/test/java/org/apache/druid/segment/BitmapOffsetTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/BitmapOffsetTest.java
@@ -30,22 +30,22 @@ import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.bitmap.MutableBitmap;
 import org.apache.druid.collections.bitmap.RoaringBitmapFactory;
 import org.apache.druid.segment.data.Offset;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class BitmapOffsetTest
 {
   private static final int[] TEST_VALS = {1, 2, 4, 291, 27412, 49120, 212312, 2412101};
   private static final int[] TEST_VALS_FLIP = {2412101, 212312, 49120, 27412, 291, 4, 2, 1};
 
-  @Parameterized.Parameters
   public static Iterable<Object[]> constructorFeeder()
   {
     return Iterables.transform(
@@ -87,12 +87,12 @@ public class BitmapOffsetTest
 
     int count = 0;
     while (offset.withinBounds()) {
-      Assert.assertEquals(expected[count], offset.getOffset());
+      Assertions.assertEquals(expected[count], offset.getOffset());
 
       int cloneCount = count;
       Offset clonedOffset = offset.clone();
       while (clonedOffset.withinBounds()) {
-        Assert.assertEquals(expected[cloneCount], clonedOffset.getOffset());
+        Assertions.assertEquals(expected[cloneCount], clonedOffset.getOffset());
 
         ++cloneCount;
         clonedOffset.increment();
@@ -101,6 +101,6 @@ public class BitmapOffsetTest
       ++count;
       offset.increment();
     }
-    Assert.assertEquals(count, expected.length);
+    Assertions.assertEquals(count, expected.length);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/CloserRuleTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CloserRuleTest.java
@@ -20,10 +20,8 @@
 package org.apache.druid.segment;
 
 import com.google.common.util.concurrent.Runnables;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
@@ -37,9 +35,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class CloserRuleTest
 {
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testCloses() throws Throwable
   {
@@ -56,7 +51,7 @@ public class CloserRuleTest
         }
     );
     run(closer, Runnables.doNothing());
-    Assert.assertTrue(closed.get());
+    Assertions.assertTrue(closed.get());
   }
 
   @Test
@@ -88,10 +83,10 @@ public class CloserRuleTest
     catch (Exception e) {
       ex = e;
     }
-    Assert.assertTrue(closed.get());
-    Assert.assertNotNull(ex);
-    Assert.assertTrue(ex instanceof ArithmeticException);
-    Assert.assertEquals(msg, ex.getMessage());
+    Assertions.assertTrue(closed.get());
+    Assertions.assertNotNull(ex);
+    Assertions.assertTrue(ex instanceof ArithmeticException);
+    Assertions.assertEquals(msg, ex.getMessage());
   }
 
 
@@ -138,10 +133,10 @@ public class CloserRuleTest
     catch (Throwable e) {
       ex = e;
     }
-    Assert.assertEquals(arithmeticException, ex);
-    Assert.assertNotNull(ex);
-    Assert.assertNotNull(ex.getSuppressed());
-    Assert.assertEquals(suppressed, ex.getSuppressed()[0]);
+    Assertions.assertEquals(arithmeticException, ex);
+    Assertions.assertNotNull(ex);
+    Assertions.assertNotNull(ex.getSuppressed());
+    Assertions.assertEquals(suppressed, ex.getSuppressed()[0]);
   }
 
   @Test
@@ -167,7 +162,7 @@ public class CloserRuleTest
     catch (Throwable throwable) {
       ex = throwable;
     }
-    Assert.assertEquals(ioException, ex);
+    Assertions.assertEquals(ioException, ex);
   }
 
 
@@ -263,12 +258,12 @@ public class CloserRuleTest
     catch (Throwable throwable) {
       ex = throwable;
     }
-    Assert.assertNotNull(ex);
-    Assert.assertEquals(ioExceptions.size(), counter.get());
-    Assert.assertEquals(2, ex.getSuppressed().length);
+    Assertions.assertNotNull(ex);
+    Assertions.assertEquals(ioExceptions.size(), counter.get());
+    Assertions.assertEquals(2, ex.getSuppressed().length);
   }
 
-  private void run(CloserRule closer, final Runnable runnable) throws Throwable
+  private void run(final CloserRule closer, final Runnable runnable) throws Throwable
   {
     closer.apply(
         new Statement()

--- a/processing/src/test/java/org/apache/druid/segment/ConciseBitmapIndexMergerV9Test.java
+++ b/processing/src/test/java/org/apache/druid/segment/ConciseBitmapIndexMergerV9Test.java
@@ -23,10 +23,12 @@ import org.apache.druid.segment.data.CompressionFactory.LongEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.ConciseBitmapSerdeFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("org.apache.druid.segment.IndexMergerTestBase#data")
 public class ConciseBitmapIndexMergerV9Test extends IndexMergerTestBase
 {
   public ConciseBitmapIndexMergerV9Test(

--- a/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CursorFactoryProjectionTest.java
@@ -95,16 +95,16 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 import org.joda.time.Period;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -117,7 +117,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
 {
   private static final Closer CLOSER = Closer.create();
@@ -402,7 +404,6 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
                         )
                         .collect(Collectors.toList());
 
-  @Parameterized.Parameters(name = "name: {0}, segmentTimeOrdered: {5}, autoSchema: {6}, writeNullColumns: {7}")
   public static Collection<?> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -515,7 +516,7 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException
   {
     CLOSER.close();
@@ -535,8 +536,8 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
   public final boolean segmentSortedByTime;
   public final boolean autoSchema;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public CursorFactoryProjectionTest(
       String name,
@@ -725,11 +726,11 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
 
     final CursorBuildSpec buildSpec = GroupingEngine.makeCursorBuildSpec(query, null);
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> projectionsCursorFactory.makeCursorHolder(buildSpec)
     );
-    Assert.assertEquals("Force projections specified, but none satisfy query", t.getMessage());
+    Assertions.assertEquals("Force projections specified, but none satisfy query", t.getMessage());
   }
 
   @Test
@@ -1459,12 +1460,12 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
                                         .build();
 
     final CursorBuildSpec buildSpec = TimeseriesQueryEngine.makeCursorBuildSpec(query, null);
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> projectionsCursorFactory.makeCursorHolder(buildSpec)
     );
-    Assert.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
-    Assert.assertEquals("Projection[b_c_sum] specified, but does not satisfy query", e.getMessage());
+    Assertions.assertEquals(DruidException.Category.INVALID_INPUT, e.getCategory());
+    Assertions.assertEquals("Projection[b_c_sum] specified, but does not satisfy query", e.getMessage());
   }
 
   @Test
@@ -1549,7 +1550,7 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
   public void testTimeseriesQueryGranularityFinerThanProjectionGranularity()
   {
     // timeseries query only works on base table if base table is sorted by time
-    Assume.assumeTrue(segmentSortedByTime);
+    Assumptions.assumeTrue(segmentSortedByTime);
     final TimeseriesQuery query = Druids.newTimeseriesQueryBuilder()
                                         .dataSource("test")
                                         .intervals(ImmutableList.of(Intervals.ETERNITY))
@@ -1887,7 +1888,7 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
     }
 
     // timeseries query only works on base table if base table is sorted by time
-    Assume.assumeTrue(segmentSortedByTime);
+    Assumptions.assumeTrue(segmentSortedByTime);
     final Sequence<Result<TimeseriesResultValue>> resultRowsNoProjection = timeseriesEngine.process(
         query.withOverriddenContext(Map.of(QueryContexts.NO_PROJECTIONS, true)),
         projectionsCursorFactory,
@@ -2069,7 +2070,7 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
     assertTimeseriesResults(query.getResultRowSignature(RowSignature.Finalization.YES), expectedResults, results);
 
     // timeseries query only works on base table if base table is sorted by time
-    Assume.assumeTrue(segmentSortedByTime);
+    Assumptions.assumeTrue(segmentSortedByTime);
     final Sequence<Result<TimeseriesResultValue>> resultRowsNoProjection = timeseriesEngine.process(
         query.withOverriddenContext(Map.of(QueryContexts.NO_PROJECTIONS, true)),
         cursorFactory,
@@ -2090,10 +2091,7 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
     Assertions.assertEquals(expected.size(), actual.size());
     Object[] actualArray = actual.stream().map(ResultRow::getArray).map(Arrays::toString).toArray();
     // print a full diff of all differing elements.
-    Assertions.assertEquals(
-        Arrays.toString(expected.stream().map(Arrays::toString).toArray()),
-        Arrays.toString(actualArray)
-    );
+    Assertions.assertEquals(Arrays.toString(expected.stream().map(Arrays::toString).toArray()), Arrays.toString(actualArray));
   }
 
   private void assertTimeseriesResults(
@@ -2139,7 +2137,7 @@ public class CursorFactoryProjectionTest extends InitializedNullHandlingTest
           cursor.advance();
         }
       }
-      Assert.assertEquals(expectedRowCount, rowCount);
+      Assertions.assertEquals(expectedRowCount, rowCount);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/CursorHolderPreaggTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/CursorHolderPreaggTest.java
@@ -52,13 +52,14 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.utils.CloseableUtils;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -74,10 +75,10 @@ public class CursorHolderPreaggTest extends InitializedNullHandlingTest
   private CursorFactory cursorFactory;
   private Segment segment;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     bufferPool = closer.closeLater(
@@ -224,11 +225,11 @@ public class CursorHolderPreaggTest extends InitializedNullHandlingTest
     );
 
     List<Result<TopNResultValue>> rows = results.toList();
-    Assert.assertEquals(1, rows.size());
+    Assertions.assertEquals(1, rows.size());
     // the cnt column is treated as pre-aggregated, so the values of the rows are summed
-    Assert.assertEquals(2, rows.get(0).getValue().getValue().size());
-    Assert.assertEquals(11L, rows.get(0).getValue().getValue().get(0).getLongMetric("cnt").longValue());
-    Assert.assertEquals(7L, rows.get(0).getValue().getValue().get(1).getLongMetric("cnt").longValue());
+    Assertions.assertEquals(2, rows.get(0).getValue().getValue().size());
+    Assertions.assertEquals(11L, rows.get(0).getValue().getValue().get(0).getLongMetric("cnt").longValue());
+    Assertions.assertEquals(7L, rows.get(0).getValue().getValue().get(1).getLongMetric("cnt").longValue());
   }
 
   @Test
@@ -251,10 +252,10 @@ public class CursorHolderPreaggTest extends InitializedNullHandlingTest
         null
     );
     List<ResultRow> rows = results.toList();
-    Assert.assertEquals(2, rows.size());
+    Assertions.assertEquals(2, rows.size());
     // the cnt column is treated as pre-aggregated, so the values of the rows are summed
-    Assert.assertArrayEquals(new Object[]{"a", "aa", 11L}, rows.get(0).getArray());
-    Assert.assertArrayEquals(new Object[]{"b", "bb", 7L}, rows.get(1).getArray());
+    Assertions.assertArrayEquals(new Object[]{"a", "aa", 11L}, rows.get(0).getArray());
+    Assertions.assertArrayEquals(new Object[]{"b", "bb", 7L}, rows.get(1).getArray());
   }
 
   @Test
@@ -273,8 +274,8 @@ public class CursorHolderPreaggTest extends InitializedNullHandlingTest
         null
     );
     List<Result<TimeseriesResultValue>> rows = results.toList();
-    Assert.assertEquals(1, rows.size());
+    Assertions.assertEquals(1, rows.size());
     // the cnt column is treated as pre-aggregated, so the values of the rows are summed
-    Assert.assertEquals(18L, (long) rows.get(0).getValue().getLongMetric("cnt"));
+    Assertions.assertEquals(18L, (long) rows.get(0).getValue().getLongMetric("cnt"));
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/EmptyIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/EmptyIndexTest.java
@@ -33,20 +33,20 @@ import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class EmptyIndexTest
 {
-
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder()
   {
     return ImmutableList.of(
@@ -96,13 +96,13 @@ public class EmptyIndexTest
 
       QueryableIndex emptyQueryableIndex = TestHelper.getTestIndexIO().loadIndex(tmpDir);
 
-      Assert.assertEquals("getDimensionNames", 0, Iterables.size(emptyQueryableIndex.getAvailableDimensions()));
-      Assert.assertEquals("getMetricNames", 0, emptyQueryableIndex.getColumnNames().size());
-      Assert.assertEquals("getDataInterval", Intervals.of("2012-08-01/P3D"), emptyQueryableIndex.getDataInterval());
-      Assert.assertEquals(
-          "getReadOnlyTimestamps",
+      Assertions.assertEquals(0, Iterables.size(emptyQueryableIndex.getAvailableDimensions()), "getDimensionNames");
+      Assertions.assertEquals(0, emptyQueryableIndex.getColumnNames().size(), "getMetricNames");
+      Assertions.assertEquals(Intervals.of("2012-08-01/P3D"), emptyQueryableIndex.getDataInterval(), "getDataInterval");
+      Assertions.assertEquals(
           0,
-          emptyQueryableIndex.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength()
+          emptyQueryableIndex.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength(),
+          "getReadOnlyTimestamps"
       );
     }
     finally {

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerTestBase.java
@@ -73,16 +73,16 @@ import org.apache.druid.segment.index.semantic.StringValueSetIndexes;
 import org.apache.druid.segment.index.semantic.ValueIndexes;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -100,12 +100,11 @@ import java.util.stream.Collectors;
 
 public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
 {
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   protected IndexMerger indexMerger;
 
-  @Parameterized.Parameters(name = "{index}: metric compression={0}, dimension compression={1}, long encoding={2}, segment write-out medium={3}")
   public static Collection<Object[]> data()
   {
     return Collections2.transform(
@@ -156,8 +155,8 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
   protected final boolean useBitmapIndexes;
   protected final BitmapSerdeFactory serdeFactory;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   protected IndexMergerTestBase(
       @Nullable BitmapSerdeFactory bitmapSerdeFactory,
@@ -192,19 +191,19 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         indexIO.loadIndex(indexMerger.persist(toPersist, tempDir, indexSpec, null))
     );
 
-    Assert.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompression());
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
         index.getMetadata().getAggregators()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Granularities.NONE,
         index.getMetadata().getQueryGranularity()
     );
@@ -249,25 +248,25 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         indexIO.loadIndex(indexMerger.persist(toPersist, tempDir, indexSpec, null))
     );
 
-    Assert.assertEquals(6, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("dim1", "dim2", "__time"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(6, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("dim1", "dim2", "__time"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompression());
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
         index.getMetadata().getAggregators()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Granularities.NONE,
         index.getMetadata().getQueryGranularity()
     );
 
-    Assert.assertEquals(6, index.getNumRows());
-    Assert.assertEquals(
+    Assertions.assertEquals(6, index.getNumRows());
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of("1", "2", timestamp, 1L),
             ImmutableList.of("1", "2", timestamp, 1L),
@@ -319,25 +318,25 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         indexIO.loadIndex(indexMerger.persist(toPersist, tempDir, indexSpec, null))
     );
 
-    Assert.assertEquals(4, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("dim1", "dim2", "__time"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(4, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("dim1", "dim2", "__time"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompression());
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
         index.getMetadata().getAggregators()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Granularities.NONE,
         index.getMetadata().getQueryGranularity()
     );
 
-    Assert.assertEquals(4, index.getNumRows());
-    Assert.assertEquals(
+    Assertions.assertEquals(4, index.getNumRows());
+    Assertions.assertEquals(
         ImmutableList.of(
             ImmutableList.of("1", "2", timestamp, 2L),
             ImmutableList.of("1", "2", timestamp + 1, 1L),
@@ -372,18 +371,18 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         indexIO.loadIndex(indexMerger.persist(toPersist, tempDir, indexSpec, null))
     );
 
-    Assert.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
     assertDimCompression(index, indexSpec.getDimensionCompression());
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(index);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(2, rowList.size());
-    Assert.assertEquals(ImmutableList.of("1", "2"), rowList.get(0).dimensionValues());
-    Assert.assertEquals(Arrays.asList("3", null), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(2, rowList.size());
+    Assertions.assertEquals(ImmutableList.of("1", "2"), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(Arrays.asList("3", null), rowList.get(1).dimensionValues());
 
     checkBitmapIndex(Collections.emptyList(), getBitmapIndex(adapter, "dim1", null));
     checkBitmapIndex(Collections.singletonList(0), getBitmapIndex(adapter, "dim1", "1"));
@@ -409,14 +408,14 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         indexIO.loadIndex(indexMerger.persist(toPersist, tempDir, indexSpec, null))
     );
 
-    Assert.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompression());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         new Metadata(
             metadataElems,
             IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
@@ -467,17 +466,17 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         indexIO.loadIndex(indexMerger.persist(toPersist1, tempDir1, indexSpec, null))
     );
 
-    Assert.assertEquals(2, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
-    Assert.assertEquals(3, index1.getColumnNames().size());
+    Assertions.assertEquals(2, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
+    Assertions.assertEquals(3, index1.getColumnNames().size());
 
     QueryableIndex index2 = closer.closeLater(
         indexIO.loadIndex(indexMerger.persist(toPersist2, tempDir2, indexSpec, null))
     );
 
-    Assert.assertEquals(2, index2.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index2.getAvailableDimensions()));
-    Assert.assertEquals(3, index2.getColumnNames().size());
+    Assertions.assertEquals(2, index2.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index2.getAvailableDimensions()));
+    Assertions.assertEquals(3, index2.getColumnNames().size());
 
     AggregatorFactory[] mergedAggregators = new AggregatorFactory[]{
         new CountAggregatorFactory("count")
@@ -496,14 +495,14 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(3, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
-    Assert.assertEquals(3, merged.getColumnNames().size());
+    Assertions.assertEquals(3, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
+    Assertions.assertEquals(3, merged.getColumnNames().size());
     assertDimCompression(index2, indexSpec.getDimensionCompression());
     assertDimCompression(index1, indexSpec.getDimensionCompression());
     assertDimCompression(merged, indexSpec.getDimensionCompression());
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         getCombiningAggregators(mergedAggregators),
         merged.getMetadata().getAggregators()
     );
@@ -562,14 +561,14 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(1, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(ImmutableList.of("dim2"), ImmutableList.copyOf(index1.getAvailableDimensions()));
+    Assertions.assertEquals(1, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(ImmutableList.of("dim2"), ImmutableList.copyOf(index1.getAvailableDimensions()));
 
-    Assert.assertEquals(1, index2.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(ImmutableList.of("dim2"), ImmutableList.copyOf(index2.getAvailableDimensions()));
+    Assertions.assertEquals(1, index2.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(ImmutableList.of("dim2"), ImmutableList.copyOf(index2.getAvailableDimensions()));
 
-    Assert.assertEquals(2, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(ImmutableList.of("dim2"), ImmutableList.copyOf(merged.getAvailableDimensions()));
+    Assertions.assertEquals(2, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(ImmutableList.of("dim2"), ImmutableList.copyOf(merged.getAvailableDimensions()));
 
     assertDimCompression(index1, indexSpec.getDimensionCompression());
     assertDimCompression(index2, indexSpec.getDimensionCompression());
@@ -601,9 +600,9 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
 
     indexIO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
-    Assert.assertEquals(2, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
-    Assert.assertEquals(3, index1.getColumnNames().size());
+    Assertions.assertEquals(2, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
+    Assertions.assertEquals(3, index1.getColumnNames().size());
 
 
     QueryableIndex merged = closer.closeLater(
@@ -620,9 +619,9 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(2, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
-    Assert.assertEquals(3, merged.getColumnNames().size());
+    Assertions.assertEquals(2, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
+    Assertions.assertEquals(3, merged.getColumnNames().size());
 
     indexIO.validateTwoSegments(tempDir1, mergedDir);
 
@@ -655,9 +654,9 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
 
     indexIO.validateTwoSegments(incrementalAdapter, queryableAdapter);
 
-    Assert.assertEquals(2, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
-    Assert.assertEquals(3, index1.getColumnNames().size());
+    Assertions.assertEquals(2, index1.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index1.getAvailableDimensions()));
+    Assertions.assertEquals(3, index1.getColumnNames().size());
 
     IndexSpec.Builder builder = IndexSpec.builder().withBitmapSerdeFactory(indexSpec.getBitmapSerdeFactory());
     if (CompressionStrategy.LZ4.equals(indexSpec.getDimensionCompression())) {
@@ -689,9 +688,9 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(2, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
-    Assert.assertEquals(3, merged.getColumnNames().size());
+    Assertions.assertEquals(2, merged.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(merged.getAvailableDimensions()));
+    Assertions.assertEquals(3, merged.getColumnNames().size());
 
     indexIO.validateTwoSegments(tempDir1, mergedDir);
 
@@ -729,14 +728,14 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         Method method = cls.getDeclaredMethod("getCompressionStrategy");
         method.setAccessible(true);
         Object strategy = method.invoke(obj);
-        Assert.assertEquals(expectedStrategy, strategy);
+        Assertions.assertEquals(expectedStrategy, strategy);
         return;
       }
       catch (NoSuchMethodException e) {
         cls = cls.getSuperclass();
       }
     }
-    Assert.fail("Could not find getCompressionStrategy() on " + obj.getClass());
+    Assertions.fail("Could not find getCompressionStrategy() on " + obj.getClass());
   }
 
 
@@ -782,21 +781,21 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("__time", "d3", "d1", "d2"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(Arrays.asList("d3", "d1", "d2"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
-    Assert.assertEquals(3, rowList.size());
+    Assertions.assertEquals(Arrays.asList("d3", "d1", "d2"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
+    Assertions.assertEquals(3, rowList.size());
 
-    Assert.assertEquals(Arrays.asList("30000", "100", "4000"), rowList.get(0).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(3L), rowList.get(0).metricValues());
+    Assertions.assertEquals(Arrays.asList("30000", "100", "4000"), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(3L), rowList.get(0).metricValues());
 
-    Assert.assertEquals(Arrays.asList("40000", "300", "2000"), rowList.get(1).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(3L), rowList.get(1).metricValues());
+    Assertions.assertEquals(Arrays.asList("40000", "300", "2000"), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(3L), rowList.get(1).metricValues());
 
-    Assert.assertEquals(Arrays.asList("50000", "200", "3000"), rowList.get(2).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(3L), rowList.get(2).metricValues());
+    Assertions.assertEquals(Arrays.asList("50000", "200", "3000"), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(3L), rowList.get(2).metricValues());
 
     checkBitmapIndex(Collections.emptyList(), getBitmapIndex(adapter, "d3", null));
     checkBitmapIndex(Collections.singletonList(0), getBitmapIndex(adapter, "d3", "30000"));
@@ -877,27 +876,27 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "dimA", "dimB", "dimC"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(ImmutableList.of("dimA", "dimB", "dimC"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
-    Assert.assertEquals(4, rowList.size());
+    Assertions.assertEquals(ImmutableList.of("dimA", "dimB", "dimC"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
+    Assertions.assertEquals(4, rowList.size());
 
-    Assert.assertEquals(Arrays.asList(null, null, "1"), rowList.get(0).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList.get(0).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, null, "1"), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList.get(0).metricValues());
 
-    Assert.assertEquals(Arrays.asList(null, null, "2"), rowList.get(1).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList.get(1).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, null, "2"), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList.get(1).metricValues());
 
-    Assert.assertEquals(Arrays.asList("1", null, null), rowList.get(2).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(2).metricValues());
+    Assertions.assertEquals(Arrays.asList("1", null, null), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(2).metricValues());
 
-    Assert.assertEquals(Arrays.asList("2", null, null), rowList.get(3).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(3).metricValues());
+    Assertions.assertEquals(Arrays.asList("2", null, null), rowList.get(3).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(3).metricValues());
 
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimA").hasBitmapIndexes());
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimC").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimA").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimC").hasBitmapIndexes());
 
     if (useBitmapIndexes) {
       checkBitmapIndex(Arrays.asList(0, 1), getBitmapIndex(adapter, "dimA", null));
@@ -985,35 +984,35 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(Arrays.asList("dimA", "dimB", "dimC"), Lists.newArrayList(merged.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("dimA", "dimB", "dimC", "__time"), Lists.newArrayList(merged.getOrdering()));
+    Assertions.assertEquals(Arrays.asList("dimA", "dimB", "dimC"), Lists.newArrayList(merged.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("dimA", "dimB", "dimC", "__time"), Lists.newArrayList(merged.getOrdering()));
 
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "dimA", "dimB", "dimC"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(ImmutableList.of("dimA", "dimB", "dimC"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
-    Assert.assertEquals(4, rowList.size());
+    Assertions.assertEquals(ImmutableList.of("dimA", "dimB", "dimC"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
+    Assertions.assertEquals(4, rowList.size());
 
-    Assert.assertEquals(Arrays.asList(null, null, "1"), rowList.get(0).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList.get(0).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, null, "1"), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList.get(0).metricValues());
 
-    Assert.assertEquals(Arrays.asList(null, null, "2"), rowList.get(1).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList.get(1).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, null, "2"), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList.get(1).metricValues());
 
-    Assert.assertEquals(Arrays.asList("1", null, null), rowList.get(2).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(2).metricValues());
+    Assertions.assertEquals(Arrays.asList("1", null, null), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(2).metricValues());
 
-    Assert.assertEquals(Arrays.asList("2", null, null), rowList.get(3).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(3).metricValues());
+    Assertions.assertEquals(Arrays.asList("2", null, null), rowList.get(3).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(3).metricValues());
 
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimA").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimA").hasBitmapIndexes());
     // we always have an "index" for a column with all null values (since everything matches or doesnt)
-    Assert.assertTrue(adapter.getCapabilities("dimB").hasBitmapIndexes());
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimC").hasBitmapIndexes());
+    Assertions.assertTrue(adapter.getCapabilities("dimB").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimC").hasBitmapIndexes());
 
     if (useBitmapIndexes) {
       checkBitmapIndex(Arrays.asList(0, 1), getBitmapIndex(adapter, "dimA", null));
@@ -1070,30 +1069,30 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
       final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
       final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of("__time", "dimA", "dimB"),
           ImmutableList.copyOf(adapter.getDimensionNames(true))
       );
-      Assert.assertEquals(ImmutableList.of("dimA", "dimB"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
-      Assert.assertEquals(5, rowList.size());
+      Assertions.assertEquals(ImmutableList.of("dimA", "dimB"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
+      Assertions.assertEquals(5, rowList.size());
 
-      Assert.assertEquals(Arrays.asList(null, "1"), rowList.get(0).dimensionValues());
-      Assert.assertEquals(Collections.singletonList(1L), rowList.get(0).metricValues());
+      Assertions.assertEquals(Arrays.asList(null, "1"), rowList.get(0).dimensionValues());
+      Assertions.assertEquals(Collections.singletonList(1L), rowList.get(0).metricValues());
 
-      Assert.assertEquals(Arrays.asList(null, "2"), rowList.get(1).dimensionValues());
-      Assert.assertEquals(Collections.singletonList(1L), rowList.get(1).metricValues());
+      Assertions.assertEquals(Arrays.asList(null, "2"), rowList.get(1).dimensionValues());
+      Assertions.assertEquals(Collections.singletonList(1L), rowList.get(1).metricValues());
 
-      Assert.assertEquals(Arrays.asList(null, "3"), rowList.get(2).dimensionValues());
-      Assert.assertEquals(Collections.singletonList(1L), rowList.get(2).metricValues());
+      Assertions.assertEquals(Arrays.asList(null, "3"), rowList.get(2).dimensionValues());
+      Assertions.assertEquals(Collections.singletonList(1L), rowList.get(2).metricValues());
 
-      Assert.assertEquals(Arrays.asList("1", null), rowList.get(3).dimensionValues());
-      Assert.assertEquals(Collections.singletonList(1L), rowList.get(3).metricValues());
+      Assertions.assertEquals(Arrays.asList("1", null), rowList.get(3).dimensionValues());
+      Assertions.assertEquals(Collections.singletonList(1L), rowList.get(3).metricValues());
 
-      Assert.assertEquals(Arrays.asList("2", null), rowList.get(4).dimensionValues());
-      Assert.assertEquals(Collections.singletonList(1L), rowList.get(4).metricValues());
+      Assertions.assertEquals(Arrays.asList("2", null), rowList.get(4).dimensionValues());
+      Assertions.assertEquals(Collections.singletonList(1L), rowList.get(4).metricValues());
 
       // dimA always has bitmap indexes, since it has them in indexA (it comes in through discovery).
-      Assert.assertTrue(adapter.getCapabilities("dimA").hasBitmapIndexes());
+      Assertions.assertTrue(adapter.getCapabilities("dimA").hasBitmapIndexes());
       checkBitmapIndex(Arrays.asList(0, 1, 2), getBitmapIndex(adapter, "dimA", null));
       checkBitmapIndex(Collections.singletonList(3), getBitmapIndex(adapter, "dimA", "1"));
       checkBitmapIndex(Collections.singletonList(4), getBitmapIndex(adapter, "dimA", "2"));
@@ -1102,7 +1101,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
       // dimB may or may not have bitmap indexes, since it comes in through explicit definition in toPersistB2.
       //noinspection ObjectEquality
       if (toPersistB == toPersistB2) {
-        Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimB").hasBitmapIndexes());
+        Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dimB").hasBitmapIndexes());
       }
       //noinspection ObjectEquality
       if (toPersistB != toPersistB2 || useBitmapIndexes) {
@@ -1211,29 +1210,29 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
       final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
       final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of("__time", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9"),
           ImmutableList.copyOf(adapter.getDimensionNames(true))
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of("d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9"),
           ImmutableList.copyOf(adapter.getDimensionNames(false))
       );
-      Assert.assertEquals(4, rowList.size());
+      Assertions.assertEquals(4, rowList.size());
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Arrays.asList("", "", "310", null, null, null, "", null, "910"),
           rowList.get(0).dimensionValues()
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Arrays.asList(null, "210", "311", null, null, null, "710", "810", "911"),
           rowList.get(1).dimensionValues()
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Arrays.asList(null, null, null, null, "520", "620", "720", "820", "920"),
           rowList.get(2).dimensionValues()
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           Arrays.asList(null, null, null, null, "", "621", "", "821", "921"),
           rowList.get(3).dimensionValues()
       );
@@ -1366,21 +1365,21 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", "d9"),
         ImmutableList.copyOf(adapter.getDimensionNames(false))
     );
 
-    Assert.assertEquals(4, rowList.size());
+    Assertions.assertEquals(4, rowList.size());
 
-    Assert.assertEquals(Arrays.asList("", "", "310", null, null, null, "", null, "910"), rowList.get(0).dimensionValues());
-    Assert.assertEquals(Arrays.asList("", "", "310", null, null, null, "", null, "910"), rowList.get(1).dimensionValues());
-    Assert.assertEquals(Arrays.asList("", "", "310", null, null, null, "", null, "910"), rowList.get(2).dimensionValues());
-    Assert.assertEquals(
+    Assertions.assertEquals(Arrays.asList("", "", "310", null, null, null, "", null, "910"), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(Arrays.asList("", "", "310", null, null, null, "", null, "910"), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(Arrays.asList("", "", "310", null, null, null, "", null, "910"), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(
         Arrays.asList(null, null, null, null, "", "621", "", "821", "921"),
         rowList.get(3).dimensionValues()
     );
@@ -1401,11 +1400,11 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
 
   private void checkBitmapIndex(List<Integer> expected, BitmapValues real)
   {
-    Assert.assertEquals("bitmap size", expected.size(), real.size());
+    Assertions.assertEquals(expected.size(), real.size(), "bitmap size");
     int i = 0;
     for (IntIterator iterator = real.iterator(); iterator.hasNext(); ) {
       int index = iterator.nextInt();
-      Assert.assertEquals(expected.get(i++), (Integer) index);
+      Assertions.assertEquals(expected.get(i++), (Integer) index);
     }
   }
 
@@ -1505,27 +1504,27 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final QueryableIndexIndexableAdapter adapter2 = new QueryableIndexIndexableAdapter(merged2);
     final List<DebugRow> rowList2 = RowIteratorHelper.toList(adapter2.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "dimB", "dimA"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(ImmutableList.of("dimB", "dimA"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
-    Assert.assertEquals(5, rowList.size());
+    Assertions.assertEquals(ImmutableList.of("dimB", "dimA"), ImmutableList.copyOf(adapter.getDimensionNames(false)));
+    Assertions.assertEquals(5, rowList.size());
 
-    Assert.assertEquals(Arrays.asList(null, "1"), rowList.get(0).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(3L), rowList.get(0).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "1"), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(3L), rowList.get(0).metricValues());
 
-    Assert.assertEquals(Arrays.asList(null, "2"), rowList.get(1).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(1).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "2"), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(1).metricValues());
 
-    Assert.assertEquals(Arrays.asList("1", null), rowList.get(2).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(3L), rowList.get(2).metricValues());
+    Assertions.assertEquals(Arrays.asList("1", null), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(3L), rowList.get(2).metricValues());
 
-    Assert.assertEquals(Arrays.asList("2", null), rowList.get(3).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(3).metricValues());
+    Assertions.assertEquals(Arrays.asList("2", null), rowList.get(3).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(3).metricValues());
 
-    Assert.assertEquals(Arrays.asList("3", null), rowList.get(4).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(4).metricValues());
+    Assertions.assertEquals(Arrays.asList("3", null), rowList.get(4).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(4).metricValues());
 
     checkBitmapIndex(Arrays.asList(2, 3, 4), getBitmapIndex(adapter, "dimA", null));
     checkBitmapIndex(Collections.singletonList(0), getBitmapIndex(adapter, "dimA", "1"));
@@ -1536,44 +1535,44 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     checkBitmapIndex(Collections.singletonList(3), getBitmapIndex(adapter, "dimB", "2"));
     checkBitmapIndex(Collections.singletonList(4), getBitmapIndex(adapter, "dimB", "3"));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "dimA", "dimB", "dimC"),
         ImmutableList.copyOf(adapter2.getDimensionNames(true))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("dimA", "dimB", "dimC"),
         ImmutableList.copyOf(adapter2.getDimensionNames(false))
     );
-    Assert.assertEquals(12, rowList2.size());
-    Assert.assertEquals(Arrays.asList(null, null, "1"), rowList2.get(0).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(0).metricValues());
-    Assert.assertEquals(Arrays.asList(null, null, "2"), rowList2.get(1).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(1).metricValues());
+    Assertions.assertEquals(12, rowList2.size());
+    Assertions.assertEquals(Arrays.asList(null, null, "1"), rowList2.get(0).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(0).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, null, "2"), rowList2.get(1).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(1).metricValues());
 
-    Assert.assertEquals(Arrays.asList(null, null, "3"), rowList2.get(2).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(2).metricValues());
-    Assert.assertEquals(Arrays.asList(null, "1", null), rowList2.get(3).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(3).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, null, "3"), rowList2.get(2).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(2).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "1", null), rowList2.get(3).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(3).metricValues());
 
-    Assert.assertEquals(Arrays.asList(null, "2", null), rowList2.get(4).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(4).metricValues());
-    Assert.assertEquals(Arrays.asList(null, "3", null), rowList2.get(5).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(5).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "2", null), rowList2.get(4).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(4).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "3", null), rowList2.get(5).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(5).metricValues());
 
-    Assert.assertEquals(Arrays.asList("1", null, null), rowList2.get(6).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(3L), rowList2.get(6).metricValues());
-    Assert.assertEquals(Arrays.asList("2", null, null), rowList2.get(7).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(7).metricValues());
+    Assertions.assertEquals(Arrays.asList("1", null, null), rowList2.get(6).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(3L), rowList2.get(6).metricValues());
+    Assertions.assertEquals(Arrays.asList("2", null, null), rowList2.get(7).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(7).metricValues());
 
-    Assert.assertEquals(Arrays.asList(null, "1", null), rowList2.get(8).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(8).metricValues());
-    Assert.assertEquals(Arrays.asList(null, "2", null), rowList2.get(9).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(9).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "1", null), rowList2.get(8).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(8).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "2", null), rowList2.get(9).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(9).metricValues());
 
-    Assert.assertEquals(Arrays.asList(null, "3", null), rowList2.get(10).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(1L), rowList2.get(10).metricValues());
-    Assert.assertEquals(Arrays.asList("2", null, null), rowList2.get(11).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList2.get(11).metricValues());
+    Assertions.assertEquals(Arrays.asList(null, "3", null), rowList2.get(10).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(1L), rowList2.get(10).metricValues());
+    Assertions.assertEquals(Arrays.asList("2", null, null), rowList2.get(11).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList2.get(11).metricValues());
 
     checkBitmapIndex(Arrays.asList(0, 1, 2, 3, 4, 5, 8, 9, 10), getBitmapIndex(adapter2, "dimA", null));
     checkBitmapIndex(Collections.singletonList(6), getBitmapIndex(adapter2, "dimA", "1"));
@@ -1693,7 +1692,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         closer.closeLater(indexIO.loadIndex(merged)),
         SegmentId.dummy("test")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("A", "C"),
         Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
     );
@@ -1769,7 +1768,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         closer.closeLater(indexIO.loadIndex(merged)),
         SegmentId.dummy("test")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("A", "C"),
         Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
     );
@@ -1841,58 +1840,56 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         closer.closeLater(indexIO.loadIndex(merged)),
         SegmentId.dummy("test")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("A", "B", "C"),
         Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
     );
   }
 
-  @Test(expected = IAE.class)
+  @Test
   public void testMismatchedMetricsVarying() throws IOException
   {
+    Assertions.assertThrows(IAE.class, () -> {
+      final IncrementalIndex index2 = IncrementalIndexTest.createIndex(new AggregatorFactory[]{
+          new LongSumAggregatorFactory("A", "A"),
+          new LongSumAggregatorFactory("C", "C")
+      });
+      closer.closeLater(index2);
 
-    IncrementalIndex index2 = IncrementalIndexTest.createIndex(new AggregatorFactory[]{
-        new LongSumAggregatorFactory("A", "A"),
-        new LongSumAggregatorFactory("C", "C")
+      final IncrementalIndex index5 = IncrementalIndexTest.createIndex(new AggregatorFactory[]{
+          new LongSumAggregatorFactory("C", "C"),
+          new LongSumAggregatorFactory("B", "B")
+      });
+      closer.closeLater(index5);
+
+
+      final Interval interval = new Interval(DateTimes.EPOCH, DateTimes.nowUtc());
+      final RoaringBitmapFactory factory = new RoaringBitmapFactory();
+      final List<IndexableAdapter> toMerge = Collections.singletonList(
+          new IncrementalIndexAdapter(interval, index2, factory)
+      );
+
+      final File tmpDirMerged = temporaryFolder.newFolder();
+
+      final File merged = indexMerger.merge(
+          toMerge,
+          true,
+          new AggregatorFactory[]{
+              new LongSumAggregatorFactory("B", "B"),
+              new LongSumAggregatorFactory("A", "A"),
+              new LongSumAggregatorFactory("D", "D")
+          },
+          tmpDirMerged,
+          null,
+          indexSpec,
+          -1
+      );
+      final QueryableIndexSegment segment = new QueryableIndexSegment(
+          closer.closeLater(indexIO.loadIndex(merged)),
+          SegmentId.dummy("test")
+      );
+      Assertions.assertEquals(ImmutableSet.of("A", "B", "C"), Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet()));
     });
-    closer.closeLater(index2);
-
-    IncrementalIndex index5 = IncrementalIndexTest.createIndex(new AggregatorFactory[]{
-        new LongSumAggregatorFactory("C", "C"),
-        new LongSumAggregatorFactory("B", "B")
-    });
-    closer.closeLater(index5);
-
-
-    Interval interval = new Interval(DateTimes.EPOCH, DateTimes.nowUtc());
-    RoaringBitmapFactory factory = new RoaringBitmapFactory();
-    List<IndexableAdapter> toMerge = Collections.singletonList(
-        new IncrementalIndexAdapter(interval, index2, factory)
-    );
-
-    final File tmpDirMerged = temporaryFolder.newFolder();
-
-    final File merged = indexMerger.merge(
-        toMerge,
-        true,
-        new AggregatorFactory[]{
-            new LongSumAggregatorFactory("B", "B"),
-            new LongSumAggregatorFactory("A", "A"),
-            new LongSumAggregatorFactory("D", "D")
-        },
-        tmpDirMerged,
-        null,
-        indexSpec,
-        -1
-    );
-    final QueryableIndexSegment segment = new QueryableIndexSegment(
-        closer.closeLater(indexIO.loadIndex(merged)),
-        SegmentId.dummy("test")
-    );
-    Assert.assertEquals(
-        ImmutableSet.of("A", "B", "C"),
-        Arrays.stream(segment.as(Metadata.class).getAggregators()).map(AggregatorFactory::getName).collect(Collectors.toSet())
-    );
   }
 
   @Test
@@ -1930,17 +1927,17 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final IndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "dimA", "dimB", "dimC"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("dimA", "dimB", "dimC"),
         ImmutableList.copyOf(adapter.getDimensionNames(false))
     );
-    Assert.assertEquals(4, rowList.size());
+    Assertions.assertEquals(4, rowList.size());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(
             null,
             null,
@@ -1948,16 +1945,16 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         ),
         rowList.get(0).dimensionValues()
     );
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(0).metricValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(0).metricValues());
 
-    Assert.assertEquals(Arrays.asList(72L, 60000.789f, "World"), rowList.get(1).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(0).metricValues());
+    Assertions.assertEquals(Arrays.asList(72L, 60000.789f, "World"), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(0).metricValues());
 
-    Assert.assertEquals(Arrays.asList(100L, 4000.567f, "Hello"), rowList.get(2).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(1).metricValues());
+    Assertions.assertEquals(Arrays.asList(100L, 4000.567f, "Hello"), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(1).metricValues());
 
-    Assert.assertEquals(Arrays.asList(3001L, 1.2345f, "Foobar"), rowList.get(3).dimensionValues());
-    Assert.assertEquals(Collections.singletonList(2L), rowList.get(2).metricValues());
+    Assertions.assertEquals(Arrays.asList(3001L, 1.2345f, "Foobar"), rowList.get(3).dimensionValues());
+    Assertions.assertEquals(Collections.singletonList(2L), rowList.get(2).metricValues());
   }
 
   private IncrementalIndex getIndexWithNumericDims()
@@ -2046,14 +2043,14 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     List<String> actualColumnNames = Lists.newArrayList(index.getColumnNames());
     Collections.sort(expectedColumnNames);
     Collections.sort(actualColumnNames);
-    Assert.assertEquals(expectedColumnNames, actualColumnNames);
+    Assertions.assertEquals(expectedColumnNames, actualColumnNames);
 
     SmooshedFileMapper sfm = closer.closeLater(SmooshedFileMapper.load(tempDir));
     List<String> expectedFilenames = Arrays.asList("A", "__time", "d1", "index.drd", "metadata.drd");
     List<String> actualFilenames = new ArrayList<>(sfm.getInternalFilenames());
     Collections.sort(expectedFilenames);
     Collections.sort(actualFilenames);
-    Assert.assertEquals(expectedFilenames, actualFilenames);
+    Assertions.assertEquals(expectedFilenames, actualFilenames);
   }
 
 
@@ -2164,23 +2161,23 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     adapter = new QueryableIndexIndexableAdapter(index);
     rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
-    Assert.assertEquals(2, rowList.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, rowList.size());
+    Assertions.assertEquals(
         Arrays.asList(Arrays.asList("a", "a", "b", "x"), Arrays.asList("a", "b", "x", "x")),
         rowList.get(0).dimensionValues()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(Arrays.asList("a", "b", "x"), Arrays.asList("a", "b", "x")),
         rowList.get(1).dimensionValues()
     );
 
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim1").hasBitmapIndexes());
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim2").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim1").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim2").hasBitmapIndexes());
 
     if (useBitmapIndexes) {
       checkBitmapIndex(Collections.emptyList(), getBitmapIndex(adapter, "dim1", null));
@@ -2197,22 +2194,22 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     schema = makeDimensionSchemas(Arrays.asList("dim1", "dim2"), MultiValueHandling.SORTED_SET);
     index = persistAndLoad(schema, rows);
 
-    Assert.assertEquals(1, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(1, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
     adapter = new QueryableIndexIndexableAdapter(index);
     rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(1, rowList.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, rowList.size());
+    Assertions.assertEquals(
         Arrays.asList(Arrays.asList("a", "b", "x"), Arrays.asList("a", "b", "x")),
         rowList.get(0).dimensionValues()
     );
 
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim1").hasBitmapIndexes());
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim2").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim1").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim2").hasBitmapIndexes());
 
     if (useBitmapIndexes) {
       checkBitmapIndex(Collections.emptyList(), getBitmapIndex(adapter, "dim1", null));
@@ -2229,26 +2226,26 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     schema = makeDimensionSchemas(Arrays.asList("dim1", "dim2"), MultiValueHandling.ARRAY);
     index = persistAndLoad(schema, rows);
 
-    Assert.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(2, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
     adapter = new QueryableIndexIndexableAdapter(index);
     rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(2, rowList.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(2, rowList.size());
+    Assertions.assertEquals(
         Arrays.asList(Arrays.asList("a", "b", "x"), Arrays.asList("x", "a", "b")),
         rowList.get(0).dimensionValues()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(Arrays.asList("x", "a", "a", "b"), Arrays.asList("a", "x", "b", "x")),
         rowList.get(1).dimensionValues()
     );
 
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim1").hasBitmapIndexes());
-    Assert.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim2").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim1").hasBitmapIndexes());
+    Assertions.assertEquals(useBitmapIndexes, adapter.getCapabilities("dim2").hasBitmapIndexes());
 
     if (useBitmapIndexes) {
       checkBitmapIndex(Collections.emptyList(), getBitmapIndex(adapter, "dim1", null));
@@ -2287,19 +2284,19 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(3, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
-    Assert.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
-    Assert.assertEquals(3, index.getColumnNames().size());
+    Assertions.assertEquals(3, index.getColumnHolder(ColumnHolder.TIME_COLUMN_NAME).getLength());
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), Lists.newArrayList(index.getAvailableDimensions()));
+    Assertions.assertEquals(makeOrderBys("__time", "dim1", "dim2"), Lists.newArrayList(index.getOrdering()));
+    Assertions.assertEquals(3, index.getColumnNames().size());
 
     assertDimCompression(index, indexSpec.getDimensionCompression());
 
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         IncrementalIndexTest.getDefaultCombiningAggregatorFactories(),
         index.getMetadata().getAggregators()
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Granularities.NONE,
         index.getMetadata().getQueryGranularity()
     );
@@ -2395,22 +2392,22 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "dimA", "dimMultiVal"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("dimA", "dimMultiVal"),
         ImmutableList.copyOf(adapter.getDimensionNames(false))
     );
 
-    Assert.assertEquals(3, rowList.size());
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("1", "2", "3", "5")), rowList.get(0).dimensionValues());
-    Assert.assertEquals(1L, rowList.get(0).metricValues().get(0));
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("1", "2", "4")), rowList.get(1).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(1).metricValues().get(0));
-    Assert.assertEquals(Arrays.asList("potato", Arrays.asList("0", "1", "4")), rowList.get(2).dimensionValues());
-    Assert.assertEquals(1L, rowList.get(2).metricValues().get(0));
+    Assertions.assertEquals(3, rowList.size());
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("1", "2", "3", "5")), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(1L, rowList.get(0).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("1", "2", "4")), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(1).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("potato", Arrays.asList("0", "1", "4")), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(1L, rowList.get(2).metricValues().get(0));
 
     checkBitmapIndex(Arrays.asList(0, 1), getBitmapIndex(adapter, "dimA", "leek"));
     checkBitmapIndex(Collections.singletonList(2), getBitmapIndex(adapter, "dimA", "potato"));
@@ -2629,58 +2626,58 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "dimA", "dimMultiVal"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("dimA", "dimMultiVal"),
         ImmutableList.copyOf(adapter.getDimensionNames(false))
     );
 
-    Assert.assertEquals(14, rowList.size());
+    Assertions.assertEquals(14, rowList.size());
 
-    Assert.assertEquals(Arrays.asList("leek", null), rowList.get(0).dimensionValues());
-    Assert.assertEquals(8L, rowList.get(0).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", null), rowList.get(0).dimensionValues());
+    Assertions.assertEquals(8L, rowList.get(0).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList(null, "1", "2", "3")), rowList.get(1).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(1).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList(null, "1", "2", "3")), rowList.get(1).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(1).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList(null, "3")), rowList.get(2).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(2).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList(null, "3")), rowList.get(2).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(2).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", ""), rowList.get(3).dimensionValues());
-    Assert.assertEquals(4L, rowList.get(3).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", ""), rowList.get(3).dimensionValues());
+    Assertions.assertEquals(4L, rowList.get(3).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("", "1", "2", "3")), rowList.get(4).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(4).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("", "1", "2", "3")), rowList.get(4).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(4).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("", "3")), rowList.get(5).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(5).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("", "3")), rowList.get(5).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(5).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", "1"), rowList.get(6).dimensionValues());
-    Assert.assertEquals(4L, rowList.get(6).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", "1"), rowList.get(6).dimensionValues());
+    Assertions.assertEquals(4L, rowList.get(6).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("1", "2", "3")), rowList.get(7).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(7).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("1", "2", "3")), rowList.get(7).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(7).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("1", "3")), rowList.get(8).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(8).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("1", "3")), rowList.get(8).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(8).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("1", "3", "5")), rowList.get(9).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(9).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("1", "3", "5")), rowList.get(9).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(9).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", Arrays.asList("1", "4")), rowList.get(10).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(10).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", Arrays.asList("1", "4")), rowList.get(10).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(10).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("leek", "2"), rowList.get(11).dimensionValues());
-    Assert.assertEquals(4L, rowList.get(11).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("leek", "2"), rowList.get(11).dimensionValues());
+    Assertions.assertEquals(4L, rowList.get(11).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("potato", Arrays.asList("1", "3")), rowList.get(12).dimensionValues());
-    Assert.assertEquals(2L, rowList.get(12).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("potato", Arrays.asList("1", "3")), rowList.get(12).dimensionValues());
+    Assertions.assertEquals(2L, rowList.get(12).metricValues().get(0));
 
-    Assert.assertEquals(Arrays.asList("potato", "2"), rowList.get(13).dimensionValues());
-    Assert.assertEquals(4L, rowList.get(13).metricValues().get(0));
+    Assertions.assertEquals(Arrays.asList("potato", "2"), rowList.get(13).dimensionValues());
+    Assertions.assertEquals(4L, rowList.get(13).metricValues().get(0));
 
     checkBitmapIndex(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11), getBitmapIndex(adapter, "dimA", "leek"));
     checkBitmapIndex(Arrays.asList(12, 13), getBitmapIndex(adapter, "dimA", "potato"));
@@ -2721,40 +2718,40 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
     final QueryableIndexIndexableAdapter adapter = new QueryableIndexIndexableAdapter(merged);
     final List<DebugRow> rowList = RowIteratorHelper.toList(adapter.getRows());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("__time", "d1", "d2", "d3", "d4", "d5"),
         ImmutableList.copyOf(adapter.getDimensionNames(true))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("d1", "d2", "d3", "d4", "d5"),
         ImmutableList.copyOf(adapter.getDimensionNames(false))
     );
 
-    Assert.assertEquals(4, rowList.size());
+    Assertions.assertEquals(4, rowList.size());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("a", "b", "c", "d", "e"),
         rowList.get(0).dimensionValues()
     );
-    Assert.assertEquals(1L, rowList.get(0).metricValues().get(0));
+    Assertions.assertEquals(1L, rowList.get(0).metricValues().get(0));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("aa", "bb", "cc", "dd", "ee"),
         rowList.get(1).dimensionValues()
     );
-    Assert.assertEquals(1L, rowList.get(1).metricValues().get(0));
+    Assertions.assertEquals(1L, rowList.get(1).metricValues().get(0));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("aaa", "bbb", "ccc", "ddd", "eee"),
         rowList.get(2).dimensionValues()
     );
-    Assert.assertEquals(1L, rowList.get(2).metricValues().get(0));
+    Assertions.assertEquals(1L, rowList.get(2).metricValues().get(0));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("1", "2", "3", "4", "5"),
         rowList.get(3).dimensionValues()
     );
-    Assert.assertEquals(3L, rowList.get(3).metricValues().get(0));
+    Assertions.assertEquals(3L, rowList.get(3).metricValues().get(0));
 
     checkBitmapIndex(Collections.singletonList(0), getBitmapIndex(adapter, "d1", "a"));
     checkBitmapIndex(Collections.singletonList(1), getBitmapIndex(adapter, "d1", "aa"));
@@ -3130,7 +3127,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         rowCount++;
         cursor.advance();
       }
-      Assert.assertEquals(5, rowCount);
+      Assertions.assertEquals(5, rowCount);
     }
 
     try (final CursorHolder cursorHolder = cursorFactory.makeCursorHolder(p2Spec)) {
@@ -3140,26 +3137,26 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
         rowCount++;
         cursor.advance();
       }
-      Assert.assertEquals(3, rowCount);
+      Assertions.assertEquals(3, rowCount);
     }
 
     QueryableIndex p1Index = merged.getProjectionQueryableIndex("a_hourly_c_sum");
-    Assert.assertNotNull(p1Index);
+    Assertions.assertNotNull(p1Index);
     ColumnHolder aHolder = p1Index.getColumnHolder("a");
     DictionaryEncodedColumn aCol = (DictionaryEncodedColumn) aHolder.getColumn();
-    Assert.assertEquals(3, aCol.getCardinality());
+    Assertions.assertEquals(3, aCol.getCardinality());
 
     QueryableIndex p2Index = merged.getProjectionQueryableIndex("a_c_sum");
-    Assert.assertNotNull(p2Index);
+    Assertions.assertNotNull(p2Index);
     ColumnHolder aHolder2 = p2Index.getColumnHolder("a");
     DictionaryEncodedColumn aCol2 = (DictionaryEncodedColumn) aHolder2.getColumn();
-    Assert.assertEquals(3, aCol2.getCardinality());
+    Assertions.assertEquals(3, aCol2.getCardinality());
 
     if (serdeFactory != null) {
 
       BitmapResultFactory resultFactory = new DefaultBitmapResultFactory(serdeFactory.getBitmapFactory());
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           2,
           resultFactory.toImmutableBitmap(
               aHolder.getIndexSupplier()
@@ -3169,7 +3166,7 @@ public abstract class IndexMergerTestBase extends InitializedNullHandlingTest
           ).size()
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           1,
           resultFactory.toImmutableBitmap(
               aHolder2.getIndexSupplier()

--- a/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/IndexMergerV9WithSpatialIndexTest.java
@@ -51,9 +51,9 @@ import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.Interval;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,7 +67,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IndexMergerV9WithSpatialIndexTest extends InitializedNullHandlingTest
 {
 
@@ -81,7 +82,6 @@ public class IndexMergerV9WithSpatialIndexTest extends InitializedNullHandlingTe
 
   private static List<String> DIMS = Lists.newArrayList("dim", "lat", "long", "lat2", "long2");
 
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder() throws IOException
   {
     List<Object[]> argumentArrays = new ArrayList<>();

--- a/processing/src/test/java/org/apache/druid/segment/NoBitmapIndexMergerV9Test.java
+++ b/processing/src/test/java/org/apache/druid/segment/NoBitmapIndexMergerV9Test.java
@@ -22,10 +22,12 @@ package org.apache.druid.segment;
 import org.apache.druid.segment.data.CompressionFactory.LongEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("org.apache.druid.segment.IndexMergerTestBase#data")
 public class NoBitmapIndexMergerV9Test extends IndexMergerTestBase
 {
   public NoBitmapIndexMergerV9Test(

--- a/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
@@ -46,12 +46,12 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -61,15 +61,15 @@ import java.util.Map;
 
 public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlingTest
 {
-  @ClassRule
-  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public static TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private static IncrementalIndex INC_INDEX;
   private static QueryableIndex MMAP_INDEX;
   private static IncrementalIndex INC_INDEX_WITH_NULLS;
   private static QueryableIndex MMAP_INDEX_WITH_NULLS;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException
   {
     InputRowSchema rowSchema = new InputRowSchema(
@@ -142,7 +142,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
     MMAP_INDEX_WITH_NULLS = builderWithNulls.buildMMappedIndex();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown()
   {
     INC_INDEX.close();
@@ -227,34 +227,34 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   public void testStringColumn()
   {
     ColumnCapabilities caps = INC_INDEX.getColumnCapabilities("d1");
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
     // multi-value is unknown unless explicitly set to 'true'
-    Assert.assertTrue(caps.hasMultipleValues().isUnknown());
+    Assertions.assertTrue(caps.hasMultipleValues().isUnknown());
     // at index merge or query time we 'complete' the capabilities to take a snapshot of the current state,
     // coercing any 'UNKNOWN' values to false
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ColumnCapabilitiesImpl.snapshot(
             caps,
             CapabilitiesBasedFormat.DIMENSION_CAPABILITY_MERGE_LOGIC
         ).hasMultipleValues().isMaybeTrue()
     );
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertTrue(caps.hasNulls().isUnknown());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertTrue(caps.hasNulls().isUnknown());
 
     caps = MMAP_INDEX.getColumnHolder("d1").getCapabilities();
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertFalse(caps.hasNulls().isMaybeTrue());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertFalse(caps.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertFalse(caps.hasNulls().isMaybeTrue());
   }
 
 
@@ -262,57 +262,57 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   public void testStringColumnWithNulls()
   {
     ColumnCapabilities caps = INC_INDEX_WITH_NULLS.getColumnCapabilities("d1");
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
     // multi-value is unknown unless explicitly set to 'true'
-    Assert.assertTrue(caps.hasMultipleValues().isUnknown());
+    Assertions.assertTrue(caps.hasMultipleValues().isUnknown());
     // at index merge or query time we 'complete' the capabilities to take a snapshot of the current state,
     // coercing any 'UNKNOWN' values to false
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ColumnCapabilitiesImpl.snapshot(
             caps,
             CapabilitiesBasedFormat.DIMENSION_CAPABILITY_MERGE_LOGIC
         ).hasMultipleValues().isMaybeTrue()
     );
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertTrue(caps.hasNulls().isTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertTrue(caps.hasNulls().isTrue());
 
     caps = MMAP_INDEX_WITH_NULLS.getColumnHolder("d1").getCapabilities();
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertTrue(caps.hasNulls().isTrue());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertFalse(caps.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertTrue(caps.hasNulls().isTrue());
   }
 
   @Test
   public void testMultiStringColumn()
   {
     ColumnCapabilities caps = INC_INDEX.getColumnCapabilities("d2");
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertTrue(caps.hasMultipleValues().isTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertTrue(caps.hasNulls().isUnknown());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertTrue(caps.hasMultipleValues().isTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertTrue(caps.hasNulls().isUnknown());
 
     caps = MMAP_INDEX.getColumnHolder("d2").getCapabilities();
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertTrue(caps.hasMultipleValues().isTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertFalse(caps.hasNulls().isMaybeTrue());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertTrue(caps.hasMultipleValues().isTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertFalse(caps.hasNulls().isMaybeTrue());
   }
 
 
@@ -320,24 +320,24 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   public void testMultiStringColumnWithNulls()
   {
     ColumnCapabilities caps = INC_INDEX_WITH_NULLS.getColumnCapabilities("d2");
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertTrue(caps.hasMultipleValues().isTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertTrue(caps.hasNulls().isTrue());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertTrue(caps.hasMultipleValues().isTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertTrue(caps.hasNulls().isTrue());
 
     caps = MMAP_INDEX_WITH_NULLS.getColumnHolder("d2").getCapabilities();
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertTrue(caps.hasBitmapIndexes());
-    Assert.assertTrue(caps.isDictionaryEncoded().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertTrue(caps.hasMultipleValues().isTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertTrue(caps.hasNulls().isTrue());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertTrue(caps.hasBitmapIndexes());
+    Assertions.assertTrue(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertTrue(caps.hasMultipleValues().isTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertTrue(caps.hasNulls().isTrue());
   }
 
   @Test
@@ -352,38 +352,38 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
 
   private void assertComplexColumnCapabilites(ColumnCapabilities caps)
   {
-    Assert.assertEquals(HyperUniquesAggregatorFactory.TYPE, caps.toColumnType());
-    Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertFalse(caps.hasMultipleValues().isUnknown());
-    Assert.assertTrue(caps.hasNulls().isTrue());
+    Assertions.assertEquals(HyperUniquesAggregatorFactory.TYPE, caps.toColumnType());
+    Assertions.assertFalse(caps.hasBitmapIndexes());
+    Assertions.assertFalse(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertFalse(caps.hasMultipleValues().isUnknown());
+    Assertions.assertTrue(caps.hasNulls().isTrue());
   }
 
   private void assertNonStringColumnCapabilities(ColumnCapabilities caps, ColumnType valueType)
   {
-    Assert.assertEquals(valueType, caps.toColumnType());
-    Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
-    Assert.assertFalse(caps.hasNulls().isTrue());
+    Assertions.assertEquals(valueType, caps.toColumnType());
+    Assertions.assertFalse(caps.hasBitmapIndexes());
+    Assertions.assertFalse(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertFalse(caps.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertFalse(caps.hasNulls().isTrue());
   }
 
   private void assertNonStringColumnCapabilitiesWithNulls(ColumnCapabilities caps, ColumnType valueType)
   {
-    Assert.assertEquals(valueType, caps.toColumnType());
-    Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertFalse(caps.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertEquals(valueType, caps.toColumnType());
+    Assertions.assertFalse(caps.hasBitmapIndexes());
+    Assertions.assertFalse(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertFalse(caps.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
     // check isMaybeTrue because incremental index uses Unknown
-    Assert.assertTrue(caps.hasNulls().isMaybeTrue());
+    Assertions.assertTrue(caps.hasNulls().isMaybeTrue());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
@@ -53,7 +53,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,7 +69,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
   private static QueryableIndex MMAP_INDEX_WITH_NULLS;
 
   @BeforeAll
-  public static void setup() throws IOException
+  public static void setup()
   {
     InputRowSchema rowSchema = new InputRowSchema(
         new TimestampSpec("time", "auto", null),

--- a/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/QueryableIndexColumnCapabilitiesTest.java
@@ -46,13 +46,13 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.apache.druid.testing.TemporaryFolderExtension;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,8 +61,8 @@ import java.util.Map;
 
 public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlingTest
 {
-  @RegisterExtension
-  public static TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
+  @TempDir
+  public static File temporaryFolder;
 
   private static IncrementalIndex INC_INDEX;
   private static QueryableIndex MMAP_INDEX;
@@ -111,7 +111,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
                                                .withRollup(false)
                                                .build()
                                        )
-                                       .tmpDir(temporaryFolder.newFolder());
+                                       .tmpDir(new File(temporaryFolder, "index"));
     INC_INDEX = builder.buildIncrementalIndex();
     MMAP_INDEX = builder.buildMMappedIndex();
 
@@ -137,7 +137,7 @@ public class QueryableIndexColumnCapabilitiesTest extends InitializedNullHandlin
                                                         .withRollup(false)
                                                         .build()
                                                 )
-                                                .tmpDir(temporaryFolder.newFolder());
+                                                .tmpDir(new File(temporaryFolder, "index-with-nulls"));
     INC_INDEX_WITH_NULLS = builderWithNulls.buildIncrementalIndex();
     MMAP_INDEX_WITH_NULLS = builderWithNulls.buildMMappedIndex();
   }

--- a/processing/src/test/java/org/apache/druid/segment/QueryableIndexIndexableAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/QueryableIndexIndexableAdapterTest.java
@@ -30,17 +30,19 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.util.Collection;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class QueryableIndexIndexableAdapterTest
 {
   private static final IndexSpec INDEX_SPEC = IndexSpec.builder()
@@ -50,7 +52,6 @@ public class QueryableIndexIndexableAdapterTest
                                                        .withLongEncoding(CompressionFactory.LongEncodingStrategy.LONGS)
                                                        .build();
 
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder()
   {
     return ImmutableList.of(
@@ -59,10 +60,10 @@ public class QueryableIndexIndexableAdapterTest
     );
   }
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   private final IndexMerger indexMerger;
   private final IndexIO indexIO;
@@ -99,7 +100,7 @@ public class QueryableIndexIndexableAdapterTest
     try (CloseableIndexed<String> dimValueLookup = adapter.getDimValueLookup(dimension)) {
       for (int i = 0; i < dimValueLookup.size(); i++) {
         bitmapValues = adapter.getBitmapValues(dimension, i);
-        Assert.assertEquals(1, bitmapValues.size());
+        Assertions.assertEquals(1, bitmapValues.size());
       }
     }
   }

--- a/processing/src/test/java/org/apache/druid/segment/RoaringBitmapIndexMergerV10Test.java
+++ b/processing/src/test/java/org/apache/druid/segment/RoaringBitmapIndexMergerV10Test.java
@@ -23,11 +23,13 @@ import org.apache.druid.segment.data.CompressionFactory;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("org.apache.druid.segment.IndexMergerTestBase#data")
 public class RoaringBitmapIndexMergerV10Test extends IndexMergerTestBase
 {
   public RoaringBitmapIndexMergerV10Test(

--- a/processing/src/test/java/org/apache/druid/segment/RoaringBitmapIndexMergerV9Test.java
+++ b/processing/src/test/java/org/apache/druid/segment/RoaringBitmapIndexMergerV9Test.java
@@ -23,10 +23,12 @@ import org.apache.druid.segment.data.CompressionFactory.LongEncodingStrategy;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.RoaringBitmapSerdeFactory;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("org.apache.druid.segment.IndexMergerTestBase#data")
 public class RoaringBitmapIndexMergerV9Test extends IndexMergerTestBase
 {
   public RoaringBitmapIndexMergerV9Test(

--- a/processing/src/test/java/org/apache/druid/segment/RowBasedCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/RowBasedCursorFactoryTest.java
@@ -23,7 +23,6 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.math.LongMath;
-import junitparams.converters.Nullable;
 import org.apache.druid.common.guava.GuavaUtils;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
@@ -43,9 +42,11 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
 
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -95,7 +96,7 @@ public class RowBasedCursorFactoryTest
   // VectorProcessors used by the "allProcessors" tasks.
   private static final LinkedHashMap<String, Function<Cursor, Supplier<Object>>> PROCESSORS = new LinkedHashMap<>();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass()
   {
     PROCESSORS.clear();
@@ -260,7 +261,7 @@ public class RowBasedCursorFactoryTest
   public void test_getRowSignature()
   {
     final RowBasedCursorFactory<Integer> adapter = createIntAdapter();
-    Assert.assertEquals(ROW_SIGNATURE, adapter.getRowSignature());
+    Assertions.assertEquals(ROW_SIGNATURE, adapter.getRowSignature());
   }
 
   @Test
@@ -269,8 +270,8 @@ public class RowBasedCursorFactoryTest
     final RowBasedCursorFactory<Integer> adapter = createIntAdapter(0, 1, 2);
 
     final ColumnCapabilities capabilities = adapter.getColumnCapabilities(ValueType.FLOAT.name());
-    Assert.assertEquals(ValueType.FLOAT, capabilities.getType());
-    Assert.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
+    Assertions.assertEquals(ValueType.FLOAT, capabilities.getType());
+    Assertions.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
   }
 
   @Test
@@ -279,8 +280,8 @@ public class RowBasedCursorFactoryTest
     final RowBasedCursorFactory<Integer> adapter = createIntAdapter(0, 1, 2);
 
     final ColumnCapabilities capabilities = adapter.getColumnCapabilities(ValueType.DOUBLE.name());
-    Assert.assertEquals(ValueType.DOUBLE, capabilities.getType());
-    Assert.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
+    Assertions.assertEquals(ValueType.DOUBLE, capabilities.getType());
+    Assertions.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
   }
 
   @Test
@@ -289,8 +290,8 @@ public class RowBasedCursorFactoryTest
     final RowBasedCursorFactory<Integer> adapter = createIntAdapter(0, 1, 2);
 
     final ColumnCapabilities capabilities = adapter.getColumnCapabilities(ValueType.LONG.name());
-    Assert.assertEquals(ValueType.LONG, capabilities.getType());
-    Assert.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
+    Assertions.assertEquals(ValueType.LONG, capabilities.getType());
+    Assertions.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
   }
 
   @Test
@@ -299,12 +300,12 @@ public class RowBasedCursorFactoryTest
     final RowBasedCursorFactory<Integer> adapter = createIntAdapter(0, 1, 2);
 
     final ColumnCapabilities capabilities = adapter.getColumnCapabilities(ValueType.STRING.name());
-    Assert.assertEquals(ValueType.STRING, capabilities.getType());
+    Assertions.assertEquals(ValueType.STRING, capabilities.getType());
 
     // Note: unlike numeric types, STRING-typed columns might have multiple values, so they report as incomplete. It
     // would be good in the future to support some way of changing this, when it is known ahead of time that
     // multi-valuedness is definitely happening or is definitely impossible.
-    Assert.assertTrue(capabilities.hasMultipleValues().isUnknown());
+    Assertions.assertTrue(capabilities.hasMultipleValues().isUnknown());
   }
 
   @Test
@@ -316,9 +317,9 @@ public class RowBasedCursorFactoryTest
 
     // Note: unlike numeric types, COMPLEX-typed columns report that they are incomplete for everything
     // except hasMultipleValues.
-    Assert.assertEquals(ColumnType.UNKNOWN_COMPLEX, capabilities.toColumnType());
-    Assert.assertFalse(capabilities.hasMultipleValues().isTrue());
-    Assert.assertTrue(capabilities.isDictionaryEncoded().isUnknown());
+    Assertions.assertEquals(ColumnType.UNKNOWN_COMPLEX, capabilities.toColumnType());
+    Assertions.assertFalse(capabilities.hasMultipleValues().isTrue());
+    Assertions.assertTrue(capabilities.isDictionaryEncoded().isUnknown());
   }
 
   @Test
@@ -327,14 +328,14 @@ public class RowBasedCursorFactoryTest
     final RowBasedCursorFactory<Integer> adapter = createIntAdapter(0, 1, 2);
 
     final ColumnCapabilities capabilities = adapter.getColumnCapabilities(UNKNOWN_TYPE_NAME);
-    Assert.assertNull(capabilities);
+    Assertions.assertNull(capabilities);
   }
 
   @Test
   public void test_getColumnCapabilities_nonexistent()
   {
     final RowBasedCursorFactory<Integer> adapter = createIntAdapter(0, 1, 2);
-    Assert.assertNull(adapter.getColumnCapabilities("nonexistent"));
+    Assertions.assertNull(adapter.getColumnCapabilities("nonexistent"));
   }
 
   @Test
@@ -344,12 +345,12 @@ public class RowBasedCursorFactoryTest
 
     for (String columnName : ROW_SIGNATURE.getColumnNames()) {
       if (UNKNOWN_TYPE_NAME.equals(columnName)) {
-        Assert.assertNull(columnName, adapter.getColumnCapabilities(columnName));
+        Assertions.assertNull(adapter.getColumnCapabilities(columnName), columnName);
       } else {
-        Assert.assertEquals(
-            columnName,
+        Assertions.assertEquals(
             ValueType.valueOf(columnName).name(),
-            adapter.getColumnCapabilities(columnName).asTypeString()
+            adapter.getColumnCapabilities(columnName).asTypeString(),
+            columnName
         );
       }
     }
@@ -364,7 +365,7 @@ public class RowBasedCursorFactoryTest
                                                      .build();
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("0"),
               ImmutableList.of("1"),
@@ -374,7 +375,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
   @Test
@@ -388,7 +389,7 @@ public class RowBasedCursorFactoryTest
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("1")
           ),
@@ -397,7 +398,7 @@ public class RowBasedCursorFactoryTest
     }
 
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
   @Test
@@ -411,7 +412,7 @@ public class RowBasedCursorFactoryTest
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("0"),
               ImmutableList.of("1")
@@ -420,7 +421,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
   @Test
@@ -444,7 +445,7 @@ public class RowBasedCursorFactoryTest
 
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("1")
           ),
@@ -452,7 +453,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
 
@@ -466,7 +467,7 @@ public class RowBasedCursorFactoryTest
                                                      .build();
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("2"),
               ImmutableList.of("1"),
@@ -476,7 +477,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(1, numCloses.get());
+    Assertions.assertEquals(1, numCloses.get());
   }
 
   @Test
@@ -489,13 +490,13 @@ public class RowBasedCursorFactoryTest
                                                      .build();
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(),
           walkCursor(cursor, READ_STRING)
       );
     }
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
   @Test
@@ -508,7 +509,7 @@ public class RowBasedCursorFactoryTest
                                                      .build();
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("1")
           ),
@@ -516,7 +517,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
   @Test
@@ -528,7 +529,7 @@ public class RowBasedCursorFactoryTest
                                                      .setInterval(Intervals.of("1970/1971"))
                                                      .build();
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of(DateTimes.of("1970-01-01T00"), "0"),
               ImmutableList.of(DateTimes.of("1970-01-01T01"), "1"),
@@ -540,7 +541,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(1, numCloses.get());
+    Assertions.assertEquals(1, numCloses.get());
   }
 
   @Test
@@ -553,7 +554,7 @@ public class RowBasedCursorFactoryTest
                                                      .build();
 
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of(DateTimes.of("1970-01-01T01"), "1"),
               ImmutableList.of(DateTimes.of("1970-01-01T01"), "1"),
@@ -563,7 +564,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(1, numCloses.get());
+    Assertions.assertEquals(1, numCloses.get());
   }
 
   @Test
@@ -577,7 +578,7 @@ public class RowBasedCursorFactoryTest
                                                      .build();
 
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of(DateTimes.of("1970-01-01T02"), "2"),
               ImmutableList.of(DateTimes.of("1970-01-01T01"), "1"),
@@ -587,7 +588,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(1, numCloses.get());
+    Assertions.assertEquals(1, numCloses.get());
   }
 
   @Test
@@ -597,7 +598,7 @@ public class RowBasedCursorFactoryTest
 
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {
       final Cursor cursor = cursorHolder.asCursor();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               Lists.newArrayList(
 
@@ -692,7 +693,7 @@ public class RowBasedCursorFactoryTest
       );
     }
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
   @Test
@@ -706,13 +707,13 @@ public class RowBasedCursorFactoryTest
 
     try (final CursorHolder cursorHolder = adapter.makeCursorHolder(buildSpec)) {
       final Cursor cursor = cursorHolder.asCursor();
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(),
           walkCursor(cursor, new ArrayList<>(PROCESSORS.values()))
       );
     }
 
-    Assert.assertEquals(2, numCloses.get());
+    Assertions.assertEquals(2, numCloses.get());
   }
 
   private static List<List<Object>> walkCursor(

--- a/processing/src/test/java/org/apache/druid/segment/SchemalessTestFullTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessTestFullTest.java
@@ -60,9 +60,9 @@ import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFacto
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,10 +72,10 @@ import java.util.Map;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class SchemalessTestFullTest extends InitializedNullHandlingTest
 {
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder()
   {
     return ImmutableList.of(

--- a/processing/src/test/java/org/apache/druid/segment/SchemalessTestSimpleTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessTestSimpleTest.java
@@ -58,10 +58,10 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -72,11 +72,10 @@ import java.util.List;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class SchemalessTestSimpleTest extends InitializedNullHandlingTest
 {
-
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder()
   {
     List<Object[]> argumentArrays = new ArrayList<>();
@@ -165,7 +164,7 @@ public class SchemalessTestSimpleTest extends InitializedNullHandlingTest
 
   //  @Test TODO: Handling of null values is inconsistent right now, need to make it all consistent and re-enable test
   // TODO: Complain to Eric when you see this.  It shouldn't be like this...
-  @Ignore
+  @Disabled
   @SuppressWarnings("unused")
   public void testFullOnTopN()
   {

--- a/processing/src/test/java/org/apache/druid/segment/SchemalessTestSimpleTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessTestSimpleTest.java
@@ -58,10 +58,10 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedClass;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -72,10 +72,11 @@ import java.util.List;
 
 /**
  */
-@ParameterizedClass
-@MethodSource("constructorFeeder")
+@RunWith(Parameterized.class)
 public class SchemalessTestSimpleTest extends InitializedNullHandlingTest
 {
+
+  @Parameterized.Parameters
   public static Collection<?> constructorFeeder()
   {
     List<Object[]> argumentArrays = new ArrayList<>();
@@ -164,7 +165,7 @@ public class SchemalessTestSimpleTest extends InitializedNullHandlingTest
 
   //  @Test TODO: Handling of null values is inconsistent right now, need to make it all consistent and re-enable test
   // TODO: Complain to Eric when you see this.  It shouldn't be like this...
-  @Disabled
+  @Ignore
   @SuppressWarnings("unused")
   public void testFullOnTopN()
   {

--- a/processing/src/test/java/org/apache/druid/segment/UnnestColumnValueSelectorCursorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestColumnValueSelectorCursorTest.java
@@ -25,9 +25,9 @@ import org.apache.druid.query.monomorphicprocessing.StringRuntimeShape;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +38,7 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
 {
   private static String OUTPUT_NAME = "unnested-column";
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass()
   {
   }
@@ -65,11 +65,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int j = 0;
     while (!unnestCursor.isDone()) {
       Object colSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(String.valueOf(j), colSelectorVal.toString());
+      Assertions.assertEquals(String.valueOf(j), colSelectorVal.toString());
       j++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(j, 4);
+    Assertions.assertEquals(j, 4);
   }
 
   @Test
@@ -97,11 +97,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
+      Assertions.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 9);
+    Assertions.assertEquals(k, 9);
   }
 
   @Test
@@ -128,13 +128,13 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertNull(valueSelectorVal);
+      Assertions.assertNull(valueSelectorVal);
       k++;
       unnestCursor.advance();
     }
     // since type is 'STRING', it follows multi-value string rules so single element arrays become scalar values,
     // so [null] becomes null, meaning we only have 2 rows
-    Assert.assertEquals(k, 2);
+    Assertions.assertEquals(k, 2);
   }
 
   @Test
@@ -161,13 +161,13 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertNull(valueSelectorVal);
+      Assertions.assertNull(valueSelectorVal);
       k++;
       unnestCursor.advance();
     }
     // since type is 'STRING', it follows multi-value string rules so single element arrays become scalar values,
     // so [null] becomes null, meaning we only have 2 rows
-    Assert.assertEquals(k, 2);
+    Assertions.assertEquals(k, 2);
   }
 
   @Test
@@ -194,11 +194,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertNull(valueSelectorVal);
+      Assertions.assertNull(valueSelectorVal);
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 4);
+    Assertions.assertEquals(k, 4);
   }
 
   @Test
@@ -233,16 +233,16 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
       if (valueSelectorVal == null) {
-        Assert.assertNull(expectedResults.get(k));
+        Assertions.assertNull(expectedResults.get(k));
       } else {
-        Assert.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
+        Assertions.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
       }
       k++;
       unnestCursor.advance();
     }
     // since type is 'STRING', it follows multi-value string rules so single element arrays become scalar values,
     // so [null] becomes null, meaning we only have 7 rows
-    Assert.assertEquals(k, 7);
+    Assertions.assertEquals(k, 7);
   }
 
   @Test
@@ -277,14 +277,14 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
       if (valueSelectorVal == null) {
-        Assert.assertNull(expectedResults.get(k));
+        Assertions.assertNull(expectedResults.get(k));
       } else {
-        Assert.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
+        Assertions.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
       }
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 8);
+    Assertions.assertEquals(k, 8);
   }
 
   @Test
@@ -308,11 +308,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
+      Assertions.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 9);
+    Assertions.assertEquals(k, 9);
   }
 
   @Test
@@ -336,11 +336,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
+      Assertions.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 9);
+    Assertions.assertEquals(k, 9);
   }
 
   @Test
@@ -369,11 +369,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
+      Assertions.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 10);
+    Assertions.assertEquals(k, 10);
   }
 
   @Test
@@ -406,11 +406,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!parentCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
+      Assertions.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
       k++;
       parentCursor.advance();
     }
-    Assert.assertEquals(k, 11);
+    Assertions.assertEquals(k, 11);
   }
 
   @Test
@@ -440,14 +440,14 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
       if (valueSelectorVal == null) {
-        Assert.assertEquals(null, expectedResults.get(k));
+        Assertions.assertEquals(null, expectedResults.get(k));
       } else {
-        Assert.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
+        Assertions.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
       }
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(expectedResults.size(), k);
+    Assertions.assertEquals(expectedResults.size(), k);
   }
 
   @Test
@@ -476,14 +476,14 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
       if (valueSelectorVal == null) {
-        Assert.assertEquals(null, expectedResults.get(k));
+        Assertions.assertEquals(null, expectedResults.get(k));
       } else {
-        Assert.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
+        Assertions.assertEquals(expectedResults.get(k), valueSelectorVal.toString());
       }
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 10);
+    Assertions.assertEquals(k, 10);
   }
 
   @Test
@@ -511,11 +511,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Double valueSelectorVal = unnestColumnValueSelector.getDouble();
-      Assert.assertEquals(expectedResults.get(k), valueSelectorVal);
+      Assertions.assertEquals(expectedResults.get(k), valueSelectorVal);
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 9);
+    Assertions.assertEquals(k, 9);
   }
 
   @Test
@@ -543,11 +543,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Float valueSelectorVal = unnestColumnValueSelector.getFloat();
-      Assert.assertEquals(expectedResults.get(k), valueSelectorVal);
+      Assertions.assertEquals(expectedResults.get(k), valueSelectorVal);
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 9);
+    Assertions.assertEquals(k, 9);
   }
 
   @Test
@@ -576,13 +576,13 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object obj = unnestColumnValueSelector.getObject();
-      Assert.assertNotNull(obj);
+      Assertions.assertNotNull(obj);
       Long valueSelectorVal = unnestColumnValueSelector.getLong();
-      Assert.assertEquals(expectedResults.get(k), valueSelectorVal);
+      Assertions.assertEquals(expectedResults.get(k), valueSelectorVal);
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 9);
+    Assertions.assertEquals(k, 9);
   }
 
   @Test
@@ -611,13 +611,13 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
+      Assertions.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 10);
+    Assertions.assertEquals(k, 10);
     unnestCursor.reset();
-    Assert.assertFalse(unnestCursor.isDoneOrInterrupted());
+    Assertions.assertFalse(unnestCursor.isDoneOrInterrupted());
   }
 
   @Test
@@ -648,16 +648,16 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       if (k < 8) {
-        Assert.assertEquals(expectedResults.get(k).toString(), unnestDimSelector.getValue());
+        Assertions.assertEquals(expectedResults.get(k).toString(), unnestDimSelector.getValue());
       } else {
-        Assert.assertNull(unnestDimSelector.getValue());
+        Assertions.assertNull(unnestDimSelector.getValue());
       }
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 8);
+    Assertions.assertEquals(k, 8);
     unnestCursor.reset();
-    Assert.assertNotNull(unnestDimSelector);
+    Assertions.assertNotNull(unnestDimSelector);
   }
 
   @Test
@@ -685,11 +685,11 @@ public class UnnestColumnValueSelectorCursorTest extends InitializedNullHandling
     int k = 0;
     while (!unnestCursor.isDone()) {
       Object valueSelectorVal = unnestColumnValueSelector.getObject();
-      Assert.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
+      Assertions.assertEquals(expectedResults.get(k).toString(), valueSelectorVal.toString());
       k++;
       unnestCursor.advance();
     }
-    Assert.assertEquals(k, 9);
+    Assertions.assertEquals(k, 9);
   }
 }
 

--- a/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
@@ -53,7 +53,6 @@ import org.apache.druid.segment.join.PostJoinCursor;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.utils.CloseableUtils;
@@ -63,8 +62,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -80,8 +80,8 @@ import static org.apache.druid.segment.filter.Filters.or;
 
 public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
 {
-  @RegisterExtension
-  public static TemporaryFolderExtension tmp = new TemporaryFolderExtension();
+  @TempDir
+  public static File tmp;
   private static Closer CLOSER;
   private static IncrementalIndex INCREMENTAL_INDEX;
   private static IncrementalIndexCursorFactory INCREMENTAL_INDEX_CURSOR_FACTORY;
@@ -132,7 +132,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
         NestedDataTestUtils.ALL_TYPES_TEST_DATA_FILE
     );
     IndexBuilder bob = IndexBuilder.create()
-                                   .tmpDir(tmp.newFolder())
+                                   .tmpDir(new File(tmp, "index"))
                                    .schema(
                                        IncrementalIndexSchema.builder()
                                                              .withTimestampSpec(TimestampSpec.DEFAULT)
@@ -146,7 +146,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
                                    .inputSource(inputSource)
                                    .inputFormat(TestIndex.DEFAULT_JSON_INPUT_FORMAT)
                                    .transform(TransformSpec.NONE)
-                                   .inputTmpDir(tmp.newFolder());
+                                   .inputTmpDir(new File(tmp, "input"));
     QUERYABLE_INDEX = CLOSER.register(bob.buildMMappedIndex());
     UNNEST_ARRAYS = new UnnestCursorFactory(
         new QueryableIndexCursorFactory(QUERYABLE_INDEX),

--- a/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
@@ -53,18 +53,17 @@ import org.apache.druid.segment.join.PostJoinCursor;
 import org.apache.druid.segment.transform.TransformSpec;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.utils.CloseableUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -81,8 +80,8 @@ import static org.apache.druid.segment.filter.Filters.or;
 
 public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
 {
-  @ClassRule
-  public static TemporaryFolder tmp = new TemporaryFolder();
+  @RegisterExtension
+  public static TemporaryFolderExtension tmp = new TemporaryFolderExtension();
   private static Closer CLOSER;
   private static IncrementalIndex INCREMENTAL_INDEX;
   private static IncrementalIndexCursorFactory INCREMENTAL_INDEX_CURSOR_FACTORY;
@@ -96,7 +95,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
   private static String OUTPUT_COLUMN_NAME1 = "unnested-multi-string1-again";
 
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException
   {
     CLOSER = Closer.create();
@@ -161,7 +160,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
     );
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown()
   {
     CloseableUtils.closeAndSuppressExceptions(CLOSER, throwable -> {
@@ -174,7 +173,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
     String colName = "multi-string1";
     for (UnnestCursorFactory cursorFactory : CURSOR_FACTORIES) {
       cursorFactory.getColumnCapabilities(colName);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           cursorFactory.getColumnCapabilities(colName).toColumnType(),
           INCREMENTAL_INDEX_CURSOR_FACTORY.getColumnCapabilities(colName).toColumnType()
       );
@@ -207,14 +206,14 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
 
     for (int i = 0; i < columnsInTable.size(); i++) {
       ColumnCapabilities capabilities = cursorFactory.getColumnCapabilities(columnsInTable.get(i));
-      Assert.assertEquals(capabilities.getType(), valueTypes.get(i));
+      Assertions.assertEquals(capabilities.getType(), valueTypes.get(i));
     }
     assertColumnReadsIdentifier(cursorFactory.getUnnestColumn(), colName);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         cursorFactory.getColumnCapabilities(OUTPUT_COLUMN_NAME).isDictionaryEncoded(),
         ColumnCapabilities.Capable.TRUE // passed through from dict-encoded input
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         cursorFactory.getColumnCapabilities(OUTPUT_COLUMN_NAME).hasMultipleValues(),
         ColumnCapabilities.Capable.FALSE
     );
@@ -248,8 +247,8 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
       each row has 8 entries.
       unnest 2 rows -> 16 rows after unnest
        */
-      Assert.assertEquals(count, 16);
-      Assert.assertEquals(
+      Assertions.assertEquals(count, 16);
+      Assertions.assertEquals(
           Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "10", "11", "12", "13", "14", "15", "8", "9"),
           rows
       );
@@ -270,10 +269,10 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
 
     final AsyncCursorHolder asyncHolder = unnest.makeCursorHolderAsync(CursorBuildSpec.FULL_SCAN);
     try {
-      Assert.assertFalse("unnest holder must wait for the base to complete", asyncHolder.isReady());
+      Assertions.assertFalse(asyncHolder.isReady(), "unnest holder must wait for the base to complete");
 
       base.complete();
-      Assert.assertTrue("unnest holder becomes ready once the base completes", asyncHolder.isReady());
+      Assertions.assertTrue(asyncHolder.isReady(), "unnest holder becomes ready once the base completes");
 
       try (final CursorHolder cursorHolder = asyncHolder.release()) {
         final Cursor cursor = cursorHolder.asCursor();
@@ -284,7 +283,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
           rows.add(dimSelector.getObject());
           cursor.advance();
         }
-        Assert.assertEquals(
+        Assertions.assertEquals(
             Arrays.asList("0", "1", "2", "3", "4", "5", "6", "7", "10", "11", "12", "13", "14", "15", "8", "9"),
             rows
         );
@@ -307,9 +306,9 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
     );
 
     final AsyncCursorHolder asyncHolder = unnest.makeCursorHolderAsync(CursorBuildSpec.FULL_SCAN);
-    Assert.assertFalse(asyncHolder.isReady());
+    Assertions.assertFalse(asyncHolder.isReady());
     asyncHolder.close();
-    Assert.assertTrue("closing the unnest holder before it's ready cancels the base load", base.canceled.get());
+    Assertions.assertTrue(base.canceled.get(), "closing the unnest holder before it's ready cancels the base load");
   }
 
   @Test
@@ -336,8 +335,8 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
         cursor.advance();
         count++;
       }
-      Assert.assertEquals(count, 12);
-      Assert.assertEquals(
+      Assertions.assertEquals(count, 12);
+      Assertions.assertEquals(
           Arrays.asList(2L, 3L, 1L, null, 3L, 1L, null, 2L, 9L, 1L, 2L, 3L),
           rows
       );
@@ -401,8 +400,8 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
         cursor.advance();
         count++;
       }
-      Assert.assertEquals(count, 11);
-      Assert.assertEquals(
+      Assertions.assertEquals(count, 11);
+      Assertions.assertEquals(
           Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, null, 7L, 8L, 9L, 10L),
           rows
       );
@@ -424,9 +423,9 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
         Object dimSelectorVal = dimSelector.getObject();
         Object valueSelectorVal = valueSelector.getObject();
         if (dimSelectorVal == null) {
-          Assert.assertNull(dimSelectorVal);
+          Assertions.assertNull(dimSelectorVal);
         } else if (valueSelectorVal == null) {
-          Assert.assertNull(valueSelectorVal);
+          Assertions.assertNull(valueSelectorVal);
         }
         cursor.advance();
         count++;
@@ -437,8 +436,8 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
                        fabricated so cardinality is 17
       unnest of unnest -> 16*8 = 128 rows
        */
-      Assert.assertEquals(count, 128);
-      Assert.assertEquals(dimSelector.getValueCardinality(), 17);
+      Assertions.assertEquals(count, 128);
+      Assertions.assertEquals(dimSelector.getValueCardinality(), 17);
     }
   }
 
@@ -473,11 +472,11 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
       Cursor cursor = cursorHolder.asCursor();
       final Filter pushDownFilter = testCursorFactory.getPushDownFilter();
 
-      Assert.assertEquals(expectedPushDownFilter, pushDownFilter);
-      Assert.assertEquals(cursor.getClass(), PostJoinCursor.class);
+      Assertions.assertEquals(expectedPushDownFilter, pushDownFilter);
+      Assertions.assertEquals(cursor.getClass(), PostJoinCursor.class);
       final Filter postFilter = ((PostJoinCursor) cursor).getPostJoinFilter();
       // OR-case so base filter should match the postJoinFilter
-      Assert.assertEquals(baseFilter, postFilter);
+      Assertions.assertEquals(baseFilter, postFilter);
     }
   }
 
@@ -518,11 +517,11 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
       Cursor cursor = cursorHolder.asCursor();
       final Filter pushDownFilter = testCursorFactory.getPushDownFilter();
 
-      Assert.assertEquals(expectedPushDownFilter, pushDownFilter);
-      Assert.assertEquals(cursor.getClass(), PostJoinCursor.class);
+      Assertions.assertEquals(expectedPushDownFilter, pushDownFilter);
+      Assertions.assertEquals(cursor.getClass(), PostJoinCursor.class);
       final Filter postFilter = ((PostJoinCursor) cursor).getPostJoinFilter();
       // OR-case so base filter should match the postJoinFilter
-      Assert.assertEquals(baseFilter, postFilter);
+      Assertions.assertEquals(baseFilter, postFilter);
     }
   }
 
@@ -794,17 +793,17 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
       Cursor cursor = cursorHolder.asCursor();
       final Filter pushDownFilter = testCursorFactory.getPushDownFilter();
 
-      Assert.assertEquals(expectedPushDownFilter, pushDownFilter);
-      Assert.assertEquals(cursor.getClass(), PostJoinCursor.class);
+      Assertions.assertEquals(expectedPushDownFilter, pushDownFilter);
+      Assertions.assertEquals(cursor.getClass(), PostJoinCursor.class);
       final Filter postFilter = ((PostJoinCursor) cursor).getPostJoinFilter();
-      Assert.assertEquals(filter.toFilter(), postFilter);
+      Assertions.assertEquals(filter.toFilter(), postFilter);
 
       int count = 0;
       while (!cursor.isDone()) {
         cursor.advance();
         count++;
       }
-      Assert.assertEquals(1, count);
+      Assertions.assertEquals(1, count);
     }
   }
 
@@ -835,17 +834,17 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
       Cursor cursor = cursorHolder.asCursor();
       final Filter pushDownFilter = testCursorFactory.getPushDownFilter();
 
-      Assert.assertEquals(expectedPushDownFilter, pushDownFilter);
-      Assert.assertEquals(cursor.getClass(), PostJoinCursor.class);
+      Assertions.assertEquals(expectedPushDownFilter, pushDownFilter);
+      Assertions.assertEquals(cursor.getClass(), PostJoinCursor.class);
       final Filter postFilter = ((PostJoinCursor) cursor).getPostJoinFilter();
-      Assert.assertEquals(queryFilter, postFilter);
+      Assertions.assertEquals(queryFilter, postFilter);
 
       int count = 0;
       while (!cursor.isDone()) {
         cursor.advance();
         count++;
       }
-      Assert.assertEquals(1, count);
+      Assertions.assertEquals(1, count);
     }
   }
 
@@ -885,14 +884,14 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
       while (!cursor.isDone()) {
         Object dimSelectorVal = dimSelector.getObject();
         if (dimSelectorVal == null) {
-          Assert.assertNull(dimSelectorVal);
-          Assert.assertTrue(matcher.matches(true));
+          Assertions.assertNull(dimSelectorVal);
+          Assertions.assertTrue(matcher.matches(true));
         }
-        Assert.assertFalse(matcher.matches(false));
+        Assertions.assertFalse(matcher.matches(false));
         cursor.advance();
         count++;
       }
-      Assert.assertEquals(count, 569);
+      Assertions.assertEquals(count, 569);
     }
   }
 
@@ -1102,7 +1101,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
   )
   {
     final String inputColumn = cursorFactory.getUnnestInputIfDirectAccess(cursorFactory.getUnnestColumn());
-    Assert.assertNotNull(inputColumn);
+    Assertions.assertNotNull(inputColumn);
     final VirtualColumn vc = cursorFactory.getUnnestColumn();
     UnnestCursorFactory.UnnestFilterSplit filterSplit = UnnestCursorFactory.computeBaseAndPostUnnestFilters(
         testQueryFilter,
@@ -1114,22 +1113,22 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
     );
     Filter actualPushDownFilter = filterSplit.getBaseTableFilter();
     Filter actualPostUnnestFilter = filterSplit.getPostUnnestFilter();
-    Assert.assertEquals(
-        "Expects only top level child of And Filter to push down to base",
+    Assertions.assertEquals(
         expectedBasePushDown,
-        actualPushDownFilter == null ? "" : actualPushDownFilter.toString()
+        actualPushDownFilter == null ? "" : actualPushDownFilter.toString(),
+        "Expects only top level child of And Filter to push down to base"
     );
-    Assert.assertEquals(
-        "Should have post unnest filter",
+    Assertions.assertEquals(
         expectedPostUnnest,
-        actualPostUnnestFilter == null ? "" : actualPostUnnestFilter.toString()
+        actualPostUnnestFilter == null ? "" : actualPostUnnestFilter.toString(),
+        "Should have post unnest filter"
     );
   }
 
   private static void assertColumnReadsIdentifier(final VirtualColumn column, final String identifier)
   {
     MatcherAssert.assertThat(column, CoreMatchers.instanceOf(ExpressionVirtualColumn.class));
-    Assert.assertEquals("\"" + identifier + "\"", ((ExpressionVirtualColumn) column).getExpression());
+    Assertions.assertEquals("\"" + identifier + "\"", ((ExpressionVirtualColumn) column).getExpression());
   }
 }
 

--- a/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/UnnestCursorFactoryTest.java
@@ -65,7 +65,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -96,7 +95,7 @@ public class UnnestCursorFactoryTest extends InitializedNullHandlingTest
 
 
   @BeforeAll
-  public static void setup() throws IOException
+  public static void setup()
   {
     CLOSER = Closer.create();
     final GeneratorSchemaInfo schemaInfo = GeneratorBasicSchemas.SCHEMA_MAP.get("expression-testbench");

--- a/processing/src/test/java/org/apache/druid/segment/column/TypeStrategiesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/column/TypeStrategiesTest.java
@@ -26,19 +26,18 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.segment.nested.StructuredData;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TypeStrategiesTest
 {
@@ -46,10 +45,7 @@ public class TypeStrategiesTest
 
   public static ColumnType NULLABLE_TEST_PAIR_TYPE = ColumnType.ofComplex("nullableLongPair");
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @BeforeClass
+  @BeforeAll
   public static void setup()
   {
     BuiltInTypesModule.registerHandlersAndSerde();
@@ -60,8 +56,8 @@ public class TypeStrategiesTest
   public void testRegister()
   {
     TypeStrategy<?> strategy = NULLABLE_TEST_PAIR_TYPE.getStrategy();
-    Assert.assertNotNull(strategy);
-    Assert.assertTrue(strategy instanceof NullableLongPairTypeStrategy);
+    Assertions.assertNotNull(strategy);
+    Assertions.assertTrue(strategy instanceof NullableLongPairTypeStrategy);
   }
 
   @Test
@@ -69,186 +65,188 @@ public class TypeStrategiesTest
   {
     TypeStrategies.registerComplex(NULLABLE_TEST_PAIR_TYPE.getComplexTypeName(), new NullableLongPairTypeStrategy());
     TypeStrategy<?> strategy = TypeStrategies.getComplex(NULLABLE_TEST_PAIR_TYPE.getComplexTypeName());
-    Assert.assertNotNull(strategy);
-    Assert.assertTrue(strategy instanceof NullableLongPairTypeStrategy);
+    Assertions.assertNotNull(strategy);
+    Assertions.assertTrue(strategy instanceof NullableLongPairTypeStrategy);
   }
 
   @Test
   public void testConflicting()
   {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage(
+    final IllegalStateException exception = Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> TypeStrategies.registerComplex(NULLABLE_TEST_PAIR_TYPE.getComplexTypeName(), new TypeStrategy<String>()
+      {
+        @Override
+        public int estimateSizeBytes(@Nullable String value)
+        {
+          return 0;
+        }
+
+        @Override
+        public String read(ByteBuffer buffer)
+        {
+          return null;
+        }
+
+        @Override
+        public boolean readRetainsBufferReference()
+        {
+          return false;
+        }
+
+        @Override
+        public int write(ByteBuffer buffer, String value, int maxSizeBytes)
+        {
+          return 1;
+        }
+
+        @Override
+        public int compare(Object o1, Object o2)
+        {
+          return 0;
+        }
+
+        @Override
+        public boolean groupable()
+        {
+          return false;
+        }
+      })
+    );
+    Assertions.assertEquals(
         "Incompatible strategy for type[nullableLongPair] already exists. "
         + "Expected [org.apache.druid.segment.column.TypeStrategiesTest$1], "
-        + "found [org.apache.druid.segment.column.TypeStrategiesTest$NullableLongPairTypeStrategy]."
+        + "found [org.apache.druid.segment.column.TypeStrategiesTest$NullableLongPairTypeStrategy].",
+        exception.getMessage()
     );
-
-    TypeStrategies.registerComplex(NULLABLE_TEST_PAIR_TYPE.getComplexTypeName(), new TypeStrategy<String>()
-    {
-      @Override
-      public int estimateSizeBytes(@Nullable String value)
-      {
-        return 0;
-      }
-
-      @Override
-      public String read(ByteBuffer buffer)
-      {
-        return null;
-      }
-
-      @Override
-      public boolean readRetainsBufferReference()
-      {
-        return false;
-      }
-
-      @Override
-      public int write(ByteBuffer buffer, String value, int maxSizeBytes)
-      {
-        return 1;
-      }
-
-      @Override
-      public int compare(Object o1, Object o2)
-      {
-        return 0;
-      }
-
-      @Override
-      public boolean groupable()
-      {
-        return false;
-      }
-    });
   }
 
   @Test
   public void testStringComparator()
   {
     TypeStrategy<String> strategy = ColumnType.STRING.getStrategy();
-    Assert.assertEquals(-1, strategy.compare("a", "b"));
+    Assertions.assertEquals(-1, strategy.compare("a", "b"));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, strategy.compare("a", "a"));
-    Assert.assertEquals(1, strategy.compare("b", "a"));
-    Assert.assertEquals(-48, strategy.compare("1", "a"));
-    Assert.assertEquals(48, strategy.compare("a", "1"));
+    Assertions.assertEquals(0, strategy.compare("a", "a"));
+    Assertions.assertEquals(1, strategy.compare("b", "a"));
+    Assertions.assertEquals(-48, strategy.compare("1", "a"));
+    Assertions.assertEquals(48, strategy.compare("a", "1"));
 
     NullableTypeStrategy<String> nullableTypeStrategy = ColumnType.STRING.getNullableStrategy();
-    Assert.assertEquals(-1, nullableTypeStrategy.compare("a", "b"));
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(null, "b"));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare("a", "b"));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(null, "b"));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, nullableTypeStrategy.compare("a", "a"));
-    Assert.assertEquals(1, nullableTypeStrategy.compare("b", "a"));
-    Assert.assertEquals(1, nullableTypeStrategy.compare("b", null));
-    Assert.assertEquals(-48, nullableTypeStrategy.compare("1", "a"));
-    Assert.assertEquals(48, nullableTypeStrategy.compare("a", "1"));
+    Assertions.assertEquals(0, nullableTypeStrategy.compare("a", "a"));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare("b", "a"));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare("b", null));
+    Assertions.assertEquals(-48, nullableTypeStrategy.compare("1", "a"));
+    Assertions.assertEquals(48, nullableTypeStrategy.compare("a", "1"));
   }
 
   @Test
   public void testDoubleComparator()
   {
     TypeStrategy<Double> strategy = ColumnType.DOUBLE.getStrategy();
-    Assert.assertEquals(-1, strategy.compare(0.01, 1.01));
+    Assertions.assertEquals(-1, strategy.compare(0.01, 1.01));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, strategy.compare(0.00001, 0.00001));
-    Assert.assertEquals(1, strategy.compare(1.01, 0.01));
+    Assertions.assertEquals(0, strategy.compare(0.00001, 0.00001));
+    Assertions.assertEquals(1, strategy.compare(1.01, 0.01));
 
     NullableTypeStrategy nullableTypeStrategy = ColumnType.DOUBLE.getNullableStrategy();
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(0.01, 1.01));
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(null, 1.01));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(0.01, 1.01));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(null, 1.01));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, nullableTypeStrategy.compare(0.00001, 0.00001));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(1.01, 0.01));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(1.01, null));
+    Assertions.assertEquals(0, nullableTypeStrategy.compare(0.00001, 0.00001));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(1.01, 0.01));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(1.01, null));
   }
 
   @Test
   public void testFloatComparator()
   {
     TypeStrategy<Float> strategy = ColumnType.FLOAT.getStrategy();
-    Assert.assertEquals(-1, strategy.compare(0.01f, 1.01f));
+    Assertions.assertEquals(-1, strategy.compare(0.01f, 1.01f));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, strategy.compare(0.00001f, 0.00001f));
-    Assert.assertEquals(1, strategy.compare(1.01f, 0.01f));
+    Assertions.assertEquals(0, strategy.compare(0.00001f, 0.00001f));
+    Assertions.assertEquals(1, strategy.compare(1.01f, 0.01f));
 
     NullableTypeStrategy<Float> nullableTypeStrategy = ColumnType.FLOAT.getNullableStrategy();
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(0.01f, 1.01f));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(0.01f, 1.01f));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, nullableTypeStrategy.compare(0.00001f, 0.00001f));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(1.01f, 0.01f));
+    Assertions.assertEquals(0, nullableTypeStrategy.compare(0.00001f, 0.00001f));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(1.01f, 0.01f));
   }
 
   @Test
   public void testLongComparator()
   {
     TypeStrategy<Long> strategy = ColumnType.LONG.getStrategy();
-    Assert.assertEquals(-1, strategy.compare(-1L, 1L));
+    Assertions.assertEquals(-1, strategy.compare(-1L, 1L));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, strategy.compare(1L, 1L));
-    Assert.assertEquals(1, strategy.compare(1L, -1L));
+    Assertions.assertEquals(0, strategy.compare(1L, 1L));
+    Assertions.assertEquals(1, strategy.compare(1L, -1L));
 
     NullableTypeStrategy<Long> nullableTypeStrategy = ColumnType.LONG.getNullableStrategy();
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(-1L, 1L));
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(null, 1L));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(-1L, 1L));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(null, 1L));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, nullableTypeStrategy.compare(1L, 1L));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(1L, -1L));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(1L, null));
+    Assertions.assertEquals(0, nullableTypeStrategy.compare(1L, 1L));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(1L, -1L));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(1L, null));
   }
 
   @Test
   public void testArrayComparator()
   {
     TypeStrategy<Object[]> strategy = ColumnType.LONG_ARRAY.getStrategy();
-    Assert.assertEquals(-1, strategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{1L, 2L, 3L}));
-    Assert.assertEquals(-1, strategy.compare(new Long[]{1L, 2L}, new Long[]{1L, 2L, 3L}));
-    Assert.assertEquals(-1, strategy.compare(new Long[]{}, new Long[]{1L}));
-    Assert.assertEquals(-1, strategy.compare(null, new Long[]{}));
+    Assertions.assertEquals(-1, strategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{1L, 2L, 3L}));
+    Assertions.assertEquals(-1, strategy.compare(new Long[]{1L, 2L}, new Long[]{1L, 2L, 3L}));
+    Assertions.assertEquals(-1, strategy.compare(new Long[]{}, new Long[]{1L}));
+    Assertions.assertEquals(-1, strategy.compare(null, new Long[]{}));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, strategy.compare(new Long[]{1L, 2L, 3L}, new Long[]{1L, 2L, 3L}));
+    Assertions.assertEquals(0, strategy.compare(new Long[]{1L, 2L, 3L}, new Long[]{1L, 2L, 3L}));
 
-    Assert.assertEquals(1, strategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{-1L, 2L, 3L}));
-    Assert.assertEquals(1, strategy.compare(new Long[]{1L, 2L, 2L}, new Long[]{1L, 2L, -3L}));
-    Assert.assertEquals(1, strategy.compare(new Long[]{1L, 2L}, new Long[]{-1L, 2L, 3L}));
-    Assert.assertEquals(1, strategy.compare(new Long[]{1L, 2L}, null));
+    Assertions.assertEquals(1, strategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{-1L, 2L, 3L}));
+    Assertions.assertEquals(1, strategy.compare(new Long[]{1L, 2L, 2L}, new Long[]{1L, 2L, -3L}));
+    Assertions.assertEquals(1, strategy.compare(new Long[]{1L, 2L}, new Long[]{-1L, 2L, 3L}));
+    Assertions.assertEquals(1, strategy.compare(new Long[]{1L, 2L}, null));
 
     NullableTypeStrategy<Object[]> nullableTypeStrategy = ColumnType.LONG_ARRAY.getNullableStrategy();
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{1L, 2L, 3L}));
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(new Long[]{1L, 2L}, new Long[]{1L, 2L, 3L}));
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(new Long[]{}, new Long[]{1L}));
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(null, new Long[]{}));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{1L, 2L, 3L}));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(new Long[]{1L, 2L}, new Long[]{1L, 2L, 3L}));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(new Long[]{}, new Long[]{1L}));
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(null, new Long[]{}));
     //noinspection EqualsWithItself
-    Assert.assertEquals(0, nullableTypeStrategy.compare(new Long[]{1L, 2L, 3L}, new Long[]{1L, 2L, 3L}));
+    Assertions.assertEquals(0, nullableTypeStrategy.compare(new Long[]{1L, 2L, 3L}, new Long[]{1L, 2L, 3L}));
 
-    Assert.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{-1L, 2L, 3L}));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 2L, 2L}, new Long[]{1L, 2L, -3L}));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 2L}, new Long[]{-1L, 2L, 3L}));
-    Assert.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 2L}, null));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 1L, 2L}, new Long[]{-1L, 2L, 3L}));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 2L, 2L}, new Long[]{1L, 2L, -3L}));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 2L}, new Long[]{-1L, 2L, 3L}));
+    Assertions.assertEquals(1, nullableTypeStrategy.compare(new Long[]{1L, 2L}, null));
 
     strategy = ColumnType.ofArray(ColumnType.ofArray(ColumnType.DOUBLE)).getStrategy();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         strategy.compare(
             new Object[]{new Object[]{1.0, 2.0}},
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         strategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -23.456}},
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         strategy.compare(
             null,
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         strategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, null},
@@ -257,7 +255,7 @@ public class TypeStrategiesTest
     );
 
     //noinspection EqualsWithItself
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         strategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, null},
@@ -265,14 +263,14 @@ public class TypeStrategiesTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         strategy.compare(
             new Object[]{new Object[]{1.0, 2.1}},
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         strategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -23.456}},
@@ -281,28 +279,28 @@ public class TypeStrategiesTest
     );
 
     nullableTypeStrategy = ColumnType.ofArray(ColumnType.ofArray(ColumnType.DOUBLE)).getNullableStrategy();
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         nullableTypeStrategy.compare(
             new Object[]{new Object[]{1.0, 2.0}},
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         nullableTypeStrategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -23.456}},
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         nullableTypeStrategy.compare(
             null,
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         -1,
         nullableTypeStrategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, null},
@@ -311,7 +309,7 @@ public class TypeStrategiesTest
     );
 
     //noinspection EqualsWithItself
-    Assert.assertEquals(
+    Assertions.assertEquals(
         0,
         nullableTypeStrategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, null},
@@ -319,14 +317,14 @@ public class TypeStrategiesTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         nullableTypeStrategy.compare(
             new Object[]{new Object[]{1.0, 2.1}},
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -12.345}}
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1,
         nullableTypeStrategy.compare(
             new Object[]{new Object[]{1.0, 2.0}, new Object[]{1.1, -23.456}},
@@ -339,16 +337,16 @@ public class TypeStrategiesTest
   public void testJsonComparator()
   {
     TypeStrategy<StructuredData> strategy = ColumnType.NESTED_DATA.getStrategy();
-    Assert.assertEquals(-1, strategy.compare(StructuredData.wrap(null), StructuredData.wrap(Map.of("key", "val"))));
+    Assertions.assertEquals(-1, strategy.compare(StructuredData.wrap(null), StructuredData.wrap(Map.of("key", "val"))));
 
     NullableTypeStrategy<StructuredData> nullableTypeStrategy = ColumnType.NESTED_DATA.getNullableStrategy();
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(null, StructuredData.wrap(Map.of("key", "val"))));
-    Assert.assertEquals(0, nullableTypeStrategy.compare(
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(null, StructuredData.wrap(Map.of("key", "val"))));
+    Assertions.assertEquals(0, nullableTypeStrategy.compare(
         StructuredData.wrap(Map.of("key1", Map.of("sub-key1", "sub-val1"), "key2", "val2")),
         StructuredData.wrap(Map.of("key1", Map.of("sub-key1", "sub-val1"), "key2", "val2"))
     ));
     // hash value is computed based on serialized bytes
-    Assert.assertEquals(-1, nullableTypeStrategy.compare(
+    Assertions.assertEquals(-1, nullableTypeStrategy.compare(
         StructuredData.wrap(Map.of("key1", Map.of("sub-key1", "sub-val1-different"), "key2", "val2")),
         StructuredData.wrap(Map.of("key1", Map.of("sub-key1", "sub-val1"), "key2", "val2"))
     ));
@@ -359,12 +357,12 @@ public class TypeStrategiesTest
   {
     int offset = 0;
     TypeStrategies.writeNull(buffer, offset);
-    Assert.assertTrue(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertTrue(TypeStrategies.isNullableNull(buffer, offset));
 
     // test non-zero offset
     offset = 128;
     TypeStrategies.writeNull(buffer, offset);
-    Assert.assertTrue(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertTrue(TypeStrategies.isNullableNull(buffer, offset));
   }
 
   @Test
@@ -373,16 +371,16 @@ public class TypeStrategiesTest
     final long someLong = 12345567L;
     int offset = 0;
     int bytesWritten = TypeStrategies.writeNotNullNullableLong(buffer, offset, someLong);
-    Assert.assertEquals(1 + Long.BYTES, bytesWritten);
-    Assert.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
-    Assert.assertEquals(someLong, TypeStrategies.readNotNullNullableLong(buffer, offset));
+    Assertions.assertEquals(1 + Long.BYTES, bytesWritten);
+    Assertions.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertEquals(someLong, TypeStrategies.readNotNullNullableLong(buffer, offset));
 
     // test non-zero offset
     offset = 1024;
     bytesWritten = TypeStrategies.writeNotNullNullableLong(buffer, offset, someLong);
-    Assert.assertEquals(1 + Long.BYTES, bytesWritten);
-    Assert.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
-    Assert.assertEquals(someLong, TypeStrategies.readNotNullNullableLong(buffer, offset));
+    Assertions.assertEquals(1 + Long.BYTES, bytesWritten);
+    Assertions.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertEquals(someLong, TypeStrategies.readNotNullNullableLong(buffer, offset));
   }
 
   @Test
@@ -391,16 +389,16 @@ public class TypeStrategiesTest
     final double someDouble = 1.234567;
     int offset = 0;
     int bytesWritten = TypeStrategies.writeNotNullNullableDouble(buffer, offset, someDouble);
-    Assert.assertEquals(1 + Double.BYTES, bytesWritten);
-    Assert.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
-    Assert.assertEquals(someDouble, TypeStrategies.readNotNullNullableDouble(buffer, offset), 0);
+    Assertions.assertEquals(1 + Double.BYTES, bytesWritten);
+    Assertions.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertEquals(someDouble, TypeStrategies.readNotNullNullableDouble(buffer, offset), 0);
 
     // test non-zero offset
     offset = 1024;
     bytesWritten = TypeStrategies.writeNotNullNullableDouble(buffer, offset, someDouble);
-    Assert.assertEquals(1 + Double.BYTES, bytesWritten);
-    Assert.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
-    Assert.assertEquals(someDouble, TypeStrategies.readNotNullNullableDouble(buffer, offset), 0);
+    Assertions.assertEquals(1 + Double.BYTES, bytesWritten);
+    Assertions.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertEquals(someDouble, TypeStrategies.readNotNullNullableDouble(buffer, offset), 0);
   }
 
   @Test
@@ -409,40 +407,45 @@ public class TypeStrategiesTest
     final float someFloat = 1.234567f;
     int offset = 0;
     int bytesWritten = TypeStrategies.writeNotNullNullableFloat(buffer, offset, someFloat);
-    Assert.assertEquals(1 + Float.BYTES, bytesWritten);
-    Assert.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
-    Assert.assertEquals(someFloat, TypeStrategies.readNotNullNullableFloat(buffer, offset), 0);
+    Assertions.assertEquals(1 + Float.BYTES, bytesWritten);
+    Assertions.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertEquals(someFloat, TypeStrategies.readNotNullNullableFloat(buffer, offset), 0);
 
     // test non-zero offset
     offset = 1024;
     bytesWritten = TypeStrategies.writeNotNullNullableFloat(buffer, offset, someFloat);
-    Assert.assertEquals(1 + Float.BYTES, bytesWritten);
-    Assert.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
-    Assert.assertEquals(someFloat, TypeStrategies.readNotNullNullableFloat(buffer, offset), 0);
+    Assertions.assertEquals(1 + Float.BYTES, bytesWritten);
+    Assertions.assertFalse(TypeStrategies.isNullableNull(buffer, offset));
+    Assertions.assertEquals(someFloat, TypeStrategies.readNotNullNullableFloat(buffer, offset), 0);
   }
 
   @Test
   public void testCheckMaxSize()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage(
-        "Unable to write [STRING], maxSizeBytes [2048] is greater than available [1024]"
+    final IAE exception = Assertions.assertThrows(
+        IAE.class,
+        () -> TypeStrategies.checkMaxSize(1 << 10, 2048, ColumnType.STRING)
     );
-    ByteBuffer buffer = ByteBuffer.allocate(1 << 10);
-    TypeStrategies.checkMaxSize(buffer.remaining(), 2048, ColumnType.STRING);
+    Assertions.assertEquals(
+        "Unable to write [STRING], maxSizeBytes [2048] is greater than available [1024]",
+        exception.getMessage()
+    );
   }
 
   @Test
   public void testCheckMaxSizePosition()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage(
-        "Unable to write [STRING], maxSizeBytes [1024] is greater than available [24]"
-    );
     final int maxSize = 1 << 10;
-    ByteBuffer buffer = ByteBuffer.allocate(maxSize);
+    final ByteBuffer buffer = ByteBuffer.allocate(maxSize);
     buffer.position(1000);
-    TypeStrategies.checkMaxSize(buffer.remaining(), maxSize, ColumnType.STRING);
+    final IAE exception = Assertions.assertThrows(
+        IAE.class,
+        () -> TypeStrategies.checkMaxSize(buffer.remaining(), maxSize, ColumnType.STRING)
+    );
+    Assertions.assertEquals(
+        "Unable to write [STRING], maxSizeBytes [1024] is greater than available [24]",
+        exception.getMessage()
+    );
   }
 
   @Test
@@ -561,57 +564,57 @@ public class TypeStrategiesTest
   {
     final int maxSize = 2048;
     final int expectedLength = strategy.estimateSizeBytes(value);
-    Assert.assertNotEquals(0, expectedLength);
+    Assertions.assertNotEquals(0, expectedLength);
 
     // test buffer
     int offset = 10;
     buffer.position(offset);
-    Assert.assertEquals(expectedLength, strategy.write(buffer, value, maxSize));
-    Assert.assertEquals(expectedLength, buffer.position() - offset);
+    Assertions.assertEquals(expectedLength, strategy.write(buffer, value, maxSize));
+    Assertions.assertEquals(expectedLength, buffer.position() - offset);
     buffer.position(offset);
-    Assert.assertEquals(value, strategy.read(buffer));
-    Assert.assertEquals(expectedLength, buffer.position() - offset);
+    Assertions.assertEquals(value, strategy.read(buffer));
+    Assertions.assertEquals(expectedLength, buffer.position() - offset);
 
     // test buffer nullable write read value
     NullableTypeStrategy nullableTypeStrategy = new NullableTypeStrategy(strategy);
     buffer.position(offset);
-    Assert.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, value, maxSize));
-    Assert.assertEquals(1 + expectedLength, buffer.position() - offset);
+    Assertions.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, value, maxSize));
+    Assertions.assertEquals(1 + expectedLength, buffer.position() - offset);
     buffer.position(offset);
-    Assert.assertEquals(value, nullableTypeStrategy.read(buffer));
-    Assert.assertEquals(1 + expectedLength, buffer.position() - offset);
+    Assertions.assertEquals(value, nullableTypeStrategy.read(buffer));
+    Assertions.assertEquals(1 + expectedLength, buffer.position() - offset);
 
     // test buffer nullable write read null
     buffer.position(offset);
-    Assert.assertEquals(1, nullableTypeStrategy.write(buffer, null, maxSize));
-    Assert.assertEquals(1, buffer.position() - offset);
+    Assertions.assertEquals(1, nullableTypeStrategy.write(buffer, null, maxSize));
+    Assertions.assertEquals(1, buffer.position() - offset);
     buffer.position(offset);
-    Assert.assertNull(nullableTypeStrategy.read(buffer));
-    Assert.assertEquals(1, buffer.position() - offset);
+    Assertions.assertNull(nullableTypeStrategy.read(buffer));
+    Assertions.assertEquals(1, buffer.position() - offset);
 
     buffer.position(0);
 
     // test buffer offset
-    Assert.assertEquals(expectedLength, strategy.write(buffer, 1024, value, maxSize));
-    Assert.assertEquals(value, strategy.read(buffer, 1024));
-    Assert.assertEquals(0, buffer.position());
+    Assertions.assertEquals(expectedLength, strategy.write(buffer, 1024, value, maxSize));
+    Assertions.assertEquals(value, strategy.read(buffer, 1024));
+    Assertions.assertEquals(0, buffer.position());
 
     // test buffer offset nullable write read value
-    Assert.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, 1024, value, maxSize));
-    Assert.assertEquals(value, nullableTypeStrategy.read(buffer, 1024));
-    Assert.assertEquals(0, buffer.position());
+    Assertions.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, 1024, value, maxSize));
+    Assertions.assertEquals(value, nullableTypeStrategy.read(buffer, 1024));
+    Assertions.assertEquals(0, buffer.position());
 
     // test buffer offset nullable write read null
-    Assert.assertEquals(1, nullableTypeStrategy.write(buffer, 1024, null, maxSize));
-    Assert.assertNull(nullableTypeStrategy.read(buffer, 1024));
-    Assert.assertEquals(0, buffer.position());
+    Assertions.assertEquals(1, nullableTypeStrategy.write(buffer, 1024, null, maxSize));
+    Assertions.assertNull(nullableTypeStrategy.read(buffer, 1024));
+    Assertions.assertEquals(0, buffer.position());
   }
 
   private void assertArrayStrategy(TypeStrategy strategy, @Nullable Object[] value)
   {
     final int maxSize = 2048;
     final int expectedLength = strategy.estimateSizeBytes(value);
-    Assert.assertNotEquals(0, expectedLength);
+    Assertions.assertNotEquals(0, expectedLength);
 
     // basic tests at some position and offset
     assertArrayStrategy(strategy, value, maxSize, 10);
@@ -620,50 +623,50 @@ public class TypeStrategiesTest
 
     // test buffer offset when with different position
     NullableTypeStrategy nullableTypeStrategy = new NullableTypeStrategy(strategy);
-    Assert.assertEquals(expectedLength, strategy.write(buffer, 1024, value, maxSize));
-    Assert.assertArrayEquals(value, (Object[]) strategy.read(buffer, 1024));
-    Assert.assertEquals(0, buffer.position());
+    Assertions.assertEquals(expectedLength, strategy.write(buffer, 1024, value, maxSize));
+    Assertions.assertArrayEquals(value, (Object[]) strategy.read(buffer, 1024));
+    Assertions.assertEquals(0, buffer.position());
 
     // test buffer offset nullable write read value
-    Assert.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, 1024, value, maxSize));
-    Assert.assertArrayEquals(value, (Object[]) nullableTypeStrategy.read(buffer, 1024));
-    Assert.assertEquals(0, buffer.position());
+    Assertions.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, 1024, value, maxSize));
+    Assertions.assertArrayEquals(value, (Object[]) nullableTypeStrategy.read(buffer, 1024));
+    Assertions.assertEquals(0, buffer.position());
 
     // test buffer offset nullable write read null
-    Assert.assertEquals(1, nullableTypeStrategy.write(buffer, 1024, null, maxSize));
-    Assert.assertNull(nullableTypeStrategy.read(buffer, 1024));
-    Assert.assertEquals(0, buffer.position());
+    Assertions.assertEquals(1, nullableTypeStrategy.write(buffer, 1024, null, maxSize));
+    Assertions.assertNull(nullableTypeStrategy.read(buffer, 1024));
+    Assertions.assertEquals(0, buffer.position());
   }
 
   private void assertArrayStrategy(TypeStrategy strategy, @Nullable Object[] value, int maxSize, int offset)
   {
     final int expectedLength = strategy.estimateSizeBytes(value);
-    Assert.assertNotEquals(0, expectedLength);
+    Assertions.assertNotEquals(0, expectedLength);
 
     // test buffer
     buffer.position(offset);
-    Assert.assertEquals(expectedLength, strategy.write(buffer, value, maxSize));
-    Assert.assertEquals(expectedLength, buffer.position() - offset);
+    Assertions.assertEquals(expectedLength, strategy.write(buffer, value, maxSize));
+    Assertions.assertEquals(expectedLength, buffer.position() - offset);
     buffer.position(offset);
-    Assert.assertArrayEquals(value, (Object[]) strategy.read(buffer));
-    Assert.assertEquals(expectedLength, buffer.position() - offset);
+    Assertions.assertArrayEquals(value, (Object[]) strategy.read(buffer));
+    Assertions.assertEquals(expectedLength, buffer.position() - offset);
 
     // test buffer nullable write read value
     NullableTypeStrategy nullableTypeStrategy = new NullableTypeStrategy(strategy);
     buffer.position(offset);
-    Assert.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, value, maxSize));
-    Assert.assertEquals(1 + expectedLength, buffer.position() - offset);
+    Assertions.assertEquals(1 + expectedLength, nullableTypeStrategy.write(buffer, value, maxSize));
+    Assertions.assertEquals(1 + expectedLength, buffer.position() - offset);
     buffer.position(offset);
-    Assert.assertArrayEquals(value, (Object[]) nullableTypeStrategy.read(buffer));
-    Assert.assertEquals(1 + expectedLength, buffer.position() - offset);
+    Assertions.assertArrayEquals(value, (Object[]) nullableTypeStrategy.read(buffer));
+    Assertions.assertEquals(1 + expectedLength, buffer.position() - offset);
 
     // test buffer nullable write read null
     buffer.position(offset);
-    Assert.assertEquals(1, nullableTypeStrategy.write(buffer, null, maxSize));
-    Assert.assertEquals(1, buffer.position() - offset);
+    Assertions.assertEquals(1, nullableTypeStrategy.write(buffer, null, maxSize));
+    Assertions.assertEquals(1, buffer.position() - offset);
     buffer.position(offset);
-    Assert.assertNull(nullableTypeStrategy.read(buffer));
-    Assert.assertEquals(1, buffer.position() - offset);
+    Assertions.assertNull(nullableTypeStrategy.read(buffer));
+    Assertions.assertEquals(1, buffer.position() - offset);
   }
 
   public static class NullableLongPair extends Pair<Long, Long> implements Comparable<NullableLongPair>

--- a/processing/src/test/java/org/apache/druid/segment/data/BenchmarkIndexibleWrites.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/BenchmarkIndexibleWrites.java
@@ -19,9 +19,6 @@
 
 package org.apache.druid.segment.data;
 
-import com.carrotsearch.junitbenchmarks.AbstractBenchmark;
-import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
-import com.carrotsearch.junitbenchmarks.Clock;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -29,11 +26,11 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,10 +49,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 
 // AbstractBenchmark makes this ignored unless explicitly run
-@RunWith(Parameterized.class)
-public class BenchmarkIndexibleWrites extends AbstractBenchmark
+@ParameterizedClass
+@MethodSource("getParameters")
+public class BenchmarkIndexibleWrites
 {
-  @Parameterized.Parameters
   public static Collection<Object[]> getParameters()
   {
     return ImmutableList.of(
@@ -175,8 +172,7 @@ public class BenchmarkIndexibleWrites extends AbstractBenchmark
   private final Integer concurrentThreads = 1 << 2;
   private final Integer totalIndexSize = 1 << 20;
 
-  @BenchmarkOptions(warmupRounds = 100, benchmarkRounds = 100, clock = Clock.REAL_TIME, callgc = true)
-  @Ignore @Test
+  @Disabled @Test
   /**
    * CALLEN - 2015-01-15 - OSX - Java 1.7.0_71-b14
    BenchmarkIndexibleWrites.testConcurrentWrites[0]: [measured 100 out of 200 rounds, threads: 1 (sequential)]
@@ -218,9 +214,9 @@ public class BenchmarkIndexibleWrites extends AbstractBenchmark
       );
     }
     Futures.allAsList(futures).get();
-    Assert.assertTrue(StringUtils.format("Index too small %d, expected %d across %d loops", index.get(), totalIndexSize, loops), index.get() >= totalIndexSize);
+    Assertions.assertTrue(index.get() >= totalIndexSize, StringUtils.format("Index too small %d, expected %d across %d loops", index.get(), totalIndexSize, loops));
     for (int i = 0; i < index.get(); ++i) {
-      Assert.assertEquals(i, concurrentIndexible.get(i).intValue());
+      Assertions.assertEquals(i, concurrentIndexible.get(i).intValue());
     }
     concurrentIndexible.clear();
     futures.clear();
@@ -234,8 +230,7 @@ public class BenchmarkIndexibleWrites extends AbstractBenchmark
    round: 0.12 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.02 [+- 0.00], GC.calls: 396, GC.time: 2.05, time.total: 29.21, time.warmup: 14.65, time.bench: 14.55
 
    */
-  @BenchmarkOptions(warmupRounds = 100, benchmarkRounds = 100, clock = Clock.REAL_TIME, callgc = true)
-  @Ignore @Test
+  @Disabled @Test
   public void testConcurrentReads() throws ExecutionException, InterruptedException
   {
     final ListeningExecutorService executorService = MoreExecutors.listeningDecorator(
@@ -274,7 +269,7 @@ public class BenchmarkIndexibleWrites extends AbstractBenchmark
                   final Random rndGen = ThreadLocalRandom.current();
                   while (!done.get()) {
                     Integer idx = rndGen.nextInt(queryableIndex.get() + 1);
-                    Assert.assertEquals(idx, concurrentIndexible.get(idx));
+                    Assertions.assertEquals(idx, concurrentIndexible.get(idx));
                   }
                 }
               }
@@ -297,9 +292,9 @@ public class BenchmarkIndexibleWrites extends AbstractBenchmark
     Futures.allAsList(futures).get();
     executorService.shutdown();
 
-    Assert.assertTrue(StringUtils.format("Index too small %d, expected %d across %d loops", index.get(), totalIndexSize, loops), index.get() >= totalIndexSize);
+    Assertions.assertTrue(index.get() >= totalIndexSize, StringUtils.format("Index too small %d, expected %d across %d loops", index.get(), totalIndexSize, loops));
     for (int i = 0; i < index.get(); ++i) {
-      Assert.assertEquals(i, concurrentIndexible.get(i).intValue());
+      Assertions.assertEquals(i, concurrentIndexible.get(i).intValue());
     }
     concurrentIndexible.clear();
     futures.clear();

--- a/processing/src/test/java/org/apache/druid/segment/data/BitmapCreationBenchmark.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/BitmapCreationBenchmark.java
@@ -19,20 +19,18 @@
 
 package org.apache.druid.segment.data;
 
-import com.carrotsearch.junitbenchmarks.AbstractBenchmark;
-import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.collections.bitmap.ImmutableBitmap;
 import org.apache.druid.collections.bitmap.MutableBitmap;
 import org.apache.druid.java.util.common.logger.Logger;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -43,13 +41,13 @@ import java.util.Random;
 /**
  *
  */
-@Ignore
-@RunWith(Parameterized.class)
-public class BitmapCreationBenchmark extends AbstractBenchmark
+@Disabled
+@ParameterizedClass
+@MethodSource("factoryClasses")
+public class BitmapCreationBenchmark
 {
   private static final Logger log = new Logger(BitmapCreationBenchmark.class);
 
-  @Parameterized.Parameters
   public static List<Class<? extends BitmapSerdeFactory>[]> factoryClasses()
   {
     return Arrays.asList(
@@ -77,7 +75,7 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   static Random random;
   static int[] randIndex = new int[NUM_BITS];
 
-  @AfterClass
+  @AfterAll
   public static void cleanupAfterClass()
   {
     List<Class<? extends BitmapSerdeFactory>[]> classes = factoryClasses();
@@ -86,7 +84,7 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupBeforeClass()
   {
     for (int i = 0; i < NUM_BITS; ++i) {
@@ -107,7 +105,7 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
   byte[] baseBytes;
   ByteBuffer baseByteBuffer;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     baseMutableBitmap = factory.makeEmptyMutableBitmap();
@@ -118,9 +116,6 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
     baseBytes = baseImmutableBitmap.toBytes();
     baseByteBuffer = ByteBuffer.wrap(baseBytes);
   }
-
-
-  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 1000)
   @Test
   public void testLinearAddition()
   {
@@ -128,10 +123,8 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
     for (int i = 0; i < NUM_BITS; ++i) {
       mutableBitmap.add(i);
     }
-    Assert.assertEquals(NUM_BITS, mutableBitmap.size());
+    Assertions.assertEquals(NUM_BITS, mutableBitmap.size());
   }
-
-  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 10)
   @Test
   public void testRandomAddition()
   {
@@ -139,10 +132,8 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
     for (int i : randIndex) {
       mutableBitmap.add(i);
     }
-    Assert.assertEquals(NUM_BITS, mutableBitmap.size());
+    Assertions.assertEquals(NUM_BITS, mutableBitmap.size());
   }
-
-  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 1000)
   @Test
   public void testLinearAdditionDescending()
   {
@@ -150,25 +141,19 @@ public class BitmapCreationBenchmark extends AbstractBenchmark
     for (int i = NUM_BITS - 1; i >= 0; --i) {
       mutableBitmap.add(i);
     }
-    Assert.assertEquals(NUM_BITS, mutableBitmap.size());
+    Assertions.assertEquals(NUM_BITS, mutableBitmap.size());
   }
-
-
-  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 1000)
   @Test
   public void testToImmutableByteArray()
   {
     ImmutableBitmap immutableBitmap = factory.makeImmutableBitmap(baseMutableBitmap);
-    Assert.assertArrayEquals(baseBytes, immutableBitmap.toBytes());
+    Assertions.assertArrayEquals(baseBytes, immutableBitmap.toBytes());
   }
-
-
-  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 1000)
   @Test
   public void testFromImmutableByteArray()
   {
     ImmutableBitmap immutableBitmap = factory.mapImmutableBitmap(baseByteBuffer);
-    Assert.assertEquals(NUM_BITS, immutableBitmap.size());
+    Assertions.assertEquals(NUM_BITS, immutableBitmap.size());
   }
 
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSerializerTest.java
@@ -60,6 +60,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 @ParameterizedClass
+
 @MethodSource("constructorFeeder")
 public class CompressedColumnarIntsSerializerTest
 {

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedColumnarIntsSupplierTest.java
@@ -25,10 +25,10 @@ import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.segment.CompressedPools;
 import org.apache.druid.utils.CloseableUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -55,7 +55,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
   private CompressedColumnarIntsSupplier supplier;
   private int[] vals;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     closer = Closer.create();
@@ -65,7 +65,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
     vals = null;
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     closer.close();
@@ -107,7 +107,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
     theSupplier.writeTo(Channels.newChannel(baos), null);
 
     final byte[] bytes = baos.toByteArray();
-    Assert.assertEquals(theSupplier.getSerializedSize(), bytes.length);
+    Assertions.assertEquals(theSupplier.getSerializedSize(), bytes.length);
 
     supplier = CompressedColumnarIntsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), ByteOrder.nativeOrder(), null);
     columnarInts = supplier.get();
@@ -129,16 +129,16 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
   {
     setupSimple(5);
 
-    Assert.assertEquals(4, supplier.getBaseIntBuffers().size());
+    Assertions.assertEquals(4, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
 
     // test powers of 2
     setupSimple(4);
-    Assert.assertEquals(4, supplier.getBaseIntBuffers().size());
+    Assertions.assertEquals(4, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
 
     setupSimple(32);
-    Assert.assertEquals(1, supplier.getBaseIntBuffers().size());
+    Assertions.assertEquals(1, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
   }
 
@@ -148,23 +148,25 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
     final int maxChunkSize = CompressedPools.BUFFER_SIZE / Long.BYTES;
 
     setupLargeChunks(maxChunkSize, 10 * maxChunkSize);
-    Assert.assertEquals(10, supplier.getBaseIntBuffers().size());
+    Assertions.assertEquals(10, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
 
     setupLargeChunks(maxChunkSize, 10 * maxChunkSize + 1);
-    Assert.assertEquals(11, supplier.getBaseIntBuffers().size());
+    Assertions.assertEquals(11, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
 
     setupLargeChunks(maxChunkSize - 1, 10 * (maxChunkSize - 1) + 1);
-    Assert.assertEquals(11, supplier.getBaseIntBuffers().size());
+    Assertions.assertEquals(11, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testChunkTooBig() throws Exception
   {
-    final int maxChunkSize = CompressedPools.BUFFER_SIZE / Integer.BYTES;
-    setupLargeChunks(maxChunkSize + 1, 10 * (maxChunkSize + 1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> {
+      final int maxChunkSize = CompressedPools.BUFFER_SIZE / Integer.BYTES;
+      setupLargeChunks(maxChunkSize + 1, 10 * (maxChunkSize + 1));
+    });
   }
 
   @Test
@@ -172,7 +174,7 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
   {
     setupSimpleWithSerde(5);
 
-    Assert.assertEquals(4, supplier.getBaseIntBuffers().size());
+    Assertions.assertEquals(4, supplier.getBaseIntBuffers().size());
     assertIndexMatchesVals();
   }
 
@@ -276,32 +278,32 @@ public class CompressedColumnarIntsSupplierTest extends CompressionStrategyTest
     }
 
     if (failureHappened.get()) {
-      Assert.fail("Failure happened.  Reason: " + reason.get());
+      Assertions.fail("Failure happened.  Reason: " + reason.get());
     }
   }
 
   private void assertIndexMatchesVals()
   {
-    Assert.assertEquals(vals.length, columnarInts.size());
+    Assertions.assertEquals(vals.length, columnarInts.size());
 
     // sequential access
     int[] indices = new int[vals.length];
     for (int i = 0, size = columnarInts.size(); i < size; ++i) {
-      Assert.assertEquals(vals[i], columnarInts.get(i), 0.0);
+      Assertions.assertEquals(vals[i], columnarInts.get(i), 0.0);
       indices[i] = i;
     }
 
     int[] offsetValues = new int[columnarInts.size() + 1];
     columnarInts.get(offsetValues, 1, 0, columnarInts.size());
-    Assert.assertEquals(0, offsetValues[0]);
-    Assert.assertArrayEquals(vals, Arrays.copyOfRange(offsetValues, 1, offsetValues.length));
+    Assertions.assertEquals(0, offsetValues[0]);
+    Assertions.assertArrayEquals(vals, Arrays.copyOfRange(offsetValues, 1, offsetValues.length));
 
     // random access, limited to 1000 elements for large lists (every element would take too long)
     IntArrays.shuffle(indices, ThreadLocalRandom.current());
     final int limit = Math.min(columnarInts.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];
-      Assert.assertEquals(vals[k], columnarInts.get(k), 0.0);
+      Assertions.assertEquals(vals[k], columnarInts.get(k), 0.0);
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedDoublesSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedDoublesSerdeTest.java
@@ -29,19 +29,17 @@ import org.apache.druid.segment.file.SegmentFileChannel;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.CloseableUtils;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -64,10 +62,10 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * It is not important that it remain a copy, the committer is just lazy
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("compressionStrategies")
 public class CompressedDoublesSerdeTest
 {
-  @Parameterized.Parameters(name = "{0} {1} {2}")
   public static Iterable<Object[]> compressionStrategies()
   {
     List<Object[]> data = new ArrayList<>();
@@ -80,11 +78,8 @@ public class CompressedDoublesSerdeTest
 
   private static final double DELTA = 0.00001;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   protected final CompressionStrategy compressionStrategy;
   protected final ByteOrder order;
@@ -145,7 +140,7 @@ public class CompressedDoublesSerdeTest
   {
     // This test only makes sense if we can use BlockLayoutColumnarDoubleSerializer directly.
     // Exclude incompatible compressionStrategy.
-    Assume.assumeThat(compressionStrategy, CoreMatchers.not(CoreMatchers.equalTo(CompressionStrategy.NONE)));
+    Assumptions.assumeTrue(compressionStrategy != CompressionStrategy.NONE);
 
     final File columnDir = temporaryFolder.newFolder();
     final String columnName = "column";
@@ -192,37 +187,41 @@ public class CompressedDoublesSerdeTest
       );
 
       try (final ColumnarDoubles column = columnSupplier.get()) {
-        Assert.assertEquals(numRows, column.size());
+        Assertions.assertEquals(numRows, column.size());
       }
     }
   }
 
   // this test takes ~45 minutes to run
-  @Ignore
+  @Disabled
   @Test
   public void testTooManyValues() throws IOException
   {
-    expectedException.expect(ColumnCapacityExceededException.class);
-    expectedException.expectMessage(ColumnCapacityExceededException.formatMessage("test"));
-    try (
-        SegmentWriteOutMedium segmentWriteOutMedium =
-            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder())
-    ) {
-      ColumnarDoublesSerializer serializer = CompressionFactory.getDoubleSerializer(
-          "test",
-          segmentWriteOutMedium,
-          "test",
-          order,
-          compressionStrategy,
-          segmentWriteOutMedium.getCloser()
-      );
-      serializer.open();
+    final ColumnCapacityExceededException exception = Assertions.assertThrows(
+        ColumnCapacityExceededException.class,
+        () -> {
+          try (
+              SegmentWriteOutMedium segmentWriteOutMedium =
+                  TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder())
+          ) {
+            ColumnarDoublesSerializer serializer = CompressionFactory.getDoubleSerializer(
+                "test",
+                segmentWriteOutMedium,
+                "test",
+                order,
+                compressionStrategy,
+                segmentWriteOutMedium.getCloser()
+            );
+            serializer.open();
 
-      final long numRows = Integer.MAX_VALUE + 100L;
-      for (long i = 0L; i < numRows; i++) {
-        serializer.add(ThreadLocalRandom.current().nextDouble());
-      }
-    }
+            final long numRows = Integer.MAX_VALUE + 100L;
+            for (long i = 0L; i < numRows; i++) {
+              serializer.add(ThreadLocalRandom.current().nextDouble());
+            }
+          }
+        }
+    );
+    Assertions.assertEquals(ColumnCapacityExceededException.formatMessage("test"), exception.getMessage());
   }
 
   public void testWithValues(double[] values) throws Exception
@@ -239,11 +238,11 @@ public class CompressedDoublesSerdeTest
     serializer.open();
 
     serializer.addAll(values, 0, values.length);
-    Assert.assertEquals(values.length, serializer.size());
+    Assertions.assertEquals(values.length, serializer.size());
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     serializer.writeTo(Channels.newChannel(baos), null);
-    Assert.assertEquals(baos.size(), serializer.getSerializedSize());
+    Assertions.assertEquals(baos.size(), serializer.getSerializedSize());
     Supplier<ColumnarDoubles> supplier = CompressedColumnarDoublesSuppliers
         .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     try (ColumnarDoubles doubles = supplier.get()) {
@@ -268,18 +267,18 @@ public class CompressedDoublesSerdeTest
     indexed.get(filled, startIndex, filled.length);
 
     for (int i = startIndex; i < filled.length; i++) {
-      Assert.assertEquals(vals[i + startIndex], filled[i], DELTA);
+      Assertions.assertEquals(vals[i + startIndex], filled[i], DELTA);
     }
   }
 
   private void assertIndexMatchesVals(ColumnarDoubles indexed, double[] vals)
   {
-    Assert.assertEquals(vals.length, indexed.size());
+    Assertions.assertEquals(vals.length, indexed.size());
 
     // sequential access
     int[] indices = new int[vals.length];
     for (int i = 0; i < indexed.size(); ++i) {
-      Assert.assertEquals(vals[i], indexed.get(i), DELTA);
+      Assertions.assertEquals(vals[i], indexed.get(i), DELTA);
       indices[i] = i;
     }
 
@@ -288,7 +287,7 @@ public class CompressedDoublesSerdeTest
     final int limit = Math.min(indexed.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];
-      Assert.assertEquals(vals[k], indexed.get(k), DELTA);
+      Assertions.assertEquals(vals[k], indexed.get(k), DELTA);
     }
   }
 
@@ -393,7 +392,7 @@ public class CompressedDoublesSerdeTest
     }
 
     if (failureHappened.get()) {
-      Assert.fail("Failure happened.  Reason: " + reason.get());
+      Assertions.fail("Failure happened.  Reason: " + reason.get());
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedFloatsSerdeTest.java
@@ -29,19 +29,17 @@ import org.apache.druid.segment.file.SegmentFileChannel;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.CloseableUtils;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -57,10 +55,11 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("compressionStrategies")
 public class CompressedFloatsSerdeTest
 {
-  @Parameterized.Parameters(name = "{0} {1} {2}")
   public static Iterable<Object[]> compressionStrategies()
   {
     List<Object[]> data = new ArrayList<>();
@@ -73,11 +72,8 @@ public class CompressedFloatsSerdeTest
 
   private static final double DELTA = 0.00001;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   protected final CompressionStrategy compressionStrategy;
   protected final ByteOrder order;
@@ -152,7 +148,7 @@ public class CompressedFloatsSerdeTest
   {
     // This test only makes sense if we can use BlockLayoutColumnarFloatSerializer directly.
     // Exclude incompatible compressionStrategy.
-    Assume.assumeThat(compressionStrategy, CoreMatchers.not(CoreMatchers.equalTo(CompressionStrategy.NONE)));
+    Assumptions.assumeTrue(compressionStrategy != CompressionStrategy.NONE);
 
     final File columnDir = temporaryFolder.newFolder();
     final String columnName = "column";
@@ -199,37 +195,41 @@ public class CompressedFloatsSerdeTest
       );
 
       try (final ColumnarFloats column = columnSupplier.get()) {
-        Assert.assertEquals(numRows, column.size());
+        Assertions.assertEquals(numRows, column.size());
       }
     }
   }
 
   // this test takes ~30 minutes to run
-  @Ignore
+  @Disabled
   @Test
   public void testTooManyValues() throws IOException
   {
-    expectedException.expect(ColumnCapacityExceededException.class);
-    expectedException.expectMessage(ColumnCapacityExceededException.formatMessage("test"));
-    try (
-        SegmentWriteOutMedium segmentWriteOutMedium =
-            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder())
-    ) {
-      ColumnarFloatsSerializer serializer = CompressionFactory.getFloatSerializer(
-          "test",
-          segmentWriteOutMedium,
-          "test",
-          order,
-          compressionStrategy,
-          segmentWriteOutMedium.getCloser()
-      );
-      serializer.open();
+    final ColumnCapacityExceededException exception = Assertions.assertThrows(
+        ColumnCapacityExceededException.class,
+        () -> {
+          try (
+              SegmentWriteOutMedium segmentWriteOutMedium =
+                  TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder())
+          ) {
+            ColumnarFloatsSerializer serializer = CompressionFactory.getFloatSerializer(
+                "test",
+                segmentWriteOutMedium,
+                "test",
+                order,
+                compressionStrategy,
+                segmentWriteOutMedium.getCloser()
+            );
+            serializer.open();
 
-      final long numRows = Integer.MAX_VALUE + 100L;
-      for (long i = 0L; i < numRows; i++) {
-        serializer.add(ThreadLocalRandom.current().nextFloat());
-      }
-    }
+            final long numRows = Integer.MAX_VALUE + 100L;
+            for (long i = 0L; i < numRows; i++) {
+              serializer.add(ThreadLocalRandom.current().nextFloat());
+            }
+          }
+        }
+    );
+    Assertions.assertEquals(ColumnCapacityExceededException.formatMessage("test"), exception.getMessage());
   }
 
   public void testWithValues(float[] values) throws Exception
@@ -248,11 +248,11 @@ public class CompressedFloatsSerdeTest
     for (float value : values) {
       serializer.add(value);
     }
-    Assert.assertEquals(values.length, serializer.size());
+    Assertions.assertEquals(values.length, serializer.size());
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     serializer.writeTo(Channels.newChannel(baos), null);
-    Assert.assertEquals(baos.size(), serializer.getSerializedSize());
+    Assertions.assertEquals(baos.size(), serializer.getSerializedSize());
     CompressedColumnarFloatsSupplier supplier = CompressedColumnarFloatsSupplier
         .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     try (ColumnarFloats floats = supplier.get()) {
@@ -276,18 +276,18 @@ public class CompressedFloatsSerdeTest
     indexed.get(filled, startIndex, filled.length);
 
     for (int i = startIndex; i < filled.length; i++) {
-      Assert.assertEquals(vals[i + startIndex], filled[i], DELTA);
+      Assertions.assertEquals(vals[i + startIndex], filled[i], DELTA);
     }
   }
 
   private void assertIndexMatchesVals(ColumnarFloats indexed, float[] vals)
   {
-    Assert.assertEquals(vals.length, indexed.size());
+    Assertions.assertEquals(vals.length, indexed.size());
 
     // sequential access
     int[] indices = new int[vals.length];
     for (int i = 0; i < indexed.size(); ++i) {
-      Assert.assertEquals(vals[i], indexed.get(i), DELTA);
+      Assertions.assertEquals(vals[i], indexed.get(i), DELTA);
       indices[i] = i;
     }
 
@@ -296,7 +296,7 @@ public class CompressedFloatsSerdeTest
     final int limit = Math.min(indexed.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];
-      Assert.assertEquals(vals[k], indexed.get(k), DELTA);
+      Assertions.assertEquals(vals[k], indexed.get(k), DELTA);
     }
   }
 
@@ -306,7 +306,7 @@ public class CompressedFloatsSerdeTest
     supplier.writeTo(Channels.newChannel(baos), null);
 
     final byte[] bytes = baos.toByteArray();
-    Assert.assertEquals(supplier.getSerializedSize(), bytes.length);
+    Assertions.assertEquals(supplier.getSerializedSize(), bytes.length);
     CompressedColumnarFloatsSupplier anotherSupplier =
         CompressedColumnarFloatsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), order, null);
     try (ColumnarFloats indexed = anotherSupplier.get()) {
@@ -414,7 +414,7 @@ public class CompressedFloatsSerdeTest
     }
 
     if (failureHappened.get()) {
-      Assert.fail("Failure happened.  Reason: " + reason.get());
+      Assertions.fail("Failure happened.  Reason: " + reason.get());
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsAutoEncodingSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsAutoEncodingSerdeTest.java
@@ -22,10 +22,10 @@ package org.apache.druid.segment.data;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -35,10 +35,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("compressionStrategies")
 public class CompressedLongsAutoEncodingSerdeTest
 {
-  @Parameterized.Parameters(name = "{0} {1} {2}")
   public static Iterable<Object[]> compressionStrategies()
   {
     List<Object[]> data = new ArrayList<>();
@@ -109,11 +110,11 @@ public class CompressedLongsAutoEncodingSerdeTest
     serializer.open();
 
     serializer.addAll(values, 0, values.length);
-    Assert.assertEquals(values.length, serializer.size());
+    Assertions.assertEquals(values.length, serializer.size());
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     serializer.writeTo(Channels.newChannel(baos), null);
-    Assert.assertEquals(baos.size(), serializer.getSerializedSize());
+    Assertions.assertEquals(baos.size(), serializer.getSerializedSize());
     CompressedColumnarLongsSupplier supplier =
         CompressedColumnarLongsSupplier.fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     ColumnarLongs longs = supplier.get();
@@ -125,17 +126,17 @@ public class CompressedLongsAutoEncodingSerdeTest
 
   private void assertIndexMatchesVals(ColumnarLongs indexed, long[] vals)
   {
-    Assert.assertEquals(vals.length, indexed.size());
+    Assertions.assertEquals(vals.length, indexed.size());
     for (int i = 0; i < indexed.size(); ++i) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
+          vals[i],
+          indexed.get(i),
           StringUtils.format(
               "Value [%d] at row '%d' does not match [%d]",
               indexed.get(i),
               i,
               vals[i]
-          ),
-          vals[i],
-          indexed.get(i)
+          )
       );
     }
   }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedLongsSerdeTest.java
@@ -29,19 +29,17 @@ import org.apache.druid.segment.file.SegmentFileChannel;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.CloseableUtils;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -57,10 +55,11 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("compressionStrategies")
 public class CompressedLongsSerdeTest
 {
-  @Parameterized.Parameters(name = "{0} {1} {2}")
   public static Iterable<Object[]> compressionStrategies()
   {
     List<Object[]> data = new ArrayList<>();
@@ -73,11 +72,8 @@ public class CompressedLongsSerdeTest
     return data;
   }
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   protected final CompressionFactory.LongEncodingStrategy encodingStrategy;
   protected final CompressionStrategy compressionStrategy;
@@ -143,7 +139,7 @@ public class CompressedLongsSerdeTest
   }
 
   // this test takes ~50 minutes to run (even skipping 'auto')
-  @Ignore
+  @Disabled
   @Test
   public void testTooManyValues() throws IOException
   {
@@ -151,28 +147,32 @@ public class CompressedLongsSerdeTest
     if (encodingStrategy.equals(CompressionFactory.LongEncodingStrategy.AUTO)) {
       return;
     }
-    expectedException.expect(ColumnCapacityExceededException.class);
-    expectedException.expectMessage(ColumnCapacityExceededException.formatMessage("test"));
-    try (
-        SegmentWriteOutMedium segmentWriteOutMedium =
-            TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder())
-    ) {
-      ColumnarLongsSerializer serializer = CompressionFactory.getLongSerializer(
-          "test",
-          segmentWriteOutMedium,
-          "test",
-          order,
-          encodingStrategy,
-          compressionStrategy,
-          segmentWriteOutMedium.getCloser()
-      );
-      serializer.open();
+    final ColumnCapacityExceededException exception = Assertions.assertThrows(
+        ColumnCapacityExceededException.class,
+        () -> {
+          try (
+              SegmentWriteOutMedium segmentWriteOutMedium =
+                  TmpFileSegmentWriteOutMediumFactory.instance().makeSegmentWriteOutMedium(temporaryFolder.newFolder())
+          ) {
+            ColumnarLongsSerializer serializer = CompressionFactory.getLongSerializer(
+                "test",
+                segmentWriteOutMedium,
+                "test",
+                order,
+                encodingStrategy,
+                compressionStrategy,
+                segmentWriteOutMedium.getCloser()
+            );
+            serializer.open();
 
-      final long numRows = Integer.MAX_VALUE + 100L;
-      for (long i = 0L; i < numRows; i++) {
-        serializer.add(ThreadLocalRandom.current().nextLong());
-      }
-    }
+            final long numRows = Integer.MAX_VALUE + 100L;
+            for (long i = 0L; i < numRows; i++) {
+              serializer.add(ThreadLocalRandom.current().nextLong());
+            }
+          }
+        }
+    );
+    Assertions.assertEquals(ColumnCapacityExceededException.formatMessage("test"), exception.getMessage());
   }
 
   @Test
@@ -180,8 +180,8 @@ public class CompressedLongsSerdeTest
   {
     // This test only makes sense if we can use BlockLayoutColumnarLongsSerializer directly. Exclude incompatible
     // combinations of compressionStrategy, encodingStrategy.
-    Assume.assumeThat(compressionStrategy, CoreMatchers.not(CoreMatchers.equalTo(CompressionStrategy.NONE)));
-    Assume.assumeThat(encodingStrategy, CoreMatchers.equalTo(CompressionFactory.LongEncodingStrategy.LONGS));
+    Assumptions.assumeTrue(compressionStrategy != CompressionStrategy.NONE);
+    Assumptions.assumeTrue(encodingStrategy == CompressionFactory.LongEncodingStrategy.LONGS);
 
     final File columnDir = temporaryFolder.newFolder();
     final String columnName = "column";
@@ -229,7 +229,7 @@ public class CompressedLongsSerdeTest
       );
 
       try (final ColumnarLongs column = columnSupplier.get()) {
-        Assert.assertEquals(numRows, column.size());
+        Assertions.assertEquals(numRows, column.size());
       }
     }
   }
@@ -255,11 +255,11 @@ public class CompressedLongsSerdeTest
     serializer.open();
 
     serializer.addAll(values, 0, values.length);
-    Assert.assertEquals(values.length, serializer.size());
+    Assertions.assertEquals(values.length, serializer.size());
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     serializer.writeTo(Channels.newChannel(baos), null);
-    Assert.assertEquals(baos.size(), serializer.getSerializedSize());
+    Assertions.assertEquals(baos.size(), serializer.getSerializedSize());
     CompressedColumnarLongsSupplier supplier = CompressedColumnarLongsSupplier
         .fromByteBuffer(ByteBuffer.wrap(baos.toByteArray()), order, null);
     try (ColumnarLongs longs = supplier.get()) {
@@ -286,13 +286,13 @@ public class CompressedLongsSerdeTest
     indexed.get(filled, startIndex, size);
 
     for (int i = startIndex; i < filled.length; i++) {
-      Assert.assertEquals(vals[i + startIndex], filled[i]);
+      Assertions.assertEquals(vals[i + startIndex], filled[i]);
     }
   }
 
   private void assertIndexMatchesVals(ColumnarLongs indexed, long[] vals)
   {
-    Assert.assertEquals(vals.length, indexed.size());
+    Assertions.assertEquals(vals.length, indexed.size());
 
     // sequential access
     long[] vector = new long[256];
@@ -301,8 +301,8 @@ public class CompressedLongsSerdeTest
       if (i % 256 == 0) {
         indexed.get(vector, i, Math.min(256, indexed.size() - i));
       }
-      Assert.assertEquals(vals[i], indexed.get(i));
-      Assert.assertEquals(vals[i], vector[i % 256]);
+      Assertions.assertEquals(vals[i], indexed.get(i));
+      Assertions.assertEquals(vals[i], vector[i % 256]);
       indices[i] = i;
     }
 
@@ -312,7 +312,7 @@ public class CompressedLongsSerdeTest
     final int limit = Math.min(indexed.size(), 1000);
     for (int i = 0; i < limit; ++i) {
       int k = indices[i];
-      Assert.assertEquals(vals[k], indexed.get(k));
+      Assertions.assertEquals(vals[k], indexed.get(k));
     }
   }
 
@@ -322,7 +322,7 @@ public class CompressedLongsSerdeTest
     supplier.writeTo(Channels.newChannel(baos), null);
 
     final byte[] bytes = baos.toByteArray();
-    Assert.assertEquals(supplier.getSerializedSize(), bytes.length);
+    Assertions.assertEquals(supplier.getSerializedSize(), bytes.length);
     CompressedColumnarLongsSupplier anotherSupplier =
         CompressedColumnarLongsSupplier.fromByteBuffer(ByteBuffer.wrap(bytes), order, null);
     try (ColumnarLongs indexed = anotherSupplier.get()) {
@@ -430,7 +430,7 @@ public class CompressedLongsSerdeTest
     }
 
     if (failureHappened.get()) {
-      Assert.fail("Failure happened.  Reason: " + reason.get());
+      Assertions.fail("Failure happened.  Reason: " + reason.get());
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressedVSizeColumnarIntsSerializerTest.java
@@ -61,6 +61,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 @ParameterizedClass
+
 @MethodSource("constructorFeeder")
 public class CompressedVSizeColumnarIntsSerializerTest
 {

--- a/processing/src/test/java/org/apache/druid/segment/data/CompressionStrategyTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/CompressionStrategyTest.java
@@ -23,11 +23,11 @@ import com.google.common.collect.Iterables;
 import org.apache.druid.collections.ResourceHolder;
 import org.apache.druid.java.util.common.ByteBufferUtils;
 import org.apache.druid.java.util.common.io.Closer;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -41,10 +41,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("compressionStrategies")
 public class CompressionStrategyTest
 {
-  @Parameterized.Parameters(name = "{0}")
   public static Iterable<Object[]> compressionStrategies()
   {
     return Iterables.transform(
@@ -64,7 +65,7 @@ public class CompressionStrategyTest
   private static final int DATA_SIZER = 0xFFFF;
   private static byte[] ORIGINAL_DATA;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     ORIGINAL_DATA = new byte[DATA_SIZER];
@@ -87,11 +88,12 @@ public class CompressionStrategyTest
       compressionStrategy.getDecompressor().decompress(compressed, compressed.remaining(), output);
       byte[] checkArray = new byte[DATA_SIZER];
       output.get(checkArray);
-      Assert.assertArrayEquals("Uncompressed data does not match", ORIGINAL_DATA, checkArray);
+      Assertions.assertArrayEquals(ORIGINAL_DATA, checkArray, "Uncompressed data does not match");
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 60_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testConcurrency() throws Exception
   {
     final int numThreads = 20;
@@ -121,7 +123,7 @@ public class CompressionStrategyTest
                   compressionStrategy.getDecompressor().decompress(compressed, compressed.remaining(), output);
                   byte[] checkArray = new byte[DATA_SIZER];
                   output.get(checkArray);
-                  Assert.assertArrayEquals("Uncompressed data does not match", ORIGINAL_DATA, checkArray);
+                  Assertions.assertArrayEquals(ORIGINAL_DATA, checkArray, "Uncompressed data does not match");
                   return true;
                 }
               }
@@ -130,7 +132,7 @@ public class CompressionStrategyTest
     }
     threadPoolExecutor.shutdown();
     for (Future<Boolean> result : results) {
-      Assert.assertTrue(result.get());
+      Assertions.assertTrue(result.get());
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
@@ -145,15 +145,13 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     }
     Iterator<Long> longIterator = writer.getIterator();
     int ctr = 0;
-    int totalCount = withNull ? 1 + LONGS.length : LONGS.length;
-    for (int i = 0; i < totalCount; i++) {
-      if (withNull) {
-        if (i == 0) {
-          Assertions.assertNull(writer.get(i));
-        } else {
-          Assertions.assertEquals(LONGS[i - 1], writer.get(i), " index: " + i);
-        }
-      } else {
+    if (withNull) {
+      Assertions.assertNull(writer.get(0));
+      for (int i = 1; i <= LONGS.length; i++) {
+        Assertions.assertEquals(LONGS[i - 1], writer.get(i), " index: " + i);
+      }
+    } else {
+      for (int i = 0; i < LONGS.length; i++) {
         Assertions.assertEquals(LONGS[i], writer.get(i), " index: " + i);
       }
     }

--- a/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FixedIndexedTest.java
@@ -23,11 +23,11 @@ import com.google.common.collect.ImmutableList;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -37,18 +37,20 @@ import java.util.Collection;
 import java.util.Iterator;
 
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+
+@MethodSource("constructorFeeder")
 public class FixedIndexedTest extends InitializedNullHandlingTest
 {
   private static final Long[] LONGS = new Long[64];
 
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> constructorFeeder()
   {
     return ImmutableList.of(new Object[]{ByteOrder.LITTLE_ENDIAN}, new Object[]{ByteOrder.BIG_ENDIAN});
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup()
   {
     for (int i = 0; i < LONGS.length; i++) {
@@ -70,14 +72,14 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     fillBuffer(buffer, order, false);
     FixedIndexed<Long> fixedIndexed =
         FixedIndexed.<Long>read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES).get();
-    Assert.assertEquals(64, fixedIndexed.size());
+    Assertions.assertEquals(64, fixedIndexed.size());
     for (int i = 0; i < LONGS.length; i++) {
-      Assert.assertEquals(LONGS[i], fixedIndexed.get(i));
-      Assert.assertEquals(i, fixedIndexed.indexOf(LONGS[i]));
+      Assertions.assertEquals(LONGS[i], fixedIndexed.get(i));
+      Assertions.assertEquals(i, fixedIndexed.indexOf(LONGS[i]));
     }
 
-    Assert.assertThrows(IllegalArgumentException.class, () -> fixedIndexed.get(-1));
-    Assert.assertThrows(IllegalArgumentException.class, () -> fixedIndexed.get(LONGS.length));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> fixedIndexed.get(-1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> fixedIndexed.get(LONGS.length));
   }
 
   @Test
@@ -90,7 +92,7 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     Iterator<Long> iterator = fixedIndexed.iterator();
     int i = 0;
     while (iterator.hasNext()) {
-      Assert.assertEquals(LONGS[i++], iterator.next());
+      Assertions.assertEquals(LONGS[i++], iterator.next());
     }
   }
 
@@ -101,11 +103,11 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     fillBuffer(buffer, order, true);
     FixedIndexed<Long> fixedIndexed =
         FixedIndexed.<Long>read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES).get();
-    Assert.assertEquals(65, fixedIndexed.size());
-    Assert.assertNull(fixedIndexed.get(0));
+    Assertions.assertEquals(65, fixedIndexed.size());
+    Assertions.assertNull(fixedIndexed.get(0));
     for (int i = 0; i < LONGS.length; i++) {
-      Assert.assertEquals(LONGS[i], fixedIndexed.get(i + 1));
-      Assert.assertEquals(i + 1, fixedIndexed.indexOf(LONGS[i]));
+      Assertions.assertEquals(LONGS[i], fixedIndexed.get(i + 1));
+      Assertions.assertEquals(i + 1, fixedIndexed.indexOf(LONGS[i]));
     }
   }
 
@@ -117,10 +119,10 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     FixedIndexed<Long> fixedIndexed =
         FixedIndexed.<Long>read(buffer, ColumnType.LONG.getStrategy(), order, Long.BYTES).get();
     Iterator<Long> iterator = fixedIndexed.iterator();
-    Assert.assertNull(iterator.next());
+    Assertions.assertNull(iterator.next());
     int i = 0;
     while (iterator.hasNext()) {
-      Assert.assertEquals(LONGS[i++], iterator.next());
+      Assertions.assertEquals(LONGS[i++], iterator.next());
     }
   }
 
@@ -147,26 +149,26 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     for (int i = 0; i < totalCount; i++) {
       if (withNull) {
         if (i == 0) {
-          Assert.assertNull(writer.get(i));
+          Assertions.assertNull(writer.get(i));
         } else {
-          Assert.assertEquals(" index: " + i, LONGS[i - 1], writer.get(i));
+          Assertions.assertEquals(LONGS[i - 1], writer.get(i), " index: " + i);
         }
       } else {
-        Assert.assertEquals(" index: " + i, LONGS[i], writer.get(i));
+        Assertions.assertEquals(LONGS[i], writer.get(i), " index: " + i);
       }
     }
     while (longIterator.hasNext()) {
       if (withNull) {
         if (ctr == 0) {
-          Assert.assertNull(longIterator.next());
-          Assert.assertNull(writer.get(ctr));
+          Assertions.assertNull(longIterator.next());
+          Assertions.assertNull(writer.get(ctr));
         } else {
-          Assert.assertEquals(LONGS[ctr - 1], longIterator.next());
-          Assert.assertEquals(LONGS[ctr - 1], writer.get(ctr));
+          Assertions.assertEquals(LONGS[ctr - 1], longIterator.next());
+          Assertions.assertEquals(LONGS[ctr - 1], writer.get(ctr));
         }
       } else {
-        Assert.assertEquals(LONGS[ctr], longIterator.next());
-        Assert.assertEquals(LONGS[ctr], writer.get(ctr));
+        Assertions.assertEquals(LONGS[ctr], longIterator.next());
+        Assertions.assertEquals(LONGS[ctr], writer.get(ctr));
       }
       ctr++;
     }
@@ -194,7 +196,7 @@ public class FixedIndexedTest extends InitializedNullHandlingTest
     long size = writer.getSerializedSize();
     buffer.position(0);
     writer.writeTo(channel, null);
-    Assert.assertEquals(size, buffer.position());
+    Assertions.assertEquals(size, buffer.position());
     buffer.position(0);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/FrontCodedIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FrontCodedIndexedTest.java
@@ -25,10 +25,10 @@ import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -40,10 +40,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.TreeSet;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class FrontCodedIndexedTest extends InitializedNullHandlingTest
 {
-  @Parameterized.Parameters(name = "byteOrder: {0} useIncrementalBuckets: {1}")
   public static Collection<Object[]> constructorFeeder()
   {
     return ImmutableList.of(
@@ -75,8 +76,8 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         buffer,
         buffer.order()
     ).get();
-    Assert.assertEquals("helloo", StringUtils.fromUtf8(codedUtf8Indexed.get(1)));
-    Assert.assertEquals("helloozy", StringUtils.fromUtf8(codedUtf8Indexed.get(4)));
+    Assertions.assertEquals("helloo", StringUtils.fromUtf8(codedUtf8Indexed.get(1)));
+    Assertions.assertEquals("helloozy", StringUtils.fromUtf8(codedUtf8Indexed.get(4)));
 
     Iterator<ByteBuffer> utf8Iterator = codedUtf8Indexed.iterator();
     Iterator<String> newListIterator = theList.iterator();
@@ -84,13 +85,13 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
     while (newListIterator.hasNext() && utf8Iterator.hasNext()) {
       final String next = newListIterator.next();
       final ByteBuffer nextUtf8 = utf8Iterator.next();
-      Assert.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
+      Assertions.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
       nextUtf8.position(0);
-      Assert.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
-      Assert.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
+      Assertions.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
+      Assertions.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
       ctr++;
     }
-    Assert.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
+    Assertions.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
   }
 
 
@@ -105,11 +106,11 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         buffer,
         buffer.order()
     ).get();
-    Assert.assertEquals("hello", StringUtils.fromUtf8(codedUtf8Indexed.get(0)));
-    Assert.assertEquals("helloo", StringUtils.fromUtf8(codedUtf8Indexed.get(1)));
-    Assert.assertEquals("hellooo", StringUtils.fromUtf8(codedUtf8Indexed.get(2)));
-    Assert.assertEquals("hellooz", StringUtils.fromUtf8(codedUtf8Indexed.get(3)));
-    Assert.assertEquals("helloozy", StringUtils.fromUtf8(codedUtf8Indexed.get(4)));
+    Assertions.assertEquals("hello", StringUtils.fromUtf8(codedUtf8Indexed.get(0)));
+    Assertions.assertEquals("helloo", StringUtils.fromUtf8(codedUtf8Indexed.get(1)));
+    Assertions.assertEquals("hellooo", StringUtils.fromUtf8(codedUtf8Indexed.get(2)));
+    Assertions.assertEquals("hellooz", StringUtils.fromUtf8(codedUtf8Indexed.get(3)));
+    Assertions.assertEquals("helloozy", StringUtils.fromUtf8(codedUtf8Indexed.get(4)));
 
     Iterator<String> newListIterator = theList.iterator();
     Iterator<ByteBuffer> utf8Iterator = codedUtf8Indexed.iterator();
@@ -117,13 +118,13 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
     while (utf8Iterator.hasNext() && newListIterator.hasNext()) {
       final String next = newListIterator.next();
       final ByteBuffer nextUtf8 = utf8Iterator.next();
-      Assert.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
+      Assertions.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
       nextUtf8.position(0);
-      Assert.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
-      Assert.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
+      Assertions.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
+      Assertions.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
       ctr++;
     }
-    Assert.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
+    Assertions.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
   }
 
   @Test
@@ -150,14 +151,14 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
       while (utf8Iterator.hasNext() && newListIterator.hasNext()) {
         final String next = newListIterator.next();
         final ByteBuffer nextUtf8 = utf8Iterator.next();
-        Assert.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
+        Assertions.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
         nextUtf8.position(0);
-        Assert.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
-        Assert.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
+        Assertions.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
+        Assertions.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
         ctr++;
       }
-      Assert.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
-      Assert.assertEquals(ctr, sizeBase + sizeAdjust);
+      Assertions.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
+      Assertions.assertEquals(ctr, sizeBase + sizeAdjust);
     }
   }
 
@@ -187,17 +188,17 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         final String next = newListIterator.next();
         final ByteBuffer nextUtf8 = utf8Iterator.next();
         if (next == null) {
-          Assert.assertNull(nextUtf8);
+          Assertions.assertNull(nextUtf8);
         } else {
-          Assert.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
+          Assertions.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
           nextUtf8.position(0);
-          Assert.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
+          Assertions.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
         }
-        Assert.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
+        Assertions.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
         ctr++;
       }
-      Assert.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
-      Assert.assertEquals(ctr, sizeBase + sizeAdjust + 1);
+      Assertions.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
+      Assertions.assertEquals(ctr, sizeBase + sizeAdjust + 1);
     }
   }
 
@@ -213,13 +214,13 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         buffer,
         buffer.order()
     ).get();
-    Assert.assertEquals(-1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("a")));
-    Assert.assertEquals(0, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
-    Assert.assertEquals(1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloo")));
-    Assert.assertEquals(-3, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloob")));
-    Assert.assertEquals(4, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozy")));
-    Assert.assertEquals(-6, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozz")));
-    Assert.assertEquals(-6, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("wat")));
+    Assertions.assertEquals(-1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("a")));
+    Assertions.assertEquals(0, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
+    Assertions.assertEquals(1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloo")));
+    Assertions.assertEquals(-3, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloob")));
+    Assertions.assertEquals(4, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozy")));
+    Assertions.assertEquals(-6, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozz")));
+    Assertions.assertEquals(-6, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("wat")));
   }
 
 
@@ -237,14 +238,14 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         buffer,
         buffer.order()
     ).get();
-    Assert.assertEquals(0, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer(null)));
-    Assert.assertEquals(-2, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("a")));
-    Assert.assertEquals(1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
-    Assert.assertEquals(2, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloo")));
-    Assert.assertEquals(-4, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloob")));
-    Assert.assertEquals(5, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozy")));
-    Assert.assertEquals(-7, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozz")));
-    Assert.assertEquals(-7, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("wat")));
+    Assertions.assertEquals(0, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer(null)));
+    Assertions.assertEquals(-2, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("a")));
+    Assertions.assertEquals(1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
+    Assertions.assertEquals(2, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloo")));
+    Assertions.assertEquals(-4, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloob")));
+    Assertions.assertEquals(5, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozy")));
+    Assertions.assertEquals(-7, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("helloozz")));
+    Assertions.assertEquals(-7, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("wat")));
   }
 
   @Test
@@ -268,13 +269,13 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
     while (newListIterator.hasNext() && utf8Iterator.hasNext()) {
       final String next = newListIterator.next();
       final ByteBuffer nextUtf8 = utf8Iterator.next();
-      Assert.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
+      Assertions.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
       nextUtf8.position(0);
-      Assert.assertEquals("mismatch row " + ctr, next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
-      Assert.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
+      Assertions.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)), "mismatch row " + ctr);
+      Assertions.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
       ctr++;
     }
-    Assert.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
+    Assertions.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
   }
 
   @Test
@@ -290,17 +291,17 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         buffer.order()
     ).get();
 
-    Assert.assertNull(codedUtf8Indexed.get(0));
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(-1));
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(theList.size()));
+    Assertions.assertNull(codedUtf8Indexed.get(0));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(-1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(theList.size()));
 
-    Assert.assertEquals(0, codedUtf8Indexed.indexOf(null));
-    Assert.assertEquals(-2, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
+    Assertions.assertEquals(0, codedUtf8Indexed.indexOf(null));
+    Assertions.assertEquals(-2, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
 
     Iterator<ByteBuffer> utf8Iterator = codedUtf8Indexed.iterator();
-    Assert.assertTrue(utf8Iterator.hasNext());
-    Assert.assertNull(utf8Iterator.next());
-    Assert.assertFalse(utf8Iterator.hasNext());
+    Assertions.assertTrue(utf8Iterator.hasNext());
+    Assertions.assertNull(utf8Iterator.next());
+    Assertions.assertFalse(utf8Iterator.hasNext());
   }
 
   @Test
@@ -316,17 +317,17 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         buffer.order()
     ).get();
 
-    Assert.assertEquals(0, codedUtf8Indexed.size());
-    Throwable t = Assert.assertThrows(IAE.class, () -> codedUtf8Indexed.get(0));
-    Assert.assertEquals("Index[0] >= size[0]", t.getMessage());
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(-1));
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(theList.size()));
+    Assertions.assertEquals(0, codedUtf8Indexed.size());
+    Throwable t = Assertions.assertThrows(IAE.class, () -> codedUtf8Indexed.get(0));
+    Assertions.assertEquals("Index[0] >= size[0]", t.getMessage());
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(-1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(theList.size()));
 
-    Assert.assertEquals(-1, codedUtf8Indexed.indexOf(null));
-    Assert.assertEquals(-1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
+    Assertions.assertEquals(-1, codedUtf8Indexed.indexOf(null));
+    Assertions.assertEquals(-1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
 
     Iterator<ByteBuffer> utf8Iterator = codedUtf8Indexed.iterator();
-    Assert.assertFalse(utf8Iterator.hasNext());
+    Assertions.assertFalse(utf8Iterator.hasNext());
   }
 
   @Test
@@ -364,17 +365,17 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         final String next = newListIterator.next();
         final ByteBuffer nextUtf8 = utf8Iterator.next();
         if (next == null) {
-          Assert.assertNull(nextUtf8);
+          Assertions.assertNull(nextUtf8);
         } else {
-          Assert.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
+          Assertions.assertEquals(next, StringUtils.fromUtf8(nextUtf8));
           nextUtf8.position(0);
-          Assert.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
+          Assertions.assertEquals(next, StringUtils.fromUtf8(codedUtf8Indexed.get(ctr)));
         }
-        Assert.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
+        Assertions.assertEquals(ctr, codedUtf8Indexed.indexOf(nextUtf8));
         ctr++;
       }
-      Assert.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
-      Assert.assertEquals(ctr, numValues + 1);
+      Assertions.assertEquals(newListIterator.hasNext(), utf8Iterator.hasNext());
+      Assertions.assertEquals(ctr, numValues + 1);
     }
   }
 
@@ -383,7 +384,7 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
   {
     OnHeapMemorySegmentWriteOutMedium medium = new OnHeapMemorySegmentWriteOutMedium();
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IAE.class,
         () -> new FrontCodedIndexedWriter(
             medium,
@@ -393,7 +394,7 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IAE.class,
         () -> new FrontCodedIndexedWriter(
             medium,
@@ -403,7 +404,7 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IAE.class,
         () -> new FrontCodedIndexedWriter(
             medium,
@@ -436,15 +437,15 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
     while (sortedStrings.hasNext()) {
       final String next = sortedStrings.next();
       final byte[] nextBytes = StringUtils.toUtf8Nullable(next);
-      Assert.assertEquals(index, writer.write(nextBytes));
+      Assertions.assertEquals(index, writer.write(nextBytes));
       if (nextBytes == null) {
-        Assert.assertNull(writer.get(index));
+        Assertions.assertNull(writer.get(index));
       } else {
-        Assert.assertArrayEquals(nextBytes, writer.get(index));
+        Assertions.assertArrayEquals(nextBytes, writer.get(index));
       }
       index++;
     }
-    Assert.assertEquals(index, writer.getCardinality());
+    Assertions.assertEquals(index, writer.getCardinality());
 
     // check 'get' again so that we aren't always reading from current page
     index = 0;
@@ -453,9 +454,9 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
       final String next = sortedStrings.next();
       final byte[] nextBytes = StringUtils.toUtf8Nullable(next);
       if (nextBytes == null) {
-        Assert.assertNull("row " + index, writer.get(index));
+        Assertions.assertNull(writer.get(index), "row " + index);
       } else {
-        Assert.assertArrayEquals("row " + index, nextBytes, writer.get(index));
+        Assertions.assertArrayEquals(nextBytes, writer.get(index), "row " + index);
       }
       index++;
     }
@@ -484,7 +485,7 @@ public class FrontCodedIndexedTest extends InitializedNullHandlingTest
     long size = writer.getSerializedSize();
     buffer.position(0);
     writer.writeTo(channel, null);
-    Assert.assertEquals(size, buffer.position());
+    Assertions.assertEquals(size, buffer.position());
     buffer.position(0);
     return size;
   }

--- a/processing/src/test/java/org/apache/druid/segment/data/FrontCodedIntArrayIndexedTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/FrontCodedIntArrayIndexedTest.java
@@ -20,14 +20,15 @@
 package org.apache.druid.segment.data;
 
 import com.google.common.collect.ImmutableList;
-import junitparams.converters.Nullable;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -41,10 +42,11 @@ import java.util.List;
 import java.util.TreeSet;
 import java.util.concurrent.ThreadLocalRandom;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class FrontCodedIntArrayIndexedTest
 {
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> constructorFeeder()
   {
     return ImmutableList.of(new Object[]{ByteOrder.LITTLE_ENDIAN}, new Object[]{ByteOrder.BIG_ENDIAN});
@@ -87,10 +89,10 @@ public class FrontCodedIntArrayIndexedTest
       final int[] next = indexedIterator.next();
       assertSame(ctr, expectedNext, next);
       assertSame(ctr, expectedNext, codedIndexed.get(ctr));
-      Assert.assertEquals("row " + ctr, ctr, codedIndexed.indexOf(next));
+      Assertions.assertEquals(ctr, codedIndexed.indexOf(next), "row " + ctr);
       ctr++;
     }
-    Assert.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
+    Assertions.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
   }
 
 
@@ -120,10 +122,10 @@ public class FrontCodedIntArrayIndexedTest
       final int[] next = indexedIterator.next();
       assertSame(ctr, expectedNext, next);
       assertSame(ctr, expectedNext, codedIndexed.get(ctr));
-      Assert.assertEquals(ctr, codedIndexed.indexOf(next));
+      Assertions.assertEquals(ctr, codedIndexed.indexOf(next));
       ctr++;
     }
-    Assert.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
+    Assertions.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
   }
 
   @Test
@@ -157,11 +159,11 @@ public class FrontCodedIntArrayIndexedTest
         final int[] next = indexedIterator.next();
         assertSame(ctr, expectedNext, next);
         assertSame(ctr, expectedNext, codedIndexed.get(ctr));
-        Assert.assertEquals(ctr, codedIndexed.indexOf(next));
+        Assertions.assertEquals(ctr, codedIndexed.indexOf(next));
         ctr++;
       }
-      Assert.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
-      Assert.assertEquals(ctr, sizeBase + sizeAdjust);
+      Assertions.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
+      Assertions.assertEquals(ctr, sizeBase + sizeAdjust);
     }
   }
 
@@ -197,11 +199,11 @@ public class FrontCodedIntArrayIndexedTest
         final int[] next = indexedIterator.next();
         assertSame(ctr, expectedNext, next);
         assertSame(ctr, expectedNext, codedIndexed.get(ctr));
-        Assert.assertEquals(ctr, codedIndexed.indexOf(next));
+        Assertions.assertEquals(ctr, codedIndexed.indexOf(next));
         ctr++;
       }
-      Assert.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
-      Assert.assertEquals(ctr, sizeBase + sizeAdjust + 1);
+      Assertions.assertEquals(expectedIterator.hasNext(), indexedIterator.hasNext());
+      Assertions.assertEquals(ctr, sizeBase + sizeAdjust + 1);
     }
   }
 
@@ -223,13 +225,13 @@ public class FrontCodedIntArrayIndexedTest
         buffer,
         buffer.order()
     ).get();
-    Assert.assertEquals(-1, codedIndexed.indexOf(new int[]{1}));
-    Assert.assertEquals(0, codedIndexed.indexOf(new int[]{1, 2}));
-    Assert.assertEquals(1, codedIndexed.indexOf(new int[]{1, 2, 1}));
-    Assert.assertEquals(-3, codedIndexed.indexOf(new int[]{1, 2, 2}));
-    Assert.assertEquals(4, codedIndexed.indexOf(new int[]{1, 3}));
-    Assert.assertEquals(-7, codedIndexed.indexOf(new int[]{1, 4, 4}));
-    Assert.assertEquals(-7, codedIndexed.indexOf(new int[]{9, 1, 1}));
+    Assertions.assertEquals(-1, codedIndexed.indexOf(new int[]{1}));
+    Assertions.assertEquals(0, codedIndexed.indexOf(new int[]{1, 2}));
+    Assertions.assertEquals(1, codedIndexed.indexOf(new int[]{1, 2, 1}));
+    Assertions.assertEquals(-3, codedIndexed.indexOf(new int[]{1, 2, 2}));
+    Assertions.assertEquals(4, codedIndexed.indexOf(new int[]{1, 3}));
+    Assertions.assertEquals(-7, codedIndexed.indexOf(new int[]{1, 4, 4}));
+    Assertions.assertEquals(-7, codedIndexed.indexOf(new int[]{9, 1, 1}));
   }
 
 
@@ -251,14 +253,14 @@ public class FrontCodedIntArrayIndexedTest
         buffer,
         buffer.order()
     ).get();
-    Assert.assertEquals(0, codedIndexed.indexOf(null));
-    Assert.assertEquals(-2, codedIndexed.indexOf(new int[]{1}));
-    Assert.assertEquals(1, codedIndexed.indexOf(new int[]{1, 2}));
-    Assert.assertEquals(2, codedIndexed.indexOf(new int[]{1, 2, 1}));
-    Assert.assertEquals(-4, codedIndexed.indexOf(new int[]{1, 2, 2}));
-    Assert.assertEquals(5, codedIndexed.indexOf(new int[]{1, 3}));
-    Assert.assertEquals(-8, codedIndexed.indexOf(new int[]{1, 4, 4}));
-    Assert.assertEquals(-8, codedIndexed.indexOf(new int[]{9, 1, 1}));
+    Assertions.assertEquals(0, codedIndexed.indexOf(null));
+    Assertions.assertEquals(-2, codedIndexed.indexOf(new int[]{1}));
+    Assertions.assertEquals(1, codedIndexed.indexOf(new int[]{1, 2}));
+    Assertions.assertEquals(2, codedIndexed.indexOf(new int[]{1, 2, 1}));
+    Assertions.assertEquals(-4, codedIndexed.indexOf(new int[]{1, 2, 2}));
+    Assertions.assertEquals(5, codedIndexed.indexOf(new int[]{1, 3}));
+    Assertions.assertEquals(-8, codedIndexed.indexOf(new int[]{1, 4, 4}));
+    Assertions.assertEquals(-8, codedIndexed.indexOf(new int[]{9, 1, 1}));
   }
 
 
@@ -275,17 +277,17 @@ public class FrontCodedIntArrayIndexedTest
         buffer.order()
     ).get();
 
-    Assert.assertNull(codedIndexed.get(0));
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedIndexed.get(-1));
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedIndexed.get(theList.size()));
+    Assertions.assertNull(codedIndexed.get(0));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedIndexed.get(-1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedIndexed.get(theList.size()));
 
-    Assert.assertEquals(0, codedIndexed.indexOf(null));
-    Assert.assertEquals(-2, codedIndexed.indexOf(new int[]{1, 2, 3, 4}));
+    Assertions.assertEquals(0, codedIndexed.indexOf(null));
+    Assertions.assertEquals(-2, codedIndexed.indexOf(new int[]{1, 2, 3, 4}));
 
     Iterator<int[]> iterator = codedIndexed.iterator();
-    Assert.assertTrue(iterator.hasNext());
-    Assert.assertNull(iterator.next());
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertTrue(iterator.hasNext());
+    Assertions.assertNull(iterator.next());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   @Test
@@ -301,17 +303,17 @@ public class FrontCodedIntArrayIndexedTest
         buffer.order()
     ).get();
 
-    Assert.assertEquals(0, codedUtf8Indexed.size());
-    Throwable t = Assert.assertThrows(IAE.class, () -> codedUtf8Indexed.get(0));
-    Assert.assertEquals("Index[0] >= size[0]", t.getMessage());
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(-1));
-    Assert.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(theList.size()));
+    Assertions.assertEquals(0, codedUtf8Indexed.size());
+    Throwable t = Assertions.assertThrows(IAE.class, () -> codedUtf8Indexed.get(0));
+    Assertions.assertEquals("Index[0] >= size[0]", t.getMessage());
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(-1));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> codedUtf8Indexed.get(theList.size()));
 
-    Assert.assertEquals(-1, codedUtf8Indexed.indexOf(null));
-    Assert.assertEquals(-1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
+    Assertions.assertEquals(-1, codedUtf8Indexed.indexOf(null));
+    Assertions.assertEquals(-1, codedUtf8Indexed.indexOf(StringUtils.toUtf8ByteBuffer("hello")));
 
     Iterator<ByteBuffer> utf8Iterator = codedUtf8Indexed.iterator();
-    Assert.assertFalse(utf8Iterator.hasNext());
+    Assertions.assertFalse(utf8Iterator.hasNext());
   }
 
   @Test
@@ -355,11 +357,11 @@ public class FrontCodedIntArrayIndexedTest
         final int[] next = iterator.next();
         assertSame(ctr, expectedNext, next);
         assertSame(ctr, expectedNext, codedIndexed.get(ctr));
-        Assert.assertEquals(ctr, codedIndexed.indexOf(next));
+        Assertions.assertEquals(ctr, codedIndexed.indexOf(next));
         ctr++;
       }
-      Assert.assertEquals(expectedIterator.hasNext(), iterator.hasNext());
-      Assert.assertEquals(ctr, numValues + 1);
+      Assertions.assertEquals(expectedIterator.hasNext(), iterator.hasNext());
+      Assertions.assertEquals(ctr, numValues + 1);
     }
   }
 
@@ -368,7 +370,7 @@ public class FrontCodedIntArrayIndexedTest
   {
     OnHeapMemorySegmentWriteOutMedium medium = new OnHeapMemorySegmentWriteOutMedium();
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IAE.class,
         () -> new FrontCodedIntArrayIndexedWriter(
             medium,
@@ -377,7 +379,7 @@ public class FrontCodedIntArrayIndexedTest
         )
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IAE.class,
         () -> new FrontCodedIntArrayIndexedWriter(
             medium,
@@ -386,7 +388,7 @@ public class FrontCodedIntArrayIndexedTest
         )
     );
 
-    Assert.assertThrows(
+    Assertions.assertThrows(
         IAE.class,
         () -> new FrontCodedIntArrayIndexedWriter(
             medium,
@@ -414,7 +416,7 @@ public class FrontCodedIntArrayIndexedTest
       assertSame(index, next, writer.get(index));
       index++;
     }
-    Assert.assertEquals(index, writer.getCardinality());
+    Assertions.assertEquals(index, writer.getCardinality());
 
     // check 'get' again so that we aren't always reading from current page
     index = 0;
@@ -448,7 +450,7 @@ public class FrontCodedIntArrayIndexedTest
     long size = writer.getSerializedSize();
     buffer.position(0);
     writer.writeTo(channel, null);
-    Assert.assertEquals(size, buffer.position());
+    Assertions.assertEquals(size, buffer.position());
     buffer.position(0);
     return size;
   }
@@ -456,12 +458,12 @@ public class FrontCodedIntArrayIndexedTest
   private static void assertSame(int index, @Nullable int[] expected, @Nullable int[] actual)
   {
     if (expected == null) {
-      Assert.assertNull("row " + index, actual);
+      Assertions.assertNull(actual, "row " + index);
     } else {
-      Assert.assertArrayEquals(
-          "row " + index + " expected: " + Arrays.toString(expected) + " actual: " + Arrays.toString(actual),
+      Assertions.assertArrayEquals(
           expected,
-          actual
+          actual,
+          "row " + index + " expected: " + Arrays.toString(expected) + " actual: " + Arrays.toString(actual)
       );
     }
   }

--- a/processing/src/test/java/org/apache/druid/segment/data/IncrementalIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/IncrementalIndexTest.java
@@ -60,7 +60,7 @@ import org.apache.druid.query.timeseries.TimeseriesQueryEngine;
 import org.apache.druid.query.timeseries.TimeseriesQueryQueryToolChest;
 import org.apache.druid.query.timeseries.TimeseriesQueryRunnerFactory;
 import org.apache.druid.query.timeseries.TimeseriesResultValue;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.segment.IncrementalIndexSegment;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.incremental.IncrementalIndex;
@@ -69,12 +69,11 @@ import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,16 +88,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IncrementalIndexTest extends InitializedNullHandlingTest
 {
   public final IncrementalIndexCreator indexCreator;
   private final boolean isPreserveExistingMetrics;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexTest(String indexType, String mode, boolean isPreserveExistingMetrics) throws JsonProcessingException
   {
@@ -111,7 +109,6 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     ));
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}, {1}, {2}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.indexTypeCartesianProduct(
@@ -229,20 +226,20 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     IncrementalIndex index = indexCreator.createIndex((Object) DEFAULT_AGGREGATOR_FACTORIES);
 
     populateIndex(timestamp, index);
-    Assert.assertEquals(Arrays.asList("__time", "dim1", "dim2"), index.getDimensionNames(true));
-    Assert.assertEquals(Arrays.asList("dim1", "dim2"), index.getDimensionNames(false));
-    Assert.assertEquals(2, index.numRows());
+    Assertions.assertEquals(Arrays.asList("__time", "dim1", "dim2"), index.getDimensionNames(true));
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2"), index.getDimensionNames(false));
+    Assertions.assertEquals(2, index.numRows());
 
     final Iterator<Row> rows = index.iterator();
     Row row = rows.next();
-    Assert.assertEquals(timestamp, row.getTimestampFromEpoch());
-    Assert.assertEquals(Collections.singletonList("1"), row.getDimension("dim1"));
-    Assert.assertEquals(Collections.singletonList("2"), row.getDimension("dim2"));
+    Assertions.assertEquals(timestamp, row.getTimestampFromEpoch());
+    Assertions.assertEquals(Collections.singletonList("1"), row.getDimension("dim1"));
+    Assertions.assertEquals(Collections.singletonList("2"), row.getDimension("dim2"));
 
     row = rows.next();
-    Assert.assertEquals(timestamp, row.getTimestampFromEpoch());
-    Assert.assertEquals(Collections.singletonList("3"), row.getDimension("dim1"));
-    Assert.assertEquals(Collections.singletonList("4"), row.getDimension("dim2"));
+    Assertions.assertEquals(timestamp, row.getTimestampFromEpoch());
+    Assertions.assertEquals(Collections.singletonList("3"), row.getDimension("dim1"));
+    Assertions.assertEquals(Collections.singletonList("4"), row.getDimension("dim2"));
   }
 
   @Test
@@ -285,9 +282,9 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(Arrays.asList("__time", "dim1", "dim2", "dim3"), index.getDimensionNames(true));
-    Assert.assertEquals(Arrays.asList("dim1", "dim2", "dim3"), index.getDimensionNames(false));
-    Assert.assertEquals(
+    Assertions.assertEquals(Arrays.asList("__time", "dim1", "dim2", "dim3"), index.getDimensionNames(true));
+    Assertions.assertEquals(Arrays.asList("dim1", "dim2", "dim3"), index.getDimensionNames(false));
+    Assertions.assertEquals(
         Arrays.asList(
             "count",
             "count_selector_filtered",
@@ -297,30 +294,30 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         ),
         index.getMetricNames()
     );
-    Assert.assertEquals(2, index.numRows());
+    Assertions.assertEquals(2, index.numRows());
 
     final Iterator<Row> rows = index.iterator();
     Row row = rows.next();
-    Assert.assertEquals(timestamp, row.getTimestampFromEpoch());
-    Assert.assertEquals(Collections.singletonList("1"), row.getDimension("dim1"));
-    Assert.assertEquals(Collections.singletonList("2"), row.getDimension("dim2"));
-    Assert.assertEquals(Arrays.asList("a", "b"), row.getDimension("dim3"));
-    Assert.assertEquals(1L, row.getMetric("count"));
-    Assert.assertEquals(1L, row.getMetric("count_selector_filtered"));
-    Assert.assertEquals(1L, row.getMetric("count_bound_filtered"));
-    Assert.assertEquals(1L, row.getMetric("count_multivaldim_filtered"));
-    Assert.assertEquals(0L, row.getMetric("count_numeric_filtered"));
+    Assertions.assertEquals(timestamp, row.getTimestampFromEpoch());
+    Assertions.assertEquals(Collections.singletonList("1"), row.getDimension("dim1"));
+    Assertions.assertEquals(Collections.singletonList("2"), row.getDimension("dim2"));
+    Assertions.assertEquals(Arrays.asList("a", "b"), row.getDimension("dim3"));
+    Assertions.assertEquals(1L, row.getMetric("count"));
+    Assertions.assertEquals(1L, row.getMetric("count_selector_filtered"));
+    Assertions.assertEquals(1L, row.getMetric("count_bound_filtered"));
+    Assertions.assertEquals(1L, row.getMetric("count_multivaldim_filtered"));
+    Assertions.assertEquals(0L, row.getMetric("count_numeric_filtered"));
 
     row = rows.next();
-    Assert.assertEquals(timestamp, row.getTimestampFromEpoch());
-    Assert.assertEquals(Collections.singletonList("3"), row.getDimension("dim1"));
-    Assert.assertEquals(Collections.singletonList("4"), row.getDimension("dim2"));
-    Assert.assertEquals(Arrays.asList("c", "d"), row.getDimension("dim3"));
-    Assert.assertEquals(1L, row.getMetric("count"));
-    Assert.assertEquals(0L, row.getMetric("count_selector_filtered"));
-    Assert.assertEquals(0L, row.getMetric("count_bound_filtered"));
-    Assert.assertEquals(0L, row.getMetric("count_multivaldim_filtered"));
-    Assert.assertEquals(1L, row.getMetric("count_numeric_filtered"));
+    Assertions.assertEquals(timestamp, row.getTimestampFromEpoch());
+    Assertions.assertEquals(Collections.singletonList("3"), row.getDimension("dim1"));
+    Assertions.assertEquals(Collections.singletonList("4"), row.getDimension("dim2"));
+    Assertions.assertEquals(Arrays.asList("c", "d"), row.getDimension("dim3"));
+    Assertions.assertEquals(1L, row.getMetric("count"));
+    Assertions.assertEquals(0L, row.getMetric("count_selector_filtered"));
+    Assertions.assertEquals(0L, row.getMetric("count_bound_filtered"));
+    Assertions.assertEquals(0L, row.getMetric("count_multivaldim_filtered"));
+    Assertions.assertEquals(1L, row.getMetric("count_numeric_filtered"));
   }
 
   @Test
@@ -403,22 +400,23 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     List<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query)).toList();
     Result<TimeseriesResultValue> result = Iterables.getOnlyElement(results);
     boolean isRollup = index.isRollup();
-    Assert.assertEquals(rows * (isRollup ? 1 : 2), result.getValue().getLongMetric("rows").intValue());
+    Assertions.assertEquals(rows * (isRollup ? 1 : 2), result.getValue().getLongMetric("rows").intValue());
     for (int i = 0; i < dimensionCount; ++i) {
-      Assert.assertEquals(
-          "Failed long sum on dimension " + i,
+      Assertions.assertEquals(
           2 * rows,
-          result.getValue().getLongMetric("sumResult" + i).intValue()
+          result.getValue().getLongMetric("sumResult" + i).intValue(),
+          "Failed long sum on dimension " + i
       );
-      Assert.assertEquals(
-          "Failed double sum on dimension " + i,
+      Assertions.assertEquals(
           2 * rows,
-          result.getValue().getDoubleMetric("doubleSumResult" + i).intValue()
+          result.getValue().getDoubleMetric("doubleSumResult" + i).intValue(),
+          "Failed double sum on dimension " + i
       );
     }
   }
 
-  @Test(timeout = 60_000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 60_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testConcurrentAddRead() throws InterruptedException, ExecutionException
   {
     final int dimensionCount = 5;
@@ -573,9 +571,9 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
                       if (maxValueExpected > 0) {
                         // Eventually consistent, but should be somewhere in that range
                         // Actual result is validated after all writes are guaranteed done.
-                        Assert.assertTrue(
-                            StringUtils.format("%d >= %g >= 0 violated", maxValueExpected, result),
-                            result >= 0 && result <= maxValueExpected
+                        Assertions.assertTrue(
+                            result >= 0 && result <= maxValueExpected,
+                            StringUtils.format("%d >= %g >= 0 violated", maxValueExpected, result)
                         );
                       }
                     }
@@ -591,8 +589,8 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     allFutures.addAll(queryFutures);
     allFutures.addAll(indexFutures);
     Futures.allAsList(allFutures).get();
-    Assert.assertTrue("Queries ran too fast", queriesAccumualted.get() > 0);
-    Assert.assertTrue("Did not hit concurrency, please try again", concurrentlyRan.get() > 0);
+    Assertions.assertTrue(queriesAccumualted.get() > 0, "Queries ran too fast");
+    Assertions.assertTrue(concurrentlyRan.get() > 0, "Did not hit concurrency, please try again");
     queryExecutor.shutdown();
     indexExecutor.shutdown();
     QueryRunner<Result<TimeseriesResultValue>> runner = new FinalizeResultsQueryRunner<Result<TimeseriesResultValue>>(
@@ -608,20 +606,20 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     List<Result<TimeseriesResultValue>> results = runner.run(QueryPlus.wrap(query)).toList();
     boolean isRollup = index.isRollup();
     for (Result<TimeseriesResultValue> result : results) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           elementsPerThread * (isRollup ? 1 : addThreads),
           result.getValue().getLongMetric("rows").intValue()
       );
       for (int i = 0; i < dimensionCount; ++i) {
-        Assert.assertEquals(
-            StringUtils.format("Failed long sum on dimension %d", i),
+        Assertions.assertEquals(
             elementsPerThread * addThreads,
-            result.getValue().getLongMetric(StringUtils.format("sumResult%s", i)).intValue()
+            result.getValue().getLongMetric(StringUtils.format("sumResult%s", i)).intValue(),
+            StringUtils.format("Failed long sum on dimension %d", i)
         );
-        Assert.assertEquals(
-            StringUtils.format("Failed double sum on dimension %d", i),
+        Assertions.assertEquals(
             elementsPerThread * addThreads,
-            result.getValue().getDoubleMetric(StringUtils.format("doubleSumResult%s", i)).intValue()
+            result.getValue().getDoubleMetric(StringUtils.format("doubleSumResult%s", i)).intValue(),
+            StringUtils.format("Failed double sum on dimension %d", i)
         );
       }
     }
@@ -644,8 +642,8 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
             .build()
     );
 
-    Assert.assertEquals(Arrays.asList("__time", "dim0", "dim1"), incrementalIndex.getDimensionNames(true));
-    Assert.assertEquals(Arrays.asList("dim0", "dim1"), incrementalIndex.getDimensionNames(false));
+    Assertions.assertEquals(Arrays.asList("__time", "dim0", "dim1"), incrementalIndex.getDimensionNames(true));
+    Assertions.assertEquals(Arrays.asList("dim0", "dim1"), incrementalIndex.getDimensionNames(false));
   }
 
   @Test
@@ -680,7 +678,7 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(2, index.numRows());
+    Assertions.assertEquals(2, index.numRows());
   }
 
   @Test
@@ -720,29 +718,29 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(index.isRollup() ? 1 : 4, index.numRows());
+    Assertions.assertEquals(index.isRollup() ? 1 : 4, index.numRows());
     Iterator<Row> iterator = index.iterator();
     int rowCount = 0;
     while (iterator.hasNext()) {
       rowCount++;
       Row row = iterator.next();
-      Assert.assertEquals(1481871600000L, row.getTimestampFromEpoch());
+      Assertions.assertEquals(1481871600000L, row.getTimestampFromEpoch());
       if (index.isRollup()) {
         // All rows are rollup into one row
-        Assert.assertEquals(isPreserveExistingMetrics ? 7 : 4, row.getMetric("count").intValue());
-        Assert.assertEquals(isPreserveExistingMetrics ? 14 : 5, row.getMetric("sum_of_x").intValue());
+        Assertions.assertEquals(isPreserveExistingMetrics ? 7 : 4, row.getMetric("count").intValue());
+        Assertions.assertEquals(isPreserveExistingMetrics ? 14 : 5, row.getMetric("sum_of_x").intValue());
       } else {
         // We still have 4 rows
         if (rowCount == 1 || rowCount == 2) {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
         } else {
           if (isPreserveExistingMetrics) {
-            Assert.assertEquals(rowCount - 1, row.getMetric("count").intValue());
-            Assert.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
+            Assertions.assertEquals(rowCount - 1, row.getMetric("count").intValue());
+            Assertions.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
           } else {
-            Assert.assertEquals(1, row.getMetric("count").intValue());
-            Assert.assertNull(row.getMetric("sum_of_x"));
+            Assertions.assertEquals(1, row.getMetric("count").intValue());
+            Assertions.assertNull(row.getMetric("sum_of_x"));
           }
         }
       }
@@ -787,29 +785,29 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(index.isRollup() ? 1 : 4, index.numRows());
+    Assertions.assertEquals(index.isRollup() ? 1 : 4, index.numRows());
     Iterator<Row> iterator = index.iterator();
     int rowCount = 0;
     while (iterator.hasNext()) {
       rowCount++;
       Row row = iterator.next();
-      Assert.assertEquals(1481871600000L, row.getTimestampFromEpoch());
+      Assertions.assertEquals(1481871600000L, row.getTimestampFromEpoch());
       if (index.isRollup()) {
         // All rows are rollup into one row
-        Assert.assertEquals(isPreserveExistingMetrics ? 7 : 4, row.getMetric("count").intValue());
-        Assert.assertEquals(isPreserveExistingMetrics ? 14 : 5, row.getMetric("sum_of_x").intValue());
+        Assertions.assertEquals(isPreserveExistingMetrics ? 7 : 4, row.getMetric("count").intValue());
+        Assertions.assertEquals(isPreserveExistingMetrics ? 14 : 5, row.getMetric("sum_of_x").intValue());
       } else {
         // We still have 4 rows
         if (rowCount == 1 || rowCount == 2) {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
         } else {
           if (isPreserveExistingMetrics) {
-            Assert.assertEquals(rowCount - 1, row.getMetric("count").intValue());
-            Assert.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
+            Assertions.assertEquals(rowCount - 1, row.getMetric("count").intValue());
+            Assertions.assertEquals(1 + rowCount, row.getMetric("sum_of_x").intValue());
           } else {
-            Assert.assertEquals(1, row.getMetric("count").intValue());
-            Assert.assertNull(row.getMetric("sum_of_x"));
+            Assertions.assertEquals(1, row.getMetric("count").intValue());
+            Assertions.assertNull(row.getMetric("sum_of_x"));
           }
         }
       }
@@ -839,30 +837,30 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
+    Assertions.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
     Iterator<Row> iterator = index.iterator();
     int rowCount = 0;
     while (iterator.hasNext()) {
       rowCount++;
       Row row = iterator.next();
-      Assert.assertEquals(1481871600000L, row.getTimestampFromEpoch());
+      Assertions.assertEquals(1481871600000L, row.getTimestampFromEpoch());
       if (index.isRollup()) {
         // All rows are rollup into one row
-        Assert.assertEquals(isPreserveExistingMetrics ? 5 : 2, row.getMetric("count").intValue());
-        Assert.assertEquals(isPreserveExistingMetrics ? 9 : 3, row.getMetric("sum_of_x").intValue());
+        Assertions.assertEquals(isPreserveExistingMetrics ? 5 : 2, row.getMetric("count").intValue());
+        Assertions.assertEquals(isPreserveExistingMetrics ? 9 : 3, row.getMetric("sum_of_x").intValue());
       } else {
         // We still have 2 rows
         if (rowCount == 1) {
           if (isPreserveExistingMetrics) {
-            Assert.assertEquals(2, row.getMetric("count").intValue());
-            Assert.assertEquals(4, row.getMetric("sum_of_x").intValue());
+            Assertions.assertEquals(2, row.getMetric("count").intValue());
+            Assertions.assertEquals(4, row.getMetric("sum_of_x").intValue());
           } else {
-            Assert.assertEquals(1, row.getMetric("count").intValue());
-            Assert.assertNull(row.getMetric("sum_of_x"));
+            Assertions.assertEquals(1, row.getMetric("count").intValue());
+            Assertions.assertNull(row.getMetric("sum_of_x"));
           }
         } else {
-          Assert.assertEquals(isPreserveExistingMetrics ? 3 : 1, row.getMetric("count").intValue());
-          Assert.assertEquals(isPreserveExistingMetrics ? 5 : 3, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(isPreserveExistingMetrics ? 3 : 1, row.getMetric("count").intValue());
+          Assertions.assertEquals(isPreserveExistingMetrics ? 5 : 3, row.getMetric("sum_of_x").intValue());
         }
       }
     }
@@ -891,25 +889,25 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
+    Assertions.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
     Iterator<Row> iterator = index.iterator();
     int rowCount = 0;
     while (iterator.hasNext()) {
       rowCount++;
       Row row = iterator.next();
-      Assert.assertEquals(1481871600000L, row.getTimestampFromEpoch());
+      Assertions.assertEquals(1481871600000L, row.getTimestampFromEpoch());
       if (index.isRollup()) {
         // All rows are rollup into one row
-        Assert.assertEquals(2, row.getMetric("count").intValue());
-        Assert.assertEquals(7, row.getMetric("sum_of_x").intValue());
+        Assertions.assertEquals(2, row.getMetric("count").intValue());
+        Assertions.assertEquals(7, row.getMetric("sum_of_x").intValue());
       } else {
         // We still have 2 rows
         if (rowCount == 1) {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertEquals(4, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertEquals(4, row.getMetric("sum_of_x").intValue());
         } else {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertEquals(3, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertEquals(3, row.getMetric("sum_of_x").intValue());
         }
       }
     }
@@ -918,48 +916,51 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
   @Test
   public void testSchemaRollupWithRowWithMixedTypeMetrics()
   {
-    if (isPreserveExistingMetrics) {
-      expectedException.expect(ParseException.class);
-    }
     AggregatorFactory[] aggregatorFactories = new AggregatorFactory[]{
         new CountAggregatorFactory("count"),
         new LongSumAggregatorFactory("sum_of_x", "x")
     };
     final IncrementalIndex index = indexCreator.createIndex((Object) aggregatorFactories);
-    index.add(
-        new MapBasedInputRow(
-            1481871600000L,
-            Arrays.asList("name", "host"),
-            ImmutableMap.of("name", "name1", "host", "host", "count", "not a number 1", "sum_of_x", 4)
-        )
+    final MapBasedInputRow firstRow = new MapBasedInputRow(
+        1481871600000L,
+        Arrays.asList("name", "host"),
+        ImmutableMap.of("name", "name1", "host", "host", "count", "not a number 1", "sum_of_x", 4)
     );
-    index.add(
-        new MapBasedInputRow(
-            1481871600000L,
-            Arrays.asList("name", "host"),
-            ImmutableMap.of("name", "name1", "host", "host", "count", 3, "x", 3, "sum_of_x", "not a number 2")
-        )
+    final MapBasedInputRow secondRow = new MapBasedInputRow(
+        1481871600000L,
+        Arrays.asList("name", "host"),
+        ImmutableMap.of("name", "name1", "host", "host", "count", 3, "x", 3, "sum_of_x", "not a number 2")
     );
 
-    Assert.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
+    if (isPreserveExistingMetrics) {
+      Assertions.assertThrows(ParseException.class, () -> {
+        index.add(firstRow);
+        index.add(secondRow);
+      });
+      return;
+    }
+    index.add(firstRow);
+    index.add(secondRow);
+
+    Assertions.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
     Iterator<Row> iterator = index.iterator();
     int rowCount = 0;
     while (iterator.hasNext()) {
       rowCount++;
       Row row = iterator.next();
-      Assert.assertEquals(1481871600000L, row.getTimestampFromEpoch());
+      Assertions.assertEquals(1481871600000L, row.getTimestampFromEpoch());
       if (index.isRollup()) {
         // All rows are rollup into one row
-        Assert.assertEquals(2, row.getMetric("count").intValue());
-        Assert.assertEquals(3, row.getMetric("sum_of_x").intValue());
+        Assertions.assertEquals(2, row.getMetric("count").intValue());
+        Assertions.assertEquals(3, row.getMetric("sum_of_x").intValue());
       } else {
         // We still have 2 rows
         if (rowCount == 1) {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertNull(row.getMetric("sum_of_x"));
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertNull(row.getMetric("sum_of_x"));
         } else {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertEquals(3, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertEquals(3, row.getMetric("sum_of_x").intValue());
         }
       }
     }
@@ -988,25 +989,25 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
+    Assertions.assertEquals(index.isRollup() ? 1 : 2, index.numRows());
     Iterator<Row> iterator = index.iterator();
     int rowCount = 0;
     while (iterator.hasNext()) {
       rowCount++;
       Row row = iterator.next();
-      Assert.assertEquals(1481871600000L, row.getTimestampFromEpoch());
+      Assertions.assertEquals(1481871600000L, row.getTimestampFromEpoch());
       if (index.isRollup()) {
         // All rows are rollup into one row
-        Assert.assertEquals(2, row.getMetric("count").intValue());
-        Assert.assertEquals(isPreserveExistingMetrics ? 200 : 7, row.getMetric("sum_of_x").intValue());
+        Assertions.assertEquals(2, row.getMetric("count").intValue());
+        Assertions.assertEquals(isPreserveExistingMetrics ? 200 : 7, row.getMetric("sum_of_x").intValue());
       } else {
         // We still have 2 rows
         if (rowCount == 1) {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertEquals(isPreserveExistingMetrics ? 100 : 4, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertEquals(isPreserveExistingMetrics ? 100 : 4, row.getMetric("sum_of_x").intValue());
         } else {
-          Assert.assertEquals(1, row.getMetric("count").intValue());
-          Assert.assertEquals(isPreserveExistingMetrics ? 100 : 3, row.getMetric("sum_of_x").intValue());
+          Assertions.assertEquals(1, row.getMetric("count").intValue());
+          Assertions.assertEquals(isPreserveExistingMetrics ? 100 : 3, row.getMetric("sum_of_x").intValue());
         }
       }
     }

--- a/processing/src/test/java/org/apache/druid/segment/data/IndexedIntsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/IndexedIntsTest.java
@@ -19,24 +19,24 @@
 
 package org.apache.druid.segment.data;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IndexedIntsTest
 {
   private static final int[] ARRAY = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
   private final IndexedInts indexed;
 
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder()
   {
     return Arrays.asList(
@@ -57,9 +57,9 @@ public class IndexedIntsTest
   @Test
   public void testSanity()
   {
-    Assert.assertEquals(ARRAY.length, indexed.size());
+    Assertions.assertEquals(ARRAY.length, indexed.size());
     for (int i = 0; i < ARRAY.length; i++) {
-      Assert.assertEquals(ARRAY[i], indexed.get(i));
+      Assertions.assertEquals(ARRAY[i], indexed.get(i));
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/TestColumnCompression.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/TestColumnCompression.java
@@ -23,11 +23,11 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import org.apache.druid.java.util.common.ByteBufferUtils;
 import org.apache.druid.java.util.common.io.Closer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -41,7 +41,9 @@ import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("compressionStrategies")
 public class TestColumnCompression
 {
 
@@ -58,7 +60,6 @@ public class TestColumnCompression
     compressionType = strategy;
   }
 
-  @Parameterized.Parameters
   public static Iterable<Object[]> compressionStrategies()
   {
     return Arrays.stream(CompressionStrategy.values())
@@ -66,7 +67,7 @@ public class TestColumnCompression
                  .map(strategy -> new Object[]{strategy}).collect(Collectors.toList());
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception
   {
     Random rand = ThreadLocalRandom.current();
@@ -107,7 +108,7 @@ public class TestColumnCompression
     }
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException
   {
     ByteBufferUtils.free(buffer);

--- a/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/V3CompressedVSizeColumnarMultiIntsSerializerTest.java
@@ -34,18 +34,17 @@ import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.SegmentWriteOutMedium;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.WriteOutBytes;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.CloseableUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,7 +57,9 @@ import java.util.Random;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("compressionStrategiesAndByteOrders")
 public class V3CompressedVSizeColumnarMultiIntsSerializerTest
 {
   private static final String TEST_COLUMN_NAME = "test";
@@ -74,11 +75,8 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
   private final Random rand = new Random(0);
   private List<int[]> vals;
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   public V3CompressedVSizeColumnarMultiIntsSerializerTest(
       CompressionStrategy compressionStrategy,
@@ -89,7 +87,6 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
     this.byteOrder = byteOrder;
   }
 
-  @Parameterized.Parameters(name = "{index}: compression={0}, byteOrder={1}")
   public static Iterable<Object[]> compressionStrategiesAndByteOrders()
   {
     Set<List<Object>> combinations = Sets.cartesianProduct(
@@ -103,7 +100,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
     );
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     vals = null;
@@ -209,25 +206,29 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       );
 
       try (final ColumnarMultiInts column = columnSupplier.get()) {
-        Assert.assertEquals(numRows, column.size());
+        Assertions.assertEquals(numRows, column.size());
       }
     }
   }
 
   // this test takes ~30 minutes to run
-  @Ignore
+  @Disabled
   @Test
   public void testTooManyValues() throws Exception
   {
-    expectedException.expect(ColumnCapacityExceededException.class);
-    expectedException.expectMessage(ColumnCapacityExceededException.formatMessage("test"));
-    // more than one chunk
-    final int offsetChunk = CompressedColumnarIntsSupplier.MAX_INTS_IN_BUFFER;
-    final int maxValue = 0x0FFFFFFF;
-    final int valueChunk = CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForValue(maxValue);
-    final int numRows = 10000000;
-    final int maxValuesPerRow = 1000;
-    generateV2SerializedSizeAndData(numRows, maxValue, maxValuesPerRow, offsetChunk, valueChunk);
+    final ColumnCapacityExceededException exception = Assertions.assertThrows(
+        ColumnCapacityExceededException.class,
+        () -> {
+          // more than one chunk
+          final int offsetChunk = CompressedColumnarIntsSupplier.MAX_INTS_IN_BUFFER;
+          final int maxValue = 0x0FFFFFFF;
+          final int valueChunk = CompressedVSizeColumnarIntsSupplier.maxIntsInBufferForValue(maxValue);
+          final int numRows = 10000000;
+          final int maxValuesPerRow = 1000;
+          generateV2SerializedSizeAndData(numRows, maxValue, maxValuesPerRow, offsetChunk, valueChunk);
+        }
+    );
+    Assertions.assertEquals(ColumnCapacityExceededException.formatMessage("test"), exception.getMessage());
   }
 
   private void generateVals(final int rowCount, final int maxValue, final int numValuesPerRow)
@@ -304,7 +305,7 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       writer.writeTo(writeOutBytes, smoosher);
       smoosher.close();
 
-      Assert.assertEquals(writtenLength, supplierFromIterable.getSerializedSize());
+      Assertions.assertEquals(writtenLength, supplierFromIterable.getSerializedSize());
 
       // read from ByteBuffer and check values
       V3CompressedVSizeColumnarMultiIntsSupplier supplierFromByteBuffer = V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(
@@ -314,12 +315,12 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       );
 
       try (final ColumnarMultiInts columnarMultiInts = supplierFromByteBuffer.get()) {
-        Assert.assertEquals(columnarMultiInts.size(), vals.size());
+        Assertions.assertEquals(columnarMultiInts.size(), vals.size());
         for (int i = 0; i < vals.size(); ++i) {
           IndexedInts subVals = columnarMultiInts.get(i);
-          Assert.assertEquals(subVals.size(), vals.get(i).length);
+          Assertions.assertEquals(subVals.size(), vals.get(i).length);
           for (int j = 0, size = subVals.size(); j < size; ++j) {
-            Assert.assertEquals(subVals.get(j), vals.get(i)[j]);
+            Assertions.assertEquals(subVals.get(j), vals.get(i)[j]);
           }
         }
       }
@@ -386,12 +387,12 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       V3CompressedVSizeColumnarMultiIntsSupplier supplierFromByteBuffer =
           V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(mapper.mapFile("test"), byteOrder, null);
       ColumnarMultiInts columnarMultiInts = supplierFromByteBuffer.get();
-      Assert.assertEquals(columnarMultiInts.size(), vals.size());
+      Assertions.assertEquals(columnarMultiInts.size(), vals.size());
       for (int i = 0; i < vals.size(); ++i) {
         IndexedInts subVals = columnarMultiInts.get(i);
-        Assert.assertEquals(subVals.size(), vals.get(i).length);
+        Assertions.assertEquals(subVals.size(), vals.get(i).length);
         for (int j = 0, size = subVals.size(); j < size; ++j) {
-          Assert.assertEquals(subVals.get(j), vals.get(i)[j]);
+          Assertions.assertEquals(subVals.get(j), vals.get(i)[j]);
         }
       }
       CloseableUtils.closeAll(columnarMultiInts, mapper);
@@ -466,14 +467,14 @@ public class V3CompressedVSizeColumnarMultiIntsSerializerTest
       V3CompressedVSizeColumnarMultiIntsSupplier supplierFromByteBuffer =
           V3CompressedVSizeColumnarMultiIntsSupplier.fromByteBuffer(mapper.mapFile("test"), byteOrder, mapper);
       ColumnarMultiInts columnarMultiInts = supplierFromByteBuffer.get();
-      Assert.assertEquals(columnarMultiInts.size(), numRows);
+      Assertions.assertEquals(columnarMultiInts.size(), numRows);
       Random verifier = new Random(0);
       for (int i = 0; i < numRows; ++i) {
         IndexedInts subVals = columnarMultiInts.get(i);
         int[] expected = generateRow(verifier, maxValue, maxValuesPerRow);
-        Assert.assertEquals(subVals.size(), expected.length);
+        Assertions.assertEquals(subVals.size(), expected.length);
         for (int j = 0, size = subVals.size(); j < size; ++j) {
-          Assert.assertEquals(subVals.get(j), expected[j]);
+          Assertions.assertEquals(subVals.get(j), expected[j]);
         }
       }
       CloseableUtils.closeAll(columnarMultiInts, mapper);

--- a/processing/src/test/java/org/apache/druid/segment/data/VByteTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/VByteTest.java
@@ -20,19 +20,20 @@
 package org.apache.druid.segment.data;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Collection;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class VByteTest
 {
-  @Parameterized.Parameters(name = "{0}")
   public static Collection<Object[]> constructorFeeder()
   {
     return ImmutableList.of(new Object[]{ByteOrder.LITTLE_ENDIAN}, new Object[]{ByteOrder.BIG_ENDIAN});
@@ -64,12 +65,12 @@ public class VByteTest
 
   private static void roundTrip(ByteBuffer buffer, int position, int value, int expectedSize)
   {
-    Assert.assertEquals(expectedSize, VByte.computeIntSize(value));
+    Assertions.assertEquals(expectedSize, VByte.computeIntSize(value));
     buffer.position(position);
     VByte.writeInt(buffer, value);
-    Assert.assertEquals(expectedSize, buffer.position() - position);
+    Assertions.assertEquals(expectedSize, buffer.position() - position);
     buffer.position(position);
-    Assert.assertEquals(value, VByte.readInt(buffer));
-    Assert.assertEquals(expectedSize, buffer.position() - position);
+    Assertions.assertEquals(value, VByte.readInt(buffer));
+    Assertions.assertEquals(expectedSize, buffer.position() - position);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/data/VSizeLongSerdeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/data/VSizeLongSerdeTest.java
@@ -22,10 +22,10 @@ package org.apache.druid.segment.data;
 
 import com.google.common.primitives.Ints;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -36,7 +36,8 @@ import java.util.stream.Collectors;
 
 public class VSizeLongSerdeTest
 {
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("data")
   public static class EveryLittleBitTest
   {
     private final int numBits;
@@ -46,7 +47,6 @@ public class VSizeLongSerdeTest
       this.numBits = numBits;
     }
 
-    @Parameterized.Parameters(name = "numBits={0}")
     public static Collection<Object[]> data()
     {
       return Arrays.stream(VSizeLongSerde.SUPPORTED_SIZES)
@@ -98,15 +98,15 @@ public class VSizeLongSerdeTest
     @Test
     public void testGetBitsForMax()
     {
-      Assert.assertEquals(1, VSizeLongSerde.getBitsForMax(1));
-      Assert.assertEquals(1, VSizeLongSerde.getBitsForMax(2));
-      Assert.assertEquals(2, VSizeLongSerde.getBitsForMax(3));
-      Assert.assertEquals(4, VSizeLongSerde.getBitsForMax(16));
-      Assert.assertEquals(8, VSizeLongSerde.getBitsForMax(200));
-      Assert.assertEquals(12, VSizeLongSerde.getBitsForMax(999));
-      Assert.assertEquals(24, VSizeLongSerde.getBitsForMax(12345678));
-      Assert.assertEquals(32, VSizeLongSerde.getBitsForMax(Integer.MAX_VALUE));
-      Assert.assertEquals(64, VSizeLongSerde.getBitsForMax(Long.MAX_VALUE));
+      Assertions.assertEquals(1, VSizeLongSerde.getBitsForMax(1));
+      Assertions.assertEquals(1, VSizeLongSerde.getBitsForMax(2));
+      Assertions.assertEquals(2, VSizeLongSerde.getBitsForMax(3));
+      Assertions.assertEquals(4, VSizeLongSerde.getBitsForMax(16));
+      Assertions.assertEquals(8, VSizeLongSerde.getBitsForMax(200));
+      Assertions.assertEquals(12, VSizeLongSerde.getBitsForMax(999));
+      Assertions.assertEquals(24, VSizeLongSerde.getBitsForMax(12345678));
+      Assertions.assertEquals(32, VSizeLongSerde.getBitsForMax(Integer.MAX_VALUE));
+      Assertions.assertEquals(64, VSizeLongSerde.getBitsForMax(Long.MAX_VALUE));
     }
 
     @Test
@@ -182,22 +182,22 @@ public class VSizeLongSerdeTest
 
     // Verify serialized sizes.
     final ByteBuffer bufferFromStream = ByteBuffer.wrap(outStream.toByteArray());
-    Assert.assertEquals(
-        StringUtils.format("Serialized size (stream, numBits = %d)", numBits),
+    Assertions.assertEquals(
         VSizeLongSerde.getSerializedSize(numBits, values.length),
-        bufferFromStream.capacity() - bufferOffset
+        bufferFromStream.capacity() - bufferOffset,
+        StringUtils.format("Serialized size (stream, numBits = %d)", numBits)
     );
-    Assert.assertEquals(
-        StringUtils.format("Serialized size (buffer, numBits = %d)", numBits),
+    Assertions.assertEquals(
         VSizeLongSerde.getSerializedSize(numBits, values.length),
-        buffer.position() - bufferOffset
+        buffer.position() - bufferOffset,
+        StringUtils.format("Serialized size (buffer, numBits = %d)", numBits)
     );
 
     // Verify the actual serialized contents.
-    Assert.assertArrayEquals(
-        StringUtils.format("Stream and buffer serialized images are equal (numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         bufferFromStream.array(),
-        buffer.array()
+        buffer.array(),
+        StringUtils.format("Stream and buffer serialized images are equal (numBits = %d)", numBits)
     );
 
     // Verify deserialization. We know the two serialized buffers are equal, so from this point on, just use one.
@@ -218,10 +218,10 @@ public class VSizeLongSerdeTest
   )
   {
     for (int i = 0; i < values.length; i++) {
-      Assert.assertEquals(
-          StringUtils.format("Deserializer (testGetSingleRow, numBits = %d, position = %d)", numBits, i),
+      Assertions.assertEquals(
           values[i],
-          deserializer.get(i)
+          deserializer.get(i),
+          StringUtils.format("Deserializer (testGetSingleRow, numBits = %d, position = %d)", numBits, i)
       );
     }
   }
@@ -240,26 +240,26 @@ public class VSizeLongSerdeTest
       Arrays.fill(out, -1);
       deserializer.getDelta(out, outPosition, i, 1, 0);
 
-      Assert.assertEquals(
-          StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+      Assertions.assertEquals(
           values[i],
-          out[outPosition]
+          out[outPosition],
+          StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i)
       );
 
       int delta = 100_000;
       deserializer.getDelta(out, outPosition, i, 1, delta);
-      Assert.assertEquals(
-          StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+      Assertions.assertEquals(
           values[i] + delta,
-          out[outPosition]
+          out[outPosition],
+          StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i)
       );
 
       deserializer.getDelta(out, outPosition, i, 1, -delta);
 
-      Assert.assertEquals(
-          StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+      Assertions.assertEquals(
           values[i] - delta,
-          out[outPosition]
+          out[outPosition],
+          StringUtils.format("Deserializer (testContiguousGetSingleRow, numBits = %d, position = %d)", numBits, i)
       );
     }
   }
@@ -275,10 +275,10 @@ public class VSizeLongSerdeTest
     Arrays.fill(out, -1);
     deserializer.getDelta(out, outPosition, 0, values.length, 0);
 
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         values,
-        Arrays.stream(out).skip(outPosition).toArray()
+        Arrays.stream(out).skip(outPosition).toArray(),
+        StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits)
     );
 
     final long[] valuesPlus = new long[values.length];
@@ -289,17 +289,17 @@ public class VSizeLongSerdeTest
       valuesMinus[i] = values[i] - delta;
     }
     deserializer.getDelta(out, outPosition, 0, values.length, delta);
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         valuesPlus,
-        Arrays.stream(out).skip(outPosition).toArray()
+        Arrays.stream(out).skip(outPosition).toArray(),
+        StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits)
     );
 
     deserializer.getDelta(out, outPosition, 0, values.length, -delta);
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         valuesMinus,
-        Arrays.stream(out).skip(outPosition).toArray()
+        Arrays.stream(out).skip(outPosition).toArray(),
+        StringUtils.format("Deserializer (testContiguousGetWholeRegion, numBits = %d)", numBits)
     );
   }
 
@@ -321,27 +321,27 @@ public class VSizeLongSerdeTest
 
       deserializer.getDelta(out, outPosition, indexes, 1, indexOffset, values.length, 0);
 
-      Assert.assertEquals(
-          StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+      Assertions.assertEquals(
           values[i],
-          out[outPosition]
+          out[outPosition],
+          StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i)
       );
 
       int delta = 100_000;
       deserializer.getDelta(out, outPosition, indexes, 1, indexOffset, values.length, delta);
 
-      Assert.assertEquals(
-          StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+      Assertions.assertEquals(
           values[i] + delta,
-          out[outPosition]
+          out[outPosition],
+          StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i)
       );
 
       deserializer.getDelta(out, outPosition, indexes, 1, indexOffset, values.length, -delta);
 
-      Assert.assertEquals(
-          StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i),
+      Assertions.assertEquals(
           values[i] - delta,
-          out[outPosition]
+          out[outPosition],
+          StringUtils.format("Deserializer (testNoncontiguousGetSingleRow, numBits = %d, position = %d)", numBits, i)
       );
     }
   }
@@ -380,26 +380,26 @@ public class VSizeLongSerdeTest
 
     deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, values.length, 0);
 
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         expectedOut,
-        out
+        out,
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits)
     );
 
     deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, values.length, delta);
 
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         expectedOutDeltaPlus,
-        out
+        out,
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits)
     );
 
     deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, values.length, -delta);
 
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         expectedOutDeltaMinus,
-        out
+        out,
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits)
     );
   }
 
@@ -442,32 +442,32 @@ public class VSizeLongSerdeTest
 
     int ret = deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, limit, 0);
 
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         expectedOut,
-        out
+        out,
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits)
     );
 
-    Assert.assertEquals(Math.max(0, cnt - 1), ret);
+    Assertions.assertEquals(Math.max(0, cnt - 1), ret);
 
     ret = deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, limit, delta);
 
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         expectedOutDeltaPlus,
-        out
+        out,
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits)
     );
 
-    Assert.assertEquals(Math.max(0, cnt - 1), ret);
+    Assertions.assertEquals(Math.max(0, cnt - 1), ret);
 
     ret = deserializer.getDelta(out, outPosition, indexes, cnt, indexOffset, limit, -delta);
 
-    Assert.assertArrayEquals(
-        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits),
+    Assertions.assertArrayEquals(
         expectedOutDeltaMinus,
-        out
+        out,
+        StringUtils.format("Deserializer (testNoncontiguousGetEveryOtherValue, numBits = %d)", numBits)
     );
 
-    Assert.assertEquals(Math.max(0, cnt - 1), ret);
+    Assertions.assertEquals(Math.max(0, cnt - 1), ret);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/generator/DataGeneratorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/generator/DataGeneratorTest.java
@@ -34,8 +34,8 @@ import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -422,22 +422,22 @@ public class DataGeneratorTest extends InitializedNullHandlingTest
   public void testBasicSchemasAndGeneratorSchemaInfo()
   {
     GeneratorSchemaInfo basicSchema = GeneratorBasicSchemas.SCHEMA_MAP.get("basic");
-    Assert.assertEquals(13, basicSchema.getColumnSchemas().size());
-    Assert.assertEquals(6, basicSchema.getAggs().size());
-    Assert.assertEquals(6, basicSchema.getAggsArray().length);
-    Assert.assertNotNull(basicSchema.getDimensionsSpec());
-    Assert.assertNotNull(basicSchema.getDataInterval());
-    Assert.assertTrue(basicSchema.isWithRollup());
+    Assertions.assertEquals(13, basicSchema.getColumnSchemas().size());
+    Assertions.assertEquals(6, basicSchema.getAggs().size());
+    Assertions.assertEquals(6, basicSchema.getAggsArray().length);
+    Assertions.assertNotNull(basicSchema.getDimensionsSpec());
+    Assertions.assertNotNull(basicSchema.getDataInterval());
+    Assertions.assertTrue(basicSchema.isWithRollup());
   }
 
   @Test
   public void testRealRoundingDistributionZeroGetters()
   {
     RealRoundingDistribution dist = new RealRoundingDistribution(new NormalDistribution());
-    Assert.assertEquals(0, dist.getSupportLowerBound());
-    Assert.assertEquals(0, dist.getSupportUpperBound());
-    Assert.assertEquals(0, dist.getNumericalMean(), 0);
-    Assert.assertEquals(0, dist.getNumericalVariance(), 0);
+    Assertions.assertEquals(0, dist.getSupportLowerBound());
+    Assertions.assertEquals(0, dist.getSupportUpperBound());
+    Assertions.assertEquals(0, dist.getNumericalMean(), 0);
+    Assertions.assertEquals(0, dist.getNumericalVariance(), 0);
   }
 
   @Test
@@ -500,7 +500,7 @@ public class DataGeneratorTest extends InitializedNullHandlingTest
     DataGenerator dataGenerator = new DataGenerator(schemas, 9999, 0, 0, 1000.0);
     for (int i = 0; i < 100000; i++) {
       InputRow row = dataGenerator.nextRow();
-      Assert.assertNotNull(row);
+      Assertions.assertNotNull(row);
       tracker.addRow(row);
     }
 
@@ -576,7 +576,7 @@ public class DataGeneratorTest extends InitializedNullHandlingTest
       String format = expected ? "%s dimension is nullable" : "%s dimension is not nullable";
       String message = String.format(Locale.US, format, dim);
       Map<Object, RowValuePropertyTracker> valueMap = dimensionMap.get(dim);
-      Assert.assertEquals(message, expected, valueMap.containsKey(""));
+      Assertions.assertEquals(expected, valueMap.containsKey(""), message);
     }
 
     private void assertTimeStamp(String dim, long startTime, long endTime)
@@ -591,7 +591,7 @@ public class DataGeneratorTest extends InitializedNullHandlingTest
       );
       for (Object val : valueMap.keySet()) {
         long timeStamp = valueMap.get(val).getTimeStamp().getMillis();
-        Assert.assertTrue(message, timeStamp >= startTime && timeStamp <= endTime);
+        Assertions.assertTrue(timeStamp >= startTime && timeStamp <= endTime, message);
       }
     }
 
@@ -603,7 +603,7 @@ public class DataGeneratorTest extends InitializedNullHandlingTest
       for (Object val : valueMap.keySet()) {
         count += valueMap.get(val).getCount();
       }
-      Assert.assertEquals(message, expected, count);
+      Assertions.assertEquals(expected, count, message);
     }
 
     public void printStuff()
@@ -671,7 +671,7 @@ public class DataGeneratorTest extends InitializedNullHandlingTest
 
     DataGenerator dataGenerator = new DataGenerator(schemas, 9999, 0, 0, 1000.0);
     List<InputRow> rows = dataGenerator.toList(100);
-    Assert.assertEquals(100, rows.size());
+    Assertions.assertEquals(100, rows.size());
 
     for (InputRow row : rows) {
       tracker.addRow(row);
@@ -744,6 +744,6 @@ public class DataGeneratorTest extends InitializedNullHandlingTest
         .build();
 
     dataGenerator.addToIndex(index, 100);
-    Assert.assertEquals(100, index.numRows());
+    Assertions.assertEquals(100, index.numRows());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexAdapterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexAdapterTest.java
@@ -22,7 +22,7 @@ package org.apache.druid.segment.incremental;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.segment.IndexSpec;
 import org.apache.druid.segment.IndexableAdapter;
 import org.apache.druid.segment.RowIterator;
@@ -33,18 +33,20 @@ import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.data.ConciseBitmapSerdeFactory;
 import org.apache.druid.segment.data.IncrementalIndexTest;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class IncrementalIndexAdapterTest extends InitializedNullHandlingTest
 {
   private static final IndexSpec INDEX_SPEC =
@@ -57,8 +59,8 @@ public class IncrementalIndexAdapterTest extends InitializedNullHandlingTest
 
   public final IncrementalIndexCreator indexCreator;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexAdapterTest(String indexType) throws JsonProcessingException
   {
@@ -69,7 +71,6 @@ public class IncrementalIndexAdapterTest extends InitializedNullHandlingTest
     ));
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.getAppendableIndexTypes();
@@ -90,7 +91,7 @@ public class IncrementalIndexAdapterTest extends InitializedNullHandlingTest
     try (CloseableIndexed<String> dimValueLookup = adapter.getDimValueLookup(dimension)) {
       for (int i = 0; i < dimValueLookup.size(); i++) {
         BitmapValues bitmapValues = adapter.getBitmapValues(dimension, i);
-        Assert.assertEquals(1, bitmapValues.size());
+        Assertions.assertEquals(1, bitmapValues.size());
       }
     }
   }
@@ -114,9 +115,9 @@ public class IncrementalIndexAdapterTest extends InitializedNullHandlingTest
     while (rows.moveToNext()) {
       rowNums.add(rows.getPointer().getRowNum());
     }
-    Assert.assertEquals(2, rowNums.size());
-    Assert.assertEquals(0, (long) rowNums.get(0));
-    Assert.assertEquals(1, (long) rowNums.get(1));
+    Assertions.assertEquals(2, rowNums.size());
+    Assertions.assertEquals(0, (long) rowNums.get(0));
+    Assertions.assertEquals(1, (long) rowNums.get(1));
   }
 
   @Test
@@ -183,16 +184,16 @@ public class IncrementalIndexAdapterTest extends InitializedNullHandlingTest
     //    RowPointer{indexNum=0, rowNumber=4, timestamp=1533347361396, dimensions={dim1=3, dim2=4}, metrics={count=1}}
     //    RowPointer{indexNum=0, rowNumber=5, timestamp=1533347361396, dimensions={dim1=3, dim2=4}, metrics={count=1}}
 
-    Assert.assertEquals(6, rowStrings.size());
+    Assertions.assertEquals(6, rowStrings.size());
     for (int i = 0; i < 6; i++) {
       if (i % 2 == 0) {
-        Assert.assertEquals(0, (long) dim1Vals.get(i));
-        Assert.assertEquals(0, (long) dim2Vals.get(i));
+        Assertions.assertEquals(0, (long) dim1Vals.get(i));
+        Assertions.assertEquals(0, (long) dim2Vals.get(i));
       } else {
-        Assert.assertEquals(1, (long) dim1Vals.get(i));
-        Assert.assertEquals(1, (long) dim2Vals.get(i));
+        Assertions.assertEquals(1, (long) dim1Vals.get(i));
+        Assertions.assertEquals(1, (long) dim2Vals.get(i));
       }
-      Assert.assertEquals(getExpected.apply(i), rowStrings.get(i));
+      Assertions.assertEquals(getExpected.apply(i), rowStrings.get(i));
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCreator.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCreator.java
@@ -188,7 +188,8 @@ public class IncrementalIndexCreator implements Closeable
    *
    * we can test all the input combinations as follows:
    * {@code
-   *   @Parameterized.Parameters(name = "{index}: {0}, {1}")
+   *   @ParameterizedClass(name = "{index}: {0}, {1}")
+   *   @MethodSource("constructorFeeder")
    *   public static Collection<?> constructorFeeder()
    *   {
    *     return IncrementalIndexCreator.indexTypeCartesianProduct(

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexCursorFactoryTest.java
@@ -61,7 +61,7 @@ import org.apache.druid.query.groupby.ResultRow;
 import org.apache.druid.query.topn.TopNQueryBuilder;
 import org.apache.druid.query.topn.TopNQueryEngine;
 import org.apache.druid.query.topn.TopNResultValue;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.CursorBuildSpec;
@@ -81,14 +81,15 @@ import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -100,7 +101,8 @@ import java.util.Set;
 /**
  *
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTest
 {
   public final IncrementalIndexCreator indexCreator;
@@ -116,8 +118,8 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
    */
   public final boolean sortByDim;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexCursorFactoryTest(String indexType, boolean sortByDim)
       throws JsonProcessingException
@@ -182,7 +184,6 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
     topnQueryEngine = new TopNQueryEngine(nonBlockingPool);
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}, sortByDim: {1}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.indexTypeCartesianProduct(
@@ -230,14 +231,14 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
 
     final List<ResultRow> results = rows.toList();
 
-    Assert.assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
 
     // GroupingEngine.process returns raw grouped results without applying the query's order-by post-processing.
     // The result order is therefore not guaranteed when the incremental index is not sorted by dimensions.
-    Assert.assertTrue(
+    Assertions.assertTrue(
         results.stream().anyMatch(row -> Arrays.deepEquals(new Object[]{null, "bo", 1L}, row.getArray()))
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         results.stream().anyMatch(row -> Arrays.deepEquals(new Object[]{"hi", null, 1L}, row.getArray()))
     );
   }
@@ -296,13 +297,13 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
 
     final List<ResultRow> results = rows.toList();
 
-    Assert.assertEquals(2, results.size());
+    Assertions.assertEquals(2, results.size());
 
     ResultRow row = results.get(0);
-    Assert.assertArrayEquals(new Object[]{"hi", null, 1L, 2.0}, row.getArray());
+    Assertions.assertArrayEquals(new Object[]{"hi", null, 1L, 2.0}, row.getArray());
 
     row = results.get(1);
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{"hip", "hop", 1L, 6.0},
         row.getArray()
     );
@@ -312,7 +313,7 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
   public void testResetSanity() throws IOException
   {
     // Test is only valid when sortByDim = false, due to usage of Granularities.NONE.
-    Assume.assumeFalse(sortByDim);
+    Assumptions.assumeFalse(sortByDim);
 
     IncrementalIndex index = indexCreator.createIndex();
     DateTime t = DateTimes.nowUtc();
@@ -350,7 +351,7 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
         dimSelector = cursor
             .getColumnSelectorFactory()
             .makeDimensionSelector(new DefaultDimensionSpec("sally", "sally"));
-        Assert.assertEquals("bo", dimSelector.lookupName(dimSelector.getRow().get(0)));
+        Assertions.assertEquals("bo", dimSelector.lookupName(dimSelector.getRow().get(0)));
 
         index.add(
             new MapBasedInputRow(
@@ -366,7 +367,7 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
         dimSelector = cursor
             .getColumnSelectorFactory()
             .makeDimensionSelector(new DefaultDimensionSpec("sally", "sally"));
-        Assert.assertEquals("bo", dimSelector.lookupName(dimSelector.getRow().get(0)));
+        Assertions.assertEquals("bo", dimSelector.lookupName(dimSelector.getRow().get(0)));
       }
     }
   }
@@ -400,8 +401,8 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
         )
         .toList();
 
-    Assert.assertEquals(1, Iterables.size(results));
-    Assert.assertEquals(1, results.iterator().next().getValue().getValue().size());
+    Assertions.assertEquals(1, Iterables.size(results));
+    Assertions.assertEquals(1, results.iterator().next().getValue().getValue().size());
   }
 
   @Test
@@ -445,10 +446,10 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
 
     final List<ResultRow> results = rows.toList();
 
-    Assert.assertEquals(1, results.size());
+    Assertions.assertEquals(1, results.size());
 
     ResultRow row = results.get(0);
-    Assert.assertArrayEquals(new Object[]{"hi", null, 1L}, row.getArray());
+    Assertions.assertArrayEquals(new Object[]{"hi", null, 1L}, row.getArray());
   }
 
   @Test
@@ -497,11 +498,11 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
       // and then, cursoring continues in the other thread
       while (!cursor.isDone()) {
         IndexedInts row = dimSelector.getRow();
-        row.forEach(i -> Assert.assertTrue(i < cardinality));
+        row.forEach(i -> Assertions.assertTrue(i < cardinality));
         cursor.advance();
         rowNumInCursor++;
       }
-      Assert.assertEquals(2, rowNumInCursor);
+      Assertions.assertEquals(2, rowNumInCursor);
     }
   }
 
@@ -539,11 +540,11 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
       int rowNumInCursor = 0;
       while (!cursor.isDone()) {
         IndexedInts row = dimSelector.getRow();
-        row.forEach(i -> Assert.assertTrue(i < cardinality));
+        row.forEach(i -> Assertions.assertTrue(i < cardinality));
         cursor.advance();
         rowNumInCursor++;
       }
-      Assert.assertEquals(5, rowNumInCursor);
+      Assertions.assertEquals(5, rowNumInCursor);
     }
   }
 
@@ -625,21 +626,21 @@ public class IncrementalIndexCursorFactoryTest extends InitializedNullHandlingTe
       // and then, cursoring continues in the other thread
       while (!cursor.isDone()) {
         IndexedInts rowA = dimSelector1A.getRow();
-        rowA.forEach(i -> Assert.assertTrue(i < cardinalityA));
+        rowA.forEach(i -> Assertions.assertTrue(i < cardinalityA));
         IndexedInts rowB = dimSelector1B.getRow();
-        rowB.forEach(i -> Assert.assertTrue(i < cardinalityA));
+        rowB.forEach(i -> Assertions.assertTrue(i < cardinalityA));
         IndexedInts rowC = dimSelector1C.getRow();
-        rowC.forEach(i -> Assert.assertTrue(i < cardinalityA));
+        rowC.forEach(i -> Assertions.assertTrue(i < cardinalityA));
         IndexedInts rowD = dimSelector2D.getRow();
-        Assert.assertEquals(1, rowD.size());
-        Assert.assertEquals(1, rowD.get(0));
+        Assertions.assertEquals(1, rowD.size());
+        Assertions.assertEquals(1, rowD.get(0));
         IndexedInts rowE = dimSelector3E.getRow();
-        Assert.assertEquals(1, rowE.size());
-        Assert.assertEquals(1, rowE.get(0));
+        Assertions.assertEquals(1, rowE.size());
+        Assertions.assertEquals(1, rowE.get(0));
         cursor.advance();
         rowNumInCursor++;
       }
-      Assert.assertEquals(2, rowNumInCursor);
+      Assertions.assertEquals(2, rowNumInCursor);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexIngestionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexIngestionTest.java
@@ -28,28 +28,30 @@ import org.apache.druid.query.aggregation.Aggregator;
 import org.apache.druid.query.aggregation.AggregatorAndSize;
 import org.apache.druid.query.aggregation.LongMaxAggregator;
 import org.apache.druid.query.aggregation.LongMaxAggregatorFactory;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.segment.ColumnSelectorFactory;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.easymock.EasyMock;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Collection;
 import java.util.Collections;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class IncrementalIndexIngestionTest extends InitializedNullHandlingTest
 {
   private static final int MAX_ROWS = 100_000;
 
   public final IncrementalIndexCreator indexCreator;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexIngestionTest(String indexType) throws JsonProcessingException
   {
@@ -61,7 +63,6 @@ public class IncrementalIndexIngestionTest extends InitializedNullHandlingTest
     ));
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.getAppendableIndexTypes();

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexMultiValueSpecTest.java
@@ -28,13 +28,13 @@ import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.data.input.impl.StringDimensionSchema;
 import org.apache.druid.data.input.impl.TimestampSpec;
 import org.apache.druid.guice.BuiltInTypesModule;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,13 +43,14 @@ import java.util.Map;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IncrementalIndexMultiValueSpecTest extends InitializedNullHandlingTest
 {
   public final IncrementalIndexCreator indexCreator;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexMultiValueSpecTest(String indexType) throws JsonProcessingException
   {
@@ -61,7 +62,6 @@ public class IncrementalIndexMultiValueSpecTest extends InitializedNullHandlingT
     ));
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.getAppendableIndexTypes();
@@ -109,8 +109,8 @@ public class IncrementalIndexMultiValueSpecTest extends InitializedNullHandlingT
     );
 
     Row row = index.iterator().next();
-    Assert.assertEquals(Lists.newArrayList("xsd", "aba", "fds", "aba"), row.getRaw("string1"));
-    Assert.assertEquals(Lists.newArrayList("aba", "aba", "fds", "xsd"), row.getRaw("string2"));
-    Assert.assertEquals(Lists.newArrayList("aba", "fds", "xsd"), row.getRaw("string3"));
+    Assertions.assertEquals(Lists.newArrayList("xsd", "aba", "fds", "aba"), row.getRaw("string1"));
+    Assertions.assertEquals(Lists.newArrayList("aba", "aba", "fds", "xsd"), row.getRaw("string2"));
+    Assertions.assertEquals(Lists.newArrayList("aba", "fds", "xsd"), row.getRaw("string3"));
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowCompTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowCompTest.java
@@ -24,13 +24,13 @@ import com.google.common.collect.Lists;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.data.input.impl.DimensionsSpec;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -42,20 +42,20 @@ import java.util.Map;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IncrementalIndexRowCompTest extends InitializedNullHandlingTest
 {
   public String indexType;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexRowCompTest(String indexType)
   {
     this.indexType = indexType;
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.getAppendableIndexTypes();
@@ -73,9 +73,9 @@ public class IncrementalIndexRowCompTest extends InitializedNullHandlingTest
     IncrementalIndex index = indexCreator.createIndex();
 
     // Expected ordering: __time
-    Assert.assertEquals(0, index.timePosition);
-    Assert.assertEquals(ImmutableList.of("__time"), index.getDimensionNames(true));
-    Assert.assertEquals(Collections.emptyList(), index.getDimensionNames(false));
+    Assertions.assertEquals(0, index.timePosition);
+    Assertions.assertEquals(ImmutableList.of("__time"), index.getDimensionNames(true));
+    Assertions.assertEquals(Collections.emptyList(), index.getDimensionNames(false));
 
     long time = System.currentTimeMillis();
     IncrementalIndexRow ir1 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "B")).getIncrementalIndexRow();
@@ -88,25 +88,25 @@ public class IncrementalIndexRowCompTest extends InitializedNullHandlingTest
 
     Comparator<IncrementalIndexRow> comparator = index.dimsComparator();
 
-    Assert.assertEquals(0, comparator.compare(ir1, ir1));
-    Assert.assertEquals(0, comparator.compare(ir2, ir2));
-    Assert.assertEquals(0, comparator.compare(ir3, ir3));
+    Assertions.assertEquals(0, comparator.compare(ir1, ir1));
+    Assertions.assertEquals(0, comparator.compare(ir2, ir2));
+    Assertions.assertEquals(0, comparator.compare(ir3, ir3));
 
-    Assert.assertTrue(comparator.compare(ir1, ir2) > 0);
-    Assert.assertTrue(comparator.compare(ir2, ir1) < 0);
-    Assert.assertTrue(comparator.compare(ir2, ir3) > 0);
-    Assert.assertTrue(comparator.compare(ir3, ir2) < 0);
-    Assert.assertTrue(comparator.compare(ir1, ir3) > 0);
-    Assert.assertTrue(comparator.compare(ir3, ir1) < 0);
+    Assertions.assertTrue(comparator.compare(ir1, ir2) > 0);
+    Assertions.assertTrue(comparator.compare(ir2, ir1) < 0);
+    Assertions.assertTrue(comparator.compare(ir2, ir3) > 0);
+    Assertions.assertTrue(comparator.compare(ir3, ir2) < 0);
+    Assertions.assertTrue(comparator.compare(ir1, ir3) > 0);
+    Assertions.assertTrue(comparator.compare(ir3, ir1) < 0);
 
-    Assert.assertTrue(comparator.compare(ir6, ir1) > 0);
-    Assert.assertTrue(comparator.compare(ir6, ir2) > 0);
-    Assert.assertTrue(comparator.compare(ir6, ir3) > 0);
+    Assertions.assertTrue(comparator.compare(ir6, ir1) > 0);
+    Assertions.assertTrue(comparator.compare(ir6, ir2) > 0);
+    Assertions.assertTrue(comparator.compare(ir6, ir3) > 0);
 
-    Assert.assertTrue(comparator.compare(ir4, ir6) > 0);
-    Assert.assertTrue(comparator.compare(ir5, ir6) > 0);
-    Assert.assertTrue(comparator.compare(ir5, ir4) < 0);
-    Assert.assertTrue(comparator.compare(ir4, ir5) > 0);
+    Assertions.assertTrue(comparator.compare(ir4, ir6) > 0);
+    Assertions.assertTrue(comparator.compare(ir5, ir6) > 0);
+    Assertions.assertTrue(comparator.compare(ir5, ir4) < 0);
+    Assertions.assertTrue(comparator.compare(ir4, ir5) > 0);
   }
 
   @Test
@@ -136,9 +136,9 @@ public class IncrementalIndexRowCompTest extends InitializedNullHandlingTest
     IncrementalIndex index = indexCreator.createIndex();
 
     // Expected ordering: [joe, __time]
-    Assert.assertEquals(1, index.timePosition);
-    Assert.assertEquals(ImmutableList.of("joe", "__time"), index.getDimensionNames(true));
-    Assert.assertEquals(ImmutableList.of("joe"), index.getDimensionNames(false));
+    Assertions.assertEquals(1, index.timePosition);
+    Assertions.assertEquals(ImmutableList.of("joe", "__time"), index.getDimensionNames(true));
+    Assertions.assertEquals(ImmutableList.of("joe"), index.getDimensionNames(false));
 
     long time = System.currentTimeMillis();
     IncrementalIndexRow ir1 = index.toIncrementalIndexRow(toMapRow(time, "billy", "A", "joe", "B")).getIncrementalIndexRow();
@@ -151,25 +151,25 @@ public class IncrementalIndexRowCompTest extends InitializedNullHandlingTest
 
     Comparator<IncrementalIndexRow> comparator = index.dimsComparator();
 
-    Assert.assertEquals(0, comparator.compare(ir1, ir1));
-    Assert.assertEquals(0, comparator.compare(ir2, ir2));
-    Assert.assertEquals(0, comparator.compare(ir3, ir3));
+    Assertions.assertEquals(0, comparator.compare(ir1, ir1));
+    Assertions.assertEquals(0, comparator.compare(ir2, ir2));
+    Assertions.assertEquals(0, comparator.compare(ir3, ir3));
 
-    Assert.assertTrue(comparator.compare(ir1, ir2) > 0);
-    Assert.assertTrue(comparator.compare(ir2, ir1) < 0);
-    Assert.assertTrue(comparator.compare(ir2, ir3) > 0);
-    Assert.assertTrue(comparator.compare(ir3, ir2) < 0);
-    Assert.assertTrue(comparator.compare(ir1, ir3) > 0);
-    Assert.assertTrue(comparator.compare(ir3, ir1) < 0);
+    Assertions.assertTrue(comparator.compare(ir1, ir2) > 0);
+    Assertions.assertTrue(comparator.compare(ir2, ir1) < 0);
+    Assertions.assertTrue(comparator.compare(ir2, ir3) > 0);
+    Assertions.assertTrue(comparator.compare(ir3, ir2) < 0);
+    Assertions.assertTrue(comparator.compare(ir1, ir3) > 0);
+    Assertions.assertTrue(comparator.compare(ir3, ir1) < 0);
 
-    Assert.assertTrue(comparator.compare(ir6, ir1) < 0);
-    Assert.assertTrue(comparator.compare(ir6, ir2) < 0);
-    Assert.assertTrue(comparator.compare(ir6, ir3) > 0);
+    Assertions.assertTrue(comparator.compare(ir6, ir1) < 0);
+    Assertions.assertTrue(comparator.compare(ir6, ir2) < 0);
+    Assertions.assertTrue(comparator.compare(ir6, ir3) > 0);
 
-    Assert.assertTrue(comparator.compare(ir4, ir6) > 0);
-    Assert.assertTrue(comparator.compare(ir5, ir6) > 0);
-    Assert.assertTrue(comparator.compare(ir5, ir4) < 0);
-    Assert.assertTrue(comparator.compare(ir4, ir5) > 0);
+    Assertions.assertTrue(comparator.compare(ir4, ir6) > 0);
+    Assertions.assertTrue(comparator.compare(ir5, ir6) > 0);
+    Assertions.assertTrue(comparator.compare(ir5, ir4) < 0);
+    Assertions.assertTrue(comparator.compare(ir4, ir5) > 0);
   }
 
   private MapBasedInputRow toMapRow(long time, Object... dimAndVal)

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowSizeTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexRowSizeTest.java
@@ -23,13 +23,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.Lists;
 import org.apache.druid.data.input.MapBasedInputRow;
 import org.apache.druid.query.aggregation.CountAggregatorFactory;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,13 +38,14 @@ import java.util.Map;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
 {
   public final IncrementalIndexCreator indexCreator;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexRowSizeTest(String indexType) throws JsonProcessingException
   {
@@ -57,7 +58,6 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
     );
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.getAppendableIndexTypes();
@@ -76,7 +76,7 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
         "B"  // 50 Bytes
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    Assert.assertEquals(196, td1.estimateBytesInMemory());
+    Assertions.assertEquals(196, td1.estimateBytesInMemory());
   }
 
   @Test
@@ -92,7 +92,7 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
         Arrays.asList("A", "B") // 100 Bytes
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    Assert.assertEquals(262, td1.estimateBytesInMemory());
+    Assertions.assertEquals(262, td1.estimateBytesInMemory());
   }
 
   @Test
@@ -108,7 +108,7 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
         Arrays.asList("123", "abcdef") // 54 + 60 Bytes
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    Assert.assertEquals(286, td1.estimateBytesInMemory());
+    Assertions.assertEquals(286, td1.estimateBytesInMemory());
   }
 
   @Test
@@ -122,7 +122,7 @@ public class IncrementalIndexRowSizeTest extends InitializedNullHandlingTest
         ""
     ));
     IncrementalIndexRow td1 = tndResult.getIncrementalIndexRow();
-    Assert.assertEquals(108, td1.estimateBytesInMemory());
+    Assertions.assertEquals(108, td1.estimateBytesInMemory());
   }
 
   private MapBasedInputRow toMapRow(long time, Object... dimAndVal)

--- a/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/IncrementalIndexTest.java
@@ -38,15 +38,15 @@ import org.apache.druid.query.aggregation.CountAggregatorFactory;
 import org.apache.druid.query.aggregation.FilteredAggregatorFactory;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.segment.AutoTypeColumnSchema;
-import org.apache.druid.segment.CloserRule;
+import org.apache.druid.segment.CloserExtension;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.nested.StructuredData;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,15 +55,16 @@ import java.util.List;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class IncrementalIndexTest extends InitializedNullHandlingTest
 {
   public final IncrementalIndexCreator indexCreator;
 
   private final String mode;
 
-  @Rule
-  public final CloserRule closer = new CloserRule(false);
+  @RegisterExtension
+  public final CloserExtension closer = new CloserExtension(false);
 
   public IncrementalIndexTest(
       String indexType,
@@ -105,7 +106,6 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     );
   }
 
-  @Parameterized.Parameters(name = "{index}: {0}, {1}")
   public static Collection<?> constructorFeeder()
   {
     return IncrementalIndexCreator.indexTypeCartesianProduct(
@@ -113,37 +113,41 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test(expected = ISE.class)
+  @Test
   public void testDuplicateDimensions()
   {
-    IncrementalIndex index = indexCreator.createIndex();
-    index.add(
-        new MapBasedInputRow(
-            System.currentTimeMillis() - 1,
-            Lists.newArrayList("billy", "joe"),
-            ImmutableMap.of("billy", "A", "joe", "B")
-        )
-    );
-    index.add(
-        new MapBasedInputRow(
-            System.currentTimeMillis() - 1,
-            Lists.newArrayList("billy", "joe", "joe"),
-            ImmutableMap.of("billy", "A", "joe", "B")
-        )
-    );
+    Assertions.assertThrows(ISE.class, () -> {
+      final IncrementalIndex index = indexCreator.createIndex();
+      index.add(
+          new MapBasedInputRow(
+              System.currentTimeMillis() - 1,
+              Lists.newArrayList("billy", "joe"),
+              ImmutableMap.of("billy", "A", "joe", "B")
+          )
+      );
+      index.add(
+          new MapBasedInputRow(
+              System.currentTimeMillis() - 1,
+              Lists.newArrayList("billy", "joe", "joe"),
+              ImmutableMap.of("billy", "A", "joe", "B")
+          )
+      );
+    });
   }
 
-  @Test(expected = ISE.class)
+  @Test
   public void testDuplicateDimensionsFirstOccurrence()
   {
-    IncrementalIndex index = indexCreator.createIndex();
-    index.add(
-        new MapBasedInputRow(
-            System.currentTimeMillis() - 1,
-            Lists.newArrayList("billy", "joe", "joe"),
-            ImmutableMap.of("billy", "A", "joe", "B")
-        )
-    );
+    Assertions.assertThrows(ISE.class, () -> {
+      final IncrementalIndex index = indexCreator.createIndex();
+      index.add(
+          new MapBasedInputRow(
+              System.currentTimeMillis() - 1,
+              Lists.newArrayList("billy", "joe", "joe"),
+              ImmutableMap.of("billy", "A", "joe", "B")
+          )
+      );
+    });
   }
 
   @Test
@@ -191,12 +195,12 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
-    Assert.assertEquals(
+    Assertions.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
+    Assertions.assertEquals(
         "{string=A, float=19.0, long=asdj, double=21.0}",
         result.getParseException().getInput()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Found unparseable columns in row: [{string=A, float=19.0, long=asdj, double=21.0}], exceptions: [Could not convert value [asdj] to long for dimension [long].]",
         result.getParseException().getMessage()
     );
@@ -213,12 +217,12 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
-    Assert.assertEquals(
+    Assertions.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
+    Assertions.assertEquals(
         "{string=A, float=aaa, long=20, double=21.0}",
         result.getParseException().getInput()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Found unparseable columns in row: [{string=A, float=aaa, long=20, double=21.0}], exceptions: [Could not convert value [aaa] to float for dimension [float].]",
         result.getParseException().getMessage()
     );
@@ -235,12 +239,12 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
-    Assert.assertEquals(
+    Assertions.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
+    Assertions.assertEquals(
         "{string=A, float=19.0, long=20, double=}",
         result.getParseException().getInput()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Found unparseable columns in row: [{string=A, float=19.0, long=20, double=}], exceptions: [Could not convert value [] to double for dimension [double].]",
         result.getParseException().getMessage()
     );
@@ -264,12 +268,12 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
-    Assert.assertEquals(
+    Assertions.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
+    Assertions.assertEquals(
         "{string=A, float=19.0, long=[10, 5], double=21.0}",
         result.getParseException().getInput()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Found unparseable columns in row: [{string=A, float=19.0, long=[10, 5], double=21.0}], exceptions: [Could not ingest value [[10, 5]] as long for dimension [long]. A long column cannot have multiple values in the same row.]",
         result.getParseException().getMessage()
     );
@@ -286,12 +290,12 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
-    Assert.assertEquals(
+    Assertions.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
+    Assertions.assertEquals(
         "{string=A, float=[10.0, 5.0], long=20, double=21.0}",
         result.getParseException().getInput()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Found unparseable columns in row: [{string=A, float=[10.0, 5.0], long=20, double=21.0}], exceptions: [Could not ingest value [[10.0, 5.0]] as float for dimension [float]. A float column cannot have multiple values in the same row.]",
         result.getParseException().getMessage()
     );
@@ -308,12 +312,12 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
             )
         )
     );
-    Assert.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
-    Assert.assertEquals(
+    Assertions.assertEquals(UnparseableColumnsParseException.class, result.getParseException().getClass());
+    Assertions.assertEquals(
         "{string=A, float=19.0, long=20, double=[10.0, 5.0]}",
         result.getParseException().getInput()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Found unparseable columns in row: [{string=A, float=19.0, long=20, double=[10.0, 5.0]}], exceptions: [Could not ingest value [[10.0, 5.0]] as double for dimension [double]. A double column cannot have multiple values in the same row.]",
         result.getParseException().getMessage()
     );
@@ -332,7 +336,7 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
     index.add(row);
     index.add(row);
 
-    Assert.assertEquals("rollup".equals(mode) ? 1 : 3, index.numRows());
+    Assertions.assertEquals("rollup".equals(mode) ? 1 : 3, index.numRows());
   }
 
   @Test
@@ -372,7 +376,7 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
                         .build()
         )
     );
-    Assert.assertNull(result.getParseException());
+    Assertions.assertNull(result.getParseException());
     result = index.add(
         new MapBasedInputRow(
             60_000, // next minute so non-rollup still orders iterator correctly
@@ -392,46 +396,46 @@ public class IncrementalIndexTest extends InitializedNullHandlingTest
                         .build()
         )
     );
-    Assert.assertNull(result.getParseException());
+    Assertions.assertNull(result.getParseException());
 
-    Assert.assertEquals(ColumnType.STRING, index.getColumnCapabilities("string").toColumnType());
-    Assert.assertEquals(ColumnType.FLOAT, index.getColumnCapabilities("float").toColumnType());
-    Assert.assertEquals(ColumnType.LONG, index.getColumnCapabilities("long").toColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE, index.getColumnCapabilities("double").toColumnType());
-    Assert.assertEquals(ColumnType.STRING, index.getColumnCapabilities("bool_string").toColumnType());
-    Assert.assertEquals(ColumnType.LONG, index.getColumnCapabilities("bool_long").toColumnType());
-    Assert.assertEquals(ColumnType.LONG, index.getColumnCapabilities("bool_auto").toColumnType());
-    Assert.assertEquals(ColumnType.STRING_ARRAY, index.getColumnCapabilities("array_string").toColumnType());
-    Assert.assertEquals(ColumnType.LONG_ARRAY, index.getColumnCapabilities("array_long").toColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, index.getColumnCapabilities("array_double").toColumnType());
-    Assert.assertEquals(ColumnType.NESTED_DATA, index.getColumnCapabilities("nested").toColumnType());
+    Assertions.assertEquals(ColumnType.STRING, index.getColumnCapabilities("string").toColumnType());
+    Assertions.assertEquals(ColumnType.FLOAT, index.getColumnCapabilities("float").toColumnType());
+    Assertions.assertEquals(ColumnType.LONG, index.getColumnCapabilities("long").toColumnType());
+    Assertions.assertEquals(ColumnType.DOUBLE, index.getColumnCapabilities("double").toColumnType());
+    Assertions.assertEquals(ColumnType.STRING, index.getColumnCapabilities("bool_string").toColumnType());
+    Assertions.assertEquals(ColumnType.LONG, index.getColumnCapabilities("bool_long").toColumnType());
+    Assertions.assertEquals(ColumnType.LONG, index.getColumnCapabilities("bool_auto").toColumnType());
+    Assertions.assertEquals(ColumnType.STRING_ARRAY, index.getColumnCapabilities("array_string").toColumnType());
+    Assertions.assertEquals(ColumnType.LONG_ARRAY, index.getColumnCapabilities("array_long").toColumnType());
+    Assertions.assertEquals(ColumnType.DOUBLE_ARRAY, index.getColumnCapabilities("array_double").toColumnType());
+    Assertions.assertEquals(ColumnType.NESTED_DATA, index.getColumnCapabilities("nested").toColumnType());
 
 
     Iterator<Row> rowIterator = index.iterator();
     Row row = rowIterator.next();
-    Assert.assertEquals("a", row.getRaw("string"));
-    Assert.assertEquals(1.0f, row.getRaw("float"));
-    Assert.assertEquals(1L, row.getRaw("long"));
-    Assert.assertEquals(1.0, row.getRaw("double"));
-    Assert.assertEquals("true", row.getRaw("bool_string"));
-    Assert.assertEquals(1L, row.getRaw("bool_long"));
-    Assert.assertEquals(StructuredData.wrap(true), row.getRaw("bool_auto"));
-    Assert.assertEquals(StructuredData.wrap(new Object[]{"a", "b", "c"}), row.getRaw("array_string"));
-    Assert.assertEquals(StructuredData.wrap(new Object[]{1L, 2L, 3L}), row.getRaw("array_long"));
-    Assert.assertEquals(StructuredData.wrap(new Object[]{1.1, 2.2, 3.3}), row.getRaw("array_double"));
-    Assert.assertEquals(StructuredData.wrap(ImmutableMap.of("x", 1, "y", ImmutableList.of("a", "b"))), row.getRaw("nested"));
+    Assertions.assertEquals("a", row.getRaw("string"));
+    Assertions.assertEquals(1.0f, row.getRaw("float"));
+    Assertions.assertEquals(1L, row.getRaw("long"));
+    Assertions.assertEquals(1.0, row.getRaw("double"));
+    Assertions.assertEquals("true", row.getRaw("bool_string"));
+    Assertions.assertEquals(1L, row.getRaw("bool_long"));
+    Assertions.assertEquals(StructuredData.wrap(true), row.getRaw("bool_auto"));
+    Assertions.assertEquals(StructuredData.wrap(new Object[]{"a", "b", "c"}), row.getRaw("array_string"));
+    Assertions.assertEquals(StructuredData.wrap(new Object[]{1L, 2L, 3L}), row.getRaw("array_long"));
+    Assertions.assertEquals(StructuredData.wrap(new Object[]{1.1, 2.2, 3.3}), row.getRaw("array_double"));
+    Assertions.assertEquals(StructuredData.wrap(ImmutableMap.of("x", 1, "y", ImmutableList.of("a", "b"))), row.getRaw("nested"));
 
     row = rowIterator.next();
-    Assert.assertEquals("b", row.getRaw("string"));
-    Assert.assertEquals(2.0f, row.getRaw("float"));
-    Assert.assertEquals(2L, row.getRaw("long"));
-    Assert.assertEquals(2.0, row.getRaw("double"));
-    Assert.assertEquals("false", row.getRaw("bool_string"));
-    Assert.assertEquals(0L, row.getRaw("bool_long"));
-    Assert.assertEquals(StructuredData.wrap(false), row.getRaw("bool_auto"));
-    Assert.assertEquals(StructuredData.wrap(new Object[]{"d", "e", "f"}), row.getRaw("array_string"));
-    Assert.assertEquals(StructuredData.wrap(new Object[]{4L, 5L, 6L}), row.getRaw("array_long"));
-    Assert.assertEquals(StructuredData.wrap(new Object[]{4.4, 5.5, 6.6}), row.getRaw("array_double"));
-    Assert.assertEquals(StructuredData.wrap(ImmutableMap.of("x", 2, "y", ImmutableList.of("c", "d"))), row.getRaw("nested"));
+    Assertions.assertEquals("b", row.getRaw("string"));
+    Assertions.assertEquals(2.0f, row.getRaw("float"));
+    Assertions.assertEquals(2L, row.getRaw("long"));
+    Assertions.assertEquals(2.0, row.getRaw("double"));
+    Assertions.assertEquals("false", row.getRaw("bool_string"));
+    Assertions.assertEquals(0L, row.getRaw("bool_long"));
+    Assertions.assertEquals(StructuredData.wrap(false), row.getRaw("bool_auto"));
+    Assertions.assertEquals(StructuredData.wrap(new Object[]{"d", "e", "f"}), row.getRaw("array_string"));
+    Assertions.assertEquals(StructuredData.wrap(new Object[]{4L, 5L, 6L}), row.getRaw("array_long"));
+    Assertions.assertEquals(StructuredData.wrap(new Object[]{4.4, 5.5, 6.6}), row.getRaw("array_double"));
+    Assertions.assertEquals(StructuredData.wrap(ImmutableMap.of("x", 2, "y", ImmutableList.of("c", "d"))), row.getRaw("nested"));
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/OnheapIncrementalIndexTest.java
@@ -40,8 +40,8 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -55,7 +55,7 @@ public class OnheapIncrementalIndexTest
   public void testSpecSerde() throws JsonProcessingException
   {
     OnheapIncrementalIndex.Spec spec = new OnheapIncrementalIndex.Spec(true);
-    Assert.assertEquals(spec, MAPPER.readValue(MAPPER.writeValueAsString(spec), OnheapIncrementalIndex.Spec.class));
+    Assertions.assertEquals(spec, MAPPER.readValue(MAPPER.writeValueAsString(spec), OnheapIncrementalIndex.Spec.class));
   }
 
   @Test
@@ -85,7 +85,7 @@ public class OnheapIncrementalIndexTest
                                                                        .withProjections(List.of(projectionSpec))
                                                                        .build())
                                          .buildIncrementalIndex();
-    Assert.assertNotNull(index.getProjection("proj"));
+    Assertions.assertNotNull(index.getProjection("proj"));
   }
 
   @Test
@@ -96,7 +96,7 @@ public class OnheapIncrementalIndexTest
     AggregatorFactory aggregatorFactory = new DoubleSumAggregatorFactory("double", "double");
     AggregateProjectionSpec.Builder bob = new AggregateProjectionSpec.Builder().aggregators(aggregatorFactory);
     // act & assert
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> IndexBuilder.create()
                           .schema(IncrementalIndexSchema.builder()
@@ -112,8 +112,8 @@ public class OnheapIncrementalIndexTest
                                                         .build())
                           .buildIncrementalIndex()
     );
-    Assert.assertEquals(DruidException.Category.DEFENSIVE, e.getCategory());
-    Assert.assertEquals("duplicate projection[proj]", e.getMessage());
+    Assertions.assertEquals(DruidException.Category.DEFENSIVE, e.getCategory());
+    Assertions.assertEquals("duplicate projection[proj]", e.getMessage());
   }
 
   @Test
@@ -127,7 +127,7 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testBadProjectionMismatchedDimensionTypes()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () ->
             IndexBuilder.create()
@@ -153,7 +153,7 @@ public class OnheapIncrementalIndexTest
                                                   .build()
                         ).buildIncrementalIndex()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "projection[mismatched dims] contains dimension[string] with different type[LONG] than type[STRING] in base table",
         t.getMessage()
     );
@@ -162,7 +162,7 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testBadProjectionDimensionNoVirtualColumnOrBaseTable()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () ->
             IndexBuilder.create()
@@ -199,7 +199,7 @@ public class OnheapIncrementalIndexTest
                                                   .build()
                         ).buildIncrementalIndex()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "projection[sad grouping column] contains dimension[missing] that is not present on the base table or a virtual column",
         t.getMessage()
     );
@@ -208,7 +208,7 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testBadProjectionVirtualColumnNoDimension()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () ->
             IndexBuilder.create()
@@ -244,7 +244,7 @@ public class OnheapIncrementalIndexTest
                                                   .build()
                         ).buildIncrementalIndex()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "projection[sad virtual column] contains virtual column[v0] that references an input[double] which is not a dimension in the base table",
         t.getMessage()
     );
@@ -253,7 +253,7 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testBadProjectionRollupMismatchedAggType()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () ->
             IndexBuilder.create()
@@ -290,7 +290,7 @@ public class OnheapIncrementalIndexTest
                                                   .build()
                         ).buildIncrementalIndex()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "projection[mismatched agg] contains aggregator[sum_double] that is not the 'combining' aggregator of base table aggregator[sum_double]",
         t.getMessage()
     );
@@ -299,7 +299,7 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testBadProjectionRollupBadAggInput()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () ->
             IndexBuilder.create()
@@ -340,7 +340,7 @@ public class OnheapIncrementalIndexTest
                                                   .build()
                         ).buildIncrementalIndex()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "projection[renamed agg] contains aggregator[sum_double] that references aggregator[double] in base table but this is not supported, projection aggregators which reference base table aggregates must be 'combining' aggregators with the same name as the base table column",
         t.getMessage()
     );
@@ -349,7 +349,7 @@ public class OnheapIncrementalIndexTest
   @Test
   public void testBadProjectionVirtualColumnAggInput()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () ->
             IndexBuilder.create()
@@ -391,7 +391,7 @@ public class OnheapIncrementalIndexTest
                                                   .build()
                         ).buildIncrementalIndex()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "projection[sad agg virtual column] contains aggregator[v0_sum] that is has required field[v0] which is a virtual column, this is not yet supported",
         t.getMessage()
     );
@@ -442,13 +442,13 @@ public class OnheapIncrementalIndexTest
             )
         )
     );
-    Assert.assertTrue(addResult.isRowAdded());
+    Assertions.assertTrue(addResult.isRowAdded());
 
     final Map<String, Object> rowMap = new LinkedHashMap<>();
     rowMap.put("string", "hello");
     rowMap.put("long", 10L);
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> index.add(
             new MapBasedInputRow(
@@ -459,7 +459,7 @@ public class OnheapIncrementalIndexTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot add row[{timestamp="
         + outOfRangeTimestamp
         + ", event={string=hello, long=10}, dimensions=[string, long]}] because it is below the minTimestamp["
@@ -487,7 +487,7 @@ public class OnheapIncrementalIndexTest
                                                                         .build())
                                           .buildIncrementalIndex();
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> index2.add(
             new MapBasedInputRow(
@@ -498,7 +498,7 @@ public class OnheapIncrementalIndexTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Cannot add row[{timestamp="
         + minTimestamp
         + ", event={string=hello, long=10}, dimensions=[string, long]}] to projection[proj] because projection effective timestamp["

--- a/processing/src/test/java/org/apache/druid/segment/incremental/ParseExceptionHandlerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/incremental/ParseExceptionHandlerTest.java
@@ -22,31 +22,19 @@ package org.apache.druid.segment.incremental;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.ParseException;
-import org.apache.druid.testing.junit.LoggerCaptureRule;
+import org.apache.druid.testing.junit.LoggerCaptureExtension;
 import org.apache.logging.log4j.core.LogEvent;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.List;
 import java.util.stream.IntStream;
 
 public class ParseExceptionHandlerTest
 {
-  private final LoggerCaptureRule logger = new LoggerCaptureRule(ParseExceptionHandler.class);
-
-  @BeforeEach
-  public void setUp() throws Throwable
-  {
-    logger.before();
-  }
-
-  @AfterEach
-  public void tearDown()
-  {
-    logger.after();
-  }
+  @RegisterExtension
+  private final LoggerCaptureExtension logger = new LoggerCaptureExtension(ParseExceptionHandler.class);
 
   @Test
   public void testMetricWhenAllConfigurationsAreTurnedOff()
@@ -79,9 +67,9 @@ public class ParseExceptionHandlerTest
     );
     parseExceptionHandler.handle(parseException);
 
-    List<LogEvent> logEvents = logger.getLogEvents();
+    final List<LogEvent> logEvents = logger.getLogEvents();
     Assertions.assertEquals(1, logEvents.size());
-    String logMessage = logEvents.get(0).getMessage().getFormattedMessage();
+    final String logMessage = logEvents.get(0).getMessage().getFormattedMessage();
     Assertions.assertTrue(logMessage.contains("Encountered parse exception"));
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/serde/cell/ByteWriterTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/serde/cell/ByteWriterTestHelper.java
@@ -23,9 +23,10 @@ import com.google.common.primitives.Ints;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.data.CompressionStrategy;
 import org.apache.druid.segment.writeout.HeapByteBufferWriteOutBytes;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -129,7 +130,7 @@ public class ByteWriterTestHelper
     int actualSize = masterByteBuffer.limit();
 
     if (expectedSize > -1) {
-      Assert.assertEquals(expectedSize, actualSize);
+      Assertions.assertEquals(expectedSize, actualSize);
     }
   }
 
@@ -167,7 +168,7 @@ public class ByteWriterTestHelper
     bufferWriteOutBytes.readFully(0, masterByteBuffer);
     masterByteBuffer.flip();
 
-    Assert.assertEquals(bytesWriter.getSerializedSize(), masterByteBuffer.limit());
+    Assertions.assertEquals(bytesWriter.getSerializedSize(), masterByteBuffer.limit());
 
     return masterByteBuffer;
   }
@@ -255,9 +256,9 @@ public class ByteWriterTestHelper
         ByteBuffer readByteBuffer = payloadReader.read(payloadEntrySpan.getStart(), payloadEntrySpan.getSize());
 
         if (expectedByteBuffer == null) {
-          Assert.assertEquals(StringUtils.format("expected empty buffer %s", index), EMPTY_BYTE_BUFFER, readByteBuffer);
+          Assertions.assertEquals(EMPTY_BYTE_BUFFER, readByteBuffer, StringUtils.format("expected empty buffer %s", index));
         } else {
-          Assert.assertEquals(StringUtils.format("failure on buffer %s", index), expectedByteBuffer, readByteBuffer);
+          Assertions.assertEquals(expectedByteBuffer, readByteBuffer, StringUtils.format("failure on buffer %s", index));
         }
       }
 
@@ -303,9 +304,9 @@ public class ByteWriterTestHelper
 
         ByteBuffer readByteBuffer = cellReader.getCell(index);
         if (expectedByteBuffer == null) {
-          Assert.assertEquals(StringUtils.format("failure on buffer %s", index), 0L, readByteBuffer.remaining());
+          Assertions.assertEquals(0L, readByteBuffer.remaining(), StringUtils.format("failure on buffer %s", index));
         } else {
-          Assert.assertEquals(StringUtils.format("failure on buffer %s", index), expectedByteBuffer, readByteBuffer);
+          Assertions.assertEquals(expectedByteBuffer, readByteBuffer, StringUtils.format("failure on buffer %s", index));
         }
       }
 

--- a/processing/src/test/java/org/apache/druid/segment/shim/ShimCursorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/shim/ShimCursorTest.java
@@ -55,9 +55,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runners.Parameterized;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,7 +81,6 @@ public class ShimCursorTest
     ExpressionProcessing.initializeForTests();
   }
 
-  @Parameterized.Parameters
   public static Collection<Object> vectorSizes()
   {
     return List.of(1, 2, 4, 7, 512);

--- a/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/transform/TransformerTest.java
@@ -35,11 +35,9 @@ import org.apache.druid.query.expression.TestExprMacroTable;
 import org.apache.druid.query.filter.SelectorDimFilter;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.DateTime;
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,15 +47,12 @@ import java.util.Map;
 
 public class TransformerTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testTransformNullRowReturnNull()
   {
     final Transformer transformer = new Transformer(new TransformSpec(null, null));
-    Assert.assertNull(transformer.transform((InputRow) null));
-    Assert.assertNull(transformer.transform((InputRowListPlusRawValues) null));
+    Assertions.assertNull(transformer.transform((InputRow) null));
+    Assertions.assertNull(transformer.transform((InputRowListPlusRawValues) null));
   }
 
   @Test
@@ -69,14 +64,14 @@ public class TransformerTest extends InitializedNullHandlingTest
     final InputRow keepRow = makeRow("keep");
     final InputRow dropRow = makeRow("drop");
 
-    Assert.assertSame(keepRow, transformer.transformWithoutFilter(keepRow));
-    Assert.assertSame(dropRow, transformer.transformWithoutFilter(dropRow));
-    Assert.assertNull(transformer.transformWithoutFilter(null));
+    Assertions.assertSame(keepRow, transformer.transformWithoutFilter(keepRow));
+    Assertions.assertSame(dropRow, transformer.transformWithoutFilter(dropRow));
+    Assertions.assertNull(transformer.transformWithoutFilter(null));
 
-    Assert.assertTrue(transformer.hasFilter());
-    Assert.assertTrue(transformer.rowMatchesFilter(keepRow));
-    Assert.assertFalse(transformer.rowMatchesFilter(dropRow));
-    Assert.assertTrue(transformer.rowMatchesFilter(null));
+    Assertions.assertTrue(transformer.hasFilter());
+    Assertions.assertTrue(transformer.rowMatchesFilter(keepRow));
+    Assertions.assertFalse(transformer.rowMatchesFilter(dropRow));
+    Assertions.assertTrue(transformer.rowMatchesFilter(null));
   }
 
   @Test
@@ -93,9 +88,9 @@ public class TransformerTest extends InitializedNullHandlingTest
     );
 
     try (final CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertSame(dropRow, iterator.next());
-      Assert.assertSame(keepRow, iterator.next());
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertSame(dropRow, iterator.next());
+      Assertions.assertSame(keepRow, iterator.next());
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -111,8 +106,8 @@ public class TransformerTest extends InitializedNullHandlingTest
     );
 
     try (final CloseableIterator<InputRow> iterator = reader.read()) {
-      Assert.assertNull(iterator.next());
-      Assert.assertFalse(iterator.hasNext());
+      Assertions.assertNull(iterator.next());
+      Assertions.assertFalse(iterator.hasNext());
     }
   }
 
@@ -134,8 +129,8 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("__time", now, "dim", false)
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(now.minusDays(2), actual.getTimestamp());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(now.minusDays(2), actual.getTimestamp());
   }
 
   @Test
@@ -155,9 +150,8 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableList.of("ts", "dim"),
         ImmutableMap.of("ts", "not_a_timestamp", "dim", false)
     );
-    expectedException.expectMessage("Could not transform value for __time.");
-    expectedException.expect(ParseException.class);
-    transformer.transform(row);
+    final ParseException exception = Assertions.assertThrows(ParseException.class, () -> transformer.transform(row));
+    Assertions.assertEquals("Could not transform value for __time.", exception.getMessage());
   }
 
   @Test
@@ -183,10 +177,10 @@ public class TransformerTest extends InitializedNullHandlingTest
             ImmutableMap.of("ts", "not_a_timestamp", "dim", false)
         )
     );
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(1, actual.getRawValuesList().size());
-    Assert.assertNull(actual.getInputRows());
-    Assert.assertEquals("Could not transform value for __time.", actual.getParseException().getMessage());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(1, actual.getRawValuesList().size());
+    Assertions.assertNull(actual.getInputRows());
+    Assertions.assertEquals("Could not transform value for __time.", actual.getParseException().getMessage());
   }
 
   @Test
@@ -204,11 +198,11 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", false)
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
     // booleans are longs by default, so strlen of false (0L) is 1
-    Assert.assertEquals(1L, actual.getRaw("dim"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertEquals(1L, actual.getRaw("dim"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -226,10 +220,10 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", 10L)
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
-    Assert.assertEquals(2L, actual.getRaw("dim"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertEquals(2L, actual.getRaw("dim"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -247,13 +241,13 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", 200.5d)
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
-    Assert.assertEquals(5L, actual.getRaw("dim"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertEquals(5L, actual.getRaw("dim"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
-  @Ignore("Disabled until https://github.com/apache/druid/issues/9824 is fixed")
+  @Disabled("Disabled until https://github.com/apache/druid/issues/9824 is fixed")
   @Test
   public void testTransformWithStringTransformOnListColumnThrowingException()
   {
@@ -269,11 +263,10 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", ImmutableList.of(10, 20, 100))
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
     // Unlike for querying, Druid doesn't explode multi-valued columns automatically for ingestion.
-    expectedException.expect(AssertionError.class);
-    actual.getRaw("dim");
+    Assertions.assertThrows(AssertionError.class, () -> actual.getRaw("dim"));
   }
 
   @Test
@@ -287,13 +280,13 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableList.of("dim"),
         ImmutableMap.of("dim", false)
     );
-    Assert.assertEquals(row1, transformer.transform(row1));
+    Assertions.assertEquals(row1, transformer.transform(row1));
     final InputRow row2 = new MapBasedInputRow(
         DateTimes.nowUtc(),
         ImmutableList.of("dim"),
         ImmutableMap.of("dim", true)
     );
-    Assert.assertNull(transformer.transform(row2));
+    Assertions.assertNull(transformer.transform(row2));
   }
 
   @Test
@@ -307,13 +300,13 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableList.of("dim"),
         ImmutableMap.of("dim", "false")
     );
-    Assert.assertEquals(row, transformer.transform(row));
+    Assertions.assertEquals(row, transformer.transform(row));
     final InputRow row2 = new MapBasedInputRow(
         DateTimes.nowUtc(),
         ImmutableList.of("dim"),
         ImmutableMap.of("dim", "true")
     );
-    Assert.assertNull(transformer.transform(row2));
+    Assertions.assertNull(transformer.transform(row2));
   }
 
   @Test
@@ -332,10 +325,10 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", "short")
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
-    Assert.assertEquals(0L, actual.getRaw("dim"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertEquals(0L, actual.getRaw("dim"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -367,11 +360,11 @@ public class TransformerTest extends InitializedNullHandlingTest
     );
 
     final InputRowListPlusRawValues actual = transformer.transform(InputRowListPlusRawValues.ofList(valList, rows));
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(1, actual.getInputRows().size());
-    Assert.assertEquals(1, actual.getRawValuesList().size());
-    Assert.assertEquals("val1", actual.getInputRows().get(0).getRaw("dim"));
-    Assert.assertEquals("val1", actual.getRawValuesList().get(0).get("dim"));
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(1, actual.getInputRows().size());
+    Assertions.assertEquals(1, actual.getRawValuesList().size());
+    Assertions.assertEquals("val1", actual.getInputRows().get(0).getRaw("dim"));
+    Assertions.assertEquals("val1", actual.getRawValuesList().get(0).get("dim"));
   }
 
   @Test
@@ -389,11 +382,11 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", ImmutableList.of("a", "b", "c"))
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
-    Assert.assertEquals(3L, actual.getRaw("dimlen"));
-    Assert.assertEquals(ImmutableList.of("3"), actual.getDimension("dimlen"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertEquals(3L, actual.getRaw("dimlen"));
+    Assertions.assertEquals(ImmutableList.of("3"), actual.getDimension("dimlen"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -411,11 +404,11 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", ImmutableList.of("a", "b", "c"))
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) actual.getRaw("dim"));
-    Assert.assertEquals(ImmutableList.of("a", "b", "c"), actual.getDimension("dim"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) actual.getRaw("dim"));
+    Assertions.assertEquals(ImmutableList.of("a", "b", "c"), actual.getDimension("dim"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -433,11 +426,11 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", Arrays.asList(1, 2, null, 3))
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) actual.getRaw("dim"));
-    Assert.assertEquals(Arrays.asList("1", "2", null, "3"), actual.getDimension("dim"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) actual.getRaw("dim"));
+    Assertions.assertEquals(Arrays.asList("1", "2", null, "3"), actual.getDimension("dim"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -455,19 +448,19 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", Arrays.asList(1.2f, 2.3f, null, 3.4f))
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
     Object[] raw = (Object[]) actual.getRaw("dim");
     // floats are converted to doubles since expressions have no doubles
-    Assert.assertEquals(1.2, (Double) raw[0], 0.00001);
-    Assert.assertEquals(2.3, (Double) raw[1], 0.00001);
-    Assert.assertNull(raw[2]);
-    Assert.assertEquals(3.4, (Double) raw[3], 0.00001);
-    Assert.assertEquals(
+    Assertions.assertEquals(1.2, (Double) raw[0], 0.00001);
+    Assertions.assertEquals(2.3, (Double) raw[1], 0.00001);
+    Assertions.assertNull(raw[2]);
+    Assertions.assertEquals(3.4, (Double) raw[3], 0.00001);
+    Assertions.assertEquals(
         Arrays.asList("1.2000000476837158", "2.299999952316284", null, "3.4000000953674316"),
         actual.getDimension("dim")
     );
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -485,15 +478,15 @@ public class TransformerTest extends InitializedNullHandlingTest
         ImmutableMap.of("dim", Arrays.asList(1.2, 2.3, null, 3.4))
     );
     final InputRow actual = transformer.transform(row);
-    Assert.assertNotNull(actual);
-    Assert.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
+    Assertions.assertNotNull(actual);
+    Assertions.assertEquals(ImmutableList.of("dim"), actual.getDimensions());
     Object[] raw = (Object[]) actual.getRaw("dim");
-    Assert.assertEquals(1.2, (Double) raw[0], 0.0);
-    Assert.assertEquals(2.3, (Double) raw[1], 0.0);
-    Assert.assertNull(raw[2]);
-    Assert.assertEquals(3.4, (Double) raw[3], 0.0);
-    Assert.assertEquals(Arrays.asList("1.2", "2.3", null, "3.4"), actual.getDimension("dim"));
-    Assert.assertEquals(row.getTimestamp(), actual.getTimestamp());
+    Assertions.assertEquals(1.2, (Double) raw[0], 0.0);
+    Assertions.assertEquals(2.3, (Double) raw[1], 0.0);
+    Assertions.assertNull(raw[2]);
+    Assertions.assertEquals(3.4, (Double) raw[3], 0.0);
+    Assertions.assertEquals(Arrays.asList("1.2", "2.3", null, "3.4"), actual.getDimension("dim"));
+    Assertions.assertEquals(row.getTimestamp(), actual.getTimestamp());
   }
 
   @Test
@@ -513,8 +506,8 @@ public class TransformerTest extends InitializedNullHandlingTest
         DateTimes.nowUtc(),
         ImmutableMap.of("dim", dimList)
     );
-    Assert.assertEquals(row.getDimension("dim"), dimList);
-    Assert.assertEquals(row.getRaw("dim"), dimList);
+    Assertions.assertEquals(row.getDimension("dim"), dimList);
+    Assertions.assertEquals(row.getRaw("dim"), dimList);
 
     final InputRow actualTranformedRow = transformer.transform(
         new MapBasedInputRow(
@@ -523,9 +516,9 @@ public class TransformerTest extends InitializedNullHandlingTest
             row.getEvent()
         )
     );
-    Assert.assertEquals(actualTranformedRow.getDimension("dim"), dimList.subList(0, 5));
-    Assert.assertArrayEquals(dimList.subList(0, 5).toArray(), (Object[]) actualTranformedRow.getRaw("dim"));
-    Assert.assertEquals(ImmutableList.of("a"), actualTranformedRow.getDimension("dim1"));
+    Assertions.assertEquals(actualTranformedRow.getDimension("dim"), dimList.subList(0, 5));
+    Assertions.assertArrayEquals(dimList.subList(0, 5).toArray(), (Object[]) actualTranformedRow.getRaw("dim"));
+    Assertions.assertEquals(ImmutableList.of("a"), actualTranformedRow.getDimension("dim1"));
   }
 
   @Test
@@ -550,15 +543,15 @@ public class TransformerTest extends InitializedNullHandlingTest
     Transformer transformer = transformSpec.toTransformer();
     InputRow transformed = transformer.transform(row);
 
-    Assert.assertNotNull(transformed);
-    Assert.assertNotNull(transformed.getRaw("ingestion_time"));
+    Assertions.assertNotNull(transformed);
+    Assertions.assertNotNull(transformed.getRaw("ingestion_time"));
 
     long ingestionTime = ((Number) transformed.getRaw("ingestion_time")).longValue();
     long afterTransform = System.currentTimeMillis();
-    Assert.assertTrue(
+    Assertions.assertTrue(
+        ingestionTime >= beforeTransform && ingestionTime <= afterTransform,
         "Ingestion time should be between transform start and end: "
-            + beforeTransform + " <= " + ingestionTime + " <= " + afterTransform,
-        ingestionTime >= beforeTransform && ingestionTime <= afterTransform
+            + beforeTransform + " <= " + ingestionTime + " <= " + afterTransform
     );
 
     // Verify lag calculation (may be slightly different from ingestionTime - __time due to timing)
@@ -568,13 +561,13 @@ public class TransformerTest extends InitializedNullHandlingTest
 
     // Allow small difference since now() is called twice (once for ingestion_time, once for lag_ms)
     long lagDiff = Math.abs(lag - expectedLag);
-    Assert.assertTrue(
-        "Lag should be approximately correct (diff=" + lagDiff + "ms): expected=" + expectedLag + ", actual=" + lag,
-        lagDiff < 100  // Allow up to 100ms difference
+    Assertions.assertTrue(
+        lagDiff < 100,
+        "Lag should be approximately correct (diff=" + lagDiff + "ms): expected=" + expectedLag + ", actual=" + lag
     );
 
     // Verify lag is positive (ingestion happened after event)
-    Assert.assertTrue("Lag should be positive", lag > 0);
+    Assertions.assertTrue(lag > 0, "Lag should be positive");
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/vector/QueryableIndexVectorColumnSelectorFactoryTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.segment.vector;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
-import junitparams.converters.Nullable;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputRowSchema;
 import org.apache.druid.data.input.impl.DimensionsSpec;
@@ -50,6 +49,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;

--- a/processing/src/test/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/SegmentWriteOutMediumTest.java
@@ -21,21 +21,21 @@ package org.apache.druid.segment.writeout;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.druid.java.util.common.io.Closer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class SegmentWriteOutMediumTest
 {
-
-  @Parameterized.Parameters(name = "medium = {0}")
   public static Iterable<?> constructorFeeder()
   {
     return ImmutableList.of(
@@ -45,8 +45,8 @@ public class SegmentWriteOutMediumTest
     );
   }
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private SegmentWriteOutMediumFactory factory;
   private SegmentWriteOutMedium medium;
@@ -56,7 +56,7 @@ public class SegmentWriteOutMediumTest
     this.factory = factory;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     this.medium = factory.makeSegmentWriteOutMedium(temporaryFolder.newFolder());
@@ -68,14 +68,14 @@ public class SegmentWriteOutMediumTest
     WriteOutBytes bytes1 = medium.makeWriteOutBytes();
     WriteOutBytes bytes2 = medium.makeWriteOutBytes();
 
-    Assert.assertTrue(bytes1.isOpen());
-    Assert.assertTrue(bytes2.isOpen());
+    Assertions.assertTrue(bytes1.isOpen());
+    Assertions.assertTrue(bytes2.isOpen());
 
     Closer closer = medium.getCloser();
     closer.close();
 
-    Assert.assertFalse(bytes1.isOpen());
-    Assert.assertFalse(bytes2.isOpen());
+    Assertions.assertFalse(bytes1.isOpen());
+    Assertions.assertFalse(bytes2.isOpen());
   }
 
   @Test
@@ -84,32 +84,32 @@ public class SegmentWriteOutMediumTest
     WriteOutBytes bytes1 = medium.makeWriteOutBytes();
     WriteOutBytes bytes2 = medium.makeWriteOutBytes();
 
-    Assert.assertTrue(bytes1.isOpen());
-    Assert.assertTrue(bytes2.isOpen());
+    Assertions.assertTrue(bytes1.isOpen());
+    Assertions.assertTrue(bytes2.isOpen());
 
     SegmentWriteOutMedium childMedium = medium.makeChildWriteOutMedium();
-    Assert.assertTrue(childMedium.getClass().equals(medium.getClass()));
+    Assertions.assertTrue(childMedium.getClass().equals(medium.getClass()));
 
     WriteOutBytes bytes3 = childMedium.makeWriteOutBytes();
     WriteOutBytes bytes4 = childMedium.makeWriteOutBytes();
 
-    Assert.assertTrue(bytes3.isOpen());
-    Assert.assertTrue(bytes4.isOpen());
+    Assertions.assertTrue(bytes3.isOpen());
+    Assertions.assertTrue(bytes4.isOpen());
 
     Closer childCloser = childMedium.getCloser();
     childCloser.close();
 
-    Assert.assertFalse(bytes3.isOpen());
-    Assert.assertFalse(bytes4.isOpen());
+    Assertions.assertFalse(bytes3.isOpen());
+    Assertions.assertFalse(bytes4.isOpen());
 
-    Assert.assertTrue(bytes1.isOpen());
-    Assert.assertTrue(bytes2.isOpen());
+    Assertions.assertTrue(bytes1.isOpen());
+    Assertions.assertTrue(bytes2.isOpen());
 
     Closer closer = medium.getCloser();
     closer.close();
 
-    Assert.assertFalse(bytes1.isOpen());
-    Assert.assertFalse(bytes2.isOpen());
+    Assertions.assertFalse(bytes1.isOpen());
+    Assertions.assertFalse(bytes2.isOpen());
   }
 
   @Test
@@ -118,25 +118,25 @@ public class SegmentWriteOutMediumTest
     WriteOutBytes bytes1 = medium.makeWriteOutBytes();
     WriteOutBytes bytes2 = medium.makeWriteOutBytes();
 
-    Assert.assertTrue(bytes1.isOpen());
-    Assert.assertTrue(bytes2.isOpen());
+    Assertions.assertTrue(bytes1.isOpen());
+    Assertions.assertTrue(bytes2.isOpen());
 
     SegmentWriteOutMedium childMedium = medium.makeChildWriteOutMedium();
-    Assert.assertTrue(childMedium.getClass().equals(medium.getClass()));
+    Assertions.assertTrue(childMedium.getClass().equals(medium.getClass()));
 
     WriteOutBytes bytes3 = childMedium.makeWriteOutBytes();
     WriteOutBytes bytes4 = childMedium.makeWriteOutBytes();
 
-    Assert.assertTrue(bytes3.isOpen());
-    Assert.assertTrue(bytes4.isOpen());
+    Assertions.assertTrue(bytes3.isOpen());
+    Assertions.assertTrue(bytes4.isOpen());
 
     Closer closer = medium.getCloser();
     closer.close();
 
-    Assert.assertFalse(bytes1.isOpen());
-    Assert.assertFalse(bytes2.isOpen());
+    Assertions.assertFalse(bytes1.isOpen());
+    Assertions.assertFalse(bytes2.isOpen());
 
-    Assert.assertFalse(bytes3.isOpen());
-    Assert.assertFalse(bytes4.isOpen());
+    Assertions.assertFalse(bytes3.isOpen());
+    Assertions.assertFalse(bytes4.isOpen());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/writeout/WriteOutBytesTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/writeout/WriteOutBytesTest.java
@@ -23,10 +23,10 @@ import com.google.common.primitives.Ints;
 import org.apache.commons.io.IOUtils;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
@@ -35,10 +35,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class WriteOutBytesTest
 {
-  @Parameterized.Parameters
   public static Collection<Object[]> constructorFeeder() throws IOException
   {
     return Arrays.asList(
@@ -75,17 +76,17 @@ public class WriteOutBytesTest
     ByteBuffer bb = ByteBuffer.wrap(new byte[]{'a', 'b', 'c'});
     bb.position(2);
     writeOutBytes.write(bb);
-    Assert.assertEquals(3, bb.position());
+    Assertions.assertEquals(3, bb.position());
     verifyContents(writeOutBytes, "12345abc");
   }
 
   private void verifyContents(WriteOutBytes writeOutBytes, String expected) throws IOException
   {
-    Assert.assertEquals(expected, IOUtils.toString(writeOutBytes.asInputStream(), StandardCharsets.US_ASCII));
+    Assertions.assertEquals(expected, IOUtils.toString(writeOutBytes.asInputStream(), StandardCharsets.US_ASCII));
     ByteBuffer bb = ByteBuffer.allocate((int) writeOutBytes.size());
     writeOutBytes.readFully(0, bb);
     bb.flip();
-    Assert.assertEquals(expected, StringUtils.fromUtf8(bb));
+    Assertions.assertEquals(expected, StringUtils.fromUtf8(bb));
   }
 
   @Test
@@ -101,15 +102,17 @@ public class WriteOutBytesTest
     ByteBuffer bb = ByteBuffer.allocate(4);
     writeOutBytes.readFully(ByteBufferWriteOutBytes.BUFFER_SIZE - 1, bb);
     bb.flip();
-    Assert.assertEquals("0123", StringUtils.fromUtf8(bb));
+    Assertions.assertEquals("0123", StringUtils.fromUtf8(bb));
   }
 
-  @Test(expected = BufferUnderflowException.class)
+  @Test
   public void testReadFullyUnderflow() throws IOException
   {
-    WriteOutBytes writeOutBytes = segmentWriteOutMedium.makeWriteOutBytes();
-    writeOutBytes.write('1');
-    writeOutBytes.readFully(0, ByteBuffer.allocate(2));
+    Assertions.assertThrows(BufferUnderflowException.class, () -> {
+      final WriteOutBytes writeOutBytes = segmentWriteOutMedium.makeWriteOutBytes();
+      writeOutBytes.write('1');
+      writeOutBytes.readFully(0, ByteBuffer.allocate(2));
+    });
   }
 
   @Test
@@ -127,6 +130,6 @@ public class WriteOutBytesTest
     writeOutBytes.write(new byte[] {0x01, 0x02, 0x03, 0x04}, 1, 2);
     ByteBuffer destination = ByteBuffer.allocate(2);
     writeOutBytes.readFully(0, destination);
-    Assert.assertArrayEquals(new byte[] {0x02, 0x03}, destination.array());
+    Assertions.assertArrayEquals(new byte[] {0x02, 0x03}, destination.array());
   }
 }


### PR DESCRIPTION
Fixes #13948.

### Description

Migrate Batch 3 processing tests to the current JUnit 5 APIs while preserving test behavior and compatibility. This covers segment core, serialization, incremental indexes, and the index-merger hierarchy.

The migration uses `TemporaryFolderExtension`, `CloserExtension`, and `LoggerCaptureExtension`, retains the existing `CloserRule` compatibility test, and preserves the shared `DruidExceptionMatcher` and `ExceptionMatcher` APIs.

### Scope

- `processing/src/test/java/org/apache/druid/segment` core and index-merger tests
- `segment/column`, `segment/data`, `segment/generator`, `segment/incremental`, `segment/serde`, `segment/shim`, `segment/transform`, `segment/vector`, and `segment/writeout`
- No query files, shared helper changes, Batch 2 paths, `CloserRule.java`, or `processing/pom.xml` changes

### Validation

- `mvn -ntp -pl processing -am test-compile -Dweb.console.skip=true -T1C` — passed with Checkstyle, PMD, forbidden APIs, enforcer, and compilation checks
- `mvn -ntp -pl processing spotbugs:check -Dweb.console.skip=true` — passed with 0 bugs and 0 errors (SpotBugs reported one missing optional `MarkerManager` class during analysis)
- Focused Batch 3 migration tests — 112 tests passed, 0 failures, 1 intentionally disabled
- `git diff --check` and scope audits — passed

The broader parameterized Schemaless run was not stable on the local OpenJDK 25 environment: it reproduced intermittent direct-buffer `Unsafe` SIGSEGVs and two parameterized-instance flakes that also occurred when the class was run in isolation. No source assertion failure was isolated.

### Key changed/added classes in this PR

- Segment core and index-merger tests
- Column, data, incremental-index, serde, transform, vector, and writeout tests
- `CloserRuleTest` compatibility coverage

This PR has:

- [x] been self-reviewed.
- [x] added or updated unit tests (existing tests migrated while preserving coverage).
