### PR TITLE
fix: Fix issue where RetryableS3OutputStream quietly aborts an s3 multipart upload but doesn't throw to indicate failure

### DIFF
--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -23,6 +23,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.io.CountingOutputStream;
 import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
 import org.apache.druid.java.util.common.FileUtils;
+import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
@@ -295,9 +296,15 @@ public class RetryableS3OutputStream extends OutputStream
     }
   }
 
-  private void completeMultipartUpload()
+  /**
+   * Waits for every queued part, then either finalizes the multipart upload or aborts it. An abort discards the parts
+   * uploaded so far and leaves no object at {@link #s3Key} and finally throws an {@link IOException} to ensure callers
+   * know an error occurred and that the object is not available for reading.
+   */
+  private void completeMultipartUpload() throws IOException
   {
     final List<CompletedPart> pushResults = new ArrayList<>();
+    Exception partUploadFailure = null;
     for (Future<UploadPartResponse> future : futures) {
       if (error) {
         future.cancel(true);
@@ -311,6 +318,9 @@ public class RetryableS3OutputStream extends OutputStream
       }
       catch (Exception e) {
         error = true;
+        if (partUploadFailure == null) {
+          partUploadFailure = e;
+        }
         LOG.error(e, "Error in uploading part for upload ID [%s]", uploadId);
       }
     }
@@ -349,6 +359,18 @@ public class RetryableS3OutputStream extends OutputStream
     }
     catch (Exception e) {
       throw new RuntimeException(e);
+    }
+
+    // If an error occurred during the upload of any part, we aborted the whole upload and there is nothing to read
+    // downstream. We must throw here to indicate that the object was not written and avoid callers assuming that the
+    // object is available for reading.
+    if (error) {
+      throw new IOE(
+          partUploadFailure,
+          "Aborted multipart upload[%s] for s3Key[%s]; no object was written",
+          uploadId,
+          s3Key
+      );
     }
   }
 

--- a/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
+++ b/extensions-core/s3-extensions/src/main/java/org/apache/druid/storage/s3/output/RetryableS3OutputStream.java
@@ -22,8 +22,8 @@ package org.apache.druid.storage.s3.output;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.CountingOutputStream;
 import it.unimi.dsi.fastutil.io.FastBufferedOutputStream;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.FileUtils;
-import org.apache.druid.java.util.common.IOE;
 import org.apache.druid.java.util.common.RetryUtils;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.io.Closer;
@@ -298,10 +298,11 @@ public class RetryableS3OutputStream extends OutputStream
 
   /**
    * Waits for every queued part, then either finalizes the multipart upload or aborts it. An abort discards the parts
-   * uploaded so far and leaves no object at {@link #s3Key} and finally throws an {@link IOException} to ensure callers
-   * know an error occurred and that the object is not available for reading.
+   * uploaded so far and leaves no object at {@link #s3Key} and finally throws a {@link DruidException} to ensure
+   * callers know an error occurred and that the object is not available for reading. The failure is an operator
+   * concern rather than a Druid defect: it means S3 rejected the parts.
    */
-  private void completeMultipartUpload() throws IOException
+  private void completeMultipartUpload()
   {
     final List<CompletedPart> pushResults = new ArrayList<>();
     Exception partUploadFailure = null;
@@ -365,12 +366,14 @@ public class RetryableS3OutputStream extends OutputStream
     // downstream. We must throw here to indicate that the object was not written and avoid callers assuming that the
     // object is available for reading.
     if (error) {
-      throw new IOE(
-          partUploadFailure,
-          "Aborted multipart upload[%s] for s3Key[%s]; no object was written",
-          uploadId,
-          s3Key
-      );
+      throw DruidException.forPersona(DruidException.Persona.OPERATOR)
+                          .ofCategory(DruidException.Category.RUNTIME_FAILURE)
+                          .build(
+                              partUploadFailure,
+                              "Aborted multipart upload[%s] for s3Key[%s]; no object was written",
+                              uploadId,
+                              s3Key
+                          );
     }
   }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -20,6 +20,7 @@
 package org.apache.druid.storage.s3.output;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.druid.error.DruidException;
 import org.apache.druid.java.util.common.FileUtils;
 import org.apache.druid.java.util.common.HumanReadableBytes;
 import org.apache.druid.java.util.common.IOE;
@@ -207,7 +208,7 @@ public class RetryableS3OutputStreamTest
     final TestAmazonS3 s3 = new TestAmazonS3(3);
 
     ByteBuffer bb = ByteBuffer.allocate(Integer.BYTES);
-    final IOException e = Assertions.assertThrows(IOException.class, () -> {
+    final DruidException e = Assertions.assertThrows(DruidException.class, () -> {
       try (RetryableS3OutputStream out =
                new RetryableS3OutputStream(config, s3, path, s3UploadManager)) {
         for (int i = 0; i < 2; i++) {
@@ -225,6 +226,9 @@ public class RetryableS3OutputStreamTest
     Assertions.assertTrue(e.getMessage().contains("no object was written"), e.getMessage());
     Assertions.assertTrue(e.getMessage().contains(path), e.getMessage());
     Assertions.assertNotNull(e.getCause());
+    // An aborted upload means S3 rejected the parts, which an operator can act on, rather than a Druid defect.
+    Assertions.assertEquals(DruidException.Persona.OPERATOR, e.getTargetPersona());
+    Assertions.assertEquals(DruidException.Category.RUNTIME_FAILURE, e.getCategory());
     s3.assertCancelled();
   }
 

--- a/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
+++ b/extensions-core/s3-extensions/src/test/java/org/apache/druid/storage/s3/output/RetryableS3OutputStreamTest.java
@@ -197,25 +197,34 @@ public class RetryableS3OutputStreamTest
     s3.assertCompleted(chunkSize, Integer.BYTES * 25);
   }
 
+  /**
+   * A part that fails every retry leaves the multipart upload aborted and no object at the key, so close() must report
+   * it. Returning normally would tell the caller its bytes are readable back when they no longer exist anywhere.
+   */
   @Test
-  public void testFailToUploadAfterRetries() throws IOException
+  public void testFailToUploadAfterRetries()
   {
     final TestAmazonS3 s3 = new TestAmazonS3(3);
 
     ByteBuffer bb = ByteBuffer.allocate(Integer.BYTES);
-    try (RetryableS3OutputStream out =
-             new RetryableS3OutputStream(config, s3, path, s3UploadManager)) {
-      for (int i = 0; i < 2; i++) {
+    final IOException e = Assertions.assertThrows(IOException.class, () -> {
+      try (RetryableS3OutputStream out =
+               new RetryableS3OutputStream(config, s3, path, s3UploadManager)) {
+        for (int i = 0; i < 2; i++) {
+          bb.clear();
+          bb.putInt(i);
+          out.write(bb.array());
+        }
+
         bb.clear();
-        bb.putInt(i);
+        bb.putInt(3);
         out.write(bb.array());
       }
+    });
 
-      bb.clear();
-      bb.putInt(3);
-      out.write(bb.array());
-    }
-
+    Assertions.assertTrue(e.getMessage().contains("no object was written"), e.getMessage());
+    Assertions.assertTrue(e.getMessage().contains(path), e.getMessage());
+    Assertions.assertNotNull(e.getCause());
     s3.assertCancelled();
   }
 


### PR DESCRIPTION
### Description

Seems to trace back to https://github.com/apache/druid/pull/16481 where we made this multipart upload async. Before this change any failed part would indeed result in an exceptional event.

Explicitly throw when RetryableS3OutputStream fails to complete a multipart upload and aborts the write to s3. Right now, if an error occurs during completion of the multipart upload, we log the failure for that part and abort the large upload (correct to avoid orphaning files) before quietly returning to caller implicitly indicating success. Problem is, downstream code will try and fail to consume the files that were supposed to be uploaded and fail due to the object not existing. This can result in a hard to troubleshoot error since the real problem was the failed upload with an error log buried somewhere else.

A common presentation I have seen for this is MSQ compaction using durable storage. During the shuffle a multipart upload to durable storage has a part that fails and aborts the rest of the upload + logs an error. But it doesn't throw and something downstream tries to access what would have been written by this worker which results in a no such key error from s3 and a task failure. Once you dig in you see that the multipart failure happened and doomed the task to fail down the road. This proposal intends to explicitly throw and in this case cause the compaction worker to fail fast instead of leave a landmine for whoever comes to read the data that wasn't written later.

#### Release note

Fixes an issue when MSQ durable storage writes to s3 could fail but not immediately report their failure, causing downstream code to fail in a way that made troubleshooting root cause more difficult.

<hr>

##### Key changed/added classes in this PR
 * `RetryableS3OutputStream`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.