### PR TITLE
minor: diagnostics when MSQ's on-demand segment cache can't fit an input segment 

### DIFF
--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQSegmentFetchCapacityTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQSegmentFetchCapacityTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.testing.embedded.msq;
+
+import org.apache.druid.indexer.TaskState;
+import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.query.http.SqlTaskStatus;
+import org.apache.druid.testing.embedded.EmbeddedBroker;
+import org.apache.druid.testing.embedded.EmbeddedCoordinator;
+import org.apache.druid.testing.embedded.EmbeddedDruidCluster;
+import org.apache.druid.testing.embedded.EmbeddedHistorical;
+import org.apache.druid.testing.embedded.EmbeddedIndexer;
+import org.apache.druid.testing.embedded.EmbeddedOverlord;
+import org.apache.druid.testing.embedded.indexing.MoreResources;
+import org.apache.druid.testing.embedded.indexing.Resources;
+import org.apache.druid.testing.embedded.junit5.EmbeddedClusterTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class MSQSegmentFetchCapacityTest extends EmbeddedClusterTestBase
+{
+  private final EmbeddedOverlord overlord = new EmbeddedOverlord();
+  private final EmbeddedCoordinator coordinator = new EmbeddedCoordinator();
+  private final EmbeddedBroker broker = new EmbeddedBroker();
+  private final EmbeddedHistorical historical = new EmbeddedHistorical();
+
+  // A tiny tmpStorageBytesPerTask means the segment-fetch cache in IndexerWorkerContext (sized at 1/3 of this
+  // value) cannot possibly hold even the small segment ingested below, so any query reading it back through MSQ
+  // must fail.
+  private final EmbeddedIndexer indexer = new EmbeddedIndexer()
+      .setServerMemory(300_000_000L)
+      .addProperty("druid.worker.capacity", "2")
+      .addProperty("druid.indexer.task.tmpStorageBytesPerTask", "3000");
+
+  private EmbeddedMSQApis msqApis;
+
+  @Override
+  protected EmbeddedDruidCluster createCluster()
+  {
+    return EmbeddedDruidCluster
+        .withEmbeddedDerbyAndZookeeper()
+        .useLatchableEmitter()
+        .addCommonProperty("druid.emitter.latching.defaultWaitTimeoutMillis", "60000")
+        .addServer(overlord)
+        .addServer(coordinator)
+        .addServer(indexer)
+        .addServer(broker)
+        .addServer(historical);
+  }
+
+  @BeforeAll
+  public void initTestClient()
+  {
+    msqApis = new EmbeddedMSQApis(cluster, overlord);
+  }
+
+  @Test
+  public void testQueryFailsWhenSegmentFetchCacheIsSmallerThanInputSegment()
+  {
+    final String insertSql = StringUtils.format(
+        MoreResources.MSQ.INSERT_TINY_WIKI_JSON,
+        dataSource,
+        Resources.DataFile.tinyWiki1Json().getAbsolutePath()
+    );
+    final SqlTaskStatus insertTaskStatus = msqApis.submitTaskSql(insertSql);
+    cluster.callApi().waitForTaskToSucceed(insertTaskStatus.getTaskId(), overlord.latchableEmitter());
+    cluster.callApi().waitForAllSegmentsToBeAvailable(dataSource, coordinator, broker);
+
+    final String selectSql = StringUtils.format(
+        "SELECT COUNT(DISTINCT isRobot) FROM %s",
+        dataSource
+    );
+    final SqlTaskStatus selectTaskStatus = msqApis.submitTaskSql(
+        Map.of("maxNumTasks", 2, "useApproximateCountDistinct", true),
+        selectSql
+    );
+
+    final TaskStatus finalStatus =
+        cluster.callApi().waitForTaskToFinish(selectTaskStatus.getTaskId(), overlord.latchableEmitter());
+
+    Assertions.assertEquals(TaskState.FAILED, finalStatus.getStatusCode());
+    Assertions.assertTrue(
+        finalStatus.getErrorMsg() != null && finalStatus.getErrorMsg().contains("Unable to load segment"),
+        StringUtils.format("Unexpected error message: %s", finalStatus.getErrorMsg())
+    );
+  }
+}

--- a/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQSegmentFetchCapacityTest.java
+++ b/embedded-tests/src/test/java/org/apache/druid/testing/embedded/msq/MSQSegmentFetchCapacityTest.java
@@ -19,9 +19,14 @@
 
 package org.apache.druid.testing.embedded.msq;
 
+import org.apache.druid.error.DruidException;
 import org.apache.druid.indexer.TaskState;
 import org.apache.druid.indexer.TaskStatus;
+import org.apache.druid.indexer.report.TaskReport;
 import org.apache.druid.java.util.common.StringUtils;
+import org.apache.druid.msq.indexing.error.DruidExceptionFault;
+import org.apache.druid.msq.indexing.report.MSQTaskReport;
+import org.apache.druid.msq.indexing.report.MSQTaskReportPayload;
 import org.apache.druid.query.http.SqlTaskStatus;
 import org.apache.druid.testing.embedded.EmbeddedBroker;
 import org.apache.druid.testing.embedded.EmbeddedCoordinator;
@@ -100,6 +105,17 @@ public class MSQSegmentFetchCapacityTest extends EmbeddedClusterTestBase
         cluster.callApi().waitForTaskToFinish(selectTaskStatus.getTaskId(), overlord.latchableEmitter());
 
     Assertions.assertEquals(TaskState.FAILED, finalStatus.getStatusCode());
+
+    final TaskReport.ReportMap taskReport = cluster.callApi().onLeaderOverlord(
+        o -> o.taskReportAsMap(selectTaskStatus.getTaskId())
+    );
+    final MSQTaskReportPayload payload = taskReport.<MSQTaskReport>findReport(MSQTaskReport.REPORT_KEY)
+                                                    .map(MSQTaskReport::getPayload)
+                                                    .orElse(null);
+    final DruidExceptionFault druidExceptionFault = (DruidExceptionFault) payload.getStatus().getErrorReport().getFault();
+
+    Assertions.assertEquals(DruidException.Category.CAPACITY_EXCEEDED.name(), druidExceptionFault.getCategory());
+    Assertions.assertEquals(DruidException.Persona.OPERATOR.name(), druidExceptionFault.getPersona());
     Assertions.assertTrue(
         finalStatus.getErrorMsg() != null && finalStatus.getErrorMsg().contains("Unable to load segment"),
         StringUtils.format("Unexpected error message: %s", finalStatus.getErrorMsg())

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
@@ -179,6 +179,8 @@ public class IndexerWorkerContext implements WorkerContext
         QueryContext.of(task.getContext()),
         taskConfig.isVirtualStoragePartialDownloadsEnabled()
     );
+    // Divide tmpStorageBytesPerTask by 3 so the local cache never takes up the majority of space.
+    // In a typical leaf stage run, we may need some disk space for inputs and some for outputs.
     final Long segmentFetchCacheMaxBytes =
         taskConfig.getTmpStorageBytesPerTask() > 0 ? taskConfig.getTmpStorageBytesPerTask() / 3 : null;
     log.info(
@@ -190,8 +192,6 @@ public class IndexerWorkerContext implements WorkerContext
         injector.getInstance(SegmentCacheManagerFactory.class)
                 .manufacturate(
                     new File(toolbox.getIndexingTmpDir(), "segment-fetch"),
-                    // Divide tmpStorageBytesPerTask by 3 so the local cache never takes up the majority of space.
-                    // In a typical leaf stage run, we may need some disk space for inputs and some for outputs.
                     segmentFetchCacheMaxBytes,
                     true,
                     partialDownloadsEnabled

--- a/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
+++ b/multi-stage-query/src/main/java/org/apache/druid/msq/indexing/IndexerWorkerContext.java
@@ -179,13 +179,20 @@ public class IndexerWorkerContext implements WorkerContext
         QueryContext.of(task.getContext()),
         taskConfig.isVirtualStoragePartialDownloadsEnabled()
     );
+    final Long segmentFetchCacheMaxBytes =
+        taskConfig.getTmpStorageBytesPerTask() > 0 ? taskConfig.getTmpStorageBytesPerTask() / 3 : null;
+    log.info(
+        "Segment-fetch cache capacity[%s] bytes (tmpStorageBytesPerTask[%,d]).",
+        segmentFetchCacheMaxBytes == null ? "unbounded" : segmentFetchCacheMaxBytes,
+        taskConfig.getTmpStorageBytesPerTask()
+    );
     final SegmentCacheManager cacheManager =
         injector.getInstance(SegmentCacheManagerFactory.class)
                 .manufacturate(
                     new File(toolbox.getIndexingTmpDir(), "segment-fetch"),
                     // Divide tmpStorageBytesPerTask by 3 so the local cache never takes up the majority of space.
                     // In a typical leaf stage run, we may need some disk space for inputs and some for outputs.
-                    taskConfig.getTmpStorageBytesPerTask() > 0 ? taskConfig.getTmpStorageBytesPerTask() / 3 : null,
+                    segmentFetchCacheMaxBytes,
                     true,
                     partialDownloadsEnabled
                 );

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -574,7 +574,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
             throw CloseableUtils.closeAndWrapInCatch(t, hold);
           }
         }
-        throw DruidException.forPersona(DruidException.Persona.USER)
+        throw DruidException.forPersona(DruidException.Persona.OPERATOR)
                             .ofCategory(DruidException.Category.CAPACITY_EXCEEDED)
                             .build(
                                 "Unable to load segment[%s] on demand, ensure enough disk space has been allocated "

--- a/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/SegmentLocalCacheManager.java
@@ -36,6 +36,7 @@ import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.IAE;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.Stopwatch;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.concurrent.Execs;
 import org.apache.druid.java.util.common.io.Closer;
 import org.apache.druid.java.util.emitter.EmittingLogger;
@@ -534,6 +535,7 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
         }
 
         final Iterator<StorageLocation> iterator = strategy.getLocations();
+        final List<String> locationFailures = new ArrayList<>();
         while (iterator.hasNext()) {
           final StorageLocation location = iterator.next();
           final StorageLocation.ReservationHold<CompleteSegmentCacheEntry> hold = location.addWeakReservationHold(
@@ -557,6 +559,15 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
                   makeOnDemandLoadSupplier(hold.getEntry(), location),
                   hold
               );
+            } else {
+              locationFailures.add(
+                  StringUtils.format(
+                      "location[%s]: max[%,d] available[%,d]",
+                      location.getPath(),
+                      location.getMaxSizeBytes(),
+                      location.availableSizeBytes()
+                  )
+              );
             }
           }
           catch (Throwable t) {
@@ -566,8 +577,13 @@ public class SegmentLocalCacheManager implements SegmentCacheManager
         throw DruidException.forPersona(DruidException.Persona.USER)
                             .ofCategory(DruidException.Category.CAPACITY_EXCEEDED)
                             .build(
-                                "Unable to load segment[%s] on demand, ensure enough disk space has been allocated to load all segments involved in the query",
-                                dataSegment.getId()
+                                "Unable to load segment[%s] on demand, ensure enough disk space has been allocated "
+                                + "to load all segments involved in the query. Segment size[%,d] exceeded the "
+                                + "remaining capacity of every configured storage location, even after evicting "
+                                + "everything evictable: %s",
+                                dataSegment.getId(),
+                                dataSegment.getSize(),
+                                String.join("; ", locationFailures)
                             );
       }
       finally {

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
@@ -154,6 +154,7 @@ public class StorageLocation
     } else {
       this.freeSpaceToKeep = 0;
     }
+    log.info("SegmentLocation[%s] configured with capacity[%,d] bytes.", path, maxSizeBytes);
     resetStaticStats();
     resetWeakStats();
   }
@@ -1000,6 +1001,14 @@ public class StorageLocation
   public long availableSizeBytes()
   {
     return maxSizeBytes - currSizeBytes.get();
+  }
+
+  /**
+   * The configured capacity of this location, i.e. the maximum value {@link #currentSizeBytes()} can reach.
+   */
+  public long getMaxSizeBytes()
+  {
+    return maxSizeBytes;
   }
 
   public long currentSizeBytes()

--- a/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
+++ b/server/src/main/java/org/apache/druid/segment/loading/StorageLocation.java
@@ -146,7 +146,7 @@ public class StorageLocation
       long totalSpaceInPartition = path.getTotalSpace();
       this.freeSpaceToKeep = (long) ((freeSpacePercent * totalSpaceInPartition) / 100);
       log.info(
-          "SegmentLocation[%s] will try and maintain [%d:%d] free space while loading segments.",
+          "StorageLocation[%s] will try and maintain [%d:%d] free space while loading segments.",
           path,
           freeSpaceToKeep,
           totalSpaceInPartition
@@ -154,7 +154,7 @@ public class StorageLocation
     } else {
       this.freeSpaceToKeep = 0;
     }
-    log.info("SegmentLocation[%s] configured with capacity[%,d] bytes.", path, maxSizeBytes);
+    log.info("StorageLocation[%s] configured with capacity[%,d] bytes.", path, maxSizeBytes);
     resetStaticStats();
     resetWeakStats();
   }


### PR DESCRIPTION
 
### Description
MSQ workers read input segments through a virtual-storage cache (SegmentLocalCacheManager/StorageLocation) sized as a fraction of tmpStorageBytesPerTask. If a single segment exceeds that cache's capacity, it fails unconditionally (nothing can be evicted to make room), and the resulting error gives no numbers, just "ensure enough disk space has been allocated." The actual size/capacity data was already computed for a debug log line but never surfaced. This PR is diagnostics-only, no behavior change. 
                                               

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.