### PR TITLE
minor: Coerce Task priority values in context to integer

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/AbstractBatchIndexTask.java
@@ -303,9 +303,9 @@ public abstract class AbstractBatchIndexTask extends AbstractTask
   public abstract Granularity getSegmentGranularity();
 
   @Override
-  public int getPriority()
+  public int getDefaultPriority()
   {
-    return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY);
+    return Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY;
   }
 
   public TaskLockHelper getTaskLockHelper()

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/CompactionTask.java
@@ -470,9 +470,9 @@ public class CompactionTask extends AbstractBatchIndexTask implements PendingSeg
   }
 
   @Override
-  public int getPriority()
+  public int getDefaultPriority()
   {
-    return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_MERGE_TASK_PRIORITY);
+    return Tasks.DEFAULT_MERGE_TASK_PRIORITY;
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/NoopTask.java
@@ -121,9 +121,9 @@ public class NoopTask extends AbstractTask implements PendingSegmentAllocatingTa
   }
 
   @Override
-  public int getPriority()
+  public int getDefaultPriority()
   {
-    return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY);
+    return Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY;
   }
 
   @Override

--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/Task.java
@@ -42,6 +42,7 @@ import org.apache.druid.indexing.common.task.batch.parallel.SinglePhaseSubTask;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.UOE;
 import org.apache.druid.query.Query;
+import org.apache.druid.query.QueryContexts;
 import org.apache.druid.query.QueryRunner;
 import org.apache.druid.server.coordination.BroadcastDatasourceLoadingSpec;
 import org.apache.druid.server.lookup.cache.LookupLoadingSpec;
@@ -118,7 +119,19 @@ public interface Task
    */
   default int getPriority()
   {
-    return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_TASK_PRIORITY);
+    return QueryContexts.getAsInt(
+        Tasks.PRIORITY_KEY,
+        getContextValue(Tasks.PRIORITY_KEY),
+        getDefaultPriority()
+    );
+  }
+
+  /**
+   * Default value for {@link Tasks#PRIORITY_KEY} if not specified in the task context.
+   */
+  default int getDefaultPriority()
+  {
+    return Tasks.DEFAULT_TASK_PRIORITY;
   }
 
   /**

--- a/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/seekablestream/SeekableStreamIndexTask.java
@@ -123,9 +123,9 @@ public abstract class SeekableStreamIndexTask<PartitionIdType, SequenceOffsetTyp
   }
 
   @Override
-  public int getPriority()
+  public int getDefaultPriority()
   {
-    return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_REALTIME_TASK_PRIORITY);
+    return Tasks.DEFAULT_REALTIME_TASK_PRIORITY;
   }
 
   @Override

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/NoopTaskTest.java
@@ -22,6 +22,8 @@ package org.apache.druid.indexing.common.task;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 public class NoopTaskTest
 {
   @Test
@@ -29,5 +31,13 @@ public class NoopTaskTest
   {
     NoopTask task = NoopTask.create();
     Assertions.assertTrue(task.getInputSourceResources().isEmpty());
+  }
+
+  @Test
+  public void test_getPriority_coercesStringValuesToInteger()
+  {
+    final NoopTask task = new NoopTask(null, null, null, 0, 0, Map.of(Tasks.PRIORITY_KEY, "1000"));
+    Assertions.assertEquals(1000, task.getPriority());
+    Assertions.assertEquals(Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY, task.getDefaultPriority());
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskQueueTest.java
@@ -751,7 +751,7 @@ public class TaskQueueTest extends IngestionTestBase
   }
 
   @Test
-  public void testTaskSubmissionToTaskRunnerBasedOnPriority() throws Exception
+  public void testTaskSubmissionToTaskRunnerBasedOnPriority()
   {
     final RecordingTaskRunner recordingRunner = new RecordingTaskRunner(serviceEmitter);
     final TaskQueue priorityQueue = new TaskQueue(
@@ -772,7 +772,9 @@ public class TaskQueueTest extends IngestionTestBase
     final NoopTask lowPriority2 = NoopTask.ofPriority(10);
     final NoopTask medPriority = NoopTask.ofPriority(50);
     final NoopTask highPriority1 = NoopTask.ofPriority(90);
-    final NoopTask highPriority2 = NoopTask.ofPriority(100);
+
+    // Create a task with a String priority value to verify that it gets coerced as an integer
+    final NoopTask highPriority2 = new NoopTask(null, null, null, 0, 0, Map.of(Tasks.PRIORITY_KEY, "100"));
 
     priorityQueue.add(lowPriority1);
     priorityQueue.add(medPriority);

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQControllerTask.java
@@ -322,9 +322,9 @@ public class MSQControllerTask extends AbstractTask implements ClientTaskQuery, 
   }
 
   @Override
-  public int getPriority()
+  public int getDefaultPriority()
   {
-    return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY);
+    return Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY;
   }
 
   @Nullable

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/MSQWorkerTask.java
@@ -175,9 +175,9 @@ public class MSQWorkerTask extends AbstractTask
   }
 
   @Override
-  public int getPriority()
+  public int getDefaultPriority()
   {
-    return getContextValue(Tasks.PRIORITY_KEY, Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY);
+    return Tasks.DEFAULT_BATCH_INDEX_TASK_PRIORITY;
   }
 
   @Override


### PR DESCRIPTION
### Description

We recently encountered an issue where the priority of a task being specified as a string would cause `TaskQueue` management to fail and essentially stall all ingestion.

### Fix

- Add method `Task.getDefaultPriority()`
- Update `Task.getPriority()` to use `getDefaultPriority()` and coerce string values to integer using `QueryContexts.getAsInt()`.

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.