### PR TITLE
fix(hdfs): remove LZ4 segments during kill tasks

### DIFF
--- a/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKiller.java
+++ b/extensions-core/hdfs-storage/src/main/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKiller.java
@@ -29,6 +29,7 @@ import org.apache.druid.java.util.emitter.EmittingLogger;
 import org.apache.druid.segment.loading.DataSegmentKiller;
 import org.apache.druid.segment.loading.SegmentLoadingException;
 import org.apache.druid.timeline.DataSegment;
+import org.apache.druid.utils.CompressionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -71,8 +72,9 @@ public class HdfsDataSegmentKiller implements DataSegmentKiller
     log.info("Killing segment[%s] mapped to path[%s]", segment.getId(), segmentPath);
 
     try (final FileSystem fs = segmentPath.getFileSystem(config)) {
-      String filename = segmentPath.getName();
-      if (!filename.endsWith(".zip")) {
+      final String filename = segmentPath.getName();
+      final CompressionUtils.Format compressionFormat = CompressionUtils.Format.fromFileName(filename);
+      if (compressionFormat != CompressionUtils.Format.ZIP && compressionFormat != CompressionUtils.Format.LZ4) {
         throw new SegmentLoadingException("Unknown file type[%s]", segmentPath);
       } else {
 
@@ -81,17 +83,20 @@ public class HdfsDataSegmentKiller implements DataSegmentKiller
           return;
         }
 
-        // There are 3 supported path formats:
+        // There are 3 supported path formats for each segment compression format:
         //    - hdfs://nn1/hdfs_base_directory/data_source_name/interval/version/shardNum/index.zip
         //    - hdfs://nn1/hdfs_base_directory/data_source_name/interval/version/shardNum_index.zip
         //    - hdfs://nn1/hdfs_base_directory/data_source_name/interval/version/shardNum_UUID_index.zip
-        String[] zipParts = filename.split("_");
+        // The same formats with an index.lz4 suffix are also supported.
+        final String[] segmentParts = filename.split("_");
 
         Path descriptorPath = new Path(segmentPath.getParent(), "descriptor.json");
-        if (zipParts.length > 1) {
-          Preconditions.checkState(zipParts.length <= 3 &&
-                                   StringUtils.isNumeric(zipParts[0]) &&
-                                   "index.zip".equals(zipParts[zipParts.length - 1]),
+        if (segmentParts.length > 1) {
+          Preconditions.checkState(segmentParts.length <= 3 &&
+                                   StringUtils.isNumeric(segmentParts[0]) &&
+                                   ("index" + compressionFormat.getSuffix()).equals(
+                                       segmentParts[segmentParts.length - 1]
+                                   ),
                                    "Unexpected segmentPath format [%s]", segmentPath
           );
 
@@ -99,8 +104,8 @@ public class HdfsDataSegmentKiller implements DataSegmentKiller
               segmentPath.getParent(),
               org.apache.druid.java.util.common.StringUtils.format(
                   "%s_%sdescriptor.json",
-                  zipParts[0],
-                  zipParts.length == 2 ? "" : zipParts[1] + "_"
+                  segmentParts[0],
+                  segmentParts.length == 2 ? "" : segmentParts[1] + "_"
               )
           );
         }
@@ -113,7 +118,7 @@ public class HdfsDataSegmentKiller implements DataSegmentKiller
         // anymore, but we still delete them if exists.
         fs.delete(descriptorPath, false);
 
-        removeEmptyParentDirectories(fs, segmentPath, zipParts.length > 1 ? 2 : 3);
+        removeEmptyParentDirectories(fs, segmentPath, segmentParts.length > 1 ? 2 : 3);
       }
     }
     catch (IOException e) {

--- a/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
+++ b/extensions-core/hdfs-storage/src/test/java/org/apache/druid/storage/hdfs/HdfsDataSegmentKillerTest.java
@@ -184,6 +184,42 @@ public class HdfsDataSegmentKillerTest
   }
 
   @Test
+  public void testKillLz4Segment() throws Exception
+  {
+    final File testRoot = FileUtils.createTempDir();
+    final Configuration config = new Configuration();
+    final HdfsDataSegmentKiller killer = new HdfsDataSegmentKiller(
+        config,
+        new HdfsDataSegmentPusherConfig()
+        {
+          @Override
+          public String getStorageDirectory()
+          {
+            return testRoot.getAbsolutePath();
+          }
+        }
+    );
+
+    final FileSystem fs = FileSystem.get(config);
+    final Path versionDir = new Path(testRoot.getAbsolutePath(), "dataSource/interval/v1");
+    final Path segmentPath = new Path(versionDir, "3_index.lz4");
+    try {
+      Assertions.assertTrue(fs.mkdirs(versionDir));
+      fs.createNewFile(segmentPath);
+
+      killer.kill(getSegmentWithPath(segmentPath.toString()));
+
+      Assertions.assertFalse(fs.exists(segmentPath));
+      Assertions.assertFalse(fs.exists(versionDir));
+      Assertions.assertFalse(fs.exists(versionDir.getParent()));
+      Assertions.assertTrue(fs.exists(new Path(testRoot.getAbsolutePath(), "dataSource")));
+    }
+    finally {
+      fs.delete(new Path(testRoot.getAbsolutePath()), true);
+    }
+  }
+
+  @Test
   public void testKillNonExistingSegment() throws Exception
   {
     Configuration config = new Configuration();


### PR DESCRIPTION
## Description

Allow the HDFS segment killer to delete segments stored with the LZ4 compression format.

## Root cause

The source feature was introduced by [Support lz4 compression in hdfs (#18982)](https://github.com/apache/druid/pull/18982), which added `index.lz4` segment push/pull support. However, `HdfsDataSegmentKiller` only accepted `.zip` files and validated `index.zip` in partitioned filenames. Kill tasks could remove the segment metadata and then fail before deleting the LZ4 object from deep storage.

## Changes

- Accept ZIP and LZ4 segment formats in `HdfsDataSegmentKiller`.
- Validate partitioned filenames against the detected compression suffix.
- Add a regression test that creates and removes a `3_index.lz4` segment and verifies empty parent directories are cleaned up.

## Tests

- `env JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-25.jdk/Contents/Home mvn test -pl extensions-core/hdfs-storage -am -Dtest='org.apache.druid.storage.hdfs.HdfsDataSegmentKillerTest' -Dsurefire.failIfNoSpecifiedTests=false -Pskip-static-checks -Dweb.console.skip=true -T1C`
- 11 tests passed
- [x] Self-reviewed
- [x] Added unit test coverage