### PR TITLE
fix: align skipIntervals to segmentGranularity in DataSourceCompactibleSegmentIterator  

### DIFF
--- a/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
@@ -450,7 +450,7 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
   )
   {
     final StringBuilder reason = new StringBuilder(
-        StringUtils.format("interval[%s] overlaps skipOffsetFromLatest[%s]", skipInterval, skipOffset)
+        StringUtils.format("interval[%s] overlaps one of the skip sources: skipOffsetFromLatest[%s]", skipInterval, skipOffset)
     );
     if (!configuredSkipIntervals.isEmpty()) {
       reason.append(", configured skipIntervals").append(configuredSkipIntervals);
@@ -468,7 +468,7 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
     }
     final DateTime alignedStart = segmentGranularity.bucketStart(interval.getStart());
     final DateTime endBucketStart = segmentGranularity.bucketStart(interval.getEnd());
-    final DateTime alignedEnd = endBucketStart.equals(interval.getEnd())
+    final DateTime alignedEnd = endBucketStart.isEqual(interval.getEnd())
                                  ? interval.getEnd()
                                  : segmentGranularity.bucketEnd(interval.getEnd());
     return new Interval(alignedStart, alignedEnd);

--- a/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
@@ -97,7 +97,28 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
     this.queue = new PriorityQueue<>(searchPolicy::compareCandidates);
     this.fingerprintMapper = indexingStateFingerprintMapper;
 
-    populateQueue(timeline, skipIntervals);
+    if (skipIntervals.contains(Intervals.ETERNITY) || config.getSkipIntervals().contains(Intervals.ETERNITY)) {
+      skipAllSegments(timeline, skipIntervals);
+    } else {
+      populateQueue(timeline, skipIntervals);
+    }
+  }
+
+  private void skipAllSegments(SegmentTimeline timeline, List<Interval> skipIntervals)
+  {
+    if (timeline == null || timeline.isEmpty()) {
+      return;
+    }
+    final List<DataSegment> allSegments = new ArrayList<>(
+        timeline.findNonOvershadowedObjectsInInterval(Intervals.ETERNITY, Partitions.ONLY_COMPLETE)
+    );
+    if (allSegments.isEmpty()) {
+      return;
+    }
+    final String reason = skipIntervals.contains(Intervals.ETERNITY)
+                           ? StringUtils.format("Interval[%s] locked by another task", Intervals.ETERNITY)
+                           : StringUtils.format("Interval[%s] skipped by compaction config", Intervals.ETERNITY);
+    skippedSegments.add(CompactionCandidate.from(allSegments, null, CompactionStatus.skipped(reason)));
   }
 
   private void populateQueue(SegmentTimeline timeline, List<Interval> skipIntervals)

--- a/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Lists;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.Intervals;
 import org.apache.druid.java.util.common.JodaUtils;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularity;
 import org.apache.druid.java.util.common.guava.Comparators;
 import org.apache.druid.java.util.common.logger.Logger;
@@ -364,15 +365,12 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
 
     final TimelineObjectHolder<String, DataSegment> first = Preconditions.checkNotNull(timeline.first(), "first");
     final TimelineObjectHolder<String, DataSegment> last = Preconditions.checkNotNull(timeline.last(), "last");
-    final Interval latestSkipInterval = computeLatestSkipInterval(
-        config.getSegmentGranularity(),
-        last.getInterval().getEnd(),
-        skipOffset
-    );
+    final Granularity segmentGranularity = config.getSegmentGranularity();
+    final DateTime latestDataTimestamp = last.getInterval().getEnd();
     final List<Interval> allSkipIntervals = JodaUtils.condenseIntervals(Iterables.concat(
-        skipIntervals,
-        config.getSkipIntervals(),
-        List.of(latestSkipInterval)
+        Iterables.transform(skipIntervals, interval -> alignToSegmentGranularity(segmentGranularity, interval)),
+        Iterables.transform(config.getSkipIntervals(), interval -> alignToSegmentGranularity(segmentGranularity, interval)),
+        List.of(alignToSegmentGranularity(segmentGranularity, new Interval(skipOffset, latestDataTimestamp)))
     ));
 
     // Collect stats for all skipped segments
@@ -380,25 +378,12 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
       final List<DataSegment> segments = new ArrayList<>(
           timeline.findNonOvershadowedObjectsInInterval(skipInterval, Partitions.ONLY_COMPLETE)
       );
-      if (!CollectionUtils.isNullOrEmpty(segments)) {
-        final Interval compactionInterval = CompactionCandidate.getCompactionInterval(
+      if (!segments.isEmpty()) {
+        skippedSegments.add(CompactionCandidate.from(
             segments,
-            config.getSegmentGranularity()
-        );
-
-        final CompactionStatus reason;
-        if (compactionInterval.overlaps(latestSkipInterval)) {
-          reason = CompactionStatus.skipped("skip offset from latest[%s]", skipOffset);
-        } else {
-          reason = CompactionStatus.skipped("interval locked by another task");
-        }
-
-        final CompactionCandidate candidatesWithStatus = CompactionCandidate.from(
-            segments,
-            config.getSegmentGranularity(),
-            reason
-        );
-        skippedSegments.add(candidatesWithStatus);
+            segmentGranularity,
+            CompactionStatus.skipped(describeSkipReason(skipInterval, skipOffset, config.getSkipIntervals(), skipIntervals))
+        ));
       }
     }
 
@@ -437,25 +422,56 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
           .map(segment -> segment.getId().getIntervalEnd())
           .max(Comparator.naturalOrder())
           .orElseThrow(AssertionError::new);
-      searchIntervals.add(new Interval(searchStart, searchEnd));
+      final Interval searchInterval = new Interval(searchStart, searchEnd);
+      final Interval overlappingSkipInterval = allSkipIntervals.stream()
+                                                                .filter(searchInterval::overlaps)
+                                                                .findFirst()
+                                                                .orElse(null);
+      // Guardrail check, this should never happen
+      if (overlappingSkipInterval != null) {
+        log.warn(
+            "searchInterval[%s] for datasource[%s] unexpectedly overlaps skipInterval[%s]: %s, skipping it",
+            searchInterval, dataSource, overlappingSkipInterval,
+            describeSkipReason(overlappingSkipInterval, skipOffset, config.getSkipIntervals(), skipIntervals)
+        );
+        continue;
+      }
+      searchIntervals.add(searchInterval);
     }
 
     return searchIntervals;
   }
 
-  static Interval computeLatestSkipInterval(
-      @Nullable Granularity configuredSegmentGranularity,
-      DateTime latestDataTimestamp,
-      Period skipOffsetFromLatest
+  private static String describeSkipReason(
+      Interval skipInterval,
+      Period skipOffset,
+      List<Interval> configuredSkipIntervals,
+      List<Interval> lockedIntervals
   )
   {
-    if (configuredSegmentGranularity == null) {
-      return new Interval(skipOffsetFromLatest, latestDataTimestamp);
-    } else {
-      DateTime skipFromLastest = new DateTime(latestDataTimestamp, latestDataTimestamp.getZone()).minus(skipOffsetFromLatest);
-      DateTime skipOffsetBucketToSegmentGranularity = configuredSegmentGranularity.bucketStart(skipFromLastest);
-      return new Interval(skipOffsetBucketToSegmentGranularity, latestDataTimestamp);
+    final StringBuilder reason = new StringBuilder(
+        StringUtils.format("interval[%s] overlaps skipOffsetFromLatest[%s]", skipInterval, skipOffset)
+    );
+    if (!configuredSkipIntervals.isEmpty()) {
+      reason.append(", configured skipIntervals").append(configuredSkipIntervals);
     }
+    if (!lockedIntervals.isEmpty()) {
+      reason.append(", locked intervals").append(lockedIntervals);
+    }
+    return reason.toString();
+  }
+
+  private static Interval alignToSegmentGranularity(@Nullable Granularity segmentGranularity, Interval interval)
+  {
+    if (segmentGranularity == null) {
+      return interval;
+    }
+    final DateTime alignedStart = segmentGranularity.bucketStart(interval.getStart());
+    final DateTime endBucketStart = segmentGranularity.bucketStart(interval.getEnd());
+    final DateTime alignedEnd = endBucketStart.equals(interval.getEnd())
+                                 ? interval.getEnd()
+                                 : segmentGranularity.bucketEnd(interval.getEnd());
+    return new Interval(alignedStart, alignedEnd);
   }
 
   /**

--- a/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
+++ b/server/src/main/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIterator.java
@@ -368,9 +368,9 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
     final Granularity segmentGranularity = config.getSegmentGranularity();
     final DateTime latestDataTimestamp = last.getInterval().getEnd();
     final List<Interval> allSkipIntervals = JodaUtils.condenseIntervals(Iterables.concat(
-        Iterables.transform(skipIntervals, interval -> alignToSegmentGranularity(segmentGranularity, interval)),
-        Iterables.transform(config.getSkipIntervals(), interval -> alignToSegmentGranularity(segmentGranularity, interval)),
-        List.of(alignToSegmentGranularity(segmentGranularity, new Interval(skipOffset, latestDataTimestamp)))
+        Iterables.transform(skipIntervals, this::alignToSegmentGranularity),
+        Iterables.transform(config.getSkipIntervals(), this::alignToSegmentGranularity),
+        List.of(alignToSegmentGranularity(new Interval(skipOffset, latestDataTimestamp)))
     ));
 
     // Collect stats for all skipped segments
@@ -422,11 +422,13 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
           .map(segment -> segment.getId().getIntervalEnd())
           .max(Comparator.naturalOrder())
           .orElseThrow(AssertionError::new);
+
       final Interval searchInterval = new Interval(searchStart, searchEnd);
       final Interval overlappingSkipInterval = allSkipIntervals.stream()
                                                                 .filter(searchInterval::overlaps)
                                                                 .findFirst()
                                                                 .orElse(null);
+
       // Guardrail check, this should never happen
       if (overlappingSkipInterval != null) {
         log.warn(
@@ -449,20 +451,18 @@ public class DataSourceCompactibleSegmentIterator implements CompactionSegmentIt
       List<Interval> lockedIntervals
   )
   {
-    final StringBuilder reason = new StringBuilder(
-        StringUtils.format("interval[%s] overlaps one of the skip sources: skipOffsetFromLatest[%s]", skipInterval, skipOffset)
-    );
-    if (!configuredSkipIntervals.isEmpty()) {
-      reason.append(", configured skipIntervals").append(configuredSkipIntervals);
+    if (lockedIntervals.stream().anyMatch(skipInterval::overlaps)) {
+      return StringUtils.format("Interval[%s] locked by another task", skipInterval);
+    } else if (configuredSkipIntervals.stream().anyMatch(skipInterval::overlaps)) {
+      return StringUtils.format("Interval[%s] skipped by compaction config", skipInterval);
+    } else {
+      return StringUtils.format("Skip offset from latest[%s]", skipOffset);
     }
-    if (!lockedIntervals.isEmpty()) {
-      reason.append(", locked intervals").append(lockedIntervals);
-    }
-    return reason.toString();
   }
 
-  private static Interval alignToSegmentGranularity(@Nullable Granularity segmentGranularity, Interval interval)
+  private Interval alignToSegmentGranularity(Interval interval)
   {
+    final Granularity segmentGranularity = config.getSegmentGranularity();
     if (segmentGranularity == null) {
       return interval;
     }

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
@@ -113,7 +113,14 @@ public class CompactionRunSimulatorTest
     );
     Assert.assertEquals(
         Collections.singletonList(
-            List.of("wiki", Intervals.of("2013-01-10/P1D"), 10, 1_000_000_000L, 1, "skip offset from latest[P1D]")
+            List.of(
+                "wiki",
+                Intervals.of("2013-01-10/P1D"),
+                10,
+                1_000_000_000L,
+                1,
+                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps skipOffsetFromLatest[P1D]"
+            )
         ),
         skippedTable.getRows()
     );
@@ -188,7 +195,14 @@ public class CompactionRunSimulatorTest
             List.of("wiki", Intervals.of("2013-01-06/P1D"), 10, 1_000_000_000L, 1, rejectedMessage),
             List.of("wiki", Intervals.of("2013-01-01/P1D"), 10, 1_000_000_000L, 1, rejectedMessage),
             List.of("wiki", Intervals.of("2013-01-09/P1D"), 10, 1_000_000_000L, 1, rejectedMessage),
-            List.of("wiki", Intervals.of("2013-01-10/P1D"), 10, 1_000_000_000L, 1, "skip offset from latest[P1D]")
+            List.of(
+                "wiki",
+                Intervals.of("2013-01-10/P1D"),
+                10,
+                1_000_000_000L,
+                1,
+                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps skipOffsetFromLatest[P1D]"
+            )
         ),
         skippedTable.getRows()
     );

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
@@ -119,7 +119,7 @@ public class CompactionRunSimulatorTest
                 10,
                 1_000_000_000L,
                 1,
-                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps one of the skip sources: skipOffsetFromLatest[P1D]"
+                "Skip offset from latest[P1D]"
             )
         ),
         skippedTable.getRows()
@@ -201,7 +201,7 @@ public class CompactionRunSimulatorTest
                 10,
                 1_000_000_000L,
                 1,
-                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps one of the skip sources: skipOffsetFromLatest[P1D]"
+                "Skip offset from latest[P1D]"
             )
         ),
         skippedTable.getRows()

--- a/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/CompactionRunSimulatorTest.java
@@ -119,7 +119,7 @@ public class CompactionRunSimulatorTest
                 10,
                 1_000_000_000L,
                 1,
-                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps skipOffsetFromLatest[P1D]"
+                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps one of the skip sources: skipOffsetFromLatest[P1D]"
             )
         ),
         skippedTable.getRows()
@@ -201,7 +201,7 @@ public class CompactionRunSimulatorTest
                 10,
                 1_000_000_000L,
                 1,
-                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps skipOffsetFromLatest[P1D]"
+                "interval[2013-01-10T00:00:00.000Z/2013-01-11T00:00:00.000Z] overlaps one of the skip sources: skipOffsetFromLatest[P1D]"
             )
         ),
         skippedTable.getRows()

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.apache.druid.jackson.DefaultObjectMapper;
 import org.apache.druid.java.util.common.Intervals;
+import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.granularity.Granularities;
 import org.apache.druid.segment.metadata.DefaultIndexingStateFingerprintMapper;
 import org.apache.druid.segment.metadata.IndexingStateFingerprintMapper;
@@ -181,5 +182,43 @@ public class DataSourceCompactibleSegmentIteratorTest
     Assert.assertEquals(1, skipped.size());
     Assert.assertEquals(Intervals.of("2018-01-01/2018-01-02"), skipped.getFirst().getUmbrellaInterval());
     Assert.assertEquals(24, skipped.getFirst().getSegments().size());
+  }
+
+  @Test
+  public void testEternitySkipIntervalInConfigSkipsAllSegments()
+  {
+    final Iterator<DataSegment> segments = CreateDataSegments.ofDatasource("test_datasource")
+                                                             .forIntervals(24, Granularities.HOUR)
+                                                             .startingAt("2018-01-01")
+                                                             .withNumPartitions(1)
+                                                             .eachOfSizeInMb(100)
+                                                             .iterator();
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(segments);
+    final DataSourceCompactionConfig config =
+        InlineSchemaDataSourceCompactionConfig.builder()
+                                              .forDataSource("test_datasource")
+                                              .withSkipOffsetFromLatest(new Period("PT0H"))
+                                              .withSegmentGranularity(Granularities.DAY)
+                                              .withSkipIntervals(List.of(Intervals.ETERNITY))
+                                              .build();
+
+    // Aligning an ETERNITY skip interval to DAY granularity would overflow; this should short-circuit
+    // compaction of the entire datasource instead of throwing.
+    final DataSourceCompactibleSegmentIterator iterator = new DataSourceCompactibleSegmentIterator(
+        config,
+        timeline,
+        List.of(),
+        POLICY,
+        FINGERPRINT_MAPPER
+    );
+
+    Assert.assertFalse(iterator.hasNext());
+    final List<CompactionCandidate> skipped = iterator.getSkippedSegments();
+    Assert.assertEquals(1, skipped.size());
+    Assert.assertEquals(24, skipped.getFirst().getSegments().size());
+    Assert.assertEquals(
+        StringUtils.format("Interval[%s] skipped by compaction config", Intervals.ETERNITY),
+        skipped.getFirst().getCurrentStatus().getReason()
+    );
   }
 }

--- a/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
+++ b/server/src/test/java/org/apache/druid/server/compaction/DataSourceCompactibleSegmentIteratorTest.java
@@ -145,4 +145,41 @@ public class DataSourceCompactibleSegmentIteratorTest
         searchIntervals
     );
   }
+
+  @Test
+  public void testSkipIntervalNotAlignedWithSegmentGranularityIsNotCompacted()
+  {
+    // Segments are hourly, and compaction is configured to bucket them into DAY chunks.
+    final Iterator<DataSegment> segments = CreateDataSegments.ofDatasource("test_datasource")
+                                                             .forIntervals(24, Granularities.HOUR)
+                                                             .startingAt("2018-01-01")
+                                                             .withNumPartitions(1)
+                                                             .eachOfSizeInMb(100)
+                                                             .iterator();
+    final SegmentTimeline timeline = SegmentTimeline.forSegments(segments);
+    final DataSourceCompactionConfig config =
+        InlineSchemaDataSourceCompactionConfig.builder()
+                                              .forDataSource("test_datasource")
+                                              .withSkipOffsetFromLatest(new Period("PT0H"))
+                                              .withSegmentGranularity(Granularities.DAY)
+                                              .build();
+
+    // Skip interval is not aligned with the DAY segment granularity
+    final List<Interval> skipIntervals = List.of(Intervals.of("2018-01-01T10:00:00/2018-01-01T14:00:00"));
+
+    final DataSourceCompactibleSegmentIterator iterator = new DataSourceCompactibleSegmentIterator(
+        config,
+        timeline,
+        skipIntervals,
+        POLICY,
+        FINGERPRINT_MAPPER
+    );
+
+    // The DAY bucket overlaps the skip interval, so none of its segments should be picked up for compaction.
+    Assert.assertFalse(iterator.hasNext());
+    final List<CompactionCandidate> skipped = iterator.getSkippedSegments();
+    Assert.assertEquals(1, skipped.size());
+    Assert.assertEquals(Intervals.of("2018-01-01/2018-01-02"), skipped.getFirst().getUmbrellaInterval());
+    Assert.assertEquals(24, skipped.getFirst().getSegments().size());
+  }
 }


### PR DESCRIPTION
### Description
Follow-up to #20007, addressing https://github.com/apache/druid/pull/20007#discussion_r3786491064.                                                                  
        

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
   - [ ] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.