### PR TITLE
test(processing): migrate Batch 2 tests to JUnit 5

### DIFF
--- a/processing/src/test/java/org/apache/druid/frame/FrameTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/FrameTest.java
@@ -37,17 +37,15 @@ import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -67,10 +65,7 @@ public class FrameTest
     private Frame columnarFrame;
     private Frame rowBasedSortedFrame;
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Before
+    @BeforeEach
     public void setUp()
     {
       final CursorFactory cursorFactory = new QueryableIndexCursorFactory(TestIndex.getNoRollupMMappedTestIndex());
@@ -101,67 +96,76 @@ public class FrameTest
     @Test
     public void test_numRows()
     {
-      Assert.assertEquals(1209, columnarFrame.numRows());
-      Assert.assertEquals(1209, rowBasedSortedFrame.numRows());
+      Assertions.assertEquals(1209, columnarFrame.numRows());
+      Assertions.assertEquals(1209, rowBasedSortedFrame.numRows());
     }
 
     @Test
     public void test_numRegions()
     {
-      Assert.assertEquals(21, columnarFrame.numRegions());
-      Assert.assertEquals(2, rowBasedSortedFrame.numRegions());
+      Assertions.assertEquals(21, columnarFrame.numRegions());
+      Assertions.assertEquals(2, rowBasedSortedFrame.numRegions());
     }
 
     @Test
     public void test_isPermuted()
     {
-      Assert.assertFalse(columnarFrame.isPermuted());
-      Assert.assertTrue(rowBasedSortedFrame.isPermuted());
+      Assertions.assertFalse(columnarFrame.isPermuted());
+      Assertions.assertTrue(rowBasedSortedFrame.isPermuted());
     }
 
     @Test
     public void test_physicalRow_standard()
     {
       for (int i = 0; i < columnarFrame.numRows(); i++) {
-        Assert.assertEquals(i, columnarFrame.physicalRow(i));
+        Assertions.assertEquals(i, columnarFrame.physicalRow(i));
       }
     }
 
     @Test
     public void test_physicalRow_standard_outOfBoundsTooLow()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Row [-1] out of bounds");
-      columnarFrame.physicalRow(-1);
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> columnarFrame.physicalRow(-1)
+      );
+      Assertions.assertEquals("Row [-1] out of bounds", exception.getMessage());
     }
 
     @Test
     public void test_physicalRow_standard_outOfBoundsTooHigh()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Row [1,209] out of bounds");
-      columnarFrame.physicalRow(Ints.checkedCast(columnarFrame.numRows()));
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> columnarFrame.physicalRow(Ints.checkedCast(columnarFrame.numRows()))
+      );
+      Assertions.assertEquals("Row [1,209] out of bounds", exception.getMessage());
     }
 
     @Test
     public void test_physicalRow_sorted_outOfBoundsTooLow()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Row [-1] out of bounds");
-      rowBasedSortedFrame.physicalRow(-1);
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> rowBasedSortedFrame.physicalRow(-1)
+      );
+      Assertions.assertEquals("Row [-1] out of bounds", exception.getMessage());
     }
 
     @Test
     public void test_physicalRow_sorted_outOfBoundsTooHigh()
     {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Row [1,209] out of bounds");
-      rowBasedSortedFrame.physicalRow(Ints.checkedCast(columnarFrame.numRows()));
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> rowBasedSortedFrame.physicalRow(Ints.checkedCast(columnarFrame.numRows()))
+      );
+      Assertions.assertEquals("Row [1,209] out of bounds", exception.getMessage());
     }
   }
 
   // Tests that explore "wrap", "decompress", and "writeTo" with different kinds of backing memory.
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class WrapAndWriteTest extends InitializedNullHandlingTest
   {
     private static byte[] FRAME_DATA;
@@ -300,7 +304,6 @@ public class FrameTest
       this.compressed = compressed;
     }
 
-    @Parameterized.Parameters(name = "memType = {0}, compressed = {1}")
     public static Iterable<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -314,7 +317,7 @@ public class FrameTest
       return constructors;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass() throws Exception
     {
       final CursorFactory cursorFactory = new IncrementalIndexCursorFactory(TestIndex.getIncrementalTestIndex());
@@ -327,14 +330,14 @@ public class FrameTest
       FRAME_DATA_COMPRESSED = frameToByteArray(frame, true);
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass()
     {
       FRAME_DATA = null;
       FRAME_DATA_COMPRESSED = null;
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws IOException
     {
       closer.close();
@@ -354,12 +357,12 @@ public class FrameTest
       );
 
       if (!compressed) {
-        Assert.assertArrayEquals(FRAME_DATA, baos.toByteArray());
+        Assertions.assertArrayEquals(FRAME_DATA, baos.toByteArray());
       } else {
         // Decompress and check.
         final byte[] compressedData = baos.toByteArray();
         final Frame frame2 = Frame.decompress(Memory.wrap(baos.toByteArray()), 0, compressedData.length);
-        Assert.assertArrayEquals(FRAME_DATA, frameToByteArray(frame2, false));
+        Assertions.assertArrayEquals(FRAME_DATA, frameToByteArray(frame2, false));
       }
     }
   }
@@ -374,7 +377,7 @@ public class FrameTest
       final Frame frame = makeGoodFrame();
       final Memory compressedFrameMemory = Memory.wrap(frameToByteArray(frame, true));
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           frame.writableMemory(),
           Frame.decompress(compressedFrameMemory, 0, compressedFrameMemory.getCapacity()).writableMemory()
       );
@@ -389,12 +392,12 @@ public class FrameTest
       // Tweak a byte.
       compressedFrameMemory.putByte(100L, (byte) 0);
 
-      final IllegalStateException e = Assert.assertThrows(
+      final IllegalStateException e = Assertions.assertThrows(
           IllegalStateException.class,
           () -> Frame.decompress(compressedFrameMemory, 0, compressedFrameMemory.getCapacity())
       );
 
-      MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("Checksum mismatch")));
+      MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("Checksum mismatch")));
     }
 
     private static Frame makeGoodFrame()

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableByteChunksFrameChannelTest.java
@@ -43,16 +43,15 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
@@ -71,11 +70,8 @@ public class ReadableByteChunksFrameChannelTest
    */
   public static class NonParameterizedTests extends InitializedNullHandlingTest
   {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
     @Test
     public void testZeroBytes()
@@ -83,14 +79,15 @@ public class ReadableByteChunksFrameChannelTest
       final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test", false, null);
       channel.doneWriting();
 
-      Assert.assertTrue(channel.canRead());
-      Assert.assertFalse(channel.isFinished());
-      Assert.assertTrue(channel.isErrorOrFinished());
+      Assertions.assertTrue(channel.canRead());
+      Assertions.assertFalse(channel.isFinished());
+      Assertions.assertTrue(channel.isErrorOrFinished());
 
-      expectedException.expect(IllegalStateException.class);
-      expectedException.expectMessage("Incomplete or missing frame at end of stream (id = test, position = 0)");
-
-      channel.readFrame();
+      final IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, channel::readFrame);
+      Assertions.assertEquals(
+          "Incomplete or missing frame at end of stream (id = test, position = 0)",
+          exception.getMessage()
+      );
     }
 
     @Test
@@ -100,14 +97,12 @@ public class ReadableByteChunksFrameChannelTest
       channel.setError(new IllegalArgumentException("test error"));
       channel.doneWriting();
 
-      Assert.assertTrue(channel.canRead());
-      Assert.assertFalse(channel.isFinished());
-      Assert.assertTrue(channel.isErrorOrFinished());
+      Assertions.assertTrue(channel.canRead());
+      Assertions.assertFalse(channel.isFinished());
+      Assertions.assertTrue(channel.isErrorOrFinished());
 
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("test error");
-
-      channel.readFrame();
+      final IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, channel::readFrame);
+      Assertions.assertEquals("test error", exception.getMessage());
     }
 
     @Test
@@ -119,15 +114,15 @@ public class ReadableByteChunksFrameChannelTest
       final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test", false, null);
       channel.addChunk(Files.toByteArray(file));
       channel.doneWriting();
-      Assert.assertEquals(file.length(), channel.getBytesAdded());
+      Assertions.assertEquals(file.length(), channel.getBytesAdded());
 
       while (channel.canRead()) {
-        Assert.assertFalse(channel.isFinished());
-        Assert.assertFalse(channel.isErrorOrFinished());
+        Assertions.assertFalse(channel.isFinished());
+        Assertions.assertFalse(channel.isErrorOrFinished());
         channel.readFrame();
       }
 
-      Assert.assertTrue(channel.isFinished());
+      Assertions.assertTrue(channel.isFinished());
       channel.close();
     }
 
@@ -137,7 +132,7 @@ public class ReadableByteChunksFrameChannelTest
       try (final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test", false, null)) {
         channel.doneWriting();
 
-        Assert.assertThrows(
+        Assertions.assertThrows(
             ChannelClosedForWritesException.class,
             () -> channel.addChunk(new byte[]{})
         );
@@ -170,25 +165,24 @@ public class ReadableByteChunksFrameChannelTest
       final ReadableByteChunksFrameChannel channel = ReadableByteChunksFrameChannel.create("test", false, null);
       channel.addChunk(truncatedFile);
       channel.doneWriting();
-      Assert.assertEquals(truncatedFile.length, channel.getBytesAdded());
+      Assertions.assertEquals(truncatedFile.length, channel.getBytesAdded());
 
-      Assert.assertTrue(channel.canRead());
-      Assert.assertFalse(channel.isFinished());
-      Assert.assertFalse(channel.isErrorOrFinished());
+      Assertions.assertTrue(channel.canRead());
+      Assertions.assertFalse(channel.isFinished());
+      Assertions.assertFalse(channel.isErrorOrFinished());
       channel.readFrame(); // Throw away value.
 
-      Assert.assertTrue(channel.canRead());
-      Assert.assertFalse(channel.isFinished());
-      Assert.assertFalse(channel.isErrorOrFinished());
+      Assertions.assertTrue(channel.canRead());
+      Assertions.assertFalse(channel.isFinished());
+      Assertions.assertFalse(channel.isErrorOrFinished());
       channel.readFrame(); // Throw away value.
 
-      Assert.assertTrue(channel.canRead());
-      Assert.assertFalse(channel.isFinished());
-      Assert.assertTrue(channel.isErrorOrFinished());
+      Assertions.assertTrue(channel.canRead());
+      Assertions.assertFalse(channel.isFinished());
+      Assertions.assertTrue(channel.isErrorOrFinished());
 
-      expectedException.expect(IllegalStateException.class);
-      expectedException.expectMessage(CoreMatchers.startsWith("Incomplete or missing frame at end of stream"));
-      channel.readFrame();
+      final IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, channel::readFrame);
+      Assertions.assertTrue(exception.getMessage().startsWith("Incomplete or missing frame at end of stream"));
     }
 
     @Test
@@ -213,26 +207,26 @@ public class ReadableByteChunksFrameChannelTest
       final byte[] chunk1 = new byte[errorAtBytePosition];
       System.arraycopy(fileBytes, 0, chunk1, 0, chunk1.length);
       channel.addChunk(chunk1);
-      Assert.assertEquals(chunk1.length, channel.getBytesAdded());
+      Assertions.assertEquals(chunk1.length, channel.getBytesAdded());
 
       channel.setError(new ISE("Test error!"));
       channel.doneWriting();
-      Assert.assertEquals(chunk1.length, channel.getBytesAdded());
+      Assertions.assertEquals(chunk1.length, channel.getBytesAdded());
 
-      expectedException.expect(IllegalStateException.class);
-      expectedException.expectMessage("Test error!");
-      channel.readFrame();
+      final IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, channel::readFrame);
+      Assertions.assertEquals("Test error!", exception.getMessage());
     }
   }
 
   /**
    * Parameterized test cases that use various FrameFiles built from {@link TestIndex#getIncrementalTestIndex()}.
    */
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class ParameterizedWithTestIndexTests extends InitializedNullHandlingTest
   {
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
     private final FrameType frameType;
     private final int maxRowsPerFrame;
@@ -252,7 +246,6 @@ public class ReadableByteChunksFrameChannelTest
       this.useLegacyFrameSerialization = useLegacyFrameSerialization;
     }
 
-    @Parameterized.Parameters(name = "frameType = {0}, maxRowsPerFrame = {1}, chunkSize = {2}, useLegacyFrameSerialization = {3}")
     public static Iterable<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -330,7 +323,7 @@ public class ReadableByteChunksFrameChannelTest
       ListenableFuture<?> firstBackpressureFuture = null;
 
       long totalSize = 0;
-      Assert.assertEquals(0, channel.getBytesBuffered());
+      Assertions.assertEquals(0, channel.getBytesBuffered());
 
       try (final Chunker chunker = new Chunker(new FileInputStream(file), chunkSize)) {
         byte[] chunk;
@@ -339,23 +332,23 @@ public class ReadableByteChunksFrameChannelTest
           totalSize += chunk.length;
 
           final ListenableFuture<?> backpressureFuture = channel.addChunk(chunk);
-          Assert.assertEquals(channel.getBytesAdded(), totalSize);
+          Assertions.assertEquals(channel.getBytesAdded(), totalSize);
 
           // Minimally-sized channel means backpressure is exerted as soon as a single frame is available.
-          Assert.assertEquals(channel.canRead(), backpressureFuture != null);
+          Assertions.assertEquals(channel.canRead(), backpressureFuture != null);
 
           if (backpressureFuture != null) {
             if (firstBackpressureFuture == null) {
               firstBackpressureFuture = backpressureFuture;
             } else {
-              Assert.assertSame(firstBackpressureFuture, backpressureFuture);
+              Assertions.assertSame(firstBackpressureFuture, backpressureFuture);
             }
           }
         }
 
         // Backpressure should be exerted right now, since this is a minimal channel with at least one full frame in it.
-        Assert.assertNotNull(firstBackpressureFuture);
-        Assert.assertFalse(firstBackpressureFuture.isDone());
+        Assertions.assertNotNull(firstBackpressureFuture);
+        Assertions.assertFalse(firstBackpressureFuture.isDone());
 
         channel.doneWriting();
       }
@@ -395,7 +388,7 @@ public class ReadableByteChunksFrameChannelTest
             }
 
             // After reading everything, backpressure should be off.
-            Assert.assertTrue(backpressureFuture == null || backpressureFuture.isDone());
+            Assertions.assertTrue(backpressureFuture == null || backpressureFuture.isDone());
           } else if (iteration % 11 == 0) {
             if (channel.canRead()) {
               outChannel.writable().write(channel.readFrame());
@@ -411,16 +404,16 @@ public class ReadableByteChunksFrameChannelTest
 
           // Write next chunk.
           final ListenableFuture<?> addVal = channel.addChunk(chunk);
-          Assert.assertEquals(totalSize, channel.getBytesAdded());
+          Assertions.assertEquals(totalSize, channel.getBytesAdded());
 
           // Minimally-sized channel means backpressure is exerted as soon as a single frame is available.
-          Assert.assertEquals(channel.canRead(), addVal != null);
+          Assertions.assertEquals(channel.canRead(), addVal != null);
 
           if (addVal != null) {
             if (backpressureFuture == null) {
               backpressureFuture = addVal;
             } else {
-              Assert.assertSame(backpressureFuture, addVal);
+              Assertions.assertSame(backpressureFuture, addVal);
             }
           }
         }
@@ -477,7 +470,7 @@ public class ReadableByteChunksFrameChannelTest
       while (channel.canRead()) {
         final RowsAndColumns rac = channel.read();
         final Frame frame = rac.as(Frame.class);
-        Assert.assertNotNull("Frame should be retrievable from RAC", frame);
+        Assertions.assertNotNull(frame, "Frame should be retrievable from RAC");
 
         // Read rows from this frame
         final Sequence<List<Object>> frameRows = FrameTestUtil.readRowsFromCursorFactory(
@@ -486,12 +479,12 @@ public class ReadableByteChunksFrameChannelTest
         readRows.addAll(frameRows.toList());
       }
 
-      Assert.assertTrue(channel.isFinished());
+      Assertions.assertTrue(channel.isFinished());
 
       // Verify data integrity
       final List<List<Object>> originalRows =
           FrameTestUtil.readRowsFromCursorFactory(cursorFactory).toList();
-      Assert.assertEquals(originalRows, readRows);
+      Assertions.assertEquals(originalRows, readRows);
     }
 
     @Test
@@ -551,12 +544,12 @@ public class ReadableByteChunksFrameChannelTest
         readRows.addAll(frameRows.toList());
       }
 
-      Assert.assertTrue(channel.isFinished());
+      Assertions.assertTrue(channel.isFinished());
 
       // Verify data integrity
       final List<List<Object>> originalRows =
           FrameTestUtil.readRowsFromCursorFactory(cursorFactory).toList();
-      Assert.assertEquals(originalRows, readRows);
+      Assertions.assertEquals(originalRows, readRows);
     }
 
     private static class Chunker implements Closeable

--- a/processing/src/test/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannelTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/channel/ReadableInputStreamFrameChannelTest.java
@@ -31,8 +31,8 @@ import org.apache.druid.java.util.common.guava.Sequences;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -136,7 +136,7 @@ public class ReadableInputStreamFrameChannelTest extends InitializedNullHandling
 
     MatcherAssert.assertThat(
         e.getMessage(),
-        CoreMatchers.startsWith("Incomplete or missing frame at end of stream")
+        Matchers.startsWith("Incomplete or missing frame at end of stream")
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/field/ComplexFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/ComplexFieldReaderTest.java
@@ -33,7 +33,7 @@ import org.apache.druid.segment.serde.ComplexMetricSerde;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +44,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.annotation.Nullable;
+
 import java.nio.ByteBuffer;
 
 @ExtendWith(MockitoExtension.class)
@@ -81,7 +82,7 @@ public class ComplexFieldReaderTest extends InitializedNullHandlingTest
 
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("Expected complex type"))
+        Matchers.hasProperty("message", CoreMatchers.containsString("Expected complex type"))
     );
   }
 
@@ -95,7 +96,7 @@ public class ComplexFieldReaderTest extends InitializedNullHandlingTest
 
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("No serde for complexTypeName[no-serde]"))
+        Matchers.hasProperty("message", CoreMatchers.containsString("No serde for complexTypeName[no-serde]"))
     );
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/field/StringFieldReaderTest.java
@@ -46,6 +46,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/processing/src/test/java/org/apache/druid/frame/file/FrameFileHttpResponseHandlerTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/file/FrameFileHttpResponseHandlerTest.java
@@ -35,8 +35,10 @@ import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.jboss.netty.buffer.ByteBufferBackedChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.handler.codec.http.DefaultHttpChunk;
@@ -45,14 +47,12 @@ import org.jboss.netty.handler.codec.http.HttpChunk;
 import org.jboss.netty.handler.codec.http.HttpResponse;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
 import org.jboss.netty.handler.codec.http.HttpVersion;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,11 +62,13 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private final int maxRowsPerFrame;
 
@@ -80,7 +82,6 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     this.maxRowsPerFrame = maxRowsPerFrame;
   }
 
-  @Parameterized.Parameters(name = "maxRowsPerFrame = {0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -92,7 +93,7 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     return constructors;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     cursorFactory = new IncrementalIndexCursorFactory(TestIndex.getIncrementalTestIndex());
@@ -116,20 +117,20 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         null
     );
 
-    Assert.assertFalse(response1.isFinished());
-    Assert.assertTrue(response1.isContinueReading());
-    Assert.assertFalse(response1.getObj().isExceptionCaught());
-    Assert.assertFalse(response1.getObj().isLastFetch());
+    Assertions.assertFalse(response1.isFinished());
+    Assertions.assertTrue(response1.isContinueReading());
+    Assertions.assertFalse(response1.getObj().isExceptionCaught());
+    Assertions.assertFalse(response1.getObj().isLastFetch());
 
     final ClientResponse<FrameFilePartialFetch> response2 = handler.done(response1);
 
-    Assert.assertTrue(response2.isFinished());
-    Assert.assertTrue(response2.isContinueReading());
-    Assert.assertFalse(response2.getObj().isExceptionCaught());
-    Assert.assertFalse(response2.getObj().isLastFetch());
+    Assertions.assertTrue(response2.isFinished());
+    Assertions.assertTrue(response2.isContinueReading());
+    Assertions.assertFalse(response2.getObj().isExceptionCaught());
+    Assertions.assertFalse(response2.getObj().isLastFetch());
 
     final ListenableFuture<?> backpressureFuture = response2.getObj().backpressureFuture();
-    Assert.assertFalse(backpressureFuture.isDone());
+    Assertions.assertFalse(backpressureFuture.isDone());
 
     channel.doneWriting();
 
@@ -139,7 +140,7 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     );
 
     // Backpressure future resolves once channel is read.
-    Assert.assertTrue(backpressureFuture.isDone());
+    Assertions.assertTrue(backpressureFuture.isDone());
   }
 
   @Test
@@ -150,18 +151,18 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         null
     );
 
-    Assert.assertFalse(response1.isFinished());
-    Assert.assertTrue(response1.isContinueReading());
-    Assert.assertFalse(response1.getObj().isExceptionCaught());
-    Assert.assertFalse(response1.getObj().isLastFetch());
+    Assertions.assertFalse(response1.isFinished());
+    Assertions.assertTrue(response1.isContinueReading());
+    Assertions.assertFalse(response1.getObj().isExceptionCaught());
+    Assertions.assertFalse(response1.getObj().isLastFetch());
 
     final ClientResponse<FrameFilePartialFetch> response2 = handler.done(response1);
 
-    Assert.assertTrue(response2.isFinished());
-    Assert.assertTrue(response2.isContinueReading());
-    Assert.assertFalse(response2.getObj().isExceptionCaught());
-    Assert.assertFalse(response2.getObj().isLastFetch());
-    Assert.assertTrue(response2.getObj().backpressureFuture().isDone());
+    Assertions.assertTrue(response2.isFinished());
+    Assertions.assertTrue(response2.isContinueReading());
+    Assertions.assertFalse(response2.getObj().isExceptionCaught());
+    Assertions.assertFalse(response2.getObj().isLastFetch());
+    Assertions.assertTrue(response2.getObj().backpressureFuture().isDone());
   }
 
   @Test
@@ -178,18 +179,18 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         null
     );
 
-    Assert.assertFalse(response1.isFinished());
-    Assert.assertTrue(response1.isContinueReading());
-    Assert.assertFalse(response1.getObj().isExceptionCaught());
-    Assert.assertTrue(response1.getObj().isLastFetch());
+    Assertions.assertFalse(response1.isFinished());
+    Assertions.assertTrue(response1.isContinueReading());
+    Assertions.assertFalse(response1.getObj().isExceptionCaught());
+    Assertions.assertTrue(response1.getObj().isLastFetch());
 
     final ClientResponse<FrameFilePartialFetch> response2 = handler.done(response1);
 
-    Assert.assertTrue(response2.isFinished());
-    Assert.assertTrue(response2.isContinueReading());
-    Assert.assertFalse(response2.getObj().isExceptionCaught());
-    Assert.assertTrue(response2.getObj().isLastFetch());
-    Assert.assertTrue(response2.getObj().backpressureFuture().isDone());
+    Assertions.assertTrue(response2.isFinished());
+    Assertions.assertTrue(response2.isContinueReading());
+    Assertions.assertFalse(response2.getObj().isExceptionCaught());
+    Assertions.assertTrue(response2.getObj().isLastFetch());
+    Assertions.assertTrue(response2.getObj().backpressureFuture().isDone());
   }
 
   @Test
@@ -203,7 +204,7 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         null
     );
 
-    Assert.assertFalse(response.isFinished());
+    Assertions.assertFalse(response.isFinished());
 
     for (int p = chunkSize; p < allBytes.length; p += chunkSize) {
       response = handler.handleChunk(
@@ -212,20 +213,20 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
           p / chunkSize
       );
 
-      Assert.assertFalse(response.isFinished());
-      Assert.assertFalse(response.getObj().isExceptionCaught());
-      Assert.assertFalse(response.getObj().isLastFetch());
+      Assertions.assertFalse(response.isFinished());
+      Assertions.assertFalse(response.getObj().isExceptionCaught());
+      Assertions.assertFalse(response.getObj().isLastFetch());
     }
 
     final ClientResponse<FrameFilePartialFetch> finalResponse = handler.done(response);
 
-    Assert.assertTrue(finalResponse.isFinished());
-    Assert.assertTrue(finalResponse.isContinueReading());
-    Assert.assertFalse(response.getObj().isExceptionCaught());
-    Assert.assertFalse(response.getObj().isLastFetch());
+    Assertions.assertTrue(finalResponse.isFinished());
+    Assertions.assertTrue(finalResponse.isContinueReading());
+    Assertions.assertFalse(response.getObj().isExceptionCaught());
+    Assertions.assertFalse(response.getObj().isLastFetch());
 
     final ListenableFuture<?> backpressureFuture = response.getObj().backpressureFuture();
-    Assert.assertFalse(backpressureFuture.isDone());
+    Assertions.assertFalse(backpressureFuture.isDone());
 
     channel.doneWriting();
 
@@ -235,7 +236,7 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     );
 
     // Backpressure future resolves after channel is read.
-    Assert.assertTrue(backpressureFuture.isDone());
+    Assertions.assertTrue(backpressureFuture.isDone());
   }
 
   @Test
@@ -247,22 +248,22 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     );
 
     final ClientResponse<FrameFilePartialFetch> finalResponse = handler.done(response);
-    Assert.assertTrue(finalResponse.isFinished());
-    Assert.assertTrue(finalResponse.isContinueReading());
+    Assertions.assertTrue(finalResponse.isFinished());
+    Assertions.assertTrue(finalResponse.isContinueReading());
 
     // Verify that the exception handler was called.
-    Assert.assertTrue(finalResponse.getObj().isExceptionCaught());
+    Assertions.assertTrue(finalResponse.getObj().isExceptionCaught());
     final Throwable e = finalResponse.getObj().getExceptionCaught();
     MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(
+        Matchers.hasProperty("message",
             CoreMatchers.equalTo("Server for [test] returned [500 Internal Server Error]")
         )
     );
 
     // Verify that the channel has not had an error state set. This enables reconnection later.
-    Assert.assertFalse(channel.isErrorOrFinished());
+    Assertions.assertFalse(channel.isErrorOrFinished());
   }
 
   @Test
@@ -276,22 +277,22 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     response = handler.handleChunk(response, makeChunk(StringUtils.toUtf8("no!")), 1);
 
     final ClientResponse<FrameFilePartialFetch> finalResponse = handler.done(response);
-    Assert.assertTrue(finalResponse.isFinished());
-    Assert.assertTrue(finalResponse.isContinueReading());
+    Assertions.assertTrue(finalResponse.isFinished());
+    Assertions.assertTrue(finalResponse.isContinueReading());
 
     // Verify that the exception handler was called.
-    Assert.assertTrue(finalResponse.getObj().isExceptionCaught());
+    Assertions.assertTrue(finalResponse.getObj().isExceptionCaught());
     final Throwable e = finalResponse.getObj().getExceptionCaught();
     MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(
+        Matchers.hasProperty("message",
             CoreMatchers.equalTo("Server for [test] returned [500 Internal Server Error]")
         )
     );
 
     // Verify that the channel has not had an error state set. This enables reconnection later.
-    Assert.assertFalse(channel.isErrorOrFinished());
+    Assertions.assertFalse(channel.isErrorOrFinished());
   }
 
   @Test
@@ -306,7 +307,7 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         null
     );
 
-    Assert.assertFalse(response.isFinished());
+    Assertions.assertFalse(response.isFinished());
 
     // Add next chunk.
     response = handler.handleChunk(
@@ -326,18 +327,18 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     );
 
     // Verify that the exception handler was called.
-    Assert.assertTrue(response.getObj().isExceptionCaught());
+    Assertions.assertTrue(response.getObj().isExceptionCaught());
     final Throwable e = response.getObj().getExceptionCaught();
     MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Oh no!")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.equalTo("Oh no!")));
 
     // Verify that the channel has not had an error state set.
-    Assert.assertFalse(channel.isErrorOrFinished());
+    Assertions.assertFalse(channel.isErrorOrFinished());
 
     // Simulate successful reconnection with a different handler: add the rest of the data directly to the channel.
     channel.addChunk(byteSlice(allBytes, chunkSize * 2, chunkSize));
     channel.addChunk(byteSlice(allBytes, chunkSize * 3, chunkSize));
-    Assert.assertEquals(allBytes.length, channel.getBytesAdded());
+    Assertions.assertEquals(allBytes.length, channel.getBytesAdded());
     channel.doneWriting();
 
     FrameTestUtil.assertRowsEqual(
@@ -362,8 +363,8 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         )
     );
 
-    Assert.assertEquals(firstPart, channel.getBytesAdded());
-    Assert.assertTrue(response.isFinished());
+    Assertions.assertEquals(firstPart, channel.getBytesAdded());
+    Assertions.assertTrue(response.isFinished());
 
     // Add first quarter after firstPart using a new handler.
     handler = new FrameFileHttpResponseHandler(channel);
@@ -383,10 +384,10 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     );
 
     // Verify that the exception handler was called.
-    Assert.assertTrue(response.getObj().isExceptionCaught());
+    Assertions.assertTrue(response.getObj().isExceptionCaught());
     final Throwable e = response.getObj().getExceptionCaught();
     MatcherAssert.assertThat(e, CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("Oh no!")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.equalTo("Oh no!")));
 
     // Retry connection with the same handler and same initial offset firstPart (don't recreate handler), but now use
     // thirds instead of quarters as chunks. (ServiceClientImpl would retry from the same offset with the same handler
@@ -396,8 +397,8 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         null
     );
 
-    Assert.assertEquals(firstPart + chunkSize * 4L, channel.getBytesAdded());
-    Assert.assertFalse(response.isFinished());
+    Assertions.assertEquals(firstPart + chunkSize * 4L, channel.getBytesAdded());
+    Assertions.assertFalse(response.isFinished());
 
     // Send the rest of the data.
     response = handler.handleChunk(
@@ -405,7 +406,7 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
         makeChunk(byteSlice(allBytes, firstPart + chunkSize * 4, chunkSize * 4)),
         1
     );
-    Assert.assertEquals(firstPart + chunkSize * 8L, channel.getBytesAdded());
+    Assertions.assertEquals(firstPart + chunkSize * 8L, channel.getBytesAdded());
 
     response = handler.handleChunk(
         response,
@@ -414,11 +415,11 @@ public class FrameFileHttpResponseHandlerTest extends InitializedNullHandlingTes
     );
     response = handler.done(response);
 
-    Assert.assertTrue(response.isFinished());
-    Assert.assertFalse(response.getObj().isExceptionCaught());
+    Assertions.assertTrue(response.isFinished());
+    Assertions.assertFalse(response.getObj().isExceptionCaught());
 
     // Verify channel.
-    Assert.assertEquals(allBytes.length, channel.getBytesAdded());
+    Assertions.assertEquals(allBytes.length, channel.getBytesAdded());
     channel.doneWriting();
     FrameTestUtil.assertRowsEqual(
         FrameTestUtil.readRowsFromCursorFactory(cursorFactory),

--- a/processing/src/test/java/org/apache/druid/frame/file/FrameFileTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/file/FrameFileTest.java
@@ -42,19 +42,18 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.hamcrest.Matchers;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -70,7 +69,9 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class FrameFileTest extends InitializedNullHandlingTest
 {
   /**
@@ -144,11 +145,8 @@ public class FrameFileTest extends InitializedNullHandlingTest
     abstract int getRowCount();
   }
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private final FrameType frameType;
   private final int maxRowsPerFrame;
@@ -178,14 +176,6 @@ public class FrameFileTest extends InitializedNullHandlingTest
     this.useLegacyFrameSerialization = useLegacyFrameSerialization;
   }
 
-  @Parameterized.Parameters(
-      name = "frameType = {0}, "
-             + "maxRowsPerFrame = {1}, "
-             + "partitioned = {2}, "
-             + "adapter = {3}, "
-             + "maxMmapSize = {4}, "
-             + "useLegacyFrameSerialization = {5}"
-  )
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -232,7 +222,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     cursorFactory = adapterType.getCursorFactory();
@@ -246,7 +236,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass()
   {
     FRAME_FILES.clear();
@@ -256,7 +246,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   public void test_numFrames() throws IOException
   {
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
-      Assert.assertEquals(computeExpectedNumFrames(), frameFile.numFrames());
+      Assertions.assertEquals(computeExpectedNumFrames(), frameFile.numFrames());
     }
   }
 
@@ -264,7 +254,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   public void test_numPartitions() throws IOException
   {
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
-      Assert.assertEquals(computeExpectedNumPartitions(), frameFile.numPartitions());
+      Assertions.assertEquals(computeExpectedNumPartitions(), frameFile.numPartitions());
     }
   }
 
@@ -273,10 +263,10 @@ public class FrameFileTest extends InitializedNullHandlingTest
   {
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
       // Skip test for empty files.
-      Assume.assumeThat(frameFile.numFrames(), Matchers.greaterThan(0));
+      Assumptions.assumeTrue(frameFile.numFrames() > 0);
 
       final Frame firstFrame = frameFile.rac(0, makeConcreteDeserializer()).as(Frame.class);
-      Assert.assertEquals(Math.min(rowCount, maxRowsPerFrame), firstFrame.numRows());
+      Assertions.assertEquals(Math.min(rowCount, maxRowsPerFrame), firstFrame.numRows());
     }
   }
 
@@ -285,10 +275,10 @@ public class FrameFileTest extends InitializedNullHandlingTest
   {
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
       // Skip test for empty files.
-      Assume.assumeThat(frameFile.numFrames(), Matchers.greaterThan(0));
+      Assumptions.assumeTrue(frameFile.numFrames() > 0);
 
       final Frame lastFrame = frameFile.rac(frameFile.numFrames() - 1, makeConcreteDeserializer()).as(Frame.class);
-      Assert.assertEquals(
+      Assertions.assertEquals(
           rowCount % maxRowsPerFrame != 0
           ? rowCount % maxRowsPerFrame
           : Math.min(rowCount, maxRowsPerFrame),
@@ -301,9 +291,11 @@ public class FrameFileTest extends InitializedNullHandlingTest
   public void test_rac_outOfBoundsNegative() throws IOException
   {
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage("Batch[-1] out of bounds");
-      frameFile.rac(-1, null);
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> frameFile.rac(-1, null)
+      );
+      Assertions.assertEquals("Batch[-1] out of bounds", exception.getMessage());
     }
   }
 
@@ -311,9 +303,14 @@ public class FrameFileTest extends InitializedNullHandlingTest
   public void test_rac_outOfBoundsTooLarge() throws IOException
   {
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
-      expectedException.expect(IllegalArgumentException.class);
-      expectedException.expectMessage(StringUtils.format("Batch[%,d] out of bounds", frameFile.numFrames()));
-      frameFile.rac(frameFile.numFrames(), null);
+      final IllegalArgumentException exception = Assertions.assertThrows(
+          IllegalArgumentException.class,
+          () -> frameFile.rac(frameFile.numFrames(), null)
+      );
+      Assertions.assertEquals(
+          StringUtils.format("Batch[%,d] out of bounds", frameFile.numFrames()),
+          exception.getMessage()
+      );
     }
   }
 
@@ -342,8 +339,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
       if (partitioned) {
         for (int partitionNum = 0; partitionNum < frameFile.numPartitions(); partitionNum++) {
-          Assert.assertEquals(
-              "partition #" + partitionNum,
+          Assertions.assertEquals(
               Math.min(
                   IntMath.divide(
                       (partitionNum >= SKIP_PARTITION ? partitionNum + 1 : partitionNum) * PARTITION_SIZE,
@@ -352,11 +348,12 @@ public class FrameFileTest extends InitializedNullHandlingTest
                   ),
                   frameFile.numFrames()
               ),
-              frameFile.getPartitionStartFrame(partitionNum)
+              frameFile.getPartitionStartFrame(partitionNum),
+              "partition #" + partitionNum
           );
         }
       } else {
-        Assert.assertEquals(frameFile.numFrames(), frameFile.getPartitionStartFrame(0));
+        Assertions.assertEquals(frameFile.numFrames(), frameFile.getPartitionStartFrame(0));
       }
     }
   }
@@ -365,7 +362,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
   public void test_file() throws IOException
   {
     try (final FrameFile frameFile = FrameFile.open(file, maxMmapSize, null)) {
-      Assert.assertEquals(file, frameFile.file());
+      Assertions.assertEquals(file, frameFile.file());
     }
   }
 
@@ -373,10 +370,10 @@ public class FrameFileTest extends InitializedNullHandlingTest
   public void test_open_withDeleteOnClose() throws IOException
   {
     FrameFile.open(file, maxMmapSize, null).close();
-    Assert.assertTrue(file.exists());
+    Assertions.assertTrue(file.exists());
 
     FrameFile.open(file, null, FrameFile.Flag.DELETE_ON_CLOSE).close();
-    Assert.assertFalse(file.exists());
+    Assertions.assertFalse(file.exists());
   }
 
   @Test
@@ -388,7 +385,7 @@ public class FrameFileTest extends InitializedNullHandlingTest
 
     // Closing original file does nothing; must wait for other files to be closed.
     frameFile1.close();
-    Assert.assertTrue(file.exists());
+    Assertions.assertTrue(file.exists());
 
     // Can still get a reference after frameFile1 is closed, just because others are still open. Strange but true.
     final FrameFile frameFile4 = frameFile1.newReference();
@@ -400,19 +397,18 @@ public class FrameFileTest extends InitializedNullHandlingTest
     frameFile2.close();
     frameFile2.close();
     frameFile2.close();
-    Assert.assertTrue(file.exists());
+    Assertions.assertTrue(file.exists());
 
     frameFile3.close();
-    Assert.assertTrue(file.exists());
+    Assertions.assertTrue(file.exists());
 
     // Final reference is closed; file is now gone.
     frameFile4.close();
-    Assert.assertFalse(file.exists());
+    Assertions.assertFalse(file.exists());
 
     // Can no longer get new references.
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage("Frame file is closed");
-    frameFile1.newReference();
+    final IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, frameFile1::newReference);
+    Assertions.assertEquals("Frame file is closed", exception.getMessage());
   }
 
   private int computeExpectedNumFrames()

--- a/processing/src/test/java/org/apache/druid/frame/file/FrameFileWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/file/FrameFileWriterTest.java
@@ -31,7 +31,7 @@ import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -81,7 +81,7 @@ public class FrameFileWriterTest extends InitializedNullHandlingTest
 
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(
+        Matchers.hasProperty("message",
             CoreMatchers.containsString("Corrupt or truncated file[")
         )
     );

--- a/processing/src/test/java/org/apache/druid/frame/key/ByteRowKeyComparatorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/ByteRowKeyComparatorTest.java
@@ -32,8 +32,8 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -219,7 +219,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("3", KeyOrder.DESCENDING),
         new KeyColumn("4", KeyOrder.DESCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
@@ -234,7 +234,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("3", KeyOrder.ASCENDING),
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
@@ -249,7 +249,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("3", KeyOrder.DESCENDING),
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
@@ -264,7 +264,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("3", KeyOrder.ASCENDING),
         new KeyColumn("4", KeyOrder.DESCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
@@ -279,7 +279,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("3", KeyOrder.DESCENDING),
         new KeyColumn("4", KeyOrder.ASCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN, NO_COMPLEX_SIGNATURE)
     );
@@ -298,7 +298,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("7", KeyOrder.DESCENDING),
         new KeyColumn("8", KeyOrder.DESCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
     );
@@ -317,7 +317,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("7", KeyOrder.ASCENDING),
         new KeyColumn("8", KeyOrder.ASCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
     );
@@ -336,7 +336,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("7", KeyOrder.ASCENDING),
         new KeyColumn("8", KeyOrder.ASCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
     );
@@ -355,7 +355,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("7", KeyOrder.DESCENDING),
         new KeyColumn("8", KeyOrder.DESCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
     );
@@ -374,7 +374,7 @@ public class ByteRowKeyComparatorTest extends InitializedNullHandlingTest
         new KeyColumn("7", KeyOrder.DESCENDING),
         new KeyColumn("8", KeyOrder.ASCENDING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         sortUsingObjectComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE),
         sortUsingByteKeyComparator(keyColumns, ALL_KEY_OBJECTS, SIGNATURE)
     );

--- a/processing/src/test/java/org/apache/druid/frame/key/FrameComparisonWidgetImplTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/FrameComparisonWidgetImplTest.java
@@ -32,9 +32,9 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +46,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
   private Frame frameWithoutComplexColumns;
   private Frame frameWithComplexColumns;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     final CursorFactory rowBasedAdapterWithoutComplexColumn = new RowBasedSegment<>(
@@ -112,10 +112,10 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
                 .allMatch(Objects::nonNull);
 
       // null key part, if any, is always the second one (1)
-      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[0]));
-      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[]{0, 2}));
-      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2}));
-      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{1}));
+      Assertions.assertTrue(widget.hasNonNullKeyParts(i, new int[0]));
+      Assertions.assertTrue(widget.hasNonNullKeyParts(i, new int[]{0, 2}));
+      Assertions.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2}));
+      Assertions.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{1}));
     }
   }
 
@@ -138,7 +138,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
     for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
       final boolean isAllNonNull =
           Arrays.stream(ByteRowKeyComparatorTest.KEY_OBJECTS_WITHOUT_COMPLEX_COLUMN.get(i)).allMatch(Objects::nonNull);
-      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2, 3}));
+      Assertions.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2, 3}));
     }
   }
 
@@ -173,7 +173,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
           0,
           keyColumns.size()
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           KeyTestUtils.createKey(signature, FrameType.latestRowBased(), expectedKeyArray),
           widget.readKey(i)
       );
@@ -197,7 +197,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
     );
 
     for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           KeyTestUtils.createKey(
               ByteRowKeyComparatorTest.NO_COMPLEX_SIGNATURE,
               FrameType.latestRowBased(),
@@ -226,7 +226,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
 
     // Compare self-to-self should be equal.
     for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           0,
           widget.compare(
               i,
@@ -275,10 +275,10 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
           Arrays.stream(ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)).limit(3).allMatch(Objects::nonNull);
 
       // Only second is non-null throughout
-      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[]{1}));
-      Assert.assertTrue(widget.hasNonNullKeyParts(i, new int[]{1}));
-      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2}));
-      Assert.assertEquals(
+      Assertions.assertTrue(widget.hasNonNullKeyParts(i, new int[]{1}));
+      Assertions.assertTrue(widget.hasNonNullKeyParts(i, new int[]{1}));
+      Assertions.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2}));
+      Assertions.assertEquals(
           isAllNonNull,
           widget.hasNonNullKeyParts(i, new int[]{0}) && widget.hasNonNullKeyParts(i, new int[]{2})
       );
@@ -308,7 +308,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
     for (int i = 0; i < frameWithoutComplexColumns.numRows(); i++) {
       final boolean isAllNonNull =
           Arrays.stream(ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i)).allMatch(Objects::nonNull);
-      Assert.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2, 3, 4, 5, 6, 7}));
+      Assertions.assertEquals(isAllNonNull, widget.hasNonNullKeyParts(i, new int[]{0, 1, 2, 3, 4, 5, 6, 7}));
     }
   }
 
@@ -337,7 +337,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
     for (int i = 0; i < frameWithComplexColumns.numRows(); i++) {
       final Object[] expectedKeyArray = new Object[keyColumns.size()];
       System.arraycopy(ByteRowKeyComparatorTest.ALL_KEY_OBJECTS.get(i), 0, expectedKeyArray, 0, keyColumns.size());
-      Assert.assertEquals(
+      Assertions.assertEquals(
           KeyTestUtils.createKey(signature, FrameType.latestRowBased(), expectedKeyArray),
           widget.readKey(i)
       );
@@ -365,7 +365,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
     );
 
     for (int i = 0; i < frameWithComplexColumns.numRows(); i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           KeyTestUtils.createKey(
               ByteRowKeyComparatorTest.SIGNATURE,
               FrameType.latestRowBased(),
@@ -398,7 +398,7 @@ public class FrameComparisonWidgetImplTest extends InitializedNullHandlingTest
 
     // Compare self-to-self should be equal.
     for (int i = 0; i < frameWithComplexColumns.numRows(); i++) {
-      Assert.assertEquals(
+      Assertions.assertEquals(
           0,
           widget.compare(
               i,

--- a/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparisonRunLengthsTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/RowKeyComparisonRunLengthsTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.java.util.common.Pair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -41,7 +41,7 @@ public class RowKeyComparisonRunLengthsTest
     final List<KeyColumn> keyColumns = Collections.emptyList();
     final RowSignature signature = RowSignature.empty();
     final RowKeyComparisonRunLengths runLengths = RowKeyComparisonRunLengths.create(keyColumns, signature);
-    Assert.assertEquals(0, runLengths.getRunLengthEntries().length);
+    Assertions.assertEquals(0, runLengths.getRunLengthEntries().length);
   }
 
   @Test
@@ -51,7 +51,7 @@ public class RowKeyComparisonRunLengthsTest
     final RowSignature signature = RowSignature.builder()
                                                .add("a", ColumnType.LONG)
                                                .build();
-    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature));
+    Assertions.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature));
   }
 
   @Test
@@ -59,7 +59,7 @@ public class RowKeyComparisonRunLengthsTest
   {
     final List<KeyColumn> keyColumns = Collections.singletonList(new KeyColumn("a", KeyOrder.NONE));
     final RowSignature signature = RowSignature.empty();
-    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature));
+    Assertions.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature));
   }
 
   @Test
@@ -69,12 +69,12 @@ public class RowKeyComparisonRunLengthsTest
     final RowSignature signature1 = RowSignature.builder()
                                                 .add("a", null)
                                                 .build();
-    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature1));
+    Assertions.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature1));
 
     final RowSignature signature2 = RowSignature.builder()
                                                 .add("a", ColumnType.UNKNOWN_COMPLEX)
                                                 .build();
-    Assert.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature2));
+    Assertions.assertThrows(DruidException.class, () -> RowKeyComparisonRunLengths.create(keyColumns, signature2));
   }
 
   @Test
@@ -97,10 +97,10 @@ public class RowKeyComparisonRunLengthsTest
                                                  .add("a", columnType)
                                                  .build();
       final RowKeyComparisonRunLengths runLengths = RowKeyComparisonRunLengths.create(keyColumns, signature);
-      Assert.assertEquals(1, runLengths.getRunLengthEntries().length);
-      Assert.assertTrue(runLengths.getRunLengthEntries()[0].isByteComparable());
-      Assert.assertEquals(1, runLengths.getRunLengthEntries()[0].getRunLength());
-      Assert.assertEquals(KeyOrder.ASCENDING, runLengths.getRunLengthEntries()[0].getOrder());
+      Assertions.assertEquals(1, runLengths.getRunLengthEntries().length);
+      Assertions.assertTrue(runLengths.getRunLengthEntries()[0].isByteComparable());
+      Assertions.assertEquals(1, runLengths.getRunLengthEntries()[0].getRunLength());
+      Assertions.assertEquals(KeyOrder.ASCENDING, runLengths.getRunLengthEntries()[0].getOrder());
     }
   }
 
@@ -116,10 +116,10 @@ public class RowKeyComparisonRunLengthsTest
                                                  .add("a", columnType)
                                                  .build();
       final RowKeyComparisonRunLengths runLengths = RowKeyComparisonRunLengths.create(keyColumns, signature);
-      Assert.assertEquals(1, runLengths.getRunLengthEntries().length);
-      Assert.assertFalse(runLengths.getRunLengthEntries()[0].isByteComparable());
-      Assert.assertEquals(1, runLengths.getRunLengthEntries()[0].getRunLength());
-      Assert.assertEquals(KeyOrder.ASCENDING, runLengths.getRunLengthEntries()[0].getOrder());
+      Assertions.assertEquals(1, runLengths.getRunLengthEntries().length);
+      Assertions.assertFalse(runLengths.getRunLengthEntries()[0].isByteComparable());
+      Assertions.assertEquals(1, runLengths.getRunLengthEntries()[0].getRunLength());
+      Assertions.assertEquals(KeyOrder.ASCENDING, runLengths.getRunLengthEntries()[0].getOrder());
     }
   }
 
@@ -157,31 +157,31 @@ public class RowKeyComparisonRunLengthsTest
     // Output runLengthEntries would be
     // (long, string ASC) (string, long DESC) (complex DESC) (complex ASC) (complex ASC) (string ASC)
 
-    Assert.assertEquals(6, runLengthEntries.length);
+    Assertions.assertEquals(6, runLengthEntries.length);
 
-    Assert.assertTrue(runLengthEntries[0].isByteComparable());
-    Assert.assertEquals(2, runLengthEntries[0].getRunLength());
-    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[0].getOrder());
+    Assertions.assertTrue(runLengthEntries[0].isByteComparable());
+    Assertions.assertEquals(2, runLengthEntries[0].getRunLength());
+    Assertions.assertEquals(KeyOrder.ASCENDING, runLengthEntries[0].getOrder());
 
-    Assert.assertTrue(runLengthEntries[1].isByteComparable());
-    Assert.assertEquals(2, runLengthEntries[1].getRunLength());
-    Assert.assertEquals(KeyOrder.DESCENDING, runLengthEntries[1].getOrder());
+    Assertions.assertTrue(runLengthEntries[1].isByteComparable());
+    Assertions.assertEquals(2, runLengthEntries[1].getRunLength());
+    Assertions.assertEquals(KeyOrder.DESCENDING, runLengthEntries[1].getOrder());
 
-    Assert.assertFalse(runLengthEntries[2].isByteComparable());
-    Assert.assertEquals(1, runLengthEntries[2].getRunLength());
-    Assert.assertEquals(KeyOrder.DESCENDING, runLengthEntries[2].getOrder());
+    Assertions.assertFalse(runLengthEntries[2].isByteComparable());
+    Assertions.assertEquals(1, runLengthEntries[2].getRunLength());
+    Assertions.assertEquals(KeyOrder.DESCENDING, runLengthEntries[2].getOrder());
 
-    Assert.assertFalse(runLengthEntries[3].isByteComparable());
-    Assert.assertEquals(1, runLengthEntries[3].getRunLength());
-    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[3].getOrder());
+    Assertions.assertFalse(runLengthEntries[3].isByteComparable());
+    Assertions.assertEquals(1, runLengthEntries[3].getRunLength());
+    Assertions.assertEquals(KeyOrder.ASCENDING, runLengthEntries[3].getOrder());
 
-    Assert.assertFalse(runLengthEntries[4].isByteComparable());
-    Assert.assertEquals(1, runLengthEntries[4].getRunLength());
-    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[4].getOrder());
+    Assertions.assertFalse(runLengthEntries[4].isByteComparable());
+    Assertions.assertEquals(1, runLengthEntries[4].getRunLength());
+    Assertions.assertEquals(KeyOrder.ASCENDING, runLengthEntries[4].getOrder());
 
-    Assert.assertTrue(runLengthEntries[5].isByteComparable());
-    Assert.assertEquals(1, runLengthEntries[5].getRunLength());
-    Assert.assertEquals(KeyOrder.ASCENDING, runLengthEntries[5].getOrder());
+    Assertions.assertTrue(runLengthEntries[5].isByteComparable());
+    Assertions.assertEquals(1, runLengthEntries[5].getRunLength());
+    Assertions.assertEquals(KeyOrder.ASCENDING, runLengthEntries[5].getOrder());
   }
 
   /**
@@ -778,7 +778,7 @@ public class RowKeyComparisonRunLengthsTest
       RunLengthEntry[] actualEntries = RowKeyComparisonRunLengths
           .create(keyColumnsAndRowSignature.lhs, keyColumnsAndRowSignature.rhs)
           .getRunLengthEntries();
-      Assert.assertArrayEquals(StringUtils.format("Result %d incorrect", i), expectedResults.get(i), actualEntries);
+      Assertions.assertArrayEquals(expectedResults.get(i), actualEntries, StringUtils.format("Result %d incorrect", i));
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/key/RowKeyReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/key/RowKeyReaderTest.java
@@ -26,7 +26,7 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -160,7 +160,7 @@ public class RowKeyReaderTest extends InitializedNullHandlingTest
         () -> keyReader.trim(key, signature.size() + 1)
     );
 
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("Cannot trim")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("Cannot trim")));
   }
 
   @Test

--- a/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
@@ -57,6 +57,8 @@ import org.apache.druid.utils.CloseableUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -148,7 +150,7 @@ public class FrameProcessorExecutorTest
       final ListenableFuture<Long> muxerFuture = exec.runFully(muxer, null);
 
       Assertions.assertEquals(index.numRows(), (long) blasterFuture.get());
-      Assertions.assertEquals(index.numRows() * 2, (long) muxerFuture.get());
+      Assertions.assertEquals((long) index.numRows() * 2, (long) muxerFuture.get());
 
       Assertions.assertEquals(
           index.numRows() * 2,
@@ -496,6 +498,8 @@ public class FrameProcessorExecutorTest
       this.numThreads = numThreads;
     }
 
+    // Keep the JUnit 4 annotations for un-migrated test-jar consumers of this shared base class.
+    @Before
     @BeforeEach
     public void setUp() throws Exception
     {
@@ -509,6 +513,7 @@ public class FrameProcessorExecutorTest
       );
     }
 
+    @After
     @AfterEach
     public void tearDown() throws Exception
     {

--- a/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/FrameProcessorExecutorTest.java
@@ -52,18 +52,18 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.utils.CloseableUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -87,7 +87,8 @@ import java.util.stream.Collectors;
 
 public class FrameProcessorExecutorTest
 {
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class SuperBlasterTests extends BaseFrameProcessorExecutorTestSuite
   {
     // Tests in this class use SuperBlasterFrameProcessor, which can exercise various kinds of await styles.
@@ -99,7 +100,6 @@ public class FrameProcessorExecutorTest
       this.awaitStyle = awaitStyle;
     }
 
-    @Parameterized.Parameters(name = "numThreads = {0}, awaitStyle = {1}")
     public static Collection<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -147,10 +147,10 @@ public class FrameProcessorExecutorTest
       final ListenableFuture<Long> blasterFuture = exec.runFully(blaster, null);
       final ListenableFuture<Long> muxerFuture = exec.runFully(muxer, null);
 
-      Assert.assertEquals(index.numRows(), (long) blasterFuture.get());
-      Assert.assertEquals(index.numRows() * 2, (long) muxerFuture.get());
+      Assertions.assertEquals(index.numRows(), (long) blasterFuture.get());
+      Assertions.assertEquals(index.numRows() * 2, (long) muxerFuture.get());
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           index.numRows() * 2,
           FrameTestUtil.readRowsFromFrameChannel(
               new ReadableFileFrameChannel(FrameFile.open(outFile, null), null),
@@ -160,7 +160,8 @@ public class FrameProcessorExecutorTest
     }
   }
 
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class MiscTests extends BaseFrameProcessorExecutorTestSuite
   {
     public MiscTests(int numThreads)
@@ -168,7 +169,6 @@ public class FrameProcessorExecutorTest
       super(numThreads);
     }
 
-    @Parameterized.Parameters(name = "numThreads = {0}")
     public static Collection<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -192,30 +192,30 @@ public class FrameProcessorExecutorTest
       final FailingFrameProcessor failer = new FailingFrameProcessor(inChannel, outChannel.writable(), 0);
       final ListenableFuture<Long> failerFuture = exec.runFully(failer, null);
 
-      final ExecutionException e = Assert.assertThrows(
+      final ExecutionException e = Assertions.assertThrows(
           ExecutionException.class,
           failerFuture::get
       );
 
       MatcherAssert.assertThat(
           e.getCause().getCause(),
-          ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("failure!"))
+          Matchers.hasProperty("message", CoreMatchers.containsString("failure!"))
       );
 
       final ReadableFrameChannel outReadableChannel = outChannel.readable();
-      Assert.assertTrue(outReadableChannel.canRead());
+      Assertions.assertTrue(outReadableChannel.canRead());
 
-      final RuntimeException readException = Assert.assertThrows(
+      final RuntimeException readException = Assertions.assertThrows(
           RuntimeException.class,
           outReadableChannel::readFrame
       );
 
       MatcherAssert.assertThat(
           readException.getCause(),
-          ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("failure!"))
+          Matchers.hasProperty("message", CoreMatchers.containsString("failure!"))
       );
 
-      Assert.assertTrue(outReadableChannel.isFinished()); // Finished now that we read the error
+      Assertions.assertTrue(outReadableChannel.isFinished()); // Finished now that we read the error
     }
 
     @Test
@@ -225,13 +225,13 @@ public class FrameProcessorExecutorTest
       final String cancellationId = "xyzzy";
 
       exec.registerCancellationId(cancellationId);
-      Assert.assertSame(future, exec.registerCancelableFuture(future, false, cancellationId));
+      Assertions.assertSame(future, exec.registerCancelableFuture(future, false, cancellationId));
       exec.cancel(cancellationId);
 
       // Don't wait for the future to resolve, because exec.cancel should have done that.
       // If we see an unresolved future here, it's a bug in exec.cancel.
-      Assert.assertTrue(future.isDone());
-      Assert.assertTrue(future.isCancelled());
+      Assertions.assertTrue(future.isDone());
+      Assertions.assertTrue(future.isCancelled());
     }
 
     @Test
@@ -248,13 +248,14 @@ public class FrameProcessorExecutorTest
 
       // Don't wait for the future to resolve, because exec.cancel should have done that.
       // If we see an unresolved future here, it's a bug in exec.cancel.
-      Assert.assertTrue(future.isDone());
-      Assert.assertTrue(future.isCancelled());
-      Assert.assertTrue(processor.didGetInterrupt());
-      Assert.assertTrue(processor.didCleanup());
+      Assertions.assertTrue(future.isDone());
+      Assertions.assertTrue(future.isCancelled());
+      Assertions.assertTrue(processor.didGetInterrupt());
+      Assertions.assertTrue(processor.didCleanup());
     }
 
-    @Test(timeout = 30_000L)
+    @Test
+    @org.junit.jupiter.api.Timeout(value = 30_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
     public void test_futureCancel_sleepy() throws Exception
     {
       final SleepyFrameProcessor processor = new SleepyFrameProcessor();
@@ -264,13 +265,13 @@ public class FrameProcessorExecutorTest
       final ListenableFuture<Long> future = exec.runFully(processor, cancellationId);
 
       processor.awaitRun();
-      Assert.assertTrue(future.cancel(true));
-      Assert.assertTrue(future.isDone());
-      Assert.assertTrue(future.isCancelled());
+      Assertions.assertTrue(future.cancel(true));
+      Assertions.assertTrue(future.isDone());
+      Assertions.assertTrue(future.isCancelled());
 
       processor.awaitCleanup(); // If this times out, it's a bug that means cancellation didn't happen as expected.
-      Assert.assertTrue(processor.didGetInterrupt());
-      Assert.assertTrue(processor.didCleanup());
+      Assertions.assertTrue(processor.didGetInterrupt());
+      Assertions.assertTrue(processor.didCleanup());
     }
 
     @Test
@@ -358,15 +359,15 @@ public class FrameProcessorExecutorTest
           // Verify numFrames on each generator.
           for (final InfiniteFrameProcessor generator : generators) {
             final Long retVal = processorFutureMap.get(generator).get();
-            Assert.assertNotNull(retVal);
-            Assert.assertEquals(generator.getNumFrames(), (long) retVal);
+            Assertions.assertNotNull(retVal);
+            Assertions.assertEquals(generator.getNumFrames(), (long) retVal);
             systemFrameCount += retVal;
           }
 
           // Verify return value of the chomper.
           final Long retVal = processorFutureMap.get(chomper).get();
-          Assert.assertNotNull(retVal);
-          Assert.assertEquals(systemFrameCount, (long) retVal);
+          Assertions.assertNotNull(retVal);
+          Assertions.assertEquals(systemFrameCount, (long) retVal);
         } else {
           // Check for cancellation.
           final List<FrameProcessor<?>> allProcessors =
@@ -377,20 +378,20 @@ public class FrameProcessorExecutorTest
 
             // Don't wait for the future to resolve, because exec.cancel should have done that.
             // If we see an unresolved future here, it's a bug in exec.cancel.
-            Assert.assertTrue(future.isDone());
-            Assert.assertTrue(future.isCancelled());
+            Assertions.assertTrue(future.isDone());
+            Assertions.assertTrue(future.isCancelled());
 
-            final Exception e = Assert.assertThrows(Exception.class, future::get);
+            final Exception e = Assertions.assertThrows(Exception.class, future::get);
             MatcherAssert.assertThat(e, CoreMatchers.instanceOf(CancellationException.class));
           }
         }
 
         // In both cases, check for cleanup.
         for (final InfiniteFrameProcessor generator : generators) {
-          Assert.assertTrue(generator.didCleanup());
+          Assertions.assertTrue(generator.didCleanup());
         }
 
-        Assert.assertTrue(chomper.didCleanup());
+        Assertions.assertTrue(chomper.didCleanup());
       }
     }
 
@@ -411,10 +412,10 @@ public class FrameProcessorExecutorTest
       final ListenableFuture<Long> future = exec.runFully(processor, cancellationId);
 
       // Future should be immediately canceled, without running the processor.
-      Assert.assertTrue(future.isDone());
-      Assert.assertTrue(future.isCancelled());
-      Assert.assertFalse(processor.didGetInterrupt());
-      Assert.assertFalse(processor.didCleanup());
+      Assertions.assertTrue(future.isDone());
+      Assertions.assertTrue(future.isCancelled());
+      Assertions.assertFalse(processor.didGetInterrupt());
+      Assertions.assertFalse(processor.didCleanup());
     }
 
     @Test
@@ -429,15 +430,15 @@ public class FrameProcessorExecutorTest
       final ListenableFuture<List<String>> processorFuture = exec.runFully(futureWaitingProcessor, null);
 
       // Processor should be waiting for futures
-      Assert.assertFalse("Processor should be waiting", processorFuture.isDone());
+      Assertions.assertFalse(processorFuture.isDone(), "Processor should be waiting");
 
       // Complete the futures
       future1.set("result1");
       future2.set("result2");
 
       // Processor should complete now
-      Assert.assertEquals(List.of("result1", "result2"), processorFuture.get());
-      Assert.assertTrue(futureWaitingProcessor.isCleanedUp());
+      Assertions.assertEquals(List.of("result1", "result2"), processorFuture.get());
+      Assertions.assertTrue(futureWaitingProcessor.isCleanedUp());
     }
 
     @Test
@@ -456,7 +457,7 @@ public class FrameProcessorExecutorTest
       future2.cancel(true);
 
       // Verify exception
-      final ExecutionException e = Assert.assertThrows(ExecutionException.class, processorFuture::get);
+      final ExecutionException e = Assertions.assertThrows(ExecutionException.class, processorFuture::get);
       MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(CancellationException.class));
     }
 
@@ -476,16 +477,16 @@ public class FrameProcessorExecutorTest
       future2.setException(new RuntimeException("oops"));
 
       // Verify exception
-      final ExecutionException e = Assert.assertThrows(ExecutionException.class, processorFuture::get);
+      final ExecutionException e = Assertions.assertThrows(ExecutionException.class, processorFuture::get);
       MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RuntimeException.class));
-      MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("oops")));
+      MatcherAssert.assertThat(e.getCause(), Matchers.hasProperty("message", CoreMatchers.equalTo("oops")));
     }
   }
 
   public abstract static class BaseFrameProcessorExecutorTestSuite extends InitializedNullHandlingTest
   {
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
     public final int numThreads;
 
     protected FrameProcessorExecutor exec;
@@ -495,7 +496,7 @@ public class FrameProcessorExecutorTest
       this.numThreads = numThreads;
     }
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception
     {
       exec = new FrameProcessorExecutor(
@@ -508,7 +509,7 @@ public class FrameProcessorExecutorTest
       );
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception
     {
       exec.getExecutorService().shutdownNow();

--- a/processing/src/test/java/org/apache/druid/frame/processor/ReturnOrAwaitTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/ReturnOrAwaitTest.java
@@ -21,8 +21,8 @@ package org.apache.druid.frame.processor;
 
 import com.google.common.util.concurrent.Futures;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +39,7 @@ public class ReturnOrAwaitTest
 
     MatcherAssert.assertThat(
         ReturnOrAwait.awaitAllFutures(Collections.singletonList(Futures.immediateFuture(1))).toString(),
-        CoreMatchers.startsWith("await futures=[com.google.")
+        Matchers.startsWith("await futures=[com.google.")
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/RunAllFullyWidgetTest.java
@@ -46,13 +46,12 @@ import org.apache.druid.segment.TestIndex;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -66,7 +65,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameProcessorExecutorTestSuite
 {
   private final int lowerBouncerPoolSize;
@@ -98,12 +99,6 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
     this.delayed = delayed;
   }
 
-  @Parameterized.Parameters(name =
-      "numThreads = {0}, "
-      + "lowerBouncerPoolSize = {1}, "
-      + "higherBouncerPoolSize = {2}, "
-      + "maxOutstandingProcessors = {3}, "
-      + "delayed = {4}")
   public static Collection<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -131,7 +126,7 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
     return constructors;
   }
 
-  @Before
+  @BeforeEach
   @Override
   public void setUp() throws Exception
   {
@@ -147,14 +142,14 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
     }
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() throws Exception
   {
     super.tearDown(); // Stops exec, waits for termination
 
     synchronized (this) {
-      Assert.assertEquals(0, concurrentNow);
+      Assertions.assertEquals(0, concurrentNow);
       MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(lowerBouncerPoolSize));
       if (higherBouncerPoolSize != -1) {
         MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(higherBouncerPoolSize));
@@ -162,13 +157,13 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
       MatcherAssert.assertThat(concurrentHighWatermark, Matchers.lessThanOrEqualTo(maxOutstandingProcessors));
     }
 
-    Assert.assertEquals("Bouncer current running count", 0, bouncer.getCurrentCount());
-    Assert.assertEquals(
-        "Bouncer max pool size",
+    Assertions.assertEquals(0, bouncer.getCurrentCount(), "Bouncer current running count");
+    Assertions.assertEquals(
         higherBouncerPoolSize == -1 ? lowerBouncerPoolSize : Math.min(lowerBouncerPoolSize, higherBouncerPoolSize),
-        bouncer.getMaxCount()
+        bouncer.getMaxCount(),
+        "Bouncer max pool size"
     );
-    Assert.assertEquals("Encountered single close (from ensureClose)", 1, closed.get());
+    Assertions.assertEquals(1, closed.get(), "Encountered single close (from ensureClose)");
   }
 
   @Test
@@ -181,7 +176,7 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    Assert.assertEquals("xyzzy", future.get());
+    Assertions.assertEquals("xyzzy", future.get());
   }
 
   @Test
@@ -226,7 +221,7 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    Assert.assertEquals(numProcessors, (long) future.get());
+    Assertions.assertEquals(numProcessors, (long) future.get());
   }
 
   @Test
@@ -256,12 +251,12 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    final ExecutionException e = Assertions.assertThrows(ExecutionException.class, future::get);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(RuntimeException.class));
     MatcherAssert.assertThat(e.getCause().getCause(), CoreMatchers.instanceOf(RuntimeException.class));
     MatcherAssert.assertThat(
         e.getCause().getCause(),
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("failure!"))
+        Matchers.hasProperty("message", CoreMatchers.equalTo("failure!"))
     );
   }
 
@@ -289,9 +284,9 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    final ExecutionException e = Assertions.assertThrows(ExecutionException.class, future::get);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+    MatcherAssert.assertThat(e.getCause(), Matchers.hasProperty("message", CoreMatchers.equalTo("error!")));
   }
 
   @Test
@@ -316,9 +311,9 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    final ExecutionException e = Assertions.assertThrows(ExecutionException.class, future::get);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+    MatcherAssert.assertThat(e.getCause(), Matchers.hasProperty("message", CoreMatchers.equalTo("error!")));
   }
 
   @Test
@@ -343,9 +338,9 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    final ExecutionException e = Assertions.assertThrows(ExecutionException.class, future::get);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+    MatcherAssert.assertThat(e.getCause(), Matchers.hasProperty("message", CoreMatchers.equalTo("error!")));
   }
 
   @Test
@@ -370,9 +365,9 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    final ExecutionException e = Assertions.assertThrows(ExecutionException.class, future::get);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+    MatcherAssert.assertThat(e.getCause(), Matchers.hasProperty("message", CoreMatchers.equalTo("error!")));
   }
 
   @Test
@@ -396,9 +391,9 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    final ExecutionException e = Assertions.assertThrows(ExecutionException.class, future::get);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+    MatcherAssert.assertThat(e.getCause(), Matchers.hasProperty("message", CoreMatchers.equalTo("error!")));
   }
 
   @Test
@@ -425,12 +420,13 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
         null
     );
 
-    final ExecutionException e = Assert.assertThrows(ExecutionException.class, future::get);
+    final ExecutionException e = Assertions.assertThrows(ExecutionException.class, future::get);
     MatcherAssert.assertThat(e.getCause(), CoreMatchers.instanceOf(IllegalStateException.class));
-    MatcherAssert.assertThat(e.getCause(), ThrowableMessageMatcher.hasMessage(CoreMatchers.equalTo("error!")));
+    MatcherAssert.assertThat(e.getCause(), Matchers.hasProperty("message", CoreMatchers.equalTo("error!")));
   }
 
-  @Test(timeout = 30_000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 30_000L, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   @SuppressWarnings("BusyWait")
   public void test_runAllFully_futureCancel() throws InterruptedException
   {
@@ -460,15 +456,15 @@ public class RunAllFullyWidgetTest extends FrameProcessorExecutorTest.BaseFrameP
       processors.get(i).awaitRun();
     }
 
-    Assert.assertTrue(future.cancel(true));
-    Assert.assertTrue(future.isCancelled());
+    Assertions.assertTrue(future.cancel(true));
+    Assertions.assertTrue(future.isCancelled());
 
     // We don't have a good way to wait for future cancellation to truly finish. Resort to a waiting-loop.
     while (exec.cancelableProcessorCount() > 0) {
       Thread.sleep(10);
     }
 
-    Assert.assertEquals(0, exec.cancelableProcessorCount());
+    Assertions.assertEquals(0, exec.cancelableProcessorCount());
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/processor/SuperSorterTest.java
@@ -61,18 +61,18 @@ import org.apache.druid.segment.column.ColumnHolder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -99,12 +99,12 @@ public class SuperSorterTest
     private static final int NUM_THREADS = 1;
     private static final int FRAME_SIZE = 1_000_000;
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
     private FrameProcessorExecutor exec;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
       exec = new FrameProcessorExecutor(
@@ -112,7 +112,7 @@ public class SuperSorterTest
       );
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
       exec.getExecutorService().shutdownNow();
@@ -149,11 +149,11 @@ public class SuperSorterTest
 
       superSorter.setNoWorkRunnable(() -> outputPartitionsFuture.set(ClusterByPartitions.oneUniversalPartition()));
       final OutputChannels channels = superSorter.run().get();
-      Assert.assertEquals(1, channels.getAllChannels().size());
+      Assertions.assertEquals(1, channels.getAllChannels().size());
 
       final ReadableFrameChannel channel = Iterables.getOnlyElement(channels.getAllChannels()).getReadableChannel();
-      Assert.assertTrue(channel.isFinished());
-      Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+      Assertions.assertTrue(channel.isFinished());
+      Assertions.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
       channel.close();
     }
 
@@ -186,11 +186,11 @@ public class SuperSorterTest
       );
 
       final OutputChannels channels = superSorter.run().get();
-      Assert.assertEquals(1, channels.getAllChannels().size());
+      Assertions.assertEquals(1, channels.getAllChannels().size());
 
       final ReadableFrameChannel channel = Iterables.getOnlyElement(channels.getAllChannels()).getReadableChannel();
-      Assert.assertTrue(channel.isFinished());
-      Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+      Assertions.assertTrue(channel.isFinished());
+      Assertions.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
       channel.close();
     }
 
@@ -223,11 +223,11 @@ public class SuperSorterTest
       );
 
       final OutputChannels channels = superSorter.run().get();
-      Assert.assertEquals(1, channels.getAllChannels().size());
+      Assertions.assertEquals(1, channels.getAllChannels().size());
 
       final ReadableFrameChannel channel = Iterables.getOnlyElement(channels.getAllChannels()).getReadableChannel();
-      Assert.assertTrue(channel.isFinished());
-      Assert.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
+      Assertions.assertTrue(channel.isFinished());
+      Assertions.assertEquals(1.0, superSorterProgressTracker.snapshot().getProgressDigest(), 0.0f);
       channel.close();
     }
   }
@@ -236,7 +236,8 @@ public class SuperSorterTest
    * Parameterized test cases that use {@link TestIndex#getNoRollupIncrementalTestIndex} with various frame sizes,
    * numbers of channels, and worker configurations.
    */
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class ParameterizedCasesTest extends InitializedNullHandlingTest
   {
     private static CursorFactory CURSOR_FACTORY;
@@ -248,8 +249,8 @@ public class SuperSorterTest
      */
     private static final Map<ClusterBy, List<List<Object>>> SORTED_TEST_ROWS = new HashMap<>();
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
     private final FrameType outputFrameType;
     private final int maxRowsPerFrame;
@@ -292,18 +293,6 @@ public class SuperSorterTest
       this.limitHint = limitHint;
     }
 
-    @Parameterized.Parameters(
-        name = "outputFrameType = {0}, "
-               + "maxRowsPerFrame = {1}, "
-               + "maxBytesPerFrame = {2}, "
-               + "numChannels = {3}, "
-               + "maxActiveProcessors = {4}, "
-               + "maxChannelsPerProcessor= {5}, "
-               + "numThreads = {6}, "
-               + "isComposedStorage = {7}, "
-               + "partitionsDeferred = {8}, "
-               + "limitHint = {9}"
-    )
     public static Iterable<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -371,7 +360,7 @@ public class SuperSorterTest
       return constructors;
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setUpClass()
     {
       CURSOR_FACTORY = new QueryableIndexCursorFactory(TestIndex.getNoRollupMMappedTestIndex());
@@ -379,7 +368,7 @@ public class SuperSorterTest
           FrameSequenceBuilder.signatureWithRowNumber(CURSOR_FACTORY.getRowSignature());
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDownClass()
     {
       CURSOR_FACTORY = null;
@@ -387,7 +376,7 @@ public class SuperSorterTest
       SORTED_TEST_ROWS.clear();
     }
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
       exec = new FrameProcessorExecutor(
@@ -395,7 +384,7 @@ public class SuperSorterTest
       );
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception
     {
       if (exec != null) {
@@ -476,8 +465,8 @@ public class SuperSorterTest
       }
 
       final OutputChannels outputChannels = superSorter.run().get();
-      Assert.assertEquals(clusterByPartitions.size(), outputChannels.getAllChannels().size());
-      Assert.assertEquals(Double.valueOf(1.0), superSorterProgressTracker.snapshot().getProgressDigest());
+      Assertions.assertEquals(clusterByPartitions.size(), outputChannels.getAllChannels().size());
+      Assertions.assertEquals(Double.valueOf(1.0), superSorterProgressTracker.snapshot().getProgressDigest());
 
       final int[] clusterByColumns = clusterBy.getColumns().stream().mapToInt(
           part -> signature.indexOf(part.columnName())
@@ -505,7 +494,7 @@ public class SuperSorterTest
 
               if (!(partition.getStart() == null || keyComparator.compare(key, partition.getStart()) >= 0)) {
                 // Defer formatting of error message until it's actually needed
-                Assert.fail(
+                Assertions.fail(
                     StringUtils.format(
                         "Key %s >= partition %,d start %s",
                         keyReader.read(key),
@@ -516,7 +505,7 @@ public class SuperSorterTest
               }
 
               if (!(partition.getEnd() == null || keyComparator.compare(key, partition.getEnd()) < 0)) {
-                Assert.fail(
+                Assertions.fail(
                     StringUtils.format(
                         "Key %s < partition %,d end %s",
                         keyReader.read(key),
@@ -616,7 +605,7 @@ public class SuperSorterTest
           )
       );
 
-      Assert.assertEquals(4, partitions.size());
+      Assertions.assertEquals(4, partitions.size());
 
       verifySuperSorter(clusterBy, partitions);
     }
@@ -656,7 +645,7 @@ public class SuperSorterTest
           )
       );
 
-      Assert.assertEquals(4, partitions.size());
+      Assertions.assertEquals(4, partitions.size());
 
       verifySuperSorter(clusterBy, partitions);
     }
@@ -695,7 +684,7 @@ public class SuperSorterTest
           )
       );
 
-      Assert.assertEquals(4, partitions.size());
+      Assertions.assertEquals(4, partitions.size());
 
       verifySuperSorter(clusterBy, partitions);
     }
@@ -734,7 +723,7 @@ public class SuperSorterTest
           )
       );
 
-      Assert.assertEquals(4, partitions.size());
+      Assertions.assertEquals(4, partitions.size());
 
       verifySuperSorter(clusterBy, partitions);
     }
@@ -773,7 +762,7 @@ public class SuperSorterTest
           )
       );
 
-      Assert.assertEquals(4, partitions.size());
+      Assertions.assertEquals(4, partitions.size());
 
       verifySuperSorter(clusterBy, partitions);
     }
@@ -831,7 +820,8 @@ public class SuperSorterTest
   /**
    * Parameterized test cases for the combiner functionality.
    */
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class CombinerTest extends InitializedNullHandlingTest
   {
     private static final int FRAME_SIZE = 1_000_000;
@@ -849,7 +839,6 @@ public class SuperSorterTest
     private static final RowSignature SORTABLE_SIGNATURE =
         FrameWriters.sortableSignature(SIGNATURE, CLUSTER_BY.getColumns());
 
-    @Parameterized.Parameters(name = "maxRowsPerFrame = {0}, maxChannelsPerMerger = {1}")
     public static Iterable<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -861,8 +850,8 @@ public class SuperSorterTest
       return constructors;
     }
 
-    @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @RegisterExtension
+    public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
     private final int maxRowsPerFrame;
     private final int maxChannelsPerMerger;
@@ -874,7 +863,7 @@ public class SuperSorterTest
       this.maxChannelsPerMerger = maxChannelsPerMerger;
     }
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
       exec = new FrameProcessorExecutor(
@@ -882,7 +871,7 @@ public class SuperSorterTest
       );
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
       exec.getExecutorService().shutdownNow();
@@ -910,7 +899,7 @@ public class SuperSorterTest
           SuperSorter.UNLIMITED
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("a", 11L),
               ImmutableList.of("b", 22L),
@@ -941,7 +930,7 @@ public class SuperSorterTest
           SuperSorter.UNLIMITED
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("a", 10L),
               ImmutableList.of("b", 10L)
@@ -985,7 +974,7 @@ public class SuperSorterTest
           SuperSorter.UNLIMITED
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("a", 11L),
               ImmutableList.of("b", 22L),
@@ -1018,7 +1007,7 @@ public class SuperSorterTest
       );
 
       // 5 channels * (1 + 2 + 3) = 30
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(ImmutableList.of("x", 30L)),
           rows
       );
@@ -1046,17 +1035,17 @@ public class SuperSorterTest
             limit
         );
 
-        Assert.assertEquals(
-            StringUtils.format("limit[%d]: expected exactly %d row(s), got %d", limit, limit, rows.size()),
+        Assertions.assertEquals(
             limit,
-            rows.size()
+            rows.size(),
+            StringUtils.format("limit[%d]: expected exactly %d row(s), got %d", limit, limit, rows.size())
         );
-        Assert.assertEquals(ImmutableList.of("a", 11L), rows.get(0));
+        Assertions.assertEquals(ImmutableList.of("a", 11L), rows.get(0));
         if (limit >= 2) {
-          Assert.assertEquals(ImmutableList.of("b", 22L), rows.get(1));
+          Assertions.assertEquals(ImmutableList.of("b", 22L), rows.get(1));
         }
         if (limit >= 3) {
-          Assert.assertEquals(ImmutableList.of("c", 33L), rows.get(2));
+          Assertions.assertEquals(ImmutableList.of("c", 33L), rows.get(2));
         }
       }
     }
@@ -1084,7 +1073,7 @@ public class SuperSorterTest
       );
 
       // All rows combine to one; rowLimit = 1 is satisfied.
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(ImmutableList.of("x", 6L)),
           rows
       );
@@ -1110,7 +1099,7 @@ public class SuperSorterTest
           SuperSorter.UNLIMITED
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of("a", 3L),
               ImmutableList.of("b", 7L)
@@ -1137,7 +1126,7 @@ public class SuperSorterTest
           SuperSorter.UNLIMITED
       );
 
-      Assert.assertEquals(ImmutableList.of(), rows);
+      Assertions.assertEquals(ImmutableList.of(), rows);
     }
 
     /**
@@ -1175,7 +1164,7 @@ public class SuperSorterTest
           SuperSorter.UNLIMITED
       );
 
-      Assert.assertEquals(
+      Assertions.assertEquals(
           ImmutableList.of(
               ImmutableList.of(1L, 110L),
               ImmutableList.of(2L, 220L),

--- a/processing/src/test/java/org/apache/druid/frame/read/FrameReaderTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/read/FrameReaderTest.java
@@ -28,16 +28,18 @@ import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.QueryableIndexCursorFactory;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.List;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class FrameReaderTest extends InitializedNullHandlingTest
 {
   private final FrameType frameType;
@@ -51,7 +53,6 @@ public class FrameReaderTest extends InitializedNullHandlingTest
     this.frameType = frameType;
   }
 
-  @Parameterized.Parameters(name = "frameType = {0}")
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -63,7 +64,7 @@ public class FrameReaderTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     inputCursorFactory = new QueryableIndexCursorFactory(TestIndex.getNoRollupMMappedTestIndex());
@@ -80,17 +81,17 @@ public class FrameReaderTest extends InitializedNullHandlingTest
   @Test
   public void testSignature()
   {
-    Assert.assertEquals(inputCursorFactory.getRowSignature(), frameReader.signature());
+    Assertions.assertEquals(inputCursorFactory.getRowSignature(), frameReader.signature());
   }
 
   @Test
   public void testColumnCapabilitiesToColumnType()
   {
     for (final String columnName : inputCursorFactory.getRowSignature().getColumnNames()) {
-      Assert.assertEquals(
-          columnName,
+      Assertions.assertEquals(
           inputCursorFactory.getRowSignature().getColumnCapabilities(columnName).toColumnType(),
-          frameReader.columnCapabilities(frame, columnName).toColumnType()
+          frameReader.columnCapabilities(frame, columnName).toColumnType(),
+          columnName
       );
     }
   }

--- a/processing/src/test/java/org/apache/druid/frame/segment/FrameCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/segment/FrameCursorFactoryTest.java
@@ -49,12 +49,12 @@ import org.apache.druid.segment.vector.VectorCursor;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.Interval;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -66,7 +66,8 @@ public class FrameCursorFactoryTest
   /**
    * Basic tests: everything except makeCursor, makeVectorCursor.
    */
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class BasicTests extends InitializedNullHandlingTest
   {
     private final FrameType frameType;
@@ -80,7 +81,6 @@ public class FrameCursorFactoryTest
       this.frameType = frameType;
     }
 
-    @Parameterized.Parameters(name = "frameType = {0}")
     public static Iterable<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -92,7 +92,7 @@ public class FrameCursorFactoryTest
       return constructors;
     }
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
 
@@ -101,7 +101,7 @@ public class FrameCursorFactoryTest
       frameCursorFactory = Objects.requireNonNull(frameSegment.as(CursorFactory.class));
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
       if (frameSegment != null) {
@@ -112,7 +112,7 @@ public class FrameCursorFactoryTest
     @Test
     public void test_getRowSignature()
     {
-      Assert.assertEquals(queryableCursorFactory.getRowSignature(), frameCursorFactory.getRowSignature());
+      Assertions.assertEquals(queryableCursorFactory.getRowSignature(), frameCursorFactory.getRowSignature());
     }
 
     @Test
@@ -122,27 +122,27 @@ public class FrameCursorFactoryTest
         final ColumnCapabilities expectedCapabilities = queryableCursorFactory.getColumnCapabilities(columnName);
         final ColumnCapabilities actualCapabilities = frameCursorFactory.getColumnCapabilities(columnName);
 
-        Assert.assertEquals(
-            StringUtils.format("column [%s] type", columnName),
+        Assertions.assertEquals(
             expectedCapabilities.toColumnType(),
-            actualCapabilities.toColumnType()
+            actualCapabilities.toColumnType(),
+            StringUtils.format("column [%s] type", columnName)
         );
 
         if (frameType == FrameType.latestColumnar()) {
           // Columnar frames retain fine-grained hasMultipleValues information
-          Assert.assertEquals(
-              StringUtils.format("column [%s] hasMultipleValues", columnName),
+          Assertions.assertEquals(
               expectedCapabilities.hasMultipleValues(),
-              actualCapabilities.hasMultipleValues()
+              actualCapabilities.hasMultipleValues(),
+              StringUtils.format("column [%s] hasMultipleValues", columnName)
           );
         } else {
           // Row-based frames do not retain fine-grained hasMultipleValues information
-          Assert.assertEquals(
-              StringUtils.format("column [%s] hasMultipleValues", columnName),
+          Assertions.assertEquals(
               expectedCapabilities.getType() == ValueType.STRING
               ? ColumnCapabilities.Capable.UNKNOWN
               : ColumnCapabilities.Capable.FALSE,
-              actualCapabilities.hasMultipleValues()
+              actualCapabilities.hasMultipleValues(),
+              StringUtils.format("column [%s] hasMultipleValues", columnName)
           );
         }
       }
@@ -151,14 +151,15 @@ public class FrameCursorFactoryTest
     @Test
     public void test_getColumnCapabilities_unknownColumn()
     {
-      Assert.assertNull(frameCursorFactory.getColumnCapabilities("nonexistent"));
+      Assertions.assertNull(frameCursorFactory.getColumnCapabilities("nonexistent"));
     }
   }
 
   /**
    * CursorTests: matrix of tests of makeCursor, makeVectorCursor
    */
-  @RunWith(Parameterized.class)
+  @ParameterizedClass
+  @MethodSource("constructorFeeder")
   public static class CursorTests extends InitializedNullHandlingTest
   {
     private static final int VECTOR_SIZE = 7;
@@ -182,9 +183,6 @@ public class FrameCursorFactoryTest
       this.interval = interval;
     }
 
-    @Parameterized.Parameters(
-        name = "frameType = {0}, interval = {1}"
-    )
     public static Iterable<Object[]> constructorFeeder()
     {
       final List<Object[]> constructors = new ArrayList<>();
@@ -206,7 +204,7 @@ public class FrameCursorFactoryTest
       return constructors;
     }
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
       queryableCursorFactory = new QueryableIndexCursorFactory(TestIndex.getMMappedTestIndex());
@@ -214,7 +212,7 @@ public class FrameCursorFactoryTest
       frameCursorFactory = Objects.requireNonNull(frameSegment.as(CursorFactory.class));
     }
 
-    @After
+    @AfterEach
     public void tearDown()
     {
       if (frameSegment != null) {
@@ -406,10 +404,10 @@ public class FrameCursorFactoryTest
      */
     private void verifyCursorFactory(final CursorBuildSpec cursorSpec, final boolean expectedCanVectorize)
     {
-      Assert.assertEquals(
-          "expected interval (if this assertion fails, the test is likely written incorrectly)",
+      Assertions.assertEquals(
           this.interval,
-          cursorSpec.getInterval()
+          cursorSpec.getInterval(),
+          "expected interval (if this assertion fails, the test is likely written incorrectly)"
       );
 
       // Frame adapters don't know the order of the underlying frames, so they should ignore the "preferred ordering"
@@ -421,8 +419,8 @@ public class FrameCursorFactoryTest
       try (final CursorHolder queryableCursorHolder = queryableCursorFactory.makeCursorHolder(queryableCursorSpec);
            final CursorHolder frameCursorHolder = frameCursorFactory.makeCursorHolder(cursorSpec)) {
         // Frames don't know their own order, so they cannot guarantee any particular ordering.
-        Assert.assertEquals("ordering", Collections.emptyList(), frameCursorHolder.getOrdering());
-        Assert.assertEquals("canVectorize", expectedCanVectorize, frameCursorHolder.canVectorize());
+        Assertions.assertEquals(Collections.emptyList(), frameCursorHolder.getOrdering(), "ordering");
+        Assertions.assertEquals(expectedCanVectorize, frameCursorHolder.canVectorize(), "canVectorize");
         verifyCursors(queryableCursorHolder, frameCursorHolder, frameCursorFactory.getRowSignature());
 
         if (expectedCanVectorize) {

--- a/processing/src/test/java/org/apache/druid/frame/testutil/FrameTestUtil.java
+++ b/processing/src/test/java/org/apache/druid/frame/testutil/FrameTestUtil.java
@@ -52,9 +52,10 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorCursor;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -154,7 +155,7 @@ public class FrameTestUtil
     final List<List<Object>> expectedRows = expected.toList();
     final List<List<Object>> actualRows = actual.toList();
 
-    Assert.assertEquals("number of rows", expectedRows.size(), actualRows.size());
+    Assertions.assertEquals(expectedRows.size(), actualRows.size(), "number of rows");
 
     for (int i = 0; i < expectedRows.size(); i++) {
       assertRowEqual("row #" + i, expectedRows.get(i), actualRows.get(i));
@@ -193,15 +194,15 @@ public class FrameTestUtil
     }
 
     if (!ok) {
-      // Call Assert.assertEquals, which we expect to fail, to get a nice failure message
-      Assert.assertEquals(
+      // Call Assertions.assertEquals, which we expect to fail, to get a nice failure message
+      Assertions.assertEquals(
           message,
           Arrays.deepToString(expected.toArray()),
           Arrays.deepToString(actual.toArray())
       );
 
       // Just in case it doesn't fail for some reason, fail anyway.
-      Assert.fail(message);
+      Assertions.fail(message);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/FrameWriterTest.java
@@ -60,15 +60,16 @@ import org.apache.druid.segment.serde.ComplexMetrics;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,7 +84,8 @@ import java.util.stream.Collectors;
 /**
  * Tests that exercise {@link FrameWriter} implementations.
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class FrameWriterTest extends InitializedNullHandlingTest
 {
 
@@ -116,7 +118,6 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     this.allocator = ArenaMemoryAllocator.createOnHeap(DEFAULT_ALLOCATOR_CAPACITY);
   }
 
-  @Parameterized.Parameters(name = "inputFrameType = {0}, outputFrameType = {1}, sorted = {2}")
   public static Iterable<Object[]> constructorFeeder()
   {
     final List<Object[]> constructors = new ArrayList<>();
@@ -140,7 +141,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass()
   {
     ComplexMetrics.registerSerde(HyperUniquesSerde.TYPE_NAME, new HyperUniquesSerde());
@@ -212,14 +213,14 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     capabilitiesAdjustFn = capabilities -> capabilities.setHasMultipleValues(ColumnCapabilities.Capable.FALSE);
 
     if (outputFrameType.isColumnar()) {
-      final IllegalStateException e = Assert.assertThrows(
+      final IllegalStateException e = Assertions.assertThrows(
           IllegalStateException.class,
           () -> testWithDataset(FrameWriterTestData.TEST_STRINGS_MULTI_VALUE)
       );
 
       MatcherAssert.assertThat(
           e,
-          ThrowableMessageMatcher.hasMessage(CoreMatchers.startsWith("Encountered unexpected multi-value row"))
+          Matchers.hasProperty("message", CoreMatchers.startsWith("Encountered unexpected multi-value row"))
       );
     } else {
       testWithDataset(FrameWriterTestData.TEST_STRINGS_MULTI_VALUE);
@@ -318,7 +319,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
 
         try {
           final Pair<Frame, Integer> writeResult = writeFrame(rowSequence, signature, sortColumns);
-          Assert.assertEquals(rowSequence.toList().size(), (int) writeResult.rhs);
+          Assertions.assertEquals(rowSequence.toList().size(), (int) writeResult.rhs);
           verifyFrame(sortIfNeeded(rowSequence, signature, sortColumns), writeResult.lhs, signature);
         }
         catch (AssertionError e) {
@@ -343,7 +344,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
   {
     // Test every possible capacity for the latest row-based frame format, up to the amount required to write all
     // items from every list.
-    Assume.assumeTrue(inputFrameType == null && outputFrameType == FrameType.latestRowBased());
+    Assumptions.assumeTrue(inputFrameType == null && outputFrameType == FrameType.latestRowBased());
     final RowSignature signature = makeSignature(FrameWriterTestData.DATASETS);
     final Sequence<List<Object>> rowSequence = unsortAndMakeRows(FrameWriterTestData.DATASETS, 3);
     final int totalRows = rowSequence.toList().size();
@@ -391,7 +392,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
 
     // We expect that at some point in this test, a partial frame would have been written. If not: that's strange
     // and may mean the test isn't testing the right thing.
-    Assert.assertTrue("did write a partial frame", didWritePartial);
+    Assertions.assertTrue(didWritePartial, "did write a partial frame");
   }
 
   /**
@@ -481,7 +482,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     final Sequence<List<Object>> rowSequence = rows(data);
     final Pair<Frame, Integer> writeResult = writeFrame(rowSequence, signature, signature.getColumnNames());
 
-    Assert.assertEquals(data.size(), (int) writeResult.rhs);
+    Assertions.assertEquals(data.size(), (int) writeResult.rhs);
     verifyFrame(rows(dataset.getData(sortedness)), writeResult.lhs, signature);
   }
 
@@ -495,7 +496,7 @@ public class FrameWriterTest extends InitializedNullHandlingTest
     final Sequence<List<Object>> rowSequence = rows(data);
     final Pair<Frame, Integer> writeResult = writeFrame(rowSequence, signature, signature.getColumnNames());
 
-    Assert.assertEquals(data.size(), (int) writeResult.rhs);
+    Assertions.assertEquals(data.size(), (int) writeResult.rhs);
     verifyFrame(rows(readDataset.getData(sortedness)), writeResult.lhs, signature);
   }
 

--- a/processing/src/test/java/org/apache/druid/frame/write/cast/TypeCastSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/frame/write/cast/TypeCastSelectorsTest.java
@@ -30,10 +30,11 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Map;
 
 public class TypeCastSelectorsTest extends InitializedNullHandlingTest
@@ -58,11 +59,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "x", ColumnType.LONG);
 
-    Assert.assertEquals(12L, selector.getLong());
-    Assert.assertEquals(12d, selector.getDouble(), 0);
-    Assert.assertEquals(12f, selector.getFloat(), 0);
-    Assert.assertFalse(selector.isNull());
-    Assert.assertEquals(12L, selector.getObject());
+    Assertions.assertEquals(12L, selector.getLong());
+    Assertions.assertEquals(12d, selector.getDouble(), 0);
+    Assertions.assertEquals(12f, selector.getFloat(), 0);
+    Assertions.assertFalse(selector.isNull());
+    Assertions.assertEquals(12L, selector.getObject());
   }
 
   @Test
@@ -71,11 +72,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "x", ColumnType.DOUBLE);
 
-    Assert.assertEquals(12L, selector.getLong());
-    Assert.assertEquals(12.3d, selector.getDouble(), 0);
-    Assert.assertEquals(12.3f, selector.getFloat(), 0);
-    Assert.assertFalse(selector.isNull());
-    Assert.assertEquals(12.3d, selector.getObject());
+    Assertions.assertEquals(12L, selector.getLong());
+    Assertions.assertEquals(12.3d, selector.getDouble(), 0);
+    Assertions.assertEquals(12.3f, selector.getFloat(), 0);
+    Assertions.assertFalse(selector.isNull());
+    Assertions.assertEquals(12.3d, selector.getObject());
   }
 
   @Test
@@ -84,11 +85,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "x", ColumnType.FLOAT);
 
-    Assert.assertEquals(12L, selector.getLong());
-    Assert.assertEquals(12.3d, selector.getDouble(), 0.001);
-    Assert.assertEquals(12.3f, selector.getFloat(), 0);
-    Assert.assertFalse(selector.isNull());
-    Assert.assertEquals(12.3d, selector.getObject());
+    Assertions.assertEquals(12L, selector.getLong());
+    Assertions.assertEquals(12.3d, selector.getDouble(), 0.001);
+    Assertions.assertEquals(12.3f, selector.getFloat(), 0);
+    Assertions.assertFalse(selector.isNull());
+    Assertions.assertEquals(12.3d, selector.getObject());
   }
 
   @Test
@@ -97,11 +98,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "x", ColumnType.LONG_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertArrayEquals(new Object[]{12L}, (Object[]) selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertArrayEquals(new Object[]{12L}, (Object[]) selector.getObject());
   }
 
   @Test
@@ -110,11 +111,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "x", ColumnType.STRING_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertArrayEquals(new Object[]{"12.3"}, (Object[]) selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertArrayEquals(new Object[]{"12.3"}, (Object[]) selector.getObject());
   }
 
   @Test
@@ -123,11 +124,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "y", ColumnType.LONG);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -136,11 +137,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "y", ColumnType.DOUBLE);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -149,11 +150,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "y", ColumnType.FLOAT);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -162,11 +163,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "y", ColumnType.LONG_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertArrayEquals(new Object[]{null}, (Object[]) selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertArrayEquals(new Object[]{null}, (Object[]) selector.getObject());
   }
 
   @Test
@@ -175,11 +176,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "y", ColumnType.STRING_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertArrayEquals(new Object[]{"abc"}, (Object[]) selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertArrayEquals(new Object[]{"abc"}, (Object[]) selector.getObject());
   }
 
   @Test
@@ -188,11 +189,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "z", ColumnType.LONG);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -201,11 +202,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "z", ColumnType.DOUBLE);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -214,11 +215,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "z", ColumnType.FLOAT);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -227,11 +228,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "z", ColumnType.LONG_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertNull(selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -240,11 +241,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "z", ColumnType.STRING_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertNull(selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -253,11 +254,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "da", ColumnType.LONG);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -266,11 +267,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "da", ColumnType.DOUBLE);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -279,11 +280,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "da", ColumnType.FLOAT);
 
-    Assert.assertEquals(0L, selector.getLong());
-    Assert.assertEquals(0d, selector.getDouble(), 0);
-    Assert.assertEquals(0f, selector.getFloat(), 0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertNull(selector.getObject());
+    Assertions.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0d, selector.getDouble(), 0);
+    Assertions.assertEquals(0f, selector.getFloat(), 0);
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertNull(selector.getObject());
   }
 
   @Test
@@ -292,11 +293,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "da", ColumnType.LONG_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertArrayEquals(new Object[]{1L, 2L}, (Object[]) selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertArrayEquals(new Object[]{1L, 2L}, (Object[]) selector.getObject());
   }
 
   @Test
@@ -305,11 +306,11 @@ public class TypeCastSelectorsTest extends InitializedNullHandlingTest
     final ColumnValueSelector<?> selector =
         TypeCastSelectors.makeColumnValueSelector(testColumnSelectorFactory, "da", ColumnType.STRING_ARRAY);
 
-    Assert.assertThrows(DruidException.class, selector::getLong);
-    Assert.assertThrows(DruidException.class, selector::getDouble);
-    Assert.assertThrows(DruidException.class, selector::getFloat);
-    Assert.assertThrows(DruidException.class, selector::isNull);
-    Assert.assertArrayEquals(new Object[]{"1.2", "2.3"}, (Object[]) selector.getObject());
+    Assertions.assertThrows(DruidException.class, selector::getLong);
+    Assertions.assertThrows(DruidException.class, selector::getDouble);
+    Assertions.assertThrows(DruidException.class, selector::getFloat);
+    Assertions.assertThrows(DruidException.class, selector::isNull);
+    Assertions.assertArrayEquals(new Object[]{"1.2", "2.3"}, (Object[]) selector.getObject());
   }
 
   /**

--- a/processing/src/test/java/org/apache/druid/math/expr/EvalTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/EvalTest.java
@@ -21,16 +21,17 @@ package org.apache.druid.math.expr;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import junitparams.converters.Nullable;
 import org.apache.druid.collections.SerializablePair;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.segment.column.TypeStrategies;
 import org.apache.druid.segment.column.TypeStrategiesTest;
 import org.apache.druid.segment.nested.StructuredData;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -39,15 +40,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  */
 public class EvalTest extends InitializedNullHandlingTest
 {
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     TypeStrategies.registerComplex(
@@ -83,37 +84,37 @@ public class EvalTest extends InitializedNullHandlingTest
     assertEquals(2.0, evalDouble("\"x\"", bindings), 0.0001);
     assertEquals(304.0, evalDouble("300 + \"x\" * 2", bindings), 0.0001);
 
-    Assert.assertEquals(0L, evalLong("1.0 && 0.0", bindings));
-    Assert.assertEquals(1L, evalLong("1.0 && 2.0", bindings));
+    Assertions.assertEquals(0L, evalLong("1.0 && 0.0", bindings));
+    Assertions.assertEquals(1L, evalLong("1.0 && 2.0", bindings));
 
-    Assert.assertEquals(1L, evalLong("1.0 || 0.0", bindings));
-    Assert.assertEquals(0L, evalLong("0.0 || 0.0", bindings));
+    Assertions.assertEquals(1L, evalLong("1.0 || 0.0", bindings));
+    Assertions.assertEquals(0L, evalLong("0.0 || 0.0", bindings));
 
-    Assert.assertEquals(1L, evalLong("2.0 > 1.0", bindings));
-    Assert.assertEquals(1L, evalLong("2.0 >= 2.0", bindings));
-    Assert.assertEquals(1L, evalLong("1.0 < 2.0", bindings));
-    Assert.assertEquals(1L, evalLong("2.0 <= 2.0", bindings));
-    Assert.assertEquals(1L, evalLong("2.0 == 2.0", bindings));
-    Assert.assertEquals(1L, evalLong("2.0 != 1.0", bindings));
+    Assertions.assertEquals(1L, evalLong("2.0 > 1.0", bindings));
+    Assertions.assertEquals(1L, evalLong("2.0 >= 2.0", bindings));
+    Assertions.assertEquals(1L, evalLong("1.0 < 2.0", bindings));
+    Assertions.assertEquals(1L, evalLong("2.0 <= 2.0", bindings));
+    Assertions.assertEquals(1L, evalLong("2.0 == 2.0", bindings));
+    Assertions.assertEquals(1L, evalLong("2.0 != 1.0", bindings));
 
-    Assert.assertEquals(1L, evalLong("notdistinctfrom(2.0, 2.0)", bindings));
-    Assert.assertEquals(1L, evalLong("isdistinctfrom(2.0, 1.0)", bindings));
-    Assert.assertEquals(0L, evalLong("notdistinctfrom(2.0, 1.0)", bindings));
-    Assert.assertEquals(0L, evalLong("isdistinctfrom(2.0, 2.0)", bindings));
+    Assertions.assertEquals(1L, evalLong("notdistinctfrom(2.0, 2.0)", bindings));
+    Assertions.assertEquals(1L, evalLong("isdistinctfrom(2.0, 1.0)", bindings));
+    Assertions.assertEquals(0L, evalLong("notdistinctfrom(2.0, 1.0)", bindings));
+    Assertions.assertEquals(0L, evalLong("isdistinctfrom(2.0, 2.0)", bindings));
 
-    Assert.assertEquals(0L, evalLong("istrue(0.0)", bindings));
-    Assert.assertEquals(1L, evalLong("isfalse(0.0)", bindings));
-    Assert.assertEquals(1L, evalLong("nottrue(0.0)", bindings));
-    Assert.assertEquals(0L, evalLong("notfalse(0.0)", bindings));
+    Assertions.assertEquals(0L, evalLong("istrue(0.0)", bindings));
+    Assertions.assertEquals(1L, evalLong("isfalse(0.0)", bindings));
+    Assertions.assertEquals(1L, evalLong("nottrue(0.0)", bindings));
+    Assertions.assertEquals(0L, evalLong("notfalse(0.0)", bindings));
 
-    Assert.assertEquals(1L, evalLong("istrue(1.0)", bindings));
-    Assert.assertEquals(0L, evalLong("isfalse(1.0)", bindings));
-    Assert.assertEquals(0L, evalLong("nottrue(1.0)", bindings));
-    Assert.assertEquals(1L, evalLong("notfalse(1.0)", bindings));
+    Assertions.assertEquals(1L, evalLong("istrue(1.0)", bindings));
+    Assertions.assertEquals(0L, evalLong("isfalse(1.0)", bindings));
+    Assertions.assertEquals(0L, evalLong("nottrue(1.0)", bindings));
+    Assertions.assertEquals(1L, evalLong("notfalse(1.0)", bindings));
 
-    Assert.assertEquals(1L, evalLong("!-1.0", bindings));
-    Assert.assertEquals(1L, evalLong("!0.0", bindings));
-    Assert.assertEquals(0L, evalLong("!2.0", bindings));
+    Assertions.assertEquals(1L, evalLong("!-1.0", bindings));
+    Assertions.assertEquals(1L, evalLong("!0.0", bindings));
+    Assertions.assertEquals(0L, evalLong("!2.0", bindings));
 
     assertEquals(3.5, evalDouble("2.0 + 1.5", bindings), 0.0001);
     assertEquals(0.5, evalDouble("2.0 - 1.5", bindings), 0.0001);
@@ -138,22 +139,22 @@ public class EvalTest extends InitializedNullHandlingTest
     assertEquals(9223372036854775807L, evalLong("\"x\"", bindings));
     assertEquals(92233720368547759L, evalLong("\"x\" / 100 + 1", bindings));
 
-    Assert.assertFalse(evalLong("9223372036854775807 && 0", bindings) > 0);
-    Assert.assertTrue(evalLong("9223372036854775807 && 9223372036854775806", bindings) > 0);
+    Assertions.assertFalse(evalLong("9223372036854775807 && 0", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775807 && 9223372036854775806", bindings) > 0);
 
-    Assert.assertTrue(evalLong("9223372036854775807 || 0", bindings) > 0);
-    Assert.assertFalse(evalLong("-9223372036854775807 || -9223372036854775807", bindings) > 0);
-    Assert.assertTrue(evalLong("-9223372036854775807 || 9223372036854775807", bindings) > 0);
-    Assert.assertFalse(evalLong("0 || 0", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775807 || 0", bindings) > 0);
+    Assertions.assertFalse(evalLong("-9223372036854775807 || -9223372036854775807", bindings) > 0);
+    Assertions.assertTrue(evalLong("-9223372036854775807 || 9223372036854775807", bindings) > 0);
+    Assertions.assertFalse(evalLong("0 || 0", bindings) > 0);
 
-    Assert.assertTrue(evalLong("9223372036854775807 > 9223372036854775806", bindings) > 0);
-    Assert.assertTrue(evalLong("9223372036854775807 >= 9223372036854775807", bindings) > 0);
-    Assert.assertTrue(evalLong("9223372036854775806 < 9223372036854775807", bindings) > 0);
-    Assert.assertTrue(evalLong("9223372036854775807 <= 9223372036854775807", bindings) > 0);
-    Assert.assertTrue(evalLong("9223372036854775807 == 9223372036854775807", bindings) > 0);
-    Assert.assertTrue(evalLong("9223372036854775807 != 9223372036854775806", bindings) > 0);
-    Assert.assertTrue(evalLong("notdistinctfrom(9223372036854775807, 9223372036854775807)", bindings) > 0);
-    Assert.assertTrue(evalLong("isdistinctfrom(9223372036854775807, 9223372036854775806)", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775807 > 9223372036854775806", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775807 >= 9223372036854775807", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775806 < 9223372036854775807", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775807 <= 9223372036854775807", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775807 == 9223372036854775807", bindings) > 0);
+    Assertions.assertTrue(evalLong("9223372036854775807 != 9223372036854775806", bindings) > 0);
+    Assertions.assertTrue(evalLong("notdistinctfrom(9223372036854775807, 9223372036854775807)", bindings) > 0);
+    Assertions.assertTrue(evalLong("isdistinctfrom(9223372036854775807, 9223372036854775806)", bindings) > 0);
 
     assertEquals(9223372036854775807L, evalLong("9223372036854775806 + 1", bindings));
     assertEquals(9223372036854775806L, evalLong("9223372036854775807 - 1", bindings));
@@ -163,9 +164,9 @@ public class EvalTest extends InitializedNullHandlingTest
     assertEquals(9223372030926249001L, evalLong("3037000499 ^ 2", bindings));
     assertEquals(-9223372036854775807L, evalLong("-9223372036854775807", bindings));
 
-    Assert.assertTrue(evalLong("!-9223372036854775807", bindings) > 0);
-    Assert.assertTrue(evalLong("!0", bindings) > 0);
-    Assert.assertFalse(evalLong("!9223372036854775807", bindings) > 0);
+    Assertions.assertTrue(evalLong("!-9223372036854775807", bindings) > 0);
+    Assertions.assertTrue(evalLong("!0", bindings) > 0);
+    Assertions.assertFalse(evalLong("!9223372036854775807", bindings) > 0);
 
     assertEquals(3037000499L, evalLong("cast(sqrt(9223372036854775807), 'long')", bindings));
     assertEquals(1L, evalLong("if(x == 9223372036854775807, 1, 0)", bindings));
@@ -445,72 +446,72 @@ public class EvalTest extends InitializedNullHandlingTest
   public void testStringArrayToScalarStringBadCast()
   {
     ExprEval cast = ExprEval.ofStringArray(new String[]{"foo", "bar"}).castTo(ExpressionType.STRING);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.STRING, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.STRING, cast.type());
   }
 
   @Test
   public void testStringArrayToScalarLongBadCast()
   {
     ExprEval cast = ExprEval.ofStringArray(new String[]{"foo", "bar"}).castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.LONG, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.LONG, cast.type());
   }
 
   @Test
   public void testStringArrayToScalarDoubleBadCast()
   {
     ExprEval cast = ExprEval.ofStringArray(new String[]{"foo", "bar"}).castTo(ExpressionType.DOUBLE);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.DOUBLE, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, cast.type());
   }
 
   @Test
   public void testLongArrayToScalarStringBadCast()
   {
     ExprEval cast = ExprEval.ofLongArray(new Long[]{1L, 2L}).castTo(ExpressionType.STRING);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.STRING, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.STRING, cast.type());
   }
 
   @Test
   public void testLongArrayToScalarLongBadCast()
   {
     ExprEval cast = ExprEval.ofLongArray(new Long[]{1L, 2L}).castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.LONG, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.LONG, cast.type());
   }
 
   @Test
   public void testLongArrayToScalarDoubleBadCast()
   {
     ExprEval cast = ExprEval.ofLongArray(new Long[]{1L, 2L}).castTo(ExpressionType.DOUBLE);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.DOUBLE, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, cast.type());
   }
 
   @Test
   public void testDoubleArrayToScalarStringBadCast()
   {
     ExprEval cast = ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).castTo(ExpressionType.STRING);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.STRING, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.STRING, cast.type());
   }
 
   @Test
   public void testDoubleArrayToScalarLongBadCast()
   {
     ExprEval cast = ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.LONG, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.LONG, cast.type());
   }
 
   @Test
   public void testDoubleArrayToScalarDoubleBadCast()
   {
     ExprEval cast = ExprEval.ofDoubleArray(new Double[]{1.1, 2.2}).castTo(ExpressionType.DOUBLE);
-    Assert.assertNull(cast.value());
-    Assert.assertEquals(ExpressionType.DOUBLE, cast.type());
+    Assertions.assertNull(cast.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, cast.type());
   }
 
   @Test
@@ -518,82 +519,82 @@ public class EvalTest extends InitializedNullHandlingTest
   {
     ExprEval cast;
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, "hello").castTo(ExpressionType.STRING);
-    Assert.assertEquals("hello", cast.value());
-    Assert.assertEquals("hello", ExprEval.ofComplex(ExpressionType.NESTED_DATA, "hello").asString());
-    Assert.assertEquals(ExpressionType.STRING, cast.type());
+    Assertions.assertEquals("hello", cast.value());
+    Assertions.assertEquals("hello", ExprEval.ofComplex(ExpressionType.NESTED_DATA, "hello").asString());
+    Assertions.assertEquals(ExpressionType.STRING, cast.type());
 
     cast = ExprEval.ofString("hello").castTo(ExpressionType.NESTED_DATA);
-    Assert.assertEquals("hello", cast.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, cast.type());
+    Assertions.assertEquals("hello", cast.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, cast.type());
 
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, 123L).castTo(ExpressionType.STRING);
-    Assert.assertEquals("123", cast.value());
-    Assert.assertEquals(ExpressionType.STRING, cast.type());
+    Assertions.assertEquals("123", cast.value());
+    Assertions.assertEquals(ExpressionType.STRING, cast.type());
 
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, 123L).castTo(ExpressionType.LONG);
-    Assert.assertEquals(123L, cast.value());
-    Assert.assertEquals(123L, ExprEval.ofComplex(ExpressionType.NESTED_DATA, 123L).asLong());
-    Assert.assertEquals(ExpressionType.LONG, cast.type());
+    Assertions.assertEquals(123L, cast.value());
+    Assertions.assertEquals(123L, ExprEval.ofComplex(ExpressionType.NESTED_DATA, 123L).asLong());
+    Assertions.assertEquals(ExpressionType.LONG, cast.type());
 
     cast = ExprEval.of(123L).castTo(ExpressionType.NESTED_DATA);
-    Assert.assertEquals(123L, cast.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, cast.type());
+    Assertions.assertEquals(123L, cast.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, cast.type());
 
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, 123L).castTo(ExpressionType.DOUBLE);
-    Assert.assertEquals(123.0, cast.value());
-    Assert.assertEquals(123.0, ExprEval.ofComplex(ExpressionType.NESTED_DATA, 123L).asDouble(), 0.0);
-    Assert.assertEquals(ExpressionType.DOUBLE, cast.type());
+    Assertions.assertEquals(123.0, cast.value());
+    Assertions.assertEquals(123.0, ExprEval.ofComplex(ExpressionType.NESTED_DATA, 123L).asDouble(), 0.0);
+    Assertions.assertEquals(ExpressionType.DOUBLE, cast.type());
 
     cast = ExprEval.of(12.3).castTo(ExpressionType.NESTED_DATA);
-    Assert.assertEquals(12.3, cast.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, cast.type());
+    Assertions.assertEquals(12.3, cast.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, cast.type());
 
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, ImmutableList.of("a", "b", "c")).castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) cast.value());
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(
         new Object[]{"a", "b", "c"},
         ExprEval.ofComplex(ExpressionType.NESTED_DATA, ImmutableList.of("a", "b", "c")).asArray()
     );
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, cast.type());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, cast.type());
 
     cast = ExprEval.ofArray(ExpressionType.STRING_ARRAY, new Object[]{"a", "b", "c"}).castTo(ExpressionType.NESTED_DATA);
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) cast.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, cast.type());
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) cast.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, cast.type());
 
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, ImmutableList.of(1L, 2L, 3L)).castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) cast.value());
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(
         new Object[]{1L, 2L, 3L},
         ExprEval.ofComplex(ExpressionType.NESTED_DATA, ImmutableList.of(1L, 2L, 3L)).asArray()
     );
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, cast.type());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, cast.type());
 
     cast = ExprEval.ofArray(ExpressionType.LONG_ARRAY, new Object[]{1L, 2L, 3L}).castTo(ExpressionType.NESTED_DATA);
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) cast.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, cast.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) cast.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, cast.type());
 
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, ImmutableList.of(1L, 2L, 3L)).castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) cast.value());
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, cast.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) cast.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, cast.type());
 
     cast = ExprEval.ofArray(ExpressionType.DOUBLE_ARRAY, new Object[]{1.1, 2.2, 3.3}).castTo(ExpressionType.NESTED_DATA);
-    Assert.assertArrayEquals(new Object[]{1.1, 2.2, 3.3}, (Object[]) cast.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, cast.type());
+    Assertions.assertArrayEquals(new Object[]{1.1, 2.2, 3.3}, (Object[]) cast.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, cast.type());
 
     ExpressionType nestedArray = ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA);
     cast = ExprEval.ofComplex(
         ExpressionType.NESTED_DATA,
         ImmutableList.of(ImmutableMap.of("x", 1, "y", 2), ImmutableMap.of("x", 3, "y", 4))
     ).castTo(nestedArray);
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             ImmutableMap.of("x", 1, "y", 2),
             ImmutableMap.of("x", 3, "y", 4)
         },
         (Object[]) cast.value()
     );
-    Assert.assertEquals(nestedArray, cast.type());
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(nestedArray, cast.type());
+    Assertions.assertArrayEquals(
         new Object[]{
             ImmutableMap.of("x", 1, "y", 2),
             ImmutableMap.of("x", 3, "y", 4)
@@ -608,106 +609,106 @@ public class EvalTest extends InitializedNullHandlingTest
     );
 
     cast = ExprEval.ofLong(1234L).castTo(nestedArray);
-    Assert.assertEquals(nestedArray, cast.type());
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(nestedArray, cast.type());
+    Assertions.assertArrayEquals(
         new Object[]{1234L},
         cast.asArray()
     );
     cast = ExprEval.ofString("hello").castTo(nestedArray);
-    Assert.assertEquals(nestedArray, cast.type());
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(nestedArray, cast.type());
+    Assertions.assertArrayEquals(
         new Object[]{"hello"},
         cast.asArray()
     );
     cast = ExprEval.ofDouble(1.234).castTo(nestedArray);
-    Assert.assertEquals(nestedArray, cast.type());
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(nestedArray, cast.type());
+    Assertions.assertArrayEquals(
         new Object[]{1.234},
         cast.asArray()
     );
     cast = ExprEval.ofComplex(ExpressionType.NESTED_DATA, 1234L).castTo(nestedArray);
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{1234L},
         cast.asArray()
     );
-    Assert.assertEquals(nestedArray, cast.type());
+    Assertions.assertEquals(nestedArray, cast.type());
   }
 
   @Test
   public void testNestedAsOtherStuff()
   {
     ExprEval eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, StructuredData.wrap(true));
-    Assert.assertTrue(eval.asBoolean());
-    Assert.assertFalse(eval.isNumericNull());
-    Assert.assertEquals(1, eval.asInt());
-    Assert.assertEquals(1L, eval.asLong());
-    Assert.assertEquals(1.0, eval.asDouble(), 0.0);
+    Assertions.assertTrue(eval.asBoolean());
+    Assertions.assertFalse(eval.isNumericNull());
+    Assertions.assertEquals(1, eval.asInt());
+    Assertions.assertEquals(1L, eval.asLong());
+    Assertions.assertEquals(1.0, eval.asDouble(), 0.0);
 
-    Assert.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, true).asBoolean());
+    Assertions.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, true).asBoolean());
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, false);
-    Assert.assertFalse(eval.asBoolean());
-    Assert.assertFalse(eval.isNumericNull());
-    Assert.assertEquals(0, eval.asInt());
-    Assert.assertEquals(0L, eval.asLong());
-    Assert.assertEquals(0.0, eval.asDouble(), 0.0);
+    Assertions.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.isNumericNull());
+    Assertions.assertEquals(0, eval.asInt());
+    Assertions.assertEquals(0L, eval.asLong());
+    Assertions.assertEquals(0.0, eval.asDouble(), 0.0);
 
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, "true");
-    Assert.assertTrue(eval.asBoolean());
-    Assert.assertFalse(eval.isNumericNull());
-    Assert.assertEquals(1L, eval.asLong());
-    Assert.assertEquals(1, eval.asInt());
-    Assert.assertEquals(1.0, eval.asDouble(), 0.0);
+    Assertions.assertTrue(eval.asBoolean());
+    Assertions.assertFalse(eval.isNumericNull());
+    Assertions.assertEquals(1L, eval.asLong());
+    Assertions.assertEquals(1, eval.asInt());
+    Assertions.assertEquals(1.0, eval.asDouble(), 0.0);
 
-    Assert.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, StructuredData.wrap("true")).asBoolean());
-    Assert.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, "TRUE").asBoolean());
-    Assert.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, "True").asBoolean());
+    Assertions.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, StructuredData.wrap("true")).asBoolean());
+    Assertions.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, "TRUE").asBoolean());
+    Assertions.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, "True").asBoolean());
 
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, StructuredData.wrap(1L));
-    Assert.assertTrue(eval.asBoolean());
-    Assert.assertFalse(eval.isNumericNull());
-    Assert.assertEquals(1L, eval.asLong());
-    Assert.assertEquals(1, eval.asInt());
-    Assert.assertEquals(1.0, eval.asDouble(), 0.0);
+    Assertions.assertTrue(eval.asBoolean());
+    Assertions.assertFalse(eval.isNumericNull());
+    Assertions.assertEquals(1L, eval.asLong());
+    Assertions.assertEquals(1, eval.asInt());
+    Assertions.assertEquals(1.0, eval.asDouble(), 0.0);
 
-    Assert.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, 1L).asBoolean());
+    Assertions.assertTrue(ExprEval.ofComplex(ExpressionType.NESTED_DATA, 1L).asBoolean());
 
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, StructuredData.wrap(1.23));
-    Assert.assertTrue(eval.asBoolean());
-    Assert.assertFalse(eval.isNumericNull());
-    Assert.assertEquals(1L, eval.asLong());
-    Assert.assertEquals(1, eval.asInt());
-    Assert.assertEquals(1.23, eval.asDouble(), 0.0);
+    Assertions.assertTrue(eval.asBoolean());
+    Assertions.assertFalse(eval.isNumericNull());
+    Assertions.assertEquals(1L, eval.asLong());
+    Assertions.assertEquals(1, eval.asInt());
+    Assertions.assertEquals(1.23, eval.asDouble(), 0.0);
 
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, "hello");
-    Assert.assertFalse(eval.asBoolean());
-    Assert.assertTrue(eval.isNumericNull());
-    Assert.assertEquals(0, eval.asInt());
-    Assert.assertEquals(0L, eval.asLong());
-    Assert.assertEquals(0.0, eval.asDouble(), 0.0);
+    Assertions.assertFalse(eval.asBoolean());
+    Assertions.assertTrue(eval.isNumericNull());
+    Assertions.assertEquals(0, eval.asInt());
+    Assertions.assertEquals(0L, eval.asLong());
+    Assertions.assertEquals(0.0, eval.asDouble(), 0.0);
 
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, Arrays.asList("1", "2", "3"));
-    Assert.assertFalse(eval.asBoolean());
-    Assert.assertTrue(eval.isNumericNull());
-    Assert.assertEquals(0, eval.asInt());
-    Assert.assertEquals(0L, eval.asLong());
-    Assert.assertEquals(0.0, eval.asDouble(), 0.0);
-    Assert.assertArrayEquals(new Object[]{"1", "2", "3"}, eval.asArray());
+    Assertions.assertFalse(eval.asBoolean());
+    Assertions.assertTrue(eval.isNumericNull());
+    Assertions.assertEquals(0, eval.asInt());
+    Assertions.assertEquals(0L, eval.asLong());
+    Assertions.assertEquals(0.0, eval.asDouble(), 0.0);
+    Assertions.assertArrayEquals(new Object[]{"1", "2", "3"}, eval.asArray());
 
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, Arrays.asList(1L, 2L, 3L));
-    Assert.assertFalse(eval.asBoolean());
-    Assert.assertTrue(eval.isNumericNull());
-    Assert.assertEquals(0, eval.asInt());
-    Assert.assertEquals(0L, eval.asLong());
-    Assert.assertEquals(0.0, eval.asDouble(), 0.0);
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, eval.asArray());
+    Assertions.assertFalse(eval.asBoolean());
+    Assertions.assertTrue(eval.isNumericNull());
+    Assertions.assertEquals(0, eval.asInt());
+    Assertions.assertEquals(0L, eval.asLong());
+    Assertions.assertEquals(0.0, eval.asDouble(), 0.0);
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, eval.asArray());
 
     eval = ExprEval.ofComplex(ExpressionType.NESTED_DATA, Arrays.asList(1.1, 2.2, 3.3));
-    Assert.assertFalse(eval.asBoolean());
-    Assert.assertTrue(eval.isNumericNull());
-    Assert.assertEquals(0, eval.asInt());
-    Assert.assertEquals(0L, eval.asLong());
-    Assert.assertEquals(0.0, eval.asDouble(), 0.0);
-    Assert.assertArrayEquals(new Object[]{1.1, 2.2, 3.3}, eval.asArray());
+    Assertions.assertFalse(eval.asBoolean());
+    Assertions.assertTrue(eval.isNumericNull());
+    Assertions.assertEquals(0, eval.asInt());
+    Assertions.assertEquals(0L, eval.asLong());
+    Assertions.assertEquals(0.0, eval.asDouble(), 0.0);
+    Assertions.assertArrayEquals(new Object[]{1.1, 2.2, 3.3}, eval.asArray());
 
     eval = ExprEval.ofComplex(
         ExpressionType.NESTED_DATA,
@@ -716,126 +717,126 @@ public class EvalTest extends InitializedNullHandlingTest
             ImmutableMap.of("x", 3, "y", 4)
         )
     );
-    Assert.assertFalse(eval.asBoolean());
-    Assert.assertEquals(0, eval.asLong());
-    Assert.assertEquals(0, eval.asInt());
-    Assert.assertEquals(0.0, eval.asDouble(), 0.0);
+    Assertions.assertFalse(eval.asBoolean());
+    Assertions.assertEquals(0, eval.asLong());
+    Assertions.assertEquals(0, eval.asInt());
+    Assertions.assertEquals(0.0, eval.asDouble(), 0.0);
   }
 
   @Test
   public void testNonNestedComplexCastThrows()
   {
     ExpressionType someComplex = ExpressionTypeFactory.getInstance().ofComplex("tester");
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofType(someComplex, "hello").castTo(ExpressionType.STRING)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [STRING]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [STRING]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofType(someComplex, "hello").castTo(ExpressionType.LONG)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [LONG]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [LONG]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofType(someComplex, "hello").castTo(ExpressionType.DOUBLE)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [DOUBLE]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [DOUBLE]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofType(someComplex, "hello").castTo(ExpressionType.STRING_ARRAY)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [ARRAY<STRING>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [ARRAY<STRING>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofType(someComplex, "hello").castTo(ExpressionType.LONG_ARRAY)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [ARRAY<LONG>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [ARRAY<LONG>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofType(someComplex, "hello").castTo(ExpressionType.DOUBLE_ARRAY)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [ARRAY<DOUBLE>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [ARRAY<DOUBLE>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofType(someComplex, "hello").castTo(ExpressionType.NESTED_DATA)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [COMPLEX<json>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<tester>] to [COMPLEX<json>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofString("hello").castTo(someComplex)
     );
-    Assert.assertEquals("Invalid type, cannot cast [STRING] to [COMPLEX<tester>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [STRING] to [COMPLEX<tester>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.of(123L).castTo(someComplex)
     );
-    Assert.assertEquals("Invalid type, cannot cast [LONG] to [COMPLEX<tester>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [LONG] to [COMPLEX<tester>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.of(1.23).castTo(someComplex)
     );
-    Assert.assertEquals("Invalid type, cannot cast [DOUBLE] to [COMPLEX<tester>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [DOUBLE] to [COMPLEX<tester>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofStringArray(new Object[]{"a", "b", "c"}).castTo(someComplex)
     );
-    Assert.assertEquals("Invalid type, cannot cast [ARRAY<STRING>] to [COMPLEX<tester>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [ARRAY<STRING>] to [COMPLEX<tester>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofLongArray(new Object[]{1L, 2L, 3L}).castTo(someComplex)
     );
-    Assert.assertEquals("Invalid type, cannot cast [ARRAY<LONG>] to [COMPLEX<tester>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [ARRAY<LONG>] to [COMPLEX<tester>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofDoubleArray(new Object[]{1.1, 2.2, 3.3}).castTo(someComplex)
     );
-    Assert.assertEquals("Invalid type, cannot cast [ARRAY<DOUBLE>] to [COMPLEX<tester>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [ARRAY<DOUBLE>] to [COMPLEX<tester>]", t.getMessage());
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> ExprEval.ofComplex(ExpressionType.NESTED_DATA, ImmutableMap.of("x", 1L)).castTo(someComplex)
     );
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<json>] to [COMPLEX<tester>]", t.getMessage());
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<json>] to [COMPLEX<tester>]", t.getMessage());
   }
 
   @Test
   public void testIsNumericNull()
   {
-    Assert.assertFalse(ExprEval.ofLong(1L).isNumericNull());
-    Assert.assertTrue(ExprEval.ofLong(null).isNumericNull());
+    Assertions.assertFalse(ExprEval.ofLong(1L).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofLong(null).isNumericNull());
 
-    Assert.assertFalse(ExprEval.ofDouble(1.0).isNumericNull());
-    Assert.assertTrue(ExprEval.ofDouble(null).isNumericNull());
+    Assertions.assertFalse(ExprEval.ofDouble(1.0).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofDouble(null).isNumericNull());
 
-    Assert.assertTrue(ExprEval.ofString(null).isNumericNull());
-    Assert.assertTrue(ExprEval.ofString("one").isNumericNull());
-    Assert.assertFalse(ExprEval.ofString("1").isNumericNull());
+    Assertions.assertTrue(ExprEval.ofString(null).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofString("one").isNumericNull());
+    Assertions.assertFalse(ExprEval.ofString("1").isNumericNull());
 
-    Assert.assertFalse(ExprEval.ofLongArray(new Long[]{1L}).isNumericNull());
-    Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
-    Assert.assertTrue(ExprEval.ofLongArray(new Long[]{null}).isNumericNull());
+    Assertions.assertFalse(ExprEval.ofLongArray(new Long[]{1L}).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofLongArray(new Long[]{null, 2L, 3L}).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofLongArray(new Long[]{null}).isNumericNull());
 
-    Assert.assertFalse(ExprEval.ofDoubleArray(new Double[]{1.1}).isNumericNull());
-    Assert.assertTrue(ExprEval.ofDoubleArray(new Double[]{null, 1.1, 2.2}).isNumericNull());
-    Assert.assertTrue(ExprEval.ofDoubleArray(new Double[]{null}).isNumericNull());
+    Assertions.assertFalse(ExprEval.ofDoubleArray(new Double[]{1.1}).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofDoubleArray(new Double[]{null, 1.1, 2.2}).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofDoubleArray(new Double[]{null}).isNumericNull());
 
-    Assert.assertFalse(ExprEval.ofStringArray(new String[]{"1"}).isNumericNull());
-    Assert.assertTrue(ExprEval.ofStringArray(new String[]{null, "1", "2"}).isNumericNull());
-    Assert.assertTrue(ExprEval.ofStringArray(new String[]{"one"}).isNumericNull());
-    Assert.assertTrue(ExprEval.ofStringArray(new String[]{null}).isNumericNull());
+    Assertions.assertFalse(ExprEval.ofStringArray(new String[]{"1"}).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofStringArray(new String[]{null, "1", "2"}).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofStringArray(new String[]{"one"}).isNumericNull());
+    Assertions.assertTrue(ExprEval.ofStringArray(new String[]{null}).isNumericNull());
   }
 
   @Test
@@ -846,27 +847,27 @@ public class EvalTest extends InitializedNullHandlingTest
     );
 
     ExprEval eval = Parser.parse("x==y", ExprMacroTable.nil()).eval(bindings);
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertTrue(eval.asBoolean());
     assertEquals(ExpressionType.LONG, eval.type());
 
     eval = Parser.parse("x!=y", ExprMacroTable.nil()).eval(bindings);
-    Assert.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.asBoolean());
     assertEquals(ExpressionType.LONG, eval.type());
 
     eval = Parser.parse("x==z", ExprMacroTable.nil()).eval(bindings);
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertTrue(eval.asBoolean());
     assertEquals(ExpressionType.LONG, eval.type());
 
     eval = Parser.parse("x!=z", ExprMacroTable.nil()).eval(bindings);
-    Assert.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.asBoolean());
     assertEquals(ExpressionType.LONG, eval.type());
 
     eval = Parser.parse("z==w", ExprMacroTable.nil()).eval(bindings);
-    Assert.assertTrue(eval.asBoolean());
+    Assertions.assertTrue(eval.asBoolean());
     assertEquals(ExpressionType.LONG, eval.type());
 
     eval = Parser.parse("z!=w", ExprMacroTable.nil()).eval(bindings);
-    Assert.assertFalse(eval.asBoolean());
+    Assertions.assertFalse(eval.asBoolean());
     assertEquals(ExpressionType.LONG, eval.type());
   }
 
@@ -999,32 +1000,32 @@ public class EvalTest extends InitializedNullHandlingTest
                     .build()
     );
 
-    Assert.assertEquals(0L, eval("['a','b',null,'c'] > stringArray", bindings).value());
-    Assert.assertEquals(1L, eval("['a','b',null,'c'] >= stringArray", bindings).value());
-    Assert.assertEquals(1L, eval("['a','b',null,'c'] == stringArray", bindings).value());
-    Assert.assertEquals(0L, eval("['a','b',null,'c'] != stringArray", bindings).value());
-    Assert.assertEquals(1L, eval("notdistinctfrom(['a','b',null,'c'], stringArray)", bindings).value());
-    Assert.assertEquals(0L, eval("isdistinctfrom(['a','b',null,'c'], stringArray)", bindings).value());
-    Assert.assertEquals(1L, eval("['a','b',null,'c'] <= stringArray", bindings).value());
-    Assert.assertEquals(0L, eval("['a','b',null,'c'] < stringArray", bindings).value());
+    Assertions.assertEquals(0L, eval("['a','b',null,'c'] > stringArray", bindings).value());
+    Assertions.assertEquals(1L, eval("['a','b',null,'c'] >= stringArray", bindings).value());
+    Assertions.assertEquals(1L, eval("['a','b',null,'c'] == stringArray", bindings).value());
+    Assertions.assertEquals(0L, eval("['a','b',null,'c'] != stringArray", bindings).value());
+    Assertions.assertEquals(1L, eval("notdistinctfrom(['a','b',null,'c'], stringArray)", bindings).value());
+    Assertions.assertEquals(0L, eval("isdistinctfrom(['a','b',null,'c'], stringArray)", bindings).value());
+    Assertions.assertEquals(1L, eval("['a','b',null,'c'] <= stringArray", bindings).value());
+    Assertions.assertEquals(0L, eval("['a','b',null,'c'] < stringArray", bindings).value());
 
-    Assert.assertEquals(0L, eval("[1,null,2,3] > longArray", bindings).value());
-    Assert.assertEquals(1L, eval("[1,null,2,3] >= longArray", bindings).value());
-    Assert.assertEquals(1L, eval("[1,null,2,3] == longArray", bindings).value());
-    Assert.assertEquals(0L, eval("[1,null,2,3] != longArray", bindings).value());
-    Assert.assertEquals(1L, eval("notdistinctfrom([1,null,2,3], longArray)", bindings).value());
-    Assert.assertEquals(0L, eval("isdistinctfrom([1,null,2,3], longArray)", bindings).value());
-    Assert.assertEquals(1L, eval("[1,null,2,3] <= longArray", bindings).value());
-    Assert.assertEquals(0L, eval("[1,null,2,3] < longArray", bindings).value());
+    Assertions.assertEquals(0L, eval("[1,null,2,3] > longArray", bindings).value());
+    Assertions.assertEquals(1L, eval("[1,null,2,3] >= longArray", bindings).value());
+    Assertions.assertEquals(1L, eval("[1,null,2,3] == longArray", bindings).value());
+    Assertions.assertEquals(0L, eval("[1,null,2,3] != longArray", bindings).value());
+    Assertions.assertEquals(1L, eval("notdistinctfrom([1,null,2,3], longArray)", bindings).value());
+    Assertions.assertEquals(0L, eval("isdistinctfrom([1,null,2,3], longArray)", bindings).value());
+    Assertions.assertEquals(1L, eval("[1,null,2,3] <= longArray", bindings).value());
+    Assertions.assertEquals(0L, eval("[1,null,2,3] < longArray", bindings).value());
 
-    Assert.assertEquals(0L, eval("[1.1,2.2,3.3,null] > doubleArray", bindings).value());
-    Assert.assertEquals(1L, eval("[1.1,2.2,3.3,null] >= doubleArray", bindings).value());
-    Assert.assertEquals(1L, eval("[1.1,2.2,3.3,null] == doubleArray", bindings).value());
-    Assert.assertEquals(0L, eval("[1.1,2.2,3.3,null] != doubleArray", bindings).value());
-    Assert.assertEquals(1L, eval("notdistinctfrom([1.1,2.2,3.3,null], doubleArray)", bindings).value());
-    Assert.assertEquals(0L, eval("isdistinctfrom([1.1,2.2,3.3,null], doubleArray)", bindings).value());
-    Assert.assertEquals(1L, eval("[1.1,2.2,3.3,null] <= doubleArray", bindings).value());
-    Assert.assertEquals(0L, eval("[1.1,2.2,3.3,null] < doubleArray", bindings).value());
+    Assertions.assertEquals(0L, eval("[1.1,2.2,3.3,null] > doubleArray", bindings).value());
+    Assertions.assertEquals(1L, eval("[1.1,2.2,3.3,null] >= doubleArray", bindings).value());
+    Assertions.assertEquals(1L, eval("[1.1,2.2,3.3,null] == doubleArray", bindings).value());
+    Assertions.assertEquals(0L, eval("[1.1,2.2,3.3,null] != doubleArray", bindings).value());
+    Assertions.assertEquals(1L, eval("notdistinctfrom([1.1,2.2,3.3,null], doubleArray)", bindings).value());
+    Assertions.assertEquals(0L, eval("isdistinctfrom([1.1,2.2,3.3,null], doubleArray)", bindings).value());
+    Assertions.assertEquals(1L, eval("[1.1,2.2,3.3,null] <= doubleArray", bindings).value());
+    Assertions.assertEquals(0L, eval("[1.1,2.2,3.3,null] < doubleArray", bindings).value());
   }
 
   @Test
@@ -1032,10 +1033,10 @@ public class EvalTest extends InitializedNullHandlingTest
   {
     ExprEval<?> longNull = ExprEval.ofLong(null);
     ExprEval<?> doubleNull = ExprEval.ofDouble(null);
-    Assert.assertTrue(longNull.isNumericNull());
-    Assert.assertTrue(doubleNull.isNumericNull());
-    Assert.assertNull(null, longNull.value());
-    Assert.assertNull(null, doubleNull.value());
+    Assertions.assertTrue(longNull.isNumericNull());
+    Assertions.assertTrue(doubleNull.isNumericNull());
+    Assertions.assertNull(longNull.value());
+    Assertions.assertNull(doubleNull.value());
   }
 
   @Test
@@ -1043,215 +1044,215 @@ public class EvalTest extends InitializedNullHandlingTest
   {
     // strings
     ExprEval eval = ExprEval.ofType(ExpressionType.STRING, "stringy");
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
-    Assert.assertEquals("stringy", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("stringy", eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING, 1L);
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
-    Assert.assertEquals("1", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("1", eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING, 1.0);
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
-    Assert.assertEquals("1.0", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("1.0", eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING, true);
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
-    Assert.assertEquals("true", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("true", eval.value());
 
     // strings might also be liars and arrays or lists
     eval = ExprEval.ofType(ExpressionType.STRING, new Object[]{"a", "b", "c"});
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING, new String[]{"a", "b", "c"});
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING, Arrays.asList("a", "b", "c"));
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
 
     // longs
     eval = ExprEval.ofType(ExpressionType.LONG, 1L);
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
-    Assert.assertEquals(1L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(1L, eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG, 1.0);
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
-    Assert.assertEquals(1L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(1L, eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG, "1");
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
-    Assert.assertEquals(1L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(1L, eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG, true);
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
-    Assert.assertEquals(1L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(1L, eval.value());
 
     // doubles
     eval = ExprEval.ofType(ExpressionType.DOUBLE, 1L);
-    Assert.assertEquals(ExpressionType.DOUBLE, eval.type());
-    Assert.assertEquals(1.0, eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, eval.type());
+    Assertions.assertEquals(1.0, eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE, 1.0);
-    Assert.assertEquals(ExpressionType.DOUBLE, eval.type());
-    Assert.assertEquals(1.0, eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, eval.type());
+    Assertions.assertEquals(1.0, eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE, "1");
-    Assert.assertEquals(ExpressionType.DOUBLE, eval.type());
-    Assert.assertEquals(1.0, eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, eval.type());
+    Assertions.assertEquals(1.0, eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE, true);
-    Assert.assertEquals(ExpressionType.DOUBLE, eval.type());
-    Assert.assertEquals(1.0, eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, eval.type());
+    Assertions.assertEquals(1.0, eval.value());
 
     // complex
     TypeStrategiesTest.NullableLongPair pair = new TypeStrategiesTest.NullableLongPair(1L, 2L);
     ExpressionType type = ExpressionType.fromColumnType(TypeStrategiesTest.NULLABLE_TEST_PAIR_TYPE);
 
     eval = ExprEval.ofType(type, pair);
-    Assert.assertEquals(type, eval.type());
-    Assert.assertEquals(pair, eval.value());
+    Assertions.assertEquals(type, eval.type());
+    Assertions.assertEquals(pair, eval.value());
 
     ByteBuffer buffer = ByteBuffer.allocate(TypeStrategiesTest.NULLABLE_TEST_PAIR_TYPE.getStrategy().estimateSizeBytes(pair));
     TypeStrategiesTest.NULLABLE_TEST_PAIR_TYPE.getStrategy().write(buffer, pair, buffer.limit());
     byte[] pairBytes = buffer.array();
     eval = ExprEval.ofType(type, pairBytes);
-    Assert.assertEquals(type, eval.type());
-    Assert.assertEquals(pair, eval.value());
+    Assertions.assertEquals(type, eval.type());
+    Assertions.assertEquals(pair, eval.value());
 
     eval = ExprEval.ofType(type, StringUtils.encodeBase64String(pairBytes));
-    Assert.assertEquals(type, eval.type());
-    Assert.assertEquals(pair, eval.value());
+    Assertions.assertEquals(type, eval.type());
+    Assertions.assertEquals(pair, eval.value());
 
     // json type best efforts its way to other types
     eval = ExprEval.ofType(ExpressionType.NESTED_DATA, ImmutableMap.of("x", 1L, "y", 2L));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
-    Assert.assertEquals(ImmutableMap.of("x", 1L, "y", 2L), eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(ImmutableMap.of("x", 1L, "y", 2L), eval.value());
 
     ExpressionType stringyComplexThing = ExpressionType.fromString("COMPLEX<somestringything>");
     eval = ExprEval.ofType(stringyComplexThing, "notbase64");
-    Assert.assertEquals(stringyComplexThing, eval.type());
-    Assert.assertEquals("notbase64", eval.value());
+    Assertions.assertEquals(stringyComplexThing, eval.type());
+    Assertions.assertEquals("notbase64", eval.value());
 
     // arrays
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{1L, 2L, 3L});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, ImmutableList.of(1L, 2L, 3L));
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Long[]{1L, 2L, 3L});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new long[]{1L, 2L, 3L});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new int[]{1, 2, 3});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{1L, 2L, null, 3L});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) eval.value());
 
     // arrays might have to fall back to using 'bestEffortOf', but will cast it to the expected output type
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{"1", "2", "3"});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new String[]{"1", "2", "3"});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{"1", "2", "wat", "3"});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{1.0, 2.0, 3.0});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new double[]{1.0, 2.0, 3.0});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{1.0, 2.0, null, 3.0});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, null, 3L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{1.0, 2L, "3", true, false});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L, 1L, 0L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L, 1L, 0L}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new float[]{1.0f, 2.0f, 3.0f});
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, (Object[]) eval.value());
 
     // etc
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Object[]{1.0, 2.0, 3.0});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Double[]{1.0, 2.0, 3.0});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new double[]{1.0, 2.0, 3.0});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Object[]{"1", "2", "3"});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Object[]{"1", "2", "wat", "3"});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, null, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, null, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Object[]{1L, 2L, 3L});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new long[]{1L, 2L, 3L});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Object[]{1L, 2L, null, 3L});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, null, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, null, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Object[]{1.0, 2L, "3", true, false});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0, 1.0, 0.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0, 1.0, 0.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new Float[]{1.0f, 2.0f, 3.0f});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE_ARRAY, new float[]{1.0f, 2.0f, 3.0f});
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING_ARRAY, new Object[]{"1", "2", "3"});
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING_ARRAY, new Object[]{1L, 2L, 3L});
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING_ARRAY, new Object[]{1.0, 2.0, 3.0});
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"1.0", "2.0", "3.0"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"1.0", "2.0", "3.0"}, (Object[]) eval.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING_ARRAY, new Object[]{1.0, 2L, "3", true, false});
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"1.0", "2", "3", "true", "false"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"1.0", "2", "3", "true", "false"}, (Object[]) eval.value());
 
     // nested arrays
     ExpressionType nestedLongArray = ExpressionTypeFactory.getInstance().ofArray(ExpressionType.LONG_ARRAY);
@@ -1291,11 +1292,11 @@ public class EvalTest extends InitializedNullHandlingTest
 
     for (Object o : longArrayInputs) {
       eval = ExprEval.ofType(nestedLongArray, o);
-      Assert.assertEquals(nestedLongArray, eval.type());
+      Assertions.assertEquals(nestedLongArray, eval.type());
       Object[] val = (Object[]) eval.value();
-      Assert.assertEquals(expectedLongArray.length, val.length);
+      Assertions.assertEquals(expectedLongArray.length, val.length);
       for (int i = 0; i < expectedLongArray.length; i++) {
-        Assert.assertArrayEquals((Object[]) expectedLongArray[i], (Object[]) val[i]);
+        Assertions.assertArrayEquals((Object[]) expectedLongArray[i], (Object[]) val[i]);
       }
     }
 
@@ -1336,11 +1337,11 @@ public class EvalTest extends InitializedNullHandlingTest
 
     for (Object o : doubleArrayInputs) {
       eval = ExprEval.ofType(nestedDoubleArray, o);
-      Assert.assertEquals(nestedDoubleArray, eval.type());
+      Assertions.assertEquals(nestedDoubleArray, eval.type());
       Object[] val = (Object[]) eval.value();
-      Assert.assertEquals(expectedLongArray.length, val.length);
+      Assertions.assertEquals(expectedLongArray.length, val.length);
       for (int i = 0; i < expectedLongArray.length; i++) {
-        Assert.assertArrayEquals((Object[]) expectedDoubleArray[i], (Object[]) val[i]);
+        Assertions.assertArrayEquals((Object[]) expectedDoubleArray[i], (Object[]) val[i]);
       }
     }
   }
@@ -1425,19 +1426,19 @@ public class EvalTest extends InitializedNullHandlingTest
   private void assertBestEffortOf(@Nullable Object val, ExpressionType expectedType, @Nullable Object expectedValue)
   {
     ExprEval eval = ExprEval.bestEffortOf(val);
-    Assert.assertEquals(expectedType, eval.type());
+    Assertions.assertEquals(expectedType, eval.type());
     if (eval.type().isArray()) {
-      Assert.assertArrayEquals((Object[]) expectedValue, eval.asArray());
+      Assertions.assertArrayEquals((Object[]) expectedValue, eval.asArray());
     } else {
-      Assert.assertEquals(expectedValue, eval.value());
+      Assertions.assertEquals(expectedValue, eval.value());
     }
     // make sure that ofType matches bestEffortOf
     eval = ExprEval.ofType(eval.type(), val);
-    Assert.assertEquals(expectedType, eval.type());
+    Assertions.assertEquals(expectedType, eval.type());
     if (eval.type().isArray()) {
-      Assert.assertArrayEquals((Object[]) expectedValue, eval.asArray());
+      Assertions.assertArrayEquals((Object[]) expectedValue, eval.asArray());
     } else {
-      Assert.assertEquals(expectedValue, eval.value());
+      Assertions.assertEquals(expectedValue, eval.value());
     }
   }
 }

--- a/processing/src/test/java/org/apache/druid/math/expr/ExprEvalTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ExprEvalTest.java
@@ -30,11 +30,9 @@ import org.apache.druid.segment.column.TypeStrategies;
 import org.apache.druid.segment.column.TypeStrategiesTest;
 import org.apache.druid.segment.column.Types;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -43,14 +41,11 @@ import java.util.Map;
 
 public class ExprEvalTest extends InitializedNullHandlingTest
 {
-  private static int MAX_SIZE_BYTES = 1 << 13;
+  private static final int MAX_SIZE_BYTES = 1 << 13;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  private final ByteBuffer buffer = ByteBuffer.allocate(1 << 16);
 
-  ByteBuffer buffer = ByteBuffer.allocate(1 << 16);
-
-  @BeforeClass
+  @BeforeAll
   public static void setup()
   {
     TypeStrategies.registerComplex(
@@ -70,14 +65,17 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   @Test
   public void testStringSerdeTooBig()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         ExpressionType.STRING,
         10,
         16
-    ));
-    assertExpr(0, ExprEval.ofString("hello world"), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(0, ExprEval.ofString("hello world"), 10)
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
 
@@ -108,28 +106,34 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   @Test
   public void testStringArraySerdeToBig()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         ExpressionType.STRING_ARRAY,
         10,
         30
-    ));
-    assertExpr(0, ExprEval.ofStringArray(new String[]{"hello", "hi", "hey"}), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(0, ExprEval.ofStringArray(new String[]{"hello", "hi", "hey"}), 10)
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test
   public void testStringArrayEvalToBig()
   {
-    expectedException.expect(ISE.class);
     // this has a different failure size than string serde because it doesn't check incrementally
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         ExpressionType.STRING_ARRAY,
         10,
         30
-    ));
-    assertExpr(0, ExprEval.ofStringArray(new String[]{"hello", "hi", "hey"}), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(0, ExprEval.ofStringArray(new String[]{"hello", "hi", "hey"}), 10)
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test
@@ -144,27 +148,33 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   @Test
   public void testLongArraySerdeTooBig()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         ExpressionType.LONG_ARRAY,
         10,
         32
-    ));
-    assertExpr(0, ExprEval.ofLongArray(new Long[]{1L, 2L, 3L}), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(0, ExprEval.ofLongArray(new Long[]{1L, 2L, 3L}), 10)
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test
   public void testLongArrayEvalTooBig()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         ExpressionType.LONG_ARRAY,
         10,
         32
-    ));
-    assertExpr(0, ExprEval.ofLongArray(new Long[]{1L, 2L, 3L}), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(0, ExprEval.ofLongArray(new Long[]{1L, 2L, 3L}), 10)
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test
@@ -179,27 +189,33 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   @Test
   public void testDoubleArraySerdeTooBig()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         ExpressionType.DOUBLE_ARRAY,
         10,
         32
-    ));
-    assertExpr(0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2, 3.3}), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2, 3.3}), 10)
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test
   public void testDoubleArrayEvalTooBig()
   {
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         ExpressionType.DOUBLE_ARRAY,
         10,
         32
-    ));
-    assertExpr(0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2, 3.3}), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(0, ExprEval.ofDoubleArray(new Double[]{1.1, 2.2, 3.3}), 10)
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test
@@ -214,65 +230,72 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   public void testComplexEvalTooBig()
   {
     final ExpressionType complexType = ExpressionType.fromColumnType(TypeStrategiesTest.NULLABLE_TEST_PAIR_TYPE);
-    expectedException.expect(ISE.class);
-    expectedException.expectMessage(StringUtils.format(
+    final String expectedMessage = StringUtils.format(
         "Unable to serialize [%s], max size bytes is [%s], but need at least [%s] bytes to write entire value",
         complexType.asTypeString(),
         10,
         19
-    ));
-    assertExpr(0, ExprEval.ofComplex(complexType, new TypeStrategiesTest.NullableLongPair(1234L, 5678L)), 10);
+    );
+    final ISE exception = Assertions.assertThrows(
+        ISE.class,
+        () -> assertExpr(
+            0,
+            ExprEval.ofComplex(complexType, new TypeStrategiesTest.NullableLongPair(1234L, 5678L)),
+            10
+        )
+    );
+    Assertions.assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test
   public void test_coerceListToArray()
   {
-    Assert.assertNull(ExprEval.coerceListToArray(null, false));
+    Assertions.assertNull(ExprEval.coerceListToArray(null, false));
 
     NonnullPair<ExpressionType, Object[]> coerced = ExprEval.coerceListToArray(ImmutableList.of(), false);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[0], coerced.rhs);
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[0], coerced.rhs);
 
     coerced = ExprEval.coerceListToArray(null, true);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{null}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{null}, coerced.rhs);
 
     coerced = ExprEval.coerceListToArray(ImmutableList.of(), true);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{null}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{null}, coerced.rhs);
 
     List<Long> longList = ImmutableList.of(1L, 2L, 3L);
     coerced = ExprEval.coerceListToArray(longList, false);
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, coerced.rhs);
 
     List<Integer> intList = ImmutableList.of(1, 2, 3);
     ExprEval.coerceListToArray(intList, false);
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{1L, 2L, 3L}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, 3L}, coerced.rhs);
 
     List<Float> floatList = ImmutableList.of(1.0f, 2.0f, 3.0f);
     coerced = ExprEval.coerceListToArray(floatList, false);
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, coerced.rhs);
 
     List<Double> doubleList = ImmutableList.of(1.0, 2.0, 3.0);
     coerced = ExprEval.coerceListToArray(doubleList, false);
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, 3.0}, coerced.rhs);
 
     List<String> stringList = ImmutableList.of("a", "b", "c");
     coerced = ExprEval.coerceListToArray(stringList, false);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, coerced.rhs);
 
     List<String> withNulls = new ArrayList<>();
     withNulls.add("a");
     withNulls.add(null);
     withNulls.add("c");
     coerced = ExprEval.coerceListToArray(withNulls, false);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{"a", null, "c"}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{"a", null, "c"}, coerced.rhs);
 
     List<Long> withNumberNulls = new ArrayList<>();
     withNumberNulls.add(1L);
@@ -280,45 +303,45 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     withNumberNulls.add(3L);
 
     coerced = ExprEval.coerceListToArray(withNumberNulls, false);
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(new Object[]{1L, null, 3L}, coerced.rhs);
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(new Object[]{1L, null, 3L}, coerced.rhs);
 
     List<Object> withStringMix = ImmutableList.of(1L, "b", 3L);
     coerced = ExprEval.coerceListToArray(withStringMix, false);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{"1", "b", "3"},
         coerced.rhs
     );
 
     List<Number> withIntsAndLongs = ImmutableList.of(1, 2L, 3);
     coerced = ExprEval.coerceListToArray(withIntsAndLongs, false);
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{1L, 2L, 3L},
         coerced.rhs
     );
 
     List<Number> withFloatsAndLongs = ImmutableList.of(1, 2L, 3.0f);
     coerced = ExprEval.coerceListToArray(withFloatsAndLongs, false);
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{1.0, 2.0, 3.0},
         coerced.rhs
     );
 
     List<Number> withDoublesAndLongs = ImmutableList.of(1, 2L, 3.0);
     coerced = ExprEval.coerceListToArray(withDoublesAndLongs, false);
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{1.0, 2.0, 3.0},
         coerced.rhs
     );
 
     List<Number> withFloatsAndDoubles = ImmutableList.of(1L, 2.0f, 3.0);
     coerced = ExprEval.coerceListToArray(withFloatsAndDoubles, false);
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{1.0, 2.0, 3.0},
         coerced.rhs
     );
@@ -328,8 +351,8 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     withAllNulls.add(null);
     withAllNulls.add(null);
     coerced = ExprEval.coerceListToArray(withAllNulls, false);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{null, null, null},
         coerced.rhs
     );
@@ -342,11 +365,11 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         nested1
     );
     coerced = ExprEval.coerceListToArray(mixedObject, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA),
         coerced.lhs
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             "a",
             1L,
@@ -363,11 +386,11 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         3.0
     );
     coerced = ExprEval.coerceListToArray(mixedObject2, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA),
         coerced.lhs
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             nested1,
             "a",
@@ -382,8 +405,8 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         ImmutableList.of("d", "e", "f")
     );
     coerced = ExprEval.coerceListToArray(nestedLists, false);
-    Assert.assertEquals(ExpressionTypeFactory.getInstance().ofArray(ExpressionType.STRING_ARRAY), coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionTypeFactory.getInstance().ofArray(ExpressionType.STRING_ARRAY), coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{new Object[]{"a", "b", "c"}, new Object[]{"d", "e", "f"}},
         coerced.rhs
     );
@@ -392,8 +415,8 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     Map<String, Object> nested2 = ImmutableMap.of("x", 4L, "y", 5L);
     List<Map<String, Object>> listUnknownComplex = ImmutableList.of(nested1, nested2);
     coerced = ExprEval.coerceListToArray(listUnknownComplex, false);
-    Assert.assertEquals(ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA), coerced.lhs);
-    Assert.assertArrayEquals(
+    Assertions.assertEquals(ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA), coerced.lhs);
+    Assertions.assertArrayEquals(
         new Object[]{nested1, nested2},
         coerced.rhs
     );
@@ -407,13 +430,13 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         ImmutableList.of(nested3, nested4)
     );
     coerced = ExprEval.coerceListToArray(nestedListsComplex, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionTypeFactory.getInstance().ofArray(
             ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA)
         ),
         coerced.lhs
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             new Object[]{nested1, nested2},
             new Object[]{nested3, nested4}
@@ -428,11 +451,11 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         ImmutableList.of("a", 2L, 3.0)
     );
     coerced = ExprEval.coerceListToArray(mixed, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionTypeFactory.getInstance().ofArray(ExpressionType.STRING_ARRAY),
         coerced.lhs
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             new Object[]{"a", "b", "c"},
             new Object[]{"1", "2", "3"},
@@ -449,13 +472,13 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         ImmutableList.of("a", 2L, 3.0, nested1)
     );
     coerced = ExprEval.coerceListToArray(mixedNested, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionTypeFactory.getInstance().ofArray(
             ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA)
         ),
         coerced.lhs
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             new Object[]{"a", "b", "c"},
             new Object[]{1L, 2L, 3L},
@@ -475,13 +498,13 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         ImmutableList.of(nested1, nested2, nested3)
     );
     coerced = ExprEval.coerceListToArray(mixedNested2, false);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionTypeFactory.getInstance().ofArray(
             ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA)
         ),
         coerced.lhs
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             new Object[]{"a"},
             new Object[]{1L},
@@ -507,11 +530,11 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     );
     coerced = ExprEval.coerceListToArray(mixedNested3, false);
     // this one is only ARRAY<COMPLEX<json>> instead of ARRAY<ARRAY<COMPLEX<json>> because of a COMPLEX<json> element..
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA),
         coerced.lhs
     );
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{
             "a",
             1L,
@@ -531,11 +554,11 @@ public class ExprEvalTest extends InitializedNullHandlingTest
         ImmutableList.of(3.0, 4.0, 5.0, new SerializablePair<>("hello", 1234L)),
         ImmutableList.of("a", 2L, 3.0, nested1)
     );
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         Types.IncompatibleTypeException.class,
         () -> ExprEval.coerceListToArray(mixedUnknown, false)
     );
-    Assert.assertEquals("Cannot implicitly cast [DOUBLE] to [COMPLEX]", t.getMessage());
+    Assertions.assertEquals("Cannot implicitly cast [DOUBLE] to [COMPLEX]", t.getMessage());
   }
 
   @Test
@@ -544,59 +567,59 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     ExprEval<?> eval = ExprEval.ofString("hello");
 
     ExprEval<?> cast = eval.castTo(ExpressionType.DOUBLE);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertArrayEquals(new Object[]{"hello"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{"hello"}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertArrayEquals(new Object[]{null}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{null}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertArrayEquals(new Object[]{null}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{null}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.NESTED_DATA);
-    Assert.assertEquals("hello", cast.value());
+    Assertions.assertEquals("hello", cast.value());
 
     cast = eval.castTo(ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA));
-    Assert.assertArrayEquals(new Object[]{"hello"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{"hello"}, (Object[]) cast.value());
 
     eval = ExprEval.ofString("1234.3");
 
     cast = eval.castTo(ExpressionType.DOUBLE);
-    Assert.assertEquals(1234.3, cast.value());
+    Assertions.assertEquals(1234.3, cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertEquals(1234L, cast.value());
+    Assertions.assertEquals(1234L, cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1234.3}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{1234.3}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1234L}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{1234L}, (Object[]) cast.value());
 
     eval = ExprEval.ofType(ExpressionType.STRING, null);
 
     cast = eval.castTo(ExpressionType.DOUBLE);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.NESTED_DATA);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
   }
 
   @Test
@@ -605,42 +628,42 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     ExprEval<?> eval = ExprEval.of(123.4);
 
     ExprEval<?> cast = eval.castTo(ExpressionType.STRING);
-    Assert.assertEquals("123.4", cast.value());
+    Assertions.assertEquals("123.4", cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertEquals(123L, cast.value());
+    Assertions.assertEquals(123L, cast.value());
 
     cast = eval.castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertArrayEquals(new Object[]{"123.4"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{"123.4"}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertArrayEquals(new Object[]{123L}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{123L}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertArrayEquals(new Object[]{123.4}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{123.4}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.NESTED_DATA);
-    Assert.assertEquals(123.4, cast.value());
+    Assertions.assertEquals(123.4, cast.value());
 
     eval = ExprEval.ofType(ExpressionType.DOUBLE, null);
 
     cast = eval.castTo(ExpressionType.STRING);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.NESTED_DATA);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
   }
 
   @Test
@@ -649,42 +672,42 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     ExprEval<?> eval = ExprEval.of(1234L);
 
     ExprEval<?> cast = eval.castTo(ExpressionType.STRING);
-    Assert.assertEquals("1234", cast.value());
+    Assertions.assertEquals("1234", cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE);
-    Assert.assertEquals(1234.0, cast.value());
+    Assertions.assertEquals(1234.0, cast.value());
 
     cast = eval.castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertArrayEquals(new Object[]{"1234"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{"1234"}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1234L}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{1234L}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1234.0}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{1234.0}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.NESTED_DATA);
-    Assert.assertEquals(1234L, cast.value());
+    Assertions.assertEquals(1234L, cast.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG, null);
 
     cast = eval.castTo(ExpressionType.STRING);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.NESTED_DATA);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
   }
 
   @Test
@@ -693,54 +716,54 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     ExprEval<?> eval = ExprEval.ofStringArray(new String[]{"1", "2", "foo", null, "3.3"});
 
     ExprEval<?> cast = eval.castTo(ExpressionType.LONG_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1L, 2L, null, null, 3L}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{1L, 2L, null, null, 3L}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1.0, 2.0, null, null, 3.3}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{1.0, 2.0, null, null, 3.3}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.NESTED_DATA);
-    Assert.assertArrayEquals(new Object[]{"1", "2", "foo", null, "3.3"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{"1", "2", "foo", null, "3.3"}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionTypeFactory.getInstance().ofArray(ExpressionType.NESTED_DATA));
-    Assert.assertArrayEquals(new Object[]{"1", "2", "foo", null, "3.3"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{"1", "2", "foo", null, "3.3"}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     cast = eval.castTo(ExpressionType.STRING);
-    Assert.assertNull(cast.value());
+    Assertions.assertNull(cast.value());
 
     eval = ExprEval.ofType(ExpressionType.LONG_ARRAY, new Object[]{1234L});
 
     cast = eval.castTo(ExpressionType.DOUBLE_ARRAY);
-    Assert.assertArrayEquals(new Object[]{1234.0}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{1234.0}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.STRING_ARRAY);
-    Assert.assertArrayEquals(new Object[]{"1234"}, (Object[]) cast.value());
+    Assertions.assertArrayEquals(new Object[]{"1234"}, (Object[]) cast.value());
 
     cast = eval.castTo(ExpressionType.STRING);
-    Assert.assertEquals("1234", cast.value());
+    Assertions.assertEquals("1234", cast.value());
 
     cast = eval.castTo(ExpressionType.DOUBLE);
-    Assert.assertEquals(1234.0, cast.value());
+    Assertions.assertEquals(1234.0, cast.value());
 
     cast = eval.castTo(ExpressionType.LONG);
-    Assert.assertEquals(1234L, cast.value());
+    Assertions.assertEquals(1234L, cast.value());
   }
 
   @Test
   public void testCastNestedData()
   {
     ExprEval<?> eval = ExprEval.ofType(ExpressionType.NESTED_DATA, ImmutableMap.of("x", 1234L, "y", 12.34));
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableMap.of("x", 1234L, "y", 12.34),
         eval.castTo(ExpressionType.NESTED_DATA).value()
     );
-    Throwable t = Assert.assertThrows(IAE.class, () -> eval.castTo(ExpressionType.LONG));
-    Assert.assertEquals("Invalid type, cannot cast [COMPLEX<json>] to [LONG]", t.getMessage());
+    Throwable t = Assertions.assertThrows(IAE.class, () -> eval.castTo(ExpressionType.LONG));
+    Assertions.assertEquals("Invalid type, cannot cast [COMPLEX<json>] to [LONG]", t.getMessage());
   }
 
   @Test
@@ -749,8 +772,8 @@ public class ExprEvalTest extends InitializedNullHandlingTest
     // empty arrays will materialize from JSON into an empty list, which coerce list to array will make into Object[]
     // make sure we can handle it
     ExprEval someEmptyArray = ExprEval.bestEffortOf(new ArrayList<>());
-    Assert.assertTrue(someEmptyArray.isArray());
-    Assert.assertEquals(0, someEmptyArray.asArray().length);
+    Assertions.assertTrue(someEmptyArray.isArray());
+    Assertions.assertEquals(0, someEmptyArray.asArray().length);
   }
 
   private void assertExpr(int position, Object expected)
@@ -767,28 +790,28 @@ public class ExprEvalTest extends InitializedNullHandlingTest
   {
     ExprEval.serialize(buffer, position, expected.type(), expected, maxSizeBytes);
     if (expected.type().isArray()) {
-      Assert.assertArrayEquals(
-          "deserialized value with buffer references allowed",
+      Assertions.assertArrayEquals(
           expected.asArray(),
-          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), true).asArray()
+          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), true).asArray(),
+          "deserialized value with buffer references allowed"
       );
 
-      Assert.assertArrayEquals(
-          "deserialized value with buffer references not allowed",
+      Assertions.assertArrayEquals(
           expected.asArray(),
-          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), false).asArray()
+          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), false).asArray(),
+          "deserialized value with buffer references not allowed"
       );
     } else {
-      Assert.assertEquals(
-          "deserialized value with buffer references allowed",
+      Assertions.assertEquals(
           expected.value(),
-          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), true).value()
+          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), true).value(),
+          "deserialized value with buffer references allowed"
       );
 
-      Assert.assertEquals(
-          "deserialized value with buffer references not allowed",
+      Assertions.assertEquals(
           expected.value(),
-          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), false).value()
+          ExprEval.deserialize(buffer, position, MAX_SIZE_BYTES, expected.type(), false).value(),
+          "deserialized value with buffer references not allowed"
       );
     }
   }

--- a/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/FunctionTest.java
@@ -33,12 +33,13 @@ import org.apache.druid.segment.column.TypeStrategiesTest;
 import org.apache.druid.segment.column.TypeStrategy;
 import org.apache.druid.segment.nested.StructuredData;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.nio.ByteBuffer;
@@ -47,8 +48,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class FunctionTest extends InitializedNullHandlingTest
 {
@@ -57,7 +58,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   private Expr.ObjectBinding[] allBindings;
 
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass()
   {
     TypeStrategies.registerComplex(
@@ -67,7 +68,7 @@ public class FunctionTest extends InitializedNullHandlingTest
     BuiltInTypesModule.registerHandlersAndSerde();
   }
 
-  @Before
+  @BeforeEach
   public void setup()
   {
     ImmutableMap.Builder<String, ExpressionType> inputTypesBuilder = ImmutableMap.builder();
@@ -148,7 +149,7 @@ public class FunctionTest extends InitializedNullHandlingTest
         throw new RuntimeException("nested-exception");
       }
     };
-    DruidException e = Assert.assertThrows(
+    DruidException e = Assertions.assertThrows(
         DruidException.class,
         () -> {
           expr.eval(bind);
@@ -814,11 +815,11 @@ public class FunctionTest extends InitializedNullHandlingTest
 
     );
     for (Pair<String, String> argAndType : invalidArguments) {
-      Throwable t = Assert.assertThrows(
+      Throwable t = Assertions.assertThrows(
           DruidException.class,
           () -> assertExpr(StringUtils.format("round(d, %s)", argAndType.lhs), null)
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           StringUtils.format(
               "Function[round] second argument should be a LONG but got %s instead",
               argAndType.rhs
@@ -842,11 +843,11 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("greatest(1, 'A')", "A");
 
     // Invalid types
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> assertExpr("greatest(1, ['A'])", null)
     );
-    Assert.assertEquals("Function[greatest] does not accept ARRAY<STRING> types", t.getMessage());
+    Assertions.assertEquals("Function[greatest] does not accept ARRAY<STRING> types", t.getMessage());
 
     // Null handling
     assertExpr("greatest()", null);
@@ -869,11 +870,11 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("least(1, 'A')", "1");
 
     // Invalid types
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> assertExpr("least(1, [2, 3])", null)
     );
-    Assert.assertEquals("Function[least] does not accept ARRAY<LONG> types", t.getMessage());
+    Assertions.assertEquals("Function[least] does not accept ARRAY<LONG> types", t.getMessage());
 
     // Null handling
     assertExpr("least()", null);
@@ -956,31 +957,31 @@ public class FunctionTest extends InitializedNullHandlingTest
   public void testSizeFormatInvalidArgumentType()
   {
     // x = "foo"
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> Parser.parse("human_readable_binary_byte_format(1024, x)", ExprMacroTable.nil()).eval(bestEffortBindings)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[human_readable_binary_byte_format] needs a LONG as its second argument but got STRING instead",
         t.getMessage()
     );
     //of = 0F
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> Parser.parse("human_readable_binary_byte_format(1024, of)", ExprMacroTable.nil()).eval(bestEffortBindings)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[human_readable_binary_byte_format] needs a LONG as its second argument but got DOUBLE instead",
         t.getMessage()
     );
 
     //of = 0F
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> Parser.parse("human_readable_binary_byte_format(1024, nonexist)", ExprMacroTable.nil())
                     .eval(bestEffortBindings)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[human_readable_binary_byte_format] needs a LONG as its second argument but got null",
         t.getMessage()
     );
@@ -989,41 +990,41 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testSizeFormatInvalidPrecision()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> Parser.parse("human_readable_binary_byte_format(1024, maxLong)", ExprMacroTable.nil())
                     .eval(bestEffortBindings)
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[human_readable_binary_byte_format] given precision[9223372036854775807] must be in the range of [0,3]",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> Parser.parse("human_readable_binary_byte_format(1024, minLong)", ExprMacroTable.nil())
                     .eval(bestEffortBindings)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[human_readable_binary_byte_format] given precision[-9223372036854775808] must be in the range of [0,3]",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> Parser.parse("human_readable_binary_byte_format(1024, -1)", ExprMacroTable.nil()).eval(bestEffortBindings)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[human_readable_binary_byte_format] given precision[-1] must be in the range of [0,3]",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         DruidException.class,
         () -> Parser.parse("human_readable_binary_byte_format(1024, 4)", ExprMacroTable.nil()).eval(bestEffortBindings)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[human_readable_binary_byte_format] given precision[4] must be in the range of [0,3]",
         t.getMessage()
     );
@@ -1032,7 +1033,7 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testSizeFormatInvalidArgumentSize()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> Parser.parse(
             "human_readable_binary_byte_format(1024, 2, 3)",
@@ -1040,7 +1041,7 @@ public class FunctionTest extends InitializedNullHandlingTest
         ).eval(bestEffortBindings)
     );
 
-    Assert.assertEquals("Function[human_readable_binary_byte_format] requires 1 or 2 arguments", t.getMessage());
+    Assertions.assertEquals("Function[human_readable_binary_byte_format] requires 1 or 2 arguments", t.getMessage());
   }
 
   @Test
@@ -1087,11 +1088,11 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("bitwiseComplement(null)", null);
 
     // data truncation
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> assertExpr("bitwiseComplement(461168601842738800000000000000.000000)", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[bitwiseComplement] Possible data truncation, param [461168601842738800000000000000.000000] is out of LONG value range",
         t.getMessage()
     );
@@ -1137,11 +1138,11 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("left(null, 10)", null);
     assertExpr("left(nonexistent, 10)", null);
 
-    Throwable t1 = Assert.assertThrows(
+    Throwable t1 = Assertions.assertThrows(
         DruidException.class,
         () -> assertExpr("left('foo', -2)", null)
     );
-    Assert.assertEquals("Function[left] needs a positive integer as the second argument", t1.getMessage());
+    Assertions.assertEquals("Function[left] needs a positive integer as the second argument", t1.getMessage());
   }
 
   @Test
@@ -1157,11 +1158,11 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("right(null, 10)", null);
     assertExpr("right(nonexistent, 10)", null);
 
-    Throwable t1 = Assert.assertThrows(
+    Throwable t1 = Assertions.assertThrows(
         DruidException.class,
         () -> assertExpr("right('foo', -2)", null)
     );
-    Assert.assertEquals("Function[right] needs a positive integer as the second argument", t1.getMessage());
+    Assertions.assertEquals("Function[right] needs a positive integer as the second argument", t1.getMessage());
   }
 
   @Test
@@ -1178,11 +1179,11 @@ public class FunctionTest extends InitializedNullHandlingTest
     assertExpr("repeat(4, 3)", "444");
     assertExpr("repeat(4.1, 3)", "4.14.14.1");
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         DruidException.class,
         () -> assertExpr("repeat('foo', 9999999999)", null)
     );
-    Assert.assertEquals("Function[repeat] needs an integer as the second argument", t.getMessage());
+    Assertions.assertEquals("Function[repeat] needs an integer as the second argument", t.getMessage());
   }
 
   @Test
@@ -1206,7 +1207,7 @@ public class FunctionTest extends InitializedNullHandlingTest
     final byte[] bytes = new byte[strategy.estimateSizeBytes(expected)];
     ByteBuffer buffer = ByteBuffer.wrap(bytes);
     int written = strategy.write(buffer, expected, bytes.length);
-    Assert.assertEquals(bytes.length, written);
+    Assertions.assertEquals(bytes.length, written);
     assertExpr(
         StringUtils.format(
             "complex_decode_base64('%s', '%s')",
@@ -1251,9 +1252,9 @@ public class FunctionTest extends InitializedNullHandlingTest
     }
     final ExprMacroTable exprMacroTable = new ExprMacroTable(macros);
     final Expr happiness = new StringExpr("happiness");
-    Assert.assertEquals(happiness, Parser.parse("drink(1,2)", exprMacroTable));
+    Assertions.assertEquals(happiness, Parser.parse("drink(1,2)", exprMacroTable));
     for (String tea : aliases) {
-      Assert.assertEquals(happiness, Parser.parse(StringUtils.format("%s(1,2)", tea), exprMacroTable));
+      Assertions.assertEquals(happiness, Parser.parse(StringUtils.format("%s(1,2)", tea), exprMacroTable));
     }
   }
 
@@ -1279,21 +1280,21 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testComplexDecodeBaseWrongArgCount()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertExpr("complex_decode_base64(string)", null)
     );
-    Assert.assertEquals("Function[complex_decode_base64] requires 2 arguments", t.getMessage());
+    Assertions.assertEquals("Function[complex_decode_base64] requires 2 arguments", t.getMessage());
   }
 
   @Test
   public void testComplexDecodeBaseArg0Null()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertExpr("complex_decode_base64(null, string)", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[complex_decode_base64] first argument must be constant STRING expression containing a valid complex type name but got NULL instead",
         t.getMessage()
     );
@@ -1302,11 +1303,11 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testComplexDecodeBaseArg0BadType()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertExpr("complex_decode_base64(1, string)", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[complex_decode_base64] first argument must be constant STRING expression containing a valid complex type name but got '1' instead",
         t.getMessage()
     );
@@ -1315,11 +1316,11 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testComplexDecodeBaseArg0Unknown()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertExpr("complex_decode_base64('unknown', string)", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[complex_decode_base64] first argument must be a valid COMPLEX type name, got unknown COMPLEX type [COMPLEX<unknown>]",
         t.getMessage()
     );
@@ -1337,38 +1338,38 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testMultiValueStringToArrayWithInvalidInputs()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array('1')", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] argument 1 should be an identifier expression. Use array() instead",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array(repeat('hello', 2))", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] argument (repeat [hello, 2]) should be an identifier expression. Use array() instead",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array(x,y)", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] requires 1 argument",
         t.getMessage()
     );
 
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array()", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] requires 1 argument",
         t.getMessage()
     );
@@ -1393,35 +1394,35 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testArrayToMultiValueStringWithInvalidInputs()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array('1')", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] argument 1 should be an identifier expression. Use array() instead",
         t.getMessage()
     );
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array(repeat('hello', 2))", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] argument (repeat [hello, 2]) should be an identifier expression. Use array() instead",
         t.getMessage()
     );
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array(x,y)", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] requires 1 argument",
         t.getMessage()
     );
-    t = Assert.assertThrows(
+    t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> assertArrayExpr("mv_to_array()", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "Function[mv_to_array] requires 1 argument",
         t.getMessage()
     );
@@ -1436,11 +1437,11 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testMultiplyOnString()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IAE.class,
         () -> assertExpr("str1 * str2", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "operator '*' in expression (\"str1\" * \"str2\") is not supported on type STRING.",
         t.getMessage()
     );
@@ -1449,11 +1450,11 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testMinusOnString()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IAE.class,
         () -> assertExpr("str1 - str2", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "operator '-' in expression (\"str1\" - \"str2\") is not supported on type STRING.",
         t.getMessage()
     );
@@ -1462,11 +1463,11 @@ public class FunctionTest extends InitializedNullHandlingTest
   @Test
   public void testDivOnString()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IAE.class,
         () -> assertExpr("str1 / str2", null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "operator '/' in expression (\"str1\" / \"str2\") is not supported on type STRING.",
         t.getMessage()
     );
@@ -1508,29 +1509,29 @@ public class FunctionTest extends InitializedNullHandlingTest
   )
   {
     final Expr expr = Parser.parse(expression, macroTable);
-    Assert.assertEquals(expression, expectedResult, expr.eval(bindings).value());
+    Assertions.assertEquals(expectedResult, expr.eval(bindings).value(), expression);
 
     final Expr exprNoFlatten = Parser.parse(expression, macroTable, false);
     final Expr roundTrip = Parser.parse(exprNoFlatten.stringify(), macroTable);
-    Assert.assertEquals(expr.stringify(), expectedResult, roundTrip.eval(bindings).value());
+    Assertions.assertEquals(expectedResult, roundTrip.eval(bindings).value(), expr.stringify());
 
     final Expr roundTripFlatten = Parser.parse(expr.stringify(), macroTable);
-    Assert.assertEquals(expr.stringify(), expectedResult, roundTripFlatten.eval(bindings).value());
+    Assertions.assertEquals(expectedResult, roundTripFlatten.eval(bindings).value(), expr.stringify());
 
     final Expr singleThreaded = Expr.singleThreaded(expr, bindings);
-    Assert.assertEquals(singleThreaded.stringify(), expectedResult, singleThreaded.eval(bindings).value());
+    Assertions.assertEquals(expectedResult, singleThreaded.eval(bindings).value(), singleThreaded.stringify());
 
     final Expr singleThreadedNoFlatten = Expr.singleThreaded(exprNoFlatten, bindings);
-    Assert.assertEquals(
-        singleThreadedNoFlatten.stringify(),
+    Assertions.assertEquals(
         expectedResult,
-        singleThreadedNoFlatten.eval(bindings).value()
+        singleThreadedNoFlatten.eval(bindings).value(),
+        singleThreadedNoFlatten.stringify()
     );
 
-    Assert.assertEquals(expr.stringify(), roundTrip.stringify());
-    Assert.assertEquals(expr.stringify(), roundTripFlatten.stringify());
-    Assert.assertArrayEquals(expr.getCacheKey(), roundTrip.getCacheKey());
-    Assert.assertArrayEquals(expr.getCacheKey(), roundTripFlatten.getCacheKey());
+    Assertions.assertEquals(expr.stringify(), roundTrip.stringify());
+    Assertions.assertEquals(expr.stringify(), roundTripFlatten.stringify());
+    Assertions.assertArrayEquals(expr.getCacheKey(), roundTrip.getCacheKey());
+    Assertions.assertArrayEquals(expr.getCacheKey(), roundTripFlatten.getCacheKey());
   }
 
   /**
@@ -1544,19 +1545,19 @@ public class FunctionTest extends InitializedNullHandlingTest
   )
   {
     final Expr expr = Parser.parse(expression, macroTable);
-    Assert.assertArrayEquals(expression, expectedResult, expr.eval(bindings).asArray());
+    Assertions.assertArrayEquals(expectedResult, expr.eval(bindings).asArray(), expression);
 
     final Expr exprNoFlatten = Parser.parse(expression, macroTable, false);
     final Expr roundTrip = Parser.parse(exprNoFlatten.stringify(), macroTable);
-    Assert.assertArrayEquals(expression, expectedResult, roundTrip.eval(bindings).asArray());
+    Assertions.assertArrayEquals(expectedResult, roundTrip.eval(bindings).asArray(), expression);
 
     final Expr roundTripFlatten = Parser.parse(expr.stringify(), macroTable);
-    Assert.assertArrayEquals(expression, expectedResult, roundTripFlatten.eval(bindings).asArray());
+    Assertions.assertArrayEquals(expectedResult, roundTripFlatten.eval(bindings).asArray(), expression);
 
-    Assert.assertEquals(expr.stringify(), roundTrip.stringify());
-    Assert.assertEquals(expr.stringify(), roundTripFlatten.stringify());
-    Assert.assertArrayEquals(expr.getCacheKey(), roundTrip.getCacheKey());
-    Assert.assertArrayEquals(expr.getCacheKey(), roundTripFlatten.getCacheKey());
+    Assertions.assertEquals(expr.stringify(), roundTrip.stringify());
+    Assertions.assertEquals(expr.stringify(), roundTripFlatten.stringify());
+    Assertions.assertArrayEquals(expr.getCacheKey(), roundTrip.getCacheKey());
+    Assertions.assertArrayEquals(expr.getCacheKey(), roundTripFlatten.getCacheKey());
   }
 
   @Test
@@ -1569,13 +1570,13 @@ public class FunctionTest extends InitializedNullHandlingTest
 
     long afterCall = System.currentTimeMillis();
 
-    Assert.assertNotNull(result.value());
-    Assert.assertEquals(ExpressionType.LONG, result.type());
+    Assertions.assertNotNull(result.value());
+    Assertions.assertEquals(ExpressionType.LONG, result.type());
 
     long timestamp = result.asLong();
-    Assert.assertTrue(
-        "Timestamp should be between before and after: " + beforeCall + " <= " + timestamp + " <= " + afterCall,
-        timestamp >= beforeCall && timestamp <= afterCall
+    Assertions.assertTrue(
+        timestamp >= beforeCall && timestamp <= afterCall,
+        "Timestamp should be between before and after: " + beforeCall + " <= " + timestamp + " <= " + afterCall
     );
   }
 
@@ -1586,25 +1587,25 @@ public class FunctionTest extends InitializedNullHandlingTest
 
     // now() must not be treated as a literal, otherwise it would be constant-folded
     // and not re-evaluated per row.
-    Assert.assertFalse(expr.isLiteral());
-    Assert.assertNull(expr.getLiteralValue());
+    Assertions.assertFalse(expr.isLiteral());
+    Assertions.assertNull(expr.getLiteralValue());
 
     long time1 = expr.eval(InputBindings.nilBindings()).asLong();
     long time2 = expr.eval(InputBindings.nilBindings()).asLong();
-    Assert.assertTrue(
-        "Second call should return same or later timestamp: " + time1 + " <= " + time2,
-        time2 >= time1
+    Assertions.assertTrue(
+        time2 >= time1,
+        "Second call should return same or later timestamp: " + time1 + " <= " + time2
     );
   }
 
   @Test
   public void testNowRejectsArguments()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         ExpressionValidationException.class,
         () -> Parser.parse("now(123)", ExprMacroTable.nil()).eval(InputBindings.nilBindings())
     );
-    Assert.assertEquals("Function[now] does not accept arguments", t.getMessage());
+    Assertions.assertEquals("Function[now] does not accept arguments", t.getMessage());
   }
 
   @Test
@@ -1618,10 +1619,10 @@ public class FunctionTest extends InitializedNullHandlingTest
     long afterCall = System.currentTimeMillis();
 
     long computed = result.asLong();
-    Assert.assertTrue(
+    Assertions.assertTrue(
+        computed >= (beforeCall - 1100) && computed <= (afterCall - 900),
         "Result should be approximately 1 second before now: computed=" + computed
-            + ", expected range=[" + (beforeCall - 1000) + ", " + (afterCall - 1000) + "]",
-        computed >= (beforeCall - 1100) && computed <= (afterCall - 900)
+            + ", expected range=[" + (beforeCall - 1000) + ", " + (afterCall - 1000) + "]"
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/math/expr/OutputTypeTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/OutputTypeTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.math.expr;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
@@ -405,36 +405,36 @@ public class OutputTypeTest extends InitializedNullHandlingTest
     final ExprEval<?> complexEval2 = ExprEval.ofComplex(new ExpressionType(ExprType.COMPLEX, null, null), new Object());
 
     // only long stays long
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.autoDetect(longEval, longEval));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.autoDetect(longEval, longEval));
     // only string stays string
-    Assert.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.autoDetect(nullStringEval, nullStringEval));
-    Assert.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.autoDetect(stringEval, stringEval));
+    Assertions.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.autoDetect(nullStringEval, nullStringEval));
+    Assertions.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.autoDetect(stringEval, stringEval));
     // if only 1 argument is a string, preserve the other type
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.autoDetect(nullStringEval, longEval));
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.autoDetect(longEval, nullStringEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, nullStringEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(nullStringEval, doubleEval));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.autoDetect(nullStringEval, longEval));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.autoDetect(longEval, nullStringEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, nullStringEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(nullStringEval, doubleEval));
     // for operators, doubles is the catch all
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, doubleEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, longEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, doubleEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, doubleEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, longEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, doubleEval));
     // ... even when non-null strings are used with non-double types
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, stringEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, stringEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(stringEval, doubleEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, stringEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, stringEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(stringEval, doubleEval));
     // arrays are not a good idea to use with this method
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, nullStringEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, doubleEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, longEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(nullStringEval, arrayEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, arrayEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, arrayEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, nullStringEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, doubleEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, longEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(nullStringEval, arrayEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, arrayEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, arrayEval));
 
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, complexEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, complexEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, complexEval));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(complexEval, complexEval));
-    Assert.assertEquals(
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(longEval, complexEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(doubleEval, complexEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(arrayEval, complexEval));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.autoDetect(complexEval, complexEval));
+    Assertions.assertEquals(
         ExpressionTypeConversion.autoDetect(complexEval, complexEval),
         ExpressionTypeConversion.autoDetect(complexEval2, complexEval)
     );
@@ -444,97 +444,97 @@ public class OutputTypeTest extends InitializedNullHandlingTest
   public void testOperatorAutoConversion()
   {
     // nulls output other
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.operator(ExpressionType.LONG, null));
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.operator(null, ExpressionType.LONG));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.operator(ExpressionType.DOUBLE, null));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.operator(null, ExpressionType.DOUBLE));
-    Assert.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.operator(ExpressionType.STRING, null));
-    Assert.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.operator(null, ExpressionType.STRING));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.operator(ExpressionType.LONG, null));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.operator(null, ExpressionType.LONG));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.operator(ExpressionType.DOUBLE, null));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.operator(null, ExpressionType.DOUBLE));
+    Assertions.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.operator(ExpressionType.STRING, null));
+    Assertions.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.operator(null, ExpressionType.STRING));
     // only long stays long
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG,
         ExpressionTypeConversion.operator(ExpressionType.LONG, ExpressionType.LONG)
     );
     // only string stays string
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.operator(ExpressionType.STRING, ExpressionType.STRING)
     );
     // for operators, doubles is the catch all
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.operator(ExpressionType.LONG, ExpressionType.DOUBLE)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.operator(ExpressionType.DOUBLE, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.operator(ExpressionType.DOUBLE, ExpressionType.DOUBLE)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.operator(ExpressionType.DOUBLE, ExpressionType.STRING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.operator(ExpressionType.STRING, ExpressionType.DOUBLE)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.operator(ExpressionType.STRING, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.operator(ExpressionType.LONG, ExpressionType.STRING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.LONG_ARRAY, ExpressionType.LONG_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.DOUBLE_ARRAY, ExpressionType.DOUBLE_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.STRING_ARRAY, ExpressionType.STRING_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.LONG_ARRAY, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.STRING, ExpressionType.LONG_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.LONG_ARRAY, ExpressionType.DOUBLE_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.LONG, ExpressionType.DOUBLE_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.LONG_ARRAY, ExpressionType.STRING_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.operator(ExpressionType.STRING_ARRAY, ExpressionType.DOUBLE_ARRAY)
     );
     ExpressionType nested = ExpressionType.fromColumnType(ColumnType.NESTED_DATA);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nested,
         ExpressionTypeConversion.operator(nested, nested)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nested,
         ExpressionTypeConversion.operator(nested, ExpressionType.UNKNOWN_COMPLEX)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nested,
         ExpressionTypeConversion.operator(ExpressionType.UNKNOWN_COMPLEX, nested)
     );
@@ -544,97 +544,97 @@ public class OutputTypeTest extends InitializedNullHandlingTest
   public void testFunctionAutoConversion()
   {
     // nulls output other
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.function(ExpressionType.LONG, null));
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.function(null, ExpressionType.LONG));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.function(ExpressionType.DOUBLE, null));
-    Assert.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.function(null, ExpressionType.DOUBLE));
-    Assert.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.function(ExpressionType.STRING, null));
-    Assert.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.function(null, ExpressionType.STRING));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.function(ExpressionType.LONG, null));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.function(null, ExpressionType.LONG));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.function(ExpressionType.DOUBLE, null));
+    Assertions.assertEquals(ExpressionType.DOUBLE, ExpressionTypeConversion.function(null, ExpressionType.DOUBLE));
+    Assertions.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.function(ExpressionType.STRING, null));
+    Assertions.assertEquals(ExpressionType.STRING, ExpressionTypeConversion.function(null, ExpressionType.STRING));
     // only long stays long
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG,
         ExpressionTypeConversion.function(ExpressionType.LONG, ExpressionType.LONG)
     );
     // any double makes all doubles
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.function(ExpressionType.LONG, ExpressionType.DOUBLE)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.function(ExpressionType.DOUBLE, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE,
         ExpressionTypeConversion.function(ExpressionType.DOUBLE, ExpressionType.DOUBLE)
     );
     // any string makes become string
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.function(ExpressionType.LONG, ExpressionType.STRING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.function(ExpressionType.STRING, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.function(ExpressionType.DOUBLE, ExpressionType.STRING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.function(ExpressionType.STRING, ExpressionType.DOUBLE)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.function(ExpressionType.STRING, ExpressionType.STRING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.LONG_ARRAY, ExpressionType.LONG_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.DOUBLE_ARRAY, ExpressionType.DOUBLE_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.STRING_ARRAY, ExpressionType.STRING_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.DOUBLE_ARRAY, ExpressionType.LONG_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.DOUBLE_ARRAY, ExpressionType.STRING_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.STRING_ARRAY, ExpressionType.LONG_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.STRING, ExpressionType.LONG_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.LONG_ARRAY, ExpressionType.DOUBLE_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.function(ExpressionType.LONG, ExpressionType.DOUBLE_ARRAY)
     );
     ExpressionType nested = ExpressionType.fromColumnType(ColumnType.NESTED_DATA);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nested,
         ExpressionTypeConversion.function(nested, nested)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nested,
         ExpressionTypeConversion.function(nested, ExpressionType.UNKNOWN_COMPLEX)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         nested,
         ExpressionTypeConversion.function(ExpressionType.UNKNOWN_COMPLEX, nested)
     );
@@ -644,69 +644,69 @@ public class OutputTypeTest extends InitializedNullHandlingTest
   public void testIntegerFunctionAutoConversion()
   {
     // nulls output other
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(ExpressionType.LONG, null));
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(null, ExpressionType.LONG));
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(ExpressionType.DOUBLE, null));
-    Assert.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(null, ExpressionType.DOUBLE));
-    Assert.assertEquals(
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(ExpressionType.LONG, null));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(null, ExpressionType.LONG));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(ExpressionType.DOUBLE, null));
+    Assertions.assertEquals(ExpressionType.LONG, ExpressionTypeConversion.integerMathFunction(null, ExpressionType.DOUBLE));
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.STRING, null)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.integerMathFunction(null, ExpressionType.STRING)
     );
     // all numbers are longs
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.LONG, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.LONG, ExpressionType.DOUBLE)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.DOUBLE, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.DOUBLE, ExpressionType.DOUBLE)
     );
     // any string makes become string
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.LONG, ExpressionType.STRING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.STRING, ExpressionType.LONG)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.DOUBLE, ExpressionType.STRING)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.STRING, ExpressionType.DOUBLE)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.STRING, ExpressionType.STRING)
     );
     // unless it is an array
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.LONG_ARRAY,
         ExpressionTypeConversion.integerMathFunction(
             ExpressionType.LONG_ARRAY,
             ExpressionType.LONG_ARRAY
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.DOUBLE_ARRAY,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.DOUBLE_ARRAY, ExpressionType.DOUBLE_ARRAY)
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExpressionType.STRING_ARRAY,
         ExpressionTypeConversion.integerMathFunction(ExpressionType.STRING_ARRAY, ExpressionType.STRING_ARRAY)
     );
@@ -715,7 +715,7 @@ public class OutputTypeTest extends InitializedNullHandlingTest
   private void assertOutputType(String expression, Expr.InputBindingInspector inspector, ExpressionType outputType)
   {
     final Expr expr = Parser.parse(expression, ExprMacroTable.nil(), false);
-    Assert.assertEquals(outputType, expr.getOutputType(inspector));
+    Assertions.assertEquals(outputType, expr.getOutputType(inspector));
   }
 
   Expr.InputBindingInspector inspectorFromMap(Map<String, ExpressionType> types)

--- a/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/ParserTest.java
@@ -29,11 +29,9 @@ import org.apache.druid.segment.column.TypeStrategy;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -47,12 +45,9 @@ import java.util.Set;
  */
 public class ParserTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   SettableVectorInputBinding emptyBinding = new SettableVectorInputBinding(8);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup()
   {
     TypeStrategies.registerComplex(
@@ -66,7 +61,7 @@ public class ParserTest extends InitializedNullHandlingTest
   {
     String actual = Parser.parse("1", ExprMacroTable.nil()).toString();
     String expected = "1";
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -103,14 +98,14 @@ public class ParserTest extends InitializedNullHandlingTest
 
     // When not flattening, the "out of long range" error happens during eval.
     final Expr expr = Parser.parse(s, ExprMacroTable.nil(), false);
-    final ArithmeticException e = Assert.assertThrows(
+    final ArithmeticException e = Assertions.assertThrows(
         ArithmeticException.class,
         () -> expr.eval(InputBindings.nilBindings())
     );
     MatcherAssert.assertThat(e.getMessage(), CoreMatchers.containsString("BigInteger out of long range"));
 
     // When flattening, the "out of long range" error happens during parse, not eval.
-    final ArithmeticException e2 = Assert.assertThrows(
+    final ArithmeticException e2 = Assertions.assertThrows(
         ArithmeticException.class,
         () -> Parser.parse(s, ExprMacroTable.nil(), true)
     );
@@ -121,20 +116,20 @@ public class ParserTest extends InitializedNullHandlingTest
   public void testFlattenBinaryOpConstantConstant()
   {
     final Expr expr = Parser.parse("(2 + -3)", ExprMacroTable.nil(), true);
-    Assert.assertTrue(expr.isLiteral());
-    Assert.assertEquals(-1L, expr.getLiteralValue());
+    Assertions.assertTrue(expr.isLiteral());
+    Assertions.assertEquals(-1L, expr.getLiteralValue());
   }
 
   @Test
   public void testFlattenBinaryOpIdentifierConstant()
   {
     final Expr expr = Parser.parse("(s + -3)", ExprMacroTable.nil(), true);
-    Assert.assertFalse(expr.isLiteral());
+    Assertions.assertFalse(expr.isLiteral());
     MatcherAssert.assertThat(expr, CoreMatchers.instanceOf(BinPlusExpr.class));
 
     final Expr right = ((BinPlusExpr) expr).right;
-    Assert.assertTrue(right.isLiteral());
-    Assert.assertEquals(-3L, right.getLiteralValue());
+    Assertions.assertTrue(right.isLiteral());
+    Assertions.assertEquals(-3L, right.getLiteralValue());
   }
 
   @Test
@@ -142,11 +137,11 @@ public class ParserTest extends InitializedNullHandlingTest
   {
     String actual = Parser.parse("-x", ExprMacroTable.nil()).toString();
     String expected = "-x";
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
 
     actual = Parser.parse("!x", ExprMacroTable.nil()).toString();
     expected = "!x";
-    Assert.assertEquals(expected, actual);
+    Assertions.assertEquals(expected, actual);
   }
 
   @Test
@@ -397,8 +392,8 @@ public class ParserTest extends InitializedNullHandlingTest
     int w1 = byteStrategy.write(bb1, l1, b1.length);
     int w2 = byteStrategy.write(bb2, l2, b2.length);
 
-    Assert.assertTrue(w1 > 0);
-    Assert.assertTrue(w2 > 0);
+    Assertions.assertTrue(w1 > 0);
+    Assertions.assertTrue(w2 > 0);
     String l1String = StringUtils.format(
         "complex_decode_base64('%s', '%s')",
         TypeStrategiesTest.NULLABLE_TEST_PAIR_TYPE.getComplexTypeName(),
@@ -424,27 +419,33 @@ public class ParserTest extends InitializedNullHandlingTest
   public void testLiteralArrayImplicitStringParseException()
   {
     // implicit typed string array cannot handle literals thate are not null or string
-    expectedException.expect(RE.class);
-    expectedException.expectMessage("Failed to parse array: element 2000 is not a string");
-    validateConstantExpression("['1', null, 2000, 1.1]", new Object[]{"1", null, "2000", "1.1"});
+    final RE exception = Assertions.assertThrows(
+        RE.class,
+        () -> validateConstantExpression("['1', null, 2000, 1.1]", new Object[]{"1", null, "2000", "1.1"})
+    );
+    Assertions.assertEquals("Failed to parse array: element 2000 is not a string", exception.getMessage());
   }
 
   @Test
   public void testLiteralArraysExplicitLongParseException()
   {
     // explicit typed long arrays only handle numeric types
-    expectedException.expect(RE.class);
-    expectedException.expectMessage("Failed to parse array element '2000' as a long");
-    validateConstantExpression("<LONG>[1, null, '2000']", new Object[]{1L, null, 2000L});
+    final RE exception = Assertions.assertThrows(
+        RE.class,
+        () -> validateConstantExpression("<LONG>[1, null, '2000']", new Object[]{1L, null, 2000L})
+    );
+    Assertions.assertEquals("Failed to parse array element '2000' as a long", exception.getMessage());
   }
 
   @Test
   public void testLiteralArraysExplicitDoubleParseException()
   {
     // explicit typed double arrays only handle numeric types
-    expectedException.expect(RE.class);
-    expectedException.expectMessage("Failed to parse array element '2000.0' as a double");
-    validateConstantExpression("<DOUBLE>[1.0, null, '2000.0']", new Object[]{1.0, null, 2000.0});
+    final RE exception = Assertions.assertThrows(
+        RE.class,
+        () -> validateConstantExpression("<DOUBLE>[1.0, null, '2000.0']", new Object[]{1.0, null, 2000.0})
+    );
+    Assertions.assertEquals("Failed to parse array element '2000.0' as a double", exception.getMessage());
   }
 
   @Test
@@ -763,20 +764,20 @@ public class ParserTest extends InitializedNullHandlingTest
   {
     Expr parsed = Parser.parse(expr, ExprMacroTable.nil(), false);
     Expr parsedFlat = Parser.parse(expr, ExprMacroTable.nil(), true);
-    Assert.assertTrue(parsed.isLiteral());
-    Assert.assertTrue(parsedFlat.isLiteral());
-    Assert.assertFalse(parsed.isIdentifier());
-    Assert.assertEquals(type, parsed.getOutputType(emptyBinding));
-    Assert.assertEquals(type, parsedFlat.getOutputType(emptyBinding));
-    Assert.assertEquals(expected, parsed.getLiteralValue());
-    Assert.assertEquals(
+    Assertions.assertTrue(parsed.isLiteral());
+    Assertions.assertTrue(parsedFlat.isLiteral());
+    Assertions.assertFalse(parsed.isIdentifier());
+    Assertions.assertEquals(type, parsed.getOutputType(emptyBinding));
+    Assertions.assertEquals(type, parsedFlat.getOutputType(emptyBinding));
+    Assertions.assertEquals(expected, parsed.getLiteralValue());
+    Assertions.assertEquals(
         // Special case comparison: literal integers start life as BigIntegerExpr; converted to LongExpr later.
         expected instanceof BigInteger ? ((BigInteger) expected).longValueExact() : expected,
         parsedFlat.getLiteralValue()
     );
     if (roundTrip) {
-      Assert.assertEquals(expr, parsed.stringify());
-      Assert.assertEquals(expr, parsedFlat.stringify());
+      Assertions.assertEquals(expr, parsed.stringify());
+      Assertions.assertEquals(expr, parsedFlat.stringify());
     }
   }
 
@@ -784,15 +785,15 @@ public class ParserTest extends InitializedNullHandlingTest
   {
     Expr notFlat = Parser.parse(expression, ExprMacroTable.nil(), false);
     Expr flat = Parser.parse(expression, ExprMacroTable.nil(), true);
-    Assert.assertEquals(expression, withoutFlatten, notFlat.toString());
-    Assert.assertEquals(expression, withFlatten, flat.toString());
+    Assertions.assertEquals(withoutFlatten, notFlat.toString(), expression);
+    Assertions.assertEquals(withFlatten, flat.toString(), expression);
 
     Expr notFlatRoundTrip = Parser.parse(notFlat.stringify(), ExprMacroTable.nil(), false);
     Expr flatRoundTrip = Parser.parse(flat.stringify(), ExprMacroTable.nil(), true);
-    Assert.assertEquals(expression, withoutFlatten, notFlatRoundTrip.toString());
-    Assert.assertEquals(expression, withFlatten, flatRoundTrip.toString());
-    Assert.assertEquals(notFlat.stringify(), notFlatRoundTrip.stringify());
-    Assert.assertEquals(flat.stringify(), flatRoundTrip.stringify());
+    Assertions.assertEquals(withoutFlatten, notFlatRoundTrip.toString(), expression);
+    Assertions.assertEquals(withFlatten, flatRoundTrip.toString(), expression);
+    Assertions.assertEquals(notFlat.stringify(), notFlatRoundTrip.stringify());
+    Assertions.assertEquals(flat.stringify(), flatRoundTrip.stringify());
   }
 
   private void validateParser(String expression, String expected, List<String> identifiers)
@@ -815,23 +816,23 @@ public class ParserTest extends InitializedNullHandlingTest
   {
     final Expr parsed = Parser.parse(expression, ExprMacroTable.nil());
     if (parsed instanceof IdentifierExpr) {
-      Assert.assertTrue(parsed.isIdentifier());
+      Assertions.assertTrue(parsed.isIdentifier());
     } else {
-      Assert.assertFalse(parsed.isIdentifier());
+      Assertions.assertFalse(parsed.isIdentifier());
     }
     final Expr.BindingAnalysis deets = parsed.analyzeInputs();
-    Assert.assertEquals(expression, expected, parsed.toString());
-    Assert.assertEquals(expression, new HashSet<>(identifiers), deets.getRequiredBindings());
-    Assert.assertEquals(expression, scalars, deets.getScalarVariables());
-    Assert.assertEquals(expression, arrays, deets.getArrayVariables());
+    Assertions.assertEquals(expected, parsed.toString(), expression);
+    Assertions.assertEquals(new HashSet<>(identifiers), deets.getRequiredBindings(), expression);
+    Assertions.assertEquals(scalars, deets.getScalarVariables(), expression);
+    Assertions.assertEquals(arrays, deets.getArrayVariables(), expression);
 
     final Expr parsedNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
     final Expr roundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
-    Assert.assertEquals(parsed.stringify(), roundTrip.stringify());
+    Assertions.assertEquals(parsed.stringify(), roundTrip.stringify());
     final Expr.BindingAnalysis roundTripDeets = roundTrip.analyzeInputs();
-    Assert.assertEquals(expression, new HashSet<>(identifiers), roundTripDeets.getRequiredBindings());
-    Assert.assertEquals(expression, scalars, roundTripDeets.getScalarVariables());
-    Assert.assertEquals(expression, arrays, roundTripDeets.getArrayVariables());
+    Assertions.assertEquals(new HashSet<>(identifiers), roundTripDeets.getRequiredBindings(), expression);
+    Assertions.assertEquals(scalars, roundTripDeets.getScalarVariables(), expression);
+    Assertions.assertEquals(arrays, roundTripDeets.getArrayVariables(), expression);
   }
 
   private void validateApplyUnapplied(
@@ -845,19 +846,19 @@ public class ParserTest extends InitializedNullHandlingTest
     Expr.BindingAnalysis deets = parsed.analyzeInputs();
     Parser.validateExpr(parsed, deets);
     final Expr transformed = Parser.applyUnappliedBindings(parsed, deets, identifiers);
-    Assert.assertEquals(expression, unapplied, parsed.toString());
-    Assert.assertEquals(applied, applied, transformed.toString());
+    Assertions.assertEquals(unapplied, parsed.toString(), expression);
+    Assertions.assertEquals(applied, transformed.toString(), applied);
 
     final Expr parsedNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
     final Expr parsedRoundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
     Expr.BindingAnalysis roundTripDeets = parsedRoundTrip.analyzeInputs();
     Parser.validateExpr(parsedRoundTrip, roundTripDeets);
     final Expr transformedRoundTrip = Parser.applyUnappliedBindings(parsedRoundTrip, roundTripDeets, identifiers);
-    Assert.assertEquals(expression, unapplied, parsedRoundTrip.toString());
-    Assert.assertEquals(applied, applied, transformedRoundTrip.toString());
+    Assertions.assertEquals(unapplied, parsedRoundTrip.toString(), expression);
+    Assertions.assertEquals(applied, transformedRoundTrip.toString(), applied);
 
-    Assert.assertEquals(parsed.stringify(), parsedRoundTrip.stringify());
-    Assert.assertEquals(transformed.stringify(), transformedRoundTrip.stringify());
+    Assertions.assertEquals(parsed.stringify(), parsedRoundTrip.stringify());
+    Assertions.assertEquals(transformed.stringify(), transformedRoundTrip.stringify());
   }
 
   private void validateFoldUnapplied(
@@ -872,58 +873,58 @@ public class ParserTest extends InitializedNullHandlingTest
     Expr.BindingAnalysis deets = parsed.analyzeInputs();
     Parser.validateExpr(parsed, deets);
     final Expr transformed = Parser.foldUnappliedBindings(parsed, deets, identifiers, accumulator);
-    Assert.assertEquals(expression, unapplied, parsed.toString());
-    Assert.assertEquals(applied, applied, transformed.toString());
+    Assertions.assertEquals(unapplied, parsed.toString(), expression);
+    Assertions.assertEquals(applied, transformed.toString(), applied);
 
     final Expr parsedNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
     final Expr parsedRoundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
     Expr.BindingAnalysis roundTripDeets = parsedRoundTrip.analyzeInputs();
     Parser.validateExpr(parsedRoundTrip, roundTripDeets);
     final Expr transformedRoundTrip = Parser.foldUnappliedBindings(parsedRoundTrip, roundTripDeets, identifiers, accumulator);
-    Assert.assertEquals(expression, unapplied, parsedRoundTrip.toString());
-    Assert.assertEquals(applied, applied, transformedRoundTrip.toString());
+    Assertions.assertEquals(unapplied, parsedRoundTrip.toString(), expression);
+    Assertions.assertEquals(applied, transformedRoundTrip.toString(), applied);
 
-    Assert.assertEquals(parsed.stringify(), parsedRoundTrip.stringify());
-    Assert.assertEquals(transformed.stringify(), transformedRoundTrip.stringify());
+    Assertions.assertEquals(parsed.stringify(), parsedRoundTrip.stringify());
+    Assertions.assertEquals(transformed.stringify(), transformedRoundTrip.stringify());
   }
 
   private void validateConstantScalarExpression(String expression, Object expected)
   {
     Expr parsed = Parser.parse(expression, ExprMacroTable.nil());
-    Assert.assertEquals(
-        expression,
+    Assertions.assertEquals(
         expected,
-        parsed.eval(InputBindings.nilBindings()).value()
+        parsed.eval(InputBindings.nilBindings()).value(),
+        expression
     );
 
     final Expr parsedNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
     Expr parsedRoundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
-    Assert.assertEquals(
-        expression,
+    Assertions.assertEquals(
         expected,
-        parsedRoundTrip.eval(InputBindings.nilBindings()).value()
+        parsedRoundTrip.eval(InputBindings.nilBindings()).value(),
+        expression
     );
-    Assert.assertEquals(parsed.stringify(), parsedRoundTrip.stringify());
+    Assertions.assertEquals(parsed.stringify(), parsedRoundTrip.stringify());
   }
 
   private void validateConstantExpression(String expression, Object[] expected)
   {
     Expr parsed = Parser.parse(expression, ExprMacroTable.nil());
     Object evaluated = parsed.eval(InputBindings.nilBindings()).value();
-    Assert.assertArrayEquals(
-        expression,
+    Assertions.assertArrayEquals(
         expected,
-        (Object[]) evaluated
+        (Object[]) evaluated,
+        expression
     );
 
-    Assert.assertEquals(expected.getClass(), evaluated.getClass());
+    Assertions.assertEquals(expected.getClass(), evaluated.getClass());
     final Expr parsedNoFlatten = Parser.parse(expression, ExprMacroTable.nil(), false);
     Expr roundTrip = Parser.parse(parsedNoFlatten.stringify(), ExprMacroTable.nil());
-    Assert.assertArrayEquals(
-        expression,
+    Assertions.assertArrayEquals(
         expected,
-        (Object[]) roundTrip.eval(InputBindings.nilBindings()).value()
+        (Object[]) roundTrip.eval(InputBindings.nilBindings()).value(),
+        expression
     );
-    Assert.assertEquals(parsed.stringify(), roundTrip.stringify());
+    Assertions.assertEquals(parsed.stringify(), roundTrip.stringify());
   }
 }

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -808,7 +809,7 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     Assertions.assertEquals(
         nonVectorEval.isError() ? nonVectorEval.error() : "",
         vectorEval.isError() ? vectorEval.error() : "",
-        StringUtils.format("Errors do not match for expr[%s], bindings[%s]", exprString, bindings.lhs)
+        StringUtils.format("Errors do not match for expr[%s], bindings[%s]", exprString, Arrays.toString(bindings.lhs))
     );
 
     if (vectorEval.isValue() && nonVectorEval.isValue()) {

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyTest.java
@@ -40,11 +40,11 @@ import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
 import org.apache.druid.query.lookup.TestMapLookupExtractorFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -799,16 +799,16 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
       NonnullPair<Expr.ObjectBinding[], Expr.VectorInputBinding> bindings
   )
   {
-    Assert.assertTrue(StringUtils.format("Cannot vectorize[%s]", expr), expr.canVectorize(bindings.rhs));
+    Assertions.assertTrue(expr.canVectorize(bindings.rhs), StringUtils.format("Cannot vectorize[%s]", expr));
 
     final ExpressionType outputType = expr.getOutputType(bindings.rhs);
     final Either<String, Object[]> vectorEval = evalVector(expr, bindings.rhs, outputType);
     final Either<String, Object[]> nonVectorEval = evalNonVector(expr, bindings.lhs, outputType);
 
-    Assert.assertEquals(
-        StringUtils.format("Errors do not match for expr[%s], bindings[%s]", exprString, bindings.lhs),
+    Assertions.assertEquals(
         nonVectorEval.isError() ? nonVectorEval.error() : "",
-        vectorEval.isError() ? vectorEval.error() : ""
+        vectorEval.isError() ? vectorEval.error() : "",
+        StringUtils.format("Errors do not match for expr[%s], bindings[%s]", exprString, bindings.lhs)
     );
 
     if (vectorEval.isValue() && nonVectorEval.isValue()) {
@@ -821,16 +821,16 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
             bindings.lhs[i]
         );
         if (outputType != null && outputType.isArray()) {
-          Assert.assertArrayEquals(
-              message,
+          Assertions.assertArrayEquals(
               (Object[]) nonVectorEval.valueOrThrow()[i],
-              (Object[]) vectorEval.valueOrThrow()[i]
+              (Object[]) vectorEval.valueOrThrow()[i],
+              message
           );
         } else {
-          Assert.assertEquals(
-              message,
+          Assertions.assertEquals(
               nonVectorEval.valueOrThrow()[i],
-              vectorEval.valueOrThrow()[i]
+              vectorEval.valueOrThrow()[i],
+              message
           );
         }
       }
@@ -996,7 +996,7 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
     final Object[] vectorVals = vectorEval.getObjectVector();
     // if outputType is known, verify the expr returns the correct type
     if (outputType != null) {
-      Assert.assertEquals("vector eval type", outputType, vectorEval.getType());
+      Assertions.assertEquals(outputType, vectorEval.getType(), "vector eval type");
     }
 
     return Either.value(vectorVals);
@@ -1024,7 +1024,7 @@ public class VectorExprResultConsistencyTest extends InitializedNullHandlingTest
       }
       // if outputType is known, verify the expr returns the correct type
       if (outputType != null && eval.value() != null) {
-        Assert.assertEquals("nonvector eval type", eval.type(), outputType);
+        Assertions.assertEquals(eval.type(), outputType, "nonvector eval type");
       }
       exprValues[i] = eval.value();
     }

--- a/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyVectorApiTest.java
+++ b/processing/src/test/java/org/apache/druid/math/expr/VectorExprResultConsistencyVectorApiTest.java
@@ -19,8 +19,8 @@
 
 package org.apache.druid.math.expr;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * Re-runs every {@link VectorExprResultConsistencyTest} case with the SIMD ({@code jdk.incubator.vector}) expression
@@ -28,13 +28,13 @@ import org.junit.Before;
  */
 public class VectorExprResultConsistencyVectorApiTest extends VectorExprResultConsistencyTest
 {
-  @Before
+  @BeforeEach
   public void enableVectorApi()
   {
     ExpressionProcessing.initializeForVectorApiTests();
   }
 
-  @After
+  @AfterEach
   public void resetExpressionProcessing()
   {
     ExpressionProcessing.initializeForTests();

--- a/processing/src/test/java/org/apache/druid/query/expression/CaseInsensitiveExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/CaseInsensitiveExprMacroTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.expression;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class CaseInsensitiveExprMacroTest extends MacroTestBase
 {
@@ -35,15 +35,21 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
   @Test
   public void testErrorZeroArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[icontains_string] requires 2 arguments");
-    eval("icontains_string()", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[icontains_string] requires 2 arguments",
+        () -> eval("icontains_string()", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testErrorThreeArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[icontains_string] requires 2 arguments");
-    eval("icontains_string('a', 'b', 'c')", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[icontains_string] requires 2 arguments",
+        () -> eval("icontains_string('a', 'b', 'c')", InputBindings.nilBindings())
+    );
   }
 
   @Test
@@ -53,7 +59,7 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
         "icontains_string(a, 'OBA')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foobar")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -66,7 +72,7 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
         "icontains_string(a, 'oba')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "FOOBAR")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -79,7 +85,7 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
         "icontains_string(a, 'bar')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(false).value(),
         result.value()
     );
@@ -88,15 +94,13 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
   @Test
   public void testNullSearch()
   {
-    expectException(IllegalArgumentException.class, "Function[icontains_string] substring must be a string literal");
-
-    final ExprEval<?> result = eval(
-        "icontains_string(a, null)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
-    );
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[icontains_string] substring must be a string literal",
+        () -> eval(
+            "icontains_string(a, null)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+        )
     );
   }
 
@@ -107,7 +111,7 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
         "icontains_string(a, '')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -116,15 +120,13 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
   @Test
   public void testNullSearchOnEmptyString()
   {
-    expectException(IllegalArgumentException.class, "Function[icontains_string] substring must be a string literal");
-
-    final ExprEval<?> result = eval(
-        "icontains_string(a, null)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
-    );
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[icontains_string] substring must be a string literal",
+        () -> eval(
+            "icontains_string(a, null)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
+        )
     );
   }
 
@@ -135,7 +137,7 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
         "icontains_string(a, '')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -144,15 +146,13 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
   @Test
   public void testNullSearchOnNull()
   {
-    expectException(IllegalArgumentException.class, "Function[icontains_string] substring must be a string literal");
-
-    final ExprEval<?> result = eval(
-        "icontains_string(a, null)",
-        InputBindings.nilBindings()
-    );
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[icontains_string] substring must be a string literal",
+        () -> eval(
+            "icontains_string(a, null)",
+            InputBindings.nilBindings()
+        )
     );
   }
 
@@ -160,6 +160,6 @@ public class CaseInsensitiveExprMacroTest extends MacroTestBase
   public void testEmptyStringSearchOnNull()
   {
     ExprEval<?> result = eval("icontains_string(a, '')", InputBindings.nilBindings());
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/ContainsExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/ContainsExprMacroTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.expression;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class ContainsExprMacroTest extends MacroTestBase
 {
@@ -35,15 +35,21 @@ public class ContainsExprMacroTest extends MacroTestBase
   @Test
   public void testErrorZeroArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[contains_string] requires 2 arguments");
-    eval("contains_string()", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[contains_string] requires 2 arguments",
+        () -> eval("contains_string()", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testErrorThreeArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[contains_string] requires 2 arguments");
-    eval("contains_string('a', 'b', 'c')", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[contains_string] requires 2 arguments",
+        () -> eval("contains_string('a', 'b', 'c')", InputBindings.nilBindings())
+    );
   }
 
   @Test
@@ -53,7 +59,7 @@ public class ContainsExprMacroTest extends MacroTestBase
         "contains_string(a, 'oba')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foobar")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -66,7 +72,7 @@ public class ContainsExprMacroTest extends MacroTestBase
         "contains_string(a, 'bar')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(false).value(),
         result.value()
     );
@@ -75,15 +81,13 @@ public class ContainsExprMacroTest extends MacroTestBase
   @Test
   public void testNullSearch()
   {
-    expectException(IllegalArgumentException.class, "Function[contains_string] substring must be a string literal");
-
-    final ExprEval<?> result = eval(
-        "contains_string(a, null)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
-    );
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[contains_string] substring must be a string literal",
+        () -> eval(
+            "contains_string(a, null)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+        )
     );
   }
 
@@ -94,7 +98,7 @@ public class ContainsExprMacroTest extends MacroTestBase
         "contains_string(a, '')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -103,15 +107,13 @@ public class ContainsExprMacroTest extends MacroTestBase
   @Test
   public void testNullSearchOnEmptyString()
   {
-    expectException(IllegalArgumentException.class, "Function[contains_string] substring must be a string literal");
-
-    final ExprEval<?> result = eval(
-        "contains_string(a, null)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
-    );
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[contains_string] substring must be a string literal",
+        () -> eval(
+            "contains_string(a, null)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
+        )
     );
   }
 
@@ -122,7 +124,7 @@ public class ContainsExprMacroTest extends MacroTestBase
         "contains_string(a, '')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -131,12 +133,10 @@ public class ContainsExprMacroTest extends MacroTestBase
   @Test
   public void testNullSearchOnNull()
   {
-    expectException(IllegalArgumentException.class, "Function[contains_string] substring must be a string literal");
-
-    final ExprEval<?> result = eval("contains_string(a, null)", InputBindings.nilBindings());
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[contains_string] substring must be a string literal",
+        () -> eval("contains_string(a, null)", InputBindings.nilBindings())
     );
   }
 
@@ -144,6 +144,6 @@ public class ContainsExprMacroTest extends MacroTestBase
   public void testEmptyStringSearchOnNull()
   {
     final ExprEval<?> result = eval("contains_string(a, '')", InputBindings.nilBindings());
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressMatchExprMacroTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.ExpressionValidationException;
 import org.apache.druid.math.expr.InputBindings;
 import org.apache.druid.math.expr.Parser;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -52,154 +52,162 @@ public class IPv4AddressMatchExprMacroTest extends MacroTestBase
   @Test
   public void testTooFewArgs()
   {
-    expectException(ExpressionValidationException.class, "requires 2 arguments");
-
-    apply(Collections.emptyList());
+    assertException(
+        ExpressionValidationException.class,
+        "requires 2 arguments",
+        () -> apply(Collections.emptyList())
+    );
   }
 
   @Test
   public void testTooManyArgs()
   {
-    expectException(ExpressionValidationException.class, "requires 2 arguments");
-
-    apply(Arrays.asList(IPV4, SUBNET_192_168, NOT_LITERAL));
+    assertException(
+        ExpressionValidationException.class,
+        "requires 2 arguments",
+        () -> apply(Arrays.asList(IPV4, SUBNET_192_168, NOT_LITERAL))
+    );
   }
 
   @Test
   public void testSubnetArgNotLiteral()
   {
-    expectException(ExpressionValidationException.class, "subnet argument must be a literal");
-
-    apply(Arrays.asList(IPV4, NOT_LITERAL));
+    assertException(
+        ExpressionValidationException.class,
+        "subnet argument must be a literal",
+        () -> apply(Arrays.asList(IPV4, NOT_LITERAL))
+    );
   }
 
   @Test
   public void testSubnetArgInvalid()
   {
-    expectException(IllegalArgumentException.class, "subnet arg has an invalid format");
-
-    Expr invalidSubnet = ExprEval.ofString("192.168.0.1/invalid").toExpr();
-    apply(Arrays.asList(IPV4, invalidSubnet));
+    final Expr invalidSubnet = ExprEval.ofString("192.168.0.1/invalid").toExpr();
+    assertException(
+        IllegalArgumentException.class,
+        "subnet arg has an invalid format",
+        () -> apply(Arrays.asList(IPV4, invalidSubnet))
+    );
   }
 
   @Test
   public void testNullStringArg()
   {
     Expr nullString = ExprEval.ofString(null).toExpr();
-    Assert.assertFalse(eval(nullString, SUBNET_192_168));
+    Assertions.assertFalse(eval(nullString, SUBNET_192_168));
   }
 
   @Test
   public void testNullLongArg()
   {
     Expr nullLong = ExprEval.ofLong(null).toExpr();
-    Assert.assertFalse(eval(nullLong, SUBNET_192_168));
+    Assertions.assertFalse(eval(nullLong, SUBNET_192_168));
   }
 
   @Test
   public void testInvalidArgType()
   {
     Expr longArray = ExprEval.ofLongArray(new Long[]{1L, 2L}).toExpr();
-    Assert.assertFalse(eval(longArray, SUBNET_192_168));
+    Assertions.assertFalse(eval(longArray, SUBNET_192_168));
   }
 
   @Test
   public void testMatchingStringArgIPv4()
   {
-    Assert.assertTrue(eval(IPV4, SUBNET_192_168));
+    Assertions.assertTrue(eval(IPV4, SUBNET_192_168));
   }
 
   @Test
   public void testNotMatchingStringArgIPv4()
   {
-    Assert.assertFalse(eval(IPV4, SUBNET_10));
+    Assertions.assertFalse(eval(IPV4, SUBNET_10));
   }
 
   @Test
   public void testMatchingStringArgIPv6Mapped()
   {
-    Assert.assertFalse(eval(IPV6_MAPPED, SUBNET_192_168));
+    Assertions.assertFalse(eval(IPV6_MAPPED, SUBNET_192_168));
   }
 
   @Test
   public void testNotMatchingStringArgIPv6Mapped()
   {
-    Assert.assertFalse(eval(IPV6_MAPPED, SUBNET_10));
+    Assertions.assertFalse(eval(IPV6_MAPPED, SUBNET_10));
   }
 
   @Test
   public void testMatchingStringArgIPv6Compatible()
   {
-    Assert.assertFalse(eval(IPV6_COMPATIBLE, SUBNET_192_168));
+    Assertions.assertFalse(eval(IPV6_COMPATIBLE, SUBNET_192_168));
   }
 
   @Test
   public void testNotMatchingStringArgIPv6Compatible()
   {
-    Assert.assertFalse(eval(IPV6_COMPATIBLE, SUBNET_10));
+    Assertions.assertFalse(eval(IPV6_COMPATIBLE, SUBNET_10));
   }
 
   @Test
   public void testNotIpAddress()
   {
     Expr notIpAddress = ExprEval.ofString("druid.apache.org").toExpr();
-    Assert.assertFalse(eval(notIpAddress, SUBNET_192_168));
+    Assertions.assertFalse(eval(notIpAddress, SUBNET_192_168));
   }
 
   @Test
   public void testMatchingLongArg()
   {
-    Assert.assertTrue(eval(IPV4_LONG, SUBNET_192_168));
+    Assertions.assertTrue(eval(IPV4_LONG, SUBNET_192_168));
   }
 
   @Test
   public void testNotMatchingLongArg()
   {
-    Assert.assertFalse(eval(IPV4_LONG, SUBNET_10));
+    Assertions.assertFalse(eval(IPV4_LONG, SUBNET_10));
   }
 
   @Test
   public void testMatchingStringArgUnsignedInt()
   {
-    Assert.assertFalse(eval(IPV4_UINT, SUBNET_192_168));
+    Assertions.assertFalse(eval(IPV4_UINT, SUBNET_192_168));
   }
 
   @Test
   public void testNotMatchingStringArgUnsignedInt()
   {
-    Assert.assertFalse(eval(IPV4_UINT, SUBNET_10));
+    Assertions.assertFalse(eval(IPV4_UINT, SUBNET_10));
   }
 
   @Test
   public void testInclusive()
   {
     Expr subnet = SUBNET_192_168;
-    Assert.assertTrue(eval(IPV4_NETWORK, subnet));
-    Assert.assertTrue(eval(IPV4, subnet));
-    Assert.assertTrue(eval(IPV4_BROADCAST, subnet));
+    Assertions.assertTrue(eval(IPV4_NETWORK, subnet));
+    Assertions.assertTrue(eval(IPV4, subnet));
+    Assertions.assertTrue(eval(IPV4_BROADCAST, subnet));
   }
 
   @Test
   public void testMatchesPrefix()
   {
-    Assert.assertTrue(eval(ExprEval.ofString("192.168.1.250").toExpr(), ExprEval.ofString("192.168.1.251/31").toExpr()));
-    Assert.assertFalse(eval(ExprEval.ofString("192.168.1.240").toExpr(), ExprEval.ofString("192.168.1.251/31").toExpr()));
-    Assert.assertFalse(eval(ExprEval.ofString("192.168.1.250").toExpr(), ExprEval.ofString("192.168.1.251/32").toExpr()));
-    Assert.assertTrue(eval(ExprEval.ofString("192.168.1.251").toExpr(), ExprEval.ofString("192.168.1.251/32").toExpr()));
+    Assertions.assertTrue(eval(ExprEval.ofString("192.168.1.250").toExpr(), ExprEval.ofString("192.168.1.251/31").toExpr()));
+    Assertions.assertFalse(eval(ExprEval.ofString("192.168.1.240").toExpr(), ExprEval.ofString("192.168.1.251/31").toExpr()));
+    Assertions.assertFalse(eval(ExprEval.ofString("192.168.1.250").toExpr(), ExprEval.ofString("192.168.1.251/32").toExpr()));
+    Assertions.assertTrue(eval(ExprEval.ofString("192.168.1.251").toExpr(), ExprEval.ofString("192.168.1.251/32").toExpr()));
 
-    Assert.assertTrue(eval(
+    Assertions.assertTrue(eval(
         ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.250").longValue()).toExpr(),
         ExprEval.ofString("192.168.1.251/31").toExpr()
     ));
-    Assert.assertFalse(eval(
+    Assertions.assertFalse(eval(
         ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.240").longValue()).toExpr(),
         ExprEval.ofString("192.168.1.251/31").toExpr()
     ));
-    Assert.assertFalse(eval(
+    Assertions.assertFalse(eval(
         ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.250").longValue()).toExpr(),
         ExprEval.ofString("192.168.1.251/32").toExpr()
     ));
-    Assert.assertTrue(eval(
+    Assertions.assertTrue(eval(
         ExprEval.of(IPv4AddressExprUtils.parse("192.168.1.251").longValue()).toExpr(),
         ExprEval.ofString("192.168.1.251/32").toExpr()
     ));

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressParseExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressParseExprMacroTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.expression;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.InputBindings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,79 +41,83 @@ public class IPv4AddressParseExprMacroTest extends MacroTestBase
   @Test
   public void testTooFewArgs()
   {
-    expectException(IllegalArgumentException.class, "requires 1 argument");
-
-    apply(Collections.emptyList());
+    assertException(
+        IllegalArgumentException.class,
+        "requires 1 argument",
+        () -> apply(Collections.emptyList())
+    );
   }
 
   @Test
   public void testTooManyArgs()
   {
-    expectException(IllegalArgumentException.class, "requires 1 argument");
-
-    apply(Arrays.asList(VALID, VALID));
+    assertException(
+        IllegalArgumentException.class,
+        "requires 1 argument",
+        () -> apply(Arrays.asList(VALID, VALID))
+    );
   }
 
   @Test
   public void testnullStringArg()
   {
     Expr nullString = ExprEval.ofString(null).toExpr();
-    Assert.assertNull(eval(nullString));
+    Assertions.assertNull(eval(nullString));
   }
 
   @Test
   public void testnullLongArg()
   {
     Expr nullLong = ExprEval.ofLong(null).toExpr();
-    Assert.assertNull(eval(nullLong));
+    Assertions.assertNull(eval(nullLong));
   }
 
   @Test
   public void testInvalidArgType()
   {
     Expr longArray = ExprEval.ofLongArray(new Long[]{1L, 2L}).toExpr();
-    Assert.assertNull(eval(longArray));
+    Assertions.assertNull(eval(longArray));
   }
 
   @Test
   public void testInvalidStringArgNotIPAddress()
   {
     Expr notIpAddress = ExprEval.ofString("druid.apache.org").toExpr();
-    Assert.assertNull(eval(notIpAddress));
+    Assertions.assertNull(eval(notIpAddress));
   }
 
   @Test
   public void testInvalidStringArgIPv6Compatible()
   {
     Expr ipv6Compatible = ExprEval.ofString("::192.168.0.1").toExpr();
-    Assert.assertNull(eval(ipv6Compatible));
+    Assertions.assertNull(eval(ipv6Compatible));
   }
 
   @Test
   public void testValidStringArgIPv6Mapped()
   {
     Expr ipv6Mapped = ExprEval.ofString("::ffff:192.168.0.1").toExpr();
-    Assert.assertNull(eval(ipv6Mapped));
+    Assertions.assertNull(eval(ipv6Mapped));
   }
 
   @Test
   public void testValidStringArgIPv4()
   {
-    Assert.assertEquals(EXPECTED, eval(VALID));
+    Assertions.assertEquals(EXPECTED, eval(VALID));
   }
 
   @Test
   public void testValidStringArgUnsignedInt()
   {
     Expr unsignedInt = ExprEval.ofString("3232235521").toExpr();
-    Assert.assertNull(eval(unsignedInt));
+    Assertions.assertNull(eval(unsignedInt));
   }
 
   @Test
   public void testInvalidLongArgTooLow()
   {
     Expr tooLow = ExprEval.ofLong(-1L).toExpr();
-    Assert.assertNull(eval(tooLow));
+    Assertions.assertNull(eval(tooLow));
   }
 
   @Test
@@ -121,7 +125,7 @@ public class IPv4AddressParseExprMacroTest extends MacroTestBase
   {
     long lowest = 0L;
     Expr tooLow = ExprEval.ofLong(lowest).toExpr();
-    Assert.assertEquals(lowest, eval(tooLow));
+    Assertions.assertEquals(lowest, eval(tooLow));
   }
 
   @Test
@@ -129,14 +133,14 @@ public class IPv4AddressParseExprMacroTest extends MacroTestBase
   {
     long highest = 0xff_ff_ff_ffL;
     Expr tooLow = ExprEval.ofLong(highest).toExpr();
-    Assert.assertEquals(highest, eval(tooLow));
+    Assertions.assertEquals(highest, eval(tooLow));
   }
 
   @Test
   public void testInvalidLongArgTooHigh()
   {
     Expr tooHigh = ExprEval.ofLong(0x1_00_00_00_00L).toExpr();
-    Assert.assertNull(eval(tooHigh));
+    Assertions.assertNull(eval(tooHigh));
   }
 
   @Test
@@ -144,7 +148,7 @@ public class IPv4AddressParseExprMacroTest extends MacroTestBase
   {
     long value = EXPECTED;
     Expr valid = ExprEval.ofLong(value).toExpr();
-    Assert.assertEquals(value, eval(valid));
+    Assertions.assertEquals(value, eval(valid));
   }
 
   private Object eval(Expr arg)

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressStringifyExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv4AddressStringifyExprMacroTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.query.expression;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.InputBindings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,106 +41,110 @@ public class IPv4AddressStringifyExprMacroTest extends MacroTestBase
   @Test
   public void testTooFewArgs()
   {
-    expectException(IllegalArgumentException.class, "requires 1 argument");
-
-    apply(Collections.emptyList());
+    assertException(
+        IllegalArgumentException.class,
+        "requires 1 argument",
+        () -> apply(Collections.emptyList())
+    );
   }
 
   @Test
   public void testTooManyArgs()
   {
-    expectException(IllegalArgumentException.class, "requires 1 argument");
-
-    apply(Arrays.asList(VALID, VALID));
+    assertException(
+        IllegalArgumentException.class,
+        "requires 1 argument",
+        () -> apply(Arrays.asList(VALID, VALID))
+    );
   }
 
   @Test
   public void testNullLongArg()
   {
     Expr nullNumeric = ExprEval.ofLong(null).toExpr();
-    Assert.assertNull(eval(nullNumeric));
+    Assertions.assertNull(eval(nullNumeric));
   }
 
   @Test
   public void testInvalidArgType()
   {
     Expr longArray = ExprEval.ofLongArray(new Long[]{1L, 2L}).toExpr();
-    Assert.assertNull(eval(longArray));
+    Assertions.assertNull(eval(longArray));
   }
 
   @Test
   public void testInvalidLongArgTooSmall()
   {
     Expr tooSmall = ExprEval.ofLong(-1L).toExpr();
-    Assert.assertNull(eval(tooSmall));
+    Assertions.assertNull(eval(tooSmall));
   }
 
   @Test
   public void testValidLongArgLowest()
   {
     Expr tooSmall = ExprEval.ofLong(0L).toExpr();
-    Assert.assertEquals("0.0.0.0", eval(tooSmall));
+    Assertions.assertEquals("0.0.0.0", eval(tooSmall));
   }
 
   @Test
   public void testValidLongArg()
   {
-    Assert.assertEquals(EXPECTED, eval(VALID));
+    Assertions.assertEquals(EXPECTED, eval(VALID));
   }
 
   @Test
   public void testValidLongArgHighest()
   {
     Expr tooSmall = ExprEval.ofLong(0xff_ff_ff_ffL).toExpr();
-    Assert.assertEquals("255.255.255.255", eval(tooSmall));
+    Assertions.assertEquals("255.255.255.255", eval(tooSmall));
   }
 
   @Test
   public void testInvalidLongArgTooLarge()
   {
     Expr tooLarge = ExprEval.ofLong(0x1_00_00_00_00L).toExpr();
-    Assert.assertNull(eval(tooLarge));
+    Assertions.assertNull(eval(tooLarge));
   }
 
   @Test
   public void testNullStringArg()
   {
     Expr nullString = ExprEval.ofString(null).toExpr();
-    Assert.assertNull(eval(nullString));
+    Assertions.assertNull(eval(nullString));
   }
 
   @Test
   public void testInvalidStringArgNotIPAddress()
   {
     Expr notIpAddress = ExprEval.ofString("druid.apache.org").toExpr();
-    Assert.assertNull(eval(notIpAddress));
+    Assertions.assertNull(eval(notIpAddress));
   }
 
   @Test
   public void testInvalidStringArgIPv6Compatible()
   {
     Expr ipv6Compatible = ExprEval.ofString("::192.168.0.1").toExpr();
-    Assert.assertNull(eval(ipv6Compatible));
+    Assertions.assertNull(eval(ipv6Compatible));
   }
 
   @Test
   public void testValidStringArgIPv6Mapped()
   {
     Expr ipv6Mapped = ExprEval.ofString("::ffff:192.168.0.1").toExpr();
-    Assert.assertNull(eval(ipv6Mapped));
+    Assertions.assertNull(eval(ipv6Mapped));
   }
 
   @Test
   public void testValidStringArgIPv4()
   {
-    Assert.assertEquals(EXPECTED, eval(VALID));
+    Assertions.assertEquals(EXPECTED, eval(VALID));
   }
 
   @Test
   public void testValidStringArgUnsignedInt()
   {
     Expr unsignedInt = ExprEval.ofString("3232235521").toExpr();
-    Assert.assertNull(eval(unsignedInt));
+    Assertions.assertNull(eval(unsignedInt));
   }
 
   private Object eval(Expr arg)

--- a/processing/src/test/java/org/apache/druid/query/expression/IPv6AddressMatchExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/IPv6AddressMatchExprMacroTest.java
@@ -24,9 +24,9 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionProcessingException;
 import org.apache.druid.math.expr.ExpressionValidationException;
 import org.apache.druid.math.expr.InputBindings;
-import org.junit.Assert;
-import org.junit.Test;
- 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
  
@@ -43,58 +43,67 @@ public class IPv6AddressMatchExprMacroTest extends MacroTestBase
   @Test
   public void testTooFewArgs()
   {
-    expectException(ExpressionValidationException.class, "requires 2 arguments");
-    apply(Collections.emptyList());
+    assertException(
+        ExpressionValidationException.class,
+        "requires 2 arguments",
+        () -> apply(Collections.emptyList())
+    );
   }
  
   @Test
   public void testTooManyArgs()
   {
     Expr extraArgument = ExprEval.ofString("An extra argument").toExpr();
-    expectException(ExpressionValidationException.class, "requires 2 arguments");
-    apply(Arrays.asList(IPV6, IPV6_CIDR, extraArgument));
+    assertException(
+        ExpressionValidationException.class,
+        "requires 2 arguments",
+        () -> apply(Arrays.asList(IPV6, IPV6_CIDR, extraArgument))
+    );
   }
  
   @Test
   public void testSubnetArgInvalid()
   {
-    expectException(ExpressionProcessingException.class, "Function[ipv6_match] failed to parse address");
-    Expr invalidSubnet = ExprEval.ofString("201:ef:168::/invalid").toExpr();
-    apply(Arrays.asList(IPV6, invalidSubnet));
+    final Expr invalidSubnet = ExprEval.ofString("201:ef:168::/invalid").toExpr();
+    assertException(
+        ExpressionProcessingException.class,
+        "Function[ipv6_match] failed to parse address",
+        () -> apply(Arrays.asList(IPV6, invalidSubnet))
+    );
   }
 
   @Test
   public void testNullStringArg()
   {
     Expr nullString = ExprEval.ofString(null).toExpr();
-    Assert.assertFalse(eval(nullString, IPV6_CIDR));
+    Assertions.assertFalse(eval(nullString, IPV6_CIDR));
   }
 
   @Test
   public void testMatchingStringArgIPv6()
   {
-    Assert.assertTrue(eval(IPV6, IPV6_CIDR));
+    Assertions.assertTrue(eval(IPV6, IPV6_CIDR));
   }
  
   @Test
   public void testNotMatchingStringArgIPv6()
   {
     Expr nonMatchingIpv6 = ExprEval.ofString("2002:ef:168::").toExpr();
-    Assert.assertFalse(eval(nonMatchingIpv6, IPV6_CIDR));
+    Assertions.assertFalse(eval(nonMatchingIpv6, IPV6_CIDR));
   }
  
   @Test
   public void testNotIpAddress()
   {
     Expr notIpAddress = ExprEval.ofString("druid.apache.org").toExpr();
-    Assert.assertFalse(eval(notIpAddress, IPV6_CIDR));
+    Assertions.assertFalse(eval(notIpAddress, IPV6_CIDR));
   }
  
   @Test
   public void testInclusive()
   {
     Expr subnet = IPV6_CIDR;
-    Assert.assertTrue(eval(IPV6, subnet));
+    Assertions.assertTrue(eval(IPV6, subnet));
   }
 
   private boolean eval(Expr... args)

--- a/processing/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/LookupExprMacroTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainer;
 import org.apache.druid.query.lookup.LookupExtractorFactoryContainerProvider;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -66,27 +66,30 @@ public class LookupExprMacroTest extends MacroTestBase
   @Test
   public void testTooFewArgs()
   {
-    expectException(IllegalArgumentException.class, "Function[lookup] requires 2 to 3 arguments");
-    apply(Collections.emptyList());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[lookup] requires 2 to 3 arguments",
+        () -> apply(Collections.emptyList())
+    );
   }
 
   @Test
   public void testNonLiteralLookupName()
   {
-    expectException(
+    assertException(
         IllegalArgumentException.class,
-        "Function[lookup] second argument must be a registered lookup name"
+        "Function[lookup] second argument must be a registered lookup name",
+        () -> apply(getArgs(Lists.newArrayList("1", new ArrayList<String>())))
     );
-    apply(getArgs(Lists.newArrayList("1", new ArrayList<String>())));
   }
 
   @Test
   public void testValidCalls()
   {
-    Assert.assertNotNull(apply(getArgs(Lists.newArrayList("1", "test_lookup"))));
-    Assert.assertNotNull(apply(getArgs(Lists.newArrayList("null", "test_lookup"))));
-    Assert.assertNotNull(apply(getArgs(Lists.newArrayList("1", "test_lookup", null))));
-    Assert.assertNotNull(apply(getArgs(Lists.newArrayList("1", "test_lookup", "N/A"))));
+    Assertions.assertNotNull(apply(getArgs(Lists.newArrayList("1", "test_lookup"))));
+    Assertions.assertNotNull(apply(getArgs(Lists.newArrayList("null", "test_lookup"))));
+    Assertions.assertNotNull(apply(getArgs(Lists.newArrayList("1", "test_lookup", null))));
+    Assertions.assertNotNull(apply(getArgs(Lists.newArrayList("1", "test_lookup", "N/A"))));
   }
 
   private List<Expr> getArgs(List<Object> args)

--- a/processing/src/test/java/org/apache/druid/query/expression/MacroTestBase.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/MacroTestBase.java
@@ -20,23 +20,19 @@
 package org.apache.druid.query.expression;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.druid.error.ExceptionMatcher;
 import org.apache.druid.math.expr.Expr;
 import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExprMacroTable;
 import org.apache.druid.math.expr.Parser;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 public abstract class MacroTestBase extends InitializedNullHandlingTest
 {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   private final ExprMacroTable.ExprMacro macro;
 
   protected MacroTestBase(ExprMacroTable.ExprMacro macro)
@@ -44,10 +40,15 @@ public abstract class MacroTestBase extends InitializedNullHandlingTest
     this.macro = macro;
   }
 
-  protected void expectException(Class<? extends Throwable> type, String message)
+  protected void assertException(
+      Class<? extends Throwable> type,
+      String message,
+      ExceptionMatcher.ThrowingSupplier action
+  )
   {
-    expectedException.expect(type);
-    expectedException.expectMessage(message);
+    ExceptionMatcher.of(type)
+                    .expectMessageContains(message)
+                    .assertThrowsAndMatches(action);
   }
 
   protected Expr apply(final List<Expr> args)
@@ -91,7 +92,7 @@ public abstract class MacroTestBase extends InitializedNullHandlingTest
     final GuiceExprMacroTable macroTable = new GuiceExprMacroTable(ImmutableSet.of(wrappedMacro));
     final Expr expr = Parser.parse(expression, macroTable);
 
-    Assert.assertTrue("Calls made to macro.apply", wrappedMacro.calls.get() > 0);
+    Assertions.assertTrue(wrappedMacro.calls.get() > 0, "Calls made to macro.apply");
 
     return expr.eval(bindings);
   }

--- a/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/NestedDataExpressionsTest.java
@@ -36,9 +36,9 @@ import org.apache.druid.segment.nested.StructuredData;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.internal.matchers.ThrowableMessageMatcher;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -107,13 +107,13 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("json_object('x',100,'y',200,'z',300)", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals(NEST, eval.value());
+    Assertions.assertEquals(NEST, eval.value());
 
     expr = Parser.parse("json_object('x',array('a','b','c'),'y',json_object('a','hello','b','world'))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
     // decompose because of array equals
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) ((Map) eval.value()).get("x"));
-    Assert.assertEquals(ImmutableMap.of("a", "hello", "b", "world"), ((Map) eval.value()).get("y"));
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) ((Map) eval.value()).get("x"));
+    Assertions.assertEquals(ImmutableMap.of("a", "hello", "b", "world"), ((Map) eval.value()).get("y"));
   }
 
   @Test
@@ -121,33 +121,33 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("json_merge('{\"a\":\"x\"}','{\"b\":\"y\"}')", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"a\":\"x\",\"b\":\"y\"}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"a\":\"x\",\"b\":\"y\"}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge('{\"a\":\"x\"}', null)", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge('{\"a\":\"x\"}','{\"b\":\"y\"}','{\"c\":[1,2,3]}')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"a\":\"x\",\"b\":\"y\",\"c\":[1,2,3]}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"a\":\"x\",\"b\":\"y\",\"c\":[1,2,3]}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge(json_object('a', 'x'),json_object('b', 'y'))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"a\":\"x\",\"b\":\"y\"}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"a\":\"x\",\"b\":\"y\"}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge('{\"a\":\"x\"}',json_merge('{\"a\":\"z\"}','{\"a\":\"y\"}'))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"a\":\"y\"}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"a\":\"y\"}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge('[\"a\", \"b\"]', '[\"c\", \"d\"]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("[\"a\",\"b\",\"c\",\"d\"]", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("[\"a\",\"b\",\"c\",\"d\"]", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
   }
 
   @Test
@@ -155,162 +155,162 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("json_merge(null, null)", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge(null, '{\"a\":\"x\"}')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge('{\"a\":\"x\"}', null)", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge('{\"a\":\"x\"}', null, null, null)", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge('{\"a\":\"x\"}', null, null, json_object())", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge(json_object(), json_object(), json_object())", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge(json_object(), json_object(), json_object(), null)", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("null", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge(json_object(), json_object(), json_object(), coalesce(null, '{}'))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_merge(coalesce(null, '{}'), '{\"a\":\"x\"}')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"a\":\"x\"}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"a\":\"x\"}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
   }
 
   @Test
   public void testJsonMergeWithNonObjectArguments()
   {
     // Test with strings that don't parse as JSON
-    RuntimeException e = Assert.assertThrows(
+    RuntimeException e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('foo', '{\"b\":\"y\"}')", MACRO_TABLE).eval(inputBindings)
     );
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("bad string input")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("bad string input")));
 
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('{\"a\":\"x\"}', 'foo')", MACRO_TABLE).eval(inputBindings)
     );
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("bad string input")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("bad string input")));
 
     // Test with strings that do parse as JSON but are not objects.
     // String 'null' is treated the same as an actual null in the first parameter.
     Expr expr = Parser.parse("json_merge('null', '{\"a\":\"x\"}')", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertNull(eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     // String 'null' is treated the same as an actual null in the second parameter.
     expr = Parser.parse("json_merge('{\"a\":\"x\"}', 'null')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertNull(eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     // When first argument is a JSON string, can't merge objects into it
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('\"foo\"', '{\"b\":\"y\"}')", MACRO_TABLE).eval(inputBindings)
     );
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("bad string input")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("bad string input")));
 
     // When second argument is a JSON string, Jackson's merge fails trying to update object with string
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('{\"a\":\"x\"}', '\"foo\"')", MACRO_TABLE).eval(inputBindings)
     );
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("bad string input")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("bad string input")));
 
     // When first argument is a JSON number string, can't merge objects into it
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('\"3\"', '{\"b\":\"y\"}')", MACRO_TABLE).eval(inputBindings)
     );
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("bad string input")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("bad string input")));
 
     // When second argument is a JSON number string, Jackson's merge fails trying to update object with string
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('{\"a\":\"x\"}', '\"3\"')", MACRO_TABLE).eval(inputBindings)
     );
-    MatcherAssert.assertThat(e, ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("bad string input")));
+    MatcherAssert.assertThat(e, Matchers.hasProperty("message", CoreMatchers.containsString("bad string input")));
 
     // Test with non-string arguments (numbers) - these throw validation exceptions
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge(3, '{\"b\":\"y\"}')", MACRO_TABLE).eval(inputBindings)
     );
     MatcherAssert.assertThat(e,
-                             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
+                             Matchers.hasProperty("message", CoreMatchers.containsString(
                                  "invalid input expected STRING but got LONG"))
     );
 
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('{\"a\":\"x\"}', 3)", MACRO_TABLE).eval(inputBindings)
     );
     MatcherAssert.assertThat(e,
-                             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
+                             Matchers.hasProperty("message", CoreMatchers.containsString(
                                  "invalid input expected STRING but got LONG"))
     );
 
     // Test with arrays - these should fail as they're not string or complex types
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge([1, 2, 3], '{\"b\":\"y\"}')", MACRO_TABLE).eval(inputBindings)
     );
     MatcherAssert.assertThat(e,
-                             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
+                             Matchers.hasProperty("message", CoreMatchers.containsString(
                                  "invalid input expected STRING but got ARRAY<LONG>"))
     );
 
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('{\"a\":\"x\"}', [1, 2, 3])", MACRO_TABLE).eval(inputBindings)
     );
     MatcherAssert.assertThat(e,
-                             ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString(
+                             Matchers.hasProperty("message", CoreMatchers.containsString(
                                  "invalid input expected STRING but got ARRAY<LONG>"))
     );
 
     // Test mixing JSON string arrays with objects - these fail because you can't merge objects into arrays or vice versa
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('[\"a\", \"b\"]', '{\"c\":\"d\"}')", MACRO_TABLE).eval(inputBindings)
     );
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("expected array but got object"))
+        Matchers.hasProperty("message", CoreMatchers.containsString("expected array but got object"))
     );
 
-    e = Assert.assertThrows(
+    e = Assertions.assertThrows(
         ExpressionProcessingException.class,
         () -> Parser.parse("json_merge('{\"a\":\"x\"}', '[\"c\", \"d\"]')", MACRO_TABLE).eval(inputBindings)
     );
     MatcherAssert.assertThat(
         e,
-        ThrowableMessageMatcher.hasMessage(CoreMatchers.containsString("expected object but got array"))
+        Matchers.hasProperty("message", CoreMatchers.containsString("expected object but got array"))
     );
   }
 
@@ -330,11 +330,11 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
 
     Expr expr = Parser.parse("json_merge(json_object(), json_object(json_value(attr, '$.key'), json_value(attr, '$.value')))", MACRO_TABLE);
     ExprEval eval = expr.eval(input1);
-    Assert.assertEquals("{\"blah\":\"blahblah\"}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"blah\":\"blahblah\"}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
     eval = expr.eval(input2);
-    Assert.assertEquals("{\"blah2\":\"blahblah2\"}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"blah2\":\"blahblah2\"}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
   }
 
   @Test
@@ -342,27 +342,27 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("json_keys(nest, '$.')", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"x", "y", "z"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"x", "y", "z"}, (Object[]) eval.value());
 
 
     expr = Parser.parse("json_keys(nester, '$.x')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"0", "1", "2"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"0", "1", "2"}, (Object[]) eval.value());
 
     expr = Parser.parse("json_keys(nester, '$.y')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"a", "b"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"a", "b"}, (Object[]) eval.value());
 
     expr = Parser.parse("json_keys(nester, '$.x.a')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_keys(nester, '$.x.a.b')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
   }
 
   @Test
@@ -370,13 +370,13 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("json_paths(nest)", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"$.x", "$.y", "$.z"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"$.x", "$.y", "$.z"}, (Object[]) eval.value());
 
     expr = Parser.parse("json_paths(nester)", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
-    Assert.assertArrayEquals(new Object[]{"$.x", "$.y.a", "$.y.b"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"$.x", "$.y.a", "$.y.b"}, (Object[]) eval.value());
   }
 
   @Test
@@ -384,127 +384,127 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("json_value(nest, '$.x')", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals(100L, eval.value());
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(100L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
 
     expr = Parser.parse("json_value(nester, '$.x')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nester, '$.x[1]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("b", eval.value());
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("b", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
 
     expr = Parser.parse("json_value(nester, '$.x[23]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_value(nester, '$.x[1].b')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_value(nester, '$.y[1]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_value(nester, '$.y.a')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("hello", eval.value());
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("hello", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
 
     expr = Parser.parse("json_value(nester, '$.y.a', 'LONG')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertNull(eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
 
     expr = Parser.parse("json_value(nester, '$.y.a.b.c[12]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_value(long, '$')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(1234L, eval.value());
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(1234L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
 
     expr = Parser.parse("json_value(long, '$', 'STRING')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("1234", eval.value());
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("1234", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
 
     expr = Parser.parse("json_value(nest, '$.x')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(100L, eval.value());
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(100L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
 
     expr = Parser.parse("json_value(nest, '$.x', 'DOUBLE')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(100.0, eval.value());
-    Assert.assertEquals(ExpressionType.DOUBLE, eval.type());
+    Assertions.assertEquals(100.0, eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE, eval.type());
 
     expr = Parser.parse("json_value(nest, '$.x', 'STRING')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("100", eval.value());
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("100", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a1')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{1L, null, 3L}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, null, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a1', 'ARRAY<STRING>')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{"1", null, "3"}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"1", null, "3"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a1', 'ARRAY<DOUBLE>')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{1.0, null, 3.0}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.0, null, 3.0}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a2')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{1.1, null, 3.3}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1.1, null, 3.3}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a2', 'ARRAY<LONG>')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{1L, null, 3L}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{1L, null, 3L}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a2', 'ARRAY<STRING>')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{"1.1", null, "3.3"}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"1.1", null, "3.3"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a3')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{"a", null, "b", "100"}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"a", null, "b", "100"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nesterer, '$.x.a3', 'ARRAY<LONG>')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new Object[]{null, null, null, 100L},
         (Object[]) eval.value()
     );
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, eval.type());
 
     // arrays of objects are not primitive
     expr = Parser.parse("json_value(nesterer, '$.y')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_value(json_object('k1', array(1,2,3), 'k2', array('a', 'b', 'c')), '$.k1', 'ARRAY<STRING>')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"1", "2", "3"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
 
     expr = Parser.parse("json_value(nester, array_offset(json_paths(nester), 0))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
+    Assertions.assertArrayEquals(new Object[]{"a", "b", "c"}, (Object[]) eval.value());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, eval.type());
   }
 
   @Test
@@ -512,49 +512,49 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("json_query(nest, '$.x')", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals(100L, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(100L, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_query(nester, '$.x')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(NESTER.get("x"), eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(NESTER.get("x"), eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_query(nester, '$.x[1]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("b", eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("b", eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_query(nester, '$.x[23]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_query(nester, '$.x[1].b')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_query(nester, '$.y[1]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_query(nester, '$.y.a')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("hello", eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("hello", eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_query(nester, '$.y.a.b.c[12]')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertNull(eval.value());
+    Assertions.assertNull(eval.value());
 
     expr = Parser.parse("json_query(long, '$')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(1234L, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(1234L, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_query(nester, array_offset(json_paths(nester), 0))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(NESTER.get("x"), eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(NESTER.get("x"), eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
   }
 
   @Test
@@ -564,44 +564,44 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
 
     Expr expr = Parser.parse("json_query_array(nest, '$.x')", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(new Object[]{100L}, (Object[]) eval.value());
-    Assert.assertEquals(nestedArray, eval.type());
+    Assertions.assertArrayEquals(new Object[]{100L}, (Object[]) eval.value());
+    Assertions.assertEquals(nestedArray, eval.type());
 
     expr = Parser.parse("json_query_array(nester, '$.x')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(((List) NESTER.get("x")).toArray(), (Object[]) eval.value());
-    Assert.assertEquals(nestedArray, eval.type());
+    Assertions.assertArrayEquals(((List) NESTER.get("x")).toArray(), (Object[]) eval.value());
+    Assertions.assertEquals(nestedArray, eval.type());
 
     expr = Parser.parse("json_query_array(nester, array_offset(json_paths(nester), 0))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(((List) NESTER.get("x")).toArray(), (Object[]) eval.value());
-    Assert.assertEquals(nestedArray, eval.type());
+    Assertions.assertArrayEquals(((List) NESTER.get("x")).toArray(), (Object[]) eval.value());
+    Assertions.assertEquals(nestedArray, eval.type());
 
     expr = Parser.parse("json_query_array(nesterer, '$.y')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertArrayEquals(((List) NESTERER.get("y")).toArray(), (Object[]) eval.value());
-    Assert.assertEquals(nestedArray, eval.type());
+    Assertions.assertArrayEquals(((List) NESTERER.get("y")).toArray(), (Object[]) eval.value());
+    Assertions.assertEquals(nestedArray, eval.type());
 
     expr = Parser.parse("array_length(json_query_array(nesterer, '$.y'))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(3L, eval.value());
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(3L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
 
     expr = Parser.parse("array_contains(json_query_array(nest, '$.x'), 100)", MACRO_TABLE);
     expr = expr.asSingleThreaded(inputBindings);
-    Assert.assertEquals(1L, expr.eval(inputBindings).value());
+    Assertions.assertEquals(1L, expr.eval(inputBindings).value());
 
     expr = Parser.parse("array_contains(json_query_array(nest, '$.x'), 101)", MACRO_TABLE);
     expr = expr.asSingleThreaded(inputBindings);
-    Assert.assertEquals(0L, expr.eval(inputBindings).value());
+    Assertions.assertEquals(0L, expr.eval(inputBindings).value());
 
     expr = Parser.parse("array_overlap(json_query_array(nest, '$.x'), [100, 101])", MACRO_TABLE);
     expr = expr.asSingleThreaded(inputBindings);
-    Assert.assertEquals(1L, expr.eval(inputBindings).value());
+    Assertions.assertEquals(1L, expr.eval(inputBindings).value());
 
     expr = Parser.parse("array_overlap(json_query_array(nest, '$.x'), [101, 102])", MACRO_TABLE);
     expr = expr.asSingleThreaded(inputBindings);
-    Assert.assertEquals(0L, expr.eval(inputBindings).value());
+    Assertions.assertEquals(0L, expr.eval(inputBindings).value());
   }
 
   @Test
@@ -609,45 +609,45 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("parse_json(null)", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals(null, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(null, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("parse_json('null')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(null, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(null, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
-    Assert.assertThrows(ExpressionProcessingException.class, () -> Parser.parse("parse_json('{')", MACRO_TABLE));
+    Assertions.assertThrows(ExpressionProcessingException.class, () -> Parser.parse("parse_json('{')", MACRO_TABLE));
     expr = Parser.parse("try_parse_json('{')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(null, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(null, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
-    Assert.assertThrows(ExpressionProcessingException.class, () -> Parser.parse("parse_json('hello world')", MACRO_TABLE));
+    Assertions.assertThrows(ExpressionProcessingException.class, () -> Parser.parse("parse_json('hello world')", MACRO_TABLE));
     expr = Parser.parse("try_parse_json('hello world')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(null, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(null, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("parse_json('\"hello world\"')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("hello world", eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("hello world", eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("parse_json('1')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(1, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(1, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("parse_json('true')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(true, eval.value());
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(true, eval.value());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("parse_json('{\"foo\":1}')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"foo\":1}", JSON_MAPPER.writeValueAsString(eval.value()));
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals("{\"foo\":1}", JSON_MAPPER.writeValueAsString(eval.value()));
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
   }
 
   @Test
@@ -655,29 +655,29 @@ public class NestedDataExpressionsTest extends InitializedNullHandlingTest
   {
     Expr expr = Parser.parse("to_json_string(nest)", MACRO_TABLE);
     ExprEval eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"x\":100,\"y\":200,\"z\":300}", eval.value());
-    Assert.assertEquals(ExpressionType.STRING, eval.type());
+    Assertions.assertEquals("{\"x\":100,\"y\":200,\"z\":300}", eval.value());
+    Assertions.assertEquals(ExpressionType.STRING, eval.type());
 
     expr = Parser.parse("parse_json(to_json_string(nest))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
     // round trip ends up as integers initially...
     for (String key : NEST.keySet()) {
       Map val = (Map) eval.value();
-      Assert.assertEquals(NEST.get(key), ((Integer) val.get(key)).longValue());
+      Assertions.assertEquals(NEST.get(key), ((Integer) val.get(key)).longValue());
     }
-    Assert.assertEquals(ExpressionType.NESTED_DATA, eval.type());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, eval.type());
 
     expr = Parser.parse("json_value(parse_json('{\"x\":100,\"y\":200,\"z\":300}'), '$.x')", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals(100L, eval.value());
-    Assert.assertEquals(ExpressionType.LONG, eval.type());
+    Assertions.assertEquals(100L, eval.value());
+    Assertions.assertEquals(ExpressionType.LONG, eval.type());
 
     expr = Parser.parse("to_json_string(json_object('x', nestWrapped))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"x\":{\"x\":100,\"y\":200,\"z\":300}}", eval.value());
+    Assertions.assertEquals("{\"x\":{\"x\":100,\"y\":200,\"z\":300}}", eval.value());
 
     expr = Parser.parse("to_json_string(json_object('xs', array(nest, nestWrapped)))", MACRO_TABLE);
     eval = expr.eval(inputBindings);
-    Assert.assertEquals("{\"xs\":[{\"x\":100,\"y\":200,\"z\":300},{\"x\":100,\"y\":200,\"z\":300}]}", eval.value());
+    Assertions.assertEquals("{\"xs\":[{\"x\":100,\"y\":200,\"z\":300},{\"x\":100,\"y\":200,\"z\":300}]}", eval.value());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/RegexpExtractExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/RegexpExtractExprMacroTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RegexpExtractExprMacroTest extends MacroTestBase
 {
@@ -38,22 +38,28 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
   @Test
   public void testErrorZeroArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_extract] requires 2 or 3 arguments");
-    eval("regexp_extract()", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_extract] requires 2 or 3 arguments",
+        () -> eval("regexp_extract()", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testErrorFourArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_extract] requires 2 or 3 arguments");
-    eval("regexp_extract('a', 'b', 'c', 'd')", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_extract] requires 2 or 3 arguments",
+        () -> eval("regexp_extract('a', 'b', 'c', 'd')", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testInvalidRegexpExtractPattern()
   {
     MatcherAssert.assertThat(
-        Assert.assertThrows(DruidException.class, () ->
+        Assertions.assertThrows(DruidException.class, () ->
             eval(
                 "regexp_extract('pod-1234-node', '[ab-0-9]')",
                 InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
@@ -73,7 +79,7 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
         "regexp_extract(a, 'f(.o)')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals("foo", result.value());
+    Assertions.assertEquals("foo", result.value());
   }
 
   @Test
@@ -83,7 +89,7 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
         "regexp_extract(a, 'f(.o)', 0)",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals("foo", result.value());
+    Assertions.assertEquals("foo", result.value());
   }
 
   @Test
@@ -93,20 +99,20 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
         "regexp_extract(a, 'f(.o)', 1)",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals("oo", result.value());
+    Assertions.assertEquals("oo", result.value());
   }
 
   @Test
   public void testMatchGroup2()
   {
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IndexOutOfBoundsException.class,
         () -> eval(
             "regexp_extract(a, 'f(.o)', 2)",
             InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
         )
     );
-    Assert.assertEquals("No group 2", t.getMessage());
+    Assertions.assertEquals("No group 2", t.getMessage());
   }
 
   @Test
@@ -116,7 +122,7 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
         "regexp_extract(a, 'f(.x)')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 
   @Test
@@ -126,19 +132,20 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
         "regexp_extract(a, '.o$')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals("oo", result.value());
+    Assertions.assertEquals("oo", result.value());
   }
 
   @Test
   public void testNullPattern()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_extract] pattern must be a string literal");
-
-    final ExprEval<?> result = eval(
-        "regexp_extract(a, null)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_extract] pattern must be a string literal",
+        () -> eval(
+            "regexp_extract(a, null)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+        )
     );
-    Assert.assertNull(result.value());
   }
 
   @Test
@@ -148,36 +155,43 @@ public class RegexpExtractExprMacroTest extends MacroTestBase
         "regexp_extract(a, '')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals("", result.value());
+    Assertions.assertEquals("", result.value());
   }
 
   @Test
   public void testNumericPattern()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_extract] pattern must be a string literal");
-    eval("regexp_extract(a, 1)", InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo"));
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_extract] pattern must be a string literal",
+        () -> eval("regexp_extract(a, 1)", InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo"))
+    );
   }
 
   @Test
   public void testNonLiteralPattern()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_extract] pattern must be a string literal");
-    eval("regexp_extract(a, a)", InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo"));
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_extract] pattern must be a string literal",
+        () -> eval("regexp_extract(a, a)", InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo"))
+    );
   }
 
   @Test
   public void testNullPatternOnNull()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_extract] pattern must be a string literal");
-
-    final ExprEval<?> result = eval("regexp_extract(a, null)", InputBindings.nilBindings());
-    Assert.assertNull(result.value());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_extract] pattern must be a string literal",
+        () -> eval("regexp_extract(a, null)", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testEmptyStringPatternOnNull()
   {
     final ExprEval<?> result = eval("regexp_extract(a, '')", InputBindings.nilBindings());
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/RegexpLikeExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/RegexpLikeExprMacroTest.java
@@ -25,8 +25,8 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RegexpLikeExprMacroTest extends MacroTestBase
 {
@@ -38,22 +38,28 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
   @Test
   public void testErrorZeroArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_like] requires 2 arguments");
-    eval("regexp_like()", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_like] requires 2 arguments",
+        () -> eval("regexp_like()", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testErrorThreeArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_like] requires 2 arguments");
-    eval("regexp_like('a', 'b', 'c')", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_like] requires 2 arguments",
+        () -> eval("regexp_like('a', 'b', 'c')", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testInvalidRegexpLikePattern()
   {
     MatcherAssert.assertThat(
-        Assert.assertThrows(
+        Assertions.assertThrows(
             DruidException.class,
             () -> eval("regexp_like('a', '[Ab-C]')", InputBindings.nilBindings())),
         DruidExceptionMatcher.invalidInput().expectMessageContains(
@@ -70,7 +76,7 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
         "regexp_like(a, 'f.o')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -83,7 +89,7 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
         "regexp_like(a, 'f.x')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(false).value(),
         result.value()
     );
@@ -92,15 +98,13 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
   @Test
   public void testNullPattern()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_like] pattern must be a STRING literal");
-
-    final ExprEval<?> result = eval(
-        "regexp_like(a, null)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
-    );
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_like] pattern must be a STRING literal",
+        () -> eval(
+            "regexp_like(a, null)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+        )
     );
   }
 
@@ -111,7 +115,7 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
         "regexp_like(a, '')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -120,15 +124,13 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
   @Test
   public void testNullPatternOnEmptyString()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_like] pattern must be a STRING literal");
-
-    final ExprEval<?> result = eval(
-        "regexp_like(a, null)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
-    );
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_like] pattern must be a STRING literal",
+        () -> eval(
+            "regexp_like(a, null)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
+        )
     );
   }
 
@@ -139,7 +141,7 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
         "regexp_like(a, '')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ExprEval.ofLongBoolean(true).value(),
         result.value()
     );
@@ -148,12 +150,10 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
   @Test
   public void testNullPatternOnNull()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_like] pattern must be a STRING literal");
-
-    final ExprEval<?> result = eval("regexp_like(a, null)", InputBindings.nilBindings());
-    Assert.assertEquals(
-        ExprEval.ofLongBoolean(true).value(),
-        result.value()
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_like] pattern must be a STRING literal",
+        () -> eval("regexp_like(a, null)", InputBindings.nilBindings())
     );
   }
 
@@ -161,6 +161,6 @@ public class RegexpLikeExprMacroTest extends MacroTestBase
   public void testEmptyStringPatternOnNull()
   {
     final ExprEval<?> result = eval("regexp_like(a, '')", InputBindings.nilBindings());
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/RegexpReplaceExprMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/RegexpReplaceExprMacroTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.math.expr.ExprEval;
 import org.apache.druid.math.expr.ExpressionType;
 import org.apache.druid.math.expr.InputBindings;
 import org.hamcrest.MatcherAssert;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class RegexpReplaceExprMacroTest extends MacroTestBase
 {
@@ -39,15 +39,18 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
   @Test
   public void testErrorZeroArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_replace] requires 3 arguments");
-    eval("regexp_replace()", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_replace] requires 3 arguments",
+        () -> eval("regexp_replace()", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testInvalidRegexpReplacePattern()
   {
     MatcherAssert.assertThat(
-        Assert.assertThrows(
+        Assertions.assertThrows(
             DruidException.class,
             () -> eval("regexp_replace(a, '[Ab-cd-0]', 'xyz')", InputBindings.nilBindings())),
         DruidExceptionMatcher.invalidInput().expectMessageContains(
@@ -60,27 +63,36 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
   @Test
   public void testErrorFourArguments()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_replace] requires 3 arguments");
-    eval("regexp_replace('a', 'b', 'c', 'd')", InputBindings.nilBindings());
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_replace] requires 3 arguments",
+        () -> eval("regexp_replace('a', 'b', 'c', 'd')", InputBindings.nilBindings())
+    );
   }
 
   @Test
   public void testErrorNonStringPattern()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_replace] pattern must be a string literal");
-    eval(
-        "regexp_replace(a, 1, 'x')",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_replace] pattern must be a string literal",
+        () -> eval(
+            "regexp_replace(a, 1, 'x')",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+        )
     );
   }
 
   @Test
   public void testErrorNonStringReplacement()
   {
-    expectException(IllegalArgumentException.class, "Function[regexp_replace] replacement must be a string literal");
-    eval(
-        "regexp_replace(a, 'x', 1)",
-        InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+    assertException(
+        IllegalArgumentException.class,
+        "Function[regexp_replace] replacement must be a string literal",
+        () -> eval(
+            "regexp_replace(a, 'x', 1)",
+            InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
+        )
     );
   }
 
@@ -92,7 +104,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
 
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 
   @Test
@@ -102,7 +114,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         "regexp_replace(a, 'f.x', 'beep')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals("foo", result.value());
+    Assertions.assertEquals("foo", result.value());
   }
 
   @Test
@@ -112,7 +124,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         "regexp_replace(a, '', 'x')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo")
     );
-    Assert.assertEquals("xfxoxox", result.value());
+    Assertions.assertEquals("xfxoxox", result.value());
   }
 
   @Test
@@ -122,7 +134,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         "regexp_replace(a, '^foo\\\\nbar$', 'xxx')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo\nbar")
     );
-    Assert.assertEquals("xxx", result.value());
+    Assertions.assertEquals("xxx", result.value());
   }
 
   @Test
@@ -132,7 +144,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         "regexp_replace(a, '^foo\\\\nbar$', 'xxx')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "foo\nbarz")
     );
-    Assert.assertEquals("foo\nbarz", result.value());
+    Assertions.assertEquals("foo\nbarz", result.value());
   }
 
   @Test
@@ -143,7 +155,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
     );
 
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 
   @Test
@@ -153,7 +165,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         "regexp_replace(a, '', 'x')",
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "")
     );
-    Assert.assertEquals("x", result.value());
+    Assertions.assertEquals("x", result.value());
   }
 
   @Test
@@ -169,7 +181,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
             )
         )
     );
-    Assert.assertEquals("x", result.value());
+    Assertions.assertEquals("x", result.value());
   }
 
   @Test
@@ -177,7 +189,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
   {
     final ExprEval<?> result = eval("regexp_replace(a, null, 'x')", InputBindings.nilBindings());
 
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 
   @Test
@@ -190,7 +202,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         )
     );
 
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 
   @Test
@@ -198,7 +210,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
   {
     final ExprEval<?> result = eval("regexp_replace(a, '', 'x')", InputBindings.nilBindings());
 
-    Assert.assertNull(result.value());
+    Assertions.assertNull(result.value());
   }
 
   @Test
@@ -209,7 +221,7 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         InputBindings.forInputSupplier("a", ExpressionType.STRING, () -> "http://example.com/path/to?query")
     );
 
-    Assert.assertEquals("http://example.com/*/*", result.value());
+    Assertions.assertEquals("http://example.com/*/*", result.value());
   }
 
   @Test
@@ -229,6 +241,6 @@ public class RegexpReplaceExprMacroTest extends MacroTestBase
         )
     );
 
-    Assert.assertEquals("http://example.com/*/*", result.value());
+    Assertions.assertEquals("http://example.com/*/*", result.value());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/expression/TimestampShiftMacroTest.java
+++ b/processing/src/test/java/org/apache/druid/query/expression/TimestampShiftMacroTest.java
@@ -33,10 +33,11 @@ import org.joda.time.Days;
 import org.joda.time.Minutes;
 import org.joda.time.Months;
 import org.joda.time.Years;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Collections;
 
 public class TimestampShiftMacroTest extends MacroTestBase
@@ -52,43 +53,58 @@ public class TimestampShiftMacroTest extends MacroTestBase
   @Test
   public void testZeroArguments()
   {
-    expectException(IAE.class, "Function[timestamp_shift] requires 3 to 4 arguments");
-    apply(Collections.emptyList());
+    assertException(
+        IAE.class,
+        "Function[timestamp_shift] requires 3 to 4 arguments",
+        () -> apply(Collections.emptyList())
+    );
   }
 
   @Test
   public void testOneArguments()
   {
-    expectException(IAE.class, "Function[timestamp_shift] requires 3 to 4 arguments");
-    apply(
-        ImmutableList.of(
-            ExprEval.of(timestamp.getMillis()).toExpr()
-        ));
+    assertException(
+        IAE.class,
+        "Function[timestamp_shift] requires 3 to 4 arguments",
+        () -> apply(
+            ImmutableList.of(
+                ExprEval.of(timestamp.getMillis()).toExpr()
+            )
+        )
+    );
   }
 
   @Test
   public void testTwoArguments()
   {
-    expectException(IAE.class, "Function[timestamp_shift] requires 3 to 4 arguments");
-    apply(
-        ImmutableList.of(
-            ExprEval.of(timestamp.getMillis()).toExpr(),
-            ExprEval.ofString("P1M").toExpr()
-        ));
+    assertException(
+        IAE.class,
+        "Function[timestamp_shift] requires 3 to 4 arguments",
+        () -> apply(
+            ImmutableList.of(
+                ExprEval.of(timestamp.getMillis()).toExpr(),
+                ExprEval.ofString("P1M").toExpr()
+            )
+        )
+    );
   }
 
   @Test
   public void testMoreThanFourArguments()
   {
-    expectException(IAE.class, "Function[timestamp_shift] requires 3 to 4 arguments");
-    apply(
-        ImmutableList.of(
-            ExprEval.of(timestamp.getMillis()).toExpr(),
-            ExprEval.ofString("P1M").toExpr(),
-            ExprEval.ofString("1").toExpr(),
-            ExprEval.ofString("+08:00").toExpr(),
-            ExprEval.ofString("extra").toExpr()
-        ));
+    assertException(
+        IAE.class,
+        "Function[timestamp_shift] requires 3 to 4 arguments",
+        () -> apply(
+            ImmutableList.of(
+                ExprEval.of(timestamp.getMillis()).toExpr(),
+                ExprEval.ofString("P1M").toExpr(),
+                ExprEval.ofString("1").toExpr(),
+                ExprEval.ofString("+08:00").toExpr(),
+                ExprEval.ofString("extra").toExpr()
+            )
+        )
+    );
   }
 
   @Test
@@ -102,7 +118,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
             ExprEval.of(step).toExpr()
         ));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         timestamp.withPeriodAdded(Months.ONE, step).getMillis(),
         expr.eval(InputBindings.nilBindings()).asLong()
     );
@@ -119,7 +135,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
             ExprEval.of(step).toExpr()
         ));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         timestamp.withPeriodAdded(Months.ONE, step).getMillis(),
         expr.eval(InputBindings.nilBindings()).asLong()
     );
@@ -136,7 +152,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
             ExprEval.of(step).toExpr()
         ));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         timestamp.withPeriodAdded(Months.ONE, step).getMillis(),
         expr.eval(InputBindings.nilBindings()).asLong()
     );
@@ -152,7 +168,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
             ExprEval.of(1).toExpr()
         ));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         timestamp.withPeriodAdded(Minutes.ONE, 1).getMillis(),
         expr.eval(InputBindings.nilBindings()).asLong()
     );
@@ -168,7 +184,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
             ExprEval.of(1).toExpr()
         ));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         timestamp.withPeriodAdded(Days.ONE, 1).getMillis(),
         expr.eval(InputBindings.nilBindings()).asLong()
     );
@@ -185,7 +201,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
             ExprEval.ofString("America/Los_Angeles").toExpr()
         ));
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         timestamp.toDateTime(DateTimes.inferTzFromString("America/Los_Angeles")).withPeriodAdded(Years.ONE, 1).getMillis(),
         expr.eval(InputBindings.nilBindings()).asLong()
     );
@@ -204,7 +220,7 @@ public class TimestampShiftMacroTest extends MacroTestBase
         ));
 
     final int step = 3;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         timestamp.toDateTime(DateTimes.inferTzFromString("America/Los_Angeles")).withPeriodAdded(Years.ONE, step).getMillis(),
         expr.eval(new Expr.ObjectBinding()
         {
@@ -240,6 +256,6 @@ public class TimestampShiftMacroTest extends MacroTestBase
         )
     );
 
-    Assert.assertNull(expr.eval(InputBindings.nilBindings()).value());
+    Assertions.assertNull(expr.eval(InputBindings.nilBindings()).value());
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/BoundDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/BoundDimFilterTest.java
@@ -30,20 +30,21 @@ import org.apache.druid.guice.annotations.Json;
 import org.apache.druid.query.extraction.ExtractionFn;
 import org.apache.druid.query.extraction.RegexDimExtractionFn;
 import org.apache.druid.query.ordering.StringComparators;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.util.Arrays;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class BoundDimFilterTest
 {
   private static final ExtractionFn EXTRACTION_FN = new RegexDimExtractionFn(".*", false, null);
 
-  @Parameterized.Parameters
   public static Iterable<Object[]> constructorFeeder()
   {
 
@@ -83,7 +84,7 @@ public class BoundDimFilterTest
     ObjectMapper mapper = defaultInjector.getInstance(Key.get(ObjectMapper.class, Json.class));
     String serBetweenDimFilter = mapper.writeValueAsString(boundDimFilter);
     BoundDimFilter actualBoundDimFilter = mapper.readerFor(DimFilter.class).readValue(serBetweenDimFilter);
-    Assert.assertEquals(boundDimFilter, actualBoundDimFilter);
+    Assertions.assertEquals(boundDimFilter, actualBoundDimFilter);
   }
 
   @Test
@@ -91,14 +92,14 @@ public class BoundDimFilterTest
   {
     BoundDimFilter boundDimFilter = new BoundDimFilter("dimension", "12", "15", null, null, true, null, StringComparators.ALPHANUMERIC);
     BoundDimFilter boundDimFilterCopy = new BoundDimFilter("dimension", "12", "15", false, false, true, null, StringComparators.ALPHANUMERIC);
-    Assert.assertArrayEquals(boundDimFilter.getCacheKey(), boundDimFilterCopy.getCacheKey());
+    Assertions.assertArrayEquals(boundDimFilter.getCacheKey(), boundDimFilterCopy.getCacheKey());
     BoundDimFilter anotherBoundDimFilter = new BoundDimFilter("dimension", "12", "15", true, null, false, null, StringComparators.LEXICOGRAPHIC);
-    Assert.assertFalse(Arrays.equals(anotherBoundDimFilter.getCacheKey(), boundDimFilter.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(anotherBoundDimFilter.getCacheKey(), boundDimFilter.getCacheKey()));
 
     BoundDimFilter boundDimFilterWithExtract = new BoundDimFilter("dimension", "12", "15", null, null, true, EXTRACTION_FN, StringComparators.ALPHANUMERIC);
     BoundDimFilter boundDimFilterWithExtractCopy = new BoundDimFilter("dimension", "12", "15", false, false, true, EXTRACTION_FN, StringComparators.ALPHANUMERIC);
-    Assert.assertFalse(Arrays.equals(boundDimFilter.getCacheKey(), boundDimFilterWithExtract.getCacheKey()));
-    Assert.assertArrayEquals(boundDimFilterWithExtract.getCacheKey(), boundDimFilterWithExtractCopy.getCacheKey());
+    Assertions.assertFalse(Arrays.equals(boundDimFilter.getCacheKey(), boundDimFilterWithExtract.getCacheKey()));
+    Assertions.assertArrayEquals(boundDimFilterWithExtract.getCacheKey(), boundDimFilterWithExtractCopy.getCacheKey());
   }
 
   @Test
@@ -107,13 +108,13 @@ public class BoundDimFilterTest
     BoundDimFilter boundDimFilter = new BoundDimFilter("dimension", "12", "15", null, null, true, null, StringComparators.ALPHANUMERIC);
     BoundDimFilter boundDimFilterWithExtract = new BoundDimFilter("dimension", "12", "15", null, null, true, EXTRACTION_FN, StringComparators.ALPHANUMERIC);
 
-    Assert.assertNotEquals(boundDimFilter.hashCode(), boundDimFilterWithExtract.hashCode());
+    Assertions.assertNotEquals(boundDimFilter.hashCode(), boundDimFilterWithExtract.hashCode());
   }
 
   @Test
   public void testGetRequiredColumns()
   {
     BoundDimFilter boundDimFilter = new BoundDimFilter("dimension", "12", "15", null, null, true, null, StringComparators.ALPHANUMERIC);
-    Assert.assertEquals(boundDimFilter.getRequiredColumns(), Sets.newHashSet("dimension"));
+    Assertions.assertEquals(boundDimFilter.getRequiredColumns(), Sets.newHashSet("dimension"));
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/InDimFilterTest.java
@@ -40,12 +40,12 @@ import org.apache.druid.segment.index.BitmapColumnIndex;
 import org.apache.druid.segment.index.semantic.StringValueSetIndexes;
 import org.apache.druid.segment.index.semantic.Utf8ValueSetIndexes;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.IOException;
@@ -56,6 +56,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class InDimFilterTest extends InitializedNullHandlingTest
 {
   private ObjectMapper mapper = new DefaultObjectMapper();
@@ -63,15 +65,12 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   private final String serializedFilter =
       "{\"type\":\"in\",\"dimension\":\"dimTest\",\"values\":[\"bad\",\"good\"]}";
 
-  @Rule
-  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
-
   @Test
   public void testDeserialization() throws IOException
   {
     final InDimFilter actualInDimFilter = mapper.readerFor(DimFilter.class).readValue(serializedFilter);
     final InDimFilter expectedInDimFilter = new InDimFilter("dimTest", Arrays.asList("good", "bad"), null);
-    Assert.assertEquals(expectedInDimFilter, actualInDimFilter);
+    Assertions.assertEquals(expectedInDimFilter, actualInDimFilter);
   }
 
   @Test
@@ -79,7 +78,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter dimInFilter = new InDimFilter("dimTest", Arrays.asList("good", "bad"), null);
     final String actualSerializedFilter = mapper.writeValueAsString(dimInFilter);
-    Assert.assertEquals(serializedFilter, actualSerializedFilter);
+    Assertions.assertEquals(serializedFilter, actualSerializedFilter);
   }
 
   @Test
@@ -88,7 +87,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final Set<String> values = new InDimFilter.ValuesSet();
     values.addAll(Arrays.asList("v1", "v2", "v3"));
     final InDimFilter filter = new InDimFilter("dim", values);
-    Assert.assertSame(values, filter.getValues());
+    Assertions.assertSame(values, filter.getValues());
   }
 
   @Test
@@ -96,8 +95,8 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter.ValuesSet values = InDimFilter.ValuesSet.copyOf(ImmutableSet.of("v1", "", "v3"));
     final InDimFilter filter = new InDimFilter("dim", values);
-    Assert.assertSame(values, filter.getValues());
-    Assert.assertEquals(Sets.newHashSet("v1", "", "v3"), filter.getValues());
+    Assertions.assertSame(values, filter.getValues());
+    Assertions.assertEquals(Sets.newHashSet("v1", "", "v3"), filter.getValues());
   }
 
   @Test
@@ -105,7 +104,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter dimFilter1 = new InDimFilter("dim", ImmutableList.of("v1", "v2"), null);
     final InDimFilter dimFilter2 = new InDimFilter("dim", ImmutableList.of("v2", "v1"), null);
-    Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter2.getCacheKey());
+    Assertions.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter2.getCacheKey());
   }
 
   @Test
@@ -114,7 +113,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final InDimFilter inDimFilter1 = new InDimFilter("dimTest", Arrays.asList(null, "abc"), null);
     final InDimFilter inDimFilter2 = new InDimFilter("dimTest", Arrays.asList("", "abc"), null);
 
-    Assert.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
   }
 
   @Test
@@ -126,9 +125,9 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final InDimFilter dimFilter3 = new InDimFilter("dim", ImmutableSortedSet.copyOf(Arrays.asList("v2", "v1")));
     reverseOrderSet.addAll(Arrays.asList("v1", "v2"));
     final InDimFilter dimFilter4 = new InDimFilter("dim", reverseOrderSet);
-    Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter2.getCacheKey());
-    Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter3.getCacheKey());
-    Assert.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter4.getCacheKey());
+    Assertions.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter2.getCacheKey());
+    Assertions.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter3.getCacheKey());
+    Assertions.assertArrayEquals(dimFilter1.getCacheKey(), dimFilter4.getCacheKey());
   }
 
   @Test
@@ -136,7 +135,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter inDimFilter1 = new InDimFilter("dimTest", Arrays.asList("good", "bad"), null);
     final InDimFilter inDimFilter2 = new InDimFilter("dimTest", Collections.singletonList("good,bad"), null);
-    Assert.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
   }
 
   @Test
@@ -144,7 +143,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter inDimFilter1 = new InDimFilter("dimTest", Arrays.asList(null, "abc"), null);
     final InDimFilter inDimFilter2 = new InDimFilter("dimTest", Arrays.asList("\0\0\0\0", "abc"), null);
-    Assert.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
   }
 
   @Test
@@ -152,7 +151,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter inDimFilter1 = new InDimFilter("dimTest", Arrays.asList("bar", "foo"), null);
     final InDimFilter inDimFilter2 = new InDimFilter("dimTest", Arrays.asList("barf", "oo"), null);
-    Assert.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
   }
 
   @Test
@@ -161,7 +160,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     RegexDimExtractionFn regexFn = new RegexDimExtractionFn(".*", false, null);
     final InDimFilter inDimFilter1 = new InDimFilter("dimTest", Arrays.asList("good", "bad"), regexFn);
     final InDimFilter inDimFilter2 = new InDimFilter("dimTest", Collections.singletonList("good,bad"), regexFn);
-    Assert.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(inDimFilter1.getCacheKey(), inDimFilter2.getCacheKey()));
   }
 
   @Test
@@ -171,7 +170,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
         "{\"type\":\"in\",\"dimension\":\"dimTest\",\"values\":[null]}",
         InDimFilter.class
     );
-    Assert.assertNotNull(inDimFilter.getCacheKey());
+    Assertions.assertNotNull(inDimFilter.getCacheKey());
   }
 
   @Test
@@ -179,7 +178,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     InDimFilter filter1 = new InDimFilter("dim", Arrays.asList("val", null), null);
     InDimFilter filter2 = new InDimFilter("dim", Collections.singletonList("val"), null);
-    Assert.assertFalse(Arrays.equals(filter1.getCacheKey(), filter2.getCacheKey()));
+    Assertions.assertFalse(Arrays.equals(filter1.getCacheKey(), filter2.getCacheKey()));
   }
 
   @Test
@@ -187,7 +186,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter filter = new InDimFilter("dim", ImmutableList.of("v1", "v2"), null);
     // Compares the array object, not the elements of the array
-    Assert.assertSame(filter.getCacheKey(), filter.getCacheKey());
+    Assertions.assertSame(filter.getCacheKey(), filter.getCacheKey());
   }
 
   @Test
@@ -195,15 +194,15 @@ public class InDimFilterTest extends InitializedNullHandlingTest
   {
     final InDimFilter dimFilter1 = new InDimFilter("dim", ImmutableList.of("v1", "v2", "v3"), null);
     final InDimFilter dimFilter2 = new InDimFilter("dim", ImmutableList.of("v3", "v2", "v1"), null);
-    Assert.assertEquals(dimFilter1.getDimensionRangeSet("dim"), dimFilter2.getDimensionRangeSet("dim"));
+    Assertions.assertEquals(dimFilter1.getDimensionRangeSet("dim"), dimFilter2.getDimensionRangeSet("dim"));
   }
 
   @Test
   public void testOptimizeSingleValueInToSelector()
   {
     final InDimFilter filter = new InDimFilter("dim", Collections.singleton("v1"), null);
-    Assert.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize(false));
-    Assert.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize(true));
+    Assertions.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize(false));
+    Assertions.assertEquals(new SelectorDimFilter("dim", "v1", null), filter.optimize(true));
   }
 
   @Test
@@ -215,58 +214,58 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
 
-    Assert.assertEquals(
-        "reverse lookup bar",
+    Assertions.assertEquals(
         Sets.newHashSet("foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false),
+        "reverse lookup bar"
     );
 
-    Assert.assertNull(
-        "reverse lookup bar (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true),
+        "reverse lookup bar (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup baz",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false),
+        "reverse lookup baz"
     );
 
-    Assert.assertNull(
-        "reverse lookup baz (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true),
+        "reverse lookup baz (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup [def, bar, baz]",
+    Assertions.assertEquals(
         Sets.newHashSet("abc", "foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false),
+        "reverse lookup [def, bar, baz]"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz] (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true),
+        "reverse lookup [def, bar, baz] (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup null",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertNull(
-        "reverse lookup null (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertNull(
-        "reverse lookup empty string (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
   }
 
@@ -279,60 +278,60 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, "baz", null, true);
 
-    Assert.assertEquals(
-        "reverse lookup bar",
+    Assertions.assertEquals(
         Sets.newHashSet("foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false),
+        "reverse lookup bar"
     );
 
-    Assert.assertEquals(
-        "reverse lookup bar (includeUnknown)",
+    Assertions.assertEquals(
         Sets.newHashSet("foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true),
+        "reverse lookup bar (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup baz",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false),
+        "reverse lookup baz"
     );
 
-    Assert.assertNull(
-        "reverse lookup baz (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true),
+        "reverse lookup baz (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz]",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false),
+        "reverse lookup [def, bar, baz]"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz] (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true),
+        "reverse lookup [def, bar, baz] (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null (includeUnknown)",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string (includeUnknown)",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
   }
 
@@ -346,58 +345,58 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, "bar", null, true);
 
-    Assert.assertNull(
-        "reverse lookup bar",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false),
+        "reverse lookup bar"
     );
 
-    Assert.assertNull(
-        "reverse lookup bar (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true),
+        "reverse lookup bar (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup baz",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false),
+        "reverse lookup baz"
     );
 
-    Assert.assertNull(
-        "reverse lookup baz (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true),
+        "reverse lookup baz (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz]",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false),
+        "reverse lookup [def, bar, baz]"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz] (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true),
+        "reverse lookup [def, bar, baz] (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null",
+    Assertions.assertEquals(
         Collections.singleton("nv"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null (includeUnknown)",
+    Assertions.assertEquals(
         Collections.singleton("nv"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertNull(
-        "reverse lookup empty string (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
   }
 
@@ -411,60 +410,60 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, "bar", null, true);
 
-    Assert.assertNull(
-        "reverse lookup bar",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false),
+        "reverse lookup bar"
     );
 
-    Assert.assertNull(
-        "reverse lookup bar (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true),
+        "reverse lookup bar (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup baz",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false),
+        "reverse lookup baz"
     );
 
-    Assert.assertEquals(
-        "reverse lookup baz (includeUnknown)",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true),
+        "reverse lookup baz (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz]",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false),
+        "reverse lookup [def, bar, baz]"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz] (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true),
+        "reverse lookup [def, bar, baz] (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null (includeUnknown)",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.singleton("emptystring"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string (includeUnknown)",
+    Assertions.assertEquals(
         Collections.singleton("emptystring"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
   }
 
@@ -476,25 +475,25 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.singleton("emptystring"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertNull(
-        "reverse lookup empty string (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup null",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertNull(
-        "reverse lookup null (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
   }
 
@@ -506,25 +505,25 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
 
-    Assert.assertEquals(
-        "reverse lookup bar",
+    Assertions.assertEquals(
         Collections.singleton(""),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false),
+        "reverse lookup bar"
     );
 
-    Assert.assertNull(
-        "reverse lookup bar (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true),
+        "reverse lookup bar (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup null",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertNull(
-        "reverse lookup null (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
   }
 
@@ -537,61 +536,61 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, true, null, null, true);
 
-    Assert.assertEquals(
-        "reverse lookup bar",
+    Assertions.assertEquals(
         Sets.newHashSet("bar", "foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false),
+        "reverse lookup bar"
     );
 
-    Assert.assertNull(
-        "reverse lookup bar (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true),
+        "reverse lookup bar (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup baz",
+    Assertions.assertEquals(
         Collections.singleton("baz"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false),
+        "reverse lookup baz"
     );
 
-    Assert.assertNull(
-        "reverse lookup baz (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true),
+        "reverse lookup baz (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup [def, bar, baz]",
+    Assertions.assertEquals(
         Sets.newHashSet("abc", "bar", "baz", "def", "foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false),
+        "reverse lookup [def, bar, baz]"
     );
 
-    Assert.assertNull(
-        "reverse lookup [def, bar, baz] (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true),
+        "reverse lookup [def, bar, baz] (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null",
+    Assertions.assertEquals(
         Collections.singleton(null),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null (includeUnknown)",
+    Assertions.assertEquals(
         Collections.singleton(null),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.singleton(""),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string (includeUnknown)",
+    Assertions.assertEquals(
         null,
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
   }
 
@@ -604,64 +603,64 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(true, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
 
-    Assert.assertEquals(
-        "reverse lookup bar",
+    Assertions.assertEquals(
         Sets.newHashSet("foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), false),
+        "reverse lookup bar"
     );
 
-    Assert.assertEquals(
-        "reverse lookup bar (includeUnknown)",
+    Assertions.assertEquals(
         Sets.newHashSet("foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("bar"), extractionFn), true),
+        "reverse lookup bar (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup baz",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), false),
+        "reverse lookup baz"
     );
 
-    Assert.assertEquals(
-        "reverse lookup baz (includeUnknown)",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("baz"), extractionFn), true),
+        "reverse lookup baz (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup [def, bar, baz]",
+    Assertions.assertEquals(
         Sets.newHashSet("abc", "foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), false),
+        "reverse lookup [def, bar, baz]"
     );
 
-    Assert.assertEquals(
-        "reverse lookup [def, bar, baz] (includeUnknown)",
+    Assertions.assertEquals(
         Sets.newHashSet("abc", "foo"),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Arrays.asList("def", "bar", "baz"), extractionFn), true),
+        "reverse lookup [def, bar, baz] (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null",
+    Assertions.assertEquals(
         Collections.singleton(null),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertEquals(
-        "reverse lookup null (includeUnknown)",
+    Assertions.assertEquals(
         Collections.singleton(null),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string (includeUnknown)",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
   }
 
@@ -673,36 +672,36 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final LookupExtractor lookup = ImmutableLookupMap.fromMap(lookupMap).asLookupExtractor(false, () -> new byte[0]);
     final LookupExtractionFn extractionFn = new LookupExtractionFn(lookup, false, null, null, true);
 
-    Assert.assertEquals(
-        "reverse lookup nv",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("nv"), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("nv"), extractionFn), false),
+        "reverse lookup nv"
     );
 
-    Assert.assertNull(
-        "reverse lookup nv (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("nv"), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton("nv"), extractionFn), true),
+        "reverse lookup nv (includeUnknown)"
     );
 
-    Assert.assertNull(
-        "reverse lookup null",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), false),
+        "reverse lookup null"
     );
 
-    Assert.assertNull(
-        "reverse lookup null (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(null), extractionFn), true),
+        "reverse lookup null (includeUnknown)"
     );
 
-    Assert.assertEquals(
-        "reverse lookup empty string",
+    Assertions.assertEquals(
         Collections.emptySet(),
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false)
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), false),
+        "reverse lookup empty string"
     );
 
-    Assert.assertNull(
-        "reverse lookup empty string (includeUnknown)",
-        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true)
+    Assertions.assertNull(
+        InDimFilter.optimizeLookup(new InDimFilter("dim", Collections.singleton(""), extractionFn), true),
+        "reverse lookup empty string (includeUnknown)"
     );
   }
 
@@ -732,15 +731,15 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     final ValueMatcher matcher = filter.toFilter().makeMatcher(columnSelectorFactory);
 
     // This would throw an exception without InDimFilter's null-checking lambda wrapping.
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
 
     row.put("dim", "foo");
     // Now it should match.
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
 
     row.put("dim", "fox");
     // Now it *shouldn't* match.
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -764,7 +763,7 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     Mockito.when(valueIndexes.forSortedValuesUtf8(expectedValuesSet.toUtf8())).thenReturn(bitmapColumnIndex);
 
     final BitmapColumnIndex retVal = inFilter.getBitmapColumnIndex(indexSelector);
-    Assert.assertSame("inFilter returns the intended bitmapColumnIndex", bitmapColumnIndex, retVal);
+    Assertions.assertSame(bitmapColumnIndex, retVal, "inFilter returns the intended bitmapColumnIndex");
   }
 
   @Test
@@ -789,6 +788,6 @@ public class InDimFilterTest extends InitializedNullHandlingTest
     Mockito.when(valueIndex.forSortedValues(expectedValuesSet)).thenReturn(bitmapColumnIndex);
 
     final BitmapColumnIndex retVal = inFilter.getBitmapColumnIndex(indexSelector);
-    Assert.assertSame("inFilter returns the intended bitmapColumnIndex", bitmapColumnIndex, retVal);
+    Assertions.assertSame(bitmapColumnIndex, retVal, "inFilter returns the intended bitmapColumnIndex");
   }
 }

--- a/processing/src/test/java/org/apache/druid/query/filter/LikeDimFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/query/filter/LikeDimFilterTest.java
@@ -32,29 +32,28 @@ import org.apache.druid.segment.index.BitmapColumnIndex;
 import org.apache.druid.segment.index.semantic.LexicographicalRangeIndexes;
 import org.apache.druid.segment.index.semantic.StringValueSetIndexes;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.IOException;
 import java.util.Arrays;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class LikeDimFilterTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
-
   @Test
   public void testSerde() throws IOException
   {
     final ObjectMapper objectMapper = new DefaultObjectMapper();
     final DimFilter filter = new LikeDimFilter("foo", "bar%", "@", new SubstringDimExtractionFn(1, 2));
     final DimFilter filter2 = objectMapper.readValue(objectMapper.writeValueAsString(filter), DimFilter.class);
-    Assert.assertEquals(filter, filter2);
+    Assertions.assertEquals(filter, filter2);
   }
 
   @Test
@@ -63,8 +62,8 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
     final DimFilter filter = new LikeDimFilter("foo", "bar%", "@", new SubstringDimExtractionFn(1, 2));
     final DimFilter filter2 = new LikeDimFilter("foo", "bar%", "@", new SubstringDimExtractionFn(1, 2));
     final DimFilter filter3 = new LikeDimFilter("foo", "bar%", null, new SubstringDimExtractionFn(1, 2));
-    Assert.assertArrayEquals(filter.getCacheKey(), filter2.getCacheKey());
-    Assert.assertFalse(Arrays.equals(filter.getCacheKey(), filter3.getCacheKey()));
+    Assertions.assertArrayEquals(filter.getCacheKey(), filter2.getCacheKey());
+    Assertions.assertFalse(Arrays.equals(filter.getCacheKey(), filter3.getCacheKey()));
   }
 
   @Test
@@ -73,17 +72,17 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
     final DimFilter filter = new LikeDimFilter("foo", "bar%", "@", new SubstringDimExtractionFn(1, 2));
     final DimFilter filter2 = new LikeDimFilter("foo", "bar%", "@", new SubstringDimExtractionFn(1, 2));
     final DimFilter filter3 = new LikeDimFilter("foo", "bar%", null, new SubstringDimExtractionFn(1, 2));
-    Assert.assertEquals(filter, filter2);
-    Assert.assertNotEquals(filter, filter3);
-    Assert.assertEquals(filter.hashCode(), filter2.hashCode());
-    Assert.assertNotEquals(filter.hashCode(), filter3.hashCode());
+    Assertions.assertEquals(filter, filter2);
+    Assertions.assertNotEquals(filter, filter3);
+    Assertions.assertEquals(filter.hashCode(), filter2.hashCode());
+    Assertions.assertNotEquals(filter.hashCode(), filter3.hashCode());
   }
 
   @Test
   public void testGetRequiredColumns()
   {
     final DimFilter filter = new LikeDimFilter("foo", "bar%", "@", new SubstringDimExtractionFn(1, 2));
-    Assert.assertEquals(filter.getRequiredColumns(), Sets.newHashSet("foo"));
+    Assertions.assertEquals(filter.getRequiredColumns(), Sets.newHashSet("foo"));
   }
 
   @Test
@@ -126,7 +125,7 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
     ).thenReturn(bitmapColumnIndex);
 
     final BitmapColumnIndex retVal = likeFilter.getBitmapColumnIndex(indexSelector);
-    Assert.assertSame("likeFilter returns the intended bitmapColumnIndex", bitmapColumnIndex, retVal);
+    Assertions.assertSame(bitmapColumnIndex, retVal, "likeFilter returns the intended bitmapColumnIndex");
   }
 
   @Test
@@ -147,7 +146,7 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
     Mockito.when(valueIndex.forValue("f")).thenReturn(bitmapColumnIndex);
 
     final BitmapColumnIndex retVal = likeFilter.getBitmapColumnIndex(indexSelector);
-    Assert.assertSame("likeFilter returns the intended bitmapColumnIndex", bitmapColumnIndex, retVal);
+    Assertions.assertSame(bitmapColumnIndex, retVal, "likeFilter returns the intended bitmapColumnIndex");
   }
 
   @Test
@@ -329,7 +328,7 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
   public void testGetDimensionRangeSet_literalPattern()
   {
     final LikeDimFilter filter = new LikeDimFilter("foo", "bar", null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableRangeSet.of(Range.singleton("bar")),
         filter.getDimensionRangeSet("foo")
     );
@@ -339,7 +338,7 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
   public void testGetDimensionRangeSet_prefixPattern()
   {
     final LikeDimFilter filter = new LikeDimFilter("foo", "bar%", null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableRangeSet.of(Range.closedOpen("bar", "bas")),
         filter.getDimensionRangeSet("foo")
     );
@@ -349,21 +348,21 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
   public void testGetDimensionRangeSet_midPatternWildcard_returnsNull()
   {
     final LikeDimFilter filter = new LikeDimFilter("foo", "bar%baz", null, null);
-    Assert.assertNull(filter.getDimensionRangeSet("foo"));
+    Assertions.assertNull(filter.getDimensionRangeSet("foo"));
   }
 
   @Test
   public void testGetDimensionRangeSet_suffixPattern_returnsNull()
   {
     final LikeDimFilter filter = new LikeDimFilter("foo", "%bar", null, null);
-    Assert.assertNull(filter.getDimensionRangeSet("foo"));
+    Assertions.assertNull(filter.getDimensionRangeSet("foo"));
   }
 
   @Test
   public void testGetDimensionRangeSet_singleWildcard_returnsAll()
   {
     final LikeDimFilter filter = new LikeDimFilter("foo", "%", null, null);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableRangeSet.of(Range.all()),
         filter.getDimensionRangeSet("foo")
     );
@@ -373,32 +372,32 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
   public void testGetDimensionRangeSet_otherDimension_returnsNull()
   {
     final LikeDimFilter filter = new LikeDimFilter("foo", "bar%", null, null);
-    Assert.assertNull(filter.getDimensionRangeSet("other"));
+    Assertions.assertNull(filter.getDimensionRangeSet("other"));
   }
 
   @Test
   public void testGetDimensionRangeSet_withExtractionFn_returnsNull()
   {
     final LikeDimFilter filter = new LikeDimFilter("foo", "bar%", null, new SubstringDimExtractionFn(0, 3));
-    Assert.assertNull(filter.getDimensionRangeSet("foo"));
+    Assertions.assertNull(filter.getDimensionRangeSet("foo"));
   }
 
   @Test
   public void testPrefixRange_singleLowercaseChar()
   {
-    Assert.assertEquals(Range.closedOpen("foo", "fop"), LikeDimFilter.prefixRange("foo"));
+    Assertions.assertEquals(Range.closedOpen("foo", "fop"), LikeDimFilter.prefixRange("foo"));
   }
 
   @Test
   public void testPrefixRange_uppercaseCarryStaysWithinAscii()
   {
-    Assert.assertEquals(Range.closedOpen("foZ", "fo["), LikeDimFilter.prefixRange("foZ"));
+    Assertions.assertEquals(Range.closedOpen("foZ", "fo["), LikeDimFilter.prefixRange("foZ"));
   }
 
   @Test
   public void testPrefixRange_trailingMaxValue_carriesPastIt()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Range.closedOpen("foo￿", "fop"),
         LikeDimFilter.prefixRange("foo￿")
     );
@@ -407,61 +406,61 @@ public class LikeDimFilterTest extends InitializedNullHandlingTest
   @Test
   public void testPrefixRange_allMaxValue_fallsBackToAtLeast()
   {
-    Assert.assertEquals(Range.atLeast("￿￿"), LikeDimFilter.prefixRange("￿￿"));
+    Assertions.assertEquals(Range.atLeast("￿￿"), LikeDimFilter.prefixRange("￿￿"));
   }
 
   @Test
   public void testPrefixRange_empty_throws()
   {
-    Assert.assertThrows(DruidException.class, () -> LikeDimFilter.prefixRange(""));
+    Assertions.assertThrows(DruidException.class, () -> LikeDimFilter.prefixRange(""));
   }
 
   @Test
   public void testPrefixRange_enclosesAllPrefixedStrings()
   {
     final Range<String> range = LikeDimFilter.prefixRange("foo");
-    Assert.assertTrue(range.contains("foo"));
-    Assert.assertTrue(range.contains("foo0"));
-    Assert.assertTrue(range.contains("foobar"));
-    Assert.assertTrue(range.contains("foozzz"));
-    Assert.assertFalse(range.contains("fo"));
-    Assert.assertFalse(range.contains("fop"));
-    Assert.assertFalse(range.contains("fox"));
+    Assertions.assertTrue(range.contains("foo"));
+    Assertions.assertTrue(range.contains("foo0"));
+    Assertions.assertTrue(range.contains("foobar"));
+    Assertions.assertTrue(range.contains("foozzz"));
+    Assertions.assertFalse(range.contains("fo"));
+    Assertions.assertFalse(range.contains("fop"));
+    Assertions.assertFalse(range.contains("fox"));
   }
 
   @Test
   public void testLexicographicSuccessor_basic()
   {
-    Assert.assertEquals("fop", LikeDimFilter.lexicographicSuccessor("foo"));
+    Assertions.assertEquals("fop", LikeDimFilter.lexicographicSuccessor("foo"));
   }
 
   @Test
   public void testLexicographicSuccessor_empty_returnsNullChar()
   {
-    Assert.assertEquals("\u0000", LikeDimFilter.lexicographicSuccessor(""));
+    Assertions.assertEquals("\u0000", LikeDimFilter.lexicographicSuccessor(""));
   }
 
   @Test
   public void testLexicographicSuccessor_singleMaxValue_returnsNull()
   {
-    Assert.assertNull(LikeDimFilter.lexicographicSuccessor("￿"));
+    Assertions.assertNull(LikeDimFilter.lexicographicSuccessor("￿"));
   }
 
   @Test
   public void testLexicographicSuccessor_trailingMaxValues_truncatedAndCarried()
   {
-    Assert.assertEquals("fop", LikeDimFilter.lexicographicSuccessor("foo￿￿"));
+    Assertions.assertEquals("fop", LikeDimFilter.lexicographicSuccessor("foo￿￿"));
   }
 
   private void assertCompilation(String pattern, String expected)
   {
     LikeDimFilter.LikeMatcher matcher = LikeDimFilter.LikeMatcher.from(pattern, '\\');
-    Assert.assertEquals(pattern + " => " + expected, matcher.describeCompilation());
+    Assertions.assertEquals(pattern + " => " + expected, matcher.describeCompilation());
   }
 
   private void assertMatch(String pattern, String value, DruidPredicateMatch expected)
   {
     LikeDimFilter.LikeMatcher matcher = LikeDimFilter.LikeMatcher.from(pattern, '\\');
-    Assert.assertEquals(matcher + " matches " + value, expected, matcher.matches(value));
+    Assertions.assertEquals(expected, matcher.matches(value), matcher + " matches " + value);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/VirtualColumnsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/VirtualColumnsTest.java
@@ -41,29 +41,29 @@ import org.apache.druid.segment.data.ZeroIndexedInts;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.segment.virtual.NestedFieldVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
 public class VirtualColumnsTest extends InitializedNullHandlingTest
 {
   private static final String REAL_COLUMN_NAME = "real_column";
-
-  @Rule
-  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Mock
   public ColumnSelectorFactory baseColumnSelectorFactory;
@@ -73,10 +73,10 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   {
     final VirtualColumns virtualColumns = makeVirtualColumns();
 
-    Assert.assertTrue(virtualColumns.exists("expr"));
-    Assert.assertTrue(virtualColumns.exists("foo"));
-    Assert.assertTrue(virtualColumns.exists("foo.5"));
-    Assert.assertFalse(virtualColumns.exists("bar"));
+    Assertions.assertTrue(virtualColumns.exists("expr"));
+    Assertions.assertTrue(virtualColumns.exists("foo"));
+    Assertions.assertTrue(virtualColumns.exists("foo.5"));
+    Assertions.assertFalse(virtualColumns.exists("bar"));
   }
 
   @Test
@@ -104,9 +104,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   {
     final VirtualColumns virtualColumns = makeVirtualColumns();
     final ColumnInspector baseInspector = column -> null;
-    Assert.assertEquals(ValueType.FLOAT, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr").getType());
-    Assert.assertEquals(ValueType.LONG, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr2").getType());
-    Assert.assertNull(virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, REAL_COLUMN_NAME));
+    Assertions.assertEquals(ValueType.FLOAT, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr").getType());
+    Assertions.assertEquals(ValueType.LONG, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr2").getType());
+    Assertions.assertNull(virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, REAL_COLUMN_NAME));
   }
 
   @Test
@@ -120,9 +120,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         return null;
       }
     };
-    Assert.assertEquals(ValueType.FLOAT, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr").getType());
-    Assert.assertEquals(ValueType.DOUBLE, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr2").getType());
-    Assert.assertNull(virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, REAL_COLUMN_NAME));
+    Assertions.assertEquals(ValueType.FLOAT, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr").getType());
+    Assertions.assertEquals(ValueType.DOUBLE, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "expr2").getType());
+    Assertions.assertNull(virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, REAL_COLUMN_NAME));
   }
 
   @Test
@@ -130,15 +130,15 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   {
     final VirtualColumns virtualColumns = makeVirtualColumns();
     final ColumnInspector baseInspector = column -> null;
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.FLOAT,
         virtualColumns.getColumnCapabilitiesWithFallback(baseInspector, "expr").getType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.LONG,
         virtualColumns.getColumnCapabilitiesWithFallback(baseInspector, "expr2").getType()
     );
-    Assert.assertNull(virtualColumns.getColumnCapabilitiesWithFallback(baseInspector, REAL_COLUMN_NAME));
+    Assertions.assertNull(virtualColumns.getColumnCapabilitiesWithFallback(baseInspector, REAL_COLUMN_NAME));
   }
 
   @Test
@@ -152,15 +152,15 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         return null;
       }
     };
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.FLOAT,
         virtualColumns.getColumnCapabilitiesWithFallback(baseInspector, "expr").getType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.DOUBLE,
         virtualColumns.getColumnCapabilitiesWithFallback(baseInspector, "expr2").getType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.DOUBLE,
         virtualColumns.getColumnCapabilitiesWithFallback(baseInspector, REAL_COLUMN_NAME).getType()
     );
@@ -172,15 +172,15 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     final VirtualColumns virtualColumns = makeVirtualColumns();
     final ColumnInspector baseInspector = column -> null;
     final ColumnInspector wrappedInspector = virtualColumns.wrapInspector(baseInspector);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.FLOAT,
         wrappedInspector.getColumnCapabilities("expr").getType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.LONG,
         wrappedInspector.getColumnCapabilities("expr2").getType()
     );
-    Assert.assertNull(wrappedInspector.getColumnCapabilities(REAL_COLUMN_NAME));
+    Assertions.assertNull(wrappedInspector.getColumnCapabilities(REAL_COLUMN_NAME));
   }
 
   @Test
@@ -195,15 +195,15 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
       }
     };
     final ColumnInspector wrappedInspector = virtualColumns.wrapInspector(baseInspector);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.FLOAT,
         wrappedInspector.getColumnCapabilities("expr").getType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.DOUBLE,
         wrappedInspector.getColumnCapabilities("expr2").getType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ValueType.DOUBLE,
         wrappedInspector.getColumnCapabilities(REAL_COLUMN_NAME).getType()
     );
@@ -214,11 +214,11 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   {
     final VirtualColumns virtualColumns = makeVirtualColumns();
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> virtualColumns.makeColumnValueSelector("bar", baseColumnSelectorFactory, null, null)
     );
-    Assert.assertEquals("No such virtual column[bar]", t.getMessage());
+    Assertions.assertEquals("No such virtual column[bar]", t.getMessage());
   }
 
   @Test
@@ -258,11 +258,11 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(1L, objectSelector.getObject());
-    Assert.assertEquals("1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-    Assert.assertEquals("0.5", extractionDimensionSelector.lookupName(extractionDimensionSelector.getRow().get(0)));
-    Assert.assertEquals(1.0f, floatSelector.getFloat(), 0.0f);
-    Assert.assertEquals(1L, longSelector.getLong());
+    Assertions.assertEquals(1L, objectSelector.getObject());
+    Assertions.assertEquals("1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+    Assertions.assertEquals("0.5", extractionDimensionSelector.lookupName(extractionDimensionSelector.getRow().get(0)));
+    Assertions.assertEquals(1.0f, floatSelector.getFloat(), 0.0f);
+    Assertions.assertEquals(1L, longSelector.getLong());
   }
 
   @Test
@@ -294,10 +294,10 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(5L, objectSelector.getObject());
-    Assert.assertEquals("5", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-    Assert.assertEquals(5.0f, floatSelector.getFloat(), 0.0f);
-    Assert.assertEquals(5L, longSelector.getLong());
+    Assertions.assertEquals(5L, objectSelector.getObject());
+    Assertions.assertEquals("5", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+    Assertions.assertEquals(5.0f, floatSelector.getFloat(), 0.0f);
+    Assertions.assertEquals(5L, longSelector.getLong());
   }
 
   @Test
@@ -329,10 +329,10 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         null
     );
 
-    Assert.assertEquals(-1L, objectSelector.getObject());
-    Assert.assertEquals("-1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-    Assert.assertEquals(-1.0f, floatSelector.getFloat(), 0.0f);
-    Assert.assertEquals(-1L, longSelector.getLong());
+    Assertions.assertEquals(-1L, objectSelector.getObject());
+    Assertions.assertEquals("-1", dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+    Assertions.assertEquals(-1.0f, floatSelector.getFloat(), 0.0f);
+    Assertions.assertEquals(-1L, longSelector.getLong());
   }
 
   @Test
@@ -345,11 +345,11 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         TestExprMacroTable.INSTANCE
     );
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> VirtualColumns.create(expr)
     );
-    Assert.assertEquals("virtualColumn name[__time] not allowed", t.getMessage());
+    Assertions.assertEquals("virtualColumn name[__time] not allowed", t.getMessage());
   }
 
   @Test
@@ -369,11 +369,11 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         TestExprMacroTable.INSTANCE
     );
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> VirtualColumns.create(expr, expr2)
     );
-    Assert.assertEquals("Duplicate virtualColumn name[expr]", t.getMessage());
+    Assertions.assertEquals("Duplicate virtualColumn name[expr]", t.getMessage());
   }
 
   @Test
@@ -396,11 +396,11 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         TestExprMacroTable.INSTANCE
     );
 
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> VirtualColumns.create(expr, expr2)
     );
-    Assert.assertEquals("Self-referential column[expr]", t.getMessage());
+    Assertions.assertEquals("Self-referential column[expr]", t.getMessage());
   }
 
   @Test
@@ -432,7 +432,7 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     );
 
     final VirtualColumns virtualColumns = VirtualColumns.create(expr, expr2, expr3);
-    Assert.assertEquals(3, virtualColumns.getColumnNames().size());
+    Assertions.assertEquals(3, virtualColumns.getColumnNames().size());
   }
 
   @Test
@@ -446,8 +446,8 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         new ExpressionVirtualColumn("expr", "x + y", ColumnType.FLOAT, TestExprMacroTable.INSTANCE)
     );
 
-    Assert.assertArrayEquals(virtualColumns.getCacheKey(), virtualColumns2.getCacheKey());
-    Assert.assertFalse(Arrays.equals(virtualColumns.getCacheKey(), VirtualColumns.EMPTY.getCacheKey()));
+    Assertions.assertArrayEquals(virtualColumns.getCacheKey(), virtualColumns2.getCacheKey());
+    Assertions.assertFalse(Arrays.equals(virtualColumns.getCacheKey(), VirtualColumns.EMPTY.getCacheKey()));
   }
 
   @Test
@@ -470,9 +470,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
   public void testGetNodeNullForNonVirtualColumn()
   {
     final VirtualColumns virtualColumns = makeVirtualColumns();
-    Assert.assertNull(virtualColumns.getNode(REAL_COLUMN_NAME));
-    Assert.assertNull(virtualColumns.getNode("doesNotExist"));
-    Assert.assertNull(VirtualColumns.EMPTY.getNode("anything"));
+    Assertions.assertNull(virtualColumns.getNode(REAL_COLUMN_NAME));
+    Assertions.assertNull(virtualColumns.getNode("doesNotExist"));
+    Assertions.assertNull(VirtualColumns.EMPTY.getNode("anything"));
   }
 
   @Test
@@ -481,9 +481,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     // "expr" is "1", a constant expression with no required columns, so no VC deps
     final VirtualColumns virtualColumns = makeVirtualColumns();
     final VirtualColumns.Node node = virtualColumns.getNode("expr");
-    Assert.assertNotNull(node);
-    Assert.assertEquals(virtualColumns.getVirtualColumn("expr"), node.getVirtualColumn());
-    Assert.assertTrue(node.getDependencies().isEmpty());
+    Assertions.assertNotNull(node);
+    Assertions.assertEquals(virtualColumns.getVirtualColumn("expr"), node.getVirtualColumn());
+    Assertions.assertTrue(node.getDependencies().isEmpty());
   }
 
   @Test
@@ -492,12 +492,12 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     // "expr2" is "expr2i + real_column", depends on expr2i (a VC) and REAL_COLUMN_NAME (physical)
     final VirtualColumns virtualColumns = makeVirtualColumns();
     final VirtualColumns.Node node = virtualColumns.getNode("expr2");
-    Assert.assertNotNull(node);
-    Assert.assertEquals(virtualColumns.getVirtualColumn("expr2"), node.getVirtualColumn());
-    Assert.assertEquals(1, node.getDependencies().size());
+    Assertions.assertNotNull(node);
+    Assertions.assertEquals(virtualColumns.getVirtualColumn("expr2"), node.getVirtualColumn());
+    Assertions.assertEquals(1, node.getDependencies().size());
     final VirtualColumns.Node depNode = node.getDependencies().get(0);
-    Assert.assertEquals(virtualColumns.getVirtualColumn("expr2i"), depNode.getVirtualColumn());
-    Assert.assertTrue(depNode.getDependencies().isEmpty());
+    Assertions.assertEquals(virtualColumns.getVirtualColumn("expr2i"), depNode.getVirtualColumn());
+    Assertions.assertTrue(depNode.getDependencies().isEmpty());
   }
 
   @Test
@@ -514,22 +514,22 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     final VirtualColumns.Node v0Node = virtualColumns.getNode("v0");
 
     // v1 is a leaf
-    Assert.assertNotNull(v1Node);
-    Assert.assertEquals(v1, v1Node.getVirtualColumn());
-    Assert.assertTrue(v1Node.getDependencies().isEmpty());
+    Assertions.assertNotNull(v1Node);
+    Assertions.assertEquals(v1, v1Node.getVirtualColumn());
+    Assertions.assertTrue(v1Node.getDependencies().isEmpty());
 
     // v2 has v1 as a dependency
-    Assert.assertNotNull(v2Node);
-    Assert.assertEquals(v2, v2Node.getVirtualColumn());
-    Assert.assertEquals(1, v2Node.getDependencies().size());
-    Assert.assertSame(v1Node, v2Node.getDependencies().get(0));
+    Assertions.assertNotNull(v2Node);
+    Assertions.assertEquals(v2, v2Node.getVirtualColumn());
+    Assertions.assertEquals(1, v2Node.getDependencies().size());
+    Assertions.assertSame(v1Node, v2Node.getDependencies().get(0));
 
     // v0 has v1 and v2 as direct dependencies; the same node instances are reused
-    Assert.assertNotNull(v0Node);
-    Assert.assertEquals(v0, v0Node.getVirtualColumn());
-    Assert.assertEquals(2, v0Node.getDependencies().size());
-    Assert.assertTrue(v0Node.getDependencies().contains(v1Node));
-    Assert.assertTrue(v0Node.getDependencies().contains(v2Node));
+    Assertions.assertNotNull(v0Node);
+    Assertions.assertEquals(v0, v0Node.getVirtualColumn());
+    Assertions.assertEquals(2, v0Node.getDependencies().size());
+    Assertions.assertTrue(v0Node.getDependencies().contains(v1Node));
+    Assertions.assertTrue(v0Node.getDependencies().contains(v2Node));
   }
 
   @Test
@@ -548,8 +548,8 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     );
     final VirtualColumns vc2 = VirtualColumns.create(n0copy, e0copy);
 
-    Assert.assertEquals(vc1.getNode("e0"), vc2.getNode("e0"));
-    Assert.assertEquals(vc1.getNode("e0").hashCode(), vc2.getNode("e0").hashCode());
+    Assertions.assertEquals(vc1.getNode("e0"), vc2.getNode("e0"));
+    Assertions.assertEquals(vc1.getNode("e0").hashCode(), vc2.getNode("e0").hashCode());
 
     // Different underlying dependency ($.b instead of $.a), even though e0's expression looks the same,
     // the node must differ because the dependency subtree differs
@@ -559,7 +559,7 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     );
     final VirtualColumns vc3 = VirtualColumns.create(n0different, e0sameName);
 
-    Assert.assertNotEquals(vc1.getNode("e0"), vc3.getNode("e0"));
+    Assertions.assertNotEquals(vc1.getNode("e0"), vc3.getNode("e0"));
   }
 
   @Test
@@ -593,10 +593,10 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     );
     VirtualColumns otherVirtualColumns = VirtualColumns.create(v1, v2, v3);
 
-    Assert.assertEquals(v0, virtualColumns.findEquivalent(virtualColumns.getNode(v0.getOutputName())));
-    Assert.assertEquals(v0, virtualColumns.findEquivalent(otherVirtualColumns.getNode(v1.getOutputName())));
-    Assert.assertNull(virtualColumns.findEquivalent(otherVirtualColumns.getNode(v2.getOutputName())));
-    Assert.assertNull(virtualColumns.findEquivalent(otherVirtualColumns.getNode(v3.getOutputName())));
+    Assertions.assertEquals(v0, virtualColumns.findEquivalent(virtualColumns.getNode(v0.getOutputName())));
+    Assertions.assertEquals(v0, virtualColumns.findEquivalent(otherVirtualColumns.getNode(v1.getOutputName())));
+    Assertions.assertNull(virtualColumns.findEquivalent(otherVirtualColumns.getNode(v2.getOutputName())));
+    Assertions.assertNull(virtualColumns.findEquivalent(otherVirtualColumns.getNode(v3.getOutputName())));
   }
 
   @Test
@@ -617,9 +617,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     );
     final VirtualColumns otherVirtualColumns = VirtualColumns.create(n1, e1);
 
-    Assert.assertEquals(n0, virtualColumns.findEquivalent(otherVirtualColumns.getNode(n1.getOutputName())));
+    Assertions.assertEquals(n0, virtualColumns.findEquivalent(otherVirtualColumns.getNode(n1.getOutputName())));
 
-    Assert.assertEquals(e0, virtualColumns.findEquivalent(otherVirtualColumns.getNode(e1.getOutputName())));
+    Assertions.assertEquals(e0, virtualColumns.findEquivalent(otherVirtualColumns.getNode(e1.getOutputName())));
 
     // a different nested field path produces no equivalence, even if it has the same name
     final NestedFieldVirtualColumn n0different = new NestedFieldVirtualColumn("obj", "$.b", "n0", ColumnType.STRING);
@@ -629,8 +629,8 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         TestExprMacroTable.INSTANCE
     );
     final VirtualColumns notEquivalent = VirtualColumns.create(n0different, e0different);
-    Assert.assertNull(virtualColumns.findEquivalent(notEquivalent.getNode(n0different.getOutputName())));
-    Assert.assertNull(virtualColumns.findEquivalent(notEquivalent.getNode(e0different.getOutputName())));
+    Assertions.assertNull(virtualColumns.findEquivalent(notEquivalent.getNode(n0different.getOutputName())));
+    Assertions.assertNull(virtualColumns.findEquivalent(notEquivalent.getNode(e0different.getOutputName())));
   }
 
   @Test
@@ -643,7 +643,7 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     );
     final VirtualColumns virtualColumns = VirtualColumns.create(theColumns);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         virtualColumns,
         mapper.readValue(
             mapper.writeValueAsString(virtualColumns),
@@ -651,7 +651,7 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         theColumns,
         mapper.readValue(
             mapper.writeValueAsString(virtualColumns),
@@ -668,9 +668,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     final ExpressionVirtualColumn expr0 = new ExpressionVirtualColumn("v0", "case_searched(notnull(1 + x), v1, v2)", ColumnType.LONG, TestExprMacroTable.INSTANCE);
     final VirtualColumns virtualColumns = VirtualColumns.create(expr0, expr1, expr2);
 
-    Assert.assertTrue(virtualColumns.exists("v0"));
-    Assert.assertTrue(virtualColumns.exists("v1"));
-    Assert.assertTrue(virtualColumns.exists("v2"));
+    Assertions.assertTrue(virtualColumns.exists("v0"));
+    Assertions.assertTrue(virtualColumns.exists("v1"));
+    Assertions.assertTrue(virtualColumns.exists("v2"));
   }
 
   @Test
@@ -681,9 +681,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     final ExpressionVirtualColumn expr0 = new ExpressionVirtualColumn("v0", "case_searched(notnull(v1), v1, v2)", ColumnType.LONG, TestExprMacroTable.INSTANCE);
     final VirtualColumns virtualColumns = VirtualColumns.create(expr0, expr1, expr2);
 
-    Assert.assertTrue(virtualColumns.exists("v0"));
-    Assert.assertTrue(virtualColumns.exists("v1"));
-    Assert.assertTrue(virtualColumns.exists("v2"));
+    Assertions.assertTrue(virtualColumns.exists("v0"));
+    Assertions.assertTrue(virtualColumns.exists("v1"));
+    Assertions.assertTrue(virtualColumns.exists("v2"));
   }
 
   @Test
@@ -694,9 +694,9 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     final ExpressionVirtualColumn expr0 = new ExpressionVirtualColumn("v0", "v1 + v2", ColumnType.LONG, TestExprMacroTable.INSTANCE);
     final VirtualColumns virtualColumns = VirtualColumns.create(expr0, expr1, expr2);
 
-    Assert.assertTrue(virtualColumns.exists("v0"));
-    Assert.assertTrue(virtualColumns.exists("v1"));
-    Assert.assertTrue(virtualColumns.exists("v2"));
+    Assertions.assertTrue(virtualColumns.exists("v0"));
+    Assertions.assertTrue(virtualColumns.exists("v1"));
+    Assertions.assertTrue(virtualColumns.exists("v2"));
   }
 
   @Test
@@ -723,11 +723,11 @@ public class VirtualColumnsTest extends InitializedNullHandlingTest
     final ExpressionVirtualColumn expr2 = new ExpressionVirtualColumn("v3", "v0 * x", null, TestExprMacroTable.INSTANCE);
     final VirtualColumns virtualColumns = VirtualColumns.create(v0, v1, expr1, expr2);
 
-    Assert.assertEquals(ColumnType.STRING, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v0").toColumnType());
-    Assert.assertEquals(ColumnType.LONG, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v1").toColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v2").toColumnType());
-    Assert.assertEquals(ColumnType.DOUBLE, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v3").toColumnType());
-    Assert.assertTrue(virtualColumns.canVectorize(baseInspector));
+    Assertions.assertEquals(ColumnType.STRING, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v0").toColumnType());
+    Assertions.assertEquals(ColumnType.LONG, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v1").toColumnType());
+    Assertions.assertEquals(ColumnType.DOUBLE, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v2").toColumnType());
+    Assertions.assertEquals(ColumnType.DOUBLE, virtualColumns.getColumnCapabilitiesWithoutFallback(baseInspector, "v3").toColumnType());
+    Assertions.assertTrue(virtualColumns.canVectorize(baseInspector));
   }
 
   private VirtualColumns makeVirtualColumns()

--- a/processing/src/test/java/org/apache/druid/segment/filter/ArrayContainsElementFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/ArrayContainsElementFilterTests.java
@@ -38,9 +38,9 @@ import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assume;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -80,7 +80,7 @@ public class ArrayContainsElementFilterTests
     @Test
     public void testArrayStringColumn()
     {
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
         /*
             dim0 .. arrayString
             "0", .. ["a", "b", "c"]
@@ -158,7 +158,7 @@ public class ArrayContainsElementFilterTests
     @Test
     public void testArrayLongColumn()
     {
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
         /*
             dim0 .. arrayLong
             "0", .. [1L, 2L, 3L]
@@ -234,7 +234,7 @@ public class ArrayContainsElementFilterTests
     @Test
     public void testArrayDoubleColumn()
     {
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
         /*
             dim0 .. arrayDouble
             "0", .. [1.1, 2.2, 3.3]
@@ -290,7 +290,7 @@ public class ArrayContainsElementFilterTests
     @Test
     public void testArrayStringColumnContainsArrays()
     {
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
       // these are not nested arrays, expect no matches
       assertFilterMatches(
           new ArrayContainsElementFilter(
@@ -317,7 +317,7 @@ public class ArrayContainsElementFilterTests
     @Test
     public void testArrayLongColumnContainsArrays()
     {
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
 
       // these are not nested arrays, expect no matches
       assertFilterMatches(
@@ -345,7 +345,7 @@ public class ArrayContainsElementFilterTests
     @Test
     public void testArrayDoubleColumnContainsArrays()
     {
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
       // these are not nested arrays, expect no matches
       assertFilterMatches(
           new ArrayContainsElementFilter(
@@ -452,7 +452,7 @@ public class ArrayContainsElementFilterTests
     public void testArrayContainsNestedArray()
     {
       // only auto schema supports array columns... skip other segment types
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
       assertFilterMatches(
           new ArrayContainsElementFilter("nestedArrayLong", ColumnType.LONG_ARRAY, new Object[]{1L, 2L, 3L}, null),
           ImmutableList.of("0", "2")
@@ -498,7 +498,7 @@ public class ArrayContainsElementFilterTests
     public void testNestedArrayStringColumn()
     {
       // duplicate of testArrayStringColumn but targeting nested.arrayString
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
         /*
             dim0 .. arrayString
             "0", .. ["a", "b", "c"]
@@ -577,7 +577,7 @@ public class ArrayContainsElementFilterTests
     public void testNestedArrayLongColumn()
     {
       // duplicate of testArrayLongColumn but targeting nested.arrayLong
-      Assume.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
+      Assumptions.assumeFalse(testName.contains("frame (columnar)") || testName.contains("rowBasedWithoutTypeSignature"));
         /*
             dim0 .. arrayLong
             "0", .. [1L, 2L, 3L]
@@ -654,7 +654,7 @@ public class ArrayContainsElementFilterTests
     public void testNestedArrayDoubleColumn()
     {
       // duplicate of testArrayDoubleColumn but targeting nested.arrayDouble
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
         /*
             dim0 .. arrayDouble
             "0", .. [1.1, 2.2, 3.3]
@@ -711,7 +711,7 @@ public class ArrayContainsElementFilterTests
     public void testNestedArrayStringColumnContainsArrays()
     {
       // duplicate of testArrayStringColumnContainsArrays but targeting nested.arrayString
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
       // these are not nested arrays, expect no matches
       assertFilterMatches(
           new ArrayContainsElementFilter(
@@ -739,7 +739,7 @@ public class ArrayContainsElementFilterTests
     public void testNestedArrayLongColumnContainsArrays()
     {
       // duplicate of testArrayLongColumnContainsArrays but targeting nested.arrayLong
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
 
       // these are not nested arrays, expect no matches
       assertFilterMatches(
@@ -768,7 +768,7 @@ public class ArrayContainsElementFilterTests
     public void testNestedArrayDoubleColumnContainsArrays()
     {
       // duplicate of testArrayDoubleColumnContainsArrays but targeting nested.arrayDouble
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
       // these are not nested arrays, expect no matches
       assertFilterMatches(
           new ArrayContainsElementFilter(
@@ -795,7 +795,7 @@ public class ArrayContainsElementFilterTests
     @Test
     public void testNestedScalarColumnContains()
     {
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
 
       // duplicate of testScalarColumnContains but targeting nested columns
       assertFilterMatches(

--- a/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/EqualityFilterTests.java
@@ -43,9 +43,9 @@ import org.apache.druid.segment.CursorFactory;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assume;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -649,7 +649,7 @@ public class EqualityFilterTests
     @Test
     public void testArrays()
     {
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
       /*
           dim0 .. arrayString               arrayLong             arrayDouble
           "0", .. ["a", "b", "c"],          [1L, 2L, 3L],         [1.1, 2.2, 3.3]
@@ -910,7 +910,7 @@ public class EqualityFilterTests
 
        */
       // only auto well supports variant types
-      Assume.assumeTrue(isAutoSchema());
+      Assumptions.assumeTrue(isAutoSchema());
       assertFilterMatches(
           new EqualityFilter(
               "variant",
@@ -1005,7 +1005,7 @@ public class EqualityFilterTests
     public void testNestedColumnEquality()
     {
       // nested column mirrors the top level columns, so these cases are copied from other tests
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
 
       assertFilterMatches(
           new EqualityFilter("nested.s0", ColumnType.STRING, "", null),
@@ -1349,7 +1349,7 @@ public class EqualityFilterTests
     @Test
     public void testArraysAsMvds()
     {
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
       /*
           dim0 .. arrayString               arrayLong             arrayDouble
           "0", .. ["a", "b", "c"],          [1L, 2L, 3L],         [1.1, 2.2, 3.3]

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterBundleTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterBundleTest.java
@@ -20,8 +20,6 @@
 package org.apache.druid.segment.filter;
 
 import com.google.common.collect.ImmutableList;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.apache.druid.collections.bitmap.BitmapFactory;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.query.DefaultBitmapResultFactory;
@@ -38,25 +36,24 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.VirtualColumns;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-@RunWith(JUnitParamsRunner.class)
 public class FilterBundleTest extends InitializedNullHandlingTest
 {
   private Closer closer;
   protected BitmapFactory bitmapFactory;
   protected ColumnIndexSelector indexSelector;
 
-  @Rule
-  public TemporaryFolder tmpDir = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension tmpDir = new TemporaryFolderExtension();
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     final QueryableIndex index = TestIndex.getMMappedWikipediaIndex();
@@ -65,15 +62,15 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     indexSelector = new ColumnCache(index, VirtualColumns.EMPTY, closer);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception
   {
     closer.close();
     indexSelector = null;
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_or_country_isRobot(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -86,7 +83,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: OR (selectionSize = 39244)\n"
         + "  index: countryName = United States (selectionSize = 528)\n"
         + "  index: isRobot = true (selectionSize = 15420)\n",
@@ -94,8 +91,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_and_country_isRobot(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -108,7 +105,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: AND (selectionSize = 0)\n"
         + "  index: countryName = United States (selectionSize = 528)\n"
         + "  index: isRobot = true (selectionSize = 15420)\n",
@@ -116,8 +113,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_or_countryIsNull_pageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -130,7 +127,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "matcher: OR\n"
         + "  matcher: countryName IS NULL\n"
         + "    with partial index: countryName IS NULL (selectionSize = 35445)\n"
@@ -139,8 +136,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_and_countryIsNull_pageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -153,7 +150,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: AND (selectionSize = 14165)\n"
         + "  index: countryName IS NULL (selectionSize = 35445)\n"
         + "  index: page LIKE '%u%' (selectionSize = 15328)\n",
@@ -161,8 +158,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_and_country_pageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -175,15 +172,15 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: countryName = United States (selectionSize = 528)\n"
         + "matcher: page LIKE '%u%'\n",
         filterBundle.getInfo().describe()
     );
   }
 
-  @Test
-  @Parameters({"true"})
+  @ParameterizedTest
+  @ValueSource(booleans = true)
   public void test_pageLike_and_country_pageLike_with_cursorAutoArrangeFilters(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -197,15 +194,15 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
 
     // With cursorAutoArrangeFilters flag on, the indexes are sorted by cost ASC, hence country name index is used first.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: countryName = United States (selectionSize = 528)\n"
         + "matcher: page LIKE '%u%'\n",
         filterBundle.getInfo().describe()
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_or_countryNotNull_pageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -218,7 +215,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: OR (selectionSize = 39244)\n"
         + "  index: ~(countryName IS NULL) (selectionSize = 3799)\n"
         + "  index: page LIKE '%u%' (selectionSize = 15328)\n",
@@ -226,8 +223,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true"})
+  @ParameterizedTest
+  @ValueSource(booleans = true)
   public void test_or_pageLike_countryNotNull_pageLike_with_cursorAutoArrangeFilters(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -241,7 +238,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
 
     // With cursorAutoArrangeFilters flag on, the indexes are sorted by cost ASC, hence country name index is used first.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: OR (selectionSize = 39244)\n"
         + "  index: ~(countryName IS NULL) (selectionSize = 3799)\n"
         + "  index: page LIKE '%u%' (selectionSize = 15328)\n",
@@ -249,8 +246,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_and_countryNotNull_pageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -263,7 +260,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: ~(countryName IS NULL) (selectionSize = 3799)\n"
         + "matcher: page LIKE '%u%'\n",
         filterBundle.getInfo().describe()
@@ -271,8 +268,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
   }
 
 
-  @Test
-  @Parameters({"true"})
+  @ParameterizedTest
+  @ValueSource(booleans = true)
   public void test_and_cursorAutoArrangeFilters(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -295,7 +292,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     // 1. countryName NullFilter: 0
     // 2. isRobot EqualityFilter: 1
     // 3. page LikeFilter with prefix and countryName EqualityFIlter: 1 + size of page dictionary with keys matching "O" prefix
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "index: AND (selectionSize = 562)\n"
         + "  index: ~(countryName IS NULL) (selectionSize = 3799)\n"
         + "  index: isRobot = false (selectionSize = 23824)\n"
@@ -306,8 +303,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true"})
+  @ParameterizedTest
+  @ValueSource(booleans = true)
   public void test_or_cursorAutoArrangeFilters(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -339,7 +336,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     // 3. isRobot TypedInFilter: 2
     // 4. page LikeFilter with prefix and countryName EqualityFilter: 1 + size of page dictionary with keys matching "O" prefix
     // 5. page LikeFilter and countryName EqualityFilter: 1 + size of page dictionary
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "matcher: OR\n"
         + "  matcher: OR\n"
         + "    with partial index: OR (selectionSize = 39244)\n"
@@ -357,8 +354,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
 
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_or_countryIsAndPageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -387,7 +384,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "matcher: OR\n"
         + "  matcher: AND\n"
         + "    with partial index: AND (selectionSize = 11851)\n"
@@ -403,8 +400,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_or_countryIsNull_and_country_pageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -422,7 +419,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "matcher: OR\n"
         + "  matcher: countryName IS NULL\n"
         + "    with partial index: countryName IS NULL (selectionSize = 35445)\n"
@@ -433,8 +430,8 @@ public class FilterBundleTest extends InitializedNullHandlingTest
     );
   }
 
-  @Test
-  @Parameters({"true", "false"})
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void test_or_countryIsNull_and_isRobotInFalseTrue_pageLike(boolean cursorAutoArrangeFilters)
   {
     final FilterBundle filterBundle = makeFilterBundle(
@@ -455,7 +452,7 @@ public class FilterBundleTest extends InitializedNullHandlingTest
         cursorAutoArrangeFilters
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "matcher: OR\n"
         + "  matcher: countryName IS NULL\n"
         + "    with partial index: countryName IS NULL (selectionSize = 35445)\n"

--- a/processing/src/test/java/org/apache/druid/segment/filter/FilterCnfConversionTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/FilterCnfConversionTest.java
@@ -32,10 +32,11 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.filter.cnf.CNFFilterExplosionException;
 import org.apache.druid.segment.filter.cnf.CalciteCnfHelper;
 import org.apache.druid.segment.filter.cnf.HiveCnfHelper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -200,7 +201,7 @@ public class FilterCnfConversionTest
         FilterTestUtils.selector("col2", "val2")
     );
     final List<Filter> normalizedOrClauses = Filters.toNormalizedOrClauses(muchReducible);
-    Assert.assertEquals(expected, normalizedOrClauses);
+    Assertions.assertEquals(expected, normalizedOrClauses);
   }
 
   @Test
@@ -408,7 +409,7 @@ public class FilterCnfConversionTest
         FilterTestUtils.not(FilterTestUtils.selector("col1", "val11"))
     );
     final List<Filter> normalizedOrClauses = Filters.toNormalizedOrClauses(filter);
-    Assert.assertEquals(expected, normalizedOrClauses);
+    Assertions.assertEquals(expected, normalizedOrClauses);
   }
 
   @Test
@@ -516,21 +517,21 @@ public class FilterCnfConversionTest
     );
     List<Filter> expected = Collections.singletonList(filter);
     List<Filter> normalizedOrClauses = Filters.toNormalizedOrClauses(filter);
-    Assert.assertEquals(expected, normalizedOrClauses);
+    Assertions.assertEquals(expected, normalizedOrClauses);
   }
 
   @Test
   public void testTrueFalseFilterRequiredColumnRewrite()
   {
-    Assert.assertTrue(TrueFilter.instance().supportsRequiredColumnRewrite());
-    Assert.assertTrue(FalseFilter.instance().supportsRequiredColumnRewrite());
+    Assertions.assertTrue(TrueFilter.instance().supportsRequiredColumnRewrite());
+    Assertions.assertTrue(FalseFilter.instance().supportsRequiredColumnRewrite());
 
-    Assert.assertEquals(TrueFilter.instance(), TrueFilter.instance().rewriteRequiredColumns(ImmutableMap.of()));
-    Assert.assertEquals(FalseFilter.instance(), FalseFilter.instance().rewriteRequiredColumns(ImmutableMap.of()));
+    Assertions.assertEquals(TrueFilter.instance(), TrueFilter.instance().rewriteRequiredColumns(ImmutableMap.of()));
+    Assertions.assertEquals(FalseFilter.instance(), FalseFilter.instance().rewriteRequiredColumns(ImmutableMap.of()));
   }
 
-  @Test(expected = CNFFilterExplosionException.class)
-  public void testExceptionOnCNFFilterExplosion() throws CNFFilterExplosionException
+  @Test
+  public void testExceptionOnCNFFilterExplosion()
   {
     Filter filter = FilterTestUtils.or(
         FilterTestUtils.and(
@@ -598,13 +599,13 @@ public class FilterCnfConversionTest
             FilterTestUtils.selector("col2", "val8")
         )
     );
-    Filters.toNormalizedOrClauses(filter);
+    Assertions.assertThrows(CNFFilterExplosionException.class, () -> Filters.toNormalizedOrClauses(filter));
   }
 
   private void assertFilter(Filter original, Filter expectedConverted, Filter actualConverted)
   {
     assertEquivalent(original, expectedConverted);
-    Assert.assertEquals(expectedConverted, actualConverted);
+    Assertions.assertEquals(expectedConverted, actualConverted);
   }
 
   /**
@@ -614,13 +615,13 @@ public class FilterCnfConversionTest
   {
     final Set<SelectorFilter> s1 = searchForSelectors(f1);
     final Set<SelectorFilter> s2 = searchForSelectors(f2);
-    Assert.assertEquals(s1, s2);
+    Assertions.assertEquals(s1, s2);
 
     // Compare truth table
     final List<SelectorFilter> selectorFilters = new ArrayList<>(s1);
     List<Map<SelectorFilter, Boolean>> truthValues = populate(selectorFilters, selectorFilters.size() - 1);
     for (Map<SelectorFilter, Boolean> truthValue : truthValues) {
-      Assert.assertEquals(evaluateFilterWith(f1, truthValue), evaluateFilterWith(f2, truthValue));
+      Assertions.assertEquals(evaluateFilterWith(f1, truthValue), evaluateFilterWith(f2, truthValue));
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/filter/InFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/InFilterTests.java
@@ -51,14 +51,15 @@ import org.apache.druid.segment.DimensionHandlerUtils;
 import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assume;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -204,7 +205,7 @@ public class InFilterTests
     @Test
     public void testMultiValueStringColumn()
     {
-      Assume.assumeFalse(isAutoSchema());
+      Assumptions.assumeFalse(isAutoSchema());
 
       assertFilterMatches(
           inFilter("dim2", ColumnType.STRING, Collections.singletonList(null)),
@@ -353,7 +354,7 @@ public class InFilterTests
       );
 
       // auto schema doesn't have float columns, so these get kind of funny
-      Assume.assumeFalse(isAutoSchema());
+      Assumptions.assumeFalse(isAutoSchema());
       assertFilterMatches(
           inFilter("f0", ColumnType.FLOAT, Arrays.asList(10.1f, 110.0f)),
           ImmutableList.of("b", "d")

--- a/processing/src/test/java/org/apache/druid/segment/filter/PredicateValueMatcherFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/PredicateValueMatcherFactoryTest.java
@@ -33,10 +33,11 @@ import org.apache.druid.segment.data.VSizeColumnarMultiInts;
 import org.apache.druid.segment.selector.TestColumnValueSelector;
 import org.apache.druid.segment.serde.StringUtf8DictionaryEncodedColumnSupplier;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -45,21 +46,21 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
   @Test
   public void testDefaultType()
   {
-    Assert.assertEquals(ColumnType.UNKNOWN_COMPLEX, forSelector(null).defaultType());
+    Assertions.assertEquals(ColumnType.UNKNOWN_COMPLEX, forSelector(null).defaultType());
   }
 
   @Test
   public void testDimensionProcessorSingleValuedDimensionMatchingValue()
   {
     final ValueMatcher matcher = forSelector("0").makeDimensionProcessor(DimensionSelector.constant("0"), false);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
   public void testDimensionProcessorSingleValuedDimensionNotMatchingValue()
   {
     final ValueMatcher matcher = forSelector("1").makeDimensionProcessor(DimensionSelector.constant("0"), false);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -81,7 +82,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     final ValueMatcher matcher = forSelector("v2")
         .makeDimensionProcessor(columnSupplier.get().makeDimensionSelector(new SimpleAscendingOffset(1), null), true);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -103,7 +104,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     final ValueMatcher matcher = forSelector("v3")
         .makeDimensionProcessor(columnSupplier.get().makeDimensionSelector(new SimpleAscendingOffset(1), null), true);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -115,7 +116,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("2.f").makeFloatProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -127,7 +128,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("5.f").makeFloatProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -139,7 +140,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("2.").makeDoubleProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -151,7 +152,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("5.").makeDoubleProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -188,7 +189,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("2").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -225,7 +226,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("5").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -237,7 +238,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("2").makeLongProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -249,7 +250,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("5").makeLongProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -261,7 +262,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector(null).makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -273,7 +274,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector(null).makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -285,7 +286,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -297,7 +298,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -309,7 +310,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -321,7 +322,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -333,7 +334,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11.f").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -345,7 +346,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11.f").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -357,7 +358,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11.d").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -369,7 +370,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("11.d").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -381,7 +382,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("val").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -393,7 +394,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("val").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -405,7 +406,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("val").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -417,7 +418,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("val").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -429,7 +430,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector(null).makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -441,7 +442,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("false").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -453,7 +454,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("false").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -466,7 +467,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     columnValueSelector.advance();
     final String base64Encoded = StringUtils.encodeBase64String(StringUtils.toUtf8("var"));
     final ValueMatcher matcher = forSelector(base64Encoded).makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -478,7 +479,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("val").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -494,7 +495,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("val").makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -507,7 +508,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector(null).makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   @Test
@@ -520,7 +521,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector("notpresent").makeComplexProcessor(columnValueSelector);
-    Assert.assertFalse(matcher.matches(false));
+    Assertions.assertFalse(matcher.matches(false));
   }
 
   @Test
@@ -533,7 +534,7 @@ public class PredicateValueMatcherFactoryTest extends InitializedNullHandlingTes
     );
     columnValueSelector.advance();
     final ValueMatcher matcher = forSelector(null).makeComplexProcessor(columnValueSelector);
-    Assert.assertTrue(matcher.matches(false));
+    Assertions.assertTrue(matcher.matches(false));
   }
 
   private static PredicateValueMatcherFactory forSelector(@Nullable String value)

--- a/processing/src/test/java/org/apache/druid/segment/filter/RangeFilterTests.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/RangeFilterTests.java
@@ -44,9 +44,9 @@ import org.apache.druid.segment.IndexBuilder;
 import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assume;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedClass;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -898,7 +898,7 @@ public class RangeFilterTests
       );
 
       // bail out, auto ingests arrays instead of mvds and this virtual column is for mvd stuff
-      Assume.assumeFalse(isAutoSchema());
+      Assumptions.assumeFalse(isAutoSchema());
 
       assertFilterMatchesSkipVectorize(
           new RangeFilter("allow-dim2", ColumnType.STRING, "a", "c", false, false, null),
@@ -934,7 +934,7 @@ public class RangeFilterTests
     {
       // only auto schema supports array columns currently, this means the match value will need to be coerceable to
       // the column value type...
-      Assume.assumeTrue(isAutoSchema());
+      Assumptions.assumeTrue(isAutoSchema());
 
       /*  dim0 .. arrayString               arrayLong             arrayDouble
           "0", .. ["a", "b", "c"],          [1L, 2L, 3L],         [1.1, 2.2, 3.3]
@@ -1281,7 +1281,7 @@ public class RangeFilterTests
     {
       // only auto schema supports array columns currently, this means the match value will need to be coerceable to
       // the column value type...
-      Assume.assumeTrue(isAutoSchema());
+      Assumptions.assumeTrue(isAutoSchema());
 
       /*  dim0 .. arrayLong
           "0", .. [1L, 2L, 3L],
@@ -1468,7 +1468,7 @@ public class RangeFilterTests
       "6", .. null
       "7", .. null
        */
-      Assume.assumeTrue(isAutoSchema());
+      Assumptions.assumeTrue(isAutoSchema());
       assertFilterMatches(
           new RangeFilter(
               "variant",
@@ -1526,7 +1526,7 @@ public class RangeFilterTests
     public void testNested()
     {
       // nested column mirrors the top level columns, so these cases are copied from other tests
-      Assume.assumeTrue(canTestArrayColumns());
+      Assumptions.assumeTrue(canTestArrayColumns());
       assertFilterMatches(
           new RangeFilter("nested.d0", ColumnType.DOUBLE, 120.0, 120.03, false, false, null),
           ImmutableList.of("3")

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterBonusTest.java
@@ -60,9 +60,9 @@ import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.joda.time.Interval;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,7 +78,8 @@ import java.util.concurrent.ThreadLocalRandom;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class SpatialFilterBonusTest
 {
   public static final int NUM_POINTS = 5000;
@@ -96,7 +97,6 @@ public class SpatialFilterBonusTest
     this.segment = segment;
   }
 
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder() throws IOException
   {
     List<Object[]> argumentArrays = new ArrayList<>();

--- a/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/filter/SpatialFilterTest.java
@@ -71,12 +71,13 @@ import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.segment.writeout.OffHeapMemorySegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.joda.time.Interval;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -90,7 +91,8 @@ import java.util.concurrent.ThreadLocalRandom;
 /**
  *
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class SpatialFilterTest extends InitializedNullHandlingTest
 {
   public static final int NUM_POINTS = 5000;
@@ -111,7 +113,6 @@ public class SpatialFilterTest extends InitializedNullHandlingTest
     this.segment = segment;
   }
 
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder() throws IOException
   {
     final IndexSpec indexSpec = IndexSpec.getDefault();
@@ -767,10 +768,10 @@ public class SpatialFilterTest extends InitializedNullHandlingTest
         new FilterTuning(false, 1, 1)
     );
     // String complex
-    Assert.assertTrue(spatialFilter.makeMatcher(new TestSpatialSelectorFactory("0,0")).matches(true));
+    Assertions.assertTrue(spatialFilter.makeMatcher(new TestSpatialSelectorFactory("0,0")).matches(true));
     // Unknown complex, invokes object predicate
-    Assert.assertFalse(spatialFilter.makeMatcher(new TestSpatialSelectorFactory(new Date())).matches(true));
-    Assert.assertFalse(spatialFilter.makeMatcher(new TestSpatialSelectorFactory(new Object())).matches(true));
+    Assertions.assertFalse(spatialFilter.makeMatcher(new TestSpatialSelectorFactory(new Date())).matches(true));
+    Assertions.assertFalse(spatialFilter.makeMatcher(new TestSpatialSelectorFactory(new Object())).matches(true));
   }
 
   static class TestSpatialSelectorFactory implements ColumnSelectorFactory

--- a/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/BaseHashJoinSegmentCursorFactoryTest.java
@@ -41,14 +41,13 @@ import org.apache.druid.segment.join.table.IndexedTable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -70,11 +69,8 @@ public class BaseHashJoinSegmentCursorFactoryTest extends InitializedNullHandlin
   public static final String REGION_TO_COUNTRY_PREFIX = "rtc.";
   public static Long NULL_COUNTRY;
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   public QueryableIndexSegment factSegment;
   public LookupExtractor countryIsoCodeToNameLookup;
@@ -82,13 +78,13 @@ public class BaseHashJoinSegmentCursorFactoryTest extends InitializedNullHandlin
   public IndexedTable countriesTable;
   public IndexedTable regionsTable;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpStatic()
   {
     NULL_COUNTRY = null;
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     factSegment = new QueryableIndexSegment(
@@ -101,7 +97,7 @@ public class BaseHashJoinSegmentCursorFactoryTest extends InitializedNullHandlin
     regionsTable = JoinTestHelper.createRegionsIndexedTable();
   }
 
-  @After
+  @AfterEach
   public void tearDown()
   {
     if (factSegment != null) {
@@ -245,15 +241,15 @@ public class BaseHashJoinSegmentCursorFactoryTest extends InitializedNullHandlin
       ExpressionVirtualColumn actualVirtualColumn
   )
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedVirtualColumn.getOutputName(),
         actualVirtualColumn.getOutputName()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedVirtualColumn.getOutputType(),
         actualVirtualColumn.getOutputType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedVirtualColumn.getParsedExpression().get().toString(),
         actualVirtualColumn.getParsedExpression().get().toString()
     );

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentCursorFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentCursorFactoryTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.join;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import org.apache.druid.error.ExceptionMatcher;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.math.expr.ExprMacroTable;
@@ -46,8 +47,8 @@ import org.apache.druid.segment.filter.SelectorFilter;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -57,7 +58,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
   @Test
   public void test_getInterval_factToCountry()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Intervals.of("2015-09-12/2015-09-12T05:21:00.060Z"),
         makeFactToCountrySegment().getDataInterval()
     );
@@ -66,7 +67,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
   @Test
   public void test_getRowSignature_factToCountry()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(
             "__time",
             "channel",
@@ -93,11 +94,11 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
   {
     final ColumnCapabilities capabilities = makeFactToCountrySegment().as(CursorFactory.class).getColumnCapabilities("countryIsoCode");
 
-    Assert.assertEquals(ValueType.STRING, capabilities.getType());
-    Assert.assertTrue(capabilities.hasBitmapIndexes());
-    Assert.assertTrue(capabilities.isDictionaryEncoded().isTrue());
-    Assert.assertTrue(capabilities.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(capabilities.areDictionaryValuesUnique().isTrue());
+    Assertions.assertEquals(ValueType.STRING, capabilities.getType());
+    Assertions.assertTrue(capabilities.hasBitmapIndexes());
+    Assertions.assertTrue(capabilities.isDictionaryEncoded().isTrue());
+    Assertions.assertTrue(capabilities.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(capabilities.areDictionaryValuesUnique().isTrue());
   }
 
   @Test
@@ -107,11 +108,11 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryIsoCode"
     );
 
-    Assert.assertEquals(ValueType.STRING, capabilities.getType());
-    Assert.assertFalse(capabilities.hasBitmapIndexes());
-    Assert.assertFalse(capabilities.areDictionaryValuesUnique().isTrue());
-    Assert.assertFalse(capabilities.areDictionaryValuesSorted().isTrue());
-    Assert.assertTrue(capabilities.isDictionaryEncoded().isTrue());
+    Assertions.assertEquals(ValueType.STRING, capabilities.getType());
+    Assertions.assertFalse(capabilities.hasBitmapIndexes());
+    Assertions.assertFalse(capabilities.areDictionaryValuesUnique().isTrue());
+    Assertions.assertFalse(capabilities.areDictionaryValuesSorted().isTrue());
+    Assertions.assertTrue(capabilities.isDictionaryEncoded().isTrue());
   }
 
   @Test
@@ -120,7 +121,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
     final ColumnCapabilities capabilities = makeFactToCountrySegment().as(CursorFactory.class)
         .getColumnCapabilities("nonexistent");
 
-    Assert.assertNull(capabilities);
+    Assertions.assertNull(capabilities);
   }
 
   @Test
@@ -129,13 +130,13 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
     final ColumnCapabilities capabilities = makeFactToCountrySegment().as(CursorFactory.class)
         .getColumnCapabilities(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "nonexistent");
 
-    Assert.assertNull(capabilities);
+    Assertions.assertNull(capabilities);
   }
 
   @Test
   public void test_getColumnCapabilities_complexTypeName_factToCountryFactColumn()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "hyperUnique",
         makeFactToCountrySegment().as(CursorFactory.class).getColumnCapabilities("channel_uniques").getComplexTypeName()
     );
@@ -144,7 +145,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
   @Test
   public void test_getColumnCapabilities_typeString_factToCountryFactColumn()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "COMPLEX<hyperUnique>",
         makeFactToCountrySegment().as(CursorFactory.class).getColumnCapabilities("channel_uniques").asTypeString()
     );
@@ -153,7 +154,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
   @Test
   public void test_getColumnCapabilities_typeString_factToCountryJoinColumn()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "STRING",
         makeFactToCountrySegment().as(CursorFactory.class)
                                   .getColumnCapabilities(FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX + "countryName")
@@ -236,7 +237,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
     ).makeCursorHolder(CursorBuildSpec.FULL_SCAN)) {
       expectedRows = countRows(syncHolder);
     }
-    Assert.assertTrue(expectedRows > 0);
+    Assertions.assertTrue(expectedRows > 0);
 
     // async path: the left/base holder loads on demand (mimics a partial base segment); build-side joinable is resident
     final DeferredCursorFactory base = new DeferredCursorFactory(factSegment.as(CursorFactory.class));
@@ -247,11 +248,11 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         joinFilterPreAnalysis
     ).makeCursorHolderAsync(CursorBuildSpec.FULL_SCAN);
     try {
-      Assert.assertFalse("join holder must wait for the base to complete", asyncHolder.isReady());
+      Assertions.assertFalse(asyncHolder.isReady(), "join holder must wait for the base to complete");
       base.complete();
-      Assert.assertTrue("join holder becomes ready once the base completes", asyncHolder.isReady());
+      Assertions.assertTrue(asyncHolder.isReady(), "join holder becomes ready once the base completes");
       try (CursorHolder holder = asyncHolder.release()) {
-        Assert.assertEquals(expectedRows, countRows(holder));
+        Assertions.assertEquals(expectedRows, countRows(holder));
       }
     }
     finally {
@@ -274,9 +275,9 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         joinFilterPreAnalysis
     ).makeCursorHolderAsync(CursorBuildSpec.FULL_SCAN);
 
-    Assert.assertFalse(asyncHolder.isReady());
+    Assertions.assertFalse(asyncHolder.isReady());
     asyncHolder.close();
-    Assert.assertTrue("closing the join holder before it's ready cancels the base load", base.canceled.get());
+    Assertions.assertTrue(base.canceled.get(), "closing the join holder before it's ready cancels the base load");
   }
 
   private static int countRows(CursorHolder holder)
@@ -1601,9 +1602,6 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
   @Test
   public void test_makeCursor_errorOnNonEquiJoin()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Cannot build hash-join matcher on non-equi-join condition: x == y");
-
     List<JoinableClause> joinableClauses = ImmutableList.of(
         new JoinableClause(
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
@@ -1623,23 +1621,24 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         VirtualColumns.EMPTY
     );
 
-    JoinTestHelper.readCursor(
-        new HashJoinSegmentCursorFactory(
-            factSegment.as(CursorFactory.class),
-            null,
-            joinableClauses,
-            joinFilterPreAnalysis
-        ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
-        ImmutableList.of()
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> JoinTestHelper.readCursor(
+            new HashJoinSegmentCursorFactory(
+                factSegment.as(CursorFactory.class),
+                null,
+                joinableClauses,
+                joinFilterPreAnalysis
+            ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
+            ImmutableList.of()
+        )
     );
+    Assertions.assertEquals("Cannot build hash-join matcher on non-equi-join condition: x == y", exception.getMessage());
   }
 
   @Test
   public void test_makeCursor_errorOnNonEquiJoinUsingLookup()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Cannot join lookup with non-equi condition: x == y");
-
     List<JoinableClause> joinableClauses = ImmutableList.of(
         new JoinableClause(
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
@@ -1659,23 +1658,24 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         VirtualColumns.EMPTY
     );
 
-    JoinTestHelper.readCursor(
-        new HashJoinSegmentCursorFactory(
-            factSegment.as(CursorFactory.class),
-            null,
-            joinableClauses,
-            joinFilterPreAnalysis
-        ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
-        ImmutableList.of()
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> JoinTestHelper.readCursor(
+            new HashJoinSegmentCursorFactory(
+                factSegment.as(CursorFactory.class),
+                null,
+                joinableClauses,
+                joinFilterPreAnalysis
+            ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
+            ImmutableList.of()
+        )
     );
+    Assertions.assertEquals("Cannot join lookup with non-equi condition: x == y", exception.getMessage());
   }
 
   @Test
   public void test_makeCursor_errorOnNonKeyBasedJoin()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage("Cannot build hash-join matcher on non-key-based condition: "
-                                    + "Equality{leftExpr=x, rightColumn='countryName', includeNull=false}");
     List<JoinableClause> joinableClauses = ImmutableList.of(
         new JoinableClause(
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
@@ -1695,23 +1695,28 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         VirtualColumns.EMPTY
     );
 
-    JoinTestHelper.readCursor(
-        new HashJoinSegmentCursorFactory(
-            factSegment.as(CursorFactory.class),
-            null,
-            joinableClauses,
-            joinFilterPreAnalysis
-        ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
-        ImmutableList.of()
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> JoinTestHelper.readCursor(
+            new HashJoinSegmentCursorFactory(
+                factSegment.as(CursorFactory.class),
+                null,
+                joinableClauses,
+                joinFilterPreAnalysis
+            ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
+            ImmutableList.of()
+        )
+    );
+    Assertions.assertEquals(
+        "Cannot build hash-join matcher on non-key-based condition: "
+        + "Equality{leftExpr=x, rightColumn='countryName', includeNull=false}",
+        exception.getMessage()
     );
   }
 
   @Test
   public void test_makeCursor_errorOnNonKeyBasedJoinUsingLookup()
   {
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "Cannot join lookup with condition referring to non-key column: x == \"c1.countryName");
     List<JoinableClause> joinableClauses = ImmutableList.of(
         new JoinableClause(
             FACT_TO_COUNTRY_ON_ISO_CODE_PREFIX,
@@ -1731,14 +1736,20 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         VirtualColumns.EMPTY
     );
 
-    JoinTestHelper.readCursor(
-        new HashJoinSegmentCursorFactory(
-            factSegment.as(CursorFactory.class),
-            null,
-            joinableClauses,
-            joinFilterPreAnalysis
-        ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
-        ImmutableList.of()
+    final ExceptionMatcher exceptionMatcher = new ExceptionMatcher(IllegalArgumentException.class);
+    exceptionMatcher.expectMessageContains(
+        "Cannot join lookup with condition referring to non-key column: x == \"c1.countryName"
+    );
+    exceptionMatcher.assertThrowsAndMatches(
+        () -> JoinTestHelper.readCursor(
+            new HashJoinSegmentCursorFactory(
+                factSegment.as(CursorFactory.class),
+                null,
+                joinableClauses,
+                joinFilterPreAnalysis
+            ).makeCursorHolder(CursorBuildSpec.FULL_SCAN),
+            ImmutableList.of()
+        )
     );
   }
 
@@ -2011,10 +2022,10 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
   @Test
   public void test_hasBuiltInFiltersForSingleJoinableClauseWithVariousJoinTypes()
   {
-    Assert.assertFalse(makeFactToCountrySegment(JoinType.INNER).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
-    Assert.assertTrue(makeFactToCountrySegment(JoinType.LEFT).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
-    Assert.assertFalse(makeFactToCountrySegment(JoinType.RIGHT).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
-    Assert.assertTrue(makeFactToCountrySegment(JoinType.FULL).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertFalse(makeFactToCountrySegment(JoinType.INNER).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertTrue(makeFactToCountrySegment(JoinType.LEFT).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertFalse(makeFactToCountrySegment(JoinType.RIGHT).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertTrue(makeFactToCountrySegment(JoinType.FULL).as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
     // cross join
     HashJoinSegment segment = new HashJoinSegment(
         ReferenceCountedSegmentProvider.unmanaged(factSegment).orElseThrow(),
@@ -2035,7 +2046,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         () -> {}
     );
     TopNOptimizationInspector inspector = segment.as(TopNOptimizationInspector.class);
-    Assert.assertTrue(inspector.areAllDictionaryIdsPresent());
+    Assertions.assertTrue(inspector.areAllDictionaryIdsPresent());
   }
 
   @Test
@@ -2049,7 +2060,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         () -> {}
     );
     final TopNOptimizationInspector inspector = segment.as(TopNOptimizationInspector.class);
-    Assert.assertFalse(inspector.areAllDictionaryIdsPresent());
+    Assertions.assertFalse(inspector.areAllDictionaryIdsPresent());
   }
 
   @Test
@@ -2065,7 +2076,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         null,
         () -> {}
     );
-    Assert.assertFalse(segment.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertFalse(segment.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
 
     final HashJoinSegment segment2 = new HashJoinSegment(
         ReferenceCountedSegmentProvider.unmanaged(factSegment).orElseThrow(),
@@ -2078,7 +2089,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         null,
         () -> {}
     );
-    Assert.assertFalse(segment2.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertFalse(segment2.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
 
     final HashJoinSegment segment3 = new HashJoinSegment(
         ReferenceCountedSegmentProvider.unmanaged(factSegment).orElseThrow(),
@@ -2090,7 +2101,7 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         null,
         () -> {}
     );
-    Assert.assertTrue(segment3.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertTrue(segment3.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
 
     final HashJoinSegment segment4 = new HashJoinSegment(
         ReferenceCountedSegmentProvider.unmanaged(factSegment).orElseThrow(),
@@ -2111,6 +2122,6 @@ public class HashJoinSegmentCursorFactoryTest extends BaseHashJoinSegmentCursorF
         null,
         () -> {}
     );
-    Assert.assertTrue(segment4.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
+    Assertions.assertTrue(segment4.as(TopNOptimizationInspector.class).areAllDictionaryIdsPresent());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/HashJoinSegmentTest.java
@@ -38,19 +38,19 @@ import org.apache.druid.segment.WrappedSegment;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.SegmentId;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
@@ -58,11 +58,8 @@ import java.util.Optional;
 
 public class HashJoinSegmentTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   private QueryableIndexSegment baseSegment;
   private ReferenceCountedSegmentProvider baseSegmentRef;
@@ -79,7 +76,7 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
   private boolean j0Closed;
   private boolean j1Closed;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException
   {
     allReferencesAcquireCount = 0;
@@ -166,7 +163,7 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
                       );
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     closer.close();
@@ -214,7 +211,7 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
   public void test_constructor_noClauses()
   {
     final List<JoinableClause> empty = ImmutableList.of();
-    Throwable t = Assert.assertThrows(
+    Throwable t = Assertions.assertThrows(
         IllegalArgumentException.class,
         () -> new HashJoinSegment(
             referencedSegment.acquireReference().orElseThrow(),
@@ -224,26 +221,26 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
             () -> allReferencesCloseCount--
         )
     );
-    Assert.assertEquals("'clauses' and 'baseFilter' are both empty, no need to create HashJoinSegment", t.getMessage());
-    Assert.assertEquals(0, allReferencesAcquireCount);
+    Assertions.assertEquals("'clauses' and 'baseFilter' are both empty, no need to create HashJoinSegment", t.getMessage());
+    Assertions.assertEquals(0, allReferencesAcquireCount);
   }
 
   @Test
   public void test_getId()
   {
-    Assert.assertEquals(baseSegment.getId(), makeJoinSegment().getId());
+    Assertions.assertEquals(baseSegment.getId(), makeJoinSegment().getId());
   }
 
   @Test
   public void test_getDataInterval()
   {
-    Assert.assertEquals(baseSegment.getDataInterval(), makeJoinSegment().getDataInterval());
+    Assertions.assertEquals(baseSegment.getDataInterval(), makeJoinSegment().getDataInterval());
   }
 
   @Test
   public void test_asQueryableIndex()
   {
-    Assert.assertNull(makeJoinSegment().as(QueryableIndex.class));
+    Assertions.assertNull(makeJoinSegment().as(QueryableIndex.class));
   }
 
   @Test
@@ -258,76 +255,76 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
   @Test
   public void testJoinableClausesAreClosedWhenReferencesUsed() throws IOException
   {
-    Assert.assertFalse(baseSegmentRef.isClosed());
+    Assertions.assertFalse(baseSegmentRef.isClosed());
 
     Optional<Segment> maybeCloseable = makeJoinSegment(joinableClauses, null, null);
-    Assert.assertTrue(maybeCloseable.isPresent());
+    Assertions.assertTrue(maybeCloseable.isPresent());
 
-    Assert.assertEquals(1, referencedSegmentAcquireCount);
-    Assert.assertEquals(2, indexedTableJoinableReferenceAcquireCount);
-    Assert.assertEquals(1, allReferencesAcquireCount);
-    Assert.assertEquals(0, referencedSegmentClosedCount);
-    Assert.assertEquals(0, indexedTableJoinableReferenceCloseCount);
-    Assert.assertEquals(0, allReferencesCloseCount);
+    Assertions.assertEquals(1, referencedSegmentAcquireCount);
+    Assertions.assertEquals(2, indexedTableJoinableReferenceAcquireCount);
+    Assertions.assertEquals(1, allReferencesAcquireCount);
+    Assertions.assertEquals(0, referencedSegmentClosedCount);
+    Assertions.assertEquals(0, indexedTableJoinableReferenceCloseCount);
+    Assertions.assertEquals(0, allReferencesCloseCount);
 
     Closeable closer = maybeCloseable.get();
     closer.close();
 
-    Assert.assertFalse(baseSegmentRef.isClosed());
-    Assert.assertEquals(1, referencedSegmentClosedCount);
-    Assert.assertEquals(2, indexedTableJoinableReferenceCloseCount);
-    Assert.assertEquals(1, allReferencesCloseCount);
+    Assertions.assertFalse(baseSegmentRef.isClosed());
+    Assertions.assertEquals(1, referencedSegmentClosedCount);
+    Assertions.assertEquals(2, indexedTableJoinableReferenceCloseCount);
+    Assertions.assertEquals(1, allReferencesCloseCount);
 
   }
 
   @Test
   public void testJoinableClausesClosedIfSegmentIsAlreadyClosed()
   {
-    Assert.assertFalse(baseSegmentRef.isClosed());
+    Assertions.assertFalse(baseSegmentRef.isClosed());
 
     baseSegmentRef.close();
-    Assert.assertTrue(baseSegmentRef.isClosed());
+    Assertions.assertTrue(baseSegmentRef.isClosed());
 
     Optional<Segment> maybeCloseable = makeJoinSegment(joinableClauses, null, null);
-    Assert.assertFalse(maybeCloseable.isPresent());
-    Assert.assertEquals(0, referencedSegmentAcquireCount);
-    Assert.assertEquals(0, indexedTableJoinableReferenceAcquireCount);
-    Assert.assertEquals(0, allReferencesAcquireCount);
-    Assert.assertEquals(0, referencedSegmentClosedCount);
-    Assert.assertEquals(0, indexedTableJoinableReferenceCloseCount);
-    Assert.assertEquals(0, allReferencesCloseCount);
+    Assertions.assertFalse(maybeCloseable.isPresent());
+    Assertions.assertEquals(0, referencedSegmentAcquireCount);
+    Assertions.assertEquals(0, indexedTableJoinableReferenceAcquireCount);
+    Assertions.assertEquals(0, allReferencesAcquireCount);
+    Assertions.assertEquals(0, referencedSegmentClosedCount);
+    Assertions.assertEquals(0, indexedTableJoinableReferenceCloseCount);
+    Assertions.assertEquals(0, allReferencesCloseCount);
   }
 
   @Test
   public void testJoinableClausesClosedIfJoinableZeroIsAlreadyClosed()
   {
-    Assert.assertFalse(baseSegmentRef.isClosed());
+    Assertions.assertFalse(baseSegmentRef.isClosed());
     j0Closed = true;
 
     Optional<Segment> maybeCloseable = makeJoinSegment(joinableClauses, null, null);
-    Assert.assertFalse(maybeCloseable.isPresent());
-    Assert.assertEquals(1, referencedSegmentAcquireCount);
-    Assert.assertEquals(0, indexedTableJoinableReferenceAcquireCount);
-    Assert.assertEquals(0, allReferencesAcquireCount);
-    Assert.assertEquals(1, referencedSegmentClosedCount);
-    Assert.assertEquals(0, indexedTableJoinableReferenceCloseCount);
-    Assert.assertEquals(0, allReferencesCloseCount);
+    Assertions.assertFalse(maybeCloseable.isPresent());
+    Assertions.assertEquals(1, referencedSegmentAcquireCount);
+    Assertions.assertEquals(0, indexedTableJoinableReferenceAcquireCount);
+    Assertions.assertEquals(0, allReferencesAcquireCount);
+    Assertions.assertEquals(1, referencedSegmentClosedCount);
+    Assertions.assertEquals(0, indexedTableJoinableReferenceCloseCount);
+    Assertions.assertEquals(0, allReferencesCloseCount);
   }
 
   @Test
   public void testJoinableClausesClosedIfJoinableOneIsAlreadyClosed()
   {
-    Assert.assertFalse(baseSegmentRef.isClosed());
+    Assertions.assertFalse(baseSegmentRef.isClosed());
     j1Closed = true;
 
     Optional<Segment> maybeCloseable = makeJoinSegment(joinableClauses, null, null);
-    Assert.assertFalse(maybeCloseable.isPresent());
-    Assert.assertEquals(1, referencedSegmentAcquireCount);
-    Assert.assertEquals(1, indexedTableJoinableReferenceAcquireCount);
-    Assert.assertEquals(0, allReferencesAcquireCount);
-    Assert.assertEquals(1, referencedSegmentClosedCount);
-    Assert.assertEquals(1, indexedTableJoinableReferenceCloseCount);
-    Assert.assertEquals(0, allReferencesCloseCount);
+    Assertions.assertFalse(maybeCloseable.isPresent());
+    Assertions.assertEquals(1, referencedSegmentAcquireCount);
+    Assertions.assertEquals(1, indexedTableJoinableReferenceAcquireCount);
+    Assertions.assertEquals(0, allReferencesAcquireCount);
+    Assertions.assertEquals(1, referencedSegmentClosedCount);
+    Assertions.assertEquals(1, indexedTableJoinableReferenceCloseCount);
+    Assertions.assertEquals(0, allReferencesCloseCount);
   }
 
 
@@ -335,16 +332,24 @@ public class HashJoinSegmentTest extends InitializedNullHandlingTest
   public void testGetMinTime()
   {
     final TimeBoundaryInspector timeBoundaryInspector = makeJoinSegment().as(TimeBoundaryInspector.class);
-    Assert.assertNotNull("non-null inspector", timeBoundaryInspector);
-    Assert.assertEquals("minTime", DateTimes.of("2015-09-12T00:46:58.771Z"), timeBoundaryInspector.getMinTime());
-    Assert.assertEquals("maxTime", DateTimes.of("2015-09-12T05:21:00.059Z"), timeBoundaryInspector.getMaxTime());
-    Assert.assertFalse("exact", timeBoundaryInspector.isMinMaxExact());
+    Assertions.assertNotNull(timeBoundaryInspector, "non-null inspector");
+    Assertions.assertEquals(
+        DateTimes.of("2015-09-12T00:46:58.771Z"),
+        timeBoundaryInspector.getMinTime(),
+        "minTime"
+    );
+    Assertions.assertEquals(
+        DateTimes.of("2015-09-12T05:21:00.059Z"),
+        timeBoundaryInspector.getMaxTime(),
+        "maxTime"
+    );
+    Assertions.assertFalse(timeBoundaryInspector.isMinMaxExact(), "exact");
   }
 
   @Test
   public void testGetMaxIngestedEventTime()
   {
     final MaxIngestedEventTimeInspector inspector = makeJoinSegment().as(MaxIngestedEventTimeInspector.class);
-    Assert.assertNull(inspector);
+    Assertions.assertNull(inspector);
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/InlineJoinableFactoryTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/InlineJoinableFactoryTest.java
@@ -26,8 +26,8 @@ import org.apache.druid.query.TableDataSource;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -71,7 +71,7 @@ public class InlineJoinableFactoryTest
   {
     final Joinable joinable = factory.build(inlineDataSource, makeCondition("x == \"j.long\"")).get();
 
-    MatcherAssert.assertThat(joinable, CoreMatchers.instanceOf(IndexedTableJoinable.class));
+    MatcherAssert.assertThat(joinable, Matchers.instanceOf(IndexedTableJoinable.class));
     Assertions.assertEquals(ImmutableList.of("str", "long"), joinable.getAvailableColumns());
     Assertions.assertEquals(3, joinable.getCardinality("str"));
     Assertions.assertEquals(3, joinable.getCardinality("long"));

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinFilterAnalyzerTest.java
@@ -51,8 +51,8 @@ import org.apache.druid.segment.join.filter.rewrite.JoinFilterRewriteConfig;
 import org.apache.druid.segment.join.lookup.LookupJoinable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.virtual.ExpressionVirtualColumn;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -115,7 +115,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
         ImmutableSet.of()
     );
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -175,7 +175,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
         ImmutableSet.of()
     );
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -237,7 +237,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -302,7 +302,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -360,7 +360,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -436,7 +436,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -493,7 +493,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -537,7 +537,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     final JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -697,7 +697,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -773,11 +773,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
         ColumnType.STRING,
         ExprMacroTable.nil()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFilterSplit.getBaseTableFilter(),
         actualFilterSplit.getBaseTableFilter()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFilterSplit.getJoinTableFilter(),
         actualFilterSplit.getJoinTableFilter()
     );
@@ -820,28 +820,32 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
         joinableClauses,
         VirtualColumns.EMPTY
     );
-    expectedException.expect(IllegalArgumentException.class);
-    expectedException.expectMessage(
-        "Cannot build hash-join matcher on non-equi-join condition: \"r1.regionIsoCode\" == regionIsoCode && reverse(\"r1.countryIsoCode\") == countryIsoCode");
-
     HashJoinSegmentCursorFactory cursorFactory = new HashJoinSegmentCursorFactory(
         factSegment.as(CursorFactory.class),
         null,
         joinableClauses,
         joinFilterPreAnalysis
     );
-    JoinTestHelper.verifyCursor(
-        cursorFactory.makeCursorHolder(
-            CursorBuildSpec.builder().setFilter(originalFilter).build()
-        ),
-        ImmutableList.of(
-            "page",
-            FACT_TO_REGION_PREFIX + "regionName",
-            REGION_TO_COUNTRY_PREFIX + "countryName"
-        ),
-        ImmutableList.of(
-            new Object[]{"Old Anatolian Turkish", "Ainigriv", "States United"}
+    final IllegalArgumentException exception = Assertions.assertThrows(
+        IllegalArgumentException.class,
+        () -> JoinTestHelper.verifyCursor(
+            cursorFactory.makeCursorHolder(
+                CursorBuildSpec.builder().setFilter(originalFilter).build()
+            ),
+            ImmutableList.of(
+                "page",
+                FACT_TO_REGION_PREFIX + "regionName",
+                REGION_TO_COUNTRY_PREFIX + "countryName"
+            ),
+            ImmutableList.of(
+                new Object[]{"Old Anatolian Turkish", "Ainigriv", "States United"}
+            )
         )
+    );
+    Assertions.assertEquals(
+        "Cannot build hash-join matcher on non-equi-join condition: "
+        + "\"r1.regionIsoCode\" == regionIsoCode && reverse(\"r1.countryIsoCode\") == countryIsoCode",
+        exception.getMessage()
     );
   }
 
@@ -933,7 +937,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1009,11 +1013,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFilterSplit.getBaseTableFilter(),
         actualFilterSplit.getBaseTableFilter()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFilterSplit.getJoinTableFilter(),
         actualFilterSplit.getJoinTableFilter()
     );
@@ -1095,11 +1099,11 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFilterSplit.getBaseTableFilter(),
         actualFilterSplit.getBaseTableFilter()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         expectedFilterSplit.getJoinTableFilter(),
         actualFilterSplit.getJoinTableFilter()
     );
@@ -1159,7 +1163,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1212,7 +1216,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1264,7 +1268,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1317,7 +1321,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1368,7 +1372,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1423,7 +1427,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1477,7 +1481,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1528,7 +1532,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1578,7 +1582,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1632,7 +1636,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1685,7 +1689,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1737,7 +1741,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1788,7 +1792,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1850,7 +1854,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -1917,7 +1921,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
 
@@ -1963,21 +1967,23 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
 
     // This query doesn't execute because regionName is not a key column, but we can still check the
     // filter rewrites.
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage(
-        "Cannot build hash-join matcher on non-key-based condition: "
-        + "Equality{leftExpr=user, rightColumn='regionName', includeNull=false}"
+    final IAE exception = Assertions.assertThrows(
+        IAE.class,
+        () -> JoinTestHelper.verifyCursor(
+            cursorFactory.makeCursorHolder(
+                CursorBuildSpec.builder().setFilter(originalFilter).build()
+            ),
+            ImmutableList.of(
+                "page",
+                FACT_TO_REGION_PREFIX + "regionName"
+            ),
+            ImmutableList.of()
+        )
     );
-
-    JoinTestHelper.verifyCursor(
-        cursorFactory.makeCursorHolder(
-            CursorBuildSpec.builder().setFilter(originalFilter).build()
-        ),
-        ImmutableList.of(
-            "page",
-            FACT_TO_REGION_PREFIX + "regionName"
-        ),
-        ImmutableList.of()
+    Assertions.assertEquals(
+        "Cannot build hash-join matcher on non-key-based condition: "
+        + "Equality{leftExpr=user, rightColumn='regionName', includeNull=false}",
+        exception.getMessage()
     );
 
     JoinFilterSplit expectedFilterSplit = new JoinFilterSplit(
@@ -1992,7 +1998,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -2047,7 +2053,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -2151,7 +2157,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -2400,7 +2406,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -2458,7 +2464,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
 
@@ -2528,7 +2534,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
     );
 
     JoinFilterSplit actualFilterSplit = split(joinFilterPreAnalysis);
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
   @Test
@@ -2575,7 +2581,7 @@ public class JoinFilterAnalyzerTest extends BaseHashJoinSegmentCursorFactoryTest
         joinFilterPreAnalysis,
         baseTableFilter
     );
-    Assert.assertEquals(expectedFilterSplit, actualFilterSplit);
+    Assertions.assertEquals(expectedFilterSplit, actualFilterSplit);
   }
 
 

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinTestHelper.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinTestHelper.java
@@ -57,9 +57,10 @@ import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.join.table.RowBasedIndexedTable;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -397,10 +398,10 @@ public class JoinTestHelper
       }
     }
 
-    Assert.assertEquals("number of rows", expectedRows.size(), rows.size());
+    Assertions.assertEquals(expectedRows.size(), rows.size(), "number of rows");
 
     for (int i = 0; i < rows.size(); i++) {
-      Assert.assertArrayEquals("row #" + i, expectedRows.get(i), rows.get(i));
+      Assertions.assertArrayEquals(expectedRows.get(i), rows.get(i), "row #" + i);
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/JoinableFactoryWrapperTest.java
@@ -39,11 +39,10 @@ import org.apache.druid.segment.join.table.IndexedTable;
 import org.apache.druid.segment.join.table.IndexedTableJoinable;
 import org.apache.druid.segment.join.table.RowBasedIndexedTable;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Arrays;
 import java.util.List;
@@ -142,11 +141,8 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
       DateTimes.nowUtc().toString()
   );
 
-  @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
   @Test
   public void test_checkClausePrefixesForDuplicatesAndShadowing_noConflicts()
@@ -167,24 +163,22 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
   @Test
   public void test_checkClausePrefixesForDuplicatesAndShadowing_duplicate()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Detected duplicate prefix in join clauses: [AA]");
-
     List<String> prefixes = Arrays.asList(
         "AA",
         "AA",
         "ABCD"
     );
 
-    JoinPrefixUtils.checkPrefixesForDuplicatesAndShadowing(prefixes);
+    final IAE exception = Assertions.assertThrows(
+        IAE.class,
+        () -> JoinPrefixUtils.checkPrefixesForDuplicatesAndShadowing(prefixes)
+    );
+    Assertions.assertEquals("Detected duplicate prefix in join clauses: [AA]", exception.getMessage());
   }
 
   @Test
   public void test_checkClausePrefixesForDuplicatesAndShadowing_shadowing()
   {
-    expectedException.expect(IAE.class);
-    expectedException.expectMessage("Detected conflicting prefixes in join clauses: [ABC.DEF, ABC.]");
-
     List<String> prefixes = Arrays.asList(
         "BASE.",
         "BASEBALL",
@@ -194,7 +188,14 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         "ABC.DEF"
     );
 
-    JoinPrefixUtils.checkPrefixesForDuplicatesAndShadowing(prefixes);
+    final IAE exception = Assertions.assertThrows(
+        IAE.class,
+        () -> JoinPrefixUtils.checkPrefixesForDuplicatesAndShadowing(prefixes)
+    );
+    Assertions.assertEquals(
+        "Detected conflicting prefixes in join clauses: [ABC.DEF, ABC.]",
+        exception.getMessage()
+    );
   }
 
   @Test
@@ -213,7 +214,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS)),
             ImmutableList.of()
@@ -237,7 +238,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new InDimFilter(
                                  "x",
@@ -269,7 +270,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
     // Although the filter created was an In Filter in equijoin (here inFilter = IN (Mexico))
     // We should receive a SelectorFilter for Filters.toFilter(inFilter) call
     // and should receive a SelectorFilter with x = Mexico
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new SelectorFilter("x", "Mexico", null)),
             ImmutableList.of()
@@ -308,7 +309,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS), new InDimFilter("x", TEST_LOOKUP_KEYS)),
             ImmutableList.of(clauses.get(2))
@@ -347,7 +348,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(
                 new InDimFilter("x", TEST_LOOKUP_KEYS),
@@ -380,7 +381,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         2
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(),
             ImmutableList.of(clause)
@@ -405,7 +406,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(),
             ImmutableList.of(clause)
@@ -430,7 +431,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS)),
             ImmutableList.of(clause)
@@ -455,7 +456,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(FalseFilter.instance()),
             ImmutableList.of()
@@ -480,7 +481,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(),
             ImmutableList.of(clause)
@@ -505,7 +506,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(),
             ImmutableList.of(clause)
@@ -530,7 +531,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(),
             ImmutableList.of(clause)
@@ -566,7 +567,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS)),
             clauses
@@ -605,7 +606,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS)),
             clauses
@@ -644,7 +645,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(new InDimFilter("x", TEST_LOOKUP_KEYS), new InDimFilter("x", TEST_LOOKUP_KEYS)),
             clauses.subList(1, clauses.size())
@@ -679,7 +680,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
         Integer.MAX_VALUE
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(),
             clauses
@@ -704,7 +705,7 @@ public class JoinableFactoryWrapperTest extends InitializedNullHandlingTest
     );
 
     // Optimization does not kick in as there are > 1 equijoins
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Pair.of(
             ImmutableList.of(),
             ImmutableList.of(joinableClause)

--- a/processing/src/test/java/org/apache/druid/segment/join/PostJoinCursorTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/PostJoinCursorTest.java
@@ -38,10 +38,11 @@ import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.join.filter.JoinFilterPreAnalysis;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -49,8 +50,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class PostJoinCursorTest extends BaseHashJoinSegmentCursorFactoryTest
 {

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcherTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinMatcherTest.java
@@ -35,12 +35,10 @@ import org.apache.druid.segment.DimensionSelector;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.data.ArrayBasedIndexedInts;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -61,7 +59,7 @@ public class IndexedTableJoinMatcherTest
       private BaseLongColumnValueSelector selector;
       private AutoCloseable mocks;
 
-      @Before
+      @BeforeEach
       public void setUp()
       {
         mocks = MockitoAnnotations.openMocks(this);
@@ -70,7 +68,7 @@ public class IndexedTableJoinMatcherTest
         Mockito.doReturn(1L).when(selector).getLong();
       }
 
-      @After
+      @AfterEach
       public void tearDown() throws Exception
       {
         mocks.close();
@@ -83,7 +81,7 @@ public class IndexedTableJoinMatcherTest
             new IndexedTableJoinMatcher.ConditionMatcherFactory(longPlusOneIndex(), false);
         final IndexedTableJoinMatcher.ConditionMatcher processor = conditionMatcherFactory.makeLongProcessor(selector);
 
-        Assert.assertEquals(ImmutableList.of(2), ImmutableList.copyOf(processor.match()));
+        Assertions.assertEquals(ImmutableList.of(2), ImmutableList.copyOf(processor.match()));
       }
 
       @Test
@@ -93,7 +91,7 @@ public class IndexedTableJoinMatcherTest
             new IndexedTableJoinMatcher.ConditionMatcherFactory(longPlusOneIndex(), false);
         final IndexedTableJoinMatcher.ConditionMatcher processor = conditionMatcherFactory.makeLongProcessor(selector);
 
-        Assert.assertEquals(2, processor.matchSingleRow());
+        Assertions.assertEquals(2, processor.matchSingleRow());
       }
 
       @Test
@@ -103,7 +101,7 @@ public class IndexedTableJoinMatcherTest
             new IndexedTableJoinMatcher.ConditionMatcherFactory(longAlwaysOneTwoThreeIndex(), false);
         final IndexedTableJoinMatcher.ConditionMatcher processor = conditionMatcherFactory.makeLongProcessor(selector);
 
-        Assert.assertEquals(ImmutableList.of(1, 2, 3), ImmutableList.copyOf(processor.match()));
+        Assertions.assertEquals(ImmutableList.of(1, 2, 3), ImmutableList.copyOf(processor.match()));
       }
 
       @Test
@@ -113,7 +111,7 @@ public class IndexedTableJoinMatcherTest
             new IndexedTableJoinMatcher.ConditionMatcherFactory(longAlwaysOneTwoThreeIndex(), false);
         final IndexedTableJoinMatcher.ConditionMatcher processor = conditionMatcherFactory.makeLongProcessor(selector);
 
-        Assert.assertThrows(UnsupportedOperationException.class, processor::matchSingleRow);
+        Assertions.assertThrows(UnsupportedOperationException.class, processor::matchSingleRow);
       }
 
       @Test
@@ -123,7 +121,7 @@ public class IndexedTableJoinMatcherTest
             new IndexedTableJoinMatcher.ConditionMatcherFactory(certainStringToThreeIndex(), false);
         final IndexedTableJoinMatcher.ConditionMatcher processor = conditionMatcherFactory.makeLongProcessor(selector);
 
-        Assert.assertEquals(ImmutableList.of(3), ImmutableList.copyOf(processor.match()));
+        Assertions.assertEquals(ImmutableList.of(3), ImmutableList.copyOf(processor.match()));
       }
 
       @Test
@@ -133,26 +131,23 @@ public class IndexedTableJoinMatcherTest
             new IndexedTableJoinMatcher.ConditionMatcherFactory(certainStringToThreeIndex(), false);
         final IndexedTableJoinMatcher.ConditionMatcher processor = conditionMatcherFactory.makeLongProcessor(selector);
 
-        Assert.assertEquals(3, processor.matchSingleRow());
+        Assertions.assertEquals(3, processor.matchSingleRow());
       }
     }
 
     public static class MakeComplexProcessorTest extends InitializedNullHandlingTest
     {
-      @Rule
-      public ExpectedException expectedException = ExpectedException.none();
-
       @Mock
       private BaseObjectColumnValueSelector<?> selector;
       private AutoCloseable mocks;
 
-      @Before
+      @BeforeEach
       public void setUp()
       {
         mocks = MockitoAnnotations.openMocks(this);
       }
 
-      @After
+      @AfterEach
       public void tearDown() throws Exception
       {
         mocks.close();
@@ -167,7 +162,7 @@ public class IndexedTableJoinMatcherTest
         final IndexedTableJoinMatcher.ConditionMatcher processor =
             conditionMatcherFactory.makeComplexProcessor(selector);
 
-        Assert.assertEquals(ImmutableList.of(), ImmutableList.copyOf(processor.match()));
+        Assertions.assertEquals(ImmutableList.of(), ImmutableList.copyOf(processor.match()));
       }
 
       @Test
@@ -179,15 +174,12 @@ public class IndexedTableJoinMatcherTest
         final IndexedTableJoinMatcher.ConditionMatcher processor =
             conditionMatcherFactory.makeComplexProcessor(selector);
 
-        Assert.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, processor.matchSingleRow());
+        Assertions.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, processor.matchSingleRow());
       }
     }
 
     public static class MakeDimensionProcessorTest extends InitializedNullHandlingTest
     {
-      @Rule
-      public ExpectedException expectedException = ExpectedException.none();
-
       @Mock
       private DimensionSelector dimensionSelector;
 
@@ -211,8 +203,7 @@ public class IndexedTableJoinMatcherTest
           );
 
           // Test match should throw exception
-          expectedException.expect(QueryUnsupportedException.class);
-          dimensionProcessor.match();
+          Assertions.assertThrows(QueryUnsupportedException.class, dimensionProcessor::match);
         }
       }
 
@@ -232,8 +223,7 @@ public class IndexedTableJoinMatcherTest
           );
 
           // Test match should throw exception
-          expectedException.expect(QueryUnsupportedException.class);
-          dimensionProcessor.match();
+          Assertions.assertThrows(QueryUnsupportedException.class, dimensionProcessor::match);
         }
       }
 
@@ -254,10 +244,10 @@ public class IndexedTableJoinMatcherTest
               false
           );
 
-          Assert.assertNotNull(dimensionProcessor.match());
-          Assert.assertTrue(dimensionProcessor.match().isEmpty());
+          Assertions.assertNotNull(dimensionProcessor.match());
+          Assertions.assertTrue(dimensionProcessor.match().isEmpty());
 
-          Assert.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
+          Assertions.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
         }
       }
 
@@ -276,10 +266,10 @@ public class IndexedTableJoinMatcherTest
               false
           );
 
-          Assert.assertNotNull(dimensionProcessor.match());
-          Assert.assertTrue(dimensionProcessor.match().isEmpty());
+          Assertions.assertNotNull(dimensionProcessor.match());
+          Assertions.assertTrue(dimensionProcessor.match().isEmpty());
 
-          Assert.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
+          Assertions.assertEquals(IndexedTableJoinMatcher.NO_CONDITION_MATCH, dimensionProcessor.matchSingleRow());
         }
       }
 
@@ -289,8 +279,8 @@ public class IndexedTableJoinMatcherTest
         IndexedTableJoinMatcher.ConditionMatcher target =
             makeConditionMatcher(DimensionDictionarySelector.CARDINALITY_UNKNOWN);
 
-        Assert.assertEquals(ImmutableList.of(KEY.length()), new IntArrayList(target.match()));
-        Assert.assertEquals(KEY.length(), target.matchSingleRow());
+        Assertions.assertEquals(ImmutableList.of(KEY.length()), new IntArrayList(target.match()));
+        Assertions.assertEquals(KEY.length(), target.matchSingleRow());
       }
 
       @Test
@@ -299,8 +289,8 @@ public class IndexedTableJoinMatcherTest
         int lowCardinality = IndexedTableJoinMatcher.ConditionMatcherFactory.CACHE_MAX_SIZE / 10;
         IndexedTableJoinMatcher.ConditionMatcher target = makeConditionMatcher(lowCardinality);
 
-        Assert.assertEquals(ImmutableList.of(KEY.length()), new IntArrayList(target.match()));
-        Assert.assertEquals(KEY.length(), target.matchSingleRow());
+        Assertions.assertEquals(ImmutableList.of(KEY.length()), new IntArrayList(target.match()));
+        Assertions.assertEquals(KEY.length(), target.matchSingleRow());
       }
 
       @Test
@@ -309,8 +299,8 @@ public class IndexedTableJoinMatcherTest
         int highCardinality = IndexedTableJoinMatcher.ConditionMatcherFactory.CACHE_MAX_SIZE / 10;
         IndexedTableJoinMatcher.ConditionMatcher target = makeConditionMatcher(highCardinality);
 
-        Assert.assertEquals(ImmutableList.of(KEY.length()), new IntArrayList(target.match()));
-        Assert.assertEquals(KEY.length(), target.matchSingleRow());
+        Assertions.assertEquals(ImmutableList.of(KEY.length()), new IntArrayList(target.match()));
+        Assertions.assertEquals(KEY.length(), target.matchSingleRow());
       }
 
       private static IndexedTableJoinMatcher.ConditionMatcher makeConditionMatcher(int valueCardinality)
@@ -349,7 +339,7 @@ public class IndexedTableJoinMatcherTest
 
     private AtomicLong counter;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
       counter = new AtomicLong(0);
@@ -365,17 +355,17 @@ public class IndexedTableJoinMatcherTest
     public void loadsValueIfAbsent()
     {
       Long key = 1L;
-      Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(1L, counter.longValue());
+      Assertions.assertEquals(key, target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(1L, counter.longValue());
     }
 
     @Test
     public void doesNotLoadIfPresent()
     {
       Long key = 1L;
-      Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(1L, counter.longValue());
+      Assertions.assertEquals(key, target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(key, target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(1L, counter.longValue());
     }
 
     @Test
@@ -386,13 +376,13 @@ public class IndexedTableJoinMatcherTest
 
       for (long i = start; i < next; i++) {
         Long key = i;
-        Assert.assertEquals(key, target.getAndLoadIfAbsent(key));
+        Assertions.assertEquals(key, target.getAndLoadIfAbsent(key));
       }
 
-      Assert.assertEquals(next, target.getAndLoadIfAbsent(next));
-      Assert.assertNull(target.get(start));
+      Assertions.assertEquals(next, target.getAndLoadIfAbsent(next));
+      Assertions.assertNull(target.get(start));
 
-      Assert.assertEquals(SIZE + 1, counter.longValue());
+      Assertions.assertEquals(SIZE + 1, counter.longValue());
     }
   }
 
@@ -402,7 +392,7 @@ public class IndexedTableJoinMatcherTest
 
     private AtomicLong counter;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
       counter = new AtomicLong(0);
@@ -418,17 +408,17 @@ public class IndexedTableJoinMatcherTest
     public void loadsValueIfAbsent()
     {
       int key = 1;
-      Assert.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(1L, counter.longValue());
+      Assertions.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(1L, counter.longValue());
     }
 
     @Test
     public void doesNotLoadIfPresent()
     {
       int key = 1;
-      Assert.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(1L, counter.longValue());
+      Assertions.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(1L, counter.longValue());
     }
   }
 
@@ -438,7 +428,7 @@ public class IndexedTableJoinMatcherTest
 
     private AtomicLong counter;
 
-    @Before
+    @BeforeEach
     public void setup()
     {
       counter = new AtomicLong(0);
@@ -454,17 +444,17 @@ public class IndexedTableJoinMatcherTest
     public void loadsValueIfAbsent()
     {
       int key = 1;
-      Assert.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(1L, counter.longValue());
+      Assertions.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(1L, counter.longValue());
     }
 
     @Test
     public void doesNotLoadIfPresent()
     {
       int key = 1;
-      Assert.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
-      Assert.assertEquals(1L, counter.longValue());
+      Assertions.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
+      Assertions.assertEquals(1L, counter.longValue());
     }
 
     @Test
@@ -474,13 +464,13 @@ public class IndexedTableJoinMatcherTest
       int next = start + SIZE;
 
       for (int key = start; key < next; key++) {
-        Assert.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
+        Assertions.assertEquals(IntSortedSets.singleton(key), target.getAndLoadIfAbsent(key));
       }
 
-      Assert.assertEquals(IntSortedSets.singleton(next), target.getAndLoadIfAbsent(next));
-      Assert.assertNull(target.get(start));
+      Assertions.assertEquals(IntSortedSets.singleton(next), target.getAndLoadIfAbsent(next));
+      Assertions.assertNull(target.get(start));
 
-      Assert.assertEquals(SIZE + 1, counter.longValue());
+      Assertions.assertEquals(SIZE + 1, counter.longValue());
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/IndexedTableJoinableTest.java
@@ -39,9 +39,9 @@ import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.join.JoinConditionAnalysis;
 import org.apache.druid.segment.join.JoinMatcher;
 import org.apache.druid.segment.join.Joinable;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -105,7 +105,7 @@ public class IndexedTableJoinableTest
 
   private IndexedTableJoinable target;
 
-  @Before
+  @BeforeEach
   public void setUp()
   {
     target = new IndexedTableJoinable(indexedTable);
@@ -114,54 +114,54 @@ public class IndexedTableJoinableTest
   @Test
   public void getAvailableColumns()
   {
-    Assert.assertEquals(ImmutableList.of(KEY_COLUMN, VALUE_COLUMN, ALL_SAME_COLUMN), target.getAvailableColumns());
+    Assertions.assertEquals(ImmutableList.of(KEY_COLUMN, VALUE_COLUMN, ALL_SAME_COLUMN), target.getAvailableColumns());
   }
 
   @Test
   public void getCardinalityForStringColumn()
   {
-    Assert.assertEquals(indexedTable.numRows() + 1, target.getCardinality("str"));
+    Assertions.assertEquals(indexedTable.numRows() + 1, target.getCardinality("str"));
   }
 
   @Test
   public void getCardinalityForLongColumn()
   {
-    Assert.assertEquals(indexedTable.numRows() + 1, target.getCardinality("long"));
+    Assertions.assertEquals(indexedTable.numRows() + 1, target.getCardinality("long"));
   }
 
   @Test
   public void getCardinalityForNonexistentColumn()
   {
-    Assert.assertEquals(1, target.getCardinality("nonexistent"));
+    Assertions.assertEquals(1, target.getCardinality("nonexistent"));
   }
 
   @Test
   public void getColumnCapabilitiesForStringColumn()
   {
     final ColumnCapabilities capabilities = target.getColumnCapabilities("str");
-    Assert.assertEquals(ValueType.STRING, capabilities.getType());
-    Assert.assertTrue(capabilities.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(capabilities.hasBitmapIndexes());
-    Assert.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(capabilities.hasSpatialIndexes());
+    Assertions.assertEquals(ValueType.STRING, capabilities.getType());
+    Assertions.assertTrue(capabilities.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(capabilities.hasBitmapIndexes());
+    Assertions.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(capabilities.hasSpatialIndexes());
   }
 
   @Test
   public void getColumnCapabilitiesForLongColumn()
   {
     final ColumnCapabilities capabilities = target.getColumnCapabilities("long");
-    Assert.assertEquals(ValueType.LONG, capabilities.getType());
-    Assert.assertFalse(capabilities.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(capabilities.hasBitmapIndexes());
-    Assert.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(capabilities.hasSpatialIndexes());
+    Assertions.assertEquals(ValueType.LONG, capabilities.getType());
+    Assertions.assertFalse(capabilities.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(capabilities.hasBitmapIndexes());
+    Assertions.assertFalse(capabilities.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(capabilities.hasSpatialIndexes());
   }
 
   @Test
   public void getColumnCapabilitiesForNonexistentColumnShouldReturnNull()
   {
     final ColumnCapabilities capabilities = target.getColumnCapabilities("nonexistent");
-    Assert.assertNull(capabilities);
+    Assertions.assertNull(capabilities);
   }
 
   @Test
@@ -183,20 +183,20 @@ public class IndexedTableJoinableTest
                                                   .makeDimensionSelector(DefaultDimensionSpec.of("str"));
 
     // getValueCardinality
-    Assert.assertEquals(5, selector.getValueCardinality());
+    Assertions.assertEquals(5, selector.getValueCardinality());
 
     // nameLookupPossibleInAdvance
-    Assert.assertTrue(selector.nameLookupPossibleInAdvance());
+    Assertions.assertTrue(selector.nameLookupPossibleInAdvance());
 
     // lookupName
-    Assert.assertEquals("foo", selector.lookupName(0));
-    Assert.assertEquals("bar", selector.lookupName(1));
-    Assert.assertEquals("baz", selector.lookupName(2));
-    Assert.assertNull(selector.lookupName(3));
-    Assert.assertNull(selector.lookupName(4));
+    Assertions.assertEquals("foo", selector.lookupName(0));
+    Assertions.assertEquals("bar", selector.lookupName(1));
+    Assertions.assertEquals("baz", selector.lookupName(2));
+    Assertions.assertNull(selector.lookupName(3));
+    Assertions.assertNull(selector.lookupName(4));
 
     // lookupId
-    Assert.assertNull(selector.idLookup());
+    Assertions.assertNull(selector.idLookup());
   }
 
   @Test
@@ -211,7 +211,7 @@ public class IndexedTableJoinableTest
             false
         );
 
-    Assert.assertEquals(Optional.empty(), correlatedValues);
+    Assertions.assertEquals(Optional.empty(), correlatedValues);
   }
 
   @Test
@@ -226,7 +226,7 @@ public class IndexedTableJoinableTest
             false
         );
 
-    Assert.assertEquals(Optional.empty(), correlatedValues);
+    Assertions.assertEquals(Optional.empty(), correlatedValues);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class IndexedTableJoinableTest
         MAX_CORRELATION_SET_SIZE,
         false
     );
-    Assert.assertEquals(Optional.of(ImmutableSet.of(SEARCH_KEY_VALUE)), correlatedValues);
+    Assertions.assertEquals(Optional.of(ImmutableSet.of(SEARCH_KEY_VALUE)), correlatedValues);
   }
 
   @Test
@@ -252,7 +252,7 @@ public class IndexedTableJoinableTest
         0,
         false
     );
-    Assert.assertEquals(Optional.empty(), correlatedValues);
+    Assertions.assertEquals(Optional.empty(), correlatedValues);
   }
 
   @Test
@@ -265,7 +265,7 @@ public class IndexedTableJoinableTest
         MAX_CORRELATION_SET_SIZE,
         false
     );
-    Assert.assertEquals(Optional.of(ImmutableSet.of(SEARCH_VALUE_VALUE)), correlatedValues);
+    Assertions.assertEquals(Optional.of(ImmutableSet.of(SEARCH_VALUE_VALUE)), correlatedValues);
   }
 
   @Test
@@ -278,7 +278,7 @@ public class IndexedTableJoinableTest
         MAX_CORRELATION_SET_SIZE,
         false
     );
-    Assert.assertEquals(Optional.of(Collections.singleton(null)), correlatedValues);
+    Assertions.assertEquals(Optional.of(Collections.singleton(null)), correlatedValues);
   }
 
   @Test
@@ -291,7 +291,7 @@ public class IndexedTableJoinableTest
         MAX_CORRELATION_SET_SIZE,
         false
     );
-    Assert.assertEquals(Optional.empty(), correlatedValues);
+    Assertions.assertEquals(Optional.empty(), correlatedValues);
     correlatedValues = target.getCorrelatedColumnValues(
         VALUE_COLUMN,
         SEARCH_VALUE_VALUE,
@@ -299,7 +299,7 @@ public class IndexedTableJoinableTest
         10,
         false
     );
-    Assert.assertEquals(Optional.empty(), correlatedValues);
+    Assertions.assertEquals(Optional.empty(), correlatedValues);
   }
 
   @Test
@@ -312,7 +312,7 @@ public class IndexedTableJoinableTest
         MAX_CORRELATION_SET_SIZE,
         true
     );
-    Assert.assertEquals(Optional.of(ImmutableSet.of(SEARCH_VALUE_VALUE)), correlatedValues);
+    Assertions.assertEquals(Optional.of(ImmutableSet.of(SEARCH_VALUE_VALUE)), correlatedValues);
   }
 
   @Test
@@ -325,7 +325,7 @@ public class IndexedTableJoinableTest
         10,
         true
     );
-    Assert.assertEquals(Optional.of(ImmutableSet.of(SEARCH_KEY_VALUE)), correlatedValues);
+    Assertions.assertEquals(Optional.of(ImmutableSet.of(SEARCH_KEY_VALUE)), correlatedValues);
   }
 
   @Test
@@ -338,7 +338,7 @@ public class IndexedTableJoinableTest
         0,
         true
     );
-    Assert.assertEquals(Optional.empty(), correlatedValues);
+    Assertions.assertEquals(Optional.empty(), correlatedValues);
   }
 
   @Test
@@ -351,7 +351,7 @@ public class IndexedTableJoinableTest
         10,
         true
     );
-    Assert.assertEquals(Optional.of(ImmutableSet.of()), correlatedValues);
+    Assertions.assertEquals(Optional.of(ImmutableSet.of()), correlatedValues);
   }
 
   @Test
@@ -360,7 +360,7 @@ public class IndexedTableJoinableTest
     final Joinable.ColumnValuesWithUniqueFlag values =
         target.getMatchableColumnValues(VALUE_COLUMN, false, Integer.MAX_VALUE);
 
-    Assert.assertEquals(ImmutableSet.of("1", "2", "3"), values.getColumnValues());
+    Assertions.assertEquals(ImmutableSet.of("1", "2", "3"), values.getColumnValues());
   }
 
   @Test
@@ -369,7 +369,7 @@ public class IndexedTableJoinableTest
     final Joinable.ColumnValuesWithUniqueFlag values =
         target.getMatchableColumnValues("nonexistent", false, Integer.MAX_VALUE);
 
-    Assert.assertEquals(ImmutableSet.of(), values.getColumnValues());
+    Assertions.assertEquals(ImmutableSet.of(), values.getColumnValues());
   }
 
   @Test
@@ -378,12 +378,12 @@ public class IndexedTableJoinableTest
     final Joinable.ColumnValuesWithUniqueFlag values =
         target.getMatchableColumnValues(KEY_COLUMN, false, Integer.MAX_VALUE);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("foo", "bar", "baz"),
         values.getColumnValues()
     );
 
-    Assert.assertTrue(values.isAllUnique());
+    Assertions.assertTrue(values.isAllUnique());
   }
 
   @Test
@@ -392,12 +392,12 @@ public class IndexedTableJoinableTest
     final Joinable.ColumnValuesWithUniqueFlag values =
         target.getMatchableColumnValues(KEY_COLUMN, true, Integer.MAX_VALUE);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         InDimFilter.ValuesSet.copyOf(Arrays.asList(null, "foo", "bar", "baz")),
         values.getColumnValues()
     );
 
-    Assert.assertTrue(values.isAllUnique());
+    Assertions.assertTrue(values.isAllUnique());
   }
 
   @Test
@@ -406,11 +406,11 @@ public class IndexedTableJoinableTest
     final Joinable.ColumnValuesWithUniqueFlag values =
         target.getMatchableColumnValues(ALL_SAME_COLUMN, false, Integer.MAX_VALUE);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of("1"),
         values.getColumnValues()
     );
-    Assert.assertFalse(values.isAllUnique());
+    Assertions.assertFalse(values.isAllUnique());
   }
 
   @Test
@@ -419,6 +419,6 @@ public class IndexedTableJoinableTest
     final Joinable.ColumnValuesWithUniqueFlag values =
         target.getMatchableColumnValues(KEY_COLUMN, false, 1);
 
-    Assert.assertEquals(ImmutableSet.of(), values.getColumnValues());
+    Assertions.assertEquals(ImmutableSet.of(), values.getColumnValues());
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/join/table/RowBasedIndexBuilderTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/join/table/RowBasedIndexBuilderTest.java
@@ -22,8 +22,8 @@ package org.apache.druid.segment.join.table;
 import it.unimi.dsi.fastutil.ints.IntAVLTreeSet;
 import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import org.apache.druid.segment.column.ColumnType;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +41,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(MapIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(MapIndex.class));
     Assertions.assertEquals(ColumnType.STRING, index.keyType());
     Assertions.assertTrue(index.areKeysUnique(false));
     Assertions.assertTrue(index.areKeysUnique(true));
@@ -70,7 +70,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(MapIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(MapIndex.class));
     Assertions.assertEquals(ColumnType.STRING, index.keyType());
     Assertions.assertTrue(index.areKeysUnique(false));
     Assertions.assertTrue(index.areKeysUnique(true));
@@ -100,7 +100,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(MapIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(MapIndex.class));
     Assertions.assertEquals(ColumnType.STRING, index.keyType());
     Assertions.assertTrue(index.areKeysUnique(false));
     Assertions.assertFalse(index.areKeysUnique(true));
@@ -130,7 +130,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(MapIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(MapIndex.class));
     Assertions.assertEquals(ColumnType.STRING, index.keyType());
     Assertions.assertFalse(index.areKeysUnique(false));
     Assertions.assertFalse(index.areKeysUnique(true));
@@ -157,7 +157,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(UniqueLongArrayIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(UniqueLongArrayIndex.class));
     Assertions.assertEquals(ColumnType.LONG, index.keyType());
     Assertions.assertTrue(index.areKeysUnique(false));
 
@@ -185,7 +185,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(MapIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(MapIndex.class));
     Assertions.assertEquals(ColumnType.LONG, index.keyType());
     Assertions.assertTrue(index.areKeysUnique(false));
     Assertions.assertTrue(index.areKeysUnique(true));
@@ -213,7 +213,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(MapIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(MapIndex.class));
     Assertions.assertEquals(ColumnType.LONG, index.keyType());
     Assertions.assertTrue(index.areKeysUnique(false));
 
@@ -241,7 +241,7 @@ public class RowBasedIndexBuilderTest
 
     final IndexedTable.Index index = builder.build();
 
-    MatcherAssert.assertThat(index, CoreMatchers.instanceOf(MapIndex.class));
+    MatcherAssert.assertThat(index, Matchers.instanceOf(MapIndex.class));
     Assertions.assertEquals(ColumnType.LONG, index.keyType());
     Assertions.assertFalse(index.areKeysUnique(false));
 

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedDataColumnSupplierTest.java
@@ -71,17 +71,18 @@ import org.apache.druid.segment.vector.VectorValueSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -98,7 +99,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
 {
   private static final ObjectMapper JSON_MAPPER = TestHelper.makeJsonMapper();
@@ -137,13 +140,11 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       TestHelper.makeMap("l", new Object[]{1L, 2L, 3L}, "d", new Object[]{3.1, 2.2, 1.9})
   );
 
-  @BeforeClass
+  @BeforeAll
   public static void staticSetup()
   {
     BuiltInTypesModule.registerHandlersAndSerde();
   }
-
-  @Parameterized.Parameters(name = "data = {0}")
   public static Collection<?> constructorFeeder()
   {
 
@@ -184,8 +185,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     return constructors;
   }
 
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension tempFolder = new TemporaryFolderExtension();
 
   Closer closer = Closer.create();
 
@@ -213,7 +214,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     this.resultFactory = new DefaultBitmapResultFactory(bitmapSerdeFactory.getBitmapFactory());
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     final String fileNameBase = "test/column";
@@ -285,7 +286,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     }
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     closer.close();
@@ -310,8 +311,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     deserializer.read(baseBuffer, bob, ColumnConfig.SELECTION_SIZE, null);
     final ColumnHolder holder = bob.build();
     final ColumnCapabilities capabilities = holder.getCapabilities();
-    Assert.assertEquals(ColumnType.NESTED_DATA, capabilities.toColumnType());
-    Assert.assertTrue(holder.getColumnFormat() instanceof NestedCommonFormatColumn.Format);
+    Assertions.assertEquals(ColumnType.NESTED_DATA, capabilities.toColumnType());
+    Assertions.assertTrue(holder.getColumnFormat() instanceof NestedCommonFormatColumn.Format);
     try (NestedDataComplexColumn column = (NestedDataComplexColumn) holder.getColumn()) {
       smokeTest(column);
     }
@@ -336,8 +337,8 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     deserializer.read(arrayBaseBuffer, bob, ColumnConfig.SELECTION_SIZE, null);
     final ColumnHolder holder = bob.build();
     final ColumnCapabilities capabilities = holder.getCapabilities();
-    Assert.assertEquals(ColumnType.NESTED_DATA, capabilities.toColumnType());
-    Assert.assertTrue(holder.getColumnFormat() instanceof NestedCommonFormatColumn.Format);
+    Assertions.assertEquals(ColumnType.NESTED_DATA, capabilities.toColumnType());
+    Assertions.assertTrue(holder.getColumnFormat() instanceof NestedCommonFormatColumn.Format);
     try (NestedDataComplexColumn column = (NestedDataComplexColumn) holder.getColumn()) {
       smokeTestArrays(column);
     }
@@ -389,7 +390,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       }
       threadsStartLatch.countDown();
       Futures.allAsList(futures).get();
-      Assert.assertEquals(expectedReason, failureReason.get());
+      Assertions.assertEquals(expectedReason, failureReason.get());
     }
     finally {
       executorService.shutdownNow();
@@ -402,64 +403,64 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     ColumnValueSelector<?> rawSelector = column.makeColumnValueSelector(offset);
 
     final List<NestedPathPart> xPath = NestedPathFinder.parseJsonPath("$.x");
-    Assert.assertEquals(ImmutableSet.of(ColumnType.LONG), column.getFieldTypes(xPath));
-    Assert.assertEquals(ColumnType.LONG, column.getColumnHolder(xPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ImmutableSet.of(ColumnType.LONG), column.getFieldTypes(xPath));
+    Assertions.assertEquals(ColumnType.LONG, column.getColumnHolder(xPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> xSelector = column.makeColumnValueSelector(xPath, null, offset);
     DimensionSelector xDimSelector = column.makeDimensionSelector(xPath, null, null, offset);
     ColumnIndexSupplier xIndexSupplier = column.getColumnIndexSupplier(xPath);
-    Assert.assertNotNull(xIndexSupplier);
+    Assertions.assertNotNull(xIndexSupplier);
     StringValueSetIndexes xValueIndex = xIndexSupplier.as(StringValueSetIndexes.class);
     DruidPredicateIndexes xPredicateIndex = xIndexSupplier.as(DruidPredicateIndexes.class);
     NullValueIndex xNulls = xIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> yPath = NestedPathFinder.parseJsonPath("$.y");
-    Assert.assertEquals(ImmutableSet.of(ColumnType.DOUBLE), column.getFieldTypes(yPath));
-    Assert.assertEquals(ColumnType.DOUBLE, column.getColumnHolder(yPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ImmutableSet.of(ColumnType.DOUBLE), column.getFieldTypes(yPath));
+    Assertions.assertEquals(ColumnType.DOUBLE, column.getColumnHolder(yPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> ySelector = column.makeColumnValueSelector(yPath, null, offset);
     DimensionSelector yDimSelector = column.makeDimensionSelector(yPath, null, null, offset);
     ColumnIndexSupplier yIndexSupplier = column.getColumnIndexSupplier(yPath);
-    Assert.assertNotNull(yIndexSupplier);
+    Assertions.assertNotNull(yIndexSupplier);
     StringValueSetIndexes yValueIndex = yIndexSupplier.as(StringValueSetIndexes.class);
     DruidPredicateIndexes yPredicateIndex = yIndexSupplier.as(DruidPredicateIndexes.class);
     NullValueIndex yNulls = yIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> zPath = NestedPathFinder.parseJsonPath("$.z");
-    Assert.assertEquals(ImmutableSet.of(ColumnType.STRING), column.getFieldTypes(zPath));
-    Assert.assertEquals(ColumnType.STRING, column.getColumnHolder(zPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ImmutableSet.of(ColumnType.STRING), column.getFieldTypes(zPath));
+    Assertions.assertEquals(ColumnType.STRING, column.getColumnHolder(zPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> zSelector = column.makeColumnValueSelector(zPath, null, offset);
     DimensionSelector zDimSelector = column.makeDimensionSelector(zPath, null, null, offset);
     ColumnIndexSupplier zIndexSupplier = column.getColumnIndexSupplier(zPath);
-    Assert.assertNotNull(zIndexSupplier);
+    Assertions.assertNotNull(zIndexSupplier);
     StringValueSetIndexes zValueIndex = zIndexSupplier.as(StringValueSetIndexes.class);
     DruidPredicateIndexes zPredicateIndex = zIndexSupplier.as(DruidPredicateIndexes.class);
     NullValueIndex zNulls = zIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> vPath = NestedPathFinder.parseJsonPath("$.v");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableSet.of(ColumnType.STRING, ColumnType.LONG, ColumnType.DOUBLE),
         column.getFieldTypes(vPath)
     );
-    Assert.assertEquals(ColumnType.STRING, column.getColumnHolder(vPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ColumnType.STRING, column.getColumnHolder(vPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> vSelector = column.makeColumnValueSelector(vPath, null, offset);
     DimensionSelector vDimSelector = column.makeDimensionSelector(vPath, null, null, offset);
     ColumnIndexSupplier vIndexSupplier = column.getColumnIndexSupplier(vPath);
-    Assert.assertNotNull(vIndexSupplier);
+    Assertions.assertNotNull(vIndexSupplier);
     StringValueSetIndexes vValueIndex = vIndexSupplier.as(StringValueSetIndexes.class);
     DruidPredicateIndexes vPredicateIndex = vIndexSupplier.as(DruidPredicateIndexes.class);
     NullValueIndex vNulls = vIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> nullishPath = NestedPathFinder.parseJsonPath("$.nullish");
-    Assert.assertEquals(ImmutableSet.of(ColumnType.STRING), column.getFieldTypes(nullishPath));
-    Assert.assertEquals(ColumnType.STRING, column.getColumnHolder(nullishPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ImmutableSet.of(ColumnType.STRING), column.getFieldTypes(nullishPath));
+    Assertions.assertEquals(ColumnType.STRING, column.getColumnHolder(nullishPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> nullishSelector = column.makeColumnValueSelector(nullishPath, null, offset);
     DimensionSelector nullishDimSelector = column.makeDimensionSelector(nullishPath, null, null, offset);
     ColumnIndexSupplier nullishIndexSupplier = column.getColumnIndexSupplier(nullishPath);
-    Assert.assertNotNull(nullishIndexSupplier);
+    Assertions.assertNotNull(nullishIndexSupplier);
     StringValueSetIndexes nullishValueIndex = nullishIndexSupplier.as(StringValueSetIndexes.class);
     DruidPredicateIndexes nullishPredicateIndex = nullishIndexSupplier.as(DruidPredicateIndexes.class);
     NullValueIndex nullishNulls = nullishIndexSupplier.as(NullValueIndex.class);
 
-    Assert.assertEquals(ImmutableList.of(nullishPath, vPath, xPath, yPath, zPath), column.getNestedFields());
+    Assertions.assertEquals(ImmutableList.of(nullishPath, vPath, xPath, yPath, zPath), column.getNestedFields());
 
     for (int i = 0; i < DATA.size(); i++) {
       final Map<String, Object> row;
@@ -470,11 +471,11 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       } else {
         row = DATA.get(i);
       }
-      Assert.assertEquals(
+      Assertions.assertEquals(
           JSON_MAPPER.writeValueAsString(row),
           JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject()))
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           JSON_MAPPER.writeValueAsString(row),
           JSON_MAPPER.writeValueAsString(StructuredData.unwrap(column.getRowValue(i)))
       );
@@ -521,20 +522,20 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     VectorObjectSelector rawVectorSelectorFiltered = column.makeVectorObjectSelector(bitmapVectorOffset);
 
     final List<NestedPathPart> sPath = NestedPathFinder.parseJsonPath("$.s");
-    Assert.assertEquals(ImmutableSet.of(ColumnType.STRING_ARRAY), column.getFieldTypes(sPath));
-    Assert.assertEquals(ColumnType.STRING_ARRAY, column.getColumnHolder(sPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ImmutableSet.of(ColumnType.STRING_ARRAY), column.getFieldTypes(sPath));
+    Assertions.assertEquals(ColumnType.STRING_ARRAY, column.getColumnHolder(sPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> sSelector = column.makeColumnValueSelector(sPath, null, offset);
     VectorObjectSelector sVectorSelector = column.makeVectorObjectSelector(sPath, null, vectorOffset);
     VectorObjectSelector sVectorSelectorFiltered = column.makeVectorObjectSelector(sPath, null, bitmapVectorOffset);
     ColumnIndexSupplier sIndexSupplier = column.getColumnIndexSupplier(sPath);
-    Assert.assertNotNull(sIndexSupplier);
-    Assert.assertNull(sIndexSupplier.as(StringValueSetIndexes.class));
-    Assert.assertNull(sIndexSupplier.as(DruidPredicateIndexes.class));
+    Assertions.assertNotNull(sIndexSupplier);
+    Assertions.assertNull(sIndexSupplier.as(StringValueSetIndexes.class));
+    Assertions.assertNull(sIndexSupplier.as(DruidPredicateIndexes.class));
     NullValueIndex sNulls = sIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> sElementPath = NestedPathFinder.parseJsonPath("$.s[1]");
-    Assert.assertEquals(Set.of(ColumnType.STRING), column.getFieldTypes(sElementPath));
-    Assert.assertEquals(ColumnType.STRING, column.getFieldLogicalType(sElementPath));
+    Assertions.assertEquals(Set.of(ColumnType.STRING), column.getFieldTypes(sElementPath));
+    Assertions.assertEquals(ColumnType.STRING, column.getFieldLogicalType(sElementPath));
     ColumnValueSelector<?> sElementSelector = column.makeColumnValueSelector(sElementPath, null, offset);
     VectorObjectSelector sElementVectorSelector = column.makeVectorObjectSelector(sElementPath, null, vectorOffset);
     VectorObjectSelector sElementFilteredVectorSelector = column.makeVectorObjectSelector(
@@ -543,26 +544,26 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
         bitmapVectorOffset
     );
     ColumnIndexSupplier sElementIndexSupplier = column.getColumnIndexSupplier(sElementPath);
-    Assert.assertNotNull(sElementIndexSupplier);
-    Assert.assertNull(sElementIndexSupplier.as(StringValueSetIndexes.class));
-    Assert.assertNull(sElementIndexSupplier.as(DruidPredicateIndexes.class));
-    Assert.assertNull(sElementIndexSupplier.as(NullValueIndex.class));
+    Assertions.assertNotNull(sElementIndexSupplier);
+    Assertions.assertNull(sElementIndexSupplier.as(StringValueSetIndexes.class));
+    Assertions.assertNull(sElementIndexSupplier.as(DruidPredicateIndexes.class));
+    Assertions.assertNull(sElementIndexSupplier.as(NullValueIndex.class));
 
     final List<NestedPathPart> lPath = NestedPathFinder.parseJsonPath("$.l");
-    Assert.assertEquals(ImmutableSet.of(ColumnType.LONG_ARRAY), column.getFieldTypes(lPath));
-    Assert.assertEquals(ColumnType.LONG_ARRAY, column.getColumnHolder(lPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ImmutableSet.of(ColumnType.LONG_ARRAY), column.getFieldTypes(lPath));
+    Assertions.assertEquals(ColumnType.LONG_ARRAY, column.getColumnHolder(lPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> lSelector = column.makeColumnValueSelector(lPath, null, offset);
     VectorObjectSelector lVectorSelector = column.makeVectorObjectSelector(lPath, null, vectorOffset);
     VectorObjectSelector lVectorSelectorFiltered = column.makeVectorObjectSelector(lPath, null, bitmapVectorOffset);
     ColumnIndexSupplier lIndexSupplier = column.getColumnIndexSupplier(lPath);
-    Assert.assertNotNull(lIndexSupplier);
-    Assert.assertNull(lIndexSupplier.as(StringValueSetIndexes.class));
-    Assert.assertNull(lIndexSupplier.as(DruidPredicateIndexes.class));
+    Assertions.assertNotNull(lIndexSupplier);
+    Assertions.assertNull(lIndexSupplier.as(StringValueSetIndexes.class));
+    Assertions.assertNull(lIndexSupplier.as(DruidPredicateIndexes.class));
     NullValueIndex lNulls = lIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> lElementPath = NestedPathFinder.parseJsonPath("$.l[1]");
-    Assert.assertEquals(Set.of(ColumnType.LONG), column.getFieldTypes(lElementPath));
-    Assert.assertEquals(ColumnType.LONG, column.getFieldLogicalType(lElementPath));
+    Assertions.assertEquals(Set.of(ColumnType.LONG), column.getFieldTypes(lElementPath));
+    Assertions.assertEquals(ColumnType.LONG, column.getFieldLogicalType(lElementPath));
     ColumnValueSelector<?> lElementSelector = column.makeColumnValueSelector(lElementPath, null, offset);
     VectorValueSelector lElementVectorSelector = column.makeVectorValueSelector(lElementPath, null, vectorOffset);
     VectorObjectSelector lElementVectorObjectSelector =
@@ -573,26 +574,26 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
         bitmapVectorOffset
     );
     ColumnIndexSupplier lElementIndexSupplier = column.getColumnIndexSupplier(lElementPath);
-    Assert.assertNotNull(lElementIndexSupplier);
-    Assert.assertNull(lElementIndexSupplier.as(StringValueSetIndexes.class));
-    Assert.assertNull(lElementIndexSupplier.as(DruidPredicateIndexes.class));
-    Assert.assertNull(lElementIndexSupplier.as(NullValueIndex.class));
+    Assertions.assertNotNull(lElementIndexSupplier);
+    Assertions.assertNull(lElementIndexSupplier.as(StringValueSetIndexes.class));
+    Assertions.assertNull(lElementIndexSupplier.as(DruidPredicateIndexes.class));
+    Assertions.assertNull(lElementIndexSupplier.as(NullValueIndex.class));
 
     final List<NestedPathPart> dPath = NestedPathFinder.parseJsonPath("$.d");
-    Assert.assertEquals(ImmutableSet.of(ColumnType.DOUBLE_ARRAY), column.getFieldTypes(dPath));
-    Assert.assertEquals(ColumnType.DOUBLE_ARRAY, column.getColumnHolder(dPath).getCapabilities().toColumnType());
+    Assertions.assertEquals(ImmutableSet.of(ColumnType.DOUBLE_ARRAY), column.getFieldTypes(dPath));
+    Assertions.assertEquals(ColumnType.DOUBLE_ARRAY, column.getColumnHolder(dPath).getCapabilities().toColumnType());
     ColumnValueSelector<?> dSelector = column.makeColumnValueSelector(dPath, null, offset);
     VectorObjectSelector dVectorSelector = column.makeVectorObjectSelector(dPath, null, vectorOffset);
     VectorObjectSelector dVectorSelectorFiltered = column.makeVectorObjectSelector(dPath, null, bitmapVectorOffset);
     ColumnIndexSupplier dIndexSupplier = column.getColumnIndexSupplier(dPath);
-    Assert.assertNotNull(dIndexSupplier);
-    Assert.assertNull(dIndexSupplier.as(StringValueSetIndexes.class));
-    Assert.assertNull(dIndexSupplier.as(DruidPredicateIndexes.class));
+    Assertions.assertNotNull(dIndexSupplier);
+    Assertions.assertNull(dIndexSupplier.as(StringValueSetIndexes.class));
+    Assertions.assertNull(dIndexSupplier.as(DruidPredicateIndexes.class));
     NullValueIndex dNulls = dIndexSupplier.as(NullValueIndex.class);
 
     final List<NestedPathPart> dElementPath = NestedPathFinder.parseJsonPath("$.d[1]");
-    Assert.assertEquals(Set.of(ColumnType.DOUBLE), column.getFieldTypes(dElementPath));
-    Assert.assertEquals(ColumnType.DOUBLE, column.getFieldLogicalType(dElementPath));
+    Assertions.assertEquals(Set.of(ColumnType.DOUBLE), column.getFieldTypes(dElementPath));
+    Assertions.assertEquals(ColumnType.DOUBLE, column.getFieldLogicalType(dElementPath));
     ColumnValueSelector<?> dElementSelector = column.makeColumnValueSelector(dElementPath, null, offset);
     VectorValueSelector dElementVectorSelector = column.makeVectorValueSelector(dElementPath, null, vectorOffset);
     VectorObjectSelector dElementVectorObjectSelector =
@@ -600,10 +601,10 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
     VectorValueSelector dElementFilteredVectorSelector =
         column.makeVectorValueSelector(dElementPath, null, bitmapVectorOffset);
     ColumnIndexSupplier dElementIndexSupplier = column.getColumnIndexSupplier(dElementPath);
-    Assert.assertNotNull(dElementIndexSupplier);
-    Assert.assertNull(dElementIndexSupplier.as(StringValueSetIndexes.class));
-    Assert.assertNull(dElementIndexSupplier.as(DruidPredicateIndexes.class));
-    Assert.assertNull(dElementIndexSupplier.as(NullValueIndex.class));
+    Assertions.assertNotNull(dElementIndexSupplier);
+    Assertions.assertNull(dElementIndexSupplier.as(StringValueSetIndexes.class));
+    Assertions.assertNull(dElementIndexSupplier.as(DruidPredicateIndexes.class));
+    Assertions.assertNull(dElementIndexSupplier.as(NullValueIndex.class));
 
 
     ImmutableBitmap sNullIndex = sNulls.get().computeBitmapResult(resultFactory, false);
@@ -620,11 +621,11 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       } else {
         row = ARRAY_TEST_DATA.get(rowCounter);
       }
-      Assert.assertEquals(
+      Assertions.assertEquals(
           JSON_MAPPER.writeValueAsString(row),
           JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawSelector.getObject()))
       );
-      Assert.assertEquals(
+      Assertions.assertEquals(
           JSON_MAPPER.writeValueAsString(row),
           JSON_MAPPER.writeValueAsString(StructuredData.unwrap(column.getRowValue(rowCounter)))
       );
@@ -632,31 +633,31 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
       Object[] s = (Object[]) row.get("s");
       Object[] l = (Object[]) row.get("l");
       Object[] d = (Object[]) row.get("d");
-      Assert.assertArrayEquals(s, (Object[]) sSelector.getObject());
-      Assert.assertArrayEquals(l, (Object[]) lSelector.getObject());
-      Assert.assertArrayEquals(d, (Object[]) dSelector.getObject());
-      Assert.assertEquals(s == null, sNullIndex.get(rowCounter));
-      Assert.assertEquals(l == null, lNullIndex.get(rowCounter));
-      Assert.assertEquals(d == null, dNullIndex.get(rowCounter));
+      Assertions.assertArrayEquals(s, (Object[]) sSelector.getObject());
+      Assertions.assertArrayEquals(l, (Object[]) lSelector.getObject());
+      Assertions.assertArrayEquals(d, (Object[]) dSelector.getObject());
+      Assertions.assertEquals(s == null, sNullIndex.get(rowCounter));
+      Assertions.assertEquals(l == null, lNullIndex.get(rowCounter));
+      Assertions.assertEquals(d == null, dNullIndex.get(rowCounter));
 
       if (s == null || s.length < 1) {
-        Assert.assertNull(sElementSelector.getObject());
+        Assertions.assertNull(sElementSelector.getObject());
       } else {
-        Assert.assertEquals(s[1], sElementSelector.getObject());
+        Assertions.assertEquals(s[1], sElementSelector.getObject());
       }
       if (l == null || l.length < 1 || l[1] == null) {
-        Assert.assertTrue(lElementSelector.isNull());
-        Assert.assertNull(lElementSelector.getObject());
+        Assertions.assertTrue(lElementSelector.isNull());
+        Assertions.assertNull(lElementSelector.getObject());
       } else {
-        Assert.assertEquals(l[1], lElementSelector.getLong());
-        Assert.assertEquals(l[1], lElementSelector.getObject());
+        Assertions.assertEquals(l[1], lElementSelector.getLong());
+        Assertions.assertEquals(l[1], lElementSelector.getObject());
       }
       if (d == null || d.length < 1 || d[1] == null) {
-        Assert.assertTrue(dElementSelector.isNull());
-        Assert.assertNull(dElementSelector.getObject());
+        Assertions.assertTrue(dElementSelector.isNull());
+        Assertions.assertNull(dElementSelector.getObject());
       } else {
-        Assert.assertEquals((Double) d[1], dElementSelector.getDouble(), 0.0);
-        Assert.assertEquals(d[1], dElementSelector.getObject());
+        Assertions.assertEquals((Double) d[1], dElementSelector.getDouble(), 0.0);
+        Assertions.assertEquals(d[1], dElementSelector.getObject());
       }
 
       offset.increment();
@@ -687,7 +688,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
         } else {
           row = ARRAY_TEST_DATA.get(rowCounter);
         }
-        Assert.assertEquals(
+        Assertions.assertEquals(
             JSON_MAPPER.writeValueAsString(row),
             JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawVector[i]))
         );
@@ -695,28 +696,28 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
         Object[] l = (Object[]) row.get("l");
         Object[] d = (Object[]) row.get("d");
 
-        Assert.assertArrayEquals(s, (Object[]) sVector[i]);
-        Assert.assertArrayEquals(l, (Object[]) lVector[i]);
-        Assert.assertArrayEquals(d, (Object[]) dVector[i]);
+        Assertions.assertArrayEquals(s, (Object[]) sVector[i]);
+        Assertions.assertArrayEquals(l, (Object[]) lVector[i]);
+        Assertions.assertArrayEquals(d, (Object[]) dVector[i]);
 
         if (s == null || s.length < 1) {
-          Assert.assertNull(sElementVector[i]);
+          Assertions.assertNull(sElementVector[i]);
         } else {
-          Assert.assertEquals(s[1], sElementVector[i]);
+          Assertions.assertEquals(s[1], sElementVector[i]);
         }
         if (l == null || l.length < 1 || l[1] == null) {
-          Assert.assertTrue(lElementNulls[i]);
-          Assert.assertNull(lElementObjectVector[i]);
+          Assertions.assertTrue(lElementNulls[i]);
+          Assertions.assertNull(lElementObjectVector[i]);
         } else {
-          Assert.assertEquals(l[1], lElementVector[i]);
-          Assert.assertEquals(l[1], lElementObjectVector[i]);
+          Assertions.assertEquals(l[1], lElementVector[i]);
+          Assertions.assertEquals(l[1], lElementObjectVector[i]);
         }
         if (d == null || d.length < 1 || d[1] == null) {
-          Assert.assertTrue(dElementNulls[i]);
-          Assert.assertNull(dElementObjectVector[i]);
+          Assertions.assertTrue(dElementNulls[i]);
+          Assertions.assertNull(dElementObjectVector[i]);
         } else {
-          Assert.assertEquals((Double) d[1], dElementVector[i], 0.0);
-          Assert.assertEquals(d[1], dElementObjectVector[i]);
+          Assertions.assertEquals((Double) d[1], dElementVector[i], 0.0);
+          Assertions.assertEquals(d[1], dElementObjectVector[i]);
         }
       }
       vectorOffset.advance();
@@ -743,7 +744,7 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
         } else {
           row = ARRAY_TEST_DATA.get(rowCounter);
         }
-        Assert.assertEquals(
+        Assertions.assertEquals(
             JSON_MAPPER.writeValueAsString(row),
             JSON_MAPPER.writeValueAsString(StructuredData.unwrap(rawVector[i]))
         );
@@ -751,24 +752,24 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
         Object[] l = (Object[]) row.get("l");
         Object[] d = (Object[]) row.get("d");
 
-        Assert.assertArrayEquals(s, (Object[]) sVector[i]);
-        Assert.assertArrayEquals(l, (Object[]) lVector[i]);
-        Assert.assertArrayEquals(d, (Object[]) dVector[i]);
+        Assertions.assertArrayEquals(s, (Object[]) sVector[i]);
+        Assertions.assertArrayEquals(l, (Object[]) lVector[i]);
+        Assertions.assertArrayEquals(d, (Object[]) dVector[i]);
 
         if (s == null || s.length < 1) {
-          Assert.assertNull(sElementVector[i]);
+          Assertions.assertNull(sElementVector[i]);
         } else {
-          Assert.assertEquals(s[1], sElementVector[i]);
+          Assertions.assertEquals(s[1], sElementVector[i]);
         }
         if (l == null || l.length < 1 || l[1] == null) {
-          Assert.assertTrue(lElementNulls[i]);
+          Assertions.assertTrue(lElementNulls[i]);
         } else {
-          Assert.assertEquals(l[1], lElementVector[i]);
+          Assertions.assertEquals(l[1], lElementVector[i]);
         }
         if (d == null || d.length < 1 || d[1] == null) {
-          Assert.assertTrue(dElementNulls[i]);
+          Assertions.assertTrue(dElementNulls[i]);
         } else {
-          Assert.assertEquals((Double) d[1], dElementVector[i], 0.0);
+          Assertions.assertEquals((Double) d[1], dElementVector[i], 0.0);
         }
       }
       bitmapVectorOffset.advance();
@@ -789,66 +790,66 @@ public class NestedDataColumnSupplierTest extends InitializedNullHandlingTest
   {
     final Object inputValue = row.get(path);
     if (row.containsKey(path) && inputValue != null) {
-      Assert.assertEquals(inputValue, valueSelector.getObject());
+      Assertions.assertEquals(inputValue, valueSelector.getObject());
       if (ColumnType.LONG.equals(singleType)) {
-        Assert.assertEquals(inputValue, valueSelector.getLong());
-        Assert.assertFalse(path + " is not null", valueSelector.isNull());
+        Assertions.assertEquals(inputValue, valueSelector.getLong());
+        Assertions.assertFalse(valueSelector.isNull(), path + " is not null");
       } else if (ColumnType.DOUBLE.equals(singleType)) {
-        Assert.assertEquals((double) inputValue, valueSelector.getDouble(), 0.0);
-        Assert.assertFalse(path + " is not null", valueSelector.isNull());
+        Assertions.assertEquals((double) inputValue, valueSelector.getDouble(), 0.0);
+        Assertions.assertFalse(valueSelector.isNull(), path + " is not null");
       }
 
       final String theString = String.valueOf(inputValue);
-      Assert.assertEquals(theString, dimSelector.getObject());
+      Assertions.assertEquals(theString, dimSelector.getObject());
       String dimSelectorLookupVal = dimSelector.lookupName(dimSelector.getRow().get(0));
-      Assert.assertEquals(theString, dimSelectorLookupVal);
-      Assert.assertEquals(dimSelector.idLookup().lookupId(dimSelectorLookupVal), dimSelector.getRow().get(0));
+      Assertions.assertEquals(theString, dimSelectorLookupVal);
+      Assertions.assertEquals(dimSelector.idLookup().lookupId(dimSelectorLookupVal), dimSelector.getRow().get(0));
 
-      Assert.assertTrue(valueSetIndex.forValue(theString).computeBitmapResult(resultFactory, false).get(rowNumber));
-      Assert.assertTrue(valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of(theString)))
+      Assertions.assertTrue(valueSetIndex.forValue(theString).computeBitmapResult(resultFactory, false).get(rowNumber));
+      Assertions.assertTrue(valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of(theString)))
                                      .computeBitmapResult(resultFactory, false)
                                      .get(rowNumber));
-      Assert.assertTrue(predicateIndex.forPredicate(new SelectorPredicateFactory(theString))
+      Assertions.assertTrue(predicateIndex.forPredicate(new SelectorPredicateFactory(theString))
                                       .computeBitmapResult(resultFactory, false)
                                       .get(rowNumber));
-      Assert.assertFalse(valueSetIndex.forValue(NO_MATCH).computeBitmapResult(resultFactory, false).get(rowNumber));
-      Assert.assertFalse(valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of(NO_MATCH)))
+      Assertions.assertFalse(valueSetIndex.forValue(NO_MATCH).computeBitmapResult(resultFactory, false).get(rowNumber));
+      Assertions.assertFalse(valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of(NO_MATCH)))
                                       .computeBitmapResult(resultFactory, false)
                                       .get(rowNumber));
-      Assert.assertFalse(predicateIndex.forPredicate(new SelectorPredicateFactory(NO_MATCH))
+      Assertions.assertFalse(predicateIndex.forPredicate(new SelectorPredicateFactory(NO_MATCH))
                                        .computeBitmapResult(resultFactory, false)
                                        .get(rowNumber));
-      Assert.assertFalse(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(rowNumber));
+      Assertions.assertFalse(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(rowNumber));
 
-      Assert.assertTrue(dimSelector.makeValueMatcher(theString).matches(false));
-      Assert.assertFalse(dimSelector.makeValueMatcher(NO_MATCH).matches(false));
-      Assert.assertTrue(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(theString)).matches(false));
-      Assert.assertFalse(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(NO_MATCH)).matches(false));
+      Assertions.assertTrue(dimSelector.makeValueMatcher(theString).matches(false));
+      Assertions.assertFalse(dimSelector.makeValueMatcher(NO_MATCH).matches(false));
+      Assertions.assertTrue(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(theString)).matches(false));
+      Assertions.assertFalse(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(NO_MATCH)).matches(false));
     } else {
-      Assert.assertNull(valueSelector.getObject());
-      Assert.assertTrue(path, valueSelector.isNull());
+      Assertions.assertNull(valueSelector.getObject());
+      Assertions.assertTrue(valueSelector.isNull(), path);
 
-      Assert.assertEquals(0, dimSelector.getRow().get(0));
-      Assert.assertNull(dimSelector.getObject());
-      Assert.assertNull(dimSelector.lookupName(dimSelector.getRow().get(0)));
+      Assertions.assertEquals(0, dimSelector.getRow().get(0));
+      Assertions.assertNull(dimSelector.getObject());
+      Assertions.assertNull(dimSelector.lookupName(dimSelector.getRow().get(0)));
 
-      Assert.assertTrue(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(rowNumber));
-      Assert.assertTrue(valueSetIndex.forValue(null).computeBitmapResult(resultFactory, false).get(rowNumber));
-      Assert.assertTrue(predicateIndex.forPredicate(new SelectorPredicateFactory(null))
+      Assertions.assertTrue(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(rowNumber));
+      Assertions.assertTrue(valueSetIndex.forValue(null).computeBitmapResult(resultFactory, false).get(rowNumber));
+      Assertions.assertTrue(predicateIndex.forPredicate(new SelectorPredicateFactory(null))
                                       .computeBitmapResult(resultFactory, false)
                                       .get(rowNumber));
-      Assert.assertFalse(valueSetIndex.forValue(NO_MATCH).computeBitmapResult(resultFactory, false).get(rowNumber));
+      Assertions.assertFalse(valueSetIndex.forValue(NO_MATCH).computeBitmapResult(resultFactory, false).get(rowNumber));
 
 
-      Assert.assertFalse(valueSetIndex.forValue(NO_MATCH).computeBitmapResult(resultFactory, false).get(rowNumber));
-      Assert.assertFalse(predicateIndex.forPredicate(new SelectorPredicateFactory(NO_MATCH))
+      Assertions.assertFalse(valueSetIndex.forValue(NO_MATCH).computeBitmapResult(resultFactory, false).get(rowNumber));
+      Assertions.assertFalse(predicateIndex.forPredicate(new SelectorPredicateFactory(NO_MATCH))
                                        .computeBitmapResult(resultFactory, false)
                                        .get(rowNumber));
 
-      Assert.assertTrue(dimSelector.makeValueMatcher((String) null).matches(false));
-      Assert.assertFalse(dimSelector.makeValueMatcher(NO_MATCH).matches(false));
-      Assert.assertTrue(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(null)).matches(false));
-      Assert.assertFalse(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(NO_MATCH)).matches(false));
+      Assertions.assertTrue(dimSelector.makeValueMatcher((String) null).matches(false));
+      Assertions.assertFalse(dimSelector.makeValueMatcher(NO_MATCH).matches(false));
+      Assertions.assertTrue(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(null)).matches(false));
+      Assertions.assertFalse(dimSelector.makeValueMatcher(StringPredicateDruidPredicateFactory.equalTo(NO_MATCH)).matches(false));
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldColumnIndexSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldColumnIndexSupplierTest.java
@@ -53,9 +53,9 @@ import org.apache.druid.segment.index.semantic.StringValueSetIndexes;
 import org.apache.druid.segment.serde.Serializer;
 import org.apache.druid.segment.writeout.OnHeapMemorySegmentWriteOutMedium;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.roaringbitmap.IntIterator;
 
 import java.io.IOException;
@@ -76,7 +76,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
   Supplier<FrontCodedIntArrayIndexed> globalArrays;
 
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     ByteBuffer stringBuffer = ByteBuffer.allocate(1 << 12);
@@ -159,19 +159,19 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringSupplier();
 
     NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
-    Assert.assertNotNull(nullIndex);
+    Assertions.assertNotNull(nullIndex);
 
     // sanity check to make sure we don't return indexes we don't support
-    Assert.assertNull(indexSupplier.as(SpatialIndex.class));
+    Assertions.assertNull(indexSupplier.as(SpatialIndex.class));
 
     // 10 rows
     // local: [b, foo, fooo, z]
     // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
 
     BitmapColumnIndex columnIndex = nullIndex.get();
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
-    Assert.assertEquals(0, bitmap.size());
+    Assertions.assertEquals(0, bitmap.size());
   }
 
   @Test
@@ -180,26 +180,26 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringSupplier();
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // 10 rows
     // local: [b, foo, fooo, z]
     // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("b");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 7, 8);
 
     // non-existent in local column
     columnIndex = valueSetIndex.forValue("fo");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     // set index
     columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("b", "fooo", "z")));
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 2, 3, 4, 5, 6, 7, 8);
   }
@@ -210,7 +210,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringSupplier();
 
     LexicographicalRangeIndexes rangeIndex = indexSupplier.as(LexicographicalRangeIndexes.class);
-    Assert.assertNotNull(rangeIndex);
+    Assertions.assertNotNull(rangeIndex);
 
     // 10 rows
     // global: [null, a, b, fo, foo, fooo, g, gg, ggg, z]
@@ -218,63 +218,63 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
 
     BitmapColumnIndex forRange = rangeIndex.forRange(null, false, "a", false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndex.forRange(null, true, "a", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndex.forRange(null, false, "b", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndex.forRange(null, false, "b", false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 7, 8);
 
 
     forRange = rangeIndex.forRange("a", false, "b", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndex.forRange("a", true, "b", false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 7, 8);
 
     forRange = rangeIndex.forRange("b", false, "fon", false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 7, 8);
 
     forRange = rangeIndex.forRange("bb", false, "fon", false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndex.forRange("b", true, "foo", false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 9);
 
     forRange = rangeIndex.forRange("f", true, "g", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 2, 5, 9);
 
     forRange = rangeIndex.forRange(null, false, "g", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 1, 2, 3, 5, 7, 8, 9);
 
     forRange = rangeIndex.forRange("f", false, null, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 2, 4, 5, 6, 9);
 
@@ -341,7 +341,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringSupplier();
 
     LexicographicalRangeIndexes rangeIndex = indexSupplier.as(LexicographicalRangeIndexes.class);
-    Assert.assertNotNull(rangeIndex);
+    Assertions.assertNotNull(rangeIndex);
 
     // 10 rows
     // local: [b, foo, fooo, z]
@@ -404,7 +404,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringSupplier();
 
     DruidPredicateIndexes predicateIndex = indexSupplier.as(DruidPredicateIndexes.class);
-    Assert.assertNotNull(predicateIndex);
+    Assertions.assertNotNull(predicateIndex);
     DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
         null,
         InDimFilter.ValuesSet.copyOf(ImmutableSet.of("b", "z"))
@@ -415,7 +415,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [foo, b, fooo, b, z, fooo, z, b, b, foo]
 
     BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 4, 6, 7, 8);
   }
@@ -426,14 +426,14 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringWithNullsSupplier();
 
     NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
-    Assert.assertNotNull(nullIndex);
+    Assertions.assertNotNull(nullIndex);
 
     // 10 rows
     // local: [null, b, foo, fooo, z]
     // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
 
     BitmapColumnIndex columnIndex = nullIndex.get();
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 7, 8);
   }
@@ -444,26 +444,26 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringWithNullsSupplier();
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // 10 rows
     // local: [null, b, foo, fooo, z]
     // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("b");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 3);
 
     // non-existent in local column
     columnIndex = valueSetIndex.forValue("fo");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     // set index
     columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("b", "fooo", "z")));
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 3, 4, 5, 6);
   }
@@ -474,40 +474,40 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringWithNullsSupplier();
 
     LexicographicalRangeIndexes rangeIndex = indexSupplier.as(LexicographicalRangeIndexes.class);
-    Assert.assertNotNull(rangeIndex);
+    Assertions.assertNotNull(rangeIndex);
 
     // 10 rows
     // local: [null, b, foo, fooo, z]
     // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
 
     BitmapColumnIndex forRange = rangeIndex.forRange("f", true, "g", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 2, 5, 9);
 
     forRange = rangeIndex.forRange(null, false, "g", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 2, 3, 5, 9);
 
     forRange = rangeIndex.forRange(null, false, "a", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndex.forRange(null, false, "b", true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndex.forRange(null, false, "b", false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 3);
 
     forRange = rangeIndex.forRange("f", false, null, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 2, 4, 5, 6, 9);
 
@@ -550,7 +550,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeStringWithNullsSupplier();
 
     DruidPredicateIndexes predicateIndex = indexSupplier.as(DruidPredicateIndexes.class);
-    Assert.assertNotNull(predicateIndex);
+    Assertions.assertNotNull(predicateIndex);
     DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
         null,
         InDimFilter.ValuesSet.copyOf(ImmutableSet.of("b", "z"))
@@ -561,7 +561,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [foo, null, fooo, b, z, fooo, z, null, null, foo]
 
     BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 3, 4, 6);
   }
@@ -572,23 +572,23 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeLongSupplier();
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // sanity check to make sure we don't return indexes we don't support
-    Assert.assertNull(indexSupplier.as(SpatialIndex.class));
+    Assertions.assertNull(indexSupplier.as(SpatialIndex.class));
 
     // 10 rows
     // local: [1, 3, 100, 300]
     // column: [100, 1, 300, 1, 3, 3, 100, 300, 300, 1]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("1");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 9);
 
     // set index
     columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1", "300", "700")));
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 2, 3, 7, 8, 9);
   }
@@ -599,14 +599,14 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeLongSupplier();
 
     NumericRangeIndexes rangeIndexes = indexSupplier.as(NumericRangeIndexes.class);
-    Assert.assertNotNull(rangeIndexes);
+    Assertions.assertNotNull(rangeIndexes);
 
     // 10 rows
     // local: [1, 3, 100, 300]
     // column: [100, 1, 300, 1, 3, 3, 100, 300, 300, 1]
 
     BitmapColumnIndex forRange = rangeIndexes.forRange(10L, true, 400L, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 2, 6, 7, 8);
@@ -658,7 +658,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeLongSupplier();
 
     DruidPredicateIndexes predicateIndex = indexSupplier.as(DruidPredicateIndexes.class);
-    Assert.assertNotNull(predicateIndex);
+    Assertions.assertNotNull(predicateIndex);
     DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
         null,
         InDimFilter.ValuesSet.copyOf(ImmutableSet.of("1", "3"))
@@ -669,7 +669,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [100, 1, 300, 1, 3, 3, 100, 300, 300, 1]
 
     BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 4, 5, 9);
   }
@@ -680,14 +680,14 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeLongSupplierWithNull();
 
     NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
-    Assert.assertNotNull(nullIndex);
+    Assertions.assertNotNull(nullIndex);
 
     // 10 rows
     // local: [null, 1, 3, 100, 300]
     // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
 
     BitmapColumnIndex columnIndex = nullIndex.get();
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 5, 8);
   }
@@ -698,20 +698,20 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeLongSupplierWithNull();
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // 10 rows
     // local: [null, 1, 3, 100, 300]
     // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("3");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 4);
 
     // set index
     columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1", "3", "300")));
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 4, 7, 9);
 
@@ -722,13 +722,13 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     treeSet.add("3");
     treeSet.add("300");
     columnIndex = valueSetIndex.forSortedValues(treeSet);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 2, 3, 4, 5, 7, 8, 9);
 
     // null value should really use NullValueIndex, but this works for classic reasons
     columnIndex = valueSetIndex.forValue(null);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 5, 8);
   }
@@ -739,14 +739,14 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeLongSupplierWithNull();
 
     NumericRangeIndexes rangeIndexes = indexSupplier.as(NumericRangeIndexes.class);
-    Assert.assertNotNull(rangeIndexes);
+    Assertions.assertNotNull(rangeIndexes);
 
     // 10 rows
     // local: [null, 1, 3, 100, 300]
     // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
 
     BitmapColumnIndex forRange = rangeIndexes.forRange(100, false, 700, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 6, 7);
@@ -794,7 +794,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeLongSupplierWithNull();
 
     DruidPredicateIndexes predicateIndex = indexSupplier.as(DruidPredicateIndexes.class);
-    Assert.assertNotNull(predicateIndex);
+    Assertions.assertNotNull(predicateIndex);
     DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
         null,
         InDimFilter.ValuesSet.copyOf(ImmutableSet.of("3", "100"))
@@ -805,7 +805,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [100, 1, null, 1, 3, null, 100, 300, null, 1]
 
     BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 4, 6);
   }
@@ -816,23 +816,23 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeDoubleSupplier();
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // sanity check to make sure we don't return indexes we don't support
-    Assert.assertNull(indexSupplier.as(SpatialIndex.class));
+    Assertions.assertNull(indexSupplier.as(SpatialIndex.class));
 
     // 10 rows
     // local: [1.1, 1.2, 3.3, 6.6]
     // column: [1.1, 1.1, 1.2, 3.3, 1.2, 6.6, 3.3, 1.2, 1.1, 3.3]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("1.2");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 4, 7);
 
     // set index
     columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1.2", "3.3", "6.6")));
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 3, 4, 5, 6, 7, 9);
   }
@@ -843,26 +843,26 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeDoubleSupplier();
 
     NumericRangeIndexes rangeIndexes = indexSupplier.as(NumericRangeIndexes.class);
-    Assert.assertNotNull(rangeIndexes);
+    Assertions.assertNotNull(rangeIndexes);
 
     // 10 rows
     // local: [1.1, 1.2, 3.3, 6.6]
     // column: [1.1, 1.1, 1.2, 3.3, 1.2, 6.6, 3.3, 1.2, 1.1, 3.3]
 
     BitmapColumnIndex forRange = rangeIndexes.forRange(1.0, true, 5.0, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 6, 7, 8, 9);
 
     forRange = rangeIndexes.forRange(1.1, false, 3.3, false);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 6, 7, 8, 9);
 
     forRange = rangeIndexes.forRange(1.1, true, 3.3, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 4, 7);
@@ -876,43 +876,43 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     checkBitmap(bitmap, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
     forRange = rangeIndexes.forRange(1.111, true, 1.19, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndexes.forRange(1.01, true, 1.09, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndexes.forRange(0.05, true, 0.98, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndexes.forRange(0.05, true, 1.1, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndexes.forRange(8.99, true, 10.10, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndexes.forRange(8.99, true, 10.10, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
 
     forRange = rangeIndexes.forRange(10.00, true, 10.10, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
@@ -924,7 +924,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeDoubleSupplier();
 
     DruidPredicateIndexes predicateIndex = indexSupplier.as(DruidPredicateIndexes.class);
-    Assert.assertNotNull(predicateIndex);
+    Assertions.assertNotNull(predicateIndex);
     DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
         null,
         InDimFilter.ValuesSet.copyOf(ImmutableSet.of("1.2", "3.3", "5.0"))
@@ -935,7 +935,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [1.1, 1.1, 1.2, 3.3, 1.2, 6.6, 3.3, 1.2, 1.1, 3.3]
 
     BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 3, 4, 6, 7, 9);
   }
@@ -946,14 +946,14 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeDoubleSupplierWithNull();
 
     NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
-    Assert.assertNotNull(nullIndex);
+    Assertions.assertNotNull(nullIndex);
 
     // 10 rows
     // local: [null, 1.1, 1.2, 3.3, 6.6]
     // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
 
     BitmapColumnIndex columnIndex = nullIndex.get();
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 6);
   }
@@ -964,20 +964,20 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeDoubleSupplierWithNull();
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // 10 rows
     // local: [null, 1.1, 1.2, 3.3, 6.6]
     // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("6.6");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 5);
 
     // set index
     columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("1.2", "3.3", "7.7")));
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 4, 7, 9);
 
@@ -988,13 +988,13 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     treeSet.add("3.3");
     treeSet.add("7.7");
     columnIndex = valueSetIndex.forSortedValues(treeSet);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 2, 3, 4, 6, 7, 9);
 
     // null value should really use NullValueIndex, but this works for classic reasons
     columnIndex = valueSetIndex.forValue(null);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 6);
   }
@@ -1005,14 +1005,14 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeDoubleSupplierWithNull();
 
     NumericRangeIndexes rangeIndexes = indexSupplier.as(NumericRangeIndexes.class);
-    Assert.assertNotNull(rangeIndexes);
+    Assertions.assertNotNull(rangeIndexes);
 
     // 10 rows
     // local: [null, 1.1, 1.2, 3.3, 6.6]
     // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
 
     BitmapColumnIndex forRange = rangeIndexes.forRange(1.1, false, 5.0, true);
-    Assert.assertNotNull(forRange);
+    Assertions.assertNotNull(forRange);
 
     ImmutableBitmap bitmap = forRange.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 2, 4, 7, 8, 9);
@@ -1048,7 +1048,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeSingleTypeDoubleSupplierWithNull();
 
     DruidPredicateIndexes predicateIndex = indexSupplier.as(DruidPredicateIndexes.class);
-    Assert.assertNotNull(predicateIndex);
+    Assertions.assertNotNull(predicateIndex);
     DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
         null,
         InDimFilter.ValuesSet.copyOf(ImmutableSet.of("1.2", "3.3"))
@@ -1059,7 +1059,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [1.1, null, 1.2, null, 1.2, 6.6, null, 1.2, 1.1, 3.3]
 
     BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 4, 7, 9);
   }
@@ -1070,17 +1070,17 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeVariantSupplierWithNull();
 
     NullValueIndex nullIndex = indexSupplier.as(NullValueIndex.class);
-    Assert.assertNotNull(nullIndex);
+    Assertions.assertNotNull(nullIndex);
 
     // sanity check to make sure we don't return indexes we don't support
-    Assert.assertNull(indexSupplier.as(SpatialIndex.class));
+    Assertions.assertNull(indexSupplier.as(SpatialIndex.class));
 
     // 10 rows
     // local: [null, b, z, 1, 300, 1.1, 9.9]
     // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
 
     BitmapColumnIndex columnIndex = nullIndex.get();
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 7);
   }
@@ -1091,30 +1091,30 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeVariantSupplierWithNull();
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // 10 rows
     // local: [null, b, z, 1, 300, 1.1, 9.9]
     // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("b");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 9);
 
     columnIndex = valueSetIndex.forValue("1");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0, 5);
 
     columnIndex = valueSetIndex.forValue("1.1");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 8);
 
     // set index
     columnIndex = valueSetIndex.forSortedValues(new TreeSet<>(ImmutableSet.of("b", "300", "9.9", "1.6")));
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 4, 9);
 
@@ -1126,13 +1126,13 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     treeSet.add("9.9");
     treeSet.add("1.6");
     columnIndex = valueSetIndex.forSortedValues(treeSet);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 2, 3, 4, 7, 9);
 
     // null value should really use NullValueIndex, but this works for classic reasons
     columnIndex = valueSetIndex.forValue(null);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2, 7);
   }
@@ -1143,10 +1143,10 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeVariantSupplierWithNull();
 
     LexicographicalRangeIndexes rangeIndex = indexSupplier.as(LexicographicalRangeIndexes.class);
-    Assert.assertNull(rangeIndex);
+    Assertions.assertNull(rangeIndex);
 
     NumericRangeIndexes numericRangeIndexes = indexSupplier.as(NumericRangeIndexes.class);
-    Assert.assertNull(numericRangeIndexes);
+    Assertions.assertNull(numericRangeIndexes);
   }
 
   @Test
@@ -1155,7 +1155,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeVariantSupplierWithNull();
 
     DruidPredicateIndexes predicateIndex = indexSupplier.as(DruidPredicateIndexes.class);
-    Assert.assertNotNull(predicateIndex);
+    Assertions.assertNotNull(predicateIndex);
     DruidPredicateFactory predicateFactory = new InDimFilter.InFilterDruidPredicateFactory(
         null,
         InDimFilter.ValuesSet.copyOf(ImmutableSet.of("b", "z", "9.9", "300"))
@@ -1166,7 +1166,7 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
 
     BitmapColumnIndex columnIndex = predicateIndex.forPredicate(predicateFactory);
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 1, 3, 4, 6, 9);
   }
@@ -1177,22 +1177,22 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     NestedFieldColumnIndexSupplier<?> indexSupplier = makeVariantSupplierWithNull();
 
     DictionaryEncodedStringValueIndex lowLevelIndex = indexSupplier.as(DictionaryEncodedStringValueIndex.class);
-    Assert.assertNotNull(lowLevelIndex);
-    Assert.assertNotNull(indexSupplier.as(DictionaryEncodedValueIndex.class));
+    Assertions.assertNotNull(lowLevelIndex);
+    Assertions.assertNotNull(indexSupplier.as(DictionaryEncodedValueIndex.class));
 
     // 10 rows
     // local: [null, b, z, 1, 300, 1.1, 9.9]
     // column: [1, b, null, 9.9, 300, 1, z, null, 1.1, b]
 
-    Assert.assertNull(lowLevelIndex.getValue(0));
-    Assert.assertEquals("b", lowLevelIndex.getValue(1));
-    Assert.assertEquals("z", lowLevelIndex.getValue(2));
-    Assert.assertEquals("1", lowLevelIndex.getValue(3));
-    Assert.assertEquals("300", lowLevelIndex.getValue(4));
-    Assert.assertEquals("1.1", lowLevelIndex.getValue(5));
-    Assert.assertEquals("9.9", lowLevelIndex.getValue(6));
+    Assertions.assertNull(lowLevelIndex.getValue(0));
+    Assertions.assertEquals("b", lowLevelIndex.getValue(1));
+    Assertions.assertEquals("z", lowLevelIndex.getValue(2));
+    Assertions.assertEquals("1", lowLevelIndex.getValue(3));
+    Assertions.assertEquals("300", lowLevelIndex.getValue(4));
+    Assertions.assertEquals("1.1", lowLevelIndex.getValue(5));
+    Assertions.assertEquals("9.9", lowLevelIndex.getValue(6));
 
-    Assert.assertEquals(7, lowLevelIndex.getCardinality());
+    Assertions.assertEquals(7, lowLevelIndex.getCardinality());
     checkBitmap(lowLevelIndex.getBitmap(0), 2, 7);
     checkBitmap(lowLevelIndex.getBitmap(1), 1, 9);
     checkBitmap(lowLevelIndex.getBitmap(-1));
@@ -1315,24 +1315,24 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
     );
 
     StringValueSetIndexes valueSetIndex = indexSupplier.as(StringValueSetIndexes.class);
-    Assert.assertNotNull(valueSetIndex);
+    Assertions.assertNotNull(valueSetIndex);
 
     // 3 rows
     // local: [null, '1', -2]
     // column: ['1', null, -2]
 
     BitmapColumnIndex columnIndex = valueSetIndex.forValue("1");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     ImmutableBitmap bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 0);
 
     columnIndex = valueSetIndex.forValue("-2");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap, 2);
 
     columnIndex = valueSetIndex.forValue("2");
-    Assert.assertNotNull(columnIndex);
+    Assertions.assertNotNull(columnIndex);
     bitmap = columnIndex.computeBitmapResult(bitmapResultFactory, false);
     checkBitmap(bitmap);
   }
@@ -1946,10 +1946,10 @@ public class NestedFieldColumnIndexSupplierTest extends InitializedNullHandlingT
   {
     IntIterator iterator = bitmap.iterator();
     for (int i : expectedRows) {
-      Assert.assertTrue(iterator.hasNext());
-      Assert.assertEquals(i, iterator.next());
+      Assertions.assertTrue(iterator.hasNext());
+      Assertions.assertEquals(i, iterator.next());
     }
-    Assert.assertFalse(iterator.hasNext());
+    Assertions.assertFalse(iterator.hasNext());
   }
 
   static void writeToBuffer(ByteBuffer buffer, Serializer serializer) throws IOException

--- a/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldColumnSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/NestedFieldColumnSelectorsTest.java
@@ -51,12 +51,12 @@ import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.vector.VectorValueSelector;
 import org.apache.druid.segment.virtual.NestedFieldVirtualColumn;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,20 +78,20 @@ public class NestedFieldColumnSelectorsTest extends InitializedNullHandlingTest
   @TempDir
   public File tempFolderDir;
 
-  private TemporaryFolder tempFolder;
+  private TemporaryFolderExtension tempFolder;
   private AggregationTestHelper helper;
   private Closer closer;
 
   @BeforeEach
   public void setup() throws IOException
   {
-    tempFolder = new TemporaryFolder(tempFolderDir);
+    tempFolder = new TemporaryFolderExtension(tempFolderDir);
     tempFolder.create();
     BuiltInTypesModule.registerHandlersAndSerde();
     List<? extends Module> mods = BuiltInTypesModule.getJacksonModulesList();
-    this.helper = AggregationTestHelper.createScanQueryAggregationTestHelper(
+    this.helper = AggregationTestHelper.createScanQueryAggregationTestHelperWithTempDir(
         mods,
-        tempFolder
+        tempFolder.getRoot()
     );
     this.closer = Closer.create();
   }

--- a/processing/src/test/java/org/apache/druid/segment/nested/VariantColumnSupplierTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/nested/VariantColumnSupplierTest.java
@@ -57,15 +57,15 @@ import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.segment.writeout.TmpFileSegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.apache.druid.testing.TemporaryFolderExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,11 +82,13 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 
-@RunWith(Parameterized.class)
+@ParameterizedClass
+
+@MethodSource("constructorFeeder")
 public class VariantColumnSupplierTest extends InitializedNullHandlingTest
 {
-  @Rule
-  public final TemporaryFolder tempFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension tempFolder = new TemporaryFolderExtension();
 
   BitmapSerdeFactory bitmapSerdeFactory = RoaringBitmapSerdeFactory.getInstance();
   DefaultBitmapResultFactory resultFactory = new DefaultBitmapResultFactory(bitmapSerdeFactory.getBitmapFactory());
@@ -163,13 +165,11 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
   );
 
 
-  @BeforeClass
+  @BeforeAll
   public static void staticSetup()
   {
     BuiltInTypesModule.registerHandlersAndSerde();
   }
-
-  @Parameterized.Parameters(name = "data = {0}")
   public static Collection<?> constructorFeeder()
   {
 
@@ -226,7 +226,7 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
     this.columnFormatSpec = columnFormatSpec;
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException
   {
     final String fileNameBase = "test";
@@ -303,7 +303,7 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
     }
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException
   {
     closer.close();
@@ -370,7 +370,7 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
       }
       threadsStartLatch.countDown();
       Futures.allAsList(futures).get();
-      Assert.assertEquals(expectedReason, failureReason.get());
+      Assertions.assertEquals(expectedReason, failureReason.get());
     }
     finally {
       executorService.shutdownNow();
@@ -394,24 +394,24 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
         expectedLogicalType.isPrimitive() ? column.makeSingleValueDimensionVectorSelector(vectorOffset) : null;
 
     StringValueSetIndexes valueSetIndex = supplier.as(StringValueSetIndexes.class);
-    Assert.assertNull(valueSetIndex);
+    Assertions.assertNull(valueSetIndex);
     DruidPredicateIndexes predicateIndex = supplier.as(DruidPredicateIndexes.class);
-    Assert.assertNull(predicateIndex);
+    Assertions.assertNull(predicateIndex);
     NullValueIndex nullValueIndex = supplier.as(NullValueIndex.class);
-    Assert.assertNotNull(nullValueIndex);
+    Assertions.assertNotNull(nullValueIndex);
     ValueIndexes valueIndexes = supplier.as(ValueIndexes.class);
     ArrayElementIndexes arrayElementIndexes = supplier.as(ArrayElementIndexes.class);
     if (expectedType.getSingleType() != null && expectedType.getSingleType().isArray()) {
-      Assert.assertNotNull(valueIndexes);
-      Assert.assertNotNull(arrayElementIndexes);
+      Assertions.assertNotNull(valueIndexes);
+      Assertions.assertNotNull(arrayElementIndexes);
     } else {
-      Assert.assertNull(valueIndexes);
-      Assert.assertNull(arrayElementIndexes);
+      Assertions.assertNull(valueIndexes);
+      Assertions.assertNull(arrayElementIndexes);
     }
 
     SortedMap<String, FieldTypeInfo.MutableTypeSet> fields = column.getFieldTypeInfo();
-    Assert.assertEquals(1, fields.size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, fields.size());
+    Assertions.assertEquals(
         expectedType,
         fields.get(NestedPathFinder.JSON_PATH_ROOT)
     );
@@ -425,25 +425,28 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
 
       if (row != null) {
         if (row instanceof List) {
-          Assert.assertArrayEquals(((List) row).toArray(), (Object[]) valueSelector.getObject());
+          Assertions.assertArrayEquals(((List) row).toArray(), (Object[]) valueSelector.getObject());
           if (expectedType.getSingleType() != null) {
-            Assert.assertArrayEquals(((List) row).toArray(), (Object[]) vectorObjectSelector.getObjectVector()[0]);
-            Assert.assertTrue(valueIndexes.forValue(row, expectedType.getSingleType()).computeBitmapResult(resultFactory,
+            Assertions.assertArrayEquals(((List) row).toArray(), (Object[]) vectorObjectSelector.getObjectVector()[0]);
+            Assertions.assertTrue(valueIndexes.forValue(row, expectedType.getSingleType()).computeBitmapResult(resultFactory,
                                                                                                            false
             ).get(i));
             for (Object o : ((List) row)) {
-              Assert.assertTrue("Failed on row: " + row, arrayElementIndexes.containsValue(o, expectedType.getSingleType().getElementType()).computeBitmapResult(resultFactory,
-                                                                                                                                                                 false
-              ).get(i));
+              Assertions.assertTrue(
+                  arrayElementIndexes.containsValue(o, expectedType.getSingleType().getElementType())
+                                      .computeBitmapResult(resultFactory, false)
+                                      .get(i),
+                  "Failed on row: " + row
+              );
             }
           } else {
             // mixed type vector object selector coerces to the most common type
-            Assert.assertArrayEquals(ExprEval.ofType(expressionType, row).asArray(), (Object[]) vectorObjectSelector.getObjectVector()[0]);
+            Assertions.assertArrayEquals(ExprEval.ofType(expressionType, row).asArray(), (Object[]) vectorObjectSelector.getObjectVector()[0]);
           }
         } else {
-          Assert.assertEquals(row, valueSelector.getObject());
+          Assertions.assertEquals(row, valueSelector.getObject());
           if (expectedType.getSingleType() != null) {
-            Assert.assertEquals(
+            Assertions.assertEquals(
                 row,
                 vectorObjectSelector.getObjectVector()[0]
             );
@@ -451,36 +454,36 @@ public class VariantColumnSupplierTest extends InitializedNullHandlingTest
             // vector object selector always coerces to the most common type
             ExprEval eval = ExprEval.ofType(expressionType, row);
             if (expectedLogicalType.isArray()) {
-              Assert.assertArrayEquals(eval.asArray(), (Object[]) vectorObjectSelector.getObjectVector()[0]);
+              Assertions.assertArrayEquals(eval.asArray(), (Object[]) vectorObjectSelector.getObjectVector()[0]);
             } else {
-              Assert.assertEquals(eval.value(), vectorObjectSelector.getObjectVector()[0]);
+              Assertions.assertEquals(eval.value(), vectorObjectSelector.getObjectVector()[0]);
             }
           }
           if (dimensionSelector != null) {
-            Assert.assertEquals(String.valueOf(row), dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+            Assertions.assertEquals(String.valueOf(row), dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
             // null is always 0
-            Assert.assertTrue(dimensionSelector.idLookup().lookupId(String.valueOf(row)) > 0);
+            Assertions.assertTrue(dimensionSelector.idLookup().lookupId(String.valueOf(row)) > 0);
             if (dimensionVectorSelector != null) {
               int[] dim = dimensionVectorSelector.getRowVector();
-              Assert.assertEquals(String.valueOf(row), dimensionVectorSelector.lookupName(dim[0]));
+              Assertions.assertEquals(String.valueOf(row), dimensionVectorSelector.lookupName(dim[0]));
             }
           }
         }
-        Assert.assertFalse(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(i));
+        Assertions.assertFalse(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(i));
 
       } else {
-        Assert.assertNull(valueSelector.getObject());
-        Assert.assertNull(vectorObjectSelector.getObjectVector()[0]);
+        Assertions.assertNull(valueSelector.getObject());
+        Assertions.assertNull(vectorObjectSelector.getObjectVector()[0]);
         if (dimensionSelector != null) {
-          Assert.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
-          Assert.assertEquals(0, dimensionSelector.idLookup().lookupId(null));
+          Assertions.assertNull(dimensionSelector.lookupName(dimensionSelector.getRow().get(0)));
+          Assertions.assertEquals(0, dimensionSelector.idLookup().lookupId(null));
           if (dimensionVectorSelector != null) {
-            Assert.assertNull(dimensionVectorSelector.lookupName(dimensionVectorSelector.getRowVector()[0]));
+            Assertions.assertNull(dimensionVectorSelector.lookupName(dimensionVectorSelector.getRowVector()[0]));
           }
         }
-        Assert.assertTrue(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(i));
+        Assertions.assertTrue(nullValueIndex.get().computeBitmapResult(resultFactory, false).get(i));
         if (expectedType.getSingleType() != null) {
-          Assert.assertFalse(arrayElementIndexes.containsValue(null, expectedType.getSingleType()).computeBitmapResult(resultFactory, false).get(i));
+          Assertions.assertFalse(arrayElementIndexes.containsValue(null, expectedType.getSingleType()).computeBitmapResult(resultFactory, false).get(i));
         }
       }
 

--- a/processing/src/test/java/org/apache/druid/segment/virtual/AlwaysTwoCounterAggregatorFactory.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/AlwaysTwoCounterAggregatorFactory.java
@@ -35,9 +35,10 @@ import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
 import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.vector.VectorValueSelector;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nullable;
+
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -151,7 +152,7 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
 
         long count = 0;
         for (int i = startRow; i < endRow; i++) {
-          Assert.assertEquals(2L, vector[i]);
+          Assertions.assertEquals(2L, vector[i]);
           count += 1;
         }
 
@@ -164,10 +165,10 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
         long count = 0;
         for (int i = startRow; i < endRow; i++) {
           if (vector[i] instanceof List) {
-            Assert.assertEquals(ImmutableList.of("2", "2"), vector[i]);
+            Assertions.assertEquals(ImmutableList.of("2", "2"), vector[i]);
             count += 2;
           } else {
-            Assert.assertEquals("2", vector[i]);
+            Assertions.assertEquals("2", vector[i]);
             count += 1;
           }
         }
@@ -180,7 +181,7 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
 
         long count = 0;
         for (int i = startRow; i < endRow; i++) {
-          Assert.assertEquals("2", singleValueDimensionSelector.lookupName(rowVector[i]));
+          Assertions.assertEquals("2", singleValueDimensionSelector.lookupName(rowVector[i]));
           count += 1;
         }
 
@@ -194,7 +195,7 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
         for (int i = startRow; i < endRow; i++) {
           //noinspection SSBasedInspection
           for (int j = 0; j < rowVector[i].size(); j++) {
-            Assert.assertEquals("2", multiValueDimensionSelector.lookupName(rowVector[i].get(j)));
+            Assertions.assertEquals("2", multiValueDimensionSelector.lookupName(rowVector[i].get(j)));
             count += 1;
           }
         }
@@ -219,7 +220,7 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
 
         for (int i = 0; i < numRows; i++) {
           final int position = positions[i] + positionOffset;
-          Assert.assertEquals(2L, vector[i]);
+          Assertions.assertEquals(2L, vector[i]);
           buf.putLong(position, buf.getLong(position) + 1);
         }
         return;
@@ -229,10 +230,10 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
         for (int i = 0; i < numRows; i++) {
           final int position = positions[i] + positionOffset;
           if (vector[i] instanceof List) {
-            Assert.assertEquals(ImmutableList.of("2", "2"), vector[i]);
+            Assertions.assertEquals(ImmutableList.of("2", "2"), vector[i]);
             buf.putLong(position, buf.getLong(position) + 2);
           } else {
-            Assert.assertEquals("2", vector[i]);
+            Assertions.assertEquals("2", vector[i]);
             buf.putLong(position, buf.getLong(position) + 1);
           }
         }
@@ -242,7 +243,7 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
         final int[] rowVector = singleValueDimensionSelector.getRowVector();
         for (int i = 0; i < numRows; i++) {
           final int position = positions[i] + positionOffset;
-          Assert.assertEquals("2", singleValueDimensionSelector.lookupName(rowVector[i]));
+          Assertions.assertEquals("2", singleValueDimensionSelector.lookupName(rowVector[i]));
           buf.putLong(position, buf.getLong(position) + 1);
         }
         return;
@@ -253,7 +254,7 @@ public class AlwaysTwoCounterAggregatorFactory extends CountAggregatorFactory
           final int position = positions[i] + positionOffset;
           //noinspection SSBasedInspection
           for (int j = 0; j < rowVector[i].size(); j++) {
-            Assert.assertEquals("2", multiValueDimensionSelector.lookupName(rowVector[i].get(j)));
+            Assertions.assertEquals("2", multiValueDimensionSelector.lookupName(rowVector[i].get(j)));
             buf.putLong(position, buf.getLong(position) + 1);
           }
         }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/AlwaysTwoVectorizedVirtualColumn.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/AlwaysTwoVectorizedVirtualColumn.java
@@ -36,9 +36,10 @@ import org.apache.druid.segment.vector.VectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.vector.VectorSizeInspector;
 import org.apache.druid.segment.vector.VectorValueSelector;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import javax.annotation.Nullable;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -78,7 +79,7 @@ public class AlwaysTwoVectorizedVirtualColumn implements VirtualColumn
   @Override
   public boolean canVectorize(ColumnInspector inspector)
   {
-    Assert.assertNotNull(inspector);
+    Assertions.assertNotNull(inspector);
     return canVectorize;
   }
 
@@ -106,7 +107,7 @@ public class AlwaysTwoVectorizedVirtualColumn implements VirtualColumn
       VectorColumnSelectorFactory factory
   )
   {
-    Assert.assertEquals(outputName, dimensionSpec.getOutputName());
+    Assertions.assertEquals(outputName, dimensionSpec.getOutputName());
     return new SingleValueDimensionVectorSelector()
     {
       private final VectorSizeInspector inspector = factory.getReadableVectorInspector();
@@ -165,7 +166,7 @@ public class AlwaysTwoVectorizedVirtualColumn implements VirtualColumn
       VectorColumnSelectorFactory factory
   )
   {
-    Assert.assertEquals(outputName, dimensionSpec.getOutputName());
+    Assertions.assertEquals(outputName, dimensionSpec.getOutputName());
     final IndexedInts[] rowVector = new IndexedInts[factory.getReadableVectorInspector().getMaxVectorSize()];
     Arrays.fill(rowVector, new ArrayBasedIndexedInts(new int[]{0, 0}));
     return new MultiValueDimensionVectorSelector()
@@ -224,7 +225,7 @@ public class AlwaysTwoVectorizedVirtualColumn implements VirtualColumn
       VectorColumnSelectorFactory factory
   )
   {
-    Assert.assertEquals(outputName, columnName);
+    Assertions.assertEquals(outputName, columnName);
     final long[] longs = new long[factory.getReadableVectorInspector().getMaxVectorSize()];
     final double[] doubles = new double[factory.getReadableVectorInspector().getMaxVectorSize()];
     final float[] floats = new float[factory.getReadableVectorInspector().getMaxVectorSize()];
@@ -278,7 +279,7 @@ public class AlwaysTwoVectorizedVirtualColumn implements VirtualColumn
       VectorColumnSelectorFactory factory
   )
   {
-    Assert.assertEquals(outputName, columnName);
+    Assertions.assertEquals(outputName, columnName);
     final Object[] objects = new Object[factory.getReadableVectorInspector().getMaxVectorSize()];
     if (capabilities.hasMultipleValues().isTrue()) {
       Arrays.fill(objects, ImmutableList.of("2", "2"));

--- a/processing/src/test/java/org/apache/druid/segment/virtual/DummyStringVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/DummyStringVirtualColumnTest.java
@@ -43,8 +43,8 @@ import org.apache.druid.segment.TestHelper;
 import org.apache.druid.segment.TestIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -106,7 +106,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testGroupBy(inMemorySegments, false, true);
-      Assert.fail("must need row based methods");
+      Assertions.fail("must need row based methods");
     }
     catch (Exception ex) {
     }
@@ -120,7 +120,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testGroupBy(mixedSegments, false, true);
-      Assert.fail("must need row based methods");
+      Assertions.fail("must need row based methods");
     }
     catch (Exception ex) {
     }
@@ -143,7 +143,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testGroupByWithSelectFilter(inMemorySegments, true, true, true, true);
-      Assert.fail("value matchers must be required");
+      Assertions.fail("value matchers must be required");
     }
     catch (Exception ex) {
 
@@ -158,7 +158,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testGroupByWithSelectFilter(mixedSegments, true, true, true, true);
-      Assert.fail("value matchers must be required");
+      Assertions.fail("value matchers must be required");
     }
     catch (Exception ex) {
 
@@ -182,7 +182,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testGroupByWithRegexFilter(inMemorySegments, true, true, true, true);
-      Assert.fail("value matchers must be required");
+      Assertions.fail("value matchers must be required");
     }
     catch (Exception ex) {
 
@@ -197,7 +197,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testGroupByWithRegexFilter(mixedSegments, true, true, true, true);
-      Assert.fail("value matchers must be required");
+      Assertions.fail("value matchers must be required");
     }
     catch (Exception ex) {
 
@@ -220,7 +220,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testTopN(inMemorySegments, false, true);
-      Assert.fail("must need row based methods");
+      Assertions.fail("must need row based methods");
     }
     catch (Exception ex) {
     }
@@ -234,7 +234,7 @@ public class DummyStringVirtualColumnTest extends InitializedNullHandlingTest
 
     try {
       testTopN(mixedSegments, false, true);
-      Assert.fail("must need row based methods");
+      Assertions.fail("must need row based methods");
     }
     catch (Exception ex) {
     }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionPlannerTest.java
@@ -36,12 +36,11 @@ import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Map;
 
@@ -167,9 +166,6 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
   private static final TestMacroTable MACRO_TABLE = new TestMacroTable();
 
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void testUnknown()
   {
@@ -180,13 +176,13 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     // row by row basis to determine if the expression needs applied to multi-valued inputs
 
     ExpressionPlan thePlan = plan("concat(x, 'x')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED,
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
@@ -197,28 +193,28 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
     // this expression has no "unapplied bindings", nothing to apply
-    Assert.assertEquals("concat(\"x\", 'x')", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals("concat(\"x\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals("concat(\"x\", 'x')", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals("concat(\"x\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
     // what if both inputs are unknown, can we know things?
     thePlan = plan("x * y");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.UNKNOWN_INPUTS
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED,
             ExpressionPlan.Trait.VECTORIZABLE,
@@ -230,27 +226,27 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals("(\"x\" * \"y\")", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals("(\"x\" * \"y\")", thePlan.getAppliedFoldExpression("__acc").stringify());
-    Assert.assertNull(thePlan.getOutputType());
-    Assert.assertNull(thePlan.inferColumnCapabilities(null));
+    Assertions.assertEquals("(\"x\" * \"y\")", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals("(\"x\" * \"y\")", thePlan.getAppliedFoldExpression("__acc").stringify());
+    Assertions.assertNull(thePlan.getOutputType());
+    Assertions.assertNull(thePlan.inferColumnCapabilities(null));
     // no we cannot
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -263,12 +259,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   public void testScalarStringNondictionaryEncoded()
   {
     ExpressionPlan thePlan = plan("concat(scalar_string, 'x')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -279,35 +275,35 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertEquals("concat(\"scalar_string\", 'x')", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals("concat(\"scalar_string\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals("concat(\"scalar_string\", 'x')", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals("concat(\"scalar_string\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -320,13 +316,13 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   public void testScalarNumeric()
   {
     ExpressionPlan thePlan = plan("long1 + 5");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
@@ -336,31 +332,31 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertEquals("(\"long1\" + 5)", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals("(\"long1\" + 5)", thePlan.getAppliedFoldExpression("__acc").stringify());
-    Assert.assertEquals("(\"long1\" + 5)", thePlan.getAppliedFoldExpression("long1").stringify());
-    Assert.assertEquals(ExpressionType.LONG, thePlan.getOutputType());
+    Assertions.assertEquals("(\"long1\" + 5)", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals("(\"long1\" + 5)", thePlan.getAppliedFoldExpression("__acc").stringify());
+    Assertions.assertEquals("(\"long1\" + 5)", thePlan.getAppliedFoldExpression("long1").stringify());
+    Assertions.assertEquals(ExpressionType.LONG, thePlan.getOutputType());
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.LONG, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isMaybeTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.LONG, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isMaybeTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
     thePlan = plan("long1 + 5.0");
-    Assert.assertEquals(ExpressionType.DOUBLE, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.DOUBLE, thePlan.getOutputType());
 
     thePlan = plan("double1 * double2");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -371,35 +367,35 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertEquals("(\"double1\" * \"double2\")", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals("(\"double1\" * \"double2\")", thePlan.getAppliedFoldExpression("__acc").stringify());
-    Assert.assertEquals("(\"double1\" * \"double2\")", thePlan.getAppliedFoldExpression("double1").stringify());
-    Assert.assertEquals(ExpressionType.DOUBLE, thePlan.getOutputType());
+    Assertions.assertEquals("(\"double1\" * \"double2\")", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals("(\"double1\" * \"double2\")", thePlan.getAppliedFoldExpression("__acc").stringify());
+    Assertions.assertEquals("(\"double1\" * \"double2\")", thePlan.getAppliedFoldExpression("double1").stringify());
+    Assertions.assertEquals(ExpressionType.DOUBLE, thePlan.getOutputType());
     inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.DOUBLE, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isMaybeTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
-    Assert.assertFalse(
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.DOUBLE, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isMaybeTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -412,14 +408,14 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   public void testScalarStringDictionaryEncoded()
   {
     ExpressionPlan thePlan = plan("concat(scalar_dictionary_string, 'x')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
@@ -428,24 +424,24 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertEquals("concat(\"scalar_dictionary_string\", 'x')", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals(
+    Assertions.assertEquals("concat(\"scalar_dictionary_string\", 'x')", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals(
         "concat(\"scalar_dictionary_string\", 'x')",
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isTrue());
-    Assert.assertTrue(inferred.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertTrue(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isTrue());
+    Assertions.assertTrue(inferred.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertTrue(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -453,14 +449,14 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
     // innately deferrable
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -471,12 +467,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
     // multiple input columns
     thePlan = plan("concat(scalar_dictionary_string, scalar_dictionary_string_nonunique)");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -487,46 +483,46 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "concat(\"scalar_dictionary_string\", \"scalar_dictionary_string_nonunique\")",
         thePlan.getAppliedExpression().stringify()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "concat(\"scalar_dictionary_string\", \"scalar_dictionary_string_nonunique\")",
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
     // what if scalar_dictionary_string_nonunique is an accumulator instead? nope, still no NEEDS_APPLIED so nothing to do
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "concat(\"scalar_dictionary_string\", \"scalar_dictionary_string_nonunique\")",
         thePlan.getAppliedFoldExpression("scalar_dictionary_string_nonunique").stringify()
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -537,12 +533,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
     // array output of dictionary encoded string are not considered single scalar/mappable, nor vectorizable
     thePlan = plan("array(scalar_dictionary_string)");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
@@ -553,21 +549,21 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -580,13 +576,13 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   public void testMultiValueStringDictionaryEncoded()
   {
     ExpressionPlan thePlan = plan("concat(multi_dictionary_string, 'x')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
@@ -595,33 +591,33 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isMaybeTrue());
-    Assert.assertTrue(inferred.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertTrue(inferred.hasMultipleValues().isTrue());
-    Assert.assertTrue(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isMaybeTrue());
+    Assertions.assertTrue(inferred.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertTrue(inferred.hasMultipleValues().isTrue());
+    Assertions.assertTrue(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -631,12 +627,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
 
     thePlan = plan("concat(scalar_string, multi_dictionary_string_nonunique)");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
@@ -645,35 +641,35 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "map((\"multi_dictionary_string_nonunique\") -> concat(\"scalar_string\", \"multi_dictionary_string_nonunique\"), \"multi_dictionary_string_nonunique\")",
         thePlan.getAppliedExpression().stringify()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "fold((\"multi_dictionary_string_nonunique\", \"scalar_string\") -> concat(\"scalar_string\", \"multi_dictionary_string_nonunique\"), \"multi_dictionary_string_nonunique\", \"scalar_string\")",
         thePlan.getAppliedFoldExpression("scalar_string").stringify()
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasMultipleValues().isTrue());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasMultipleValues().isTrue());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -682,12 +678,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     );
 
     thePlan = plan("concat(multi_dictionary_string, multi_dictionary_string_nonunique)");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
@@ -696,37 +692,37 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     // whoa
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "cartesian_map((\"multi_dictionary_string\", \"multi_dictionary_string_nonunique\") -> concat(\"multi_dictionary_string\", \"multi_dictionary_string_nonunique\"), \"multi_dictionary_string\", \"multi_dictionary_string_nonunique\")",
         thePlan.getAppliedExpression().stringify()
     );
     // sort of funny, but technically correct
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "cartesian_fold((\"multi_dictionary_string\", \"multi_dictionary_string_nonunique\", \"__acc\") -> concat(\"multi_dictionary_string\", \"multi_dictionary_string_nonunique\"), \"multi_dictionary_string\", \"multi_dictionary_string_nonunique\", \"__acc\")",
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
     inferred = thePlan.inferColumnCapabilities(null);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasMultipleValues().isTrue());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasMultipleValues().isTrue());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -735,12 +731,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     );
 
     thePlan = plan("array_append(multi_dictionary_string, 'foo')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED,
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
@@ -749,21 +745,21 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -775,18 +771,14 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   @Test
   public void testMultiValueStringDictionaryEncodedIllegalAccumulator()
   {
-    expectedException.expect(IllegalStateException.class);
-    expectedException.expectMessage(
-        "Accumulator cannot be implicitly transformed, if it is an ARRAY or multi-valued type it must be used explicitly as such"
-    );
     ExpressionPlan thePlan = plan("concat(multi_dictionary_string, 'x')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
@@ -795,22 +787,22 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.VECTORIZABLE
         )
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
-    Assert.assertFalse(
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -819,12 +811,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     );
 
     thePlan = plan("concat(multi_dictionary_string, multi_dictionary_string_nonunique)");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NEEDS_APPLIED
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.UNKNOWN_INPUTS,
@@ -835,20 +827,27 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     );
     // what happens if we try to use a multi-valued input that was not explicitly used as multi-valued as the
     // accumulator?
-    thePlan.getAppliedFoldExpression("multi_dictionary_string");
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    final ExpressionPlan illegalAccumulatorPlan = thePlan;
+    final IllegalStateException exception = Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> illegalAccumulatorPlan.getAppliedFoldExpression("multi_dictionary_string")
+    );
+    Assertions.assertEquals(
+        "Accumulator cannot be implicitly transformed, if it is an ARRAY or multi-valued type it must be used explicitly as such",
+        exception.getMessage()
+    );
   }
 
   @Test
   public void testIncompleteString()
   {
     ExpressionPlan thePlan = plan("concat(string_unknown, 'x')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.INCOMPLETE_INPUTS
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -861,27 +860,27 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     );
     // incomplete inputs are not transformed either, rather this will need to be detected and handled on a row-by-row
     // basis
-    Assert.assertEquals("concat(\"string_unknown\", 'x')", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals("concat(\"string_unknown\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
+    Assertions.assertEquals("concat(\"string_unknown\", 'x')", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals("concat(\"string_unknown\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
     // incomplete and unknown skip output type since we don't reliably know
-    Assert.assertNull(thePlan.getOutputType());
-    Assert.assertNull(thePlan.inferColumnCapabilities(null));
+    Assertions.assertNull(thePlan.getOutputType());
+    Assertions.assertNull(thePlan.inferColumnCapabilities(null));
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -899,46 +898,46 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     assertArrayInAndOut(thePlan);
     // with a string hint, it should look like a multi-valued string
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(ColumnType.STRING);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isMaybeTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertTrue(inferred.hasMultipleValues().isTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isMaybeTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertTrue(inferred.hasMultipleValues().isTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
     // with no hint though, let the array free
     inferred = thePlan.inferColumnCapabilities(ColumnType.STRING_ARRAY);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ColumnType.STRING_ARRAY, inferred.toColumnType());
-    Assert.assertTrue(inferred.hasNulls().isMaybeTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ColumnType.STRING_ARRAY, inferred.toColumnType());
+    Assertions.assertTrue(inferred.hasNulls().isMaybeTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
-    Assert.assertEquals("array_append(\"scalar_string\", 'x')", thePlan.getAppliedExpression().stringify());
-    Assert.assertEquals("array_append(\"scalar_string\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
+    Assertions.assertEquals("array_append(\"scalar_string\", 'x')", thePlan.getAppliedExpression().stringify());
+    Assertions.assertEquals("array_append(\"scalar_string\", 'x')", thePlan.getAppliedFoldExpression("__acc").stringify());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -949,21 +948,21 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     // multi-valued are cool too
     thePlan = plan("array_append(multi_dictionary_string, 'x')");
     assertArrayInAndOut(thePlan);
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -974,22 +973,22 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     // what about incomplete inputs with arrays? they are not reported as incomplete because they are treated as arrays
     thePlan = plan("array_append(string_unknown, 'x')");
     assertArrayInAndOut(thePlan);
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
-    Assert.assertFalse(
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -999,14 +998,14 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
     // what about if it is the scalar argument? there it is
     thePlan = plan("array_append(multi_dictionary_string, string_unknown)");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NON_SCALAR_INPUTS,
             ExpressionPlan.Trait.INCOMPLETE_INPUTS,
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -1016,22 +1015,22 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
     // incomplete and unknown skip output type since we don't reliably know
-    Assert.assertNull(thePlan.getOutputType());
-    Assert.assertFalse(
+    Assertions.assertNull(thePlan.getOutputType());
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1042,21 +1041,21 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     // array types are cool too
     thePlan = plan("array_append(string_array_1, 'x')");
     assertArrayInAndOut(thePlan);
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1066,21 +1065,21 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
     thePlan = plan("array_append(string_array_1, 'x')");
     assertArrayInAndOut(thePlan);
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1096,41 +1095,41 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     ExpressionPlan thePlan = plan("array_to_string(array_append(scalar_string, 'x'), ',')");
     assertArrayInput(thePlan);
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(ColumnType.STRING);
-    Assert.assertNotNull(inferred);
-    Assert.assertEquals(ValueType.STRING, inferred.getType());
-    Assert.assertTrue(inferred.hasNulls().isTrue());
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
-    Assert.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
-    Assert.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(inferred.hasBitmapIndexes());
-    Assert.assertFalse(inferred.hasSpatialIndexes());
+    Assertions.assertNotNull(inferred);
+    Assertions.assertEquals(ValueType.STRING, inferred.getType());
+    Assertions.assertTrue(inferred.hasNulls().isTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesSorted().isMaybeTrue());
+    Assertions.assertFalse(inferred.areDictionaryValuesUnique().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(inferred.hasBitmapIndexes());
+    Assertions.assertFalse(inferred.hasSpatialIndexes());
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "array_to_string(array_append(\"scalar_string\", 'x'), ',')",
         thePlan.getAppliedExpression().stringify()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "array_to_string(array_append(\"scalar_string\", 'x'), ',')",
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1140,13 +1139,13 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
     // what about a multi-valued input
     thePlan = plan("array_to_string(array_append(scalar_string, multi_dictionary_string), ',')");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NON_SCALAR_INPUTS,
             ExpressionPlan.Trait.NEEDS_APPLIED
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -1157,32 +1156,32 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "array_to_string(map((\"multi_dictionary_string\") -> array_append(\"scalar_string\", \"multi_dictionary_string\"), \"multi_dictionary_string\"), ',')",
         thePlan.getAppliedExpression().stringify()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "array_to_string(fold((\"multi_dictionary_string\", \"scalar_string\") -> array_append(\"scalar_string\", \"multi_dictionary_string\"), \"multi_dictionary_string\", \"scalar_string\"), ',')",
         thePlan.getAppliedFoldExpression("scalar_string").stringify()
     );
     // why is this null
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1197,56 +1196,56 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
     ExpressionPlan thePlan = plan("array_to_string(array_append(string_array_1, 'x'), ',')");
     assertArrayInput(thePlan);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "array_to_string(array_append(\"string_array_1\", 'x'), ',')",
         thePlan.getAppliedExpression().stringify()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "array_to_string(array_append(\"string_array_1\", 'x'), ',')",
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
 
 
     thePlan = plan("array_to_string(array_concat(string_array_1, string_array_2), ',')");
     assertArrayInput(thePlan);
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
 
     thePlan = plan("fold((x, acc) -> acc + x, array_concat(long_array_1, long_array_2), 0)");
     assertArrayInput(thePlan);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "fold((\"x\", \"acc\") -> (\"acc\" + \"x\"), array_concat(\"long_array_1\", \"long_array_2\"), 0)",
         thePlan.getAppliedExpression().stringify()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "fold((\"x\", \"acc\") -> (\"acc\" + \"x\"), array_concat(\"long_array_1\", \"long_array_2\"), 0)",
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
-    Assert.assertEquals(ExpressionType.LONG, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.LONG, thePlan.getOutputType());
 
     thePlan = plan("fold((x, acc) -> acc * x, array_concat(double_array_1, double_array_2), 0.0)");
     assertArrayInput(thePlan);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "fold((\"x\", \"acc\") -> (\"acc\" * \"x\"), array_concat(\"double_array_1\", \"double_array_2\"), 0.0)",
         thePlan.getAppliedExpression().stringify()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "fold((\"x\", \"acc\") -> (\"acc\" * \"x\"), array_concat(\"double_array_1\", \"double_array_2\"), 0.0)",
         thePlan.getAppliedFoldExpression("__acc").stringify()
     );
-    Assert.assertEquals(ExpressionType.DOUBLE, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.DOUBLE, thePlan.getOutputType());
   }
 
   @Test
   public void testArrayConstruction()
   {
     ExpressionPlan thePlan = plan("array(long1, long2)");
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -1257,19 +1256,19 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
     assertFallbackVectorizable(thePlan);
-    Assert.assertEquals(ExpressionType.LONG_ARRAY, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.LONG_ARRAY, thePlan.getOutputType());
 
     thePlan = plan("array(long1, double1)");
-    Assert.assertEquals(ExpressionType.DOUBLE_ARRAY, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.DOUBLE_ARRAY, thePlan.getOutputType());
     thePlan = plan("array(long1, double1, scalar_string)");
-    Assert.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING_ARRAY, thePlan.getOutputType());
   }
 
   @Test
   public void testNestedColumnExpression()
   {
     ExpressionPlan thePlan = plan("json_object('long1', long1, 'long2', long2)");
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT,
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
@@ -1280,20 +1279,20 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.NON_SCALAR_INPUTS
         )
     );
-    Assert.assertEquals(ExpressionType.NESTED_DATA, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.NESTED_DATA, thePlan.getOutputType());
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(
         ExpressionType.toColumnType(thePlan.getOutputType())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ColumnType.NESTED_DATA.getType(),
         inferred.getType()
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ColumnType.NESTED_DATA.getComplexTypeName(),
         inferred.getComplexTypeName()
     );
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1301,14 +1300,14 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
         )
     );
     // all numeric inputs so these are true
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1321,7 +1320,7 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   public void testDictionaryComplexStringOutput()
   {
     ExpressionPlan thePlan = plan("dict_complex_to_string(dictionary_complex)");
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -1331,38 +1330,38 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
             ExpressionPlan.Trait.NON_SCALAR_INPUTS
         )
     );
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR
         )
     );
     assertFallbackVectorizable(thePlan);
 
-    Assert.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
+    Assertions.assertEquals(ExpressionType.STRING, thePlan.getOutputType());
     ColumnCapabilities inferred = thePlan.inferColumnCapabilities(
         ExpressionType.toColumnType(thePlan.getOutputType())
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ColumnType.STRING.getType(),
         inferred.getType()
     );
-    Assert.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
+    Assertions.assertFalse(inferred.isDictionaryEncoded().isMaybeTrue());
 
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.SINGLE_STRING.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH_NON_NUMERIC.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
             SYNTHETIC_INSPECTOR
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         DeferExpressionDimensions.FIXED_WIDTH.useDeferredGroupBySelector(
             thePlan,
             thePlan.getAnalysis().getRequiredBindingsList(),
@@ -1375,20 +1374,20 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   public void testNowIsNotConstant()
   {
     ExpressionPlan thePlan = plan("now()");
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(ExpressionPlan.Trait.CONSTANT)
     );
-    Assert.assertFalse(thePlan.isConstant());
+    Assertions.assertFalse(thePlan.isConstant());
   }
 
   @Test
   public void testNowWrappedInExpressionIsNotConstant()
   {
     ExpressionPlan thePlan = plan("now() + 1000");
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.is(ExpressionPlan.Trait.CONSTANT)
     );
-    Assert.assertFalse(thePlan.isConstant());
+    Assertions.assertFalse(thePlan.isConstant());
   }
 
   private static ExpressionPlan plan(String expression)
@@ -1398,12 +1397,12 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
   private static void assertArrayInput(ExpressionPlan thePlan)
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NON_SCALAR_INPUTS
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -1418,13 +1417,13 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
 
   private static void assertArrayInAndOut(ExpressionPlan thePlan)
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         thePlan.is(
             ExpressionPlan.Trait.NON_SCALAR_INPUTS,
             ExpressionPlan.Trait.NON_SCALAR_OUTPUT
         )
     );
-    Assert.assertFalse(
+    Assertions.assertFalse(
         thePlan.any(
             ExpressionPlan.Trait.SINGLE_INPUT_SCALAR,
             ExpressionPlan.Trait.SINGLE_INPUT_MAPPABLE,
@@ -1440,13 +1439,13 @@ public class ExpressionPlannerTest extends InitializedNullHandlingTest
   private static void assertFallbackVectorizable(ExpressionPlan thePlan)
   {
     if (ExpressionProcessing.allowVectorizeFallback()) {
-      Assert.assertTrue(
+      Assertions.assertTrue(
           thePlan.is(
               ExpressionPlan.Trait.VECTORIZABLE
           )
       );
     } else {
-      Assert.assertFalse(
+      Assertions.assertFalse(
           thePlan.is(
               ExpressionPlan.Trait.VECTORIZABLE
           )

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionSelectorsTest.java
@@ -80,17 +80,17 @@ import org.apache.druid.segment.incremental.IncrementalIndexCursorFactory;
 import org.apache.druid.segment.incremental.IncrementalIndexSchema;
 import org.apache.druid.segment.incremental.OnheapIncrementalIndex;
 import org.apache.druid.testing.InitializedNullHandlingTest;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.DataSegment;
 import org.apache.druid.timeline.SegmentId;
 import org.apache.druid.timeline.partition.LinearShardSpec;
 import org.apache.druid.utils.CloseableUtils;
 import org.joda.time.DateTime;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -118,7 +118,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
                                                                                   .setHasMultipleValues(true)
                                                                                   .setHasNulls(true);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup()
   {
     CLOSER = Closer.create();
@@ -150,15 +150,15 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     );
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown()
   {
     CloseableUtils.closeAndSuppressExceptions(CLOSER, throwable -> {
     });
   }
 
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @RegisterExtension
+  public final TemporaryFolderExtension temporaryFolder = new TemporaryFolderExtension();
 
 
   @Test
@@ -197,26 +197,26 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
           Object bindingVal = bindings.get(columnName);
           Object bindingVal2 = bindings2.get(columnName);
           if (dimSelectorVal == null) {
-            Assert.assertNull(dimSelectorVal);
-            Assert.assertNull(valueSelectorVal);
-            Assert.assertNull(bindingVal);
+            Assertions.assertNull(dimSelectorVal);
+            Assertions.assertNull(valueSelectorVal);
+            Assertions.assertNull(bindingVal);
             if (isMultiVal) {
-              Assert.assertNull(((Object[]) bindingVal2)[0]);
+              Assertions.assertNull(((Object[]) bindingVal2)[0]);
             } else {
-              Assert.assertNull(bindingVal2);
+              Assertions.assertNull(bindingVal2);
             }
 
           } else {
             if (isMultiVal) {
-              Assert.assertEquals(dimSelectorVal, ((Object[]) bindingVal)[0]);
-              Assert.assertEquals(valueSelectorVal, ((Object[]) bindingVal)[0]);
-              Assert.assertEquals(dimSelectorVal, ((Object[]) bindingVal2)[0]);
-              Assert.assertEquals(valueSelectorVal, ((Object[]) bindingVal2)[0]);
+              Assertions.assertEquals(dimSelectorVal, ((Object[]) bindingVal)[0]);
+              Assertions.assertEquals(valueSelectorVal, ((Object[]) bindingVal)[0]);
+              Assertions.assertEquals(dimSelectorVal, ((Object[]) bindingVal2)[0]);
+              Assertions.assertEquals(valueSelectorVal, ((Object[]) bindingVal2)[0]);
             } else {
-              Assert.assertEquals(dimSelectorVal, bindingVal);
-              Assert.assertEquals(valueSelectorVal, bindingVal);
-              Assert.assertEquals(dimSelectorVal, bindingVal2);
-              Assert.assertEquals(valueSelectorVal, bindingVal2);
+              Assertions.assertEquals(dimSelectorVal, bindingVal);
+              Assertions.assertEquals(valueSelectorVal, bindingVal);
+              Assertions.assertEquals(dimSelectorVal, bindingVal2);
+              Assertions.assertEquals(valueSelectorVal, bindingVal2);
             }
           }
 
@@ -281,20 +281,20 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
           Object bindingVal4 = bindings4.get(columnName);
 
           if (dimSelectorVal == null) {
-            Assert.assertNull(dimSelectorVal);
-            Assert.assertNull(valueSelectorVal);
-            Assert.assertNull(bindingVal);
-            Assert.assertNull(bindingVal2);
-            Assert.assertNull(bindingVal3);
+            Assertions.assertNull(dimSelectorVal);
+            Assertions.assertNull(valueSelectorVal);
+            Assertions.assertNull(bindingVal);
+            Assertions.assertNull(bindingVal2);
+            Assertions.assertNull(bindingVal3);
             // binding4 has null coercion
-            Assert.assertArrayEquals(new Object[]{null}, (Object[]) bindingVal4);
+            Assertions.assertArrayEquals(new Object[]{null}, (Object[]) bindingVal4);
           } else {
-            Assert.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal);
-            Assert.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal);
-            Assert.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal2);
-            Assert.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal2);
-            Assert.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal3);
-            Assert.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal3);
+            Assertions.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal);
+            Assertions.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal);
+            Assertions.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal2);
+            Assertions.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal2);
+            Assertions.assertArrayEquals(((List) dimSelectorVal).toArray(), (Object[]) bindingVal3);
+            Assertions.assertArrayEquals(((List) valueSelectorVal).toArray(), (Object[]) bindingVal3);
           }
 
           cursor.advance();
@@ -333,14 +333,14 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
           Object bindingVal = bindings.get(columnName);
           Object bindingVal2 = bindings2.get(columnName);
           if (valueSelector.isNull()) {
-            Assert.assertNull(valueSelector.getObject());
-            Assert.assertNull(bindingVal);
-            Assert.assertNull(bindingVal2);
+            Assertions.assertNull(valueSelector.getObject());
+            Assertions.assertNull(bindingVal);
+            Assertions.assertNull(bindingVal2);
           } else {
-            Assert.assertEquals(valueSelector.getObject(), bindingVal);
-            Assert.assertEquals(valueSelector.getLong(), bindingVal);
-            Assert.assertEquals(valueSelector.getObject(), bindingVal2);
-            Assert.assertEquals(valueSelector.getLong(), bindingVal2);
+            Assertions.assertEquals(valueSelector.getObject(), bindingVal);
+            Assertions.assertEquals(valueSelector.getLong(), bindingVal);
+            Assertions.assertEquals(valueSelector.getObject(), bindingVal2);
+            Assertions.assertEquals(valueSelector.getLong(), bindingVal2);
           }
           cursor.advance();
         }
@@ -378,14 +378,14 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
           Object bindingVal = bindings.get(columnName);
           Object bindingVal2 = bindings2.get(columnName);
           if (valueSelector.isNull()) {
-            Assert.assertNull(valueSelector.getObject());
-            Assert.assertNull(bindingVal);
-            Assert.assertNull(bindingVal2);
+            Assertions.assertNull(valueSelector.getObject());
+            Assertions.assertNull(bindingVal);
+            Assertions.assertNull(bindingVal2);
           } else {
-            Assert.assertEquals(valueSelector.getObject(), bindingVal);
-            Assert.assertEquals(valueSelector.getDouble(), bindingVal);
-            Assert.assertEquals(valueSelector.getObject(), bindingVal2);
-            Assert.assertEquals(valueSelector.getDouble(), bindingVal2);
+            Assertions.assertEquals(valueSelector.getObject(), bindingVal);
+            Assertions.assertEquals(valueSelector.getDouble(), bindingVal);
+            Assertions.assertEquals(valueSelector.getObject(), bindingVal2);
+            Assertions.assertEquals(valueSelector.getDouble(), bindingVal2);
           }
           cursor.advance();
         }
@@ -396,7 +396,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary_oneSingleValueInput()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
             SINGLE_VALUE
@@ -407,7 +407,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary_oneSingleValueInputSpecifiedTwice()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("concat(dim1, dim1) == 2", ExprMacroTable.nil()).analyzeInputs(),
             SINGLE_VALUE
@@ -418,7 +418,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary_oneMultiValueInput()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
             MULTI_VAL
@@ -429,7 +429,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary_oneUnknownInput()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
             new ColumnCapabilitiesImpl()
@@ -440,7 +440,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary_oneSingleValueInputInArrayContext()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("array_contains(dim1, 2)", ExprMacroTable.nil()).analyzeInputs(),
             ColumnCapabilitiesImpl.createDefault().setType(ColumnType.STRING_ARRAY)
@@ -451,7 +451,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary_oneMultiValueInputInArrayContext()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("array_contains(dim1, 2)", ExprMacroTable.nil()).analyzeInputs(),
             MULTI_VAL
@@ -462,7 +462,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary_oneUnknownInputInArrayContext()
   {
-    Assert.assertFalse(
+    Assertions.assertFalse(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("array_contains(dim1, 2)", ExprMacroTable.nil()).analyzeInputs(),
             new ColumnCapabilitiesImpl()
@@ -473,7 +473,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
   @Test
   public void test_canMapOverDictionary()
   {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         ExpressionSelectors.canMapOverDictionary(
             Parser.parse("dim1 == 2", ExprMacroTable.nil()).analyzeInputs(),
             SINGLE_VALUE
@@ -491,14 +491,14 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         false
     );
 
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(null, supplier.get());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(null, supplier.get());
 
     settableSupplier.set(null);
-    Assert.assertEquals(null, supplier.get());
+    Assertions.assertEquals(null, supplier.get());
 
     settableSupplier.set("1234");
-    Assert.assertEquals("1234", supplier.get());
+    Assertions.assertEquals("1234", supplier.get());
   }
 
   @Test
@@ -510,20 +510,20 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         true
     );
 
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(null, supplier.get());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(null, supplier.get());
 
     settableSupplier.set(1.1f);
-    Assert.assertEquals(1.1f, supplier.get());
+    Assertions.assertEquals(1.1f, supplier.get());
 
     settableSupplier.set(1L);
-    Assert.assertEquals(1L, supplier.get());
+    Assertions.assertEquals(1L, supplier.get());
 
     settableSupplier.set("1234");
-    Assert.assertEquals("1234", supplier.get());
+    Assertions.assertEquals("1234", supplier.get());
 
     settableSupplier.set("1.234");
-    Assert.assertEquals("1.234", supplier.get());
+    Assertions.assertEquals("1.234", supplier.get());
   }
 
   @Test
@@ -536,14 +536,14 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     );
 
 
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(null, supplier.get());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(null, supplier.get());
 
     settableSupplier.set(1.1f);
-    Assert.assertEquals(1.1f, supplier.get());
+    Assertions.assertEquals(1.1f, supplier.get());
 
     settableSupplier.set(1L);
-    Assert.assertEquals(1L, supplier.get());
+    Assertions.assertEquals(1L, supplier.get());
   }
 
   @Test
@@ -555,14 +555,14 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         true
     );
 
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(null, supplier.get());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(null, supplier.get());
 
     settableSupplier.set("1.1");
-    Assert.assertEquals("1.1", supplier.get());
+    Assertions.assertEquals("1.1", supplier.get());
 
     settableSupplier.set("1");
-    Assert.assertEquals("1", supplier.get());
+    Assertions.assertEquals("1", supplier.get());
   }
 
   @Test
@@ -574,11 +574,11 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         true
     );
 
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(null, supplier.get());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(null, supplier.get());
 
     settableSupplier.set(ImmutableList.of("1", "2", "3"));
-    Assert.assertArrayEquals(new String[]{"1", "2", "3"}, (Object[]) supplier.get());
+    Assertions.assertArrayEquals(new String[]{"1", "2", "3"}, (Object[]) supplier.get());
   }
 
   @Test
@@ -590,27 +590,27 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         true
     );
 
-    Assert.assertNotNull(supplier);
-    Assert.assertEquals(null, supplier.get());
+    Assertions.assertNotNull(supplier);
+    Assertions.assertEquals(null, supplier.get());
 
     settableSupplier.set(new String[]{"1", "2", "3"});
-    Assert.assertArrayEquals(new String[]{"1", "2", "3"}, (Object[]) supplier.get());
+    Assertions.assertArrayEquals(new String[]{"1", "2", "3"}, (Object[]) supplier.get());
   }
 
   @Test
   public void test_coerceEvalToSelectorObject()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(1L, 2L, 3L),
         ExpressionSelectors.coerceEvalToObjectOrList(ExprEval.ofLongArray(new Long[]{1L, 2L, 3L}))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of(1.0, 2.0, 3.0),
         ExpressionSelectors.coerceEvalToObjectOrList(ExprEval.ofDoubleArray(new Double[]{1.0, 2.0, 3.0}))
     );
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ImmutableList.of("a", "b", "c"),
         ExpressionSelectors.coerceEvalToObjectOrList(ExprEval.ofStringArray(new String[]{"a", "b", "c"}))
     );
@@ -619,19 +619,19 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
     withNulls.add("a");
     withNulls.add(null);
     withNulls.add("c");
-    Assert.assertEquals(
+    Assertions.assertEquals(
         withNulls,
         ExpressionSelectors.coerceEvalToObjectOrList(ExprEval.ofStringArray(new String[]{"a", null, "c"}))
     );
 
-    Assert.assertNull(
+    Assertions.assertNull(
         ExpressionSelectors.coerceEvalToObjectOrList(ExprEval.ofLongArray(null))
     );
-    Assert.assertEquals(
+    Assertions.assertEquals(
         1L,
         ExpressionSelectors.coerceEvalToObjectOrList(ExprEval.ofLongArray(new Long[]{1L}))
     );
-    Assert.assertNull(
+    Assertions.assertNull(
         ExpressionSelectors.coerceEvalToObjectOrList(ExprEval.ofLongArray(new Long[]{null}))
     );
   }
@@ -685,17 +685,17 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         Object y = yExprSelector.getObject();
         String expectedFoo = "foofoo";
         if (rowCount == 0) {
-          Assert.assertEquals(expectedFoo, x);
-          Assert.assertNull(y);
+          Assertions.assertEquals(expectedFoo, x);
+          Assertions.assertNull(y);
         } else {
-          Assert.assertNull(x);
-          Assert.assertEquals(expectedFoo, y);
+          Assertions.assertNull(x);
+          Assertions.assertEquals(expectedFoo, y);
         }
         rowCount++;
         cursor.advance();
       }
 
-      Assert.assertEquals(2, rowCount);
+      Assertions.assertEquals(2, rowCount);
     }
   }
 
@@ -727,12 +727,12 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
       while (!cursor.isDone()) {
         Object x = xExprSelector.getObject();
         double expectedFoo = 1.1;
-        Assert.assertEquals(expectedFoo, x);
+        Assertions.assertEquals(expectedFoo, x);
         rowCount++;
         cursor.advance();
       }
 
-      Assert.assertEquals(1, rowCount);
+      Assertions.assertEquals(1, rowCount);
     }
   }
 
@@ -848,7 +848,7 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
 
       for (Segment segment : segments) {
         final CursorFactory cursorFactory = segment.as(CursorFactory.class);
-        Assert.assertNotNull(cursorFactory);
+        Assertions.assertNotNull(cursorFactory);
         final CursorHolder holder = closer.register(cursorFactory.makeCursorHolder(CursorBuildSpec.FULL_SCAN));
 
         final Cursor cursor = holder.asCursor();
@@ -974,68 +974,68 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
 
         // first row
         // "a"
-        Assert.assertNull(stringSelectorToLong.getObject());
-        Assert.assertNull(stringSelectorToDouble.getObject());
-        Assert.assertArrayEquals(new Object[]{"a"}, (Object[]) stringToArraySelector.getObject());
+        Assertions.assertNull(stringSelectorToLong.getObject());
+        Assertions.assertNull(stringSelectorToDouble.getObject());
+        Assertions.assertArrayEquals(new Object[]{"a"}, (Object[]) stringToArraySelector.getObject());
 
         // ["a1", "a2"]
-        Assert.assertNull(multiStringToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{"a1", "a2"}, (Object[]) multiStringToStringArraySelector.getObject());
+        Assertions.assertNull(multiStringToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{"a1", "a2"}, (Object[]) multiStringToStringArraySelector.getObject());
 
         // 1
-        Assert.assertEquals("1", longToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{1.0}, (Object[]) longToDoubleArraySelector.getObject());
+        Assertions.assertEquals("1", longToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{1.0}, (Object[]) longToDoubleArraySelector.getObject());
 
         // 1.1
-        Assert.assertEquals("1.1", doubleToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{1L}, (Object[]) doubleToLongArraySelector.getObject());
+        Assertions.assertEquals("1.1", doubleToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{1L}, (Object[]) doubleToLongArraySelector.getObject());
 
         // ["a1", "a2"]
-        Assert.assertNull(stringArrayToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{null, null}, (Object[]) stringArrayToLongArraySelector.getObject());
-        Assert.assertNull(stringArrayToDoubleSelector.getObject());
+        Assertions.assertNull(stringArrayToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{null, null}, (Object[]) stringArrayToLongArraySelector.getObject());
+        Assertions.assertNull(stringArrayToDoubleSelector.getObject());
 
         // [1, 1]
-        Assert.assertNull(longArrayToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{1.0, 1.0}, (Object[]) longArrayToDoubleArraySelector.getObject());
+        Assertions.assertNull(longArrayToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{1.0, 1.0}, (Object[]) longArrayToDoubleArraySelector.getObject());
 
         // [1.1, 1.1]
-        Assert.assertArrayEquals(new Object[]{"1.1", "1.1"}, (Object[]) doubleArrayToStringArraySelector.getObject());
-        Assert.assertNull(doubleArrayToLongSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{"1.1", "1.1"}, (Object[]) doubleArrayToStringArraySelector.getObject());
+        Assertions.assertNull(doubleArrayToLongSelector.getObject());
 
         cursor.advance();
         offset.increment();
 
         // first row
         // "b"
-        Assert.assertNull(stringSelectorToLong.getObject());
-        Assert.assertNull(stringSelectorToDouble.getObject());
-        Assert.assertArrayEquals(new Object[]{"b"}, (Object[]) stringToArraySelector.getObject());
+        Assertions.assertNull(stringSelectorToLong.getObject());
+        Assertions.assertNull(stringSelectorToDouble.getObject());
+        Assertions.assertArrayEquals(new Object[]{"b"}, (Object[]) stringToArraySelector.getObject());
 
         // ["b1"]
-        Assert.assertEquals("b1", multiStringToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{"b1"}, (Object[]) multiStringToStringArraySelector.getObject());
+        Assertions.assertEquals("b1", multiStringToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{"b1"}, (Object[]) multiStringToStringArraySelector.getObject());
 
         // 2
-        Assert.assertEquals("2", longToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{2.0}, (Object[]) longToDoubleArraySelector.getObject());
+        Assertions.assertEquals("2", longToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{2.0}, (Object[]) longToDoubleArraySelector.getObject());
 
         // 2.2
-        Assert.assertEquals("2.2", doubleToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{2L}, (Object[]) doubleToLongArraySelector.getObject());
+        Assertions.assertEquals("2.2", doubleToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{2L}, (Object[]) doubleToLongArraySelector.getObject());
 
         // ["2.2"]
-        Assert.assertEquals("2.2", stringArrayToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{2L}, (Object[]) stringArrayToLongArraySelector.getObject());
-        Assert.assertEquals(2.2, stringArrayToDoubleSelector.getObject());
+        Assertions.assertEquals("2.2", stringArrayToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{2L}, (Object[]) stringArrayToLongArraySelector.getObject());
+        Assertions.assertEquals(2.2, stringArrayToDoubleSelector.getObject());
 
         // [2]
-        Assert.assertEquals("2", longArrayToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{2.0}, (Object[]) longArrayToDoubleArraySelector.getObject());
+        Assertions.assertEquals("2", longArrayToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{2.0}, (Object[]) longArrayToDoubleArraySelector.getObject());
 
         // [2.2]
-        Assert.assertArrayEquals(new Object[]{"2.2"}, (Object[]) doubleArrayToStringArraySelector.getObject());
-        Assert.assertEquals(2L, doubleArrayToLongSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{"2.2"}, (Object[]) doubleArrayToStringArraySelector.getObject());
+        Assertions.assertEquals(2L, doubleArrayToLongSelector.getObject());
 
         cursor.advance();
         offset.increment();
@@ -1043,74 +1043,74 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
 
         // third row
         // null
-        Assert.assertNull(stringSelectorToLong.getObject());
-        Assert.assertNull(stringSelectorToDouble.getObject());
-        Assert.assertNull(stringToArraySelector.getObject());
+        Assertions.assertNull(stringSelectorToLong.getObject());
+        Assertions.assertNull(stringSelectorToDouble.getObject());
+        Assertions.assertNull(stringToArraySelector.getObject());
 
         // []
-        Assert.assertNull(multiStringToStringSelector.getObject());
+        Assertions.assertNull(multiStringToStringSelector.getObject());
         if (segment instanceof IncrementalIndexSegment || segment instanceof QueryableIndexSegment || segment instanceof FrameSegment) {
-          Assert.assertNull(multiStringToStringSelector.getObject());
+          Assertions.assertNull(multiStringToStringSelector.getObject());
         } else {
           // this one is kind of weird, the row based segment selector does not convert the empty list into null like
           // the others do
-          Assert.assertArrayEquals(new Object[0], (Object[]) multiStringToStringArraySelector.getObject());
+          Assertions.assertArrayEquals(new Object[0], (Object[]) multiStringToStringArraySelector.getObject());
         }
 
         // null
-        Assert.assertNull(longToStringSelector.getObject());
-        Assert.assertNull(longToDoubleArraySelector.getObject());
+        Assertions.assertNull(longToStringSelector.getObject());
+        Assertions.assertNull(longToDoubleArraySelector.getObject());
 
         // null
-        Assert.assertNull(doubleToStringSelector.getObject());
-        Assert.assertNull(doubleToLongArraySelector.getObject());
+        Assertions.assertNull(doubleToStringSelector.getObject());
+        Assertions.assertNull(doubleToLongArraySelector.getObject());
 
         // null
-        Assert.assertNull(stringArrayToStringSelector.getObject());
-        Assert.assertNull(stringArrayToLongArraySelector.getObject());
-        Assert.assertNull(stringArrayToDoubleSelector.getObject());
+        Assertions.assertNull(stringArrayToStringSelector.getObject());
+        Assertions.assertNull(stringArrayToLongArraySelector.getObject());
+        Assertions.assertNull(stringArrayToDoubleSelector.getObject());
 
         // null
-        Assert.assertNull(longArrayToStringSelector.getObject());
-        Assert.assertNull(longArrayToDoubleArraySelector.getObject());
+        Assertions.assertNull(longArrayToStringSelector.getObject());
+        Assertions.assertNull(longArrayToDoubleArraySelector.getObject());
 
         // null
-        Assert.assertNull(doubleArrayToStringArraySelector.getObject());
-        Assert.assertNull(doubleArrayToLongSelector.getObject());
+        Assertions.assertNull(doubleArrayToStringArraySelector.getObject());
+        Assertions.assertNull(doubleArrayToLongSelector.getObject());
 
         cursor.advance();
         offset.increment();
 
         // fourth row
         // "4"
-        Assert.assertEquals(4L, stringSelectorToLong.getObject());
-        Assert.assertEquals(4.0, stringSelectorToDouble.getObject());
-        Assert.assertArrayEquals(new Object[]{"4"}, (Object[]) stringToArraySelector.getObject());
+        Assertions.assertEquals(4L, stringSelectorToLong.getObject());
+        Assertions.assertEquals(4.0, stringSelectorToDouble.getObject());
+        Assertions.assertArrayEquals(new Object[]{"4"}, (Object[]) stringToArraySelector.getObject());
 
         // [null, null, 4.4]
-        Assert.assertNull(multiStringToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{null, null, "4.4"}, (Object[]) multiStringToStringArraySelector.getObject());
+        Assertions.assertNull(multiStringToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{null, null, "4.4"}, (Object[]) multiStringToStringArraySelector.getObject());
 
         // 4
-        Assert.assertEquals("4", longToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{4.0}, (Object[]) longToDoubleArraySelector.getObject());
+        Assertions.assertEquals("4", longToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{4.0}, (Object[]) longToDoubleArraySelector.getObject());
 
         // 4.4
-        Assert.assertEquals("4.4", doubleToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[]{4L}, (Object[]) doubleToLongArraySelector.getObject());
+        Assertions.assertEquals("4.4", doubleToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[]{4L}, (Object[]) doubleToLongArraySelector.getObject());
 
         // []
-        Assert.assertNull(stringArrayToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[0], (Object[]) stringArrayToLongArraySelector.getObject());
-        Assert.assertNull(stringArrayToDoubleSelector.getObject());
+        Assertions.assertNull(stringArrayToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[0], (Object[]) stringArrayToLongArraySelector.getObject());
+        Assertions.assertNull(stringArrayToDoubleSelector.getObject());
 
         // []
-        Assert.assertNull(longArrayToStringSelector.getObject());
-        Assert.assertArrayEquals(new Object[0], (Object[]) longArrayToDoubleArraySelector.getObject());
+        Assertions.assertNull(longArrayToStringSelector.getObject());
+        Assertions.assertArrayEquals(new Object[0], (Object[]) longArrayToDoubleArraySelector.getObject());
 
         // []
-        Assert.assertArrayEquals(new Object[0], (Object[]) doubleArrayToStringArraySelector.getObject());
-        Assert.assertNull(doubleArrayToLongSelector.getObject());
+        Assertions.assertArrayEquals(new Object[0], (Object[]) doubleArrayToStringArraySelector.getObject());
+        Assertions.assertNull(doubleArrayToLongSelector.getObject());
       }
     }
   }
@@ -1146,9 +1146,9 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         ColumnSelectorFactory factory = cursor.getColumnSelectorFactory();
 
         ColumnValueSelector<ExprEval> selector = ExpressionSelectors.makeExprEvalSelector(factory, nowExpr);
-        Assert.assertFalse(
-            "now() must not be folded into a ConstantExprEvalSelector because its value changes over time",
-            selector instanceof ConstantExprEvalSelector
+        Assertions.assertFalse(
+            selector instanceof ConstantExprEvalSelector,
+            "now() must not be folded into a ConstantExprEvalSelector because its value changes over time"
         );
 
         final long first = selector.getLong();
@@ -1156,14 +1156,14 @@ public class ExpressionSelectorsTest extends InitializedNullHandlingTest
         cursor.advance();
         final long second = selector.getLong();
 
-        Assert.assertTrue(
-            "now() must be monotonic across rows; got first=" + first + " second=" + second,
-            second >= first
+        Assertions.assertTrue(
+            second >= first,
+            "now() must be monotonic across rows; got first=" + first + " second=" + second
         );
-        Assert.assertNotEquals(
-            "now() must re-evaluate after the cursor advances; a ConstantExprEvalSelector would return the same value",
+        Assertions.assertNotEquals(
             first,
-            second
+            second,
+            "now() must re-evaluate after the cursor advances; a ConstantExprEvalSelector would return the same value"
         );
       }
     }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/ExpressionVirtualColumnTest.java
@@ -55,10 +55,11 @@ import org.apache.druid.segment.column.RowSignature;
 import org.apache.druid.segment.column.ValueType;
 import org.apache.druid.segment.data.IndexedInts;
 import org.apache.druid.testing.InitializedNullHandlingTest;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+
 import java.util.Arrays;
 
 public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
@@ -215,17 +216,17 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     final BaseObjectColumnValueSelector selector = X_PLUS_Y.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(null, selector.getObject());
+    Assertions.assertEquals(null, selector.getObject());
 
     CURRENT_ROW.set(ROW1);
     // y is null for row1
-    Assert.assertEquals(null, selector.getObject());
+    Assertions.assertEquals(null, selector.getObject());
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(5.1d, selector.getObject());
+    Assertions.assertEquals(5.1d, selector.getObject());
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(5L, selector.getObject());
+    Assertions.assertEquals(5L, selector.getObject());
   }
 
   @Test
@@ -238,11 +239,11 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         COLUMN_SELECTOR_FACTORY
     );
     CURRENT_ROW.set(ROWMULTI);
-    Assert.assertEquals(ImmutableList.of("2.0", "4.0", "6.0"), selectorImplicit.getObject());
+    Assertions.assertEquals(ImmutableList.of("2.0", "4.0", "6.0"), selectorImplicit.getObject());
     CURRENT_ROW.set(ROWMULTI2);
-    Assert.assertEquals(ImmutableList.of("6.0", "8.0", "10.0"), selectorImplicit.getObject());
+    Assertions.assertEquals(ImmutableList.of("6.0", "8.0", "10.0"), selectorImplicit.getObject());
     CURRENT_ROW.set(ROWMULTI3);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("6.0", null, "10.0"),
         selectorImplicit.getObject()
     );
@@ -252,11 +253,11 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         COLUMN_SELECTOR_FACTORY
     );
     CURRENT_ROW.set(ROWMULTI);
-    Assert.assertEquals(ImmutableList.of("2.0", "4.0", "6.0"), selectorExplicit.getObject());
+    Assertions.assertEquals(ImmutableList.of("2.0", "4.0", "6.0"), selectorExplicit.getObject());
     CURRENT_ROW.set(ROWMULTI2);
-    Assert.assertEquals(ImmutableList.of("6.0", "8.0", "10.0"), selectorExplicit.getObject());
+    Assertions.assertEquals(ImmutableList.of("6.0", "8.0", "10.0"), selectorExplicit.getObject());
     CURRENT_ROW.set(ROWMULTI3);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("6.0", null, "10.0"),
         selectorExplicit.getObject()
     );
@@ -364,8 +365,8 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     final BaseObjectColumnValueSelector selectorExplicit =
         SCALE_LIST_SELF_EXPLICIT.makeDimensionSelector(spec, factory);
 
-    Assert.assertTrue(selectorImplicit instanceof SingleStringInputDeferredEvaluationExpressionDimensionSelector);
-    Assert.assertTrue(selectorExplicit instanceof ExpressionMultiValueDimensionSelector);
+    Assertions.assertTrue(selectorImplicit instanceof SingleStringInputDeferredEvaluationExpressionDimensionSelector);
+    Assertions.assertTrue(selectorExplicit instanceof ExpressionMultiValueDimensionSelector);
   }
 
   @Test
@@ -374,17 +375,17 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     final BaseLongColumnValueSelector selector = X_PLUS_Y.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
 
     CURRENT_ROW.set(ROW1);
     // y is null for row1
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(5L, selector.getLong());
+    Assertions.assertEquals(5L, selector.getLong());
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(5L, selector.getLong());
+    Assertions.assertEquals(5L, selector.getLong());
   }
 
   @Test
@@ -393,17 +394,17 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     final BaseLongColumnValueSelector selector = Z_CONCAT_X.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
 
     CURRENT_ROW.set(ROW1);
     // y is null for row1
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
   }
 
   @Test
@@ -412,17 +413,17 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     final BaseFloatColumnValueSelector selector = X_PLUS_Y.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
 
     CURRENT_ROW.set(ROW1);
     // y is null for row1
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(5.1f, selector.getFloat(), 0.0f);
+    Assertions.assertEquals(5.1f, selector.getFloat(), 0.0f);
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(5.0f, selector.getFloat(), 0.0f);
+    Assertions.assertEquals(5.0f, selector.getFloat(), 0.0f);
   }
 
   @Test
@@ -442,29 +443,29 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     );
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(true, nullMatcher.matches(false));
-    Assert.assertEquals(false, fiveMatcher.matches(false));
-    Assert.assertEquals(false, nonNullMatcher.matches(false));
-    Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(true, nullMatcher.matches(false));
+    Assertions.assertEquals(false, fiveMatcher.matches(false));
+    Assertions.assertEquals(false, nonNullMatcher.matches(false));
+    Assertions.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
     // y is null in row1
-    Assert.assertEquals(true, nullMatcher.matches(false));
-    Assert.assertEquals(false, fiveMatcher.matches(false));
-    Assert.assertEquals(false, nonNullMatcher.matches(false));
-    Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(true, nullMatcher.matches(false));
+    Assertions.assertEquals(false, fiveMatcher.matches(false));
+    Assertions.assertEquals(false, nonNullMatcher.matches(false));
+    Assertions.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(false, nullMatcher.matches(false));
-    Assert.assertEquals(false, fiveMatcher.matches(false));
-    Assert.assertEquals(true, nonNullMatcher.matches(false));
-    Assert.assertEquals("5.1", selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(false, nullMatcher.matches(false));
+    Assertions.assertEquals(false, fiveMatcher.matches(false));
+    Assertions.assertEquals(true, nonNullMatcher.matches(false));
+    Assertions.assertEquals("5.1", selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(false, nullMatcher.matches(false));
-    Assert.assertEquals(true, fiveMatcher.matches(false));
-    Assert.assertEquals(true, nonNullMatcher.matches(false));
-    Assert.assertEquals("5", selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(false, nullMatcher.matches(false));
+    Assertions.assertEquals(true, fiveMatcher.matches(false));
+    Assertions.assertEquals(true, nonNullMatcher.matches(false));
+    Assertions.assertEquals("5", selector.lookupName(selector.getRow().get(0)));
   }
 
   @Test
@@ -482,7 +483,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     );
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(false, nonNullMatcher.matches(false));
+    Assertions.assertEquals(false, nonNullMatcher.matches(false));
 
 
   }
@@ -495,26 +496,26 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         COLUMN_SELECTOR_FACTORY
     );
 
-    Assert.assertNotNull(selector);
+    Assertions.assertNotNull(selector);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertEquals(
         null,
         selector.lookupName(selector.getRow().get(0))
     );
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertEquals("foobar2.1", selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertEquals("foobar2.1", selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertEquals("foobar2", selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertEquals("foobar2", selector.lookupName(selector.getRow().get(0)));
   }
 
   @Test
@@ -525,26 +526,26 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         COLUMN_SELECTOR_FACTORY
     );
 
-    Assert.assertNotNull(selector);
+    Assertions.assertNotNull(selector);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertNull(selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertNull(selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertNull(selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertNull(selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertEquals(
         null,
         selector.lookupName(selector.getRow().get(0))
     );
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(1, selector.getRow().size());
-    Assert.assertEquals(
+    Assertions.assertEquals(1, selector.getRow().size());
+    Assertions.assertEquals(
         null,
         selector.lookupName(selector.getRow().get(0))
     );
@@ -567,29 +568,29 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     );
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(true, nullMatcher.matches(false));
-    Assert.assertEquals(false, fiveMatcher.matches(false));
-    Assert.assertEquals(false, nonNullMatcher.matches(false));
-    Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(true, nullMatcher.matches(false));
+    Assertions.assertEquals(false, fiveMatcher.matches(false));
+    Assertions.assertEquals(false, nonNullMatcher.matches(false));
+    Assertions.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW1);
     // y is null in row1
-    Assert.assertEquals(true, nullMatcher.matches(false));
-    Assert.assertEquals(false, fiveMatcher.matches(false));
-    Assert.assertEquals(false, nonNullMatcher.matches(false));
-    Assert.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(true, nullMatcher.matches(false));
+    Assertions.assertEquals(false, fiveMatcher.matches(false));
+    Assertions.assertEquals(false, nonNullMatcher.matches(false));
+    Assertions.assertEquals(null, selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(false, nullMatcher.matches(false));
-    Assert.assertEquals(true, fiveMatcher.matches(false));
-    Assert.assertEquals(true, nonNullMatcher.matches(false));
-    Assert.assertEquals("5.1", selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(false, nullMatcher.matches(false));
+    Assertions.assertEquals(true, fiveMatcher.matches(false));
+    Assertions.assertEquals(true, nonNullMatcher.matches(false));
+    Assertions.assertEquals("5.1", selector.lookupName(selector.getRow().get(0)));
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(false, nullMatcher.matches(false));
-    Assert.assertEquals(true, fiveMatcher.matches(false));
-    Assert.assertEquals(true, nonNullMatcher.matches(false));
-    Assert.assertEquals("5", selector.lookupName(selector.getRow().get(0)));
+    Assertions.assertEquals(false, nullMatcher.matches(false));
+    Assertions.assertEquals(true, fiveMatcher.matches(false));
+    Assertions.assertEquals(true, nonNullMatcher.matches(false));
+    Assertions.assertEquals("5", selector.lookupName(selector.getRow().get(0)));
   }
 
   @Test
@@ -599,7 +600,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         CONSTANT_LIKE.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(1L, selector.getLong());
+    Assertions.assertEquals(1L, selector.getLong());
   }
 
   @Test
@@ -609,7 +610,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         CONSTANT_NULL_ARITHMETIC.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
   }
 
   @Test
@@ -619,7 +620,7 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         CONSTANT_NULL_ARITHMETIC.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.isNull());
   }
 
   @Test
@@ -631,8 +632,8 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     );
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertTrue(selector.getObject().isNumericNull());
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.getObject().isNumericNull());
   }
 
   @Test
@@ -641,16 +642,16 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     final ColumnValueSelector selector = Z_LIKE.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0L, selector.getLong());
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(0L, selector.getLong());
+    Assertions.assertEquals(0L, selector.getLong());
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(1L, selector.getLong());
+    Assertions.assertEquals(1L, selector.getLong());
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(1L, selector.getLong());
+    Assertions.assertEquals(1L, selector.getLong());
   }
 
   @Test
@@ -659,29 +660,29 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     final ColumnValueSelector selector = TIME_FLOOR.makeColumnValueSelector("expr", COLUMN_SELECTOR_FACTORY);
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getLong());
-    Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getFloat(), 0.0f);
-    Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getDouble(), 0.0d);
-    Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getObject());
+    Assertions.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getLong());
+    Assertions.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getFloat(), 0.0f);
+    Assertions.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getDouble(), 0.0d);
+    Assertions.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getObject());
 
     CURRENT_ROW.set(ROW1);
-    Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getLong());
+    Assertions.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getLong());
 
     CURRENT_ROW.set(ROW2);
-    Assert.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getLong());
+    Assertions.assertEquals(DateTimes.of("2000-01-01").getMillis(), selector.getLong());
 
     CURRENT_ROW.set(ROW3);
-    Assert.assertEquals(DateTimes.of("2000-01-02").getMillis(), selector.getLong());
-    Assert.assertEquals(DateTimes.of("2000-01-02").getMillis(), selector.getDouble(), 0.0);
+    Assertions.assertEquals(DateTimes.of("2000-01-02").getMillis(), selector.getLong());
+    Assertions.assertEquals(DateTimes.of("2000-01-02").getMillis(), selector.getDouble(), 0.0);
   }
 
   @Test
   public void testRequiredColumns()
   {
-    Assert.assertEquals(ImmutableList.of("x", "y"), X_PLUS_Y.requiredColumns());
-    Assert.assertEquals(ImmutableList.of(), CONSTANT_LIKE.requiredColumns());
-    Assert.assertEquals(ImmutableList.of("z"), Z_LIKE.requiredColumns());
-    Assert.assertEquals(ImmutableList.of("x", "z"), Z_CONCAT_X.requiredColumns());
+    Assertions.assertEquals(ImmutableList.of("x", "y"), X_PLUS_Y.requiredColumns());
+    Assertions.assertEquals(ImmutableList.of(), CONSTANT_LIKE.requiredColumns());
+    Assertions.assertEquals(ImmutableList.of("z"), Z_LIKE.requiredColumns());
+    Assertions.assertEquals(ImmutableList.of("x", "z"), Z_CONCAT_X.requiredColumns());
   }
 
   @Test
@@ -698,8 +699,8 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     );
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertTrue(selector.getObject().isNumericNull());
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.getObject().isNumericNull());
   }
 
   @Test
@@ -716,8 +717,8 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     );
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertTrue(selector.getObject().isNumericNull());
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.getObject().isNumericNull());
   }
 
   @Test
@@ -734,32 +735,32 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
     );
 
     CURRENT_ROW.set(ROW0);
-    Assert.assertTrue(selector.isNull());
-    Assert.assertTrue(selector.getObject().isNumericNull());
+    Assertions.assertTrue(selector.isNull());
+    Assertions.assertTrue(selector.getObject().isNumericNull());
   }
 
   @Test
   public void testCapabilities()
   {
     ColumnCapabilities caps = X_PLUS_Y.capabilities("expr");
-    Assert.assertEquals(ValueType.FLOAT, caps.getType());
-    Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertTrue(caps.hasMultipleValues().isUnknown());
-    Assert.assertTrue(caps.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertEquals(ValueType.FLOAT, caps.getType());
+    Assertions.assertFalse(caps.hasBitmapIndexes());
+    Assertions.assertFalse(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertTrue(caps.hasMultipleValues().isUnknown());
+    Assertions.assertTrue(caps.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
 
     caps = Z_CONCAT_X.capabilities("expr");
-    Assert.assertEquals(ValueType.STRING, caps.getType());
-    Assert.assertFalse(caps.hasBitmapIndexes());
-    Assert.assertFalse(caps.isDictionaryEncoded().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesSorted().isTrue());
-    Assert.assertFalse(caps.areDictionaryValuesUnique().isTrue());
-    Assert.assertTrue(caps.hasMultipleValues().isUnknown());
-    Assert.assertTrue(caps.hasMultipleValues().isMaybeTrue());
-    Assert.assertFalse(caps.hasSpatialIndexes());
+    Assertions.assertEquals(ValueType.STRING, caps.getType());
+    Assertions.assertFalse(caps.hasBitmapIndexes());
+    Assertions.assertFalse(caps.isDictionaryEncoded().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesSorted().isTrue());
+    Assertions.assertFalse(caps.areDictionaryValuesUnique().isTrue());
+    Assertions.assertTrue(caps.hasMultipleValues().isUnknown());
+    Assertions.assertTrue(caps.hasMultipleValues().isMaybeTrue());
+    Assertions.assertFalse(caps.hasSpatialIndexes());
   }
 
   @Test
@@ -774,8 +775,8 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         DefaultDimensionSpec.of("constant"),
         COLUMN_SELECTOR_FACTORY
     );
-    Assert.assertTrue(constantSelector instanceof ConstantDimensionSelector);
-    Assert.assertEquals("3", constantSelector.getObject());
+    Assertions.assertTrue(constantSelector instanceof ConstantDimensionSelector);
+    Assertions.assertEquals("3", constantSelector.getObject());
 
 
     ExpressionVirtualColumn multiConstant = new ExpressionVirtualColumn(
@@ -789,8 +790,8 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         COLUMN_SELECTOR_FACTORY
     );
 
-    Assert.assertTrue(multiConstantSelector instanceof ConstantMultiValueDimensionSelector);
-    Assert.assertEquals(ImmutableList.of("a", "b", "c"), multiConstantSelector.getObject());
+    Assertions.assertTrue(multiConstantSelector instanceof ConstantMultiValueDimensionSelector);
+    Assertions.assertEquals(ImmutableList.of("a", "b", "c"), multiConstantSelector.getObject());
   }
 
   @Test
@@ -809,9 +810,9 @@ public class ExpressionVirtualColumnTest extends InitializedNullHandlingTest
         TestExprMacroTable.INSTANCE
     );
 
-    Assert.assertFalse(
-        "ExpressionVirtualColumn cache keys for now() must differ across instances to defeat result caching",
-        Arrays.equals(vc1.getCacheKey(), vc2.getCacheKey())
+    Assertions.assertFalse(
+        Arrays.equals(vc1.getCacheKey(), vc2.getCacheKey()),
+        "ExpressionVirtualColumn cache keys for now() must differ across instances to defeat result caching"
     );
   }
 }

--- a/processing/src/test/java/org/apache/druid/segment/virtual/FallbackVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/FallbackVirtualColumnTest.java
@@ -45,19 +45,20 @@ import org.apache.druid.segment.vector.SingleValueDimensionVectorSelector;
 import org.apache.druid.segment.vector.TestVectorColumnSelectorFactory;
 import org.apache.druid.segment.vector.VectorObjectSelector;
 import org.apache.druid.segment.vector.VectorValueSelector;
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class FallbackVirtualColumnTest
 {
   @Mock
@@ -66,13 +67,13 @@ public class FallbackVirtualColumnTest
   @Test
   public void testGetOutputName()
   {
-    Assert.assertEquals("slimshady", makeCol("slimshady", "test1", "test2").getOutputName());
+    Assertions.assertEquals("slimshady", makeCol("slimshady", "test1", "test2").getOutputName());
   }
 
   @Test
   public void testGetColumns()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList(DefaultDimensionSpec.of("test1"), DefaultDimensionSpec.of("test2")),
         makeCol("slimshady", "test1", "test2").getColumns()
     );
@@ -81,7 +82,7 @@ public class FallbackVirtualColumnTest
   @Test
   public void testGetCacheKey()
   {
-    Assert.assertArrayEquals(
+    Assertions.assertArrayEquals(
         new CacheKeyBuilder((byte) 0x3)
             .appendString("slimshady")
             .appendCacheable(DefaultDimensionSpec.of("test1"))
@@ -108,16 +109,16 @@ public class FallbackVirtualColumnTest
         .addCapabilities("colB", ColumnCapabilitiesImpl.createDefault())
         .addCapabilities("colC", ColumnCapabilitiesImpl.createDefault());
 
-    Assert.assertSame(colA, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colA, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colA", null);
-    Assert.assertSame(colB, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colB, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colB", null);
-    Assert.assertSame(colC, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colC, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colC", null);
-    Assert.assertSame(colA, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colA, col.makeDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
   }
 
   @Test
@@ -136,23 +137,23 @@ public class FallbackVirtualColumnTest
         .addCapabilities("colB", ColumnCapabilitiesImpl.createDefault())
         .addCapabilities("colC", ColumnCapabilitiesImpl.createDefault());
 
-    Assert.assertSame(colA, col.makeColumnValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colA, col.makeColumnValueSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colA", null);
-    Assert.assertSame(colB, col.makeColumnValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colB, col.makeColumnValueSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colB", null);
-    Assert.assertSame(colC, col.makeColumnValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colC, col.makeColumnValueSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colC", null);
-    Assert.assertSame(colA, col.makeColumnValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colA, col.makeColumnValueSelector("abcd", selectorFactory));
   }
 
   @SuppressWarnings("ConstantConditions")
   @Test
   public void testCanVectorize()
   {
-    Assert.assertTrue(makeCol("slimshady", "test1").canVectorize(null));
+    Assertions.assertTrue(makeCol("slimshady", "test1").canVectorize(null));
   }
 
   @Test
@@ -171,16 +172,16 @@ public class FallbackVirtualColumnTest
         .addCapabilities("colB", ColumnCapabilitiesImpl.createDefault())
         .addCapabilities("colC", ColumnCapabilitiesImpl.createDefault());
 
-    Assert.assertSame(colA, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colA, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colA", null);
-    Assert.assertSame(colB, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colB, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colB", null);
-    Assert.assertSame(colC, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colC, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colC", null);
-    Assert.assertSame(colA, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colA, col.makeSingleValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
   }
 
   @Test
@@ -199,16 +200,16 @@ public class FallbackVirtualColumnTest
         .addCapabilities("colB", ColumnCapabilitiesImpl.createDefault())
         .addCapabilities("colC", ColumnCapabilitiesImpl.createDefault());
 
-    Assert.assertSame(colA, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colA, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colA", null);
-    Assert.assertSame(colB, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colB, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colB", null);
-    Assert.assertSame(colC, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colC, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
 
     selectorFactory.addCapabilities("colC", null);
-    Assert.assertSame(colA, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
+    Assertions.assertSame(colA, col.makeMultiValueVectorDimensionSelector(new IgnoredDimensionSpec(), selectorFactory));
   }
 
   @Test
@@ -227,16 +228,16 @@ public class FallbackVirtualColumnTest
         .addCapabilities("colB", ColumnCapabilitiesImpl.createDefault())
         .addCapabilities("colC", ColumnCapabilitiesImpl.createDefault());
 
-    Assert.assertSame(colA, col.makeVectorValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colA, col.makeVectorValueSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colA", null);
-    Assert.assertSame(colB, col.makeVectorValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colB, col.makeVectorValueSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colB", null);
-    Assert.assertSame(colC, col.makeVectorValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colC, col.makeVectorValueSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colC", null);
-    Assert.assertSame(colA, col.makeVectorValueSelector("abcd", selectorFactory));
+    Assertions.assertSame(colA, col.makeVectorValueSelector("abcd", selectorFactory));
   }
 
   @Test
@@ -255,16 +256,16 @@ public class FallbackVirtualColumnTest
         .addCapabilities("colB", ColumnCapabilitiesImpl.createDefault())
         .addCapabilities("colC", ColumnCapabilitiesImpl.createDefault());
 
-    Assert.assertSame(colA, col.makeVectorObjectSelector("abcd", selectorFactory));
+    Assertions.assertSame(colA, col.makeVectorObjectSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colA", null);
-    Assert.assertSame(colB, col.makeVectorObjectSelector("abcd", selectorFactory));
+    Assertions.assertSame(colB, col.makeVectorObjectSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colB", null);
-    Assert.assertSame(colC, col.makeVectorObjectSelector("abcd", selectorFactory));
+    Assertions.assertSame(colC, col.makeVectorObjectSelector("abcd", selectorFactory));
 
     selectorFactory.addCapabilities("colC", null);
-    Assert.assertSame(colA, col.makeVectorObjectSelector("abcd", selectorFactory));
+    Assertions.assertSame(colA, col.makeVectorObjectSelector("abcd", selectorFactory));
   }
 
   @Test
@@ -280,24 +281,24 @@ public class FallbackVirtualColumnTest
         .addCapabilities("colB", colB)
         .addCapabilities("colC", colC);
 
-    Assert.assertEquals(ColumnCapabilitiesImpl.createDefault().getType(), col.capabilities("abcd").getType());
+    Assertions.assertEquals(ColumnCapabilitiesImpl.createDefault().getType(), col.capabilities("abcd").getType());
 
-    Assert.assertSame(colA, col.capabilities(selectorFactory, "abcd"));
+    Assertions.assertSame(colA, col.capabilities(selectorFactory, "abcd"));
 
     selectorFactory.addCapabilities("colA", null);
-    Assert.assertSame(colB, col.capabilities(selectorFactory, "abcd"));
+    Assertions.assertSame(colB, col.capabilities(selectorFactory, "abcd"));
 
     selectorFactory.addCapabilities("colB", null);
-    Assert.assertSame(colC, col.capabilities(selectorFactory, "abcd"));
+    Assertions.assertSame(colC, col.capabilities(selectorFactory, "abcd"));
 
     selectorFactory.addCapabilities("colC", null);
-    Assert.assertNull(col.capabilities(selectorFactory, "abcd"));
+    Assertions.assertNull(col.capabilities(selectorFactory, "abcd"));
   }
 
   @Test
   public void testRequiredColumns()
   {
-    Assert.assertEquals(
+    Assertions.assertEquals(
         Arrays.asList("colA", "colB", "oneMore"),
         makeCol("slimshady", "colA", "colB", "oneMore").requiredColumns()
     );
@@ -306,7 +307,7 @@ public class FallbackVirtualColumnTest
   @Test
   public void testUsesDotNotation()
   {
-    Assert.assertFalse(makeCol("hi", "my", "name", "is").usesDotNotation());
+    Assertions.assertFalse(makeCol("hi", "my", "name", "is").usesDotNotation());
   }
 
   @Test
@@ -325,25 +326,25 @@ public class FallbackVirtualColumnTest
 
     try (final Closer closer = Closer.create()) {
       final ColumnIndexSelector columnIndexSelector = new ColumnCache(testIndex, VirtualColumns.EMPTY, closer);
-      Assert.assertSame(colA, col.getIndexSupplier("abcd", columnIndexSelector));
+      Assertions.assertSame(colA, col.getIndexSupplier("abcd", columnIndexSelector));
     }
 
     Mockito.when(testIndex.getColumnHolder("colA")).thenReturn(new HolderForIndexSupplier(colA, null));
     try (final Closer closer = Closer.create()) {
       final ColumnIndexSelector columnIndexSelector = new ColumnCache(testIndex, VirtualColumns.EMPTY, closer);
-      Assert.assertSame(colB, col.getIndexSupplier("abcd", columnIndexSelector));
+      Assertions.assertSame(colB, col.getIndexSupplier("abcd", columnIndexSelector));
     }
 
     Mockito.when(testIndex.getColumnHolder("colB")).thenReturn(new HolderForIndexSupplier(colB, null));
     try (final Closer closer = Closer.create()) {
       final ColumnIndexSelector columnIndexSelector = new ColumnCache(testIndex, VirtualColumns.EMPTY, closer);
-      Assert.assertSame(colC, col.getIndexSupplier("abcd", columnIndexSelector));
+      Assertions.assertSame(colC, col.getIndexSupplier("abcd", columnIndexSelector));
     }
 
     Mockito.when(testIndex.getColumnHolder("colC")).thenReturn(new HolderForIndexSupplier(colC, null));
     try (final Closer closer = Closer.create()) {
       final ColumnIndexSelector columnIndexSelector = new ColumnCache(testIndex, VirtualColumns.EMPTY, closer);
-      Assert.assertSame(colA, col.getIndexSupplier("abcd", columnIndexSelector));
+      Assertions.assertSame(colA, col.getIndexSupplier("abcd", columnIndexSelector));
     }
   }
 

--- a/processing/src/test/java/org/apache/druid/segment/virtual/VectorizedVirtualColumnTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/virtual/VectorizedVirtualColumnTest.java
@@ -22,6 +22,7 @@ package org.apache.druid.segment.virtual;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import org.apache.druid.error.ExceptionMatcher;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -45,12 +46,11 @@ import org.apache.druid.segment.TestIndex;
 import org.apache.druid.segment.column.ColumnCapabilities;
 import org.apache.druid.segment.column.ColumnCapabilitiesImpl;
 import org.apache.druid.segment.column.ColumnType;
+import org.apache.druid.testing.TemporaryFolderExtension;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.List;
@@ -86,27 +86,24 @@ public class VectorizedVirtualColumnTest
       "false"
   );
 
-  @Rule
-  public final TemporaryFolder tmpFolder = new TemporaryFolder();
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  @RegisterExtension
+  public final TemporaryFolderExtension tmpFolder = new TemporaryFolderExtension();
 
   private AggregationTestHelper groupByTestHelper;
   private AggregationTestHelper timeseriesTestHelper;
   private List<Segment> segments = null;
 
-  @Before
+  @BeforeEach
   public void setup()
   {
-    groupByTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelper(
+    groupByTestHelper = AggregationTestHelper.createGroupByQueryAggregationTestHelperWithTempDir(
         Collections.emptyList(),
         new GroupByQueryConfig(),
-        tmpFolder
+        tmpFolder.getRoot()
     );
-    timeseriesTestHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelper(
+    timeseriesTestHelper = AggregationTestHelper.createTimeseriesQueryAggregationTestHelperWithTempDir(
         Collections.emptyList(),
-        tmpFolder
+        tmpFolder.getRoot()
     );
     QueryableIndexSegment queryableIndexSegment = new QueryableIndexSegment(
         TestIndex.getMMappedTestIndex(),
@@ -131,12 +128,13 @@ public class VectorizedVirtualColumnTest
   public void testGroupByMultiValueString()
   {
     // cannot currently group by string columns that might be multi valued
-    cannotVectorize();
-    testGroupBy(new ColumnCapabilitiesImpl()
-                    .setType(ColumnType.STRING)
-                    .setDictionaryEncoded(true)
-                    .setDictionaryValuesUnique(true)
-                    .setHasMultipleValues(true)
+    assertException(
+        "Cannot vectorize!",
+        () -> testGroupBy(new ColumnCapabilitiesImpl()
+                              .setType(ColumnType.STRING)
+                              .setDictionaryEncoded(true)
+                              .setDictionaryValuesUnique(true)
+                              .setHasMultipleValues(true))
     );
   }
 
@@ -144,11 +142,12 @@ public class VectorizedVirtualColumnTest
   public void testGroupByMultiValueStringUnknown()
   {
     // cannot currently group by string columns that might be multi valued
-    cannotVectorize();
-    testGroupBy(new ColumnCapabilitiesImpl()
-                    .setType(ColumnType.STRING)
-                    .setDictionaryEncoded(true)
-                    .setDictionaryValuesUnique(true)
+    assertException(
+        "Cannot vectorize!",
+        () -> testGroupBy(new ColumnCapabilitiesImpl()
+                              .setType(ColumnType.STRING)
+                              .setDictionaryEncoded(true)
+                              .setDictionaryValuesUnique(true))
     );
   }
 
@@ -167,12 +166,13 @@ public class VectorizedVirtualColumnTest
   public void testGroupByMultiValueStringNotDictionaryEncoded()
   {
     // cannot currently group by string columns that might be multi valued
-    cannotVectorize();
-    testGroupBy(new ColumnCapabilitiesImpl()
-                    .setType(ColumnType.STRING)
-                    .setDictionaryEncoded(false)
-                    .setDictionaryValuesUnique(false)
-                    .setHasMultipleValues(true)
+    assertException(
+        "Cannot vectorize!",
+        () -> testGroupBy(new ColumnCapabilitiesImpl()
+                              .setType(ColumnType.STRING)
+                              .setDictionaryEncoded(false)
+                              .setDictionaryValuesUnique(false)
+                              .setHasMultipleValues(true))
     );
   }
 
@@ -269,22 +269,26 @@ public class VectorizedVirtualColumnTest
   @Test
   public void testTimeseriesForceContextCannotVectorize()
   {
-    cannotVectorize();
-    testTimeseries(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_VECTORIZE_FORCE,
-        false
+    assertException(
+        "Cannot vectorize!",
+        () -> testTimeseries(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_VECTORIZE_FORCE,
+            false
+        )
     );
   }
 
   @Test
   public void testTimeseriesForceVirtualContextCannotVectorize()
   {
-    cannotVectorize();
-    testTimeseries(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_VECTORIZE_TRUE_VIRTUAL_FORCE,
-        false
+    assertException(
+        "Cannot vectorize!",
+        () -> testTimeseries(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_VECTORIZE_TRUE_VIRTUAL_FORCE,
+            false
+        )
     );
   }
 
@@ -301,22 +305,26 @@ public class VectorizedVirtualColumnTest
   @Test
   public void testTimeseriesContradictionVectorizeFalseVirtualForce()
   {
-    expectNonvectorized();
-    testTimeseries(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_CONTRADICTION_VECTORIZE_FALSE_VIRTUAL_FORCE,
-        true
+    assertException(
+        AlwaysTwoVectorizedVirtualColumn.DONT_CALL_THIS,
+        () -> testTimeseries(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_CONTRADICTION_VECTORIZE_FALSE_VIRTUAL_FORCE,
+            true
+        )
     );
   }
 
   @Test
   public void testTimeseriesContradictionVectorizeForceVirtualFalse()
   {
-    cannotVectorize();
-    testTimeseries(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_CONTRADICTION_VECTORIZE_FORCE_VIRTUAL_FALSE,
-        true
+    assertException(
+        "Cannot vectorize!",
+        () -> testTimeseries(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_CONTRADICTION_VECTORIZE_FORCE_VIRTUAL_FALSE,
+            true
+        )
     );
   }
 
@@ -349,59 +357,69 @@ public class VectorizedVirtualColumnTest
   @Test
   public void testGroupByForceContextCannotVectorize()
   {
-    cannotVectorize();
-    testGroupBy(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_VECTORIZE_FORCE,
-        false
+    assertException(
+        "Cannot vectorize!",
+        () -> testGroupBy(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_VECTORIZE_FORCE,
+            false
+        )
     );
   }
 
   @Test
   public void testGroupByForceVirtualContextCannotVectorize()
   {
-    cannotVectorize();
-    testGroupBy(
-        new ColumnCapabilitiesImpl()
-            .setType(ColumnType.STRING)
-            .setDictionaryEncoded(true)
-            .setDictionaryValuesUnique(true)
-            .setHasMultipleValues(false),
-        CONTEXT_VECTORIZE_TRUE_VIRTUAL_FORCE,
-        false
+    assertException(
+        "Cannot vectorize!",
+        () -> testGroupBy(
+            new ColumnCapabilitiesImpl()
+                .setType(ColumnType.STRING)
+                .setDictionaryEncoded(true)
+                .setDictionaryValuesUnique(true)
+                .setHasMultipleValues(false),
+            CONTEXT_VECTORIZE_TRUE_VIRTUAL_FORCE,
+            false
+        )
     );
   }
 
   @Test
   public void testGroupByTrueVirtualContextCannotVectorize()
   {
-    expectNonvectorized();
-    testGroupBy(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_USE_DEFAULTS,
-        false
+    assertException(
+        AlwaysTwoVectorizedVirtualColumn.DONT_CALL_THIS,
+        () -> testGroupBy(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_USE_DEFAULTS,
+            false
+        )
     );
   }
 
   @Test
   public void testGroupByContradictionVectorizeFalseVirtualForce()
   {
-    expectNonvectorized();
-    testGroupBy(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_CONTRADICTION_VECTORIZE_FALSE_VIRTUAL_FORCE,
-        true
+    assertException(
+        AlwaysTwoVectorizedVirtualColumn.DONT_CALL_THIS,
+        () -> testGroupBy(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_CONTRADICTION_VECTORIZE_FALSE_VIRTUAL_FORCE,
+            true
+        )
     );
   }
 
   @Test
   public void testGroupByContradictionVectorizeForceVirtualFalse()
   {
-    cannotVectorize();
-    testGroupBy(
-        ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
-        CONTEXT_CONTRADICTION_VECTORIZE_FORCE_VIRTUAL_FALSE,
-        true
+    assertException(
+        "Cannot vectorize!",
+        () -> testGroupBy(
+            ColumnCapabilitiesImpl.createSimpleNumericColumnCapabilities(ColumnType.FLOAT),
+            CONTEXT_CONTRADICTION_VECTORIZE_FORCE_VIRTUAL_FALSE,
+            true
+        )
     );
   }
 
@@ -611,15 +629,10 @@ public class VectorizedVirtualColumnTest
     }
   }
 
-  private void expectNonvectorized()
+  private void assertException(final String message, final Runnable action)
   {
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage(AlwaysTwoVectorizedVirtualColumn.DONT_CALL_THIS);
-  }
-
-  private void cannotVectorize()
-  {
-    expectedException.expect(RuntimeException.class);
-    expectedException.expectMessage("Cannot vectorize!");
+    ExceptionMatcher.of(RuntimeException.class)
+                    .expectMessageContains(message)
+                    .assertThrowsAndMatches(action::run);
   }
 }


### PR DESCRIPTION
## Summary

Migrate the Batch 2 processing tests to JUnit 5, covering frame tests, expressions and expression macros, segment filters, joins, nested columns, and virtual columns. The migration uses the current Druid Jupiter extensions and shared exception matchers while preserving existing processing dependencies and shared Hamcrest APIs.

Relates to #13948.

## Scope

Only the assigned 77 files under the Batch 2 paths are changed. No query/NestedDataTestUtils.java or Batch 3/4 files are included.

## Checks

- `mvn -ntp test-compile -pl processing -am -Dweb.console.skip=true -T1C` — passed, including Checkstyle, PMD/enforcer, and forbidden API checks.
- Exact assigned focused tests — 8,801 run, 0 failures, 0 errors, 0 skipped.
- `git diff --check` — passed.

The optional broad focused run was stopped after producing no failure summary; the exact assigned focused rerun completed successfully.