### PR TITLE
test(processing): reproduce JDK 25 crash

### DIFF
--- a/processing/src/test/java/org/apache/druid/segment/SchemalessTestSimpleTest.java
+++ b/processing/src/test/java/org/apache/druid/segment/SchemalessTestSimpleTest.java
@@ -58,10 +58,10 @@ import org.apache.druid.segment.incremental.IncrementalIndex;
 import org.apache.druid.segment.writeout.SegmentWriteOutMediumFactory;
 import org.apache.druid.testing.InitializedNullHandlingTest;
 import org.apache.druid.timeline.SegmentId;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedClass;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -72,11 +72,10 @@ import java.util.List;
 
 /**
  */
-@RunWith(Parameterized.class)
+@ParameterizedClass
+@MethodSource("constructorFeeder")
 public class SchemalessTestSimpleTest extends InitializedNullHandlingTest
 {
-
-  @Parameterized.Parameters
   public static Collection<?> constructorFeeder()
   {
     List<Object[]> argumentArrays = new ArrayList<>();
@@ -165,7 +164,7 @@ public class SchemalessTestSimpleTest extends InitializedNullHandlingTest
 
   //  @Test TODO: Handling of null values is inconsistent right now, need to make it all consistent and re-enable test
   // TODO: Complain to Eric when you see this.  It shouldn't be like this...
-  @Ignore
+  @Disabled
   @SuppressWarnings("unused")
   public void testFullOnTopN()
   {


### PR DESCRIPTION
## What changed

- Migrate only `SchemalessTestSimpleTest` from JUnit 4 parameterization to JUnit 5 `@ParameterizedClass`/`@MethodSource`.
- Replace the matching `@Ignore` annotation with `@Disabled`.

This is an intentionally minimal reproduction for [#19983](https://github.com/apache/druid/issues/19983); it does not attempt to fix the JDK 25 failure.

## Validation

Ran the focused test with Temurin JDK 25.0.3:

```text
mvn test -pl processing -am -Dtest="org.apache.druid.segment.SchemalessTestSimpleTest" -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C
```

The run reproduced the issue: three runs passed, run 4 returned zero rows and zero search hits for both affected methods, and the Surefire fork then terminated with SIGSEGV in `Unsafe.getIntUnaligned` (exit code 134). Surefire recorded the two expected flakes on run 5.

Refs #19983