### PR TITLE
feat: For k8s-overlord-extensions users, emit the pod template as a dimension for peon metrics

### DIFF
--- a/docs/development/extensions-core/k8s-jobs.md
+++ b/docs/development/extensions-core/k8s-jobs.md
@@ -844,6 +844,14 @@ Set the `podTemplateSelectionKey` key in a task's context to pick a configured p
 
 This is gated by the runtime property `druid.indexer.runner.allowTaskPodTemplateSelection`, which defaults to `false`. If the key doesn't match any configured template, the task fails to launch.
 
+##### Pod template metrics dimension
+
+Every metric emitted by a task pod carries a `podTemplate` dimension naming the pod template the pod runs under, alongside the existing `taskType`, `dataSource`, `taskId`, and `groupId` dimensions. Use it to group metrics by task type and pod template, for example to see which task types run on which templates.
+
+The dimension reflects the template actually applied to the pod, whichever selection strategy or context override chose it. Druid passes the name to the pod through the `DRUID_POD_TEMPLATE` environment variable, sourced from the pod's own `task.jobTemplate` annotation; you don't need to declare it in your pod templates.
+
+The dimension requires `druid-kubernetes-overlord-extensions` in the task pod's `druid.extensions.loadList`. Task pods that have no pod template, such as those launched by another task adapter, omit the dimension.
+
 #### Running Task Pods in Another Namespace
 
 It is possible to run task pods in a different namespace from the rest of your Druid cluster.

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonMetricsModule.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/KubernetesPeonMetricsModule.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Binder;
+import com.google.inject.multibindings.MapBinder;
+import org.apache.druid.discovery.NodeRole;
+import org.apache.druid.guice.annotations.LoadScope;
+import org.apache.druid.initialization.DruidModule;
+import org.apache.druid.java.util.common.logger.Logger;
+import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
+import org.apache.druid.server.emitter.ExtraServiceDimensions;
+
+import javax.annotation.Nullable;
+
+/**
+ * Tags every metric a task pod emits with the pod template it runs under, so metrics can be grouped
+ * by pod template alongside the task dimensions the peon already reports.
+ * <p>
+ * The template name arrives in {@link DruidK8sConstants#POD_TEMPLATE_ENV}, which
+ * {@link org.apache.druid.k8s.overlord.taskadapter.PodTemplateTaskAdapter} populates from the pod's
+ * own {@link DruidK8sConstants#TASK_JOB_TEMPLATE} annotation. Peons launched without a pod template,
+ * such as those from another task adapter, leave the variable unset and emit no extra dimension.
+ */
+@LoadScope(roles = NodeRole.PEON_JSON_NAME)
+public class KubernetesPeonMetricsModule implements DruidModule
+{
+  private static final Logger log = new Logger(KubernetesPeonMetricsModule.class);
+
+  @Override
+  public void configure(Binder binder)
+  {
+    final MapBinder<String, String> extraServiceDimensions = MapBinder.newMapBinder(
+        binder,
+        String.class,
+        String.class,
+        ExtraServiceDimensions.class
+    );
+
+    final String podTemplate = getPodTemplateName();
+    if (podTemplate == null || podTemplate.isEmpty()) {
+      log.debug(
+          "Env variable [%s] is not set, so metrics will not carry a [%s] dimension.",
+          DruidK8sConstants.POD_TEMPLATE_ENV,
+          DruidK8sConstants.POD_TEMPLATE_DIMENSION
+      );
+      return;
+    }
+
+    log.info("Emitting metrics with dimension [%s] set to [%s].", DruidK8sConstants.POD_TEMPLATE_DIMENSION, podTemplate);
+    extraServiceDimensions.addBinding(DruidK8sConstants.POD_TEMPLATE_DIMENSION).toInstance(podTemplate);
+  }
+
+  /**
+   * Overridden by tests, which cannot set an environment variable on the running process.
+   */
+  @VisibleForTesting
+  @Nullable
+  String getPodTemplateName()
+  {
+    return System.getenv(DruidK8sConstants.POD_TEMPLATE_ENV);
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/common/DruidK8sConstants.java
@@ -35,6 +35,8 @@ public class DruidK8sConstants
   public static final String DEFAULT_JAVA_HEAP_SIZE = "1G";
   public static final String TLS_ENABLED = "tls.enabled";
   public static final String TASK_JSON_ENV = "TASK_JSON";
+  public static final String POD_TEMPLATE_ENV = "DRUID_POD_TEMPLATE";
+  public static final String POD_TEMPLATE_DIMENSION = "podTemplate";
   public static final String TASK_DIR_ENV = "TASK_DIR";
   public static final String TASK_ID_ENV = "TASK_ID";
   public static final String LOAD_BROADCAST_DATASOURCE_MODE_ENV = "LOAD_BROADCAST_DATASOURCE_MODE";

--- a/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/java/org/apache/druid/k8s/overlord/taskadapter/PodTemplateTaskAdapter.java
@@ -240,7 +240,15 @@ public class PodTemplateTaskAdapter implements TaskAdapter
         new EnvVarBuilder()
             .withName(DruidK8sConstants.LOAD_BROADCAST_SEGMENTS_ENV)
             .withValue(Boolean.toString(task.getBroadcastDatasourceLoadingSpec().getMode().needsBroadcastSegments()))
-            .build()
+            .build(),
+        // Lets the peon tag its metrics with the template it runs under. Sourced from the annotation
+        // rather than passed by value so it always reflects the template actually applied to the pod.
+        new EnvVarBuilder()
+            .withName(DruidK8sConstants.POD_TEMPLATE_ENV)
+            .withValueFrom(new EnvVarSourceBuilder().withFieldRef(new ObjectFieldSelector(
+                null,
+                StringUtils.format("metadata.annotations['%s']", DruidK8sConstants.TASK_JOB_TEMPLATE)
+            )).build()).build()
     );
     if (!shouldUseDeepStorageForTaskPayload(task)) {
       envVars.add(new EnvVarBuilder()

--- a/extensions-core/kubernetes-overlord-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
+++ b/extensions-core/kubernetes-overlord-extensions/src/main/resources/META-INF/services/org.apache.druid.initialization.DruidModule
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.druid.k8s.overlord.KubernetesOverlordModule
+org.apache.druid.k8s.overlord.KubernetesPeonMetricsModule

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonMetricsModuleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonMetricsModuleTest.java
@@ -20,21 +20,37 @@
 package org.apache.druid.k8s.overlord;
 
 import com.google.inject.Guice;
-import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
+import org.apache.druid.initialization.DruidModule;
 import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
 import org.apache.druid.server.emitter.ExtraServiceDimensions;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 
 public class KubernetesPeonMetricsModuleTest
 {
   private static final Key<Map<String, String>> EXTRA_DIMENSIONS_KEY =
       Key.get(new TypeLiteral<>() {}, ExtraServiceDimensions.class);
+
+  @Test
+  public void test_moduleIsRegisteredAsDruidModule()
+  {
+    final List<String> registered = ServiceLoader.load(DruidModule.class)
+                                                 .stream()
+                                                 .map(provider -> provider.type().getName())
+                                                 .toList();
+
+    Assertions.assertTrue(
+        registered.contains(KubernetesPeonMetricsModule.class.getName()),
+        "KubernetesPeonMetricsModule must be listed in META-INF/services/org.apache.druid.initialization.DruidModule"
+    );
+  }
 
   @Test
   public void test_podTemplateEnvSet_addsDimension()
@@ -57,16 +73,24 @@ public class KubernetesPeonMetricsModuleTest
     Assertions.assertEquals(Map.of(), extraDimensions(""));
   }
 
+  /**
+   * Resolves what the module contributes to {@link ExtraServiceDimensions}. {@code EmitterModule}
+   * owns getting these onto emitted events, and {@code EmitterModuleTest} covers that.
+   */
   private static Map<String, String> extraDimensions(@Nullable String podTemplateName)
   {
-    Injector injector = Guice.createInjector(new KubernetesPeonMetricsModule()
+    return Guice.createInjector(podTemplateModule(podTemplateName)).getInstance(EXTRA_DIMENSIONS_KEY);
+  }
+
+  private static KubernetesPeonMetricsModule podTemplateModule(@Nullable String podTemplateName)
+  {
+    return new KubernetesPeonMetricsModule()
     {
       @Override
       String getPodTemplateName()
       {
         return podTemplateName;
       }
-    });
-    return injector.getInstance(EXTRA_DIMENSIONS_KEY);
+    };
   }
 }

--- a/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonMetricsModuleTest.java
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/java/org/apache/druid/k8s/overlord/KubernetesPeonMetricsModuleTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.k8s.overlord;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.TypeLiteral;
+import org.apache.druid.k8s.overlord.common.DruidK8sConstants;
+import org.apache.druid.server.emitter.ExtraServiceDimensions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class KubernetesPeonMetricsModuleTest
+{
+  private static final Key<Map<String, String>> EXTRA_DIMENSIONS_KEY =
+      Key.get(new TypeLiteral<>() {}, ExtraServiceDimensions.class);
+
+  @Test
+  public void test_podTemplateEnvSet_addsDimension()
+  {
+    Assertions.assertEquals(
+        Map.of(DruidK8sConstants.POD_TEMPLATE_DIMENSION, "podSpec1"),
+        extraDimensions("podSpec1")
+    );
+  }
+
+  @Test
+  public void test_podTemplateEnvUnset_addsNoDimension()
+  {
+    Assertions.assertEquals(Map.of(), extraDimensions(null));
+  }
+
+  @Test
+  public void test_podTemplateEnvEmpty_addsNoDimension()
+  {
+    Assertions.assertEquals(Map.of(), extraDimensions(""));
+  }
+
+  private static Map<String, String> extraDimensions(@Nullable String podTemplateName)
+  {
+    Injector injector = Guice.createInjector(new KubernetesPeonMetricsModule()
+    {
+      @Override
+      String getPodTemplateName()
+      {
+        return podTemplateName;
+      }
+    });
+    return injector.getInstance(EXTRA_DIMENSIONS_KEY);
+  }
+}

--- a/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobLongIds.yaml
@@ -52,6 +52,10 @@ spec:
               value: "NONE"
             - name: "LOAD_BROADCAST_SEGMENTS"
               value: "false"
+            - name: "DRUID_POD_TEMPLATE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.annotations['task.jobTemplate']"
             - name: "TASK_JSON"
               valueFrom:
                 fieldRef:

--- a/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobNoTaskJson.yaml
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobNoTaskJson.yaml
@@ -51,5 +51,9 @@ spec:
               value: "NONE"
             - name: "LOAD_BROADCAST_SEGMENTS"
               value: "false"
+            - name: "DRUID_POD_TEMPLATE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.annotations['task.jobTemplate']"
           image: one
           name: primary

--- a/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabledBase.yaml
+++ b/extensions-core/kubernetes-overlord-extensions/src/test/resources/expectedNoopJobTlsEnabledBase.yaml
@@ -52,6 +52,10 @@ spec:
               value: "NONE"
             - name: "LOAD_BROADCAST_SEGMENTS"
               value: "false"
+            - name: "DRUID_POD_TEMPLATE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "metadata.annotations['task.jobTemplate']"
             - name: "TASK_JSON"
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
### Description

For users of the `kubernetes-overlord-extensions` add a new dimension to peon task metrics `podTemplate` that is the string name of the template selected for the task. This offers better visibility into what task types are running on what pod template in metrics so operators can be more informed on the behavior of tasks depending on template used.

#### Release note

Peon task metrics for clusters using `kubernetes-overlord-extensions` will now emit a new dimension `podTemplate`, improving observability for operators who have different tasks mapping to different templates.


<hr>

##### Key changed/added classes in this PR
 * `KubernetesPeonMetricsModule`
 * `PodTemplateTaskAdapter`
 
<hr>

This PR has:

- [ ] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.